### PR TITLE
[Paged KV] Add ShareGPT avg generation length tool

### DIFF
--- a/tools/avg_gen_length.py
+++ b/tools/avg_gen_length.py
@@ -4,7 +4,7 @@
 
 Usage:
     # Download ShareGPT dataset (~642 MB):
-    huggingface-cli download anon8231489123/ShareGPT_Vicuna_unfiltered \
+    hf download anon8231489123/ShareGPT_Vicuna_unfiltered \
         --repo-type dataset --local-dir . ShareGPT_V3_unfiltered_cleaned_split.json
 
     # Batch size 1 (sequential):
@@ -55,6 +55,7 @@ def run_offline(
     max_tokens: int,
     max_model_len: int,
     max_num_seqs: int,
+    seed: int,
 ) -> list[int]:
     """Run offline inference, return list of completion token counts."""
     llm = LLM(
@@ -62,7 +63,7 @@ def run_offline(
         max_model_len=max_model_len,
         max_num_seqs=max_num_seqs,
     )
-    sampling_params = SamplingParams(temperature=0, seed=42, max_tokens=max_tokens)
+    sampling_params = SamplingParams(temperature=0, seed=seed, max_tokens=max_tokens)
 
     conversations = [[{"role": "user", "content": p}] for p in prompts]
 
@@ -119,7 +120,7 @@ def main() -> None:
     for mns in args.max_num_seqs:
         print(f"\nRunning with max_num_seqs={mns} ...")
         counts = run_offline(
-            args.model, prompts, args.max_tokens, args.max_model_len, mns
+            args.model, prompts, args.max_tokens, args.max_model_len, mns, args.seed
         )
         results[mns] = counts
 


### PR DESCRIPTION
## Summary
 Add a diagnostic tool for paged KV cache development. Runs offline vLLM inference on ShareGPT prompts and reports response length statistics (mean/std tokens). 

The intended workflow is to compare the non-paged (standard MLX cache) and paged (Metal kernel) paths: if a KV cache bugfix improves alignment between the two distributions, that's a strong signal the fix is correct. 

Also useful for comparing across batch sizes (--max-num-seqs 1 vs 8) to verify batched decode consistency. Related: #119

I learnt this from https://arxiv.org/pdf/2601.11580 table 1. 

relevant post from thinking machine lab: https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/

## Usage
```bash
VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION=0.7 \
    python tools/avg_gen_length.py --max-num-seqs 1 8
```