### PR TITLE
[Gemma4] Add text generation support with paged attention

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -160,6 +160,16 @@ class TestPadQKVToCacheHeadDim:
         with pytest.raises(ValueError, match="exceeds cache_head_dim"):
             pad_qkv_to_cache_head_dim(q, q, q, _CACHE_HEAD_DIM, _HEAD_DIM)
 
+    def test_rejects_mismatched_qkv_last_dim(self) -> None:
+        # Arrange — caller passes Q at one head_dim but K/V at another
+        q = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM))
+        k = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _CACHE_HEAD_DIM))
+        v = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _CACHE_HEAD_DIM))
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="last-dim mismatch"):
+            pad_qkv_to_cache_head_dim(q, k, v, _HEAD_DIM, _CACHE_HEAD_DIM)
+
 
 # === truncate_padded_output ===
 
@@ -286,3 +296,24 @@ class TestPrepareSDPAQKV:
         assert keys is shared_k
         assert values is shared_v
         assert kv_for_sharing == (shared_k, shared_v)
+
+    def test_yoco_requires_rope_attribute(self) -> None:
+        # Arrange — YOCO path must still reject non-RoPE models; without a
+        # guard we would silently return un-rotated queries.
+        inner = _make_inner(with_v_proj=True)
+        del inner.rope
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        shared_k = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 1.0)
+        shared_v = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 1.0)
+
+        # Act / Assert
+        with pytest.raises(NotImplementedError, match="rope"):
+            prepare_sdpa_qkv(
+                inner,
+                x,
+                ctx,
+                _N_HEADS,
+                _N_KV_HEADS,
+                shared_kv=(shared_k, shared_v),
+            )

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for Gemma4-specific branches in attention_sdpa.
+
+Covers:
+- ``pad_qkv_to_cache_head_dim`` / ``truncate_padded_output`` pure helpers.
+- ``prepare_sdpa_qkv`` branches (K-eq-V fallback, v_norm, YOCO shared_kv).
+
+The ``prepare_sdpa_qkv`` tests use minimal fake attention modules rather
+than real mlx_lm Attention modules so they stay fast and deterministic.
+Metal kernel dispatch itself is covered by the end-to-end smoke tests,
+not here.
+"""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.metal_kernel_backend.attention_sdpa import (
+    pad_qkv_to_cache_head_dim,
+    prepare_sdpa_qkv,
+    truncate_padded_output,
+)
+from vllm_metal.paged_attention_common import PagedAttentionContext
+
+# === Test fixtures (shared shapes) ===
+
+_BATCH = 1
+_SEQ_LEN = 4
+_HIDDEN = 8
+_N_HEADS = 2
+_N_KV_HEADS = 2
+_HEAD_DIM = 4  # small enough for fast unit tests
+_CACHE_HEAD_DIM = 8  # Gemma4-style: cache wider than layer head_dim
+
+
+class _FakeLinear:
+    """Minimal linear-like callable with a ``.weight`` attribute.
+
+    Matches what ``prepare_sdpa_qkv`` needs from ``inner.{q,k,v}_proj``:
+    a callable that projects ``x`` and exposes ``.weight.shape`` for
+    head_dim resolution.
+    """
+
+    def __init__(self, weight: mx.array) -> None:
+        self.weight = weight
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight.T
+
+
+class _RaisingLinear:
+    """Linear stub that fails if called — used to prove a branch is skipped."""
+
+    def __init__(self, weight: mx.array, message: str) -> None:
+        self.weight = weight
+        self._message = message
+
+    def __call__(self, x: mx.array) -> mx.array:
+        raise AssertionError(self._message)
+
+
+def _make_ctx(seq_len: int) -> PagedAttentionContext:
+    """Return a minimal paged context sufficient for apply_packed_rope."""
+    return PagedAttentionContext(
+        slot_mapping=list(range(seq_len)),
+        block_tables=[[0]],
+        context_lens=[seq_len],
+        offsets=[],
+        cu_seqlens=[0, seq_len],
+    )
+
+
+def _identity_rope(x: mx.array, offset: int = 0) -> mx.array:
+    """Stand-in RoPE that leaves inputs unchanged (tests call-site plumbing,
+    not the rotation math itself)."""
+    return x
+
+
+def _make_inner(
+    *,
+    with_v_proj: bool = True,
+    with_v_norm: bool = False,
+) -> SimpleNamespace:
+    """Build a fake Attention module matching sdpa_forward's contract."""
+    q_weight = mx.ones((_N_HEADS * _HEAD_DIM, _HIDDEN))
+    k_weight = mx.ones((_N_KV_HEADS * _HEAD_DIM, _HIDDEN))
+    v_weight = mx.ones((_N_KV_HEADS * _HEAD_DIM, _HIDDEN))
+
+    inner = SimpleNamespace(
+        n_heads=_N_HEADS,
+        n_kv_heads=_N_KV_HEADS,
+        scale=_HEAD_DIM**-0.5,
+        q_proj=_FakeLinear(q_weight),
+        k_proj=_FakeLinear(k_weight),
+        rope=_identity_rope,
+    )
+    if with_v_proj:
+        inner.v_proj = _FakeLinear(v_weight)
+    if with_v_norm:
+        # Track invocation so the test can assert the norm was actually
+        # applied rather than silently skipped.
+        inner._v_norm_calls = 0
+
+        def v_norm(v: mx.array) -> mx.array:
+            inner._v_norm_calls += 1
+            return v * 2.0
+
+        inner.v_norm = v_norm
+    return inner
+
+
+# === pad_qkv_to_cache_head_dim ===
+
+
+class TestPadQKVToCacheHeadDim:
+    """Tests for ``pad_qkv_to_cache_head_dim``."""
+
+    def test_noop_when_head_dim_matches(self) -> None:
+        # Arrange
+        shape = (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        q = mx.ones(shape)
+        k = mx.ones(shape)
+        v = mx.ones(shape)
+
+        # Act
+        qp, kp, vp = pad_qkv_to_cache_head_dim(q, k, v, _HEAD_DIM, _HEAD_DIM)
+
+        # Assert — no change, same objects returned
+        assert qp is q
+        assert kp is k
+        assert vp is v
+
+    def test_pads_last_axis_with_zeros(self) -> None:
+        # Arrange — Gemma4 sliding layer: head_dim=4, cache_head_dim=8
+        shape = (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        q = mx.ones(shape)
+        k = mx.ones(shape)
+        v = mx.ones(shape)
+
+        # Act
+        qp, kp, vp = pad_qkv_to_cache_head_dim(q, k, v, _HEAD_DIM, _CACHE_HEAD_DIM)
+
+        # Assert — shape padded to cache_head_dim
+        expected_shape = (_BATCH, _N_HEADS, _SEQ_LEN, _CACHE_HEAD_DIM)
+        assert qp.shape == expected_shape
+        assert kp.shape == expected_shape
+        assert vp.shape == expected_shape
+        # Leading values preserved, trailing positions zeroed
+        mx.eval(qp, kp, vp)
+        trailing = qp[..., _HEAD_DIM:]
+        assert bool(mx.all(trailing == 0).item())
+
+    def test_rejects_head_dim_larger_than_cache(self) -> None:
+        # Arrange
+        shape = (_BATCH, _N_HEADS, _SEQ_LEN, _CACHE_HEAD_DIM)
+        q = mx.ones(shape)
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="exceeds cache_head_dim"):
+            pad_qkv_to_cache_head_dim(q, q, q, _CACHE_HEAD_DIM, _HEAD_DIM)
+
+
+# === truncate_padded_output ===
+
+
+class TestTruncatePaddedOutput:
+    """Tests for ``truncate_padded_output``."""
+
+    def test_noop_when_not_padded(self) -> None:
+        # Arrange — same head_dim, no padding to strip
+        out = mx.ones((_SEQ_LEN, _N_HEADS, _CACHE_HEAD_DIM))
+
+        # Act
+        flat = truncate_padded_output(
+            out,
+            _BATCH,
+            _SEQ_LEN,
+            _N_HEADS,
+            _CACHE_HEAD_DIM,
+            _CACHE_HEAD_DIM,
+        )
+
+        # Assert
+        assert flat.shape == (_BATCH, _SEQ_LEN, _N_HEADS * _CACHE_HEAD_DIM)
+
+    def test_strips_trailing_padded_dims(self) -> None:
+        # Arrange — kernel output at cache width, actual layer is narrower
+        out = mx.ones((_SEQ_LEN, _N_HEADS, _CACHE_HEAD_DIM))
+
+        # Act
+        flat = truncate_padded_output(
+            out,
+            _BATCH,
+            _SEQ_LEN,
+            _N_HEADS,
+            _CACHE_HEAD_DIM,
+            _HEAD_DIM,
+        )
+
+        # Assert — trailing per-head dims dropped before flatten
+        assert flat.shape == (_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)
+
+
+# === prepare_sdpa_qkv ===
+
+
+class TestPrepareSDPAQKV:
+    """Tests for ``prepare_sdpa_qkv`` Gemma4 branches."""
+
+    def test_standard_path_projects_independent_kv(self) -> None:
+        # Arrange — Qwen3/Llama-style with v_proj present
+        inner = _make_inner(with_v_proj=True)
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
+            inner, x, ctx, _N_HEADS, _N_KV_HEADS, shared_kv=None
+        )
+
+        # Assert — canonical (B, H, L, D) shapes
+        assert queries.shape == (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert keys.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert gate is None
+        assert kv_for_sharing == (keys, values)
+
+    def test_k_eq_v_fallback_when_v_proj_missing(self) -> None:
+        # Arrange — Gemma4 26B/31B style: no v_proj
+        inner = _make_inner(with_v_proj=False)
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        _, keys, values, _, _ = prepare_sdpa_qkv(
+            inner, x, ctx, _N_HEADS, _N_KV_HEADS, shared_kv=None
+        )
+
+        # Assert — without v_proj we expect values to share K's projection.
+        # After transpose they must be element-equal (same weights, same x).
+        mx.eval(keys, values)
+        assert bool(mx.all(keys == values).item())
+
+    def test_v_norm_is_applied_when_present(self) -> None:
+        # Arrange
+        inner = _make_inner(with_v_proj=True, with_v_norm=True)
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        prepare_sdpa_qkv(inner, x, ctx, _N_HEADS, _N_KV_HEADS, shared_kv=None)
+
+        # Assert — v_norm callback was invoked exactly once on values
+        assert inner._v_norm_calls == 1
+
+    def test_yoco_reuses_shared_kv_without_reprojection(self) -> None:
+        # Arrange — Gemma4 YOCO: shared_kv comes from a prior layer and
+        # should be returned untouched (no reprojection, no re-norm).
+        inner = _make_inner(with_v_proj=True)
+        # Swap in a linear that explodes if called — proves the YOCO path
+        # skips v_proj rather than silently falling back to projection.
+        inner.v_proj = _RaisingLinear(
+            inner.v_proj.weight, "v_proj must not be called on YOCO path"
+        )
+        inner.k_proj = _RaisingLinear(
+            inner.k_proj.weight, "k_proj must not be called on YOCO path"
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        shared_k = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 7.0)
+        shared_v = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 9.0)
+
+        # Act
+        _, keys, values, _, kv_for_sharing = prepare_sdpa_qkv(
+            inner,
+            x,
+            ctx,
+            _N_HEADS,
+            _N_KV_HEADS,
+            shared_kv=(shared_k, shared_v),
+        )
+
+        # Assert — shared tensors flow through unchanged
+        assert keys is shared_k
+        assert values is shared_v
+        assert kv_for_sharing == (shared_k, shared_v)

