### PR TITLE
Bump vllm to 0.16.0 and install from wheel

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,16 +123,8 @@ main() {
 
   ensure_venv "$venv"
 
-  local vllm_v="0.14.1"
-  local url_base="https://github.com/vllm-project/vllm/releases/download"
-  local filename="vllm-$vllm_v.tar.gz"
-  curl -OL $url_base/v$vllm_v/$filename
-  tar xf $filename
-  cd vllm-$vllm_v
-  uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
-  uv pip install .
-  cd -
-  rm -rf vllm-$vllm_v*
+  local vllm_v="0.16.0"
+  uv pip install "vllm==$vllm_v"
 
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
     uv pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ paged = [
     # Paged attention Metal kernel (opt-in, experimental)
     "kernels>=0.4.5; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
-vllm = ["vllm>=0.14.0"]
+vllm = ["vllm>=0.16.0"]
 stt = [
     # Speech-to-text audio processing (Whisper models)
     "librosa>=0.10.2",


### PR DESCRIPTION
Install vllm 0.16.0 from the macOS wheel on PyPI instead of building from source, and update the optional dependency lower bound to match.