### PR TITLE
Fix batched decode crash for hybrid cache models (Qwen3.5)

### DIFF
--- a/vllm_metal/v1/cache_utils.py
+++ b/vllm_metal/v1/cache_utils.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Utilities for KV cache introspection."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mlx_lm.models.cache import KVCache, RotatingKVCache, make_prompt_cache
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def supports_batched_decode(model: Any, *, is_vlm: bool = False) -> bool:
+    """Check whether *model*'s prompt cache is compatible with ``BatchKVCache``.
+
+    Hybrid models (e.g. Qwen3.5 with mixed attention + linear/SSM layers)
+    produce caches containing ``ArraysCache`` entries whose attention code
+    uses ``cache.offset`` as a Python ``int`` for mask slicing.
+    ``BatchKVCache.offset`` returns an ``mx.array``, which causes::
+
+        ValueError: Slice indices must be integers or None.
+
+    Returns ``True`` when every cache layer is a ``KVCache`` or
+    ``RotatingKVCache`` (safe to batch), ``False`` otherwise.
+
+    NOTE: This is an interim workaround for the mlx-native (non-paged) path.
+    The proper fix is per-layer attention dispatching (#201) combined with a
+    paged linear attention kernel (roadmap #148).
+    """
+    cache_model = (
+        model.language_model
+        if is_vlm and hasattr(model, "language_model")
+        else model
+    )
+    try:
+        cache = make_prompt_cache(cache_model)
+        return all(isinstance(c, (KVCache, RotatingKVCache)) for c in cache)
+    except Exception:
+        # If we can't determine, default to sequential (safe).
+        return False

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -61,6 +61,7 @@ from vllm_metal.stt.config import (
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.cache_utils import supports_batched_decode
 
 logger = init_logger(__name__)
 
@@ -664,6 +665,10 @@ class MetalModelRunner:
         self._paged_request_seq_lens: dict[str, int] = {}  # req_id → seq_len
         self.kv_cache_dtype: mx.Dtype | None = None
 
+        # Whether the model supports batched decode via BatchKVCache.
+        # Determined in load_model() by probing cache layer types.
+        self._supports_batched_decode: bool = True
+
     @property
     def is_stt(self) -> bool:
         """Whether the loaded model is a Speech-to-Text model."""
@@ -736,6 +741,7 @@ class MetalModelRunner:
                 self._extract_model_args()
                 self._resolve_model_dims()
                 self._initialize_kv_cache_dtype()
+                self._detect_batched_decode_support()
                 return
 
         # Load model using appropriate backend
@@ -760,6 +766,7 @@ class MetalModelRunner:
         self._extract_model_args()
         self._resolve_model_dims()
         self._initialize_kv_cache_dtype()
+        self._detect_batched_decode_support()
         load_time = time.time() - start_time
         logger.info(f"Model loaded in {load_time:.2f}s: {model_name}")
 
@@ -811,6 +818,17 @@ class MetalModelRunner:
         self.kv_cache_dtype = torch_to_mlx(
             torch.empty(0, dtype=self.model_config.dtype)
         ).dtype
+
+    def _detect_batched_decode_support(self) -> None:
+        """Probe cache types and disable batched decode for hybrid models."""
+        self._supports_batched_decode = supports_batched_decode(
+            self.model, is_vlm=self._is_vlm
+        )
+        if not self._supports_batched_decode:
+            logger.info(
+                "Model uses hybrid cache (e.g. ArraysCache + KVCache); "
+                "batched decode disabled, using sequential decode."
+            )
 
     def _extract_model_args(self) -> None:
         """Extract model configuration from loaded model.
@@ -1861,7 +1879,10 @@ class MetalModelRunner:
                         valid_decode_reqs.append((req_id, state))
 
                 if valid_decode_reqs:
-                    if len(valid_decode_reqs) >= _MIN_BATCH_SIZE_FOR_BATCHING:
+                    if (
+                        self._supports_batched_decode
+                        and len(valid_decode_reqs) >= _MIN_BATCH_SIZE_FOR_BATCHING
+                    ):
                         decode_tokens = self._batched_decode(valid_decode_reqs)
                     else:
                         decode_tokens = self._sequential_decode(valid_decode_reqs)


### PR DESCRIPTION
## Summary

Interim fix for the **mlx-native (non-paged) path** so hybrid models like Qwen3.5 can serve today.

- Hybrid models (e.g. Qwen3.5-35B-A3B) use mixed cache types (`ArraysCache` for linear/SSM layers + `KVCache` for attention layers). `BatchKVCache.offset` returns `mx.array` but hybrid attention code uses `cache.offset` as a Python `int` for mask slicing, causing `ValueError: Slice indices must be integers or None.`
- Detects hybrid caches at model load time via `make_prompt_cache()` and falls back to sequential decode for incompatible models.
- Core detection logic in `vllm_metal/v1/cache_utils.py` (standalone pure function), keeping `model_runner.py` changes minimal per #122.

**NOTE:** This is a band-aid until per-layer attention dispatching (#201) and a paged linear attention kernel (roadmap #148) land, at which point hybrid models will be handled properly at the dispatch level.

## Test plan
- [x] Verified fix resolves `ValueError` when serving Qwen3.5 via vllm-metal
- [x] Verified standard (non-hybrid) models still use batched decode path (Qwen3-0.6B: all `KVCache` → `True`)
- [x] Verified Qwen3.5-35B-A3B hybrid model falls back gracefully (`{ArraysCache, KVCache}` → `False`)