--- a/tests/test_gemma4_golden.py
+++ b/tests/test_gemma4_golden.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic golden-token test for Gemma4 on the paged attention path.
+
+Verifies that vllm-metal's paged attention implementation produces the same
+greedy-decoded token IDs as running the same Gemma4 checkpoint through
+mlx_lm directly.  This catches regressions in YOCO sharing, K-eq-V fallback,
+v_norm, and variable head_dim padding — the paths exercised by Gemma4 that
+are not stressed by other models.
+
+Golden token IDs are generated once offline via ``tools/gen_gemma4_golden.py``
+using ``mlx_lm.stream_generate(..., sampler=temp=0)`` with the tokenizer's
+EOS set cleared so every sequence is exactly ``MAX_TOKENS`` long.
+
+Run:
+    GEMMA4_MODEL_PATH=/path/to/gemma-4-E2B-it \
+        pytest tests/test_gemma4_golden.py -v -s -m slow
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from vllm import LLM, SamplingParams
+
+MODEL_ENV = "GEMMA4_MODEL_PATH"
+MAX_TOKENS = 10
+
+PROMPTS = [
+    "The capital of France is",
+    "The weather today is not",
+    "One plus one equals",
+    "The largest planet in our solar system is",
+    "Water boils at a temperature of",
+]
+
+# fmt: off
+# Golden token IDs from mlx_lm stream_generate (greedy, EOS disabled).
+# Regenerate with tools/gen_gemma4_golden.py.
+GOLDEN_MLX_LM = {
+    "The capital of France is":                   [7001, 563, 7001, 563, 7001, 563, 7001, 563, 7001, 563],
+    "The weather today is not":                   [711, 711, 711, 711, 711, 108, 106, 108, 106, 108],
+    "One plus one equals":                        [2915, 886, 14339, 2915, 886, 107, 106, 107, 1, 107],
+    "The largest planet in our solar system is":  [10321, 1458, 563, 10321, 1458, 10321, 1458, 10321, 1458, 10321],
+    "Water boils at a temperature of":            [104264, 657, 104264, 657, 104264, 106, 106, 106, 106, 106],
+}
+# fmt: on
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _set_env():
+    """Run the paged attention path in single-process mode for determinism."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+        yield
+
+
+@pytest.fixture(scope="module")
+def vllm_outputs():
+    """Run Gemma4 inference once through vllm-metal's paged attention path."""
+    model_path = os.environ.get(MODEL_ENV)
+    if not model_path:
+        pytest.skip(f"{MODEL_ENV} not set — skipping Gemma4 deterministic test")
+    if not os.path.isdir(model_path):
+        pytest.skip(f"{MODEL_ENV}={model_path} is not a directory")
+
+    llm = LLM(model=model_path, max_model_len=512, max_num_seqs=1)
+    sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS, ignore_eos=True)
+    outputs = llm.generate(PROMPTS, sp)
+    return {o.prompt: o for o in outputs}
+
+
+class TestGemma4Golden:
+    @pytest.mark.slow
+    @pytest.mark.parametrize("prompt", PROMPTS)
+    def test_matches_mlx_lm_groundtruth(self, vllm_outputs, prompt):
+        output = vllm_outputs[prompt]
+        token_ids = list(output.outputs[0].token_ids)
+        expected = GOLDEN_MLX_LM[prompt]
+
+        print(f"\n  prompt:   {prompt!r}")
+        print(f"  got:      {token_ids}")
+        print(f"  expected: {expected}")
+
+        assert token_ids == expected, (
+            f"Paged attention output for {prompt!r} diverged from mlx_lm "
+            f"groundtruth.\nGot:      {token_ids}\nExpected: {expected}"
+        )

