### PR TITLE
fix: set SDKROOT for macOS C++ builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -116,6 +116,8 @@ main() {
     exit 1
   fi
 
+  setup_macos_sdk
+
   local venv="$HOME/.venv-vllm-metal"
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
     venv="$PWD/.venv-vllm-metal"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -21,6 +21,18 @@ is_apple_silicon() {
   [ "$(uname -m)" = "arm64" ]
 }
 
+# This fixes "cstdlib file not found" errors when building with CMake
+setup_macos_sdk() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    local sdk_path
+    sdk_path=$(xcrun --show-sdk-path 2>/dev/null)
+    if [[ -n "$sdk_path" ]]; then
+      export SDKROOT="$sdk_path"
+      export CPLUS_INCLUDE_PATH="${sdk_path}/usr/include/c++/v1:${CPLUS_INCLUDE_PATH:-}"
+    fi
+  fi
+}
+
 # Ensure uv is installed
 ensure_uv() {
   if ! command -v uv &> /dev/null; then


### PR DESCRIPTION
On macOS, CMake builds can fail with 'cstdlib file not found' errors when the SDK path isn't properly configured. This adds a setup_macos_sdk function that exports SDKROOT and CPLUS_INCLUDE_PATH before building vLLM.

The function is called automatically in install.sh to ensure C++ standard library headers are found during compilation.

---

Its possible that this might be a self-inflicted problem with my xcode paths being misconfigured but this might help with some issues I was having building this