### PR TITLE
chore: Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown: # applies only to version-updates (not security-updates)
+      default-days: 10
+      semver-minor-days: 14 # wait 14 days before applying minor updates
+      semver-major-days: 28
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 10
+  - package-ecosystem: uv
+    directory: / # Updates pyproject.toml + uv.lock
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 10
+      semver-minor-days: 14
+      semver-major-days: 28

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: recursive
 
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: recursive
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ name = "_rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module"] }
-numpy = "0.24"
+pyo3 = { version = "0.28", features = ["extension-module"] }
+numpy = "0.28"
 
 [profile.release]
 lto = true

--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,7 @@ main() {
 
   ensure_venv "$venv"
 
-  local vllm_v="0.14.1"
+  local vllm_v="0.16.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   curl -OL $url_base/v$vllm_v/$filename


### PR DESCRIPTION
### Chores
- Update cargo dependencies and GitHub Actions (use pinning to improve supply chain security)
- Let Dependabot update `cargo`, `github-actions` and `uv` (use cooldown to improve supply chain security)
- Update install.sh to latest stable `vllm 0.16.0`