### PR TITLE
Fix mlx_to_torch for MLX view/slice buffers

### DIFF
--- a/tests/test_tensor_bridge.py
+++ b/tests/test_tensor_bridge.py
@@ -115,6 +115,18 @@ class TestTensorConversion:
             torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
         )
 
+    def test_mlx_to_torch_view(self) -> None:
+        """MLX views (e.g. slices) should be convertible to torch."""
+        mlx_array = mx.random.normal((2, 3, 4))
+        mlx_view = mlx_array[:, -1, :]
+        mx.eval(mlx_view)
+
+        torch_tensor = mlx_to_torch(mlx_view, device="cpu")
+
+        assert torch_tensor.shape == (2, 4)
+        assert torch_tensor.dtype == torch.float32
+        np.testing.assert_allclose(torch_tensor.numpy(), np.array(mlx_view), rtol=1e-5)
+
     def test_round_trip_conversion(self) -> None:
         """Test round-trip conversion preserves values."""
         # PyTorch -> MLX -> PyTorch


### PR DESCRIPTION
 This PR is:
 - To make mlx_to_torch robust when given MLX views/slices (e.g., logits[:, -1, :]) by only copying when the buffer is non-contiguous.
 - To add a regression test that converts a slice view so the logits[:, -1, :] pattern in v1 batched decode cannot crash.

Tests:
```bash
$ pytest tests/test_tensor_bridge.py::TestTensorConversion::test_mlx_to_torch_view
```

---


**Verifications:**

1. To show `frombuffer(memoryview(...))` only works on a contiguous buffer:
- Fails on a non-contiguous view
<img width="470" height="158" alt="Screenshot 2026-01-02 at 9 18 07 PM" src="https://github.com/user-attachments/assets/50d8a6d6-b846-4356-be26-5f093c2fe815" />


- Succeeds after making it contiguous
<img width="452" height="160" alt="Screenshot 2026-01-02 at 9 22 52 PM" src="https://github.com/user-attachments/assets/12b743aa-00c7-4f8c-a645-6b1a616cc4e1" />


2. Trigger _batched_decode (v1 path) via the harness:
With the fix, this should run and print “Batched decode output: [...]”.
Pre-fix, it raises at torch.frombuffer on the non-contiguous logits slice
```python
$ python scripts/harness_v1_batched_decode.py
```

```python
#!/usr/bin/env python3
"""
Tiny harness to exercise v1 MetalModelRunner._batched_decode on a non-contiguous
logits slice. With the pre-fix code, this raised:

    RuntimeError: could not retrieve buffer from object

because torch.frombuffer cannot consume the strided view returned by
logits[:, -1, :]. With the current fix, it succeeds by making the slice
contiguous before conversion.
"""

import mlx.core as mx
import torch
from vllm.sampling_params import SamplingParams

from vllm_metal.v1 import model_runner as mr


class FakeModel:
    """Tiny stand-in model that returns logits with a strided last-token view."""

    def __call__(self, input_ids, cache=None):
        batch = input_ids.shape[0]
        vocab = 8
        # Shape (batch, 3, vocab) so logits[:, -1, :] is a non-contiguous view.
        return mx.arange(batch * 3 * vocab).reshape(batch, 3, vocab).astype(mx.float32)


def build_runner() -> mr.MetalModelRunner:
    """Construct a minimal runner that reuses the real Sampler/RequestState."""
    runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)  # bypass __init__
    runner.device = torch.device("cpu")
    runner.model_args = {"vocab_size": 8}
    runner._sampler = mr.Sampler()
    runner._rust_state_manager = None
    runner._max_batch_size = mr._MAX_BATCH_SIZE
    runner._request_states = {}
    runner.model = FakeModel()
    runner.cache_config = None
    runner.scheduler_config = None
    runner.vllm_config = None
    return runner


def make_request(token_id: int) -> mr.RequestState:
    """Create a RequestState with a simple single-token history."""
    sampling = SamplingParams(max_tokens=5, temperature=0.0)
    return mr.RequestState(token_ids=[token_id], cache=[], sampling_params=sampling)


def main() -> None:
    runner = build_runner()
    # Two requests to force the v1 batched decode path
    requests = [("req-a", make_request(1)), ("req-b", make_request(2))]
    out = runner._batched_decode(requests)
    print("Batched decode output:", out)


if __name__ == "__main__":
    main()
```