### PR TITLE
Ensure install venv always provides pip entrypoints

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -39,38 +39,11 @@ ensure_uv() {
 ensure_venv() {
   if [ ! -d "$1" ]; then
     section "Creating virtual environment"
-    uv venv "$1" --clear --python 3.12
+    uv venv "$1" --clear --python 3.12 --seed
   fi
 
   # shellcheck source=/dev/null
   source "$1/bin/activate"
-
-  # Some uv-created environments may not expose pip entrypoints depending on
-  # platform/python build; ensure pip module and scripts are present.
-  if ! "$1/bin/python" -m pip --version >/dev/null 2>&1; then
-    section "Bootstrapping pip in virtual environment"
-    if ! "$1/bin/python" -m ensurepip --upgrade >/dev/null 2>&1; then
-      error "Failed to bootstrap pip in virtual environment: $1"
-      return 1
-    fi
-  fi
-
-  # Ensure both pip and pip3 are available as scripts in the venv bin dir.
-  if [ ! -x "$1/bin/pip" ]; then
-    cat > "$1/bin/pip" <<'EOF'
-#!/usr/bin/env sh
-exec "$(dirname "$0")/python" -m pip "$@"
-EOF
-    chmod +x "$1/bin/pip"
-  fi
-
-  if [ ! -x "$1/bin/pip3" ]; then
-    cat > "$1/bin/pip3" <<'EOF'
-#!/usr/bin/env sh
-exec "$(dirname "$0")/python" -m pip "$@"
-EOF
-    chmod +x "$1/bin/pip3"
-  fi
 }
 
 # Install dev dependencies


### PR DESCRIPTION
When using the venv provided by vllm-metal you can't install pip dependencies in the environment for projects that might incorporate vllm-metal because pip seems to be missing. This fix is to bootstrap pip with ensurepip when missing and create pip/pip3 wrappers in scripts/lib.sh ensure_venv. 