### PR TITLE
fix: support Mamba cache for MoE models on Metal & fix install shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ download_and_install_wheel() {
 }
 
 main() {
-  set -eu -o pipefail
+  set -e -o pipefail
 
   local repo_owner="vllm-project"
   local repo_name="vllm-metal"


### PR DESCRIPTION
This PR addresses the crash when running MoE models on vllm-metal. Changes:

Updated model_runner.py to correctly handle MambaCache objects. Previously, the runner assumed all layers were standard KV-cache, causing issues with Hybrid architectures.

Removed set -u from install.sh to fix installation failures on certain shell environments.

Tested on Mac Studio (M3 Ultra) with Qwen3-Next-80B-A3B.