### PR TITLE
remove stale xfail for batched decode paged-parity test

### DIFF
--- a/tests/test_metal_kernel_paged.py
+++ b/tests/test_metal_kernel_paged.py
@@ -189,11 +189,6 @@ class TestMetalKernelPagedVsStandard:
         )
 
     @pytest.mark.slow
-    @pytest.mark.xfail(
-        reason="B=2 batched GEMM produces different floats than B=1, "
-        "causing token divergence after ~5 decode steps (not a kernel bug). "
-        "See https://github.com/vllm-project/vllm-metal/issues/119"
-    )
     def test_batched_decode_matches(self, qwen3_model):
         """Batched Metal kernel paged decode must match per-request sequential."""
         model, tokenizer = qwen3_model


### PR DESCRIPTION
## Summary

- Remove the stale `xfail` marker on `test_batched_decode_matches` in `test_metal_kernel_paged.py`
- The test was marked `xfail` for issue #119 (B=2 batched GEMM float divergence), but now passes consistently on `main` after recent paged kernel fixes (#146, #151)
- Follows the same pattern as PR #149 which removed the `xfail` for `test_greedy_output_matches`

## Test plan

- [x] `test_batched_decode_matches` passes locally on M3 Ultra (was previously `xpassed`)
- [x] Full test suite passes: 283 passed, 0 xpassed, 4 skipped