### PR TITLE
chore: restrict Python version to 3.11-3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Community maintained hardware plugin for vLLM on Apple Silicon"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 authors = [
     {name = "vLLM Team"}
 ]
@@ -19,9 +19,9 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS :: MacOS X",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 


### PR DESCRIPTION
vLLM requires Python >=3.10,<3.14, so align vllm-metal with the same upper bound. Also add Python 3.13 to classifiers.
See https://github.com/vllm-project/vllm/blob/main/pyproject.toml#L33.