### PR TITLE
Upgrade transformers to >=5.0.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -134,6 +134,12 @@ main() {
   cd -
   rm -rf vllm-$vllm_v*
 
+  # Upgrade transformers beyond vllm's <5 pin.
+  # mlx-lm 0.30+ and mlx-vlm 0.3.10+ require transformers>=5.0.0 for newer
+  # model architectures (Qwen3.5, Nemotron, etc.). vllm works fine with v5 —
+  # upstream is tracking the official upgrade in vllm-project/vllm#30566.
+  uv pip install 'transformers>=5.0.0'
+
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
     uv pip install .
   else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "mlx-lm>=0.28.4; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-vlm>=0.3.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
     # Model loading and weights
-    "transformers>=4.40.0",
+    "transformers>=5.0.0",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
     # Native Metal extension JIT build


### PR DESCRIPTION
## Summary

Upgrade transformers from >=4.40.0 to >=5.0.0. mlx-lm 0.30+ and mlx-vlm 0.3.10+ require transformers 5.x for newer model architectures (Qwen3.5,Nemotron, etc.). vllm upstream is tracking the official upgrade in vllm-project/vllm#30566 but it hasn't landed yet — this unblocks the MLX side first.

## Test results

All tests run with vllm 0.17.1 + transformers 5.3.0:

- Smoke test (`scripts/test.sh`): server starts, chat completions pass
<img width="1119" height="596" alt="截圖 2026-03-17 晚上9 35 28" src="https://github.com/user-attachments/assets/bfb57897-7bf2-411d-bff3-dc54c81d59ec" />

- Golden token test (`test_paged_deterministic.py`):
<img width="1109" height="572" alt="截圖 2026-03-17 晚上9 36 13" src="https://github.com/user-attachments/assets/8a98de01-7739-4b81-820f-9bd1a2942ba8" />