--- a/tests/test_model_compat.py
+++ b/tests/test_model_compat.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for model-specific compatibility helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_metal.v1.model_compat import (
+    require_uniform_kv_heads,
+    resolve_max_head_dim,
+    should_force_text_backbone,
+)
+
+
+class TestShouldForceTextBackbone:
+    """Tests for should_force_text_backbone()."""
+
+    def test_gemma4_model_type_is_overridden(self) -> None:
+        # Arrange
+        hf_config = SimpleNamespace(model_type="gemma4")
+
+        # Act
+        result = should_force_text_backbone(hf_config)
+
+        # Assert
+        assert result is True
+
+    def test_non_overridden_model_type_is_not_forced(self) -> None:
+        # Arrange
+        hf_config = SimpleNamespace(model_type="qwen3_5")
+
+        # Act
+        result = should_force_text_backbone(hf_config)
+
+        # Assert
+        assert result is False
+
+    def test_missing_model_type_is_not_forced(self) -> None:
+        # Arrange
+        hf_config = SimpleNamespace()
+
+        # Act
+        result = should_force_text_backbone(hf_config)
+
+        # Assert
+        assert result is False
+
+
+class TestResolveMaxHeadDim:
+    """Tests for resolve_max_head_dim()."""
+
+    def test_returns_global_when_larger(self) -> None:
+        # Arrange — Gemma4-style: sliding=256, full=512
+        args = {"global_head_dim": 512}
+        head_dim = 256
+
+        # Act
+        result = resolve_max_head_dim(args, head_dim)
+
+        # Assert
+        assert result == 512
+
+    def test_returns_head_dim_when_larger(self) -> None:
+        # Arrange — hypothetical inverse case
+        args = {"global_head_dim": 128}
+        head_dim = 256
+
+        # Act
+        result = resolve_max_head_dim(args, head_dim)
+
+        # Assert
+        assert result == 256
+
+    def test_returns_head_dim_when_global_missing(self) -> None:
+        # Arrange — uniform-head_dim models (most models)
+        args = {}
+        head_dim = 128
+
+        # Act
+        result = resolve_max_head_dim(args, head_dim)
+
+        # Assert
+        assert result == 128
+
+    def test_returns_none_when_head_dim_none(self) -> None:
+        # Arrange
+        args = {"global_head_dim": 512}
+        head_dim = None
+
+        # Act
+        result = resolve_max_head_dim(args, head_dim)
+
+        # Assert
+        assert result is None
+
+
+class TestRequireUniformKvHeads:
+    """Tests for require_uniform_kv_heads()."""
+
+    def test_allows_uniform_heads(self) -> None:
+        # Arrange — typical model
+        args = {"num_global_key_value_heads": 8}
+        num_kv_heads = 8
+
+        # Act — should not raise
+        require_uniform_kv_heads(args, num_kv_heads)
+
+    def test_allows_missing_global(self) -> None:
+        # Arrange — no global KV head count set (most models)
+        args = {}
+        num_kv_heads = 8
+
+        # Act — should not raise
+        require_uniform_kv_heads(args, num_kv_heads)
+
+    def test_rejects_gemma4_31b_config(self) -> None:
+        # Arrange — Gemma4 31B: sliding=16, full=4
+        args = {"num_global_key_value_heads": 4}
+        num_kv_heads = 16
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="variable KV head count"):
+            require_uniform_kv_heads(args, num_kv_heads)
+
+    def test_rejects_gemma4_26b_config(self) -> None:
+        # Arrange — Gemma4 26B: sliding=8, full=2
+        args = {"num_global_key_value_heads": 2}
+        num_kv_heads = 8
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="VLLM_METAL_USE_PAGED_ATTENTION=0"):
+            require_uniform_kv_heads(args, num_kv_heads)

