### PR TITLE
Bump vllm minimum version to 0.19.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,7 @@ main() {
 
   ensure_venv "$venv"
 
-  local vllm_v="0.17.1"
+  local vllm_v="0.19.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   curl -OL $url_base/v$vllm_v/$filename


### PR DESCRIPTION
Grab Gemma4 support and latest enhancements from upstream vLLM.