### PR TITLE
Fix vllm_metal logging integration with vLLM

### DIFF
--- a/tests/test_macos_defaults.py
+++ b/tests/test_macos_defaults.py
@@ -37,7 +37,14 @@ def test_apply_macos_defaults_logs_when_setting(monkeypatch, caplog) -> None:
     monkeypatch.delenv("VLLM_WORKER_MULTIPROC_METHOD", raising=False)
     monkeypatch.setattr(sys, "platform", "darwin")
 
-    with caplog.at_level(logging.DEBUG):
+    metal_logger = logging.getLogger("vllm_metal")
+    original_level = metal_logger.level
+    metal_logger.addHandler(caplog.handler)
+    metal_logger.setLevel(logging.DEBUG)
+    try:
         vm._apply_macos_defaults()
+    finally:
+        metal_logger.removeHandler(caplog.handler)
+        metal_logger.setLevel(original_level)
 
     assert "defaulting VLLM_WORKER_MULTIPROC_METHOD" in caplog.text

--- a/tests/test_platform_update_block_size.py
+++ b/tests/test_platform_update_block_size.py
@@ -365,32 +365,39 @@ class TestUpdateBlockSizeForBackend:
         """
         import logging
 
-        with (
-            patch("vllm.model_executor.models.ModelRegistry") as mock_registry,
-            patch("vllm_metal.config.get_config") as mock_get_config,
-            caplog.at_level(logging.WARNING),
-        ):
-            mock_model_cls = MagicMock()
-            mock_model_cls.get_mamba_state_shape_from_config.return_value = (
-                mock_mamba_state["shape"]
-            )
-            mock_model_cls.get_mamba_state_dtype_from_config.return_value = (
-                mock_mamba_state["dtype"]
-            )
-            mock_registry.resolve_model_cls.return_value = (mock_model_cls, None)
+        platform_logger = logging.getLogger("vllm_metal.platform")
+        original_level = platform_logger.level
+        platform_logger.addHandler(caplog.handler)
+        platform_logger.setLevel(logging.WARNING)
+        try:
+            with (
+                patch("vllm.model_executor.models.ModelRegistry") as mock_registry,
+                patch("vllm_metal.config.get_config") as mock_get_config,
+            ):
+                mock_model_cls = MagicMock()
+                mock_model_cls.get_mamba_state_shape_from_config.return_value = (
+                    mock_mamba_state["shape"]
+                )
+                mock_model_cls.get_mamba_state_dtype_from_config.return_value = (
+                    mock_mamba_state["dtype"]
+                )
+                mock_registry.resolve_model_cls.return_value = (mock_model_cls, None)
 
-            # Mock metal config with paged attention enabled
-            mock_metal_config = MagicMock()
-            mock_metal_config.use_paged_attention = True
-            mock_get_config.return_value = mock_metal_config
+                # Mock metal config with paged attention enabled
+                mock_metal_config = MagicMock()
+                mock_metal_config.use_paged_attention = True
+                mock_get_config.return_value = mock_metal_config
 
-            # Execute - should NOT raise, just log warning
-            MetalPlatform.update_block_size_for_backend(vllm_config)
+                # Execute - should NOT raise, just log warning
+                MetalPlatform.update_block_size_for_backend(vllm_config)
 
-            # Verify warning was logged with explanation
-            assert "block-size translation" in caplog.text
-            assert "PR #235" in caplog.text
-            assert "kernel blocks" in caplog.text
+                # Verify warning was logged with explanation
+                assert "block-size translation" in caplog.text
+                assert "PR #235" in caplog.text
+                assert "kernel blocks" in caplog.text
+        finally:
+            platform_logger.removeHandler(caplog.handler)
+            platform_logger.setLevel(original_level)
 
 
 # ============================================================================

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -14,6 +14,20 @@ __version__ = "0.2.0"
 logger = logging.getLogger(__name__)
 
 
+def _configure_logging() -> None:
+    """Configure vllm_metal logging to mirror vLLM settings."""
+    from vllm.envs import VLLM_LOGGING_LEVEL
+
+    vllm_logger = logging.getLogger("vllm")
+    metal_logger = logging.getLogger("vllm_metal")
+    metal_logger.setLevel(logging.getLevelName(VLLM_LOGGING_LEVEL))
+
+    if vllm_logger.handlers and not metal_logger.handlers:
+        for handler in vllm_logger.handlers:
+            metal_logger.addHandler(handler)
+        metal_logger.propagate = False
+
+
 def _apply_macos_defaults() -> None:
     """Apply safe defaults for macOS when using the Metal plugin.
 
@@ -83,6 +97,7 @@ def _register() -> str | None:
     Returns:
         Fully qualified class name if platform is available, None otherwise
     """
+    _configure_logging()
     _apply_macos_defaults()
 
     from vllm_metal.compat import apply_compat_patches


### PR DESCRIPTION
This PR is:
- To ensure `vllm_metal` logs respect vLLM’s logging level and handlers at registration time.
- To prevent INFO logs from being silently dropped due to the root logger default.
- To stabilize log capture in tests under the new logger wiring.

Problem
`vllm_metal` loggers were inheriting the root logger (default `WARNING`) instead of vLLM’s configured logger, so INFO logs were filtered out even when vLLM was logging at INFO.

Before
```
root (WARNING/30)
├── vllm (INFO/20)        <- configured by vLLM
└── vllm_metal (NOTSET)   <- inherits root => WARNING
```

After
```
root (WARNING/30)
├── vllm (INFO/20)        <- configured by vLLM
└── vllm_metal (INFO/20)  <- explicitly synced + handlers copied
```

Before/After Capture
```bash
# main
effective_level 30 handlers 0
WARNING should appear on main

# fix/logger-init-minimal
effective_level 20 handlers 1
INFO 04-09 17:54:24 [<stdin>:7] INFO should appear after sync
WARNING 04-09 17:54:24 [<stdin>:8] WARNING should appear after sync
```
