### PR TITLE
Pin nanobind to 2.10.2 for ABI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
     # Native Metal extension JIT build
-    "nanobind>=2.0.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "nanobind==2.10.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Core utilities
     "numpy>=1.24.0",
     "psutil>=5.9.0",


### PR DESCRIPTION
The issue does not appear to be that mlx::core::array lacks typed bridge support in general. The real problem is nanobind compatibility: mlx.core was built against nanobind 2.10.2, while our external extension was initially built with 2.12.0, which likely caused an ABI/domain mismatch and isolated the typed casts.

After downgrading the local environment to nanobind 2.10.2, the same minimal external extension started working correctly: typed mlx::core::array -> mlx::core::array bindings succeeded, and the previous incompatible function arguments error disappeared. This strongly suggests the blocker was nanobind version/ABI mismatch rather than missing mlx::core::array bridge support.

Related:

https://github.com/vllm-project/vllm-metal/issues/188
https://github.com/ml-explore/mlx/issues/3303