### PR TITLE
Add paged attention backend for MLA models

### DIFF
--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import math
+from collections.abc import Generator
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+import vllm_metal.paged_attention_common as pac
+
+from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
+from vllm_metal.paged_attention_backend.mla import (
+    MLAPagedAttentionBackend,
+    MLAPagedAttentionWrapper,
+    patch_model_attention_mla,
+)
+from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
+
+# Fixture dimensions matching GLM/DeepSeek-V2 defaults
+_KV_LORA_RANK = 512
+_QK_ROPE_HEAD_DIM = 64
+_LATENT_DIM = _KV_LORA_RANK + _QK_ROPE_HEAD_DIM
+
+
+class TestMLAPagedLatentCache:
+    def test_latent_dim_is_sum_of_lora_rank_and_rope_head_dim(self) -> None:
+        cache = MLAPagedLatentCache(
+            num_layers=4,
+            kv_lora_rank=_KV_LORA_RANK,
+            qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+            num_blocks=10,
+            block_size=16,
+            dtype=mx.float16,
+        )
+
+        assert cache.latent_dim == _LATENT_DIM
+
+    def test_per_layer_array_shape(self) -> None:
+        cache = MLAPagedLatentCache(
+            num_layers=3,
+            kv_lora_rank=256,
+            qk_rope_head_dim=32,
+            num_blocks=8,
+            block_size=16,
+            dtype=mx.float16,
+        )
+
+        assert len(cache.latent_caches) == 3
+        for arr in cache.latent_caches:
+            assert arr.shape == (8, 16, 288)  # (num_blocks, block_size, latent_dim)
+            assert arr.dtype == mx.float16
+
+    def test_bfloat16_dtype_accepted(self) -> None:
+        cache = MLAPagedLatentCache(
+            num_layers=2,
+            kv_lora_rank=128,
+            qk_rope_head_dim=64,
+            num_blocks=4,
+            block_size=8,
+            dtype=mx.bfloat16,
+        )
+
+        assert cache.dtype == mx.bfloat16
+
+    def test_invalid_dtype_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            MLAPagedLatentCache(
+                num_layers=2,
+                kv_lora_rank=_KV_LORA_RANK,
+                qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+                num_blocks=5,
+                block_size=16,
+                dtype=mx.int32,
+            )
+
+
+class TestMLAPagedAttentionBackend:
+    def _make_backend(self) -> MLAPagedAttentionBackend:
+        return MLAPagedAttentionBackend(
+            num_layers=4,
+            kv_lora_rank=_KV_LORA_RANK,
+            qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+            block_size=16,
+            dtype=mx.float16,
+        )
+
+    def test_implements_paged_attention_backend_protocol(self) -> None:
+        backend = self._make_backend()
+
+        assert isinstance(backend, PagedAttentionBackend)
+
+    def test_num_blocks_raises_before_initialize(self) -> None:
+        backend = self._make_backend()
+
+        with pytest.raises(RuntimeError, match="called before initialize"):
+            backend.num_blocks()
+
+    def test_warm_up_raises_before_initialize(self) -> None:
+        backend = self._make_backend()
+
+        with pytest.raises(RuntimeError, match="called before initialize"):
+            backend.warm_up()
+
+    def test_patch_model_raises_before_initialize(self) -> None:
+        backend = self._make_backend()
+
+        with pytest.raises(RuntimeError, match="called before initialize"):
+            backend.patch_model(object())
+
+    def test_num_blocks_after_initialize(self) -> None:
+        backend = self._make_backend()
+        backend.initialize(50)
+
+        assert backend.num_blocks() == 50
+
+    def test_warm_up_after_initialize_does_not_raise(self) -> None:
+        backend = self._make_backend()
+        backend.initialize(10)
+
+        backend.warm_up()
+
+    def test_initialize_allocates_cache_with_correct_shape(self) -> None:
+        backend = self._make_backend()
+
+        backend.initialize(20)
+
+        assert backend._cache is not None
+        assert backend._cache.num_blocks == 20
+        assert backend._cache.latent_dim == _LATENT_DIM
+        assert backend._cache.num_layers == 4
+
+
+class _FakeAttn(nn.Module):
+    """Minimal stand-in for an MLA attention module."""
+
+
+class _FakeLayer:
+    def __init__(self) -> None:
+        self.self_attn = _FakeAttn()
+
+
+class _FakeModel:
+    """Minimal stand-in for a model with .model.layers."""
+
+    def __init__(self, num_layers: int) -> None:
+        self.model = SimpleNamespace(layers=[_FakeLayer() for _ in range(num_layers)])
+
+
+class TestPatchModelAttentionMla:
+    def _make_cache(self, num_layers: int) -> MLAPagedLatentCache:
+        return MLAPagedLatentCache(
+            num_layers=num_layers,
+            kv_lora_rank=_KV_LORA_RANK,
+            qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+            num_blocks=5,
+            block_size=16,
+            dtype=mx.float16,
+        )
+
+    def test_replaces_all_attention_layers(self) -> None:
+        model = _FakeModel(num_layers=3)
+        cache = self._make_cache(num_layers=3)
+
+        n = patch_model_attention_mla(model, cache)
+
+        assert n == 3
+        for layer in model.model.layers:
+            assert isinstance(layer.self_attn, MLAPagedAttentionWrapper)
+
+    def test_wrapped_layer_has_correct_index(self) -> None:
+        model = _FakeModel(num_layers=2)
+        cache = self._make_cache(num_layers=2)
+
+        patch_model_attention_mla(model, cache)
+
+        for idx, layer in enumerate(model.model.layers):
+            assert layer.self_attn._mla_layer_idx == idx
+
+    def test_already_patched_layers_update_cache_reference(self) -> None:
+        model = _FakeModel(num_layers=1)
+        cache_a = self._make_cache(num_layers=1)
+        cache_b = self._make_cache(num_layers=1)
+        patch_model_attention_mla(model, cache_a)
+
+        n = patch_model_attention_mla(model, cache_b)
+
+        assert n == 1
+        assert model.model.layers[0].self_attn._mla_latent_cache is cache_b
+
+    def test_returns_correct_patch_count(self) -> None:
+        for n_layers in (1, 4, 10):
+            model = _FakeModel(num_layers=n_layers)
+            cache = self._make_cache(num_layers=n_layers)
+
+            count = patch_model_attention_mla(model, cache)
+
+            assert count == n_layers
+
+
+class TestMLAPagedAttentionWrapperFallback:
+    def test_delegates_to_inner_when_no_paged_context(self) -> None:
+        sentinel = object()
+        inner = MagicMock(return_value=sentinel)
+        latent_cache = MagicMock(spec=MLAPagedLatentCache)
+
+        wrapper = MLAPagedAttentionWrapper(
+            inner, layer_idx=0, latent_cache=latent_cache
+        )
+
+        x = mx.zeros((1, 3, 64))
+        result = wrapper(x, mask=None, cache=None)
+
+        inner.assert_called_once_with(x, mask=None, cache=None)
+        assert result is sentinel
+
+    def test_passes_mask_and_cache_to_inner(self) -> None:
+        inner = MagicMock(return_value=mx.zeros((1, 2, 32)))
+        latent_cache = MagicMock(spec=MLAPagedLatentCache)
+        wrapper = MLAPagedAttentionWrapper(
+            inner, layer_idx=1, latent_cache=latent_cache
+        )
+        x = mx.zeros((1, 2, 32))
+        mask = object()
+        cache = object()
+
+        wrapper(x, mask=mask, cache=cache)
+
+        inner.assert_called_once_with(x, mask=mask, cache=cache)
+
+
+# ---------------------------------------------------------------------------
+# Paged path tests — small dims that exercise all shape paths without being slow
+# ---------------------------------------------------------------------------
+_HIDDEN = 32
+_NUM_HEADS = 2
+_NOPE_DIM = 8   # qk_nope_head_dim
+_ROPE_DIM = 4   # qk_rope_head_dim
+_KV_RANK = 16   # kv_lora_rank
+_V_DIM = 8      # v_head_dim
+
+
+class _MinimalMLAInner(nn.Module):
+    """Minimal MLA attention stub with correct shapes for paged path tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.q_lora_rank = None
+        self.num_heads = _NUM_HEADS
+        self.q_head_dim = _NOPE_DIM + _ROPE_DIM
+        self.qk_nope_head_dim = _NOPE_DIM
+        self.qk_rope_head_dim = _ROPE_DIM
+        self.kv_lora_rank = _KV_RANK
+        self.scale = 1.0 / math.sqrt(_KV_RANK)
+
+        self.q_proj = nn.Linear(_HIDDEN, _NUM_HEADS * self.q_head_dim, bias=False)
+        self.kv_a_proj_with_mqa = nn.Linear(_HIDDEN, _KV_RANK + _ROPE_DIM, bias=False)
+        self.kv_a_layernorm = nn.LayerNorm(_KV_RANK)
+        self.embed_q = nn.Linear(_NOPE_DIM, _KV_RANK, bias=False)
+        self.unembed_out = nn.Linear(_KV_RANK, _V_DIM, bias=False)
+        self.o_proj = nn.Linear(_NUM_HEADS * _V_DIM, _HIDDEN, bias=False)
+
+    def rope(self, x: mx.array, offset: int = 0) -> mx.array:
+        # Identity RoPE: preserves shape, sufficient for testing shape logic.
+        return x
+
+
+class TestMLAPagedAttentionWrapperPagedPath:
+    """Exercises the paged attention computation path (PagedAttentionContext set)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_ctx(self) -> Generator[None, None, None]:
+        pac.clear_context()
+        yield
+        pac.clear_context()
+
+    def _make_cache(self) -> MLAPagedLatentCache:
+        return MLAPagedLatentCache(
+            num_layers=1,
+            kv_lora_rank=_KV_RANK,
+            qk_rope_head_dim=_ROPE_DIM,
+            num_blocks=4,
+            block_size=4,
+            dtype=mx.float16,
+        )
+
+    def test_decode_output_shape(self) -> None:
+        # 1 request, 3 cached tokens, 1 new decode token
+        inner = _MinimalMLAInner()
+        cache = self._make_cache()
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+
+        pac.set_context(
+            pac.PagedAttentionContext(
+                slot_mapping=[3],
+                block_tables=[[0]],
+                context_lens=[4],
+                cu_seqlens=[0, 1],
+                offsets=[3],
+            )
+        )
+
+        out = wrapper(mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16), mask=None, cache=None)
+        mx.eval(out)
+
+        assert out.shape == (1, 1, _HIDDEN)
+
+    def test_prefill_output_shape(self) -> None:
+        # 1 request, 0 past tokens, 4 new prefill tokens
+        inner = _MinimalMLAInner()
+        cache = self._make_cache()
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+
+        pac.set_context(
+            pac.PagedAttentionContext(
+                slot_mapping=[0, 1, 2, 3],
+                block_tables=[[0]],
+                context_lens=[4],
+                cu_seqlens=[0, 4],
+                offsets=[0],
+            )
+        )
+
+        out = wrapper(mx.random.normal((1, 4, _HIDDEN)).astype(mx.float16), mask=None, cache=None)
+        mx.eval(out)
+
+        assert out.shape == (1, 4, _HIDDEN)
+
+    def test_cache_written_at_correct_slot(self) -> None:
+        # Scatter-write: only the assigned slot is non-zero after the call
+        inner = _MinimalMLAInner()
+        cache = self._make_cache()
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+
+        pac.set_context(
+            pac.PagedAttentionContext(
+                slot_mapping=[2],
+                block_tables=[[0]],
+                context_lens=[3],
+                cu_seqlens=[0, 1],
+                offsets=[2],
+            )
+        )
+
+        wrapper(mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16), mask=None, cache=None)
+
+        # block 0, position 2 should now hold the new latent
+        written = cache.latent_caches[0][0, 2, :]
+        untouched = cache.latent_caches[0][0, 0, :]
+
+        assert bool(mx.any(written != 0))
+        assert not bool(mx.any(untouched != 0))
+
+    def test_two_decode_requests_combined_output_shape(self) -> None:
+        # Two decode requests in one batch — outputs must be concatenated along seq axis.
+        inner = _MinimalMLAInner()
+        cache = self._make_cache()
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+
+        # Request A: 2 past tokens, decode token at slot 2 in block 0
+        # Request B: 1 past token,  decode token at slot 5 in block 1
+        pac.set_context(
+            pac.PagedAttentionContext(
+                slot_mapping=[2, 5],
+                block_tables=[[0], [1]],
+                context_lens=[3, 2],
+                cu_seqlens=[0, 1, 2],
+                offsets=[2, 1],
+            )
+        )
+
+        x = mx.random.normal((1, 2, _HIDDEN)).astype(mx.float16)
+        out = wrapper(x, mask=None, cache=None)
+        mx.eval(out)
+
+        assert out.shape == (1, 2, _HIDDEN)
+
+    def test_causal_mask_token0_output_independent_of_later_tokens(self) -> None:
+        # Token 0 in a prefill can only attend to itself (causal mask).
+        # Changing tokens 1-3 must not change token 0's output.
+        inner = _MinimalMLAInner()
+
+        # Run 1: prefill with input_a
+        cache_a = self._make_cache()
+        wrapper_a = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache_a)
+        pac.set_context(
+            pac.PagedAttentionContext(
+                slot_mapping=[0, 1, 2, 3],
+                block_tables=[[0]],
+                context_lens=[4],
+                cu_seqlens=[0, 4],
+                offsets=[0],
+            )
+        )
+        mx.random.seed(0)
+        token0 = mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16)
+        other = mx.random.normal((1, 3, _HIDDEN)).astype(mx.float16)
+        input_a = mx.concatenate([token0, other], axis=1)
+        out_a = wrapper_a(input_a, mask=None, cache=None)
+        mx.eval(out_a)
+
+        pac.clear_context()
+
+        # Run 2: same token 0, completely different tokens 1-3
+        cache_b = self._make_cache()
+        wrapper_b = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache_b)
+        pac.set_context(
+            pac.PagedAttentionContext(
+                slot_mapping=[0, 1, 2, 3],
+                block_tables=[[0]],
+                context_lens=[4],
+                cu_seqlens=[0, 4],
+                offsets=[0],
+            )
+        )
+        mx.random.seed(99)
+        different_other = mx.random.normal((1, 3, _HIDDEN)).astype(mx.float16)
+        input_b = mx.concatenate([token0, different_other], axis=1)
+        out_b = wrapper_b(input_b, mask=None, cache=None)
+        mx.eval(out_b)
+
+        # Token 0 output must be identical — it attends only to position 0
+        assert bool(mx.all(out_a[0, 0, :] == out_b[0, 0, :]))

