### PR TITLE
[CI] Remove vllm from [all] extra to fix release CI  

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     "mypy>=1.19.1",
 ]
 all = [
-    "vllm-metal[vllm,stt,dev]",
+    "vllm-metal[stt,dev]",
 ]
 
 [project.urls]


### PR DESCRIPTION

`uv build` validates all extras during build isolation. The `[all]` extra includes `vllm>=0.17.1`, which pins `transformers<5`, conflicting with `transformers>=5.0.0` added in #169.

Remove `vllm` from `[all]` — vllm must be installed separately via `install.sh` (which overrides the transformers pin after installing vllm).

https://github.com/vllm-project/vllm-metal/actions/runs/23237769107/job/67548510927