### PR TITLE
[Bugfix] support MambaCache in batched decode for hybrid models 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ exclude = ["extern", ".venv*", "test_vllm.py", "target"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "C4"]
-ignore = ["E501"]
+ignore = ["E501", "UP040"]
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary

This change adds a `BatchMambaCache` to properly handle batched caches for Mamba/SSM layers.
It also updates `_merge_kv_caches` to detect the cache type and use the correct merge logic.

This fixes an issue where concurrent requests on hybrid models could fail with
`AttributeError: 'MambaCache' object has no attribute 'keys'`.

Fixes #57

## Testing

Tested with **Qwen3-Next-80B-A3B-Instruct-4bit** on **M2 Ultra (192GB)**.

I ran 10 concurrent requests via `vllm serve`, and all completed successfully.
Observed generation throughput was around **130 tokens/s**.