--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -26,11 +26,10 @@ _LATENT_DIM = _KV_LORA_RANK + _QK_ROPE_HEAD_DIM
 
 
 class TestMLAPagedLatentCache:
-    def test_latent_dim_is_sum_of_lora_rank_and_rope_head_dim(self) -> None:
+    def test_latent_dim_stored_correctly(self) -> None:
         cache = MLAPagedLatentCache(
             num_layers=4,
-            kv_lora_rank=_KV_LORA_RANK,
-            qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+            latent_dim=_LATENT_DIM,
             num_blocks=10,
             block_size=16,
             dtype=mx.float16,
@@ -41,8 +40,7 @@ class TestMLAPagedLatentCache:
     def test_per_layer_array_shape(self) -> None:
         cache = MLAPagedLatentCache(
             num_layers=3,
-            kv_lora_rank=256,
-            qk_rope_head_dim=32,
+            latent_dim=288,
             num_blocks=8,
             block_size=16,
             dtype=mx.float16,
@@ -56,8 +54,7 @@ class TestMLAPagedLatentCache:
     def test_bfloat16_dtype_accepted(self) -> None:
         cache = MLAPagedLatentCache(
             num_layers=2,
-            kv_lora_rank=128,
-            qk_rope_head_dim=64,
+            latent_dim=192,
             num_blocks=4,
             block_size=8,
             dtype=mx.bfloat16,
@@ -69,8 +66,7 @@ class TestMLAPagedLatentCache:
         with pytest.raises(ValueError, match="Unsupported dtype"):
             MLAPagedLatentCache(
                 num_layers=2,
-                kv_lora_rank=_KV_LORA_RANK,
-                qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+                latent_dim=_LATENT_DIM,
                 num_blocks=5,
                 block_size=16,
                 dtype=mx.int32,
@@ -81,8 +77,7 @@ class TestMLAPagedAttentionBackend:
     def _make_backend(self) -> MLAPagedAttentionBackend:
         return MLAPagedAttentionBackend(
             num_layers=4,
-            kv_lora_rank=_KV_LORA_RANK,
-            qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+            latent_dim=_LATENT_DIM,
             block_size=16,
             dtype=mx.float16,
         )
@@ -153,8 +148,7 @@ class TestPatchModelAttentionMla:
     def _make_backend(self, num_layers: int) -> MLAPagedAttentionBackend:
         backend = MLAPagedAttentionBackend(
             num_layers=num_layers,
-            kv_lora_rank=_KV_LORA_RANK,
-            qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
+            latent_dim=_LATENT_DIM,
             block_size=16,
             dtype=mx.float16,
         )
@@ -274,8 +268,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
     def _make_cache(self) -> MLAPagedLatentCache:
         return MLAPagedLatentCache(
             num_layers=1,
-            kv_lora_rank=_KV_RANK,
-            qk_rope_head_dim=_ROPE_DIM,
+            latent_dim=_KV_RANK + _ROPE_DIM,
             num_blocks=4,
             block_size=4,
             dtype=mx.float16,

--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -129,7 +129,7 @@ class TestMLAPagedAttentionBackend:
 
 
 class _FakeAttn(nn.Module):
-    """Minimal stand-in for an MLA attention module."""
+    pass
 
 
 class _FakeLayer:

--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -16,7 +16,6 @@ from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
 from vllm_metal.paged_attention_backend.mla import (
     MLAPagedAttentionBackend,
     MLAPagedAttentionWrapper,
-    patch_model_attention_mla,
 )
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 
@@ -151,21 +150,21 @@ class _FakeModel:
 
 
 class TestPatchModelAttentionMla:
-    def _make_cache(self, num_layers: int) -> MLAPagedLatentCache:
-        return MLAPagedLatentCache(
+    def _make_backend(self, num_layers: int) -> MLAPagedAttentionBackend:
+        backend = MLAPagedAttentionBackend(
             num_layers=num_layers,
             kv_lora_rank=_KV_LORA_RANK,
             qk_rope_head_dim=_QK_ROPE_HEAD_DIM,
-            num_blocks=5,
             block_size=16,
             dtype=mx.float16,
         )
+        backend.initialize(5)
+        return backend
 
     def test_replaces_all_attention_layers(self) -> None:
         model = _FakeModel(num_layers=3)
-        cache = self._make_cache(num_layers=3)
 
-        n = patch_model_attention_mla(model, cache)
+        n = self._make_backend(num_layers=3).patch_model(model)
 
         assert n == 3
         for layer in model.model.layers:
@@ -173,30 +172,28 @@ class TestPatchModelAttentionMla:
 
     def test_wrapped_layer_has_correct_index(self) -> None:
         model = _FakeModel(num_layers=2)
-        cache = self._make_cache(num_layers=2)
 
-        patch_model_attention_mla(model, cache)
+        self._make_backend(num_layers=2).patch_model(model)
 
         for idx, layer in enumerate(model.model.layers):
             assert layer.self_attn._mla_layer_idx == idx
 
     def test_already_patched_layers_update_cache_reference(self) -> None:
         model = _FakeModel(num_layers=1)
-        cache_a = self._make_cache(num_layers=1)
-        cache_b = self._make_cache(num_layers=1)
-        patch_model_attention_mla(model, cache_a)
+        backend_a = self._make_backend(num_layers=1)
+        backend_b = self._make_backend(num_layers=1)
+        backend_a.patch_model(model)
 
-        n = patch_model_attention_mla(model, cache_b)
+        n = backend_b.patch_model(model)
 
         assert n == 1
-        assert model.model.layers[0].self_attn._mla_latent_cache is cache_b
+        assert model.model.layers[0].self_attn._mla_latent_cache is backend_b._cache
 
     def test_returns_correct_patch_count(self) -> None:
         for n_layers in (1, 4, 10):
             model = _FakeModel(num_layers=n_layers)
-            cache = self._make_cache(num_layers=n_layers)
 
-            count = patch_model_attention_mla(model, cache)
+            count = self._make_backend(num_layers=n_layers).patch_model(model)
 
             assert count == n_layers
 

--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -11,7 +11,6 @@ import mlx.nn as nn
 import pytest
 
 import vllm_metal.paged_attention_common as pac
-
 from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
 from vllm_metal.paged_attention_backend.mla import (
     MLAPagedAttentionBackend,
@@ -225,10 +224,10 @@ class TestMLAPagedAttentionWrapperFallback:
 
 _HIDDEN = 32
 _NUM_HEADS = 2
-_NOPE_DIM = 8   # qk_nope_head_dim
-_ROPE_DIM = 4   # qk_rope_head_dim
-_KV_RANK = 16   # kv_lora_rank
-_V_DIM = 8      # v_head_dim
+_NOPE_DIM = 8  # qk_nope_head_dim
+_ROPE_DIM = 4  # qk_rope_head_dim
+_KV_RANK = 16  # kv_lora_rank
+_V_DIM = 8  # v_head_dim
 
 
 class _MinimalMLAInner(nn.Module):
@@ -290,7 +289,9 @@ class TestMLAPagedAttentionWrapperPagedPath:
             )
         )
 
-        out = wrapper(mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16), mask=None, cache=None)
+        out = wrapper(
+            mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16), mask=None, cache=None
+        )
         mx.eval(out)
 
         assert out.shape == (1, 1, _HIDDEN)
@@ -311,7 +312,9 @@ class TestMLAPagedAttentionWrapperPagedPath:
             )
         )
 
-        out = wrapper(mx.random.normal((1, 4, _HIDDEN)).astype(mx.float16), mask=None, cache=None)
+        out = wrapper(
+            mx.random.normal((1, 4, _HIDDEN)).astype(mx.float16), mask=None, cache=None
+        )
         mx.eval(out)
 
         assert out.shape == (1, 4, _HIDDEN)
@@ -332,7 +335,9 @@ class TestMLAPagedAttentionWrapperPagedPath:
             )
         )
 
