### PR TITLE
Enhance README with installation and uninstallation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 - macOS on Apple Silicon
 
 ## Installation
+Using the install script, the following will be installed under the `~/.venv-vllm-metal` directory (the default).
+- vllm-metal plugin
+- vllm core
+- Related libraries
+
+If you run `source ~/.venv-vllm-metal/bin/activate`, the `vllm` CLI becomes available and you can access the vLLM right away.
+
+For how to use the `vllm` CLI, please refer to the official vLLM guide.
+https://docs.vllm.ai/en/latest/cli/
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh | bash
@@ -25,9 +34,17 @@ curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/instal
 ## Reinstallation and Update
 If any issues occur, please use the following command to switch to the latest release version and check if the problem is resolved.
 If the issue continues to occur in the latest release, please report the details of the issue.
+(If you have installed it in a directory other than the default `~/.venv-vllm-metal`, substitute that path and run the command accordingly.)
 
 ```bash
 rm -rf ~/.venv-vllm-metal && curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh | bash
+```
+
+## Uninstall
+Please delete the directory that was installed by the installation script.
+(If you have installed it in a directory other than the default `~/.venv-vllm-metal`, substitute that path and run the command accordingly.)
+```bash
+rm -rf ~/.venv-vllm-metal
 ```
 
 ## Architecture


### PR DESCRIPTION
Added the following text, considered the bare minimum, to the README.

- Added text explaining an overview of what exactly happens to the terminal when the installation script is executed.
- Added a note explaining that vLLM can be started immediately using the vllm command after the installation script completes.
- Added text directing users to refer to the official guide for instructions on using the vllm command.
- Added a note stating that this command is only valid if the default directory has not been changed for that part.
- Added instructions on how to uninstall.