### PR TITLE
Enable chunked prefill for paged attention path

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -17,7 +17,7 @@ run_smoke_test() {
   GLOO_SOCKET_IFNAME=lo0 \
     VLLM_METAL_USE_PAGED_ATTENTION=1 \
     VLLM_METAL_MEMORY_FRACTION=0.8 \
-    vllm serve "$model" --revision "$revision" --max-model-len 512 ${extra_args[@]+"${extra_args[@]}"} &
+    vllm serve "$model" --revision "$revision" --max-model-len 512 --max-num-batched-tokens 64 ${extra_args[@]+"${extra_args[@]}"} &
 
   local vllm_pid=$!
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -10,7 +10,7 @@ import torch
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 
-from vllm_metal.config import PAGED_ATTENTION_OVERHEAD_BYTES
+from vllm_metal.config import PAGED_ATTENTION_OVERHEAD_BYTES, reset_config
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.worker import MetalWorker
 
@@ -167,46 +167,95 @@ class TestMetalPlatform:
         MetalPlatform.verify_quantization("awq")
         MetalPlatform.verify_quantization("compressed-tensors")
 
-    def test_check_and_update_config_disables_chunked_prefill(
+    def test_check_and_update_config_disables_chunked_prefill_non_paged(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Metal should disable chunked prefill until the runner supports it.
+        """Non-paged path should disable chunked prefill.
 
         When chunked prefill is disabled, max_num_batched_tokens must be at
         least max_model_len so the scheduler can schedule the entire prompt
         in a single step.
         """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
-        vllm_config = SimpleNamespace(
-            parallel_config=SimpleNamespace(
-                worker_cls="auto",
-                distributed_executor_backend="auto",
-                disable_custom_all_reduce=False,
-            ),
-            cache_config=SimpleNamespace(block_size=None),
-            model_config=SimpleNamespace(
-                model="test-model",
-                disable_cascade_attn=False,
-                tokenizer=None,
-                max_model_len=32768,
-            ),
-            scheduler_config=SimpleNamespace(
-                async_scheduling=True,
-                enable_chunked_prefill=True,
-                max_num_batched_tokens=2048,
-                max_num_scheduled_tokens=None,
-            ),
-        )
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(block_size=None),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=True,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
 
-        MetalPlatform.check_and_update_config(vllm_config)
+            MetalPlatform.check_and_update_config(vllm_config)
 
-        assert vllm_config.scheduler_config.enable_chunked_prefill is False
-        assert vllm_config.scheduler_config.max_num_batched_tokens == 32768
-        assert (
-            vllm_config.parallel_config.worker_cls == "vllm_metal.v1.worker.MetalWorker"
-        )
-        assert vllm_config.parallel_config.distributed_executor_backend == "uni"
-        assert vllm_config.parallel_config.disable_custom_all_reduce is True
+            assert vllm_config.scheduler_config.enable_chunked_prefill is False
+            assert vllm_config.scheduler_config.max_num_batched_tokens == 32768
+            assert (
+                vllm_config.parallel_config.worker_cls
+                == "vllm_metal.v1.worker.MetalWorker"
+            )
+            assert vllm_config.parallel_config.distributed_executor_backend == "uni"
+            assert vllm_config.parallel_config.disable_custom_all_reduce is True
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_keeps_chunked_prefill_for_paged_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Paged path should keep chunked prefill enabled.
+
+        The unified varlen Metal kernel handles mixed prefill + decode,
+        so chunked prefill works correctly on the paged path.
+        """
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=True,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.scheduler_config.enable_chunked_prefill is True
+            # max_num_batched_tokens should NOT be bumped (chunked prefill handles it)
+            assert vllm_config.scheduler_config.max_num_batched_tokens == 2048
+        finally:
+            reset_config()
 
     def test_check_and_update_config_increases_max_num_scheduled_tokens_below_max_model_len(
         self, monkeypatch: pytest.MonkeyPatch
@@ -218,32 +267,37 @@ class TestMetalPlatform:
         the scheduler can schedule the full prompt in a single step.
         """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
-        vllm_config = SimpleNamespace(
-            parallel_config=SimpleNamespace(
-                worker_cls="auto",
-                distributed_executor_backend="auto",
-                disable_custom_all_reduce=False,
-            ),
-            cache_config=SimpleNamespace(block_size=None),
-            model_config=SimpleNamespace(
-                model="test-model",
-                disable_cascade_attn=False,
-                tokenizer=None,
-                max_model_len=32768,
-            ),
-            scheduler_config=SimpleNamespace(
-                async_scheduling=True,
-                enable_chunked_prefill=True,
-                max_num_batched_tokens=2048,
-                max_num_scheduled_tokens=2048,
-            ),
-        )
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(block_size=None),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=True,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=2048,
+                ),
+            )
 
-        MetalPlatform.check_and_update_config(vllm_config)
+            MetalPlatform.check_and_update_config(vllm_config)
 
-        assert vllm_config.scheduler_config.enable_chunked_prefill is False
-        assert vllm_config.scheduler_config.max_num_batched_tokens == 32768
-        assert vllm_config.scheduler_config.max_num_scheduled_tokens == 32768
+            assert vllm_config.scheduler_config.enable_chunked_prefill is False
+            assert vllm_config.scheduler_config.max_num_batched_tokens == 32768
+            assert vllm_config.scheduler_config.max_num_scheduled_tokens == 32768
+        finally:
+            reset_config()
 
     def test_check_and_update_config_does_not_reduce_large_max_num_batched_tokens(
         self, monkeypatch: pytest.MonkeyPatch
@@ -254,32 +308,37 @@ class TestMetalPlatform:
         that setting must be preserved.
         """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
-        vllm_config = SimpleNamespace(
-            parallel_config=SimpleNamespace(
-                worker_cls="auto",
-                distributed_executor_backend="auto",
-                disable_custom_all_reduce=False,
-            ),
-            cache_config=SimpleNamespace(block_size=None),
-            model_config=SimpleNamespace(
-                model="test-model",
-                disable_cascade_attn=False,
-                tokenizer=None,
-                max_model_len=32768,
-            ),
-            scheduler_config=SimpleNamespace(
-                async_scheduling=True,
-                enable_chunked_prefill=True,
-                max_num_batched_tokens=65536,
-                max_num_scheduled_tokens=None,
-            ),
-        )
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(block_size=None),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=True,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=65536,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
 
-        MetalPlatform.check_and_update_config(vllm_config)
+            MetalPlatform.check_and_update_config(vllm_config)
 
-        assert vllm_config.scheduler_config.enable_chunked_prefill is False
-        # 65536 > 32768, so the value must stay at 65536
-        assert vllm_config.scheduler_config.max_num_batched_tokens == 65536
+            assert vllm_config.scheduler_config.enable_chunked_prefill is False
+            # 65536 > 32768, so the value must stay at 65536
+            assert vllm_config.scheduler_config.max_num_batched_tokens == 65536
+        finally:
+            reset_config()
 
     @pytest.mark.parametrize("max_num_scheduled_tokens", [32768, 65536])
     def test_check_and_update_config_does_not_reduce_max_num_scheduled_tokens_when_at_least_max_model_len(
@@ -294,35 +353,40 @@ class TestMetalPlatform:
         below max_model_len are bumped up).
         """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
-        vllm_config = SimpleNamespace(
-            parallel_config=SimpleNamespace(
-                worker_cls="auto",
-                distributed_executor_backend="auto",
-                disable_custom_all_reduce=False,
-            ),
-            cache_config=SimpleNamespace(block_size=None),
-            model_config=SimpleNamespace(
-                model="test-model",
-                disable_cascade_attn=False,
-                tokenizer=None,
-                max_model_len=32768,
-            ),
-            scheduler_config=SimpleNamespace(
-                async_scheduling=True,
-                enable_chunked_prefill=True,
-                max_num_batched_tokens=65536,
-                max_num_scheduled_tokens=max_num_scheduled_tokens,
-            ),
-        )
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(block_size=None),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=True,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=65536,
+                    max_num_scheduled_tokens=max_num_scheduled_tokens,
+                ),
+            )
 
