### PR TITLE
Add STT data types, config, and formatting

### DIFF
--- a/docs/stt.md
+++ b/docs/stt.md
@@ -4,9 +4,16 @@ vllm-metal supports OpenAI-compatible Speech-to-Text using Whisper models, runni
 
 ## Installation
 
-STT requires optional audio processing dependencies:
+First, install vllm-metal using the install script (see [README](../README.md)):
 
 ```bash
+./install.sh
+```
+
+Then install the optional STT dependencies inside the virtual environment:
+
+```bash
+source .venv/bin/activate
 pip install vllm-metal[stt]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "mypy>=1.19.1",
 ]
 all = [
-    "vllm-metal[vllm,dev]",
+    "vllm-metal[vllm,stt,dev]",
 ]
 
 [project.urls]

--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for STT data types, config, and formatting."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_metal.stt.config import (
+    SpeechToTextConfig,
+    get_supported_languages,
+    get_whisper_languages,
+    validate_language,
+)
+from vllm_metal.stt.formatting import format_as_srt, format_as_vtt
+from vllm_metal.stt.protocol import TranscriptionSegment
+
+# ===========================================================================
+# SpeechToTextConfig
+# ===========================================================================
+
+
+class TestSpeechToTextConfig:
+    """Tests for SpeechToTextConfig dataclass."""
+
+    def test_default_values(self) -> None:
+        cfg = SpeechToTextConfig()
+        assert cfg.max_audio_clip_s == 30.0
+        assert cfg.overlap_chunk_second == 1.0
+        assert cfg.min_energy_split_window_size == 1600
+        assert cfg.sample_rate == 16000  # deprecated but still accepted
+
+    def test_custom_values(self) -> None:
+        cfg = SpeechToTextConfig(
+            max_audio_clip_s=15.0,
+            overlap_chunk_second=0.5,
+            min_energy_split_window_size=800,
+        )
+        assert cfg.max_audio_clip_s == 15.0
+        assert cfg.overlap_chunk_second == 0.5
+        assert cfg.min_energy_split_window_size == 800
+
+
+# ===========================================================================
+# validate_language
+# ===========================================================================
+
+
+class TestValidateLanguage:
+    """Tests for validate_language() — three-tier validation."""
+
+    def test_none_defaults_to_en(self) -> None:
+        assert validate_language(None) == "en"
+
+    def test_none_with_no_default(self) -> None:
+        assert validate_language(None, default=None) is None
+
+    def test_officially_supported(self) -> None:
+        assert validate_language("en") == "en"
+        assert validate_language("zh") == "zh"
+        assert validate_language("ja") == "ja"
+
+    def test_known_but_unsupported(self) -> None:
+        code = "yue"  # cantonese — in Whisper but not officially supported
+        whisper_langs = get_whisper_languages()
+        supported = get_supported_languages()
+        assert code in whisper_langs
+        assert code not in supported
+        assert validate_language(code) == "yue"
+
+    def test_unknown_code_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported language"):
+            validate_language("zz")
+
+    def test_case_insensitive(self) -> None:
+        assert validate_language("EN") == "en"
+        assert validate_language("Zh") == "zh"
+
+    def test_strips_whitespace(self) -> None:
+        assert validate_language("  fr  ") == "fr"
+
+    def test_whisper_languages_count(self) -> None:
+        assert len(get_whisper_languages()) == 100
+
+    def test_supported_is_subset_of_whisper(self) -> None:
+        assert get_supported_languages().issubset(set(get_whisper_languages()))
+
+
+# ===========================================================================
+# TranscriptionSegment
+# ===========================================================================
+
+
+class TestTranscriptionSegment:
+    """Tests for TranscriptionSegment pydantic model."""
+
+    def test_create_segment(self) -> None:
+        seg = TranscriptionSegment(
+            id=0, seek=0, start=0.0, end=2.5, text=" Hello.", tokens=[1, 2]
+        )
+        assert seg.id == 0
+        assert seg.start == 0.0
+        assert seg.end == 2.5
+        assert seg.text == " Hello."
+        assert seg.tokens == [1, 2]
+
+    def test_default_values(self) -> None:
+        seg = TranscriptionSegment(
+            id=0, seek=0, start=0.0, end=1.0, text="hi", tokens=[]
+        )
+        assert seg.avg_logprob == 0.0
+        assert seg.compression_ratio == 0.0
+        assert seg.no_speech_prob == 0.0
+
+
+# ===========================================================================
+# Formatting (SRT / VTT)
+# ===========================================================================
+
+
+class TestFormatting:
+    """Tests for SRT and VTT subtitle formatting."""
+
+    @pytest.fixture()
+    def sample_segments(self) -> list[TranscriptionSegment]:
+        return [
+            TranscriptionSegment(
+                id=0,
+                seek=0,
+                start=0.0,
+                end=2.5,
+                text=" Hello world.",
+                tokens=[1, 2, 3],
+            ),
+            TranscriptionSegment(
+                id=1,
+                seek=250,
+                start=2.5,
+                end=5.0,
+                text=" How are you?",
+                tokens=[4, 5, 6],
+            ),
+        ]
+
+    def test_srt_format(self, sample_segments: list[TranscriptionSegment]) -> None:
+        srt = format_as_srt(sample_segments)
+        lines = srt.split("\n")
+        assert lines[0] == "1"
+        assert "00:00:00,000 --> 00:00:02,500" in lines[1]
+        assert "Hello world." in lines[2]
+        assert lines[4] == "2"
+        assert "00:00:02,500 --> 00:00:05,000" in lines[5]
+
+    def test_vtt_format(self, sample_segments: list[TranscriptionSegment]) -> None:
+        vtt = format_as_vtt(sample_segments)
+        lines = vtt.split("\n")
+        assert lines[0] == "WEBVTT"
+        assert lines[1] == ""
+        assert "00:00:00.000 --> 00:00:02.500" in lines[2]
+        assert "Hello world." in lines[3]
+
+    def test_srt_empty_segments(self) -> None:
+        assert format_as_srt([]) == ""
+
+    def test_vtt_empty_segments(self) -> None:
+        vtt = format_as_vtt([])
+        assert vtt.startswith("WEBVTT")
+
+    def test_srt_long_timestamps(self) -> None:
+        seg = TranscriptionSegment(
+            id=0,
+            seek=0,
+            start=3661.123,
+            end=3665.456,
+            text=" One hour in.",
+            tokens=[1],
+        )
+        srt = format_as_srt([seg])
+        assert "01:01:01,123" in srt
+        assert "01:01:05,456" in srt

--- a/vllm_metal/stt/__init__.py
+++ b/vllm_metal/stt/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Speech-to-Text support for vLLM Metal."""
+
+from vllm_metal.stt.config import (
+    SpeechToTextConfig,
+    get_supported_languages,
+    get_whisper_languages,
+    is_stt_model,
+    validate_language,
+)
+from vllm_metal.stt.formatting import format_as_srt, format_as_vtt
+from vllm_metal.stt.protocol import TranscriptionSegment
+
+__all__ = [
+    "SpeechToTextConfig",
+    "TranscriptionSegment",
+    "format_as_srt",
+    "format_as_vtt",
+    "get_supported_languages",
+    "get_whisper_languages",
+    "is_stt_model",
+    "validate_language",
+]

--- a/vllm_metal/stt/config.py
+++ b/vllm_metal/stt/config.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Speech-to-Text configuration and language constants."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# STT model types that can be auto-detected from config.json
+_STT_MODEL_TYPES = {"whisper"}
+
+# Officially supported languages (OpenAI docs subset).
+# fmt: off
+_OFFICIALLY_SUPPORTED = {
+    "af", "ar", "hy", "az", "be", "bs", "bg", "ca", "zh", "hr", "cs", "da",
+    "nl", "en", "et", "fi", "fr", "gl", "de", "el", "he", "hi", "hu", "is",
+    "id", "it", "ja", "kn", "kk", "ko", "lv", "lt", "mk", "ms", "mr", "mi",
+    "ne", "no", "fa", "pl", "pt", "ro", "ru", "sr", "sk", "sl", "es", "sw",
+    "sv", "tl", "ta", "th", "tr", "uk", "ur", "vi", "cy",
+}
+# fmt: on
+
+
+@lru_cache(maxsize=1)
+def _get_whisper_languages() -> dict[str, str]:
+    """Get Whisper language map from transformers."""
+    try:
+        from transformers.models.whisper.tokenization_whisper import LANGUAGES
+
+        return dict(LANGUAGES)
+    except ImportError:
+        logger.warning("transformers not available, using fallback language list")
+        return {"en": "english"}
+
+
+def get_whisper_languages() -> dict[str, str]:
+    """Get full Whisper language map (100 languages)."""
+    return _get_whisper_languages()
+
+
+def get_supported_languages() -> set[str]:
+    """Get officially supported language codes."""
+    return _OFFICIALLY_SUPPORTED.copy()
+
+
+@dataclass
+class SpeechToTextConfig:
+    """Runtime configuration for STT processing.
+
+    Controls audio chunking and energy-based splitting parameters.
+    """
+
+    max_audio_clip_s: float = 30.0
+    overlap_chunk_second: float = 1.0
+    min_energy_split_window_size: int = 1600
+    # Deprecated: Whisper requires 16kHz; this field is ignored.
+    sample_rate: int = 16000
+
+
+def is_stt_model(model_path: str) -> bool:
+    """Return ``True`` if *model_path* points to a Speech-to-Text model.
+
+    Detection is based on ``model_type`` in the model's ``config.json``.
+    Falls back to ``False`` if the config cannot be read.
+    """
+    p = Path(model_path)
+    config_file = p / "config.json" if p.is_dir() else None
+
+    # For HuggingFace hub IDs, try downloading config.json
+    if config_file is None or not config_file.exists():
+        try:
+            from huggingface_hub import hf_hub_download
+
+            config_file = Path(
+                hf_hub_download(repo_id=model_path, filename="config.json")
+            )
+        except (ImportError, OSError, ValueError):
+            return False
+
+    if config_file is None or not config_file.exists():
+        return False
+
+    try:
+        with open(config_file) as f:
+            cfg = json.load(f)
+        return cfg.get("model_type", "").lower() in _STT_MODEL_TYPES
+    except (OSError, json.JSONDecodeError, KeyError):
+        return False
+
+
+def validate_language(
+    code: str | None,
+    *,
+    default: str | None = "en",
+) -> str | None:
+    """Validate and normalise an ISO 639-1 language code.
+
+    Three-tier validation:
+    1. Officially supported codes — accepted silently.
+    2. Known Whisper codes but not official — accepted with debug log.
+    3. Unknown codes — raises ValueError.
+
+    Returns *default* when *code* is None.
+    """
+    if code is None:
+        return default
+
+    code = code.strip().lower()
+    whisper_langs = get_whisper_languages()
+
+    if code in _OFFICIALLY_SUPPORTED:
+        return code
+
+    if code in whisper_langs:
+        logger.debug("Language %r is not officially supported", code)
+        return code
+
+    raise ValueError(
+        f"Unsupported language: {code!r}. Must be one of "
+        f"{', '.join(sorted(_OFFICIALLY_SUPPORTED))}."
+    )

--- a/vllm_metal/stt/formatting.py
+++ b/vllm_metal/stt/formatting.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subtitle formatting utilities (SRT / WebVTT)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm_metal.stt.protocol import TranscriptionSegment
+
+
+def _format_timestamp(seconds: float, ms_sep: str = ".") -> str:
+    """Format *seconds* as ``HH:MM:SS<sep>mmm``.
+
+    Args:
+        seconds: Time in seconds.
+        ms_sep: Millisecond separator — ``,`` for SRT, ``.`` for WebVTT.
+
+    Returns:
+        Formatted timestamp string, e.g. ``"01:02:03.456"``.
+    """
+    hrs = int(seconds // 3600)
+    mins = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    millis = int(round((seconds - int(seconds)) * 1000))
+    return f"{hrs:02d}:{mins:02d}:{secs:02d}{ms_sep}{millis:03d}"
+
+
+def format_as_srt(segments: list[TranscriptionSegment]) -> str:
+    """Render segments as an SRT subtitle string."""
+    lines: list[str] = []
+    for seg in segments:
+        lines.append(str(seg.id + 1))
+        start = _format_timestamp(seg.start, ms_sep=",")
+        end = _format_timestamp(seg.end, ms_sep=",")
+        lines.append(f"{start} --> {end}")
+        lines.append(seg.text.strip())
+        lines.append("")
+    return "\n".join(lines)
+
+
+def format_as_vtt(segments: list[TranscriptionSegment]) -> str:
+    """Render segments as a WebVTT subtitle string."""
+    lines: list[str] = ["WEBVTT", ""]
+    for seg in segments:
+        start = _format_timestamp(seg.start, ms_sep=".")
+        end = _format_timestamp(seg.end, ms_sep=".")
+        lines.append(f"{start} --> {end}")
+        lines.append(seg.text.strip())
+        lines.append("")
+    return "\n".join(lines)

--- a/vllm_metal/stt/protocol.py
+++ b/vllm_metal/stt/protocol.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Response types for Speech-to-Text."""
+
+from pydantic import BaseModel
+
+
+class TranscriptionSegment(BaseModel):
+    """Single segment of a transcription with timing information."""
+
+    id: int
+    seek: int
+    start: float
+    end: float
+    text: str
+    tokens: list[int]
+    avg_logprob: float = 0.0
+    compression_ratio: float = 0.0
+    no_speech_prob: float = 0.0


### PR DESCRIPTION
## Summary
Add the foundational STT types, configuration, and subtitle formatting utilities.

## Included
- `vllm_metal/stt/protocol.py` — `TranscriptionSegment` data type
- `vllm_metal/stt/config.py` — language validation, `SpeechToTextConfig`, model detection
- `vllm_metal/stt/formatting.py` — SRT / WebVTT output
- `tests/test_stt.py` — 18 unit tests

## Reviewer Feedback Addressed
Related #91

- Languages derived from `transformers.models.whisper.tokenization_whisper.LANGUAGES`
- `except Exception` → specific exception types
- Docstrings follow project Google-style convention