-        wrapper(mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16), mask=None, cache=None)
+        wrapper(
+            mx.random.normal((1, 1, _HIDDEN)).astype(mx.float16), mask=None, cache=None
+        )
 
         # block 0, position 2 should now hold the new latent
         written = cache.latent_caches[0][0, 2, :]

--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -232,9 +232,6 @@ class TestMLAPagedAttentionWrapperFallback:
         inner.assert_called_once_with(x, mask=mask, cache=cache)
 
 
-# ---------------------------------------------------------------------------
-# Paged path tests — small dims that exercise all shape paths without being slow
-# ---------------------------------------------------------------------------
 _HIDDEN = 32
 _NUM_HEADS = 2
 _NOPE_DIM = 8   # qk_nope_head_dim

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -58,8 +58,8 @@ class TestMetalPlatform:
         backend = MetalPlatform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg)
         assert backend == AttentionBackendEnum.CPU_ATTN.get_path()
 
-    def test_get_attn_backend_cls_rejects_mla(self) -> None:
-        """MLA is not supported on Metal/MLX."""
+    def test_get_attn_backend_cls_accepts_mla(self) -> None:
+        """MLA is handled by the vllm-metal model runner; CPU_ATTN is returned."""
         cfg = AttentionSelectorConfig(
             head_size=128,
             dtype=torch.float16,
@@ -67,8 +67,8 @@ class TestMetalPlatform:
             block_size=16,
             use_mla=True,
         )
