### PR TITLE
Add MLX VLM support to MetalModelRunner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     # MLX - Required for Apple Silicon GPU acceleration
     "mlx>=0.20.0",
     "mlx-lm>=0.20.0",
+    "mlx-vlm>=0.3.0",  # Vision-language model support
     # Model loading and weights
     "transformers>=4.40.0",
     "accelerate>=0.26.0",


### PR DESCRIPTION
MetalModelRunner now supports vision-language models (VLMs) through mlx-vlm while maintaining backward compatibility with text-only models using mlx-lm. The implementation includes automatic detection of VLM models, conditional loading based on model type, and proper handling of different model output formats. VLM-specific configurations are extracted from nested text_config when present, and model forward passes now route through a common logits extraction method to handle different output types from mlx-lm and mlx-vlm.