### PR TITLE
[Refactor] Move TranscriptionResult to shared STT base module

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import mlx.core as mx
 import pytest
 
+from vllm_metal.stt.base import TranscriptionResult as SharedTranscriptionResult
 from vllm_metal.stt.transcribe import (
     _MAX_PROMPT_TOKENS,
     TranscriptionResult,
@@ -45,6 +46,10 @@ def transcriber():
 
 class TestTranscriptionResult:
     """Tests for TranscriptionResult dataclass."""
+
+    def test_reexport_matches_shared_base(self) -> None:
+        """transcribe.py should re-export the shared TranscriptionResult."""
+        assert TranscriptionResult is SharedTranscriptionResult
 
     def test_defaults(self) -> None:
         """Default fields should be None / empty / zero."""

--- a/vllm_metal/stt/__init__.py
+++ b/vllm_metal/stt/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Speech-to-Text support for vLLM Metal."""
 
+from vllm_metal.stt.base import TranscriptionResult
 from vllm_metal.stt.config import (
     SpeechToTextConfig,
     get_supported_languages,
@@ -12,7 +13,6 @@ from vllm_metal.stt.formatting import format_as_srt, format_as_vtt
 from vllm_metal.stt.protocol import TranscriptionSegment
 from vllm_metal.stt.transcribe import (
     Qwen3ASRTranscriber,
-    TranscriptionResult,
     WhisperTranscriber,
     load_model,
     transcribe,

--- a/vllm_metal/stt/base.py
+++ b/vllm_metal/stt/base.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared Speech-to-Text result types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from vllm_metal.stt.protocol import TranscriptionSegment
+
+
+@dataclass
+class TranscriptionResult:
+    """Result of a transcription operation.
+
+    Attributes:
+        text: Full transcribed text.
+        language: Language code used for transcription.
+        segments: Timestamped segments (populated only with ``with_timestamps``).
+        duration: Total audio duration in seconds.
+    """
+
+    text: str
+    language: str | None = None
+    segments: list[TranscriptionSegment] = field(default_factory=list)
+    duration: float = 0.0

--- a/vllm_metal/stt/transcribe.py
+++ b/vllm_metal/stt/transcribe.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Speech-to-Text transcription orchestration.
 
-Provides :class:`WhisperTranscriber` — the single owning class for Whisper
-inference — plus a convenience :func:`transcribe` entrypoint and
-:func:`load_model` for checkpoint loading.
+Provides model-specific transcribers plus convenience helpers for checkpoint
+loading and one-shot transcription.
 """
 
 from __future__ import annotations
@@ -11,7 +10,6 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import mlx.core as mx
@@ -27,6 +25,7 @@ from vllm_metal.stt.audio import (
     pad_or_trim,
     split_audio,
 )
+from vllm_metal.stt.base import TranscriptionResult
 from vllm_metal.stt.config import (
     QWEN3_ASR_MAX_DECODE_TOKENS,
     WHISPER_MAX_DECODE_TOKENS,
@@ -63,28 +62,6 @@ _WHISPER_TASKS = frozenset({"transcribe", "translate"})
 
 # Supported floating-point dtypes for STT model loading.
 _SUPPORTED_LOAD_DTYPES = frozenset({mx.float16, mx.float32, mx.bfloat16})
-
-
-# ===========================================================================
-# Data types
-# ===========================================================================
-
-
-@dataclass
-class TranscriptionResult:
-    """Result of a transcription operation.
-
-    Attributes:
-        text: Full transcribed text.
-        language: Language code used for transcription.
-        segments: Timestamped segments (populated only with ``with_timestamps``).
-        duration: Total audio duration in seconds.
-    """
-
-    text: str
-    language: str | None = None
-    segments: list[TranscriptionSegment] = field(default_factory=list)
-    duration: float = 0.0
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

This PR is a small preparatory STT refactor with no intended behavior change.

It moves `TranscriptionResult` out of `vllm_metal/stt/transcribe.py` into a shared module:

- `vllm_metal/stt/base.py`

To preserve compatibility, `TranscriptionResult` is still re-exported from:

- `vllm_metal.stt.transcribe`
- `vllm_metal.stt`

## Why

This is a minimal first step toward cleaning up the STT package structure before any larger Whisper/Qwen3 split.

I intentionally kept this PR narrow to make review easier and avoid mixing structural cleanup with runtime changes.


## Next Steps
- move model-specific STT code into dedicated subpackages such as `stt/whisper/` and `stt/qwen3/`
- keep `transcribe.py` focused on orchestration and shared entrypoints