-        with pytest.raises(NotImplementedError, match="MLA is not supported"):
-            MetalPlatform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg)
+        backend = MetalPlatform.get_attn_backend_cls(AttentionBackendEnum.CPU_ATTN, cfg)
+        assert backend == AttentionBackendEnum.CPU_ATTN.get_path()
 
     def test_get_attn_backend_cls_rejects_sparse(self) -> None:
         """Sparse attention is not supported on Metal/MLX."""

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -146,6 +146,7 @@ class TestResolveModelDims:
         r._resolve_model_dims()
         assert r.num_kv_heads == 1
         assert r.head_dim == 576  # 512 + 64
+        assert r.mla_latent_dim == 576
 
     def test_mla_default_rope_head_dim(self) -> None:
         r = self._make_runner(
@@ -158,6 +159,20 @@ class TestResolveModelDims:
         )
         r._resolve_model_dims()
         assert r.head_dim == 320  # 256 + default 64
+        assert r.mla_latent_dim == 320  # default qk_rope_head_dim applied
+
+    def test_mla_latent_dim_does_not_require_resolve_model_dims(self) -> None:
+        r = self._make_runner(
+            {
+                "num_hidden_layers": 4,
+                "num_attention_heads": 8,
+                "hidden_size": 512,
+                "kv_lora_rank": 512,
+                "qk_rope_head_dim": 64,
+            }
+        )
+
+        assert r.mla_latent_dim == 576
 
     def test_missing_dims_raise(self) -> None:
         r = self._make_runner({"num_hidden_layers": 32})

--- a/vllm_metal/mlx_backend/__init__.py
+++ b/vllm_metal/mlx_backend/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/vllm_metal/mlx_backend/mla_cache.py
+++ b/vllm_metal/mlx_backend/mla_cache.py
@@ -11,8 +11,7 @@ class MLAPagedLatentCache:
       - kv_norm = kv_a_layernorm(compressed_kv) — the normalised KV latent
       - k_pe    = rope(k_pe_raw)                — RoPE-encoded position key
 