--- a/tools/gen_gemma4_golden.py
+++ b/tools/gen_gemma4_golden.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Generate Gemma4 golden token IDs via mlx_lm (independent reference).
+
+Runs greedy decoding directly through mlx_lm (bypassing vllm-metal) so the
+resulting token IDs can serve as groundtruth for
+``tests/test_gemma4_golden.py``.
+
+Usage:
+    python tools/gen_gemma4_golden.py /path/to/gemma-4-E2B-it
+"""
+
+from __future__ import annotations
+
+import sys
+
+from mlx_lm import load, stream_generate
+from mlx_lm.sample_utils import make_sampler
+
+_PROMPTS = [
+    "The capital of France is",
+    "The weather today is not",
+    "One plus one equals",
+    "The largest planet in our solar system is",
+    "Water boils at a temperature of",
+]
+_MAX_TOKENS = 10
+
+
+def _greedy_tokens(model, tokenizer, prompt: str, max_tokens: int) -> list[int]:
+    # Force full-length generation: disable EOS so the stream doesn't stop
+    # early and produces a deterministic fixed-size reference.
+    tokenizer._eos_token_ids = set()
+    sampler = make_sampler(temp=0.0)
+    return [
+        resp.token
+        for resp in stream_generate(
+            model, tokenizer, prompt, max_tokens=max_tokens, sampler=sampler
+        )
+    ]
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: python tools/gen_gemma4_golden.py <model-path>")
+        sys.exit(1)
+    model_path = sys.argv[1]
+
+    print(f"Loading {model_path} via mlx_lm...")
+    model, tokenizer = load(model_path)
+    print("Loaded.\n")
+
+    print("GOLDEN_MLX_LM = {")
+    for prompt in _PROMPTS:
+        ids = _greedy_tokens(model, tokenizer, prompt, _MAX_TOKENS)
+        text = tokenizer.decode(ids)
+        pad = 50 - len(prompt)
+        print(f"    {prompt!r}:{' ' * max(pad, 1)}{ids},")
+        print(f"        # → {text!r}")
+    print("}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -1428,6 +1428,9 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
                                     partition_size);                           \
   instantiate_paged_attention_inner(type, cache_type, 256, block_size,         \
                                     num_threads, num_simd_lanes,               \
+                                    partition_size);                           \
+  instantiate_paged_attention_inner(type, cache_type, 512, block_size,         \
+                                    num_threads, num_simd_lanes,               \
                                     partition_size);
 
 #define instantiate_paged_attention_v2_reduce_heads(                           \
@@ -1445,6 +1448,8 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   instantiate_paged_attention_v2_reduce_inner(type, 192, num_threads,          \
                                               num_simd_lanes, partition_size); \
   instantiate_paged_attention_v2_reduce_inner(type, 256, num_threads,          \
+                                              num_simd_lanes, partition_size); \
+  instantiate_paged_attention_v2_reduce_inner(type, 512, num_threads,          \
                                               num_simd_lanes, partition_size);
 
 #define instantiate_paged_attention_block_size(type, cache_type, num_threads,  \

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -99,6 +99,197 @@ def _build_block_tables(
     return expanded, kernel_bs
 
 
+# === Q/K/V preparation (YOCO, K-eq-V, v_norm variants) ===
+
+
+def prepare_sdpa_qkv(
+    inner: nn.Module,
+    x: mx.array,
+    ctx: PagedAttentionContext,
+    n_heads: int,
+    n_kv_heads: int,
+    shared_kv: tuple[mx.array, mx.array] | None = None,
+) -> tuple[mx.array, mx.array, mx.array, mx.array | None, tuple[mx.array, mx.array]]:
+    """Project ``x`` into Q/K/V with norms, RoPE and Gemma4 variants.
+
+    Handles three Gemma4-specific branches:
+
+    - **YOCO** (``shared_kv`` given): reuse K/V from a prior layer; skip
+      projection and only apply Q norm + RoPE.
+    - **K-eq-V** (no ``inner.v_proj``): 26B/31B checkpoints share the
+      projection so ``values`` references the same tensor as ``keys``.
+    - **v_norm** (``inner.v_norm`` present): apply per-head RMSNorm to
+      values alongside q_norm and k_norm.
+
+    Args:
+        inner: mlx_lm Attention module (or compatible).
+        x: Input hidden states shaped ``(B, L, D)``.
+        ctx: Paged attention context (supplies ``cu_seqlens`` / offsets
+            for per-request RoPE).
+        n_heads: Query head count.
+        n_kv_heads: K/V head count.
+        shared_kv: Optional ``(keys, values)`` from a reference layer,
+            already normed and RoPE'd, in ``(B, H, L, head_dim)`` layout.
+
+    Returns:
+        Tuple ``(queries, keys, values, gate, kv_for_sharing)``:
+
+        - ``queries``, ``keys``, ``values``: ``(B, H, L, head_dim)`` tensors
+          ready for the Metal kernel.
+        - ``gate``: optional gate tensor for gated attention (Qwen3.5
+          Qwen3Next style), else ``None``.
+        - ``kv_for_sharing``: the post-norm+RoPE ``(keys, values)`` pair so
+          the caller can forward them to the next YOCO layer.
+
+    Raises:
+        NotImplementedError: If ``inner`` has neither ``rope`` nor
+            ``rotary_emb`` (only RoPE-based models are supported).
+    """
+    B, L, _ = x.shape  # noqa: N806
+
+    # Projections + reshape.  Qwen3.5 uses gated q_proj (2x head_dim).
+    q_proj_out = inner.q_proj(x)
+    gate: mx.array | None = None
+    head_dim = inner.k_proj.weight.shape[0] // n_kv_heads
+    q_full_head = q_proj_out.shape[-1] // n_heads
+    if q_full_head == 2 * head_dim:
+        q_reshaped = q_proj_out.reshape(B, L, n_heads, q_full_head)
+        queries, gate = mx.split(q_reshaped, 2, axis=-1)
+        gate = gate.reshape(B, L, -1)
+    else:
+        queries = q_proj_out.reshape(B, L, n_heads, -1)
+
+    if shared_kv is not None:
+        # YOCO: reuse K/V from a reference layer.  Q still needs norm + RoPE.
+        keys, values = shared_kv
+        if hasattr(inner, "q_norm"):
+            queries = inner.q_norm(queries)
+        queries = queries.transpose(0, 2, 1, 3)
+        if hasattr(inner, "rope") or hasattr(inner, "rotary_emb"):
+            queries, _ = apply_packed_rope(
+                inner,
+                queries,
+                keys,
+                ctx.cu_seqlens,
+                offsets=ctx.offsets if ctx.offsets else None,
+                apply_keys=False,
+            )
+    else:
+        keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
+        # K-eq-V variant (Gemma4 26B/31B): no v_proj, values = keys.
+        if hasattr(inner, "v_proj"):
+            values = inner.v_proj(x).reshape(B, L, n_kv_heads, -1)
+        else:
+            values = keys
+
+        # Per-head RMSNorm (Qwen3, Qwen3.5, Gemma4).
+        if hasattr(inner, "q_norm"):
+            queries = inner.q_norm(queries)
+        if hasattr(inner, "k_norm"):
+            keys = inner.k_norm(keys)
+        if hasattr(inner, "v_norm"):
+            values = inner.v_norm(values)
+
+        # Transpose to (B, H, L, head_dim).
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
+            raise NotImplementedError(
+                f"Attention module {type(inner).__name__} does not have a "
+                "'rope' or 'rotary_emb' attribute."
+            )
+        queries, keys = apply_packed_rope(
+            inner,
+            queries,
+            keys,
+            ctx.cu_seqlens,
+            offsets=ctx.offsets if ctx.offsets else None,
+        )
+
+    kv_for_sharing = (keys, values)
+    return queries, keys, values, gate, kv_for_sharing
+
+
+# === Variable head_dim helpers (Gemma4) ===
+
+
+def pad_qkv_to_cache_head_dim(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    head_dim: int,
+    cache_head_dim: int,
+) -> tuple[mx.array, mx.array, mx.array]:
+    """Zero-pad Q/K/V on the last axis up to ``cache_head_dim``.
+
+    Variable head_dim models (e.g. Gemma4 sliding=256, full=512) allocate
+    the paged KV cache at the max head_dim.  Layers with smaller head_dim
+    are padded so scatter writes and the kernel both operate at the cache's
+    native head_dim.  Zero-padded positions do not affect QK dot products
+    or V aggregation.  No-op when ``head_dim == cache_head_dim``.
+
+    Args:
+        queries, keys, values: Tensors shaped ``(B, H, L, head_dim)``.
+        head_dim: Current layer's head_dim.
+        cache_head_dim: Cache's allocated head_dim (the target).
+
+    Returns:
+        Padded ``(queries, keys, values)``.
+
+    Raises:
+        ValueError: If ``head_dim > cache_head_dim`` (unsupported).
+    """
+    if head_dim == cache_head_dim:
+        return queries, keys, values
+    if head_dim > cache_head_dim:
+        raise ValueError(
+            f"head_dim={head_dim} exceeds cache_head_dim={cache_head_dim}; "
+            f"cache must be sized for the largest per-layer head_dim."
+        )
+    pad_spec = [(0, 0), (0, 0), (0, 0), (0, cache_head_dim - head_dim)]
+    return (
+        mx.pad(queries, pad_spec),
+        mx.pad(keys, pad_spec),
+        mx.pad(values, pad_spec),
+    )
+
+
+def truncate_padded_output(
+    out: mx.array,
+    batch_size: int,
+    seq_len: int,
+    n_heads: int,
+    cache_head_dim: int,
+    actual_head_dim: int,
+) -> mx.array:
+    """Reshape kernel output and strip padding back to ``actual_head_dim``.
+
+    Inverse of :func:`pad_qkv_to_cache_head_dim`: before the output goes to
+    ``o_proj``, we slice off the zero-padded tail so the trailing
+    projection sees the layer's real head_dim.  No-op when the layer was
+    never padded (``actual_head_dim == cache_head_dim``).
+
+    Args:
+        out: Kernel output shaped ``(seq_len, n_heads, cache_head_dim)``.
+        batch_size: Batch size (typically 1 for packed sequences).
+        seq_len: Total tokens in the packed sequence.
+        n_heads: Number of query heads.
+        cache_head_dim: Head_dim the kernel operated on.
+        actual_head_dim: Layer's original head_dim before padding.
+
+    Returns:
+        Flat output shaped ``(batch_size, seq_len, n_heads * actual_head_dim)``.
+    """
+    if actual_head_dim == cache_head_dim:
+        return out.reshape(batch_size, seq_len, n_heads * cache_head_dim)
+    out = out.reshape(batch_size, seq_len, n_heads, cache_head_dim)[
+        ..., :actual_head_dim
+    ]
+    return out.reshape(batch_size, seq_len, n_heads * actual_head_dim)
+
+
 # === SDPA forward ===
 
 
@@ -120,7 +311,7 @@ def sdpa_forward(
         Tuple of (output, kv_pair) where kv_pair is (keys, values)
         after norm + RoPE, for YOCO KV sharing across layers.
     """
-    B, L, D = x.shape  # noqa: N806
+    B, L, _ = x.shape  # noqa: N806
 
     # Resolve head counts — mlx_lm uses different attribute names:
     #   Qwen3/Llama/Gemma: n_heads, n_kv_heads
