### PR TITLE
Avoid upgrading deps when installing wheel

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ download_and_install_wheel() {
   success "Downloaded wheel"
 
   # Install vllm-metal package
-  if ! uv pip install --upgrade "$wheel_path"; then
+  if ! uv pip install "$wheel_path"; then
     error "Failed to install ${package_name}."
     exit 1
   fi
@@ -162,4 +162,3 @@ main() {
 }
 
 main "$@"
-


### PR DESCRIPTION
This PR is:

- To stop the installer from upgrading already-installed deps when installing the vllm-metal wheel.
- To prevent torch/torchvision mismatches ("operator torchvision::nms does not exist") on fresh installs.
- To keep the install.sh pinned vLLM stack stable now that upstream vLLM 0.15.x moved to torch 2.10.
 
How to test:

```bash
$ rm -rf ~/.venv-vllm-metal && curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh | bash

$ source ~/.venv-vllm-metal/bin/activate

$ python -c "import torch, torchvision; print(torch.__version__, torchvision.__version__)"

$ vllm --help

```


TLDR: install.sh now installs the vllm-metal wheel without --upgrade, so it won’t re-resolve and unexpectedly upgrade the pinned vLLM stack. Fresh installs stay on vLLM 0.14.1 + torch 2.9.1 (with torchvision 0.24.1),
instead of drifting into torch 2.10 (as used by upstream vLLM 0.15.x) and triggering operator torchvision::nms does not exist.


Related: #107, #102 (and reduces the installer-triggered drift that can surface as #100)