-    Layout per layer: [num_blocks, block_size, latent_dim]
-    where latent_dim = kv_lora_rank + qk_rope_head_dim.
+    Layout per layer: [num_blocks, block_size, latent_dim].
 
     Block allocation is managed externally by the scheduler's KV cache manager.
     """
@@ -20,8 +19,7 @@ class MLAPagedLatentCache:
     def __init__(
         self,
         num_layers: int,
-        kv_lora_rank: int,
-        qk_rope_head_dim: int,
+        latent_dim: int,
         num_blocks: int,
         block_size: int,
         dtype: mx.Dtype = mx.float16,
@@ -30,16 +28,13 @@ class MLAPagedLatentCache:
             raise ValueError(f"Unsupported dtype for MLA paged cache: {dtype}")
 
         self.num_layers = num_layers
-        self.kv_lora_rank = kv_lora_rank
-        self.qk_rope_head_dim = qk_rope_head_dim
-        self.latent_dim = kv_lora_rank + qk_rope_head_dim
+        self.latent_dim = latent_dim
         self.num_blocks = num_blocks
         self.block_size = block_size
         self.dtype = dtype
 
-        # Per-layer latent caches: [num_blocks, block_size, latent_dim]
         self.latent_caches: list[mx.array] = [
-            mx.zeros((num_blocks, block_size, self.latent_dim), dtype=dtype)
+            mx.zeros((num_blocks, block_size, latent_dim), dtype=dtype)
             for _ in range(num_layers)
         ]
         # Force allocation so Metal buffers exist before use

--- a/vllm_metal/mlx_backend/mla_cache.py
+++ b/vllm_metal/mlx_backend/mla_cache.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import mlx.core as mx
+
+
+class MLAPagedLatentCache:
+    """Per-layer MLX arrays for MLA paged attention.
+
+    Each token's cache entry is a combined latent vector [kv_norm || k_pe]:
+      - kv_norm = kv_a_layernorm(compressed_kv) — the normalised KV latent
+      - k_pe    = rope(k_pe_raw)                — RoPE-encoded position key
+
+    Layout per layer: [num_blocks, block_size, latent_dim]
+    where latent_dim = kv_lora_rank + qk_rope_head_dim.
+
+    Block allocation is managed externally by the scheduler's KV cache manager.
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        kv_lora_rank: int,
+        qk_rope_head_dim: int,
+        num_blocks: int,
+        block_size: int,
+        dtype: mx.Dtype = mx.float16,
+    ) -> None:
+        if dtype not in (mx.float16, mx.bfloat16, mx.float32):
+            raise ValueError(f"Unsupported dtype for MLA paged cache: {dtype}")
+
+        self.num_layers = num_layers
+        self.kv_lora_rank = kv_lora_rank
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.latent_dim = kv_lora_rank + qk_rope_head_dim
+        self.num_blocks = num_blocks
+        self.block_size = block_size
+        self.dtype = dtype
+
+        # Per-layer latent caches: [num_blocks, block_size, latent_dim]
+        self.latent_caches: list[mx.array] = [
+            mx.zeros((num_blocks, block_size, self.latent_dim), dtype=dtype)
+            for _ in range(num_layers)
+        ]
+        # Force allocation so Metal buffers exist before use
+        mx.eval(*self.latent_caches)

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import scaled_dot_product_attention
+from vllm.logger import init_logger
+
+from vllm_metal.metal_kernel_backend.packed_prefill_compat import apply_packed_rope
+from vllm_metal.paged_attention_common import find_layers_and_attr, get_context
+
+if TYPE_CHECKING:
+    from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
+
+logger = init_logger(__name__)
+
+
+class MLAPagedAttentionWrapper(nn.Module):
+    """Wraps an MLA attention module to use a paged latent cache.
+
+    MLA (GLM/DeepSeek lineage) compresses KV into a latent before caching:
+
+        latent = [kv_norm || k_pe_roped]  # kv_lora_rank + qk_rope_head_dim dims
+
+    Each call scatter-writes the new tokens' latents into the scheduled cache
+    slots, then gather-reads all past latents per request via block tables.
+
+    At decode time the original model absorbs embed_q into q_nope (projects it
+    into kv_lora_rank space) and sets k=v=kv_norm shared across all heads.
+    This wrapper uses the same formulation for prefill too — the decode and
+    prefill attention scores are identical by linearity of embed_q. After the
+    attention output, unembed_out maps back to v_head_dim.
+
+    When no PagedAttentionContext is active the original module is called as-is.
+    """
+
+    def __init__(
+        self,
+        inner: nn.Module,
+        layer_idx: int,
+        latent_cache: MLAPagedLatentCache,
+    ) -> None:
+        super().__init__()
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_mla_layer_idx", layer_idx)
+        object.__setattr__(self, "_mla_latent_cache", latent_cache)
+
+    def __call__(self, x: mx.array, mask: Any = None, cache: Any = None) -> mx.array:
+        ctx = get_context()
+        if ctx is None:
+            return self._inner(x, mask=mask, cache=cache)
+        if not ctx.block_tables:
+            raise RuntimeError(
+                "MLAPagedAttentionWrapper called with empty block_tables"
+            )
+
+        inner = self._inner
+        layer_idx: int = self._mla_layer_idx
+        latent_cache: MLAPagedLatentCache = self._mla_latent_cache
+
+        _, seq_len, _ = x.shape  # B=1, seq_len = total new tokens across all requests
+
+        # Query path — q_lora_rank is None for models without query compression
+        if inner.q_lora_rank is None:
+            q = inner.q_proj(x)
+        else:
+            q = inner.q_b_proj(inner.q_a_layernorm(inner.q_a_proj(x)))
+        q = q.reshape(1, seq_len, inner.num_heads, inner.q_head_dim).transpose(
+            0, 2, 1, 3
+        )
+        q_nope, q_pe = mx.split(q, [inner.qk_nope_head_dim], axis=-1)
+
+        # KV path — kv_a_proj produces both the lora latent and the rope key in one shot
+        kv_out = inner.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe_raw = mx.split(kv_out, [inner.kv_lora_rank], axis=-1)
+        kv_norm = inner.kv_a_layernorm(compressed_kv)  # what ends up in the cache
+        k_pe = k_pe_raw.reshape(1, seq_len, 1, inner.qk_rope_head_dim).transpose(
+            0, 2, 1, 3
+        )
+
+        # RoPE is applied per request segment so each request starts at its own position
+        q_pe, k_pe = apply_packed_rope(
+            inner,
+            q_pe,
+            k_pe,
+            ctx.cu_seqlens,
+            offsets=ctx.offsets if ctx.offsets else None,
+        )
+
+        # Concatenate kv_norm and the roped k_pe into a single per-token latent,
+        # then scatter-write it into the cache at the scheduler-assigned slots.
+        # MLX arrays are functional, so the indexed update returns a new array
+        # that we explicitly reassign back into the cache list.
+        k_pe_seq = k_pe.transpose(0, 2, 1, 3).reshape(
+            1, seq_len, inner.qk_rope_head_dim
+        )
+        latent_new = mx.concatenate([kv_norm, k_pe_seq], axis=-1)
+        latent_flat = latent_new.reshape(seq_len, latent_cache.latent_dim).astype(
+            latent_cache.dtype
+        )
+
+        flat = latent_cache.latent_caches[layer_idx].reshape(
+            -1, latent_cache.latent_dim
+        )
+        flat[mx.array(ctx.slot_mapping, dtype=mx.uint32)] = latent_flat
+        latent_cache.latent_caches[layer_idx] = flat.reshape(
+            latent_cache.num_blocks, latent_cache.block_size, latent_cache.latent_dim
+        )
+        outputs = []
+        for req_idx, (block_ids, ctx_len) in enumerate(
+            zip(ctx.block_tables, ctx.context_lens, strict=True)
+        ):
+            req_start = ctx.cu_seqlens[req_idx]
+            req_end = ctx.cu_seqlens[req_idx + 1]
+            num_new = req_end - req_start
+            past_len = ctx_len - num_new  # tokens cached before this step
+
+            # Gather this request's full context from the paged cache.
+            # Block indexing: each block holds block_size contiguous token slots.
+            n_blocks = math.ceil(ctx_len / latent_cache.block_size)
+            blocks = mx.array(block_ids[:n_blocks], dtype=mx.uint32)
+            all_latent = latent_cache.latent_caches[layer_idx][blocks].reshape(
+                -1, latent_cache.latent_dim
+            )[:ctx_len]
+
+            all_kv_norm = all_latent[:, : inner.kv_lora_rank]
+            all_k_pe = all_latent[:, inner.kv_lora_rank :]
+
+            rq_nope = q_nope[:, :, req_start:req_end, :]
+            rq_pe = q_pe[:, :, req_start:req_end, :]
+
+            # PE branch: q_pe · k_pe contributes an additive score bias.
+            # Passing this as the `mask` to scaled_dot_product_attention adds it
+            # to the nope scores before softmax, matching the original model exactly.
+            k_pe_r = all_k_pe.reshape(1, 1, ctx_len, inner.qk_rope_head_dim)
+            pe_scores = (rq_pe * inner.scale) @ k_pe_r.swapaxes(-1, -2)
+
+            # Causal mask for prefill: new token i can attend to positions 0..past_len+i.
+            # Decode (num_new==1) needs no mask — the single token attends everywhere.
+            if num_new > 1:
+                rows = mx.arange(num_new).reshape(-1, 1)
+                cols = mx.arange(ctx_len).reshape(1, -1)
+                valid = (cols <= (past_len + rows)).reshape(1, 1, num_new, ctx_len)
+                fill = mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype)
+                pe_scores = mx.where(valid, pe_scores, fill)
+
+            # Nope branch: embed_q absorbs q_nope into kv_lora_rank space;
+            # kv_norm is shared across heads as k=v (single-head broadcast).
+            rq_nope_proj = inner.embed_q(rq_nope)
+            kv = all_kv_norm.reshape(1, 1, ctx_len, inner.kv_lora_rank)
+
+            out = scaled_dot_product_attention(
+                rq_nope_proj, kv, kv, cache=None, scale=inner.scale, mask=pe_scores
+            )
+            out = inner.unembed_out(out)  # recover v_head_dim from kv_lora_rank
+            out = out.transpose(0, 2, 1, 3).reshape(1, num_new, -1)
+            outputs.append(out)
+
+        final = mx.concatenate(outputs, axis=1) if len(outputs) > 1 else outputs[0]
+        return inner.o_proj(final)
+
+
+class MLAPagedAttentionBackend:
+    """Paged attention backend for MLA models (GLM/DeepSeek lineage).
+
+    Implements the PagedAttentionBackend protocol. Uses MLX-native
+    scatter/gather (no vendored C++/Metal kernel) because MLA latents
+    do not fit the standard (num_heads, head_dim) kernel layout.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_layers: int,
+        kv_lora_rank: int,
+        qk_rope_head_dim: int,
+        block_size: int,
+        dtype: mx.Dtype,
+    ) -> None:
+        self._num_layers = num_layers
+        self._kv_lora_rank = kv_lora_rank
+        self._qk_rope_head_dim = qk_rope_head_dim
+        self._block_size = block_size
+        self._dtype = dtype
+        self._cache: MLAPagedLatentCache | None = None
+
+    def _require_initialized(self, caller: str) -> MLAPagedLatentCache:
+        if self._cache is None:
+            raise RuntimeError(f"{caller}() called before initialize()")
+        return self._cache
+
+    def initialize(self, num_blocks: int) -> None:
+        from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
+
+        self._cache = MLAPagedLatentCache(
+            num_layers=self._num_layers,
+            kv_lora_rank=self._kv_lora_rank,
+            qk_rope_head_dim=self._qk_rope_head_dim,
+            num_blocks=num_blocks,
+            block_size=self._block_size,
+            dtype=self._dtype,
+        )
+
+    def patch_model(self, model: Any) -> int:
+        cache = self._require_initialized("patch_model")
+        return patch_model_attention_mla(model, cache)
+
+    def warm_up(self) -> None:
+        # MLX ops JIT-compile on first use; no Metal shader warm-up needed.
+        self._require_initialized("warm_up")
+        logger.info("MLA paged attention (MLX-native): skipping Metal kernel warm-up")
+
+    def num_blocks(self) -> int:
+        return self._require_initialized("num_blocks").num_blocks
+
+
+def patch_model_attention_mla(
+    model: Any,
+    latent_cache: MLAPagedLatentCache,
+) -> int:
+    """Walk model layers and replace each attention module with MLAPagedAttentionWrapper.
+
+    Mirrors patch_model_attention_metal_kernel from the MHA backend — separating
+    the layer-walk logic from the backend lifecycle keeps each concern independently
+    testable and lets the worker call patch_model without knowing the walk details.
+
+    Returns the number of patched layers.
+    """
+    layer_list, attn_attr = find_layers_and_attr(model)
+    patched = 0
+
+    for layer_idx, layer in enumerate(layer_list):
+        attn = getattr(layer, attn_attr)
+        if isinstance(attn, MLAPagedAttentionWrapper):
+            # Already patched — refresh cache reference (e.g. after re-initialisation)
+            object.__setattr__(attn, "_mla_latent_cache", latent_cache)
+            patched += 1
+            continue
+
+        setattr(
+            layer, attn_attr, MLAPagedAttentionWrapper(attn, layer_idx, latent_cache)
+        )
+        patched += 1
+
+    return patched

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -203,7 +203,26 @@ class MLAPagedAttentionBackend:
 
     def patch_model(self, model: Any) -> int:
         cache = self._require_initialized("patch_model")
-        return patch_model_attention_mla(model, cache)
+        return self._patch_model(model, cache)
+
+    def _patch_model(self, model: Any, latent_cache: MLAPagedLatentCache) -> int:
+        layer_list, attn_attr = find_layers_and_attr(model)
+        patched = 0
+
+        for layer_idx, layer in enumerate(layer_list):
+            attn = getattr(layer, attn_attr)
+            if isinstance(attn, MLAPagedAttentionWrapper):
+                # Already patched — refresh cache reference (e.g. after re-initialisation)
+                object.__setattr__(attn, "_mla_latent_cache", latent_cache)
+                patched += 1
+                continue
+
+            setattr(
+                layer, attn_attr, MLAPagedAttentionWrapper(attn, layer_idx, latent_cache)
+            )
+            patched += 1
+
+        return patched
 
     def warm_up(self) -> None:
         # MLX ops JIT-compile on first use; no Metal shader warm-up needed.
@@ -212,34 +231,3 @@ class MLAPagedAttentionBackend:
 
     def num_blocks(self) -> int:
         return self._require_initialized("num_blocks").num_blocks
-
-
-def patch_model_attention_mla(
-    model: Any,
-    latent_cache: MLAPagedLatentCache,
-) -> int:
-    """Walk model layers and replace each attention module with MLAPagedAttentionWrapper.
-
-    Mirrors patch_model_attention_metal_kernel from the MHA backend — separating
-    the layer-walk logic from the backend lifecycle keeps each concern independently
-    testable and lets the worker call patch_model without knowing the walk details.
-
-    Returns the number of patched layers.
-    """
-    layer_list, attn_attr = find_layers_and_attr(model)
-    patched = 0
-
-    for layer_idx, layer in enumerate(layer_list):
-        attn = getattr(layer, attn_attr)
-        if isinstance(attn, MLAPagedAttentionWrapper):
-            # Already patched — refresh cache reference (e.g. after re-initialisation)
-            object.__setattr__(attn, "_mla_latent_cache", latent_cache)
-            patched += 1
-            continue
-
-        setattr(
-            layer, attn_attr, MLAPagedAttentionWrapper(attn, layer_idx, latent_cache)
-        )
-        patched += 1
-
-    return patched

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -174,14 +174,12 @@ class MLAPagedAttentionBackend:
         self,
         *,
         num_layers: int,
-        kv_lora_rank: int,
-        qk_rope_head_dim: int,
+        latent_dim: int,
         block_size: int,
         dtype: mx.Dtype,
     ) -> None:
         self._num_layers = num_layers
-        self._kv_lora_rank = kv_lora_rank
-        self._qk_rope_head_dim = qk_rope_head_dim
+        self._latent_dim = latent_dim
         self._block_size = block_size
         self._dtype = dtype
         self._cache: MLAPagedLatentCache | None = None
@@ -194,8 +192,7 @@ class MLAPagedAttentionBackend:
     def initialize(self, num_blocks: int) -> None:
         self._cache = MLAPagedLatentCache(
             num_layers=self._num_layers,
-            kv_lora_rank=self._kv_lora_rank,
-            qk_rope_head_dim=self._qk_rope_head_dim,
+            latent_dim=self._latent_dim,
             num_blocks=num_blocks,
             block_size=self._block_size,
             dtype=self._dtype,

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -85,7 +85,7 @@ class MLAPagedAttentionWrapper(nn.Module):
             q_pe,
             k_pe,
             ctx.cu_seqlens,
-            offsets=ctx.offsets if ctx.offsets else None,
+            offsets=ctx.offsets or None,
         )
 
         # Concatenate kv_norm and the roped k_pe into a single per-token latent,
@@ -103,15 +103,16 @@ class MLAPagedAttentionWrapper(nn.Module):
         flat = latent_cache.latent_caches[layer_idx].reshape(
             -1, latent_cache.latent_dim
         )
-        flat[mx.array(ctx.slot_mapping, dtype=mx.uint32)] = latent_flat
+        flat[mx.array(ctx.slot_mapping, dtype=mx.int64)] = latent_flat
         latent_cache.latent_caches[layer_idx] = flat.reshape(
             latent_cache.num_blocks, latent_cache.block_size, latent_cache.latent_dim
         )
 
+        # Pre-convert block tables once to avoid a new mx.array allocation per request
+        block_tables_mx = [mx.array(bt, dtype=mx.int32) for bt in ctx.block_tables]
+
         outputs = []
-        for req_idx, (block_ids, ctx_len) in enumerate(
-            zip(ctx.block_tables, ctx.context_lens, strict=True)
-        ):
+        for req_idx, ctx_len in enumerate(ctx.context_lens):
             req_start = ctx.cu_seqlens[req_idx]
             req_end = ctx.cu_seqlens[req_idx + 1]
             num_new = req_end - req_start
@@ -120,7 +121,7 @@ class MLAPagedAttentionWrapper(nn.Module):
             # Gather this request's full context from the paged cache.
             # Block indexing: each block holds block_size contiguous token slots.
             n_blocks = math.ceil(ctx_len / latent_cache.block_size)
-            blocks = mx.array(block_ids[:n_blocks], dtype=mx.uint32)
+            blocks = block_tables_mx[req_idx][:n_blocks]
             all_latent = latent_cache.latent_caches[layer_idx][blocks].reshape(
                 -1, latent_cache.latent_dim
             )[:ctx_len]

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -15,6 +15,10 @@ from vllm_metal.paged_attention_common import find_attn_attr, find_layers, get_c
 
 logger = init_logger(__name__)
 
+# Default rope head dim for GLM/DeepSeek-V2 lineage models.
+# Used as fallback when qk_rope_head_dim is absent from model config.
+MLA_DEFAULT_QK_ROPE_HEAD_DIM = 64
+
 
 class MLAPagedAttentionWrapper(nn.Module):
     """Wraps an MLA attention module to use a paged latent cache.