@@ -128,96 +319,22 @@ def sdpa_forward(
     n_heads = getattr(inner, "n_heads", None) or inner.num_attention_heads
     n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
 
-    # --- Projections + reshape ---
-    # Qwen3.5 (Qwen3Next) uses gated attention: q_proj outputs 2x head_dim,
-    # split into queries (for attention) + gate (applied after attention).
-    q_proj_out = inner.q_proj(x)
-    gate = None
-    head_dim = inner.k_proj.weight.shape[0] // n_kv_heads
-    q_full_head = q_proj_out.shape[-1] // n_heads
-    if q_full_head == 2 * head_dim:
-        # Gated: split into queries + gate
-        q_reshaped = q_proj_out.reshape(B, L, n_heads, q_full_head)
-        queries, gate = mx.split(q_reshaped, 2, axis=-1)
-        gate = gate.reshape(B, L, -1)
-    else:
-        queries = q_proj_out.reshape(B, L, n_heads, -1)
-
-    # YOCO KV sharing (Gemma4): reuse K/V from a reference layer instead
-    # of projecting new ones.  shared_kv arrives as (keys, values) in
-    # (B, n_kv_heads, L, head_dim) layout — already normed and RoPE'd.
-    if shared_kv is not None:
-        keys, values = shared_kv
-        # Q still needs norm + RoPE
-        if hasattr(inner, "q_norm"):
-            queries = inner.q_norm(queries)
-        queries = queries.transpose(0, 2, 1, 3)
-        if hasattr(inner, "rope") or hasattr(inner, "rotary_emb"):
-            # Keys are already RoPE'd from the reference layer; skip them.
-            queries, _ = apply_packed_rope(
-                inner,
-                queries,
-                keys,
-                ctx.cu_seqlens,
-                offsets=ctx.offsets if ctx.offsets else None,
-                apply_keys=False,
-            )
-    else:
-        keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
-        # Gemma4 K-eq-V variant (26B/31B): no v_proj, values = keys.
-        if hasattr(inner, "v_proj"):
-            values = inner.v_proj(x).reshape(B, L, n_kv_heads, -1)
-        else:
-            values = keys
-
-        # Per-head RMSNorm (Qwen3, Qwen3.5, Gemma4)
-        if hasattr(inner, "q_norm"):
-            queries = inner.q_norm(queries)
-        if hasattr(inner, "k_norm"):
-            keys = inner.k_norm(keys)
-        if hasattr(inner, "v_norm"):
-            values = inner.v_norm(values)
-
-        # transpose → (B, heads, L, head_dim)
-        queries = queries.transpose(0, 2, 1, 3)
-        keys = keys.transpose(0, 2, 1, 3)
-        values = values.transpose(0, 2, 1, 3)
-
-        # --- RoPE (per-request position reset) ---
-        if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
-            raise NotImplementedError(
-                f"Attention module {type(inner).__name__} does not have a "
-                "'rope' or 'rotary_emb' attribute."
-            )
-
-        queries, keys = apply_packed_rope(
-            inner,
-            queries,
-            keys,
-            ctx.cu_seqlens,
-            offsets=ctx.offsets if ctx.offsets else None,
-        )
-
-    # Save K/V for YOCO sharing before any padding
-    kv_for_sharing = (keys, values)
+    queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
+        inner, x, ctx, n_heads, n_kv_heads, shared_kv
+    )
 
     # --- Metal kernel dispatch ---
     n_heads = queries.shape[1]
     head_dim = queries.shape[3]
 
-    # Variable head_dim models (e.g. Gemma4: sliding=256, full=512):
-    # Cache is allocated with max head_dim.  When this layer's head_dim is
-    # smaller, pad Q/K/V with zeros so scatter writes and the kernel both
-    # operate at the cache's native head_dim.  The zero-padded dimensions
-    # do not affect attention scores (QK dot product) or V aggregation.
+    # Variable head_dim models (e.g. Gemma4): pad Q/K/V to the cache's
+    # allocated head_dim.  Output is truncated back before o_proj.
     cache_head_dim = kv_cache.head_dim
     actual_head_dim = head_dim
-    if head_dim < cache_head_dim:
-        pad_width = cache_head_dim - head_dim
-        queries = mx.pad(queries, [(0, 0), (0, 0), (0, 0), (0, pad_width)])
-        keys = mx.pad(keys, [(0, 0), (0, 0), (0, 0), (0, pad_width)])
-        values = mx.pad(values, [(0, 0), (0, 0), (0, 0), (0, pad_width)])
-        head_dim = cache_head_dim
+    queries, keys, values = pad_qkv_to_cache_head_dim(
+        queries, keys, values, head_dim, cache_head_dim
+    )
+    head_dim = cache_head_dim
 
     # Reshape to 3D: (1, heads, L, hd) → (L, heads, hd)
     q_3d = mx.contiguous(queries[0].transpose(1, 0, 2).astype(kv_cache.dtype))
@@ -302,14 +419,8 @@ def sdpa_forward(
         out,
     )
 
-    # output: (L, n_heads, head_dim) → (B, L, n_heads * head_dim)
-    # Truncate padded dimensions back to the layer's actual head_dim
-    # before o_proj, which expects n_heads * actual_head_dim.
-    if actual_head_dim < cache_head_dim:
-        out = out.reshape(B, L, n_heads, cache_head_dim)[..., :actual_head_dim]
-        out = out.reshape(B, L, n_heads * actual_head_dim)
-    else:
-        out = out.reshape(B, L, n_heads * head_dim)
+    # Reshape + strip padding back to actual head_dim before o_proj.
+    out = truncate_padded_output(out, B, L, n_heads, cache_head_dim, actual_head_dim)
     if gate is not None:
         out = out * mx.sigmoid(gate)
     return inner.o_proj(out), kv_for_sharing

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -108,12 +108,17 @@ def sdpa_forward(
     ctx: PagedAttentionContext,
     kv_cache: MetalPagedKVCache,
     layer_idx: int,
-) -> mx.array:
+    shared_kv: tuple[mx.array, mx.array] | None = None,
+) -> tuple[mx.array, tuple[mx.array, mx.array] | None]:
     """Full SDPA forward pass: project → norm → RoPE → Metal kernel.
 
     Handles MHA, GQA, and MQA uniformly — the head ratio between
     query and KV heads is passed to the Metal kernel which handles
     the broadcast internally.
+
+    Returns:
+        Tuple of (output, kv_pair) where kv_pair is (keys, values)
+        after norm + RoPE, for YOCO KV sharing across layers.
     """
     B, L, D = x.shape  # noqa: N806
 
