### PR TITLE
Gate MLX dependencies to macOS arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 
 dependencies = [
     # MLX - Required for Apple Silicon GPU acceleration
-    "mlx>=0.20.0",
-    "mlx-lm>=0.20.0",
-    "mlx-vlm>=0.3.0",  # Vision-language model support
+    "mlx>=0.20.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.20.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-vlm>=0.3.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
     # Model loading and weights
     "transformers>=4.40.0",
     "accelerate>=0.26.0",


### PR DESCRIPTION
This PR is:
- To prevent non-macOS installs from failing dependency resolution due to Apple-only MLX packages.

It gates `mlx`, `mlx-lm`, and `mlx-vlm` behind PEP 508 markers (`platform_system == 'Darwin' and platform_machine == 'arm64'`). On other platforms these deps are skipped, while macOS Apple Silicon behavior is unchanged.

Verification:
- On Linux: `pip install .` should no longer attempt to resolve `mlx*` dependencies.

Double check this PR on CPU colab:
<img width="1674" height="829" alt="Screenshot 2026-01-08 at 12 37 31 PM" src="https://github.com/user-attachments/assets/a0ec04c6-56f7-4cc7-9dea-02b970fd7411" />

