### PR TITLE
[varlen Kernel] Add test spec for unified varlen paged attention [2/n]

### DIFF
--- a/tests/test_metal_unified_attention.py
+++ b/tests/test_metal_unified_attention.py
@@ -15,6 +15,15 @@ import pytest
 # TODO: import from vllm_metal.metal once the kernel is implemented
 # from vllm_metal.metal import metal_unified_attention
 
+# Original upstream parameters (vLLM Triton/CUDA test_triton_unified_attention.py):
+#   HEAD_SIZES = [128, 256]
+#   NUM_BLOCKS = [32768, 2048]
+#   sliding_window = [None, 64, 128, 256]
+#   DTYPES = [torch.bfloat16]
+#   Also tested: FP8 output quantization (QDTYPES), 3D decode kernel
+#     (SEQ_THRESHOLD_3D) — both CUDA-specific, omitted here.
+# Current sizes are reduced for Apple Silicon unified memory.
+# TODO: try head_size=256 and larger num_blocks as @pytest.mark.slow variants.
 NUM_HEADS = [(4, 4), (8, 2), (5, 1)]
 HEAD_SIZES = [128]
 BLOCK_SIZES = [16]


### PR DESCRIPTION
## Goal

This is the spec to smoothly migrate v1 kernel (only paged) to v2 kernel (paged + varlen), without break anything on main, but enable us to support continuous batching. 




## Summary

Adds `test_metal_unified_attention.py`, adapted from vLLM upstream's `test_triton_unified_attention.py`.

Three test functions form a triangle validation:

```
        v1 kernel (production)
           /        \
  PASS    /          \   xfail
 (runs   /            \  (v2 not built)
  now)  /              \
       v                v
  ref_paged_attn ----> v2 kernel (unified varlen)
     (naive MLX)  xfail
```

- `test_v1_kernel_vs_reference` - v1 == ref (12 cases, runs now, validates the reference)
- `test_metal_unified_attn_decode_only` - v2 == v1 (24 cases, xfail, proves v2 is a drop-in replacement for decode)
- `test_metal_unified_attn` - v2 == ref (192 cases, xfail, full varlen with mixed prefill+decode, GQA, sliding window, soft cap)

## Migration plan

```
Step 1: Build v2 kernel, test decode-only (q_len=1)
        Scaffolding test goes green: v2 == v1
                    |
Step 2: Extend v2 to handle varlen (q_len > 1)
        Full test goes green: v2 == ref
                    |
Step 3: Delete scaffolding test, replace v1 with v2 in production
```
