### PR TITLE
[Memory] Cap MLX buffer cache via measured warm-up overhead (#234)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     permissions:
       contents: read
     strategy:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,7 +18,7 @@ run_smoke_test() {
   GLOO_SOCKET_IFNAME=lo0 \
     VLLM_METAL_USE_PAGED_ATTENTION=1 \
     VLLM_METAL_MEMORY_FRACTION=0.8 \
-    vllm serve "$model" --revision "$revision" --max-model-len 512 --port "$port" ${extra_args[@]+"${extra_args[@]}"} &
+    vllm serve "$model" --revision "$revision" --max-model-len 512 --max-num-batched-tokens 64 --port "$port" ${extra_args[@]+"${extra_args[@]}"} &
 
   local vllm_pid=$!
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,26 +4,27 @@
 #
 # Usage: run_smoke_test <model> <revision> <prompt> <expected> [extra_serve_args...]
 run_smoke_test() {
-  local model="$1"
-  local revision="$2"
-  local prompt="$3"
-  local expected="$4"
-  shift 4
+  local port="$1"
+  local model="$2"
+  local revision="$3"
+  local prompt="$4"
+  local expected="$5"
+  shift 5
   local extra_args=("$@")
 
-  section "Smoke test: $model"
+  section "Smoke test: $model (port $port)"
 
-  # 1. Start vLLM with paged attention
+  # 1. Start vLLM with paged attention on a dedicated port
   GLOO_SOCKET_IFNAME=lo0 \
     VLLM_METAL_USE_PAGED_ATTENTION=1 \
     VLLM_METAL_MEMORY_FRACTION=0.8 \
-    vllm serve "$model" --revision "$revision" --max-model-len 512 ${extra_args[@]+"${extra_args[@]}"} &
+    vllm serve "$model" --revision "$revision" --max-model-len 512 --port "$port" ${extra_args[@]+"${extra_args[@]}"} &
 
   local vllm_pid=$!
 
   # 2. Wait for the server to be ready
   echo "Waiting for vLLM to start..."
-  local health_url="http://localhost:8000/health"
+  local health_url="http://localhost:${port}/health"
   if ! curl --retry 30 --retry-delay 10 --retry-all-errors -s "$health_url" > /dev/null; then
     echo "vLLM failed to start."
     kill $vllm_pid
@@ -35,7 +36,7 @@ run_smoke_test() {
   # 3. Test completions endpoint with golden comparison
   echo "Testing completions with golden output..."
   local response
-  response=$(curl -s -X POST "http://localhost:8000/v1/completions" \
+  response=$(curl -s -X POST "http://localhost:${port}/v1/completions" \
     -H "Content-Type: application/json" \
     -d "{
       \"model\": \"$model\",
@@ -69,7 +70,7 @@ run_smoke_test() {
 
 smoke_tests() {
   # Qwen3-0.6B: standard GQA paged attention path
-  run_smoke_test \
+  run_smoke_test 8100 \
     "Qwen/Qwen3-0.6B" \
     "c1899de289a04d12100db370d81485cdf75e47ca" \
     "The capital of France is" \
@@ -78,7 +79,7 @@ smoke_tests() {
   # Qwen3.5-0.8B: hybrid SDPA + GDN linear attention paged path
   # max-num-seqs=1: limits GDN linear state allocation (~10MB/slot × N slots)
   # which is critical on CI runners with only ~5GB Metal memory.
-  run_smoke_test \
+  run_smoke_test 8101 \
     "Qwen/Qwen3.5-0.8B" \
     "2fc06364715b967f1860aea9cf38778875588b17" \
     "The capital of France is" \

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -10,6 +10,7 @@ import torch
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 
+from vllm_metal.config import reset_config
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.worker import MetalWorker
 
@@ -166,10 +167,10 @@ class TestMetalPlatform:
         MetalPlatform.verify_quantization("awq")
         MetalPlatform.verify_quantization("compressed-tensors")
 
-    def test_check_and_update_config_disables_chunked_prefill(
+    def test_check_and_update_config_disables_chunked_prefill_non_paged(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Metal should disable chunked prefill until the runner supports it.
+        """Non-paged path should disable chunked prefill.
 
         When chunked prefill is disabled, max_num_batched_tokens must be at
         least max_model_len so the scheduler can schedule the entire prompt
@@ -206,6 +207,49 @@ class TestMetalPlatform:
         )
         assert vllm_config.parallel_config.distributed_executor_backend == "uni"
         assert vllm_config.parallel_config.disable_custom_all_reduce is True
+
+    def test_check_and_update_config_keeps_chunked_prefill_for_paged_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Paged path should keep chunked prefill enabled.
+
+        The unified varlen Metal kernel handles mixed prefill + decode,
+        so chunked prefill works correctly on the paged path.
+        """
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=True,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.scheduler_config.enable_chunked_prefill is True
+            # max_num_batched_tokens should NOT be bumped (chunked prefill handles it)
+            assert vllm_config.scheduler_config.max_num_batched_tokens == 2048
+        finally:
+            reset_config()
 
     def test_check_and_update_config_increases_max_num_scheduled_tokens_below_max_model_len(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -458,22 +458,21 @@ class TestKvBudgetBytes:
 
     def test_normal_case(self) -> None:
         budget = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9,
+            self._METAL_LIMIT,
+            self._MODEL_MEM,
+            fraction=0.9,
             overhead=self._OVERHEAD,
         )
 
-        assert (
-            budget
-            == int(self._METAL_LIMIT * 0.9)
-            - self._MODEL_MEM
-            - self._OVERHEAD
-        )
+        assert budget == int(self._METAL_LIMIT * 0.9) - self._MODEL_MEM - self._OVERHEAD
         assert budget > 0
 
     def test_fraction_too_low_yields_negative_budget(self) -> None:
         # fraction=0.3 → usable=6.9 GB < model(16.85 GB) → negative
         budget = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.3,
+            self._METAL_LIMIT,
+            self._MODEL_MEM,
+            fraction=0.3,
             overhead=self._OVERHEAD,
         )
 
@@ -484,7 +483,10 @@ class TestKvBudgetBytes:
         limit = self._MODEL_MEM + self._OVERHEAD
 
         budget = MetalWorker._kv_budget_bytes(
-            limit, self._MODEL_MEM, fraction=1.0, overhead=self._OVERHEAD,
+            limit,
+            self._MODEL_MEM,
+            fraction=1.0,
+            overhead=self._OVERHEAD,
         )
 
         assert budget == 0
@@ -494,7 +496,9 @@ class TestKvBudgetBytes:
             self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9, overhead=0
         )
         budget_with_overhead = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9,
+            self._METAL_LIMIT,
+            self._MODEL_MEM,
+            fraction=0.9,
             overhead=self._OVERHEAD,
         )
 
@@ -503,7 +507,9 @@ class TestKvBudgetBytes:
     def test_large_model_has_positive_budget_at_default_fraction(self) -> None:
         # GLM-4.7-Flash-4bit at fraction=0.9 must yield > 1 GB for KV cache.
         budget = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9,
+            self._METAL_LIMIT,
+            self._MODEL_MEM,
+            fraction=0.9,
             overhead=self._OVERHEAD,
         )
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -10,7 +10,6 @@ import torch
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 
-from vllm_metal.config import PAGED_ATTENTION_OVERHEAD_BYTES
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.worker import MetalWorker
 
@@ -454,33 +453,39 @@ class TestKvBudgetBytes:
 
     _METAL_LIMIT = int(22.9e9)
     _MODEL_MEM = int(16.85e9)
+    # Simulated measured overhead (e.g. from warm-up forward pass).
+    _OVERHEAD = 200 * 1024 * 1024  # 200 MB
 
     def test_normal_case(self) -> None:
         budget = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9
+            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9,
+            overhead=self._OVERHEAD,
         )
 
         assert (
             budget
             == int(self._METAL_LIMIT * 0.9)
             - self._MODEL_MEM
-            - PAGED_ATTENTION_OVERHEAD_BYTES
+            - self._OVERHEAD
         )
         assert budget > 0
 
     def test_fraction_too_low_yields_negative_budget(self) -> None:
         # fraction=0.3 → usable=6.9 GB < model(16.85 GB) → negative
         budget = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.3
+            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.3,
+            overhead=self._OVERHEAD,
         )
 
         assert budget < 0
 
     def test_boundary_zero(self) -> None:
         # Craft inputs so budget lands exactly at zero.
-        limit = self._MODEL_MEM + PAGED_ATTENTION_OVERHEAD_BYTES
+        limit = self._MODEL_MEM + self._OVERHEAD
 
-        budget = MetalWorker._kv_budget_bytes(limit, self._MODEL_MEM, fraction=1.0)
+        budget = MetalWorker._kv_budget_bytes(
+            limit, self._MODEL_MEM, fraction=1.0, overhead=self._OVERHEAD,
+        )
 
         assert budget == 0
 
@@ -488,16 +493,18 @@ class TestKvBudgetBytes:
         budget_zero_overhead = MetalWorker._kv_budget_bytes(
             self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9, overhead=0
         )
-        budget_default = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9
+        budget_with_overhead = MetalWorker._kv_budget_bytes(
+            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9,
+            overhead=self._OVERHEAD,
         )
 
-        assert budget_zero_overhead - budget_default == PAGED_ATTENTION_OVERHEAD_BYTES
+        assert budget_zero_overhead - budget_with_overhead == self._OVERHEAD
 
     def test_large_model_has_positive_budget_at_default_fraction(self) -> None:
         # GLM-4.7-Flash-4bit at fraction=0.9 must yield > 1 GB for KV cache.
         budget = MetalWorker._kv_budget_bytes(
-            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9
+            self._METAL_LIMIT, self._MODEL_MEM, fraction=0.9,
+            overhead=self._OVERHEAD,
         )
 
         assert budget > 1e9

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -52,20 +52,20 @@ class TestWorkerRunnerBoundaryDelegation:
             (False, True, False, 0),
         ],
     )
-    def test_warm_up_delegates_paged_attention_setup(
+    def test_compile_delegates_paged_attention_setup(
         self,
         use_paged_attention: bool,
         runner_allows_setup: bool,
         expect_setup: bool,
         expect_cap_call: int,
     ) -> None:
-        """Paged attention setup uses warm-up measured overhead (issue #234)."""
+        """Paged attention setup uses overhead measured in determine_available_memory."""
         model_runner = MagicMock()
         model_runner.is_hybrid = False
-        model_runner.warm_up.return_value = 200 * 1024 * 1024  # 200 MB
         model_runner.should_setup_paged_attention.return_value = runner_allows_setup
         worker = _make_worker(model_runner, use_paged_attention=use_paged_attention)
         worker._setup_paged_attention = MagicMock()
+        worker._measured_overhead = 200 * 1024 * 1024  # stored from profiling
         worker.model_config = SimpleNamespace(seed=42)
 
         MetalWorker.compile_or_warm_up_model(worker)
@@ -79,43 +79,50 @@ class TestWorkerRunnerBoundaryDelegation:
             )
 
     def test_determine_available_memory_stt_nominal_mode(self) -> None:
-        model_runner = SimpleNamespace(
-            scheduler_memory_reporting_mode=MagicMock(return_value="stt_nominal"),
-        )
+        model_runner = SimpleNamespace(_is_stt=True)
         worker = _make_worker(model_runner, use_paged_attention=True)
 
         available = MetalWorker.determine_available_memory(worker)
 
         assert available == STT_SCHED_AVAILABLE_BYTES
-        model_runner.scheduler_memory_reporting_mode.assert_called_once_with(
-            paged_attention_enabled=True
-        )
 
-    def test_determine_available_memory_paged_capacity_mode(self) -> None:
-        num_blocks = 8
-        block_size_bytes = 16
+    def test_determine_available_memory_paged_profiles_and_reports_budget(self) -> None:
+        """Paged path profiles overhead then reports KV budget."""
+        measured_overhead = 200 * 1024 * 1024  # 200 MB
         model_runner = SimpleNamespace(
-            scheduler_memory_reporting_mode=MagicMock(
-                return_value="paged_attention_capacity"
-            ),
-            _paged_attention_backend=SimpleNamespace(num_blocks=lambda: num_blocks),
+            _is_stt=False,
+            is_hybrid=False,
+            should_setup_paged_attention=MagicMock(return_value=True),
+            profile_run=MagicMock(return_value=measured_overhead),
         )
         worker = _make_worker(model_runner, use_paged_attention=True)
-        worker.get_cache_block_size_bytes = MagicMock(return_value=block_size_bytes)
+        worker.metal_config = SimpleNamespace(
+            use_paged_attention=True,
+            is_auto_memory=False,
+            memory_fraction=0.9,
+        )
+        # Mock _get_model_memory_usage and mx.device_info
+        worker._get_model_memory_usage = MagicMock(return_value=int(1e9))
+        import unittest.mock as um
 
-        available = MetalWorker.determine_available_memory(worker)
+        metal_limit = int(5e9)
+        with um.patch(
+            "mlx.core.device_info",
+            return_value={
+                "max_recommended_working_set_size": metal_limit,
+            },
+        ):
+            available = MetalWorker.determine_available_memory(worker)
 
-        assert available == num_blocks * block_size_bytes
-        worker.get_cache_block_size_bytes.assert_called_once_with()
+        model_runner.profile_run.assert_called_once_with()
+        expected = int(metal_limit * 0.9) - int(1e9) - measured_overhead
+        assert available == expected
+        assert worker._measured_overhead == measured_overhead
 
     def test_determine_available_memory_single_sequence_mode(self) -> None:
         """Test MLX path returns one max-length sequence estimate (PR #229)."""
-        import mlx.core as mx
-
         model_runner = SimpleNamespace(
-            scheduler_memory_reporting_mode=MagicMock(
-                return_value="single_sequence_estimate"
-            ),
+            _is_stt=False,
             kv_cache_dtype=mx.float16,
             is_hybrid=False,
             is_mla=False,
@@ -126,15 +133,12 @@ class TestWorkerRunnerBoundaryDelegation:
         worker = _make_worker(model_runner, use_paged_attention=False)
         worker.model_config = SimpleNamespace(max_model_len=2048)
 
-        try:
-            available = MetalWorker.determine_available_memory(worker)
+        available = MetalWorker.determine_available_memory(worker)
 
-            # Should return one max-length sequence KV cache bytes
-            # 2 (K+V) * 16 layers * 2048 tokens * 8 heads * 128 head_dim * 2 bytes
-            expected = 2 * 16 * 2048 * 8 * 128 * 2
-            assert available == expected
-        finally:
-            pass
+        # Should return one max-length sequence KV cache bytes
+        # 2 (K+V) * 16 layers * 2048 tokens * 8 heads * 128 head_dim * 2 bytes
+        expected = 2 * 16 * 2048 * 8 * 128 * 2
+        assert available == expected
 
     def test_get_supported_tasks_delegates_to_runner_capability(self) -> None:
         model_runner = SimpleNamespace(

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -28,6 +28,17 @@ def _make_worker(model_runner: object, *, use_paged_attention: bool) -> MetalWor
 class TestWorkerRunnerBoundaryDelegation:
     """Worker should delegate STT capability decisions to model runner."""
 
+    def test_load_model_does_not_setup_paged_attention(self) -> None:
+        """Paged attention setup moved to compile_or_warm_up_model (issue #234)."""
+        model_runner = MagicMock()
+        worker = _make_worker(model_runner, use_paged_attention=True)
+        worker._setup_paged_attention = MagicMock()
+
+        MetalWorker.load_model(worker)
+
+        model_runner.load_model.assert_called_once_with()
+        worker._setup_paged_attention.assert_not_called()
+
     @pytest.mark.parametrize(
         (
             "use_paged_attention",
@@ -41,24 +52,31 @@ class TestWorkerRunnerBoundaryDelegation:
             (False, True, False, 0),
         ],
     )
-    def test_load_model_delegates_paged_attention_setup_decision(
+    def test_warm_up_delegates_paged_attention_setup(
         self,
         use_paged_attention: bool,
         runner_allows_setup: bool,
         expect_setup: bool,
         expect_cap_call: int,
     ) -> None:
+        """Paged attention setup uses warm-up measured overhead (issue #234)."""
         model_runner = MagicMock()
         model_runner.is_hybrid = False
+        model_runner.warm_up.return_value = 200 * 1024 * 1024  # 200 MB
         model_runner.should_setup_paged_attention.return_value = runner_allows_setup
         worker = _make_worker(model_runner, use_paged_attention=use_paged_attention)
         worker._setup_paged_attention = MagicMock()
+        worker.model_config = SimpleNamespace(seed=42)
 
-        MetalWorker.load_model(worker)
+        MetalWorker.compile_or_warm_up_model(worker)
 
-        model_runner.load_model.assert_called_once_with()
+        model_runner.warm_up.assert_called_once_with()
         assert model_runner.should_setup_paged_attention.call_count == expect_cap_call
         assert worker._setup_paged_attention.called is expect_setup
+        if expect_setup:
+            worker._setup_paged_attention.assert_called_once_with(
+                overhead=200 * 1024 * 1024
+            )
 
     def test_determine_available_memory_stt_nominal_mode(self) -> None:
         model_runner = SimpleNamespace(

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -8,10 +8,6 @@ from typing import Literal
 # Sentinel value indicating auto memory calculation
 AUTO_MEMORY_FRACTION = -1.0
 
-# Paged attention: placeholder overhead for activations, framework, OS, etc.
-# Will be replaced by a profiling pass in a future PR.
-PAGED_ATTENTION_OVERHEAD_BYTES = 800 * 1024 * 1024  # 800 MB
-
 # Default memory fraction when user leaves VLLM_METAL_MEMORY_FRACTION as "auto"
 # but enables paged attention (auto is for the MLX path).
 PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION = 0.9

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -271,8 +271,14 @@ class MetalPlatform(Platform):
             cache_config.enable_prefix_caching = False
             logger.info("Metal: disabled prefix caching")
 
-        # Configure cache
-        if cache_config.block_size is None:
+        # Configure cache — ensure block_size is at least the Metal kernel
+        # minimum.  With chunked prefill enabled, upstream may default to
+        # block_size=1 for fine-grained scheduling, but our Metal paged
+        # attention kernel requires multiples of 8.
+        if (
+            cache_config.block_size is None
+            or cache_config.block_size < config.block_size
+        ):
             cache_config.block_size = config.block_size
 
         # Disable cascade attention (not supported)

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -225,32 +225,42 @@ class MetalPlatform(Platform):
 
         scheduler_config = vllm_config.scheduler_config
         if getattr(scheduler_config, "enable_chunked_prefill", False):
-            # MetalModelRunner does not yet honor chunked-prefill scheduler
-            # boundaries on the non-paged MLX path. Disable the feature so the
-            # scheduler only requests full prefills, which matches the current
-            # model-runner contract.
-            scheduler_config.enable_chunked_prefill = False
+            if config.use_paged_attention:
+                # The paged path uses a unified varlen Metal kernel that
+                # handles mixed prefill + decode in a single forward pass,
+                # so chunked prefill works correctly.
+                logger.info(
+                    "Metal: chunked prefill enabled (paged attention), "
+                    "max_num_batched_tokens=%d",
+                    scheduler_config.max_num_batched_tokens,
+                )
+            else:
+                # The non-paged MLX path does not honor chunked-prefill
+                # scheduler boundaries.  Disable so the scheduler only
+                # requests full prefills.
+                scheduler_config.enable_chunked_prefill = False
 
-            # Without chunked prefill, the scheduler must fit the entire
-            # prompt in a single step.  Ensure max_num_batched_tokens (and
-            # max_num_scheduled_tokens) are at least max_model_len;
-            # otherwise the scheduler silently refuses to schedule any
-            # prompt that exceeds the budget (see Scheduler.schedule —
-            # the "chunked_prefill is disabled" break).
-            if model_config is not None:
-                model_max = model_config.max_model_len
-                if scheduler_config.max_num_batched_tokens < model_max:
-                    scheduler_config.max_num_batched_tokens = model_max
-                if (
-                    scheduler_config.max_num_scheduled_tokens is not None
-                    and scheduler_config.max_num_scheduled_tokens < model_max
-                ):
-                    scheduler_config.max_num_scheduled_tokens = model_max
+                # Without chunked prefill, the scheduler must fit the
+                # entire prompt in a single step.  Ensure
+                # max_num_batched_tokens (and max_num_scheduled_tokens)
+                # are at least max_model_len; otherwise the scheduler
+                # silently refuses to schedule any prompt that exceeds
+                # the budget.
+                if model_config is not None:
+                    model_max = model_config.max_model_len
+                    if scheduler_config.max_num_batched_tokens < model_max:
+                        scheduler_config.max_num_batched_tokens = model_max
+                    if (
+                        scheduler_config.max_num_scheduled_tokens is not None
+                        and scheduler_config.max_num_scheduled_tokens < model_max
+                    ):
+                        scheduler_config.max_num_scheduled_tokens = model_max
 
-            logger.info(
-                "Metal: disabled chunked prefill, max_num_batched_tokens=%d",
-                scheduler_config.max_num_batched_tokens,
-            )
+                logger.info(
+                    "Metal: disabled chunked prefill (non-paged path), "
+                    "max_num_batched_tokens=%d",
+                    scheduler_config.max_num_batched_tokens,
+                )
 
         if config.use_paged_attention and getattr(
             cache_config, "enable_prefix_caching", False

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -85,8 +85,8 @@ _MIN_BATCH_SIZE_FOR_BATCHING = 2  # Minimum requests to use BatchKVCache
 _MAX_BATCH_SIZE = 64  # Maximum batch size for decode
 
 
-# Performance tuning
-_CACHE_CLEAR_INTERVAL = 50  # Clear cache every N finished requests
+# Periodic prefix-cache stats logging interval (in finished requests).
+_STATS_LOG_INTERVAL = 50
 
 # Prefix cache configuration — enabled by setting VLLM_METAL_PREFIX_CACHE
 # in the environment (any value; unset to disable).
@@ -1197,39 +1197,51 @@ class MetalModelRunner:
         )
         return self.num_linear_layers * (conv_bytes + recurrent_bytes)
 
-    def warm_up(self) -> None:
+    def warm_up(self) -> int:
         """Warm up the model with a dummy forward pass.
 
-        When paged attention is enabled, also loads the HF Metal kernel and
-        runs a tiny ``reshape_and_cache`` to force Metal library creation.
-        This catches Metal language-version incompatibilities at startup
-        rather than during the first real inference request.
+        Measures MLX buffer cache usage during the forward pass so the caller
+        can use it as the activation-overhead term when sizing the KV cache.
+        Also calls ``mx.set_cache_limit`` to cap the buffer cache, preventing
+        unbounded memory growth during serving (see GitHub issue #234).
+
+        Returns:
+            Measured intermediate buffer overhead in bytes.
         """
         if self.model is None:
             logger.warning("Model not loaded, skipping warm-up")
-            return
+            return 0
 
         if self._is_stt:
             assert self._stt_runtime_adapter is not None
             logger.info("Warming up STT model...")
             self._stt_runtime_adapter.warm_up()
             logger.info("STT model warm-up complete")
-            return
+            return 0
 
         logger.info("Warming up model...")
 
-        # Run a small dummy inference (standard MLX path)
+        # Run a small dummy inference and measure intermediate buffer usage.
+        measured_overhead = 0
         try:
+            mx.clear_cache()
+            cache_before = mx.get_cache_memory()
             dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
             output = self.model(dummy_tokens)
             logits = self._extract_logits(output)
             mx.eval(logits)
-            logger.info("Model warm-up complete")
+            cache_after = mx.get_cache_memory()
+            measured_overhead = max(0, cache_after - cache_before)
+            mx.set_cache_limit(measured_overhead)
+            logger.info(
+                "Model warm-up complete: "
+                "measured buffer overhead=%.2fMB, cache_limit set",
+                measured_overhead / (1024 * 1024),
+            )
         except Exception as e:
             logger.warning(f"Model warm-up failed: {e}")
 
-        if self._paged_attention_backend is not None:
-            self._paged_attention_backend.warm_up()
+        return measured_overhead
 
     def _make_sampling_metadata(
         self,
@@ -1917,7 +1929,7 @@ class MetalModelRunner:
         self,
         finished_req_ids: set[str],
     ) -> None:
-        """Evict finished request state and periodically clear MLX cache."""
+        """Evict finished request state and periodically log prefix cache stats."""
         if not finished_req_ids:
             return
 
@@ -1933,10 +1945,8 @@ class MetalModelRunner:
             self._gdn_free_slot(req_id)
 
         self._finished_request_count += len(finished_req_ids)
-        if self._finished_request_count < _CACHE_CLEAR_INTERVAL:
+        if self._finished_request_count < _STATS_LOG_INTERVAL:
             return
-
-        mx.clear_cache()
         self._finished_request_count = 0
 
         if self._prefix_cache is None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1229,9 +1229,7 @@ class MetalModelRunner:
         try:
             mx.clear_cache()
             cache_before = mx.get_cache_memory()
-            dummy_tokens = mx.array(
-                [list(range(warmup_len))], dtype=mx.int32
-            )
+            dummy_tokens = mx.array([list(range(warmup_len))], dtype=mx.int32)
             output = self.model(dummy_tokens)
             logits = self._extract_logits(output)
             mx.eval(logits)

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1221,12 +1221,17 @@ class MetalModelRunner:
 
         logger.info("Warming up model...")
 
-        # Run a small dummy inference and measure intermediate buffer usage.
+        # Profile with max_num_batched_tokens — the scheduler's ceiling for a
+        # single forward pass — so the measured overhead reflects realistic
+        # worst-case serving, matching upstream vLLM's profile_run approach.
+        warmup_len = self.scheduler_config.max_num_batched_tokens
         measured_overhead = 0
         try:
             mx.clear_cache()
             cache_before = mx.get_cache_memory()
-            dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
+            dummy_tokens = mx.array(
+                [list(range(warmup_len))], dtype=mx.int32
+            )
             output = self.model(dummy_tokens)
             logits = self._extract_logits(output)
             mx.eval(logits)
@@ -1234,8 +1239,9 @@ class MetalModelRunner:
             measured_overhead = max(0, cache_after - cache_before)
             mx.set_cache_limit(measured_overhead)
             logger.info(
-                "Model warm-up complete: "
+                "Model warm-up complete (warmup_len=%d): "
                 "measured buffer overhead=%.2fMB, cache_limit set",
+                warmup_len,
                 measured_overhead / (1024 * 1024),
             )
         except Exception as e:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -310,11 +310,6 @@ class PrefixCacheManager:
 # - Some models (e.g. gpt_oss) use `RotatingKVCache` for sliding-window attention.
 # - Hybrid models use `ArraysCache` for non-attention state.
 AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
-SchedulerMemoryReportingMode: TypeAlias = Literal[
-    "stt_nominal",
-    "paged_attention_capacity",
-    "single_sequence_estimate",
-]
 
 
 def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
@@ -765,20 +760,6 @@ class MetalModelRunner:
         """
         return not self._is_stt
 
-    def scheduler_memory_reporting_mode(
-        self, *, paged_attention_enabled: bool
-    ) -> SchedulerMemoryReportingMode:
-        """Return which scheduler memory-reporting mode worker should use.
-
-        Worker delegates this decision to the runner so STT-specific policy is
-        not open-coded in `worker.py`.
-        """
-        if self._is_stt:
-            return "stt_nominal"
-        if paged_attention_enabled and self._paged_attention_backend is not None:
-            return "paged_attention_capacity"
-        return "single_sequence_estimate"
-
     def supported_worker_tasks(self) -> tuple[SupportedTask, ...]:
         """Return worker task capabilities for the loaded model."""
         if self._is_stt:
@@ -1197,33 +1178,25 @@ class MetalModelRunner:
         )
         return self.num_linear_layers * (conv_bytes + recurrent_bytes)
 
-    def warm_up(self) -> int:
-        """Warm up the model with a dummy forward pass.
+    def profile_run(self) -> int:
+        """Profile activation overhead with a dummy forward pass.
 
-        Measures MLX buffer cache usage during the forward pass so the caller
-        can use it as the activation-overhead term when sizing the KV cache.
-        Also calls ``mx.set_cache_limit`` to cap the buffer cache, preventing
-        unbounded memory growth during serving (see GitHub issue #234).
+        Measures MLX buffer cache usage during a forward pass sized to
+        ``max_num_batched_tokens`` (the scheduler's ceiling for a single
+        step), matching upstream vLLM's ``profile_run`` approach.  Also
+        calls ``mx.set_cache_limit`` to cap the buffer cache, preventing
+        unbounded memory growth during serving (GitHub issue #234).
+
+        Called from ``MetalWorker.determine_available_memory`` so the
+        measured overhead is available *before* upstream sizes the KV cache.
 
         Returns:
             Measured intermediate buffer overhead in bytes.
         """
         if self.model is None:
-            logger.warning("Model not loaded, skipping warm-up")
+            logger.warning("Model not loaded, skipping profile run")
             return 0
 
-        if self._is_stt:
-            assert self._stt_runtime_adapter is not None
-            logger.info("Warming up STT model...")
-            self._stt_runtime_adapter.warm_up()
-            logger.info("STT model warm-up complete")
-            return 0
-
-        logger.info("Warming up model...")
-
-        # Profile with max_num_batched_tokens — the scheduler's ceiling for a
-        # single forward pass — so the measured overhead reflects realistic
-        # worst-case serving, matching upstream vLLM's profile_run approach.
         warmup_len = self.scheduler_config.max_num_batched_tokens
         measured_overhead = 0
         try:
@@ -1237,15 +1210,31 @@ class MetalModelRunner:
             measured_overhead = max(0, cache_after - cache_before)
             mx.set_cache_limit(measured_overhead)
             logger.info(
-                "Model warm-up complete (warmup_len=%d): "
+                "Profile run complete (warmup_len=%d): "
                 "measured buffer overhead=%.2fMB, cache_limit set",
                 warmup_len,
                 measured_overhead / (1024 * 1024),
             )
         except Exception as e:
-            logger.warning(f"Model warm-up failed: {e}")
+            logger.warning(f"Profile run failed: {e}")
 
         return measured_overhead
+
+    def warm_up(self) -> None:
+        """Warm up the model (STT adapter, shader compilation, etc.).
+
+        The activation-overhead profiling is done separately in
+        ``profile_run``, called from the worker before KV cache init.
+        """
+        if self.model is None:
+            logger.warning("Model not loaded, skipping warm-up")
+            return
+
+        if self._is_stt:
+            assert self._stt_runtime_adapter is not None
+            logger.info("Warming up STT model...")
+            self._stt_runtime_adapter.warm_up()
+            logger.info("STT model warm-up complete")
 
     def _make_sampling_metadata(
         self,

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -24,7 +24,6 @@ from vllm.v1.worker.worker_base import WorkerBase
 from vllm_metal.config import (
     PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION,
     PAGED_ATTENTION_MIN_BLOCKS,
-    PAGED_ATTENTION_OVERHEAD_BYTES,
     get_config,
 )
 from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
@@ -140,27 +139,17 @@ class MetalWorker(WorkerBase):
         """Load the model onto the Metal device."""
         self.model_runner.load_model()
 
-        # Boundary ownership:
-        # - Worker owns resource setup.
-        # - Runner owns STT/runtime capability decisions.
-        # Note: For hybrid models (Qwen3.5), we don't auto-enable paged attention
-        # because MLX's make_prompt_cache() handles hybrid KV cache natively.
-        # Paged attention for hybrid models requires splitting KV cache across
-        # multiple buffers to avoid Metal's max buffer size limit (~9.5GB).
-        if (
-            self.metal_config.use_paged_attention
-            and self.model_runner.should_setup_paged_attention()
-        ):
-            self._setup_paged_attention()
-
     @staticmethod
     def _kv_budget_bytes(
         metal_limit: int,
         model_memory: int,
         fraction: float,
-        overhead: int = PAGED_ATTENTION_OVERHEAD_BYTES,
+        overhead: int,
     ) -> int:
         """KV cache budget = fraction of Metal limit minus model and overhead.
+
+        ``overhead`` is the measured intermediate-buffer footprint from the
+        warm-up forward pass — see :pymethod:`MetalModelRunner.warm_up`.
 
         All three quantities live in the same domain: Metal-managed memory.
         psutil.available is intentionally excluded — it reflects OS page-cache
@@ -168,12 +157,15 @@ class MetalWorker(WorkerBase):
         """
         return int(metal_limit * fraction) - model_memory - overhead
 
-    def _setup_paged_attention(self) -> None:
+    def _setup_paged_attention(self, overhead: int) -> None:
         """Allocate paged KV cache and patch model attention layers.
 
         Computes num_blocks from Metal memory headroom, model weight size, and
         a configurable memory fraction, rather than blindly scaling from
         max_model_len.
+
+        Args:
+            overhead: Measured intermediate-buffer footprint from warm-up (bytes).
         """
         runner = self.model_runner
         # Use cache_config.block_size (not metal_config) because vLLM's
@@ -211,7 +203,9 @@ class MetalWorker(WorkerBase):
 
         # --- Compute KV budget ---
         usable_metal = int(metal_limit * fraction)
-        kv_budget = self._kv_budget_bytes(metal_limit, model_memory, fraction)
+        kv_budget = self._kv_budget_bytes(
+            metal_limit, model_memory, fraction, overhead
+        )
 
         # For hybrid models, subtract the fixed linear state cost first.
         if runner.is_hybrid:
@@ -226,7 +220,7 @@ class MetalWorker(WorkerBase):
                 f"fraction={fraction}, "
                 f"usable_metal={usable_metal / 1e9:.2f}GB, "
                 f"model_memory={model_memory / 1e9:.2f}GB, "
-                f"overhead={PAGED_ATTENTION_OVERHEAD_BYTES / 1e9:.2f}GB, "
+                f"overhead={overhead / 1e9:.2f}GB, "
                 f"kv_budget={kv_budget / 1e9:.2f}GB. "
                 "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
                 "use a smaller or more quantized model."
@@ -242,7 +236,7 @@ class MetalWorker(WorkerBase):
                 f"fraction={fraction}, "
                 f"usable_metal={usable_metal / 1e9:.2f}GB, "
                 f"model_memory={model_memory / 1e9:.2f}GB, "
-                f"overhead={PAGED_ATTENTION_OVERHEAD_BYTES / 1e9:.2f}GB, "
+                f"overhead={overhead / 1e9:.2f}GB, "
                 f"kv_budget={kv_budget / 1e9:.2f}GB, "
                 f"per_block_bytes={per_block_bytes}. "
                 "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
@@ -254,14 +248,14 @@ class MetalWorker(WorkerBase):
         logger.info(
             "Paged attention memory breakdown: "
             "metal_limit=%.2fGB, fraction=%.2f, usable_metal=%.2fGB, "
-            "model_memory=%.2fGB, overhead=%.2fGB, "
+            "model_memory=%.2fGB, overhead=%.2fGB (measured), "
             "kv_budget=%.2fGB, per_block_bytes=%d, "
             "num_blocks=%d, max_tokens_cached=%d",
             metal_limit / 1e9,
             fraction,
             usable_metal / 1e9,
             model_memory / 1e9,
-            PAGED_ATTENTION_OVERHEAD_BYTES / 1e9,
+            overhead / 1e9,
             kv_budget / 1e9,
             per_block_bytes,
             num_blocks,
@@ -286,6 +280,9 @@ class MetalWorker(WorkerBase):
 
         runner._paged_attention_backend = backend
         runner._paged_block_size = block_size
+
+        # Warm up the paged attention backend (Metal shader compilation).
+        backend.warm_up()
 
     @staticmethod
     def _make_backend(runner: MetalModelRunner, block_size: int) -> Any:
@@ -464,10 +461,24 @@ class MetalWorker(WorkerBase):
         self.model_runner.initialize_kv_cache(kv_cache_config)
 
     def compile_or_warm_up_model(self) -> None:
-        """Warm up the model for inference."""
+        """Warm up the model and set up paged attention if enabled.
+
+        Runs a dummy forward pass to measure the intermediate-buffer overhead,
+        then uses that measurement to size the KV cache within the configured
+        ``VLLM_METAL_MEMORY_FRACTION``.  ``mx.set_cache_limit`` is set during
+        warm-up so the MLX buffer cache stays bounded (GitHub issue #234).
+        """
         # Reset seed for reproducibility
         set_random_seed(self.model_config.seed)
-        self.model_runner.warm_up()
+        measured_overhead = self.model_runner.warm_up()
+
+        # Paged attention setup runs *after* warm-up so the measured overhead
+        # replaces the former 800 MB placeholder in the KV budget calculation.
+        if (
+            self.metal_config.use_paged_attention
+            and self.model_runner.should_setup_paged_attention()
+        ):
+            self._setup_paged_attention(overhead=measured_overhead)
 
     def execute_model(
         self, scheduler_output: SchedulerOutput

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -33,10 +33,7 @@ from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES
 from vllm_metal.utils import set_wired_limit
 
 if TYPE_CHECKING:
-    from vllm_metal.v1.model_runner import (
-        MetalModelRunner,
-        SchedulerMemoryReportingMode,
-    )
+    from vllm_metal.v1.model_runner import MetalModelRunner
 
 logger = init_logger(__name__)
 
@@ -383,46 +380,60 @@ class MetalWorker(WorkerBase):
     def determine_available_memory(self) -> int:
         """Determine available memory for KV cache.
 
-        Paged attention: reports the actual MPS paged cache capacity.
+        Paged attention: runs a profile forward pass to measure activation
+        overhead, then computes the KV budget.  This mirrors upstream vLLM's
+        pattern of profiling inside ``determine_available_memory`` so the
+        measurement is available *before* upstream sizes the KV cache.
+
         MLX path (default): reports one max-length sequence of KV cache
         so the scheduler budgets for one concurrent sequence.
 
         Returns:
             Available memory in bytes
         """
-        mode: SchedulerMemoryReportingMode = (
-            self.model_runner.scheduler_memory_reporting_mode(
-                paged_attention_enabled=self.metal_config.use_paged_attention
-            )
-        )
-
-        if mode == "stt_nominal":
-            # STT models don't use vLLM's KV cache. Return a nominal value so
-            # scheduler minimum-memory checks pass.
+        if self.model_runner._is_stt:
             logger.info("STT model: reporting nominal memory for scheduler")
             return STT_SCHED_AVAILABLE_BYTES
 
-        if mode == "paged_attention_capacity":
-            # Runner only reports this mode when paged cache is initialized.
-            backend = self.model_runner._paged_attention_backend
-            assert backend is not None
-            num_blocks = backend.num_blocks()
-            block_size_bytes = self.get_cache_block_size_bytes()
-            available = num_blocks * block_size_bytes
+        if (
+            self.metal_config.use_paged_attention
+            and self.model_runner.should_setup_paged_attention()
+        ):
+            # Profile activation overhead (matching upstream's profile_run
+            # inside determine_available_memory).
+            self._measured_overhead = self.model_runner.profile_run()
+
+            # Compute KV budget using the same formula as _setup_paged_attention
+            # so upstream and our block allocation agree.
+            if self.metal_config.is_auto_memory:
+                fraction = PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION
+            else:
+                fraction = self.metal_config.memory_fraction
+
+            device_info = mx.device_info()
+            metal_limit = int(device_info.get("max_recommended_working_set_size", 0))
+            model_memory = self._get_model_memory_usage()
+            kv_budget = self._kv_budget_bytes(
+                metal_limit, model_memory, fraction, self._measured_overhead
+            )
+
+            # For hybrid models, deduct fixed linear state cost.
+            runner = self.model_runner
+            if runner.is_hybrid:
+                kv_budget -= runner.linear_cache_bytes_per_slot() * (
+                    runner.scheduler_config.max_num_seqs
+                )
+
+            available = max(0, kv_budget)
             logger.info(
-                "Paged attention: reporting MPS cache capacity "
-                "(%d blocks × %d bytes = %.2f GB)",
-                num_blocks,
-                block_size_bytes,
+                "Paged attention: profiled overhead=%.2fMB, "
+                "reporting %.2f GB KV budget for scheduler",
+                self._measured_overhead / (1024 * 1024),
                 available / 1e9,
             )
             return available
 
         # Default MLX path: report one max-length sequence for admission control.
-        # This matches the design from PR #229, which ensures the scheduler
-        # can admit at least one sequence without over-committing memory.
-        # MLX's make_prompt_cache() dynamically allocates KV cache per request,
-        # so we only need to report enough for one sequence.
         available = self._one_sequence_kv_bytes()
         logger.info(
             "MLX path: reporting %.2f GB for scheduler admission control "
@@ -459,24 +470,25 @@ class MetalWorker(WorkerBase):
         self.model_runner.initialize_kv_cache(kv_cache_config)
 
     def compile_or_warm_up_model(self) -> None:
-        """Warm up the model and set up paged attention if enabled.
+        """Set up paged attention and warm up the model.
 
-        Runs a dummy forward pass to measure the intermediate-buffer overhead,
-        then uses that measurement to size the KV cache within the configured
-        ``VLLM_METAL_MEMORY_FRACTION``.  ``mx.set_cache_limit`` is set during
-        warm-up so the MLX buffer cache stays bounded (GitHub issue #234).
+        Activation-overhead profiling was already done in
+        ``determine_available_memory`` (matching upstream's pattern).
+        This method uses the stored measurement to allocate the paged KV
+        cache, then runs any remaining warm-up (STT adapter, etc.).
         """
         # Reset seed for reproducibility
         set_random_seed(self.model_config.seed)
-        measured_overhead = self.model_runner.warm_up()
 
-        # Paged attention setup runs *after* warm-up so the measured overhead
-        # replaces the former 800 MB placeholder in the KV budget calculation.
+        # Set up paged attention using the overhead measured during profiling.
         if (
             self.metal_config.use_paged_attention
             and self.model_runner.should_setup_paged_attention()
         ):
-            self._setup_paged_attention(overhead=measured_overhead)
+            overhead = getattr(self, "_measured_overhead", 0)
+            self._setup_paged_attention(overhead=overhead)
+
+        self.model_runner.warm_up()
 
     def execute_model(
         self, scheduler_output: SchedulerOutput

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -203,9 +203,7 @@ class MetalWorker(WorkerBase):
 
         # --- Compute KV budget ---
         usable_metal = int(metal_limit * fraction)
-        kv_budget = self._kv_budget_bytes(
-            metal_limit, model_memory, fraction, overhead
-        )
+        kv_budget = self._kv_budget_bytes(metal_limit, model_memory, fraction, overhead)
 
         # For hybrid models, subtract the fixed linear state cost first.
         if runner.is_hybrid:


### PR DESCRIPTION

## Summary

- Replace the hardcoded 800 MB `PAGED_ATTENTION_OVERHEAD_BYTES` placeholder with the actual intermediate-buffer footprint measured during warm-up (now it's using `self.scheduler_config.max_num_batched_tokens` for a realistic warmup)
- Call `mx.set_cache_limit()` with the measured value so the MLX buffer cache stays bounded — eliminates the 40 GB → 62 GB sawtooth observed during sustained serving
- Remove the periodic `mx.clear_cache()` every 50 requests, which is no longer needed
- Add `timeout-minutes: 10` to the test job in `ci.yml` as a safety net

- **`model_runner.py`** -- `warm_up()` split into `profile_run()` (measurement) + `warm_up()` (STT/other), removed `SchedulerMemoryReportingMode`
- **`worker.py`** -- `determine_available_memory()` now calls `profile_run()` for paged path, `compile_or_warm_up_model()` uses stored `_measured_overhead`


## Motivation

During sustained serving, MLX's buffer cache retains freed GPU buffers keyed by exact byte size. Because `total_tokens` varies each step, intermediate buffers are cached but never reused — they accumulate as dead weight until the OS reclaims memory. The previous mitigation (`mx.clear_cache()` every 50 requests) created a sawtooth pattern rather than bounding memory. See #234 for full analysis.

## Approach

Reorder startup so the dummy forward pass (warm-up) runs **before** KV cache allocation:

```
load_model()                          # load weights
compile_or_warm_up_model()
  ├─ warm_up()                        # dummy forward → measure overhead → set_cache_limit
  └─ _setup_paged_attention(overhead) # KV budget uses measured overhead
       └─ backend.warm_up()           # Metal shader compilation
```

The measured overhead replaces both the 800 MB placeholder (for KV budget sizing) and the periodic `clear_cache` (for runtime memory control). `VLLM_METAL_MEMORY_FRACTION` remains the single knob controlling total memory usage.

## Test plan


- [x] 6 Qwen3-0.6B golden-token deterministic tests pass
- [ ] Serving benchmark to confirm sawtooth elimination and throughput parity


Results look good. Here's the summary:

### Benchmark (sonnet 1024+128, 100 prompts, concurrency 32)

| Metric | main | PR #247 | Change |
|---|---:|---:|---:|
| Output tok/s | 60.52 | 64.17 | **+6.0%** |
| Total tok/s | 539.12 | 571.66 | **+6.0%** |
| Mean TTFT (ms) | 11777.78 | 11656.72 | -1.0% |
| Mean TPOT (ms) | 420.09 | 390.62 | **-7.0%** |
| P99 TPOT (ms) | 542.40 | 473.47 | **-12.7%** |
| Mean ITL (ms) | 420.09 | 390.62 | **-7.0%** |


