### PR TITLE
Harden STT audio decode timeout and split-audio boundary handling

### DIFF
--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -261,7 +261,9 @@ class TestAudioLoading:
             called["timeout_s"] = timeout_s
             return mx.array(np.zeros(4, dtype=np.float32))
 
-        monkeypatch.setitem(sys.modules, "librosa", SimpleNamespace(load=fake_librosa_load))
+        monkeypatch.setitem(
+            sys.modules, "librosa", SimpleNamespace(load=fake_librosa_load)
+        )
         monkeypatch.setattr(audio_mod, "_load_audio_ffmpeg", fake_load_audio_ffmpeg)
 
         audio = audio_mod.load_audio("dummy.wav")

--- a/vllm_metal/stt/audio.py
+++ b/vllm_metal/stt/audio.py
@@ -125,7 +125,9 @@ def _load_audio_ffmpeg(
     try:
         result = subprocess.run(cmd, capture_output=True, timeout=timeout_s)
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"ffmpeg timed out after {timeout_s}s decoding {file_path}") from exc
+        raise RuntimeError(
+            f"ffmpeg timed out after {timeout_s}s decoding {file_path}"
+        ) from exc
     if result.returncode != 0:
         raise RuntimeError(f"ffmpeg error: {result.stderr.decode()}")
     return mx.array(np.frombuffer(result.stdout, np.float32), mx.float32)


### PR DESCRIPTION
This PR is:
- To bound STT ffmpeg decode time and surface timeout failures with clear errors.
- To add focused tests for librosa->ffmpeg fallback, timeout behavior, and timeout validation.
- To fix split-audio boundary handling so chunk size is capped without triggering tiny-chunk regression.
- To add regression tests for split chunk limits and small-clip silent-audio behavior.

Context:
The ffmpeg fallback path previously had no timeout bound, and split boundary clamping could regress into pathological tiny chunks when the energy-based split point was not forward. This update keeps behavior bounded, predictable, and covered by targeted tests.