-        MetalPlatform.check_and_update_config(vllm_config)
+            MetalPlatform.check_and_update_config(vllm_config)
 
-        assert vllm_config.scheduler_config.enable_chunked_prefill is False
-        assert vllm_config.scheduler_config.max_num_batched_tokens == 65536
-        assert (
-            vllm_config.scheduler_config.max_num_scheduled_tokens
-            == max_num_scheduled_tokens
-        )
+            assert vllm_config.scheduler_config.enable_chunked_prefill is False
+            assert vllm_config.scheduler_config.max_num_batched_tokens == 65536
+            assert (
+                vllm_config.scheduler_config.max_num_scheduled_tokens
+                == max_num_scheduled_tokens
+            )
+        finally:
+            reset_config()
 
     def test_check_and_update_config_applies_stt_scheduler_policy(
         self, monkeypatch: pytest.MonkeyPatch

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -225,32 +225,42 @@ class MetalPlatform(Platform):
 
         scheduler_config = vllm_config.scheduler_config
         if getattr(scheduler_config, "enable_chunked_prefill", False):
-            # MetalModelRunner does not yet honor chunked-prefill scheduler
-            # boundaries on the non-paged MLX path. Disable the feature so the
-            # scheduler only requests full prefills, which matches the current
-            # model-runner contract.
-            scheduler_config.enable_chunked_prefill = False
+            if config.use_paged_attention:
+                # The paged path uses a unified varlen Metal kernel that
+                # handles mixed prefill + decode in a single forward pass,
+                # so chunked prefill works correctly.
+                logger.info(
+                    "Metal: chunked prefill enabled (paged attention), "
+                    "max_num_batched_tokens=%d",
+                    scheduler_config.max_num_batched_tokens,
+                )
+            else:
+                # The non-paged MLX path does not honor chunked-prefill
+                # scheduler boundaries.  Disable so the scheduler only
+                # requests full prefills.
+                scheduler_config.enable_chunked_prefill = False
 
-            # Without chunked prefill, the scheduler must fit the entire
-            # prompt in a single step.  Ensure max_num_batched_tokens (and
-            # max_num_scheduled_tokens) are at least max_model_len;
-            # otherwise the scheduler silently refuses to schedule any
-            # prompt that exceeds the budget (see Scheduler.schedule —
-            # the "chunked_prefill is disabled" break).
-            if model_config is not None:
-                model_max = model_config.max_model_len
-                if scheduler_config.max_num_batched_tokens < model_max:
-                    scheduler_config.max_num_batched_tokens = model_max
-                if (
-                    scheduler_config.max_num_scheduled_tokens is not None
-                    and scheduler_config.max_num_scheduled_tokens < model_max
-                ):
-                    scheduler_config.max_num_scheduled_tokens = model_max
+                # Without chunked prefill, the scheduler must fit the
+                # entire prompt in a single step.  Ensure
+                # max_num_batched_tokens (and max_num_scheduled_tokens)
+                # are at least max_model_len; otherwise the scheduler
+                # silently refuses to schedule any prompt that exceeds
+                # the budget.
+                if model_config is not None:
+                    model_max = model_config.max_model_len
+                    if scheduler_config.max_num_batched_tokens < model_max:
+                        scheduler_config.max_num_batched_tokens = model_max
+                    if (
+                        scheduler_config.max_num_scheduled_tokens is not None
+                        and scheduler_config.max_num_scheduled_tokens < model_max
+                    ):
+                        scheduler_config.max_num_scheduled_tokens = model_max
 
-            logger.info(
-                "Metal: disabled chunked prefill, max_num_batched_tokens=%d",
-                scheduler_config.max_num_batched_tokens,
-            )
+                logger.info(
+                    "Metal: disabled chunked prefill (non-paged path), "
+                    "max_num_batched_tokens=%d",
+                    scheduler_config.max_num_batched_tokens,
+                )
 
         if config.use_paged_attention and getattr(
             cache_config, "enable_prefix_caching", False
@@ -261,8 +271,14 @@ class MetalPlatform(Platform):
             cache_config.enable_prefix_caching = False
             logger.info("Metal: disabled prefix caching")
 
-        # Configure cache
-        if cache_config.block_size is None:
+        # Configure cache — ensure block_size is at least the Metal kernel
+        # minimum.  With chunked prefill enabled, upstream may default to
+        # block_size=1 for fine-grained scheduling, but our Metal paged
+        # attention kernel requires multiples of 8.
+        if (
+            cache_config.block_size is None
+            or cache_config.block_size < config.block_size
+        ):
             cache_config.block_size = config.block_size
 
         # Disable cascade attention (not supported)


### PR DESCRIPTION
<img width="2498" height="925" alt="bench_chunked_prefill" src="https://github.com/user-attachments/assets/9509c0c8-d8b2-433b-b27b-bd4082f8a4a2" />

## Summary

- Enable chunked prefill on the paged attention path — the unified varlen Metal kernel already handles mixed prefill + decode correctly
- Keep chunked prefill disabled only on the non-paged MLX path (which doesn't honor scheduler chunk boundaries)
- Enforce minimum `block_size` (default 16) since upstream vLLM may default to `block_size=1` when chunked prefill is enabled, but our Metal paged attention kernel requires multiples of 8
- Add `--max-num-batched-tokens 64` to smoke tests (previously chunked prefill was force-disabled and `max_num_batched_tokens` was bumped to `max_model_len`)

Split out from #247 to keep the memory profiling changes separate.



### Benchmark (sonnet 1024+128, 100 prompts, concurrency 32)

| Metric | main | this PR | Change |
|---|---:|---:|---:|
| Output tok/s | 59.88 | 65.13 | **+8.8%** |
| Total tok/s | 533.43 | 580.17 | **+8.8%** |
| Mean TTFT (ms) | 12009.03 | 11154.55 | **-7.1%** |
| Mean TPOT (ms) | 424.14 | 386.89 | **-8.8%** |
| P99 TPOT (ms) | 569.55 | 468.48 | **-17.7%** |
| Mean ITL (ms) | 424.14 | 386.89 | **-8.8%** |

<details>
<summary>Full benchmark output</summary>

**main**
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             32        
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  213.77    
Total input tokens:                      101230    
Total generated tokens:                  12800     
Request throughput (req/s):              0.47      
Output token throughput (tok/s):         59.88     
Peak output token throughput (tok/s):    224.00    
Peak concurrent requests:                35.00     
Total token throughput (tok/s):          533.43    
---------------Time to First Token----------------
Mean TTFT (ms):                          12009.03  
Median TTFT (ms):                        8933.70   
P99 TTFT (ms):                           42426.72  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          424.14    
Median TPOT (ms):                        436.76    
P99 TPOT (ms):                           569.55    
---------------Inter-token Latency----------------
Mean ITL (ms):                           424.14    
Median ITL (ms):                         148.23    
P99 ITL (ms):                            3000.21   
==================================================
```

**this PR (enable-chunked-prefill-paged)**
```
============ Serving Benchmark Result ============
Successful requests:                     100       
Failed requests:                         0         
Maximum request concurrency:             32        
Request rate configured (RPS):           10.00     
Benchmark duration (s):                  196.54    
Total input tokens:                      101230    
Total generated tokens:                  12800     
Request throughput (req/s):              0.51      
Output token throughput (tok/s):         65.13     
Peak output token throughput (tok/s):    224.00    
Peak concurrent requests:                35.00     
Total token throughput (tok/s):          580.17    
---------------Time to First Token----------------
Mean TTFT (ms):                          11154.55  
Median TTFT (ms):                        8107.79   
P99 TTFT (ms):                           39664.48  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          386.89    
Median TPOT (ms):                        428.35    
P99 TPOT (ms):                           468.48    
---------------Inter-token Latency----------------
Mean ITL (ms):                           386.89    
Median ITL (ms):                         150.03    
P99 ITL (ms):                            2760.63   
==================================================
```
</details>

<details>
<summary>Benchmark config</summary>

- Model: Qwen/Qwen3-0.6B
- Dataset: sonnet (1024 input + 128 output)
- Prompts: 100, rate: 10, concurrency: 32
- Memory fraction: 0.3
- Hardware: Apple M1 Pro, 32 GB RAM
</details>