@@ -138,39 +143,81 @@ def sdpa_forward(
     else:
         queries = q_proj_out.reshape(B, L, n_heads, -1)
 
-    keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
-    values = inner.v_proj(x).reshape(B, L, n_kv_heads, -1)
+    # YOCO KV sharing (Gemma4): reuse K/V from a reference layer instead
+    # of projecting new ones.  shared_kv arrives as (keys, values) in
+    # (B, n_kv_heads, L, head_dim) layout — already normed and RoPE'd.
+    if shared_kv is not None:
+        keys, values = shared_kv
+        # Q still needs norm + RoPE
+        if hasattr(inner, "q_norm"):
+            queries = inner.q_norm(queries)
+        queries = queries.transpose(0, 2, 1, 3)
+        if hasattr(inner, "rope") or hasattr(inner, "rotary_emb"):
+            # Keys are already RoPE'd from the reference layer; skip them.
+            queries, _ = apply_packed_rope(
+                inner,
+                queries,
+                keys,
+                ctx.cu_seqlens,
+                offsets=ctx.offsets if ctx.offsets else None,
+                apply_keys=False,
+            )
+    else:
+        keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
+        # Gemma4 K-eq-V variant (26B/31B): no v_proj, values = keys.
+        if hasattr(inner, "v_proj"):
+            values = inner.v_proj(x).reshape(B, L, n_kv_heads, -1)
+        else:
+            values = keys
 
-    # Per-head RMSNorm before RoPE (Qwen3, Qwen3.5)
-    if hasattr(inner, "q_norm"):
-        queries = inner.q_norm(queries)
-    if hasattr(inner, "k_norm"):
-        keys = inner.k_norm(keys)
+        # Per-head RMSNorm (Qwen3, Qwen3.5, Gemma4)
+        if hasattr(inner, "q_norm"):
+            queries = inner.q_norm(queries)
+        if hasattr(inner, "k_norm"):
+            keys = inner.k_norm(keys)
+        if hasattr(inner, "v_norm"):
+            values = inner.v_norm(values)
 
-    # transpose → (B, heads, L, head_dim)
-    queries = queries.transpose(0, 2, 1, 3)
-    keys = keys.transpose(0, 2, 1, 3)
-    values = values.transpose(0, 2, 1, 3)
+        # transpose → (B, heads, L, head_dim)
+        queries = queries.transpose(0, 2, 1, 3)
+        keys = keys.transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
 
-    # --- RoPE (per-request position reset) ---
-    # mlx_lm uses "rope", mlx_vlm Qwen3.5 uses "rotary_emb"
-    if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
-        raise NotImplementedError(
-            f"Attention module {type(inner).__name__} does not have a 'rope' "
-            "or 'rotary_emb' attribute. Only RoPE-based models are supported."
+        # --- RoPE (per-request position reset) ---
+        if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
+            raise NotImplementedError(
+                f"Attention module {type(inner).__name__} does not have a "
+                "'rope' or 'rotary_emb' attribute."
+            )
+
+        queries, keys = apply_packed_rope(
+            inner,
+            queries,
+            keys,
+            ctx.cu_seqlens,
+            offsets=ctx.offsets if ctx.offsets else None,
         )
 
-    queries, keys = apply_packed_rope(
-        inner,
-        queries,
-        keys,
-        ctx.cu_seqlens,
-        offsets=ctx.offsets if ctx.offsets else None,
-    )
+    # Save K/V for YOCO sharing before any padding
+    kv_for_sharing = (keys, values)
 
     # --- Metal kernel dispatch ---
     n_heads = queries.shape[1]
     head_dim = queries.shape[3]
+
+    # Variable head_dim models (e.g. Gemma4: sliding=256, full=512):
+    # Cache is allocated with max head_dim.  When this layer's head_dim is
+    # smaller, pad Q/K/V with zeros so scatter writes and the kernel both
+    # operate at the cache's native head_dim.  The zero-padded dimensions
+    # do not affect attention scores (QK dot product) or V aggregation.
+    cache_head_dim = kv_cache.head_dim
+    actual_head_dim = head_dim
+    if head_dim < cache_head_dim:
+        pad_width = cache_head_dim - head_dim
+        queries = mx.pad(queries, [(0, 0), (0, 0), (0, 0), (0, pad_width)])
+        keys = mx.pad(keys, [(0, 0), (0, 0), (0, 0), (0, pad_width)])
+        values = mx.pad(values, [(0, 0), (0, 0), (0, 0), (0, pad_width)])
+        head_dim = cache_head_dim
 
     # Reshape to 3D: (1, heads, L, hd) → (L, heads, hd)
     q_3d = mx.contiguous(queries[0].transpose(1, 0, 2).astype(kv_cache.dtype))
@@ -256,7 +303,13 @@ def sdpa_forward(
     )
 
     # output: (L, n_heads, head_dim) → (B, L, n_heads * head_dim)
-    out = out.reshape(B, L, n_heads * head_dim)
+    # Truncate padded dimensions back to the layer's actual head_dim
+    # before o_proj, which expects n_heads * actual_head_dim.
+    if actual_head_dim < cache_head_dim:
+        out = out.reshape(B, L, n_heads, cache_head_dim)[..., :actual_head_dim]
+        out = out.reshape(B, L, n_heads * actual_head_dim)
+    else:
+        out = out.reshape(B, L, n_heads * head_dim)
     if gate is not None:
         out = out * mx.sigmoid(gate)
-    return inner.o_proj(out)
+    return inner.o_proj(out), kv_for_sharing

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -6,12 +6,21 @@ between ``n_heads`` (queries) and ``n_kv_heads`` (keys/values) is handled
 transparently by the Metal paged attention kernel.
 
 Handles models whose attention module exposes:
-- ``q_proj``, ``k_proj``, ``v_proj``, ``o_proj`` linear projections
-- ``rope`` for rotary position embeddings
+- ``q_proj``, ``k_proj``, ``o_proj`` linear projections (``v_proj`` optional —
+  see K-eq-V variant below)
+- ``rope`` or ``rotary_emb`` for rotary position embeddings
 - ``n_heads``, ``n_kv_heads`` head counts
-- Optionally ``q_norm``, ``k_norm`` (Qwen3 per-head RMSNorm before RoPE)
+- Optionally ``q_norm``, ``k_norm``, ``v_norm`` per-head RMSNorms
 
-Covers: Qwen3, Llama, Mistral, and other standard transformer architectures.
+Gemma4 variants (see :func:`prepare_sdpa_qkv`):
+- **YOCO**: later layers reuse K/V from a reference layer via ``shared_kv``.
+- **K-eq-V**: 26B/31B drop ``v_proj`` and reuse ``keys`` as ``values``.
+- **Variable head_dim**: sliding vs. full-attention layers use different
+  head_dim; Q/K/V are zero-padded up to the cache's allocated head_dim
+  via :func:`pad_qkv_to_cache_head_dim`.
+
+Covers: Qwen3, Qwen3.5, Llama, Mistral, Gemma, Gemma4, and other
+RoPE-based transformer architectures.
 
 All operations use MLX arrays end-to-end — no PyTorch MPS bridge.
 """
@@ -243,8 +252,16 @@ def pad_qkv_to_cache_head_dim(
         Padded ``(queries, keys, values)``.
 
     Raises:
-        ValueError: If ``head_dim > cache_head_dim`` (unsupported).
+        ValueError: If ``head_dim > cache_head_dim`` (unsupported), or if
+            ``queries`` / ``keys`` / ``values`` do not share the same last
+            dimension (caller invariant).
     """
+    if not (queries.shape[-1] == keys.shape[-1] == values.shape[-1] == head_dim):
+        raise ValueError(
+            "Q/K/V last-dim mismatch: "
+            f"q={queries.shape[-1]}, k={keys.shape[-1]}, "
+            f"v={values.shape[-1]}, head_dim={head_dim}"
+        )
     if head_dim == cache_head_dim:
         return queries, keys, values
     if head_dim > cache_head_dim:
@@ -318,8 +335,8 @@ def sdpa_forward(
     B, L, _ = x.shape  # noqa: N806
 
     # Resolve head counts — mlx_lm uses different attribute names:
-    #   Qwen3/Llama/Gemma: n_heads, n_kv_heads
-    #   Qwen3.5 (Qwen3Next): num_attention_heads, num_key_value_heads
+    #   Qwen3/Llama/Gemma/Gemma4: n_heads, n_kv_heads
+    #   Qwen3.5 (Qwen3Next):      num_attention_heads, num_key_value_heads
     n_heads = getattr(inner, "n_heads", None) or inner.num_attention_heads
     n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
 

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -165,15 +165,19 @@ def prepare_sdpa_qkv(
         if hasattr(inner, "q_norm"):
             queries = inner.q_norm(queries)
         queries = queries.transpose(0, 2, 1, 3)
-        if hasattr(inner, "rope") or hasattr(inner, "rotary_emb"):
-            queries, _ = apply_packed_rope(
-                inner,
-                queries,
-                keys,
-                ctx.cu_seqlens,
-                offsets=ctx.offsets if ctx.offsets else None,
-                apply_keys=False,
+        if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
+            raise NotImplementedError(
+                f"Attention module {type(inner).__name__} does not have a "
+                "'rope' or 'rotary_emb' attribute."
             )
+        queries, _ = apply_packed_rope(
+            inner,
+            queries,
+            keys,
+            ctx.cu_seqlens,
+            offsets=ctx.offsets if ctx.offsets else None,
+            apply_keys=False,
+        )
     else:
         keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
         # K-eq-V variant (Gemma4 26B/31B): no v_proj, values = keys.
@@ -300,7 +304,7 @@ def sdpa_forward(
     kv_cache: MetalPagedKVCache,
     layer_idx: int,
     shared_kv: tuple[mx.array, mx.array] | None = None,
-) -> tuple[mx.array, tuple[mx.array, mx.array] | None]:
+) -> tuple[mx.array, tuple[mx.array, mx.array]]:
     """Full SDPA forward pass: project → norm → RoPE → Metal kernel.
 
     Handles MHA, GQA, and MQA uniformly — the head ratio between

--- a/vllm_metal/metal_kernel_backend/packed_prefill_compat.py
+++ b/vllm_metal/metal_kernel_backend/packed_prefill_compat.py
@@ -67,11 +67,13 @@ def apply_packed_rope(
         q_seg = queries[:, :, start:end, :]
 
         if rope_fn is not None:
+            # mlx_lm API: rope(x, offset=off) → rotated_x
             q_parts.append(rope_fn(q_seg, offset=off))
             if apply_keys:
                 k_seg = keys[:, :, start:end, :]
                 k_parts.append(rope_fn(k_seg, offset=off))
         else:
+            # mlx_vlm M-RoPE API: rotary_emb(x, position_ids) → (cos, sin)
             k_seg = keys[:, :, start:end, :]
             q_rot, k_rot = _apply_mrope_segment(rotary_emb, q_seg, k_seg, off)
             q_parts.append(q_rot)

--- a/vllm_metal/metal_kernel_backend/packed_prefill_compat.py
+++ b/vllm_metal/metal_kernel_backend/packed_prefill_compat.py
@@ -39,6 +39,7 @@ def apply_packed_rope(
     keys: mx.array,
     cu_seqlens: list[int],
     offsets: list[int] | None = None,
+    apply_keys: bool = True,
 ) -> tuple[mx.array, mx.array]:
     """Apply per-request RoPE for packed sequences.
 
@@ -47,6 +48,9 @@ def apply_packed_rope(
     segment starts at position 0 (pure prefill).  For unified prefill+decode
     batches, decode segments carry ``offset=seq_len`` while prefill segments
     keep ``offset=0``.
+
+    When ``apply_keys`` is False, keys are returned unchanged (used by
+    YOCO KV sharing where keys arrive already RoPE'd from a prior layer).
 
     Supports both mlx_lm's ``rope(x, offset=)`` API and mlx_vlm's
     ``rotary_emb(x, position_ids)`` M-RoPE API (Qwen3.5).
@@ -61,16 +65,19 @@ def apply_packed_rope(
         end = cu_seqlens[i + 1]
         off = offsets[i] if offsets is not None else 0
         q_seg = queries[:, :, start:end, :]
-        k_seg = keys[:, :, start:end, :]
 
         if rope_fn is not None:
-            # mlx_lm API: rope(x, offset=off) → rotated_x
             q_parts.append(rope_fn(q_seg, offset=off))
-            k_parts.append(rope_fn(k_seg, offset=off))
+            if apply_keys:
+                k_seg = keys[:, :, start:end, :]
+                k_parts.append(rope_fn(k_seg, offset=off))
         else:
-            # mlx_vlm M-RoPE API: rotary_emb(x, position_ids) → (cos, sin)
+            k_seg = keys[:, :, start:end, :]
             q_rot, k_rot = _apply_mrope_segment(rotary_emb, q_seg, k_seg, off)
             q_parts.append(q_rot)
-            k_parts.append(k_rot)
+            if apply_keys:
+                k_parts.append(k_rot)
 
-    return mx.concatenate(q_parts, axis=2), mx.concatenate(k_parts, axis=2)
+    rotated_q = mx.concatenate(q_parts, axis=2) if q_parts else queries
+    rotated_k = mx.concatenate(k_parts, axis=2) if apply_keys and k_parts else keys
+    return rotated_q, rotated_k

--- a/vllm_metal/metal_kernel_backend/paged_attention.py
+++ b/vllm_metal/metal_kernel_backend/paged_attention.py
@@ -42,6 +42,14 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
     Uses ``object.__setattr__`` to bypass MLX nn.Module's ``__setattr__``.
 
     When no ``PagedAttentionContext`` is set, falls back to original attention.
+
+    Return contract:
+        - Standard models: returns ``mx.array`` (attention output).
+        - YOCO models (e.g. Gemma4): when ``shared_kv`` is in kwargs,
+          returns ``(output, kv_pair, offset)`` so the caller can forward
+          the K/V pair to the next same-type layer.  The return type is
+          selected by kwarg presence rather than a class flag because
+          mlx_lm's attention signature is fixed.
     """
 
     def __init__(

--- a/vllm_metal/metal_kernel_backend/paged_attention.py
+++ b/vllm_metal/metal_kernel_backend/paged_attention.py
@@ -71,18 +71,39 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         cache: nn.Module | None = None,
         position_ids: mx.array | None = None,
         **kwargs: Any,
-    ) -> mx.array:
+    ) -> Any:
         ctx = get_context()
         if ctx is None:
-            # No paged context → delegate to original attention
-            return self._inner(
-                x, mask=mask, cache=cache, position_ids=position_ids, **kwargs
-            )
+            # No paged context → delegate to original attention.
+            # Only pass position_ids when provided (mlx_vlm models);
+            # mlx_lm models (e.g. Gemma4) use offset via **kwargs instead.
+            if position_ids is not None:
+                return self._inner(
+                    x, mask=mask, cache=cache, position_ids=position_ids, **kwargs
+                )
+            return self._inner(x, mask=mask, cache=cache, **kwargs)
 
         inner = self._inner
 
-        # SDPA attention via Metal kernel
-        return sdpa_forward(inner, x, ctx, self._mk_kv_cache, self._mk_cache_idx)
+        # SDPA attention via Metal kernel.
+        # Pass shared_kv for YOCO KV sharing (Gemma4: later layers reuse
+        # K/V from earlier same-type layers instead of projecting their own).
+        shared_kv = kwargs.get("shared_kv")
+        output, kv_pair = sdpa_forward(
+            inner,
+            x,
+            ctx,
+            self._mk_kv_cache,
+            self._mk_cache_idx,
+            shared_kv=shared_kv,
+        )
+
+        # YOCO models (Gemma4) expect (output, shared_kv, offset) return.
+        # Key off shared_kv presence — it's the definitive YOCO indicator.
+        if "shared_kv" in kwargs:
+            return (output, kv_pair, kwargs.get("offset", 0))
+
+        return output
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_metal/v1/model_compat.py
+++ b/vllm_metal/v1/model_compat.py
@@ -13,11 +13,12 @@ from typing import Any
 # Model loading
 # ---------------------------------------------------------------------------
 
-# Models that vLLM flags as multimodal but must be loaded via mlx_lm instead
-# of mlx_vlm.  Reasons are model-specific (see comment per entry).
+# Workaround: models that vLLM flags as multimodal but must be loaded
+# via mlx_lm instead of mlx_vlm.  Reasons are model-specific.
 #
-# - "gemma4": mlx_vlm's Gemma4 forward pass yields garbled text; mlx_lm loads
-#   the text backbone correctly.  Remove when mlx_vlm fixes this upstream.
+# - "gemma4": mlx_vlm's Gemma4 forward pass emits garbled output on the
+#   same checkpoint that mlx_lm decodes correctly.  This override can be
+#   removed once the mlx_vlm Gemma4 implementation matches mlx_lm's.
 _TEXT_BACKBONE_OVERRIDE_TYPES: frozenset[str] = frozenset({"gemma4"})
 
 

--- a/vllm_metal/v1/model_compat.py
+++ b/vllm_metal/v1/model_compat.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-specific compatibility helpers for MetalModelRunner.
+
+Houses per-model workarounds and dim-resolution logic so that
+``model_runner.py`` stays model-agnostic (per its coding style guide).
+Any Gemma4/Qwen/etc. specific behavior belongs here, not inline in
+the shared runner.
+"""
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+
+# Models that vLLM flags as multimodal but must be loaded via mlx_lm instead
+# of mlx_vlm.  Reasons are model-specific (see comment per entry).
+#
+# - "gemma4": mlx_vlm's Gemma4 forward pass yields garbled text; mlx_lm loads
+#   the text backbone correctly.  Remove when mlx_vlm fixes this upstream.
+_TEXT_BACKBONE_OVERRIDE_TYPES: frozenset[str] = frozenset({"gemma4"})
+
+
+def should_force_text_backbone(hf_config: Any) -> bool:
+    """Return True if the model should be loaded via mlx_lm despite
+    vLLM flagging it as multimodal.
+
+    Args:
+        hf_config: HuggingFace config object (with ``model_type`` attr).
+
+    Returns:
+        True if this model_type needs the mlx_lm text-backbone override.
+    """
+    model_type = getattr(hf_config, "model_type", "")
+    return model_type in _TEXT_BACKBONE_OVERRIDE_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Variable head dimension (Gemma4-style)
+# ---------------------------------------------------------------------------
+
+
+def resolve_max_head_dim(
+    args: dict[str, Any],
+    head_dim: int | None,
+) -> int | None:
+    """Return the max head_dim across all attention layer types.
+
+    Gemma4-style models use different ``head_dim`` for sliding attention
+    (256) versus full attention (512) layers.  The paged KV cache is
+    sized for a single head_dim, so we use the larger value to ensure
+    every layer's K/V fits in a cache block.
+
+    Args:
+        args: Model config dict (expects optional ``global_head_dim``).
+        head_dim: The base head_dim from config.
+
+    Returns:
+        ``max(head_dim, global_head_dim)`` if both are set, else
+        ``head_dim``.
+    """
+    global_head_dim = args.get("global_head_dim")
+    if global_head_dim and head_dim:
+        return max(int(head_dim), int(global_head_dim))
+    return head_dim
+
+
+# ---------------------------------------------------------------------------
+# Variable KV head count (Gemma4 26B/31B)
+# ---------------------------------------------------------------------------
+
+
+def require_uniform_kv_heads(
+    args: dict[str, Any],
+    num_kv_heads: int | None,
+) -> None:
+    """Reject models that vary KV head count across attention layer types.
+
+    Gemma4 26B/31B set ``num_global_key_value_heads`` different from
+    ``num_key_value_heads`` for full vs. sliding attention layers.  The
+    paged KV cache currently assumes a single ``num_kv_heads`` — these
+    models need per-layer KV head allocation which is not yet supported.
+
+    Args:
+        args: Model config dict.
+        num_kv_heads: Resolved base ``num_key_value_heads``.
+
+    Raises:
+        ValueError: If ``num_global_key_value_heads`` differs from
+            ``num_kv_heads`` (paged path cannot handle it).
+    """
+    global_kv_heads = args.get("num_global_key_value_heads")
+    if global_kv_heads and num_kv_heads and int(global_kv_heads) != int(num_kv_heads):
+        raise ValueError(
+            f"Paged attention does not support variable KV head count: "
+            f"num_key_value_heads={num_kv_heads}, "
+            f"num_global_key_value_heads={global_kv_heads}. "
+            f"Use VLLM_METAL_USE_PAGED_ATTENTION=0 to fall back to the "
+            f"non-paged path."
+        )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -70,6 +70,10 @@ from vllm_metal.v1.contiguous_cache import (
     _extract_kv_cache,
     _merge_kv_caches,
 )
+from vllm_metal.v1.model_compat import (
+    resolve_max_head_dim,
+    should_force_text_backbone,
+)
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
     SamplingBatch,
@@ -344,7 +348,9 @@ class MetalModelRunner:
         Returns:
             True if the model is multimodal/VLM, False otherwise
         """
-        # Check vLLM's multimodal detection
+        hf_config = getattr(self.model_config, "hf_config", None)
+        if hf_config is not None and should_force_text_backbone(hf_config):
+            return False
         if hasattr(self.model_config, "is_multimodal_model"):
             return self.model_config.is_multimodal_model
         return False
@@ -529,6 +535,7 @@ class MetalModelRunner:
             if hidden_size and num_attention_heads
             else None
         )
+        head_dim = resolve_max_head_dim(args, head_dim)
 
         # Fail fast if critical dims are missing
         missing = []

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -32,6 +32,7 @@ from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES
 from vllm_metal.utils import set_wired_limit
+from vllm_metal.v1.model_compat import require_uniform_kv_heads
 
 if TYPE_CHECKING:
     from vllm_metal.v1.model_runner import (
@@ -176,6 +177,8 @@ class MetalWorker(WorkerBase):
         max_model_len.
         """
         runner = self.model_runner
+        require_uniform_kv_heads(runner.model_args, runner.num_kv_heads)
+
         # Use cache_config.block_size (not metal_config) because vLLM's
         # hybrid alignment may have adjusted it to match mamba page size.
         block_size = self.vllm_config.cache_config.block_size


### PR DESCRIPTION
## Summary
- Add Gemma4 text generation with paged KV cache on Metal
- **hs512 Metal kernel**: instantiate paged attention for head_dim=512 (v1 + v2)
- **Variable head_dim**: pad Q/K/V to cache's max head_dim for models with mixed sliding (256) / full (512) attention layers
- **YOCO KV sharing**: SDPA forward accepts `shared_kv` so later layers reuse K/V from earlier same-type layers
- **v_norm**: support per-head RMSNorm on values (Gemma4 uses q_norm + k_norm + v_norm)
- **global_head_dim**: use `max(head_dim, global_head_dim)` for KV cache block sizing
- **mlx_lm loading workaround**: Gemma4 loaded via mlx_lm (text backbone) because mlx_vlm produces garbled output; remove when mlx_vlm fixes this
- **K-eq-V**: handle Gemma4 variants without v_proj (26B/31B use values = keys)                                           
- **Variable KV head guard**: reject `num_global_key_value_heads != num_key_value_heads` with clear error (26B/31B need per-layer KV allocation)
## What's not included
- Multimodal support (vision/audio) — blocked by mlx_vlm Gemma4 forward pass bug, will track separately
- Sliding window enforcement in kernel (currently disabled)
- YOCO memory optimization (shared layers currently duplicate cache)
- Per-layer KV head allocation (needed for 26B/31B where global_kv_heads != kv_heads) 

## Test
- Gemma4-E2B-it verified with `vllm serve` (paged attention, thinking mode, max-model-len 4096)
- Qwen3-0.6B / Qwen3.5-0.8B unaffected — unit tests 411/411 passed
- hs512 kernel instantiation does not affect existing hs≤256 models
```
VLLM_METAL_MEMORY_FRACTION=0.5 \
  vllm serve /Users/rickychen/llm/models/gemma-4-E2B-it \
  --port 8000 --max-model-len 4096 --max-num-seqs 4 \
  --default-chat-template-kwargs '{"enable_thinking": true}' \
  --reasoning-parser gemma4   
```
