### PR TITLE
Follow vLLM attention backend contract for Metal platform

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -76,7 +76,9 @@ class TestMetalPlatform:
             block_size=16,
             use_sparse=True,
         )
-        with pytest.raises(NotImplementedError, match="Sparse Attention is not supported"):
+        with pytest.raises(
+            NotImplementedError, match="Sparse Attention is not supported"
+        ):
             MetalPlatform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg)
 
     def test_memory_info(self) -> None:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -3,7 +3,7 @@
 
 import logging
 import platform as py_platform
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import psutil
 import torch


### PR DESCRIPTION
This PR is:

- To implement `MetalPlatform.get_attn_backend_cls` with the vLLM interface (returns the CPU backend path, rejects unsupported MLA/sparse)
- To add contract tests that verify the backend path and the expected NotImplementedError paths.
- To provide a minimal repro script demonstrating the broken call on main and the fixed behavior after this change.

**Why this matters:**

- MetalPlatform.get_attn_backend_cls must match vLLM’s interface (signature + non-None return); the old stub violated it and crashes when attention setup calls it.
- Returning the CPU backend and explicitly rejecting unsupported MLA/sparse keeps the plugin a drop-in Platform
  implementation and avoids brittle latent failures.



Minimal repro (before vs after):

```python
#!/usr/bin/env python3
"""Quick contract check for MetalPlatform.get_attn_backend_cls."""

import torch
from vllm.attention.backends.registry import AttentionBackendEnum
from vllm.attention.selector import AttentionSelectorConfig
from vllm.platforms import current_platform


def main() -> None:
    cfg = AttentionSelectorConfig(
        head_size=128,
        dtype=torch.float16,
        kv_cache_dtype="auto",
        block_size=16,
    )
    backend = current_platform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg)
    print("Backend path:", backend)

    try:
        cfg_mla = AttentionSelectorConfig(
            head_size=128,
            dtype=torch.float16,
            kv_cache_dtype="auto",
            block_size=16,
            use_mla=True,
        )
        current_platform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg_mla)
    except NotImplementedError as e:
        print("MLA call raised (expected):", e)

    try:
        cfg_sparse = AttentionSelectorConfig(
            head_size=128,
            dtype=torch.float16,
            kv_cache_dtype="auto",
            block_size=16,
            use_sparse=True,
        )
        current_platform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg_sparse)
    except NotImplementedError as e:
        print("Sparse call raised (expected):", e)


if __name__ == "__main__":
    main()
```

- Before (main): got error:  `TypeError: MetalPlatform.get_attn_backend_cls() takes 1 positional argument but 3 were given`
- After (this branch): prints Backend path: vllm.v1.attention.backends.cpu_attn.CPUAttentionBackend; MLA/sparse raise expected NotImplementedError.

Reference: https://github.com/vllm-project/vllm/blob/v0.13.0/vllm/attention/selector.py#L96