### PR TITLE
Consolidate dev dependencies in extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ vllm-metal = "vllm_metal.server:main"
 [project.optional-dependencies]
 vllm = ["vllm>=0.13.0"]
 dev = [
-    "pytest>=7.0.0",
+    "pytest>=9.0.2",
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
-    "mypy>=1.0.0",
+    "mypy>=1.19.1",
 ]
 all = [
     "vllm-metal[vllm,dev]",
@@ -104,12 +104,4 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "slow: opt-in performance or long-running tests",
-]
-
-[dependency-groups]
-dev = [
-    "mypy>=1.19.1",
-    "pytest>=9.0.2",
-    "pytest-asyncio>=0.21.0",
-    "ruff>=0.1.0",
 ]


### PR DESCRIPTION
This PR is:
- To remove duplicated dev dependency lists and keep one source of truth
- To align dev tooling versions across contributor workflows

Context
The repo defined dev deps in both optional-dependencies and dependency-groups with different minimum versions. The scripts install via .[dev], so extras are the real source of truth. This change removes the duplicate group and aligns the dev extra to the newer versions.