### PR TITLE
Pin mlx-lm <0.30.6 to avoid MambaCache import break

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,9 @@ classifiers = [
 dependencies = [
     # MLX - Required for Apple Silicon GPU acceleration
     "mlx>=0.20.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "mlx-lm>=0.20.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # mlx-lm 0.30.6 removed MambaCache; pin until we support ArraysCache-only versions.
+    # See: https://github.com/vllm-project/vllm-metal/issues/100
+    "mlx-lm>=0.20.0,<0.30.6; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-vlm>=0.3.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
     # Model loading and weights
     "transformers>=4.40.0",


### PR DESCRIPTION
This PR is:

- To prevent fresh installs from breaking due to `mlx-lm==0.30.6` removing `MambaCache` (see #100).
- To cap `mlx-lm` to a known-working range until we land the real compatibility update (ArraysCache-only) and can relax/remove the upper bound.
 
How to test:
```bash
$  python -c "from mlx_lm.models.cache import MambaCache; import vllm_metal.v1.model_runner; print('OK')"

INFO 02-21 15:37:06 [__init__.py:43] Available plugins for group vllm.platform_plugins:
INFO 02-21 15:37:06 [__init__.py:45] - metal -> vllm_metal:register
INFO 02-21 15:37:06 [__init__.py:48] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 02-21 15:37:06 [__init__.py:217] Platform plugin metal is activated
INFO 02-21 15:37:07 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
OK
```