### PR TITLE
[CI] Remove [vllm] extra to fix uv build deps conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-vllm = ["vllm>=0.17.1"]
 stt = [
     # Speech-to-text audio processing (Whisper models)
     "librosa>=0.10.2",


### PR DESCRIPTION
Follow-up to #176. `uv build` validates every extra individually, not just `[all]`. The `[vllm]` extra (`vllm>=0.17.1`) conflicts with `transformers>=5.0.0` in main deps because vllm pins `transformers<5`.

Remove the `[vllm]` extra entirely — vllm must be installed via `install.sh`, which handles the transformers override separately.

Tested locally: `uv build` succeeds after this change.