### PR TITLE
Seed test RNGs; gate perf benchmark behind -m slow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ disable_error_code = ["override", "misc", "assignment", "arg-type", "index", "ca
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "slow: opt-in performance or long-running tests",
+]
 
 [dependency-groups]
 dev = [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -77,7 +77,9 @@ main() {
 
     smoke_test
     section "Running tests"
-    pytest tests/ -v --tb=short
+    # Exclude perf/long-running tests by default; run them explicitly via:
+    #   pytest -m slow tests/ -v --tb=short
+    pytest -m "not slow" tests/ -v --tb=short
   fi
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Pytest configuration and shared fixtures."""
+
+from __future__ import annotations
+
+import os
+import random
+
+import numpy as np
+import pytest
+import torch
+
+
+def _get_test_seed() -> int:
+    """Return the deterministic seed used across tests.
+
+    Override via `VLLM_METAL_TEST_SEED` for debugging.
+    """
+
+    raw_seed = os.environ.get("VLLM_METAL_TEST_SEED", "0")
+    try:
+        return int(raw_seed)
+    except ValueError as exc:  # pragma: no cover
+        raise ValueError("VLLM_METAL_TEST_SEED must be an integer") from exc
+
+
+@pytest.fixture(autouse=True)
+def _seed_random_generators() -> None:
+    """Seed common RNGs to keep tests deterministic."""
+
+    seed = _get_test_seed()
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    try:
+        import mlx.core as mx
+    except ImportError:
+        return
+
+    mlx_seed = getattr(mx.random, "seed", None)
+    if mlx_seed is None:
+        return
+    mlx_seed(seed)

--- a/tests/test_rust_integration.py
+++ b/tests/test_rust_integration.py
@@ -207,8 +207,9 @@ class TestRustRequestStateManager:
         assert manager.num_requests == 0
 
 
+@pytest.mark.slow
 def test_performance_comparison():
-    """Benchmark Rust vs Python block allocation."""
+    """Ensure Rust allocator stays >5x faster than naive Python baseline."""
     num_blocks = 10000
     num_seqs = 200
     blocks_per_seq = 4


### PR DESCRIPTION
This PR is:
- To make tests deterministic by seeding Python/numpy/torch RNGs (and MLX when available).
- To keep CI stable by making the timing-based perf micro-benchmark opt-in (`pytest -m slow`) instead of part of the default test gate.

i found it:
- While running `pytest` locally and looking at what CI executes, I noticed we were running a speedup threshold micro-benchmark as a normal unit test, and some tests generate random inputs without a shared seed. That makes failures harder to reproduce and can be flaky on busy runners.

Verification:
- `pytest -q`
- `pytest -q -m slow`
