### PR TITLE
Set wired_limit to fix low GPU utilization

### DIFF
--- a/vllm_metal/model_runner.py
+++ b/vllm_metal/model_runner.py
@@ -11,6 +11,7 @@ from mlx_lm.sample_utils import make_sampler
 
 from vllm_metal.config import get_config
 from vllm_metal.mlx_backend.cache import PagedKVCache
+from vllm_metal.platform import set_wired_limit
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -44,6 +45,7 @@ class MetalModelRunner:
         model_name = model_config.model
 
         logger.info(f"Loading model: {model_name}")
+        set_wired_limit()
 
         # Load model and tokenizer using mlx_lm
         self.model, self.tokenizer = mlx_load(

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -19,6 +19,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def set_wired_limit() -> None:
+    """Set Metal wired memory limit for optimal GPU performance.
+
+    Pins model weights in GPU-accessible memory to prevent memory paging
+    and GPU stalls during inference.
+
+    See: https://github.com/ml-explore/mlx-lm/pull/652
+    """
+    try:
+        import mlx.core as mx
+
+        device_info = mx.metal.device_info()
+        max_wired = device_info.get("max_recommended_working_set_size", 0)
+        if max_wired > 0:
+            if hasattr(mx, "set_wired_limit"):
+                mx.set_wired_limit(max_wired)
+            elif hasattr(mx.metal, "set_wired_limit"):
+                mx.metal.set_wired_limit(max_wired)
+            logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
+    except Exception as e:
+        logger.warning(f"Failed to set wired_limit: {e}")
+
+
 class MetalPlatform(Platform):
     """Platform implementation for Apple Silicon Metal/MLX.
 

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -22,7 +22,7 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
 
 from vllm_metal.config import get_config
-from vllm_metal.platform import MetalPlatform
+from vllm_metal.platform import MetalPlatform, set_wired_limit
 
 if TYPE_CHECKING:
     from vllm_metal.v1.model_runner import MetalModelRunner
@@ -95,6 +95,7 @@ class MetalWorker(WorkerBase):
             )
             mx.set_default_device(mx.Device(device_type))
             logger.info(f"MLX device set to: {mx.default_device()}")
+            set_wired_limit()
 
         # Use MetalPlatform.get_torch_device() to properly support MPS when available.
         # This ensures consistency with the platform's device selection logic and


### PR DESCRIPTION
## Summary

Without `wired_limit` set, model weights cannot stay pinned in GPU-accessible memory, causing frequent memory paging and GPU stalls. This results in ~30% GPU utilization instead of ~100%.

This fix sets `max_recommended_working_set_size` as the wired limit before model loading, matching the fix in https://github.com/ml-explore/mlx-lm/pull/652.

## Changes

- Set `wired_limit` in `MetalWorker.init_device()` for v1 engine
- Set `wired_limit` in `MetalModelRunner.load_model()` for legacy path
- Use new `mx.set_wired_limit()` API with fallback to deprecated `mx.metal.set_wired_limit()`
- Add error handling for graceful degradation

## Test plan

- [x] Verified GPU utilization increases from ~30% to ~100% on Mac Studio with MiniMax-M2.1-Q8
- [x] Confirmed log message shows wired_limit being set on startup