### PR TITLE
Disable chunked prefill on Metal

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -2,6 +2,7 @@
 """Tests for Metal platform."""
 
 import platform
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -125,6 +126,43 @@ class TestMetalPlatform:
         MetalPlatform.verify_quantization("int8")
         MetalPlatform.verify_quantization("awq")
         MetalPlatform.verify_quantization("compressed-tensors")
+
+    def test_check_and_update_config_disables_chunked_prefill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Metal should disable chunked prefill until the runner supports it."""
+        import vllm_metal.stt.config as stt_config
+        import vllm_metal.utils as metal_utils
+
+        monkeypatch.setattr(metal_utils, "get_model_download_path", lambda model: model)
+        monkeypatch.setattr(stt_config, "is_stt_model", lambda _model: False)
+
+        vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                worker_cls="auto",
+                distributed_executor_backend="auto",
+                disable_custom_all_reduce=False,
+            ),
+            cache_config=SimpleNamespace(block_size=None),
+            model_config=SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+            ),
+            scheduler_config=SimpleNamespace(
+                async_scheduling=True,
+                enable_chunked_prefill=True,
+            ),
+        )
+
+        MetalPlatform.check_and_update_config(vllm_config)
+
+        assert vllm_config.scheduler_config.enable_chunked_prefill is False
+        assert (
+            vllm_config.parallel_config.worker_cls == "vllm_metal.v1.worker.MetalWorker"
+        )
+        assert vllm_config.parallel_config.distributed_executor_backend == "uni"
+        assert vllm_config.parallel_config.disable_custom_all_reduce is True
 
     def test_synchronize_runs_mlx_barrier(
         self, monkeypatch: pytest.MonkeyPatch

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -223,6 +223,15 @@ class MetalPlatform(Platform):
         # Disable features not supported on Metal
         parallel_config.disable_custom_all_reduce = True
 
+        scheduler_config = vllm_config.scheduler_config
+        if getattr(scheduler_config, "enable_chunked_prefill", False):
+            # MetalModelRunner does not yet honor chunked-prefill scheduler
+            # boundaries on the non-paged MLX path. Disable the feature so the
+            # scheduler only requests full prefills, which matches the current
+            # model-runner contract.
+            scheduler_config.enable_chunked_prefill = False
+            logger.info("Metal: disabled chunked prefill")
+
         # Configure cache
         if cache_config.block_size is None:
             cache_config.block_size = config.block_size
@@ -246,7 +255,6 @@ class MetalPlatform(Platform):
             # STT processes entire audio in one execute_model call;
             # async scheduling's batch queue expects incremental decode
             # and would schedule cached requests that STT cannot handle.
-            scheduler_config = vllm_config.scheduler_config
             if getattr(scheduler_config, "async_scheduling", False):
                 scheduler_config.async_scheduling = False
                 logger.info("STT: disabled async_scheduling")


### PR DESCRIPTION
This PR is:
- To disable chunked prefill on Metal until the default non-paged MLX path handles chunked-prefill scheduler boundaries correctly.
- To fix the long-prompt async serving crash reported in issue #171 on the default Metal text-generation path.
- To add a regression test that keeps `enable_chunked_prefill` disabled for Metal.

## Note

This issue looked like an async-scheduling problem at first, but the actual root cause is narrower: the default non-paged MLX path does not fully support chunked prefill yet.

In simple terms, vLLM can split long prompt prefill into chunks, but the current non-paged MLX path still behaves like prefill always finishes in one shot. That mismatch breaks scheduler expectations and can crash the server.

This change fixes the issue by disabling chunked prefill for Metal so the scheduler stays on the full-prefill behavior that the current runtime actually supports.

The tradeoff is that long-prompt serving on the default non-paged MLX path may be slower for now. The long-term fix is to make the non-paged MLX path truly chunk-aware, and then re-enable chunked prefill safely instead of broad-brushing the platform by disabling async scheduling.
