### PR TITLE
Default vLLM worker multiprocessing method to spawn on macOS

### DIFF
--- a/tests/test_macos_defaults.py
+++ b/tests/test_macos_defaults.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 
 import vllm_metal as vm
 
 
 def test_apply_macos_defaults_sets_spawn(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_WORKER_MULTIPROC_METHOD", raising=False)
-    monkeypatch.setattr(vm, "_is_macos", lambda: True)
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     vm._apply_macos_defaults()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
@@ -18,7 +19,7 @@ def test_apply_macos_defaults_sets_spawn(monkeypatch) -> None:
 
 def test_apply_macos_defaults_respects_user_value(monkeypatch) -> None:
     monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")
-    monkeypatch.setattr(vm, "_is_macos", lambda: True)
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     vm._apply_macos_defaults()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "fork"
@@ -26,7 +27,7 @@ def test_apply_macos_defaults_respects_user_value(monkeypatch) -> None:
 
 def test_apply_macos_defaults_noop_on_non_macos(monkeypatch) -> None:
     monkeypatch.delenv("VLLM_WORKER_MULTIPROC_METHOD", raising=False)
-    monkeypatch.setattr(vm, "_is_macos", lambda: False)
+    monkeypatch.setattr(sys, "platform", "linux")
 
     vm._apply_macos_defaults()
     assert "VLLM_WORKER_MULTIPROC_METHOD" not in os.environ
@@ -34,7 +35,7 @@ def test_apply_macos_defaults_noop_on_non_macos(monkeypatch) -> None:
 
 def test_apply_macos_defaults_logs_when_setting(monkeypatch, caplog) -> None:
     monkeypatch.delenv("VLLM_WORKER_MULTIPROC_METHOD", raising=False)
-    monkeypatch.setattr(vm, "_is_macos", lambda: True)
+    monkeypatch.setattr(sys, "platform", "darwin")
 
     with caplog.at_level(logging.DEBUG):
         vm._apply_macos_defaults()

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -14,10 +14,6 @@ __version__ = "0.1.0"
 logger = logging.getLogger(__name__)
 
 
-def _is_macos() -> bool:
-    return sys.platform == "darwin"
-
-
 def _apply_macos_defaults() -> None:
     """Apply safe defaults for macOS when using the Metal plugin.
 
@@ -28,7 +24,7 @@ def _apply_macos_defaults() -> None:
 
     Defaulting to `spawn` avoids forking a partially-initialized runtime.
     """
-    if not _is_macos():
+    if sys.platform != "darwin":
         return
     if os.environ.get("VLLM_WORKER_MULTIPROC_METHOD") is not None:
         return


### PR DESCRIPTION
This PR is:

- To prevent macOS objc_initializeAfterForkError crashes when vLLM starts its engine-core worker process under vllm-metal.
- To align vllm-metal with vLLM’s existing fork-safety policy (vLLM forces spawn in environments where fork is unsafe).

How i found this:

- While testing “regular” vLLM on CUDA (Colab), vLLM explicitly logs that it overrides the worker start method to spawn for safety once CUDA is initialized
- On macOS, we observed the same failure pattern (engine core fails to start) caused by fork() after libraries touch the
  Objective‑C runtime (commonly via Metal/MPS/MLX)

What we changed:

- When the Metal platform plugin activates on macOS, we default VLLM_WORKER_MULTIPROC_METHOD to spawn if the user hasn’t set it
- This is a default-only change: explicit user overrides are respected.

Why this works:

- spawn starts a fresh Python interpreter for the worker process, avoiding inheriting partially-initialized Objective‑C runtime state from the parent process (the root cause of the crash).

Verification:

- python -m pytest -q
- Expected behavior (after fix): 
```bash
python -c "from vllm import LLM; LLM(model='HuggingFaceTB/SmolLM2-135M', max_model_len=128, dtype='float16')"
```

- To show override is respected (expected to crash on macOS): the point is we don’t override an explicit user setting: 

```bash
VLLM_WORKER_MULTIPROC_METHOD=fork python -c "from vllm import LLM; LLM(model='HuggingFaceTB/SmolLM2-135M', max_model_len=128, dtype='float16')"
```

Screenshot:
<img width="941" height="804" alt="Screenshot 2026-01-07 at 11 28 33 PM" src="https://github.com/user-attachments/assets/cebde2b2-48a0-402a-ac4d-522c3b47af6b" />
