### PR TITLE
Update torch_to_mlx to have better perf on dtype=bfloat16

### DIFF
--- a/vllm_metal/pytorch_backend/tensor_bridge.py
+++ b/vllm_metal/pytorch_backend/tensor_bridge.py
@@ -87,14 +87,14 @@ def torch_to_mlx(tensor: torch.Tensor) -> mx.array:
         MLX array with the same data
     """
     # Move to CPU if on MPS for numpy conversion
-    if tensor.device.type == "mps":
+    if tensor.device.type != "cpu":
         tensor = tensor.cpu()
 
     tensor = tensor.detach()
 
     # Note: numpy does not support bfloat16.
     if tensor.dtype == torch.bfloat16:
-        return mx.array(tensor.float().numpy(), dtype=mx.bfloat16)
+        return mx.array(tensor)
 
     return mx.array(tensor.numpy())
 


### PR DESCRIPTION
Use `mx.array(tensor)` for bf16, numpy path for others.

Perf data (M1+16G MBP, median of 50 runs after 5 warmup iterations)
| Shape | dtype | Previous (µs) | Current (µs) | Speedup |
|-------|-------|---:|---:|---:|
| (1, 512) | **bfloat16** | 3.6 | **2.5** | **1.46×** |
| (4, 512) | **bfloat16** | 4.0 | **2.5** | **1.60×** |
| (1, 4096) | **bfloat16** | 4.7 | **2.6** | **1.78×** |
| (4, 4096) | **bfloat16** | 8.8 | **3.0** | **2.90×** |
| (32, 4096) | **bfloat16** | 39.2 | **7.5** | **5.19×** |
| (1, 16384) | **bfloat16** | 8.9 | **3.2** | **2.80×** |