### PR TITLE
[Feature] Add transcription orchestration (WhisperTranscriber) 

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for transcription orchestration: segment extraction, prompt encoding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vllm_metal.stt.transcribe import (
+    _MAX_PROMPT_TOKENS,
+    TranscriptionResult,
+    WhisperTranscriber,
+)
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture()
+def transcriber():
+    """Create a WhisperTranscriber with tokenizer only (no model needed).
+
+    Skips if transformers is not available.
+    """
+    try:
+        from transformers import WhisperTokenizer
+    except ImportError:
+        pytest.skip("transformers not available")
+
+    t = WhisperTranscriber(model=None, model_path=None)  # type: ignore[arg-type]
+    t._tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-small")
+    return t
+
+
+# ===========================================================================
+# TranscriptionResult
+# ===========================================================================
+
+
+class TestTranscriptionResult:
+    """Tests for TranscriptionResult dataclass."""
+
+    def test_defaults(self) -> None:
+        """Default fields should be None / empty / zero."""
+        result = TranscriptionResult(text="hello")
+        assert result.text == "hello"
+        assert result.language is None
+        assert result.segments == []
+        assert result.duration == 0.0
+
+    def test_with_all_fields(self) -> None:
+        """All fields should be stored correctly."""
+        result = TranscriptionResult(
+            text="hello", language="en", segments=[], duration=5.0
+        )
+        assert result.language == "en"
+        assert result.duration == 5.0
+
+
+# ===========================================================================
+# Segment extraction
+# ===========================================================================
+
+
+class TestExtractSegments:
+    """Tests for WhisperTranscriber._extract_segments.
+
+    These tests use the actual Whisper tokenizer, so they require
+    ``transformers`` but do **not** need a model checkpoint.
+    """
+
+    def _make_tokens(
+        self, transcriber: WhisperTranscriber, start_ts: str, end_ts: str
+    ) -> list[int]:
+        """Build a token list: ``<|start_ts|> text_token <|end_ts|>``.
+
+        Args:
+            transcriber: Transcriber with a loaded tokenizer.
+            start_ts: Start timestamp string (e.g. ``"0.00"``).
+            end_ts: End timestamp string (e.g. ``"2.00"``).
+
+        Returns:
+            List of three token IDs.
+        """
+        start_tok = transcriber._get_token_id(f"<|{start_ts}|>")
+        end_tok = transcriber._get_token_id(f"<|{end_ts}|>")
+        # Token 2425 = " Hello" in Whisper vocab
+        text_tok = 2425
+        return [start_tok, text_tok, end_tok]
+
+    def test_paired_timestamps(self, transcriber: WhisperTranscriber) -> None:
+        """Two timestamp tokens surrounding text produce one segment."""
+        tokens = self._make_tokens(transcriber, "0.00", "2.00")
+        segments = transcriber._extract_segments(tokens)
+        assert len(segments) == 1
+        assert segments[0].start == 0.0
+        assert segments[0].end == 2.0
+
+    def test_time_offset(self, transcriber: WhisperTranscriber) -> None:
+        """Time offset is added to segment boundaries."""
+        tokens = self._make_tokens(transcriber, "0.00", "3.00")
+        segments = transcriber._extract_segments(tokens, time_offset=10.0)
+        assert len(segments) == 1
+        assert segments[0].start == pytest.approx(10.0)
+        assert segments[0].end == pytest.approx(13.0)
+
+    def test_empty_tokens(self, transcriber: WhisperTranscriber) -> None:
+        """No tokens yields no segments."""
+        assert transcriber._extract_segments([]) == []
+
+    def test_segment_id_offset(self, transcriber: WhisperTranscriber) -> None:
+        """Segments start numbering from the given offset."""
+        tokens = self._make_tokens(transcriber, "0.00", "1.00")
+        segments = transcriber._extract_segments(tokens, segment_id_offset=5)
+        assert len(segments) == 1
+        assert segments[0].id == 5
+
+
+# ===========================================================================
+# Prompt encoding
+# ===========================================================================
+
+
+class TestEncodePrompt:
+    """Tests for WhisperTranscriber._encode_prompt."""
+
+    def test_none_returns_empty(self, transcriber: WhisperTranscriber) -> None:
+        """None prompt should return an empty list."""
+        assert transcriber._encode_prompt(None) == []
+
+    def test_empty_string_returns_empty(self, transcriber: WhisperTranscriber) -> None:
+        """Empty string should return an empty list."""
+        assert transcriber._encode_prompt("") == []
+
+    def test_prompt_starts_with_startofprev(
+        self, transcriber: WhisperTranscriber
+    ) -> None:
+        """Encoded prompt should begin with ``<|startofprev|>``."""
+        result = transcriber._encode_prompt("Kubernetes")
+        startofprev = transcriber._get_token_id("<|startofprev|>")
+        assert result[0] == startofprev
+        assert len(result) > 1
+
+    def test_prompt_contains_text_tokens(self, transcriber: WhisperTranscriber) -> None:
+        """Prompt should have at least startofprev + one text token."""
+        result = transcriber._encode_prompt("hello world")
+        assert len(result) >= 2
+
+    def test_long_prompt_truncated(self, transcriber: WhisperTranscriber) -> None:
+        """Very long prompt should be truncated to _MAX_PROMPT_TOKENS + 1."""
+        long_text = "word " * 500
+        result = transcriber._encode_prompt(long_text)
+        # startofprev (1) + at most _MAX_PROMPT_TOKENS text tokens
+        assert len(result) <= _MAX_PROMPT_TOKENS + 1
+
+
+# ===========================================================================
+# Model loading (error paths)
+# ===========================================================================
+
+
+class TestLoadModel:
+    """Tests for load_model() error paths using temporary directories."""
+
+    def test_missing_config_json(self, tmp_path: Path) -> None:
+        """Should raise FileNotFoundError when config.json is absent."""
+        from vllm_metal.stt.transcribe import load_model
+
+        with pytest.raises(FileNotFoundError, match="config.json not found"):
+            load_model(tmp_path)
+
+    def test_missing_weight_files(self, tmp_path: Path) -> None:
+        """Should raise FileNotFoundError when no weight files exist."""
+        import json
+
+        from vllm_metal.stt.transcribe import load_model
+
+        config = {
+            "n_mels": 80,
+            "n_audio_ctx": 10,
+            "n_audio_state": 64,
+            "n_audio_head": 2,
+            "n_audio_layer": 1,
+            "n_vocab": 100,
+            "n_text_ctx": 32,
+            "n_text_state": 64,
+            "n_text_head": 2,
+            "n_text_layer": 1,
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+
+        with pytest.raises(FileNotFoundError, match="No weight files"):
+            load_model(tmp_path)
+
+
+# ===========================================================================
+# Greedy decode and encode chunk (require tiny model)
+# ===========================================================================
+
+
+class TestGreedyDecode:
+    """Tests for WhisperTranscriber._greedy_decode with a tiny model."""
+
+    @pytest.fixture()
+    def tiny_transcriber(self):
+        """Create a WhisperTranscriber with a tiny model and tokenizer."""
+        try:
+            from transformers import WhisperTokenizer
+        except ImportError:
+            pytest.skip("transformers not available")
+
+        import mlx.core as mx
+
+        from vllm_metal.stt.whisper import WhisperConfig, WhisperModel
+
+        config = WhisperConfig(
+            n_mels=80,
+            n_audio_ctx=10,
+            n_audio_state=64,
+            n_audio_head=2,
+            n_audio_layer=1,
+            n_vocab=100,
+            n_text_ctx=32,
+            n_text_state=64,
+            n_text_head=2,
+            n_text_layer=1,
+        )
+        model = WhisperModel(config, dtype=mx.float32)
+        t = WhisperTranscriber(model=model, model_path=None)
+        t._tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-small")
+        return t
+
+    def test_greedy_decode_returns_list(self, tiny_transcriber) -> None:
+        """Greedy decode should return a list of integer token IDs."""
+        import mlx.core as mx
+
+        mel = mx.random.normal((1, 20, 80))
+        audio_features = tiny_transcriber.model.encode(mel)
+        mx.eval(audio_features)
+
+        tokens = tiny_transcriber._greedy_decode(
+            audio_features, language="en", max_tokens=5
+        )
+        assert isinstance(tokens, list)
+        assert all(isinstance(t, int) for t in tokens)
+
+    def test_greedy_decode_with_timestamps(self, tiny_transcriber) -> None:
+        """Timestamp mode should not include <|notimestamps|> in prefix."""
+        import mlx.core as mx
+
+        mel = mx.random.normal((1, 20, 80))
+        audio_features = tiny_transcriber.model.encode(mel)
+        mx.eval(audio_features)
+
+        tokens = tiny_transcriber._greedy_decode(
+            audio_features, language="en", with_timestamps=True, max_tokens=5
+        )
+        assert isinstance(tokens, list)
+
+
+class TestEncodeChunk:
+    """Tests for WhisperTranscriber._encode_chunk."""
+
+    def test_encode_chunk_output_shape(self) -> None:
+        """Encoded features should have shape (1, n_audio_ctx, n_audio_state).
+
+        ``_encode_chunk`` calls ``pad_or_trim(mel, N_FRAMES=3000)`` then
+        conv2 (stride=2), so the output is always 1500 frames regardless
+        of input length.  ``n_audio_ctx`` must match (1500).
+        """
+        import mlx.core as mx
+
+        from vllm_metal.stt.whisper import WhisperConfig, WhisperModel
+
+        config = WhisperConfig(
+            n_mels=80,
+            n_audio_ctx=1500,
+            n_audio_state=64,
+            n_audio_head=2,
+            n_audio_layer=1,
+            n_vocab=100,
+            n_text_ctx=32,
+            n_text_state=64,
+            n_text_head=2,
+            n_text_layer=1,
+        )
+        model = WhisperModel(config, dtype=mx.float32)
+        t = WhisperTranscriber(model=model, model_path=None)
+
+        audio_chunk = mx.zeros(16000)  # 1 second
+        features = t._encode_chunk(audio_chunk)
+
+        assert features.ndim == 3
+        assert features.shape == (1, 1500, 64)
+
+
+# ===========================================================================
+# Integration tests (require model download)
+# ===========================================================================
+
+
+@pytest.mark.slow
+class TestTranscribeIntegration:
+    """End-to-end transcription tests that need a model checkpoint.
+
+    Run with ``pytest -m slow`` to include these.
+    """
+
+    def test_transcribe_silence(self) -> None:
+        """Transcribing silence should return an empty or near-empty string."""
+        import mlx.core as mx
+
+        from vllm_metal.stt.audio import SAMPLE_RATE
+        from vllm_metal.stt.transcribe import load_model, transcribe
+
+        model = load_model("openai/whisper-tiny")
+        audio = mx.zeros(SAMPLE_RATE * 3)  # 3s silence
+        result = transcribe(model, audio)
+        # Whisper may hallucinate on silence; just check it doesn't crash
+        assert isinstance(result.text, str)
+
+    def test_transcribe_with_timestamps(self) -> None:
+        """Timestamp mode should populate segments and duration."""
+        import mlx.core as mx
+
+        from vllm_metal.stt.audio import SAMPLE_RATE
+        from vllm_metal.stt.transcribe import load_model, transcribe
+
+        model = load_model("openai/whisper-tiny")
+        audio = mx.zeros(SAMPLE_RATE * 3)
+        result = transcribe(model, audio, with_timestamps=True)
+        assert result.duration == pytest.approx(3.0)

--- a/vllm_metal/stt/__init__.py
+++ b/vllm_metal/stt/__init__.py
@@ -10,14 +10,24 @@ from vllm_metal.stt.config import (
 )
 from vllm_metal.stt.formatting import format_as_srt, format_as_vtt
 from vllm_metal.stt.protocol import TranscriptionSegment
+from vllm_metal.stt.transcribe import (
+    TranscriptionResult,
+    WhisperTranscriber,
+    load_model,
+    transcribe,
+)
 
 __all__ = [
     "SpeechToTextConfig",
+    "TranscriptionResult",
     "TranscriptionSegment",
+    "WhisperTranscriber",
     "format_as_srt",
     "format_as_vtt",
     "get_supported_languages",
     "get_whisper_languages",
     "is_stt_model",
+    "load_model",
+    "transcribe",
     "validate_language",
 ]

--- a/vllm_metal/stt/transcribe.py
+++ b/vllm_metal/stt/transcribe.py
@@ -1,0 +1,490 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Speech-to-Text transcription orchestration.
+
+Provides :class:`WhisperTranscriber` — the single owning class for Whisper
+inference — plus a convenience :func:`transcribe` entrypoint and
+:func:`load_model` for checkpoint loading.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from vllm_metal.stt.audio import (
+    N_FRAMES,
+    SAMPLE_RATE,
+    audio_duration,
+    load_audio,
+    log_mel_spectrogram,
+    pad_or_trim,
+    split_audio,
+)
+from vllm_metal.stt.config import SpeechToTextConfig
+from vllm_metal.stt.protocol import TranscriptionSegment
+from vllm_metal.stt.whisper import WhisperConfig, WhisperModel
+
+logger = logging.getLogger(__name__)
+
+# ===========================================================================
+# Constants
+# ===========================================================================
+
+# Whisper uses centiseconds for the ``seek`` field in segments.
+_SEEK_MULTIPLIER = 100
+
+# Fallback segment duration when the closing timestamp is missing.
+_DEFAULT_SEGMENT_DURATION = 30.0
+
+# Maximum prompt tokens to inject via ``<|startofprev|>``.
+# Leaves room in the 448-token context window for the actual transcription.
+_MAX_PROMPT_TOKENS = 224
+
+# Regex to detect Whisper timestamp tokens like ``<|0.00|>``.
+_TIMESTAMP_RE = re.compile(r"<\|(\d+\.\d+)\|>")
+
+
+# ===========================================================================
+# Data types
+# ===========================================================================
+
+
+@dataclass
+class TranscriptionResult:
+    """Result of a transcription operation.
+
+    Attributes:
+        text: Full transcribed text.
+        language: Language code used for transcription.
+        segments: Timestamped segments (populated only with ``with_timestamps``).
+        duration: Total audio duration in seconds.
+    """
+
+    text: str
+    language: str | None = None
+    segments: list[TranscriptionSegment] = field(default_factory=list)
+    duration: float = 0.0
+
+
+# ===========================================================================
+# WhisperTranscriber
+# ===========================================================================
+
+
+class WhisperTranscriber:
+    """Owns model, tokenizer, and config for Whisper transcription.
+
+    Each instance holds its own tokenizer to avoid cross-instance
+    interference when multiple transcribers are active.
+
+    Args:
+        model: Loaded :class:`WhisperModel`.
+        model_path: Path to model directory (used for tokenizer loading).
+        config: Optional :class:`SpeechToTextConfig` overrides.
+    """
+
+    def __init__(
+        self,
+        model: WhisperModel,
+        model_path: str | None = None,
+        config: SpeechToTextConfig | None = None,
+    ):
+        self.model = model
+        self.model_path = model_path
+        self.config = config or SpeechToTextConfig()
+        self._tokenizer = None
+
+    @property
+    def tokenizer(self):
+        """Lazily-loaded per-instance tokenizer."""
+        if self._tokenizer is None:
+            self._tokenizer = _load_tokenizer(self.model_path)
+        return self._tokenizer
+
+    def transcribe(
+        self,
+        audio: str | np.ndarray | mx.array,
+        language: str | None = None,
+        task: str = "transcribe",
+        prompt: str | None = None,
+        with_timestamps: bool = False,
+    ) -> TranscriptionResult:
+        """Transcribe audio to text.
+
+        Args:
+            audio: File path, numpy array, or MLX array of audio samples.
+            language: Language code (e.g. ``"en"``, ``"zh"``).
+            task: ``"transcribe"`` or ``"translate"``.
+            prompt: Optional prompt for guiding proper noun spelling.
+            with_timestamps: If True, emit timestamped segments.
+
+        Returns:
+            :class:`TranscriptionResult` with text and optional segments.
+        """
+        if isinstance(audio, str):
+            audio = load_audio(audio, sample_rate=SAMPLE_RATE)
+        elif isinstance(audio, np.ndarray):
+            audio = mx.array(audio, mx.float32)
+
+        total_duration = audio_duration(audio, SAMPLE_RATE)
+
+        chunks = split_audio(
+            audio,
+            max_clip_s=self.config.max_audio_clip_s,
+            overlap_s=self.config.overlap_chunk_second,
+            window_size=self.config.min_energy_split_window_size,
+            sample_rate=SAMPLE_RATE,
+        )
+
+        all_segments: list[TranscriptionSegment] = []
+        all_text_parts: list[str] = []
+        seg_id_offset = 0
+
+        for chunk_audio, chunk_start in chunks:
+            features = self._encode_chunk(chunk_audio)
+            output_tokens = self._greedy_decode(
+                features, language, task, prompt, with_timestamps=with_timestamps
+            )
+
+            if with_timestamps:
+                segments = self._extract_segments(
+                    output_tokens, chunk_start, seg_id_offset
+                )
+                for seg in segments:
+                    all_segments.append(seg)
+                    all_text_parts.append(seg.text)
+                seg_id_offset += len(segments)
+                # Fallback if no segments extracted
+                if not segments:
+                    text = self.tokenizer.decode(
+                        output_tokens, skip_special_tokens=True
+                    )
+                    if text.strip():
+                        all_text_parts.append(text.strip())
+            else:
+                text = self.tokenizer.decode(output_tokens, skip_special_tokens=True)
+                if text.strip():
+                    all_text_parts.append(text.strip())
+
+        return TranscriptionResult(
+            text=" ".join(all_text_parts).strip(),
+            language=language,
+            segments=all_segments if with_timestamps else [],
+            duration=total_duration,
+        )
+
+    # ---- private helpers ---------------------------------------------------
+
+    def _get_token_id(self, token: str) -> int:
+        """Resolve a special token string to its integer ID."""
+        return self.tokenizer.convert_tokens_to_ids(token)
+
+    def _encode_prompt(self, prompt: str | None) -> list[int]:
+        """Encode a user prompt into ``<|startofprev|>`` prefix tokens.
+
+        Whisper uses ``<|startofprev|> ...tokens...`` before
+        ``<|startoftranscript|>`` to condition the decoder on prior
+        context (e.g. correct spelling of proper nouns).
+
+        Args:
+            prompt: User-supplied prompt string.
+
+        Returns:
+            Token IDs to prepend, or empty list if no prompt.
+        """
+        if not prompt:
+            return []
+        prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False)
+        prompt_ids = prompt_ids[-_MAX_PROMPT_TOKENS:]
+        return [self._get_token_id("<|startofprev|>"), *prompt_ids]
+
+    def _greedy_decode(
+        self,
+        audio_features: mx.array,
+        language: str | None = None,
+        task: str = "transcribe",
+        prompt: str | None = None,
+        with_timestamps: bool = False,
+        max_tokens: int | None = None,
+    ) -> list[int]:
+        """Greedy autoregressive decoding.
+
+        A single method handles both timestamp and non-timestamp modes.
+        The only difference is whether ``<|notimestamps|>`` is prepended.
+
+        Args:
+            audio_features: Encoded audio from the encoder.
+            language: Language code.
+            task: ``"transcribe"`` or ``"translate"``.
+            prompt: Optional context prompt.
+            with_timestamps: Allow timestamp token emission.
+            max_tokens: Decoding budget (default: 448 with / 224 without).
+
+        Returns:
+            List of decoded token IDs (excluding special prefix).
+        """
+        if max_tokens is None:
+            max_tokens = 448 if with_timestamps else _MAX_PROMPT_TOKENS
+
+        prefix = self._encode_prompt(prompt)
+        prefix.append(self._get_token_id("<|startoftranscript|>"))
+        if self.model.is_multilingual:
+            prefix.append(self._get_token_id(f"<|{language or 'en'}|>"))
+            prefix.append(self._get_token_id(f"<|{task}|>"))
+        if not with_timestamps:
+            prefix.append(self._get_token_id("<|notimestamps|>"))
+
+        eot_token = self._get_token_id("<|endoftext|>")
+        tokens = mx.array([prefix], dtype=mx.int32)
+        kv_cache = None
+        output_tokens: list[int] = []
+
+        for _ in range(max_tokens):
+            logits, kv_cache = self.model.decode(tokens, audio_features, kv_cache)
+            next_token = int(mx.argmax(logits[:, -1, :], axis=-1).item())
+            if next_token == eot_token:
+                break
+            output_tokens.append(next_token)
+            tokens = mx.array([[next_token]], dtype=mx.int32)
+
+        return output_tokens
+
+    def _extract_segments(
+        self,
+        token_ids: list[int],
+        time_offset: float = 0.0,
+        segment_id_offset: int = 0,
+    ) -> list[TranscriptionSegment]:
+        """Parse timestamp token IDs into :class:`TranscriptionSegment` objects.
+
+        Whisper emits pairs of ``<|start|> ... <|end|>`` timestamp tokens
+        around each phrase. This groups them into segments.
+
+        Args:
+            token_ids: Raw decoded token IDs.
+            time_offset: Offset to add (for chunked audio).
+            segment_id_offset: Starting segment ID.
+
+        Returns:
+            List of :class:`TranscriptionSegment`.
+        """
+        raw_tokens = [self.tokenizer.convert_ids_to_tokens(tid) for tid in token_ids]
+
+        segments: list[TranscriptionSegment] = []
+        seg_start: float | None = None
+        seg_tokens: list[int] = []
+        seg_id = segment_id_offset
+
+        for tid, text in zip(token_ids, raw_tokens, strict=True):
+            m = _TIMESTAMP_RE.match(text)
+            if m:
+                ts = float(m.group(1))
+                if seg_start is None:
+                    seg_start = ts
+                    seg_tokens = []
+                else:
+                    seg_text = self.tokenizer.decode(
+                        seg_tokens, skip_special_tokens=True
+                    )
+                    if seg_text.strip():
+                        segments.append(
+                            TranscriptionSegment(
+                                id=seg_id,
+                                seek=int(seg_start * _SEEK_MULTIPLIER),
+                                start=round(seg_start + time_offset, 2),
+                                end=round(ts + time_offset, 2),
+                                text=seg_text,
+                                tokens=list(seg_tokens),
+                            )
+                        )
+                        seg_id += 1
+                    seg_start = None
+                    seg_tokens = []
+            else:
+                seg_tokens.append(tid)
+
+        # Trailing tokens without a closing timestamp
+        if seg_start is not None and seg_tokens:
+            seg_text = self.tokenizer.decode(seg_tokens, skip_special_tokens=True)
+            if seg_text.strip():
+                segments.append(
+                    TranscriptionSegment(
+                        id=seg_id,
+                        seek=int(seg_start * _SEEK_MULTIPLIER),
+                        start=round(seg_start + time_offset, 2),
+                        end=round(
+                            seg_start + time_offset + _DEFAULT_SEGMENT_DURATION, 2
+                        ),
+                        text=seg_text,
+                        tokens=list(seg_tokens),
+                    )
+                )
+
+        return segments
+
+    def _encode_chunk(self, audio_chunk: mx.array) -> mx.array:
+        """Encode a single audio chunk into encoder features.
+
+        Args:
+            audio_chunk: Raw audio samples.
+
+        Returns:
+            Encoder hidden states.
+        """
+        n_mels = self.model.config.n_mels
+        mel = log_mel_spectrogram(audio_chunk, n_mels=n_mels)
+        mel = pad_or_trim(mel, N_FRAMES, axis=-1)
+        if mel.ndim == 2:
+            mel = mel[None, ...]
+        mel = mel.transpose(0, 2, 1)
+        features = self.model.encode(mel)
+        mx.eval(features)
+        return features
+
+
+# ===========================================================================
+# Model loading
+# ===========================================================================
+
+
+def load_model(model_path: str | Path, dtype: mx.Dtype = mx.float16) -> WhisperModel:
+    """Load a Whisper model from a local directory or HuggingFace repo.
+
+    Args:
+        model_path: Local path or HuggingFace repo ID.
+        dtype: Model dtype (default: float16).
+
+    Returns:
+        Loaded :class:`WhisperModel` ready for inference.
+
+    Raises:
+        ValueError: If the model cannot be found or downloaded.
+        FileNotFoundError: If config.json or weight files are missing.
+    """
+    model_path = Path(model_path)
+
+    if not model_path.exists():
+        try:
+            from huggingface_hub import snapshot_download
+
+            model_path = Path(snapshot_download(repo_id=str(model_path)))
+        except ImportError as e:
+            raise ValueError(
+                f"Could not download model {model_path}: "
+                "huggingface_hub is not installed"
+            ) from e
+        except OSError as e:
+            raise ValueError(f"Could not download model: {model_path}") from e
+
+    config_path = model_path / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"config.json not found in {model_path}")
+
+    with open(config_path) as f:
+        config_dict = json.load(f)
+
+    config = WhisperConfig.from_dict(config_dict)
+    model = WhisperModel(config, dtype)
+
+    # Load weights — prefer safetensors over npz
+    weight_files = sorted(model_path.glob("*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("*.npz"))
+    if not weight_files:
+        raise FileNotFoundError(f"No weight files in {model_path}")
+
+    weights: dict[str, mx.array] = {}
+    for wf in weight_files:
+        weights.update(mx.load(str(wf)))
+
+    # Apply quantization if specified in config
+    quantization = config_dict.get("quantization")
+    if quantization is not None:
+
+        def class_predicate(p, m):
+            return isinstance(m, (nn.Linear, nn.Embedding)) and f"{p}.scales" in weights
+
+        nn.quantize(model, **quantization, class_predicate=class_predicate)
+
+    weights = model.sanitize(weights)
+    model.load_weights(list(weights.items()), strict=False)
+    mx.eval(model.parameters())
+    return model
+
+
+# ===========================================================================
+# Module-level helpers
+# ===========================================================================
+
+
+def _load_tokenizer(model_path: str | None = None):
+    """Load a Whisper tokenizer.
+
+    Tries the local model path first (works offline if tokenizer files
+    are present), then falls back to ``openai/whisper-small``.
+
+    Args:
+        model_path: Local model directory.
+
+    Returns:
+        A ``WhisperTokenizer`` instance.
+    """
+    from transformers import WhisperTokenizer
+
+    if model_path:
+        try:
+            return WhisperTokenizer.from_pretrained(model_path)
+        except (OSError, ValueError) as e:
+            logger.debug("Local tokenizer load failed for %s: %s", model_path, e)
+
+    try:
+        return WhisperTokenizer.from_pretrained("openai/whisper-small")
+    except OSError:
+        return WhisperTokenizer.from_pretrained(
+            "openai/whisper-small", local_files_only=True
+        )
+
+
+# ===========================================================================
+# Convenience entrypoint
+# ===========================================================================
+
+
+def transcribe(
+    model: WhisperModel,
+    audio: str | np.ndarray | mx.array,
+    language: str | None = None,
+    task: str = "transcribe",
+    prompt: str | None = None,
+    with_timestamps: bool = False,
+    model_path: str | None = None,
+    stt_config: SpeechToTextConfig | None = None,
+) -> TranscriptionResult:
+    """Transcribe audio to text (convenience wrapper).
+
+    Creates a :class:`WhisperTranscriber` and delegates. For repeated
+    calls, prefer constructing a transcriber directly to reuse the
+    tokenizer.
+
+    Args:
+        model: Loaded :class:`WhisperModel`.
+        audio: File path, numpy array, or MLX array.
+        language: Language code.
+        task: ``"transcribe"`` or ``"translate"``.
+        prompt: Optional context prompt.
+        with_timestamps: Emit timestamped segments.
+        model_path: Path to model directory (for tokenizer loading).
+        stt_config: Optional config overrides.
+
+    Returns:
+        :class:`TranscriptionResult`.
+    """
+    transcriber = WhisperTranscriber(model, model_path=model_path, config=stt_config)
+    return transcriber.transcribe(audio, language, task, prompt, with_timestamps)


### PR DESCRIPTION
## Summary

- Add `WhisperTranscriber` class that owns model, tokenizer, and config for Whisper inference
- Add `load_model()` for checkpoint loading (HuggingFace / local, safetensors priority)
- Add convenience `transcribe()` entrypoint
- Export new public API from `vllm_metal.stt.__init__`
- Add 16 unit tests + 2 integration tests in `tests/test_transcribe.py`

## How to verify

### Run tests

```bash
source ~/.venv-vllm-metal/bin/activate
pytest tests/test_transcribe.py -v -m "not slow"
````

All 16 tests should pass:

* TestTranscriptionResult — 2 tests (dataclass defaults / all fields)
* TestExtractSegments — 4 tests (paired timestamps, time offset, empty tokens, segment ID offset)
* TestEncodePrompt — 5 tests (None, empty string, startofprev prefix, text tokens, long prompt truncation)
* TestLoadModel — 2 tests (missing config.json, missing weight files)                                                                                               
* TestGreedyDecode — 2 tests (basic decode, timestamp mode)                                                                                                         
* TestEncodeChunk — 1 test (output shape verification) 
Existing tests should still pass:

```bash
pytest tests/test_stt.py tests/test_whisper.py -v -m "not slow"
```

Minimal repro

```python
from vllm_metal.stt.transcribe import WhisperTranscriber, _MAX_PROMPT_TOKENS
from transformers import WhisperTokenizer

t = WhisperTranscriber(model=None, model_path=None)
t._tokenizer = WhisperTokenizer.from_pretrained("openai/whisper-small")

# Prompt encoding
result = t._encode_prompt("Kubernetes")
print(f"prompt tokens: {result}")  #[50361, 42, 22457] 

# Segment extraction
start_tok = t._get_token_id("<|0.00|>")
end_tok = t._get_token_id("<|2.00|>")
segments = t._extract_segments([start_tok, 2425, end_tok])
print(f"segments: {segments}")  # [TranscriptionSegment(start=0.0, end=2.0, ...)]
```

End-to-end (requires model download)

```bash
pytest tests/test_transcribe.py -v -m slow
```

Test plan

* `pytest tests/test_transcribe.py -v -m "not slow"` — 16 passed
* `pytest tests/test_stt.py tests/test_whisper.py -v -m "not slow"` — 43 passed (no regression)



