### PR TITLE
Fix false-positive wired_limit success log when MLX setter API is unavailable

### DIFF
--- a/vllm_metal/utils.py
+++ b/vllm_metal/utils.py
@@ -68,8 +68,11 @@ def set_wired_limit() -> None:
         if max_wired > 0:
             if hasattr(mx, "set_wired_limit"):
                 mx.set_wired_limit(max_wired)
+                logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
             elif hasattr(mx.metal, "set_wired_limit"):
                 mx.metal.set_wired_limit(max_wired)
-            logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
+                logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
+            else:
+                logger.debug("No set_wired_limit API available, skipping")
     except Exception as e:
         logger.warning(f"Failed to set wired_limit: {e}")


### PR DESCRIPTION
This PR is:
- To prevent false-positive wired_limit success logs when no setter API is available.
- To log wired_limit success only after an actual setter call.
- To improve diagnostics by logging an explicit DEBUG no-op when setters are absent.

Context:
On some MLX versions, neither `mx.set_wired_limit` nor `mx.metal.set_wired_limit` is available. The previous code still emitted a success INFO log, which made runtime diagnostics misleading.
