### PR TITLE
Add VLM support with mlx-vlm integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,69 @@ curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/instal
 └─────────────────────────────────────────────────────────────┘
 ```
 
+## Vision-Language Models (VLM)
+
+vLLM Metal supports vision-language models like Qwen2-VL using [mlx-vlm](https://github.com/Blaizzy/mlx-vlm).
+
+### Supported VLM Models
+
+- Qwen2-VL (e.g., `mlx-community/Qwen2-VL-2B-Instruct-4bit`)
+- Qwen2.5-VL
+- LLaVA
+- Pixtral
+- Idefics
+
+### Usage with Vision Models
+
+Start the server with a VLM:
+
+```bash
+vllm-metal --model mlx-community/Qwen2-VL-2B-Instruct-4bit
+```
+
+Send requests with images using the OpenAI-compatible API:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/Qwen2-VL-2B-Instruct-4bit",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "text", "text": "What is in this image?"},
+          {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+        ]
+      }
+    ],
+    "max_tokens": 100
+  }'
+```
+
+### Python API
+
+```python
+from vllm_metal.model_runner import MetalModelRunner
+
+# Create a minimal config for VLM
+class Config:
+    class ModelConfig:
+        model = "mlx-community/Qwen2-VL-2B-Instruct-4bit"
+    model_config = ModelConfig()
+
+runner = MetalModelRunner(Config())
+runner.load_model()
+
+# Generate with an image
+output = runner.generate(
+    prompt="Describe this image",
+    images=["https://example.com/image.jpg"],
+    max_tokens=100,
+)
+print(output)
+```
+
 ## Configuration
 
 Environment variables for customization:

--- a/tests/test_model_runner_generate.py
+++ b/tests/test_model_runner_generate.py
@@ -12,6 +12,19 @@ class TestMetalModelRunnerGenerate:
         runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
         runner.model = object()
         runner.tokenizer = object()
+        runner.processor = None
+        runner.vlm_config = None
+        runner._is_vlm = False
+        return runner
+
+    def _make_vlm_runner(self) -> mr.MetalModelRunner:
+        """Create a VLM-enabled runner for testing."""
+        runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
+        runner.model = object()
+        runner.tokenizer = object()
+        runner.processor = object()
+        runner.vlm_config = object()
+        runner._is_vlm = True
         return runner
 
     def test_accumulates_streamed_segments(self, monkeypatch) -> None:
@@ -40,3 +53,55 @@ class TestMetalModelRunnerGenerate:
         assert captured["max_tokens"] == 3
         assert captured["temp"] == 0.7
         assert "sampler" in captured["kwargs"]
+
+    def test_vlm_generate_with_images(self, monkeypatch) -> None:
+        """Test VLM generation with images uses mlx-vlm path."""
+        captured: dict[str, object] = {}
+
+        def fake_apply_chat_template(processor, config, prompt, num_images):
+            captured["num_images"] = num_images
+            return f"<image>{prompt}"
+
+        def fake_mlx_vlm_generate(model, processor, prompt, images, **kwargs):
+            captured["prompt"] = prompt
+            captured["images"] = images
+            captured["kwargs"] = kwargs
+            return "A cat sitting on a mat"
+
+        monkeypatch.setattr(mr, "apply_chat_template", fake_apply_chat_template)
+        monkeypatch.setattr(mr, "mlx_vlm_generate", fake_mlx_vlm_generate)
+
+        runner = self._make_vlm_runner()
+        out = runner.generate(
+            "Describe this image",
+            images=["test.jpg", "test2.jpg"],
+            max_tokens=50,
+            temperature=0.5,
+        )
+
+        assert out == "A cat sitting on a mat"
+        assert captured["num_images"] == 2
+        assert captured["images"] == ["test.jpg", "test2.jpg"]
+        assert captured["kwargs"]["max_tokens"] == 50
+        assert captured["kwargs"]["temp"] == 0.5
+
+    def test_vlm_without_images_uses_text_path(self, monkeypatch) -> None:
+        """Test VLM without images falls back to text generation."""
+        captured: dict[str, object] = {}
+
+        def fake_make_sampler(*, temp: float):
+            captured["temp"] = temp
+            return object()
+
+        def fake_stream_generate(model, tokenizer, prompt, max_tokens=256, **kwargs):
+            captured["prompt"] = prompt
+            yield SimpleNamespace(text="text response")
+
+        monkeypatch.setattr(mr, "make_sampler", fake_make_sampler)
+        monkeypatch.setattr(mr, "stream_generate", fake_stream_generate)
+
+        runner = self._make_vlm_runner()
+        out = runner.generate("Hello", max_tokens=10)
+
+        assert out == "text response"
+        assert captured["prompt"] == "Hello"

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -12,6 +12,7 @@ class TestV1MetalModelRunnerGenerate:
         runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
         runner.model = object()
         runner.tokenizer = object()
+        runner._is_vlm = False  # Initialize the missing attribute
         return runner
 
     def test_accumulates_streamed_segments(self, monkeypatch) -> None:


### PR DESCRIPTION
vLLM Metal now supports vision-language models like Qwen2-VL using
mlx-vlm. The MetalModelRunner class has been updated to detect VLM
models and load them with the appropriate processor and configuration.
The generate method now accepts an optional images parameter for
multimodal input. The server has been enhanced to handle multimodal
messages in the OpenAI-compatible API, extracting image URLs from
content parts. Documentation has been added to the README with usage
examples for VLMs.

Signed-off-by: Eric Curtin <eric.curtin@docker.com>
