### PR TITLE
Fix venv activation instructions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -153,10 +153,10 @@ main() {
   success "Installation complete!"
   echo ""
   echo "To use vllm, activate the virtual environment:"
-  echo "  source $venv"
+  echo "  source $venv/bin/activate"
   echo ""
   echo "Or add the venv to your PATH:"
-  echo "  export PATH=\"$venv:\$PATH\""
+  echo "  export PATH=\"$venv/bin:\$PATH\""
 }
 
 main "$@"


### PR DESCRIPTION
The ending instructions on the `install.sh` are incorrect since you need to do `.venv/bin/activate`

```
✓ Installation complete!

To use vllm, activate the virtual environment:
  source /Users/mgoin/code/vllm-metal/.venv-vllm-metal

Or add the venv to your PATH:
  export PATH="/Users/mgoin/code/vllm-metal/.venv-vllm-metal:$PATH
  ```