@@ -219,7 +223,9 @@ class MLAPagedAttentionBackend:
                 continue
 
             setattr(
-                layer, attn_attr, MLAPagedAttentionWrapper(attn, layer_idx, latent_cache)
+                layer,
+                attn_attr,
+                MLAPagedAttentionWrapper(attn, layer_idx, latent_cache),
             )
             patched += 1
 

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -10,10 +10,8 @@ from mlx_lm.models.base import scaled_dot_product_attention
 from vllm.logger import init_logger
 
 from vllm_metal.metal_kernel_backend.packed_prefill_compat import apply_packed_rope
+from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
 from vllm_metal.paged_attention_common import find_layers_and_attr, get_context
-
-if TYPE_CHECKING:
-    from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
 
 logger = init_logger(__name__)
 
@@ -109,6 +107,7 @@ class MLAPagedAttentionWrapper(nn.Module):
         latent_cache.latent_caches[layer_idx] = flat.reshape(
             latent_cache.num_blocks, latent_cache.block_size, latent_cache.latent_dim
         )
+
         outputs = []
         for req_idx, (block_ids, ctx_len) in enumerate(
             zip(ctx.block_tables, ctx.context_lens, strict=True)
@@ -193,8 +192,6 @@ class MLAPagedAttentionBackend:
         return self._cache
 
     def initialize(self, num_blocks: int) -> None:
-        from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
-
         self._cache = MLAPagedLatentCache(
             num_layers=self._num_layers,
             kv_lora_rank=self._kv_lora_rank,

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -11,7 +11,7 @@ from vllm.logger import init_logger
 
 from vllm_metal.metal_kernel_backend.packed_prefill_compat import apply_packed_rope
 from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
-from vllm_metal.paged_attention_common import find_layers_and_attr, get_context
+from vllm_metal.paged_attention_common import find_attn_attr, find_layers, get_context
 
 logger = init_logger(__name__)
 
@@ -206,10 +206,13 @@ class MLAPagedAttentionBackend:
         return self._patch_model(model, cache)
 
     def _patch_model(self, model: Any, latent_cache: MLAPagedLatentCache) -> int:
-        layer_list, attn_attr = find_layers_and_attr(model)
         patched = 0
 
-        for layer_idx, layer in enumerate(layer_list):
+        for layer_idx, layer in enumerate(find_layers(model)):
+            attn_attr = find_attn_attr(layer)
+            if attn_attr is None:
+                continue
+
             attn = getattr(layer, attn_attr)
             if isinstance(attn, MLAPagedAttentionWrapper):
                 # Already patched — refresh cache reference (e.g. after re-initialisation)

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -284,7 +284,11 @@ class MetalPlatform(Platform):
         if selected_backend and selected_backend != AttentionBackendEnum.CPU_ATTN:
             logger.info(f"Cannot use {selected_backend} backend on Metal/MLX.")
         if attn_selector_config.use_mla:
-            raise NotImplementedError("MLA is not supported on Metal/MLX.")
+            # MLA attention is handled by the vllm-metal model runner (MLAPagedAttentionWrapper),
+            # not by vLLM's attention backend selector. Continue to return CPU_ATTN below.
+            logger.info(
+                "MLA model detected; attention handled by vllm-metal model runner"
+            )
         if attn_selector_config.use_sparse:
             raise NotImplementedError("Sparse Attention is not supported on Metal/MLX.")
         return AttentionBackendEnum.CPU_ATTN.get_path()

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -682,6 +682,19 @@ class MetalModelRunner:
         """
         return "kv_lora_rank" in self.model_args
 
+    @property
+    def mla_latent_dim(self) -> int:
+        """Combined latent dimension for MLA cache: kv_lora_rank + qk_rope_head_dim.
+
+        Only valid when is_mla is True. Derived directly from model_args so
+        callers do not depend on the _resolve_model_dims head_dim override.
+        """
+        if not self.is_mla:
+            raise AttributeError("mla_latent_dim is only valid for MLA models")
+        return int(self.model_args["kv_lora_rank"]) + int(
+            self.model_args.get("qk_rope_head_dim", _MLA_DEFAULT_QK_ROPE_HEAD_DIM)
+        )
+
     def should_setup_paged_attention(self) -> bool:
         """Whether worker-side paged-attention setup should run.
 
@@ -908,8 +921,8 @@ class MetalModelRunner:
 
         # MLA (GLM/DeepSeek lineage): cache stores a joint latent vector per
         # layer, not per-head K/V. One virtual head sized kv_lora_rank +
-        # qk_rope_head_dim keeps get_cache_block_size_bytes() correct without
-        # MLA-specific logic in the sizing path.
+        # qk_rope_head_dim keeps get_cache_block_size_bytes() conservative (2x)
+        # without MLA-specific logic in the sizing path. See todo item 3.
         if self.is_mla:
             self.num_kv_heads = 1
             self.head_dim = int(args["kv_lora_rank"]) + int(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -47,6 +47,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.config import get_config
+from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.paged_attention_common import (
     OffsetCache,
@@ -73,9 +74,6 @@ _model_cache_lock = Lock()
 _MIN_BATCH_SIZE_FOR_BATCHING = 2  # Minimum requests to use BatchKVCache
 _MAX_BATCH_SIZE = 64  # Maximum batch size for decode
 
-# MLA default rope head dim (GLM/DeepSeek lineage; used when qk_rope_head_dim
-# is absent from model config).
-_MLA_DEFAULT_QK_ROPE_HEAD_DIM = 64
 
 # Performance tuning
 _CACHE_CLEAR_INTERVAL = 50  # Clear cache every N finished requests
@@ -692,7 +690,7 @@ class MetalModelRunner:
         if not self.is_mla:
             raise AttributeError("mla_latent_dim is only valid for MLA models")
         return int(self.model_args["kv_lora_rank"]) + int(
-            self.model_args.get("qk_rope_head_dim", _MLA_DEFAULT_QK_ROPE_HEAD_DIM)
+            self.model_args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
         )
 
     def should_setup_paged_attention(self) -> bool:
@@ -926,7 +924,7 @@ class MetalModelRunner:
         if self.is_mla:
             self.num_kv_heads = 1
             self.head_dim = int(args["kv_lora_rank"]) + int(
-                args.get("qk_rope_head_dim", _MLA_DEFAULT_QK_ROPE_HEAD_DIM)
+                args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
             )
 
     def _extract_logits(self, model_output: Any) -> mx.array:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -922,7 +922,7 @@ class MetalModelRunner:
         # MLA (GLM/DeepSeek lineage): cache stores a joint latent vector per
         # layer, not per-head K/V. One virtual head sized kv_lora_rank +
         # qk_rope_head_dim keeps get_cache_block_size_bytes() conservative (2x)
-        # without MLA-specific logic in the sizing path. See todo item 3.
+        # without MLA-specific logic in the sizing path.
         if self.is_mla:
             self.num_kv_heads = 1
             self.head_dim = int(args["kv_lora_rank"]) + int(

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -284,7 +284,7 @@ class MetalWorker(WorkerBase):
                 n_patched,
                 num_blocks,
                 block_size,
-                latent_dim,
+                runner.mla_latent_dim,
             )
         else:
             logger.info(

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -260,24 +260,47 @@ class MetalWorker(WorkerBase):
         if runner.kv_cache_dtype is None:
             raise RuntimeError("KV cache dtype not initialized; runner.load_model()")
 
-        backend = MHAPagedAttentionBackend(
-            num_layers=runner.num_layers,
-            num_kv_heads=runner.num_kv_heads,
-            head_dim=runner.head_dim,
-            block_size=block_size,
-            dtype=runner.kv_cache_dtype,
-        )
+        if runner.is_mla:
+            from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
+
+            kv_lora_rank = int(runner.model_args["kv_lora_rank"])
+            latent_dim = runner.mla_latent_dim  # kv_lora_rank + qk_rope_head_dim
+            backend = MLAPagedAttentionBackend(
+                num_layers=runner.num_layers,
+                kv_lora_rank=kv_lora_rank,
+                qk_rope_head_dim=latent_dim - kv_lora_rank,
+                block_size=block_size,
+                dtype=runner.kv_cache_dtype,
+            )
+        else:
+            backend = MHAPagedAttentionBackend(
+                num_layers=runner.num_layers,
+                num_kv_heads=runner.num_kv_heads,
+                head_dim=runner.head_dim,
+                block_size=block_size,
+                dtype=runner.kv_cache_dtype,
+            )
         backend.initialize(num_blocks)
         n_patched = backend.patch_model(runner.model)
-        logger.info(
-            "Metal kernel paged attention enabled: %d layers patched, "
-            "%d blocks allocated (block_size=%d, kv_heads=%d, head_dim=%d)",
-            n_patched,
-            num_blocks,
-            block_size,
-            runner.num_kv_heads,
-            runner.head_dim,
-        )
+        if runner.is_mla:
+            logger.info(
+                "MLA paged attention enabled: %d layers patched, "
+                "%d blocks allocated (block_size=%d, latent_dim=%d)",
+                n_patched,
+                num_blocks,
+                block_size,
+                latent_dim,
+            )
+        else:
+            logger.info(
+                "Metal kernel paged attention enabled: %d layers patched, "
+                "%d blocks allocated (block_size=%d, kv_heads=%d, head_dim=%d)",
+                n_patched,
+                num_blocks,
+                block_size,
+                runner.num_kv_heads,
+                runner.head_dim,
+            )
 
         runner._paged_attention_backend = backend
         runner._paged_block_size = block_size

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -261,12 +261,9 @@ class MetalWorker(WorkerBase):
             raise RuntimeError("KV cache dtype not initialized; runner.load_model()")
 
         if runner.is_mla:
-            kv_lora_rank = int(runner.model_args["kv_lora_rank"])
-            latent_dim = runner.mla_latent_dim  # kv_lora_rank + qk_rope_head_dim
             backend = MLAPagedAttentionBackend(
                 num_layers=runner.num_layers,
-                kv_lora_rank=kv_lora_rank,
-                qk_rope_head_dim=latent_dim - kv_lora_rank,
+                latent_dim=runner.mla_latent_dim,
                 block_size=block_size,
                 dtype=runner.kv_cache_dtype,
             )

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -27,6 +27,8 @@ from vllm_metal.config import (
     PAGED_ATTENTION_OVERHEAD_BYTES,
     get_config,
 )
+from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
+from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.stt.config import STT_SCHED_AVAILABLE_BYTES
 from vllm_metal.utils import set_wired_limit
@@ -169,8 +171,6 @@ class MetalWorker(WorkerBase):
         a configurable memory fraction, rather than blindly scaling from
         max_model_len.
         """
-        from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
-
         runner = self.model_runner
         block_size = self.metal_config.block_size
 
@@ -261,8 +261,6 @@ class MetalWorker(WorkerBase):
             raise RuntimeError("KV cache dtype not initialized; runner.load_model()")
 
         if runner.is_mla:
-            from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
-
             kv_lora_rank = int(runner.model_args["kv_lora_rank"])
             latent_dim = runner.mla_latent_dim  # kv_lora_rank + qk_rope_head_dim
             backend = MLAPagedAttentionBackend(


### PR DESCRIPTION
This PR is:
- To add MLAPagedAttentionBackend and MLAPagedAttentionWrapper implementing the PagedAttentionBackend protocol from #203, using MLX-native scatter/gather in place of the vendored Metal kernel
- To add MLAPagedLatentCache storing a joint [kv_norm || k_pe_roped] latent per token per layer
- To wire MLA backend dispatch in the worker and add mla_latent_dim to avoid depending on the _resolve_model_dims head_dim override
- To drop the NotImplementedError("MLA is not supported") gate, letting MLA models load on Metal/MLX
- To move MLA_DEFAULT_QK_ROPE_HEAD_DIM into mla.py as committed in #203 review

Context:

GLM/DeepSeek models use Multi-head Latent Attention (MLA). Unlike standard transformers that cache separate K and V tensors per head, MLA compresses all KV information into a single low-rank latent vector per token. The existing Metal paged attention kernel expects per-head K/V arrays and cannot be used. This backend stores the compressed latent in an MLX-native paged cache and computes attention by splitting the latent back into its positional (RoPE) and content (no-positional-encoding, nope) components at query time.

Smoke test:

```bash
VLLM_HOST_IP=127.0.0.1 \
VLLM_METAL_USE_PAGED_ATTENTION=1 \
vllm serve mlx-community/GLM-4.7-Flash-4bit --max-model-len 512
```

```bash
curl -s http://localhost:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{"model":"mlx-community/GLM-4.7-Flash-4bit","messages":[{"role":"user","content":"What is MLA?"}],"max_tokens":64}' | jq -r '.choices[0].message.content'
```

Confirm in server logs: `MLA paged attention enabled`

Note:

`get_cache_block_size_bytes()` currently reports ~2x conservative capacity for MLA models due to the virtual-head override (`num_kv_heads=1`, `head_dim=latent_dim`) going through the standard 2 * K+V sizing path. This is safe but wastes capacity, tracked for follow-up.
