### PR TITLE
Add MPS size limit checks to tensor bridge

### DIFF
--- a/tests/test_tensor_bridge.py
+++ b/tests/test_tensor_bridge.py
@@ -6,8 +6,11 @@ import numpy as np
 import torch
 
 from vllm_metal.pytorch_backend.tensor_bridge import (
+    _MPS_SAFE_SIZE_BYTES,
     MLX_TO_TORCH_DTYPE,
     TORCH_TO_MLX_DTYPE,
+    _get_tensor_size_bytes,
+    _is_safe_for_mps,
     get_torch_device,
     mlx_to_torch,
     sync_mlx,
@@ -161,3 +164,67 @@ class TestSynchronization:
         """Test PyTorch synchronization."""
         # Should not raise
         sync_torch()
+
+
+class TestMPSSizeLimit:
+    """Tests for MPS 4GB size limit handling.
+
+    See: https://github.com/anthropics/vllm-metal/issues/43
+    """
+
+    def test_get_tensor_size_bytes_float32(self) -> None:
+        """Test tensor size calculation for float32."""
+        # 2x3 float32 = 6 elements * 4 bytes = 24 bytes
+        array = mx.zeros((2, 3), dtype=mx.float32)
+        assert _get_tensor_size_bytes(array) == 24
+
+    def test_get_tensor_size_bytes_float16(self) -> None:
+        """Test tensor size calculation for float16."""
+        # 4x5 float16 = 20 elements * 2 bytes = 40 bytes
+        array = mx.zeros((4, 5), dtype=mx.float16)
+        assert _get_tensor_size_bytes(array) == 40
+
+    def test_get_tensor_size_bytes_int32(self) -> None:
+        """Test tensor size calculation for int32."""
+        # 10x10 int32 = 100 elements * 4 bytes = 400 bytes
+        array = mx.zeros((10, 10), dtype=mx.int32)
+        assert _get_tensor_size_bytes(array) == 400
+
+    def test_is_safe_for_mps_small_tensor(self) -> None:
+        """Test that small tensors are safe for MPS."""
+        # 100 float32 = 400 bytes, well under 1GB limit
+        array = mx.zeros((100,), dtype=mx.float32)
+        assert _is_safe_for_mps(array) is True
+
+    def test_is_safe_for_mps_large_tensor(self) -> None:
+        """Test that large tensors are detected as unsafe for MPS."""
+        # Create a tensor larger than the safe limit
+        # _MPS_SAFE_SIZE_BYTES is 1GB = 2^30 bytes
+        # We need more than 2^30 / 4 = 2^28 = 268,435,456 float32 elements
+        # Use a shape that exceeds this: e.g., 512 * 1024 * 1024 = 536,870,912
+        # But we don't want to actually allocate that much memory in tests
+        # Instead, verify the threshold constant is correct
+        assert _MPS_SAFE_SIZE_BYTES == 1 << 30  # 1GB
+
+        # Small tensor should be safe
+        small_array = mx.zeros((1000, 1000), dtype=mx.float32)  # 4MB
+        assert _is_safe_for_mps(small_array) is True
+
+    def test_mlx_to_torch_small_tensor_uses_mps(self) -> None:
+        """Test that small tensors go to MPS when available."""
+        if not torch.backends.mps.is_available():
+            return  # Skip on non-MPS systems
+
+        array = mx.array([1.0, 2.0, 3.0], dtype=mx.float32)
+        mx.eval(array)
+
+        tensor = mlx_to_torch(array, device="mps")
+        assert tensor.device.type == "mps"
+
+    def test_mlx_to_torch_explicit_cpu(self) -> None:
+        """Test that explicit CPU device is respected."""
+        array = mx.array([1.0, 2.0, 3.0], dtype=mx.float32)
+        mx.eval(array)
+
+        tensor = mlx_to_torch(array, device="cpu")
+        assert tensor.device.type == "cpu"


### PR DESCRIPTION
Add size limit checks to prevent MPS crashes when transferring large tensors. The MPS backend has a 4GB limit for MPSTemporaryNDArray allocations, but Metal may allocate multiple temporary buffers internally. A conservative 1GB threshold is used to avoid hitting the limit. New helper functions calculate tensor sizes and check safety before device transfers. Tests verify the size calculations and MPS behavior for different tensor sizes.