### PR TITLE
vLLM 0.14.x compatibility: async sample_tokens fix + dependency cleanup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,7 @@ main() {
 
   ensure_venv "$venv"
 
-  local vllm_v="0.13.0"
+  local vllm_v="0.14.1"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   curl -OL $url_base/v$vllm_v/$filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-vllm = ["vllm>=0.13.0"]
+vllm = ["vllm>=0.14.0"]
 stt = [
     # Speech-to-text audio processing (Whisper models)
     "librosa>=0.10.2",

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -5,8 +5,8 @@ import platform
 
 import pytest
 import torch
-from vllm.attention.backends.registry import AttentionBackendEnum
-from vllm.attention.selector import AttentionSelectorConfig
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+from vllm.v1.attention.selector import AttentionSelectorConfig
 
 from vllm_metal.platform import MetalPlatform
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -7,14 +7,14 @@ from typing import TYPE_CHECKING
 
 import psutil
 import torch
-from vllm.attention.backends.registry import AttentionBackendEnum
 from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_metal.config import get_config
 
 if TYPE_CHECKING:
-    from vllm.attention.selector import AttentionSelectorConfig
     from vllm.config import VllmConfig
+    from vllm.v1.attention.selector import AttentionSelectorConfig
 
 logger = logging.getLogger(__name__)
 

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -15,9 +15,9 @@ from vllm.distributed import (
 )
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.model_executor import set_random_seed
 from vllm.tasks import SupportedTask
-from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
@@ -326,6 +326,10 @@ class MetalWorker(WorkerBase):
             Model runner output with generated tokens
         """
         return self.model_runner.execute_model(scheduler_output)
+
+    def sample_tokens(self, grammar_output: GrammarOutput | None) -> ModelRunnerOutput:
+        """Return sampled tokens for the previously executed batch."""
+        return self.model_runner.sample_tokens(grammar_output)
 
     def get_model(self) -> Any:
         """Get the underlying model.


### PR DESCRIPTION
## Summary

1. Upgrade vLLM target version
- `install.sh`: `vllm_v` from `0.13.0` to `0.14.1`
- `pyproject.toml` optional extra: `vllm>=0.13.0` to `vllm>=0.14.0`

2. Align imports with vLLM 0.14 API moves
- `vllm_metal/platform.py`: `vllm.attention.*` -> `vllm.v1.attention.*`
- `vllm_metal/v1/worker.py`: `set_random_seed` import to `vllm.utils.torch_utils`
- `tests/test_platform.py`: update imports to `vllm.v1.attention.*`

3. Fix async scheduling runtime path
- `vllm_metal/v1/worker.py`: implement `sample_tokens(...)`
- `vllm_metal/v1/model_runner.py`:
  - store pending output in `execute_model(...)`
  - return it in `sample_tokens(...)`

## Why

vLLM 0.14 changes API paths and the execution flow in async scheduling.
Without these updates, plugin import/runtime compatibility regresses on v0.14.x.

## Validation

Ran locally on macOS/Apple Silicon:

- `./scripts/lint.sh`
  - `ruff check`: pass
  - `ruff format --check`: pass
  - `mypy`: pass
- `./scripts/test.sh`
  - smoke test chat completion: passed
  - pytest suite: `110 passed, 1 deselected`
- `pytest -m "not slow" tests/ -q --tb=short`
  - `110 passed, 1 deselected`
