### PR TITLE
refactor env register in a vllm way

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,8 +21,18 @@ class TestMetalConfig:
         yield
         reset_config()
 
-    def test_default_config(self) -> None:
+    def test_default_config(self, monkeypatch) -> None:
         """Test default configuration values."""
+        for var in [
+            "VLLM_METAL_MEMORY_FRACTION",
+            "VLLM_METAL_USE_MLX",
+            "VLLM_MLX_DEVICE",
+            "VLLM_METAL_BLOCK_SIZE",
+            "VLLM_METAL_DEBUG",
+            "VLLM_METAL_USE_PAGED_ATTENTION",
+        ]:
+            monkeypatch.delenv(var, raising=False)
+
         config = MetalConfig.from_env()
 
         assert config.memory_fraction == AUTO_MEMORY_FRACTION

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+import vllm_metal.envs as envs
 from vllm_metal.config import (
     AUTO_MEMORY_FRACTION,
     MetalConfig,
@@ -15,24 +16,16 @@ class TestMetalConfig:
     """Tests for MetalConfig class."""
 
     @pytest.fixture(autouse=True)
-    def _reset(self):
+    def _reset(self, monkeypatch):
         """Reset config singleton before and after each test."""
+        for var in envs.environment_variables:
+            monkeypatch.delenv(var, raising=False)
         reset_config()
         yield
         reset_config()
 
-    def test_default_config(self, monkeypatch) -> None:
+    def test_default_config(self) -> None:
         """Test default configuration values."""
-        for var in [
-            "VLLM_METAL_MEMORY_FRACTION",
-            "VLLM_METAL_USE_MLX",
-            "VLLM_MLX_DEVICE",
-            "VLLM_METAL_BLOCK_SIZE",
-            "VLLM_METAL_DEBUG",
-            "VLLM_METAL_USE_PAGED_ATTENTION",
-        ]:
-            monkeypatch.delenv(var, raising=False)
-
         config = MetalConfig.from_env()
 
         assert config.memory_fraction == AUTO_MEMORY_FRACTION

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for vLLM Metal configuration."""
 
-import os
-
 import pytest
 
 from vllm_metal.config import (
@@ -16,32 +14,12 @@ from vllm_metal.config import (
 class TestMetalConfig:
     """Tests for MetalConfig class."""
 
-    def setup_method(self) -> None:
-        """Reset config before each test."""
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        """Reset config singleton before and after each test."""
         reset_config()
-        # Clear environment variables
-        for var in [
-            "VLLM_METAL_MEMORY_FRACTION",
-            "VLLM_METAL_USE_MLX",
-            "VLLM_MLX_DEVICE",
-            "VLLM_METAL_BLOCK_SIZE",
-            "VLLM_METAL_DEBUG",
-            "VLLM_METAL_USE_PAGED_ATTENTION",
-        ]:
-            os.environ.pop(var, None)
-
-    def teardown_method(self) -> None:
-        """Reset config after each test."""
+        yield
         reset_config()
-        for var in [
-            "VLLM_METAL_MEMORY_FRACTION",
-            "VLLM_METAL_USE_MLX",
-            "VLLM_MLX_DEVICE",
-            "VLLM_METAL_BLOCK_SIZE",
-            "VLLM_METAL_DEBUG",
-            "VLLM_METAL_USE_PAGED_ATTENTION",
-        ]:
-            os.environ.pop(var, None)
 
     def test_default_config(self) -> None:
         """Test default configuration values."""
@@ -55,14 +33,14 @@ class TestMetalConfig:
         assert config.debug is False
         assert config.use_paged_attention is True
 
-    def test_custom_config_from_env(self) -> None:
+    def test_custom_config_from_env(self, monkeypatch) -> None:
         """Test configuration from environment variables."""
-        os.environ["VLLM_METAL_MEMORY_FRACTION"] = "0.75"
-        os.environ["VLLM_METAL_USE_MLX"] = "0"
-        os.environ["VLLM_MLX_DEVICE"] = "cpu"
-        os.environ["VLLM_METAL_BLOCK_SIZE"] = "32"
-        os.environ["VLLM_METAL_DEBUG"] = "1"
-        os.environ["VLLM_METAL_USE_PAGED_ATTENTION"] = "1"
+        monkeypatch.setenv("VLLM_METAL_MEMORY_FRACTION", "0.75")
+        monkeypatch.setenv("VLLM_METAL_USE_MLX", "0")
+        monkeypatch.setenv("VLLM_MLX_DEVICE", "cpu")
+        monkeypatch.setenv("VLLM_METAL_BLOCK_SIZE", "32")
+        monkeypatch.setenv("VLLM_METAL_DEBUG", "1")
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
 
         config = MetalConfig.from_env()
 
@@ -89,30 +67,29 @@ class TestMetalConfig:
         # (but with same values since env vars haven't changed)
         assert config1 is not config2
 
-    def test_auto_memory_fraction(self) -> None:
+    def test_auto_memory_fraction(self, monkeypatch) -> None:
         """Test that 'auto' is parsed as AUTO_MEMORY_FRACTION."""
-        os.environ["VLLM_METAL_MEMORY_FRACTION"] = "auto"
+        monkeypatch.setenv("VLLM_METAL_MEMORY_FRACTION", "auto")
 
         config = MetalConfig.from_env()
 
         assert config.memory_fraction == AUTO_MEMORY_FRACTION
         assert config.is_auto_memory is True
 
-    def test_auto_memory_fraction_case_insensitive(self) -> None:
+    def test_auto_memory_fraction_case_insensitive(self, monkeypatch) -> None:
         """Test that 'AUTO' and 'Auto' are also accepted."""
         for value in ["AUTO", "Auto", "AuTo"]:
             reset_config()
-            os.environ["VLLM_METAL_MEMORY_FRACTION"] = value
+            monkeypatch.setenv("VLLM_METAL_MEMORY_FRACTION", value)
 
             config = MetalConfig.from_env()
 
             assert config.memory_fraction == AUTO_MEMORY_FRACTION
             assert config.is_auto_memory is True
 
-    def test_is_auto_memory_false_for_numeric(self) -> None:
+    def test_is_auto_memory_false_for_numeric(self, monkeypatch) -> None:
         """Test that is_auto_memory is False for numeric values."""
-        os.environ["VLLM_METAL_MEMORY_FRACTION"] = "0.5"
-        # Paged attention is now default, so no need to set env var
+        monkeypatch.setenv("VLLM_METAL_MEMORY_FRACTION", "0.5")
 
         config = MetalConfig.from_env()
 
@@ -131,10 +108,10 @@ class TestMetalConfig:
                 use_paged_attention=False,
             )
 
-    def test_block_size_must_be_positive(self) -> None:
+    def test_block_size_must_be_positive(self, monkeypatch) -> None:
         for value in ["0", "-1"]:
             reset_config()
-            os.environ["VLLM_METAL_BLOCK_SIZE"] = value
+            monkeypatch.setenv("VLLM_METAL_BLOCK_SIZE", value)
             with pytest.raises(ValueError, match="Invalid VLLM_METAL_BLOCK_SIZE"):
                 MetalConfig.from_env()
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import vllm.envs
+
+import vllm_metal as vm
+from vllm_metal.envs import environment_variables as metal_env_vars
+
+
+def test_register_merges_metal_env_vars_into_vllm() -> None:
+    vm._register()
+
+    missing = [k for k in metal_env_vars if k not in vllm.envs.environment_variables]
+    assert not missing, f"metal env vars not registered with vllm: {missing}"

--- a/tools/gen_golden_token_ids_for_deterministics.py
+++ b/tools/gen_golden_token_ids_for_deterministics.py
@@ -28,6 +28,8 @@ os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 
 from vllm import LLM, SamplingParams  # noqa: E402
 
+import vllm_metal.envs as envs  # noqa: E402
+
 PROMPTS = [
     "The capital of France is",
     "The weather today is not",
@@ -66,7 +68,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    paged = os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") == "1"
+    paged = envs.VLLM_METAL_USE_PAGED_ATTENTION
     label = "PAGED" if paged else "MLX"
     print(f"\n--- Generating golden values for {label} path ({args.model}) ---\n")
 

--- a/tools/test_qwen35_golden.py
+++ b/tools/test_qwen35_golden.py
@@ -27,6 +27,8 @@ os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 
 from vllm import LLM, SamplingParams  # noqa: E402
 
+import vllm_metal.envs as envs  # noqa: E402
+
 MODEL_DEFAULT = os.environ.get("QWEN35_MODEL_PATH", "Qwen/Qwen3.5-4B")
 MAX_TOKENS = 20
 
@@ -152,7 +154,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.gen_golden:
-        paged = os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") == "1"
+        paged = envs.VLLM_METAL_USE_PAGED_ATTENTION
         label = "PAGED" if paged else "MLX"
         print(f"Generating golden tokens ({label} path, {args.model})")
         results = _run_in_subprocess(args.model, args.max_tokens, paged=paged)

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -102,8 +102,9 @@ def _register() -> str | None:
 
     # Register our env vars with vLLM's registry so validate_environ()
     # does not warn about unknown VLLM_METAL_* / VLLM_MLX_* variables.
-    from vllm_metal.envs import environment_variables as metal_env_vars
     import vllm.envs
+
+    from vllm_metal.envs import environment_variables as metal_env_vars
 
     vllm.envs.environment_variables.update(metal_env_vars)
 

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -100,6 +100,13 @@ def _register() -> str | None:
     _configure_logging()
     _apply_macos_defaults()
 
+    # Register our env vars with vLLM's registry so validate_environ()
+    # does not warn about unknown VLLM_METAL_* / VLLM_MLX_* variables.
+    from vllm_metal.envs import environment_variables as metal_env_vars
+    import vllm.envs
+
+    vllm.envs.environment_variables.update(metal_env_vars)
+
     from vllm_metal.compat import apply_compat_patches
 
     apply_compat_patches()

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -68,13 +68,28 @@ class MetalConfig:
         if memory_fraction_str.lower() == "auto":
             memory_fraction = AUTO_MEMORY_FRACTION
         else:
-            memory_fraction = float(memory_fraction_str)
+            try:
+                memory_fraction = float(memory_fraction_str)
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid VLLM_METAL_MEMORY_FRACTION={memory_fraction_str!r}. "
+                    "Must be 'auto' or a numeric value in (0, 1]."
+                ) from e
+
+        block_size_str = envs.VLLM_METAL_BLOCK_SIZE
+        try:
+            block_size = int(block_size_str)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid VLLM_METAL_BLOCK_SIZE={block_size_str!r}. "
+                "Must be a positive integer."
+            ) from e
 
         return cls(
             memory_fraction=memory_fraction,
             use_mlx=envs.VLLM_METAL_USE_MLX,
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
-            block_size=envs.VLLM_METAL_BLOCK_SIZE,
+            block_size=block_size,
             debug=envs.VLLM_METAL_DEBUG,
             use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
         )

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -64,8 +64,14 @@ class MetalConfig:
     @classmethod
     def from_env(cls) -> "MetalConfig":
         """Load configuration from environment variables."""
+        memory_fraction_str = envs.VLLM_METAL_MEMORY_FRACTION
+        if memory_fraction_str.lower() == "auto":
+            memory_fraction = AUTO_MEMORY_FRACTION
+        else:
+            memory_fraction = float(memory_fraction_str)
+
         return cls(
-            memory_fraction=envs.VLLM_METAL_MEMORY_FRACTION,
+            memory_fraction=memory_fraction,
             use_mlx=envs.VLLM_METAL_USE_MLX,
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
             block_size=envs.VLLM_METAL_BLOCK_SIZE,

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Configuration for vLLM Metal plugin via environment variables."""
 
-import os
 from dataclasses import dataclass
 from typing import Literal
+
+import vllm_metal.envs as envs
 
 # Sentinel value indicating auto memory calculation
 AUTO_MEMORY_FRACTION = -1.0
@@ -63,20 +64,13 @@ class MetalConfig:
     @classmethod
     def from_env(cls) -> "MetalConfig":
         """Load configuration from environment variables."""
-        memory_fraction_str = os.environ.get("VLLM_METAL_MEMORY_FRACTION", "auto")
-        if memory_fraction_str.lower() == "auto":
-            memory_fraction = AUTO_MEMORY_FRACTION
-        else:
-            memory_fraction = float(memory_fraction_str)
-
         return cls(
-            memory_fraction=memory_fraction,
-            use_mlx=os.environ.get("VLLM_METAL_USE_MLX", "1") == "1",
-            mlx_device=os.environ.get("VLLM_MLX_DEVICE", "gpu"),  # type: ignore[arg-type]
-            block_size=int(os.environ.get("VLLM_METAL_BLOCK_SIZE", "16")),
-            debug=os.environ.get("VLLM_METAL_DEBUG", "0") == "1",
-            use_paged_attention=os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "1")
-            == "1",
+            memory_fraction=envs.VLLM_METAL_MEMORY_FRACTION,
+            use_mlx=envs.VLLM_METAL_USE_MLX,
+            mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
+            block_size=envs.VLLM_METAL_BLOCK_SIZE,
+            debug=envs.VLLM_METAL_DEBUG,
+            use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
         )
 
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -34,10 +34,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable verbose debug logging (default False).
     "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
     # Use native Metal paged attention (default True).
-    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: os.getenv(
-        "VLLM_METAL_USE_PAGED_ATTENTION", "1"
-    )
-    == "1",
+    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
+        os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
+    ),
     # Enable content-hash prefix caching (presence-based: set to any
     # value to enable, unset to disable).
     "VLLM_METAL_PREFIX_CACHE": lambda: "VLLM_METAL_PREFIX_CACHE" in os.environ,

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -18,20 +18,13 @@ import os
 from collections.abc import Callable
 from typing import Any
 
-# Sentinel value indicating auto memory calculation (matches config.py).
-_AUTO_MEMORY_FRACTION: float = -1.0
-
-
-def _parse_memory_fraction() -> float:
-    """Parse VLLM_METAL_MEMORY_FRACTION, returning -1.0 for 'auto'."""
-    raw = os.getenv("VLLM_METAL_MEMORY_FRACTION", "auto")
-    return _AUTO_MEMORY_FRACTION if raw.lower() == "auto" else float(raw)
-
-
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
     # plugin calculates the minimal amount needed at startup.
-    "VLLM_METAL_MEMORY_FRACTION": _parse_memory_fraction,
+    # Returns the raw string; config.py handles "auto" → sentinel conversion.
+    "VLLM_METAL_MEMORY_FRACTION": lambda: os.getenv(
+        "VLLM_METAL_MEMORY_FRACTION", "auto"
+    ),
     # Whether to use MLX as the compute backend (default True).
     "VLLM_METAL_USE_MLX": lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
     # MLX device type: "gpu" (default) or "cpu".
@@ -65,11 +58,16 @@ def __getattr__(name: str) -> Any:
 
 
 def __dir__() -> list[str]:
+    # Mirrors vllm/envs.py; enables tab-completion and introspection.
     return list(environment_variables.keys())
 
 
 def is_set(name: str) -> bool:
-    """Check if an environment variable is explicitly set in os.environ."""
+    """Check if an environment variable is explicitly set in os.environ.
+
+    Mirrors ``vllm.envs.is_set``; not yet used but kept for parity
+    with upstream so plugin code can adopt it without a new PR.
+    """
     if name in environment_variables:
         return name in os.environ
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     VLLM_METAL_MEMORY_FRACTION: str = "auto"
     VLLM_METAL_USE_MLX: bool = True
     VLLM_MLX_DEVICE: str = "gpu"
-    VLLM_METAL_BLOCK_SIZE: int = 16
+    VLLM_METAL_BLOCK_SIZE: str = "16"
     VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
     VLLM_METAL_PREFIX_CACHE: bool = False
@@ -41,7 +41,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # MLX device type: "gpu" (default) or "cpu".
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
     # Tokens per KV-cache block (default 16).
-    "VLLM_METAL_BLOCK_SIZE": lambda: int(os.getenv("VLLM_METAL_BLOCK_SIZE", "16")),
+    # Returns the raw string; config.py parses and validates.
+    "VLLM_METAL_BLOCK_SIZE": lambda: os.getenv("VLLM_METAL_BLOCK_SIZE", "16"),
     # Enable verbose debug logging (default False).
     "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
     # Use native Metal paged attention (default True).

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -70,14 +70,3 @@ def __getattr__(name: str) -> Any:
 def __dir__() -> list[str]:
     # Mirrors vllm/envs.py; enables tab-completion and introspection.
     return list(environment_variables.keys())
-
-
-def is_set(name: str) -> bool:
-    """Check if an environment variable is explicitly set in os.environ.
-
-    Mirrors ``vllm.envs.is_set``; not yet used but kept for parity
-    with upstream so plugin code can adopt it without a new PR.
-    """
-    if name in environment_variables:
-        return name in os.environ
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Environment variable definitions for the vLLM Metal plugin.
+
+This module is the single source of truth for all ``VLLM_METAL_*`` (and
+``VLLM_MLX_*``) environment variables.  It mirrors the lazy-evaluation
+pattern used by ``vllm/envs.py``: each variable is read from
+``os.environ`` on access via ``__getattr__``, so values are never stale
+and ``monkeypatch.setenv`` works in tests without extra resets.
+
+During plugin registration (``vllm_metal._register``), the
+``environment_variables`` dict is merged into
+``vllm.envs.environment_variables`` so that ``validate_environ()``
+recognises our variables and does not emit spurious "Unknown vLLM
+environment variable" warnings.
+"""
+
+import os
+from collections.abc import Callable
+from typing import Any
+
+# Sentinel value indicating auto memory calculation (matches config.py).
+_AUTO_MEMORY_FRACTION: float = -1.0
+
+
+def _parse_memory_fraction() -> float:
+    """Parse VLLM_METAL_MEMORY_FRACTION, returning -1.0 for 'auto'."""
+    raw = os.getenv("VLLM_METAL_MEMORY_FRACTION", "auto")
+    return _AUTO_MEMORY_FRACTION if raw.lower() == "auto" else float(raw)
+
+
+environment_variables: dict[str, Callable[[], Any]] = {
+    # Fraction of unified memory to use.  "auto" (the default) means the
+    # plugin calculates the minimal amount needed at startup.
+    "VLLM_METAL_MEMORY_FRACTION":
+        _parse_memory_fraction,
+    # Whether to use MLX as the compute backend (default True).
+    "VLLM_METAL_USE_MLX":
+        lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
+    # MLX device type: "gpu" (default) or "cpu".
+    "VLLM_MLX_DEVICE":
+        lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
+    # Tokens per KV-cache block (default 16).
+    "VLLM_METAL_BLOCK_SIZE":
+        lambda: int(os.getenv("VLLM_METAL_BLOCK_SIZE", "16")),
+    # Enable verbose debug logging (default False).
+    "VLLM_METAL_DEBUG":
+        lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
+    # Use native Metal paged attention (default True).
+    "VLLM_METAL_USE_PAGED_ATTENTION":
+        lambda: os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1",
+    # Enable content-hash prefix caching (presence-based: set to any
+    # value to enable, unset to disable).
+    "VLLM_METAL_PREFIX_CACHE":
+        lambda: "VLLM_METAL_PREFIX_CACHE" in os.environ,
+    # Fraction of MLX working set for the prefix cache (raw string;
+    # the consumer in model_runner.py validates and applies a default).
+    "VLLM_METAL_PREFIX_CACHE_FRACTION":
+        lambda: os.getenv("VLLM_METAL_PREFIX_CACHE_FRACTION", ""),
+    # Custom cache directory for ModelScope downloads (None if unset).
+    "VLLM_METAL_MODELSCOPE_CACHE":
+        lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in environment_variables:
+        return environment_variables[name]()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return list(environment_variables.keys())
+
+
+def is_set(name: str) -> bool:
+    """Check if an environment variable is explicitly set in os.environ."""
+    if name in environment_variables:
+        return name in os.environ
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -31,34 +31,30 @@ def _parse_memory_fraction() -> float:
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
     # plugin calculates the minimal amount needed at startup.
-    "VLLM_METAL_MEMORY_FRACTION":
-        _parse_memory_fraction,
+    "VLLM_METAL_MEMORY_FRACTION": _parse_memory_fraction,
     # Whether to use MLX as the compute backend (default True).
-    "VLLM_METAL_USE_MLX":
-        lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
+    "VLLM_METAL_USE_MLX": lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
     # MLX device type: "gpu" (default) or "cpu".
-    "VLLM_MLX_DEVICE":
-        lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
+    "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
     # Tokens per KV-cache block (default 16).
-    "VLLM_METAL_BLOCK_SIZE":
-        lambda: int(os.getenv("VLLM_METAL_BLOCK_SIZE", "16")),
+    "VLLM_METAL_BLOCK_SIZE": lambda: int(os.getenv("VLLM_METAL_BLOCK_SIZE", "16")),
     # Enable verbose debug logging (default False).
-    "VLLM_METAL_DEBUG":
-        lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
+    "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
     # Use native Metal paged attention (default True).
-    "VLLM_METAL_USE_PAGED_ATTENTION":
-        lambda: os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1",
+    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: os.getenv(
+        "VLLM_METAL_USE_PAGED_ATTENTION", "1"
+    )
+    == "1",
     # Enable content-hash prefix caching (presence-based: set to any
     # value to enable, unset to disable).
-    "VLLM_METAL_PREFIX_CACHE":
-        lambda: "VLLM_METAL_PREFIX_CACHE" in os.environ,
+    "VLLM_METAL_PREFIX_CACHE": lambda: "VLLM_METAL_PREFIX_CACHE" in os.environ,
     # Fraction of MLX working set for the prefix cache (raw string;
     # the consumer in model_runner.py validates and applies a default).
-    "VLLM_METAL_PREFIX_CACHE_FRACTION":
-        lambda: os.getenv("VLLM_METAL_PREFIX_CACHE_FRACTION", ""),
+    "VLLM_METAL_PREFIX_CACHE_FRACTION": lambda: os.getenv(
+        "VLLM_METAL_PREFIX_CACHE_FRACTION", ""
+    ),
     # Custom cache directory for ModelScope downloads (None if unset).
-    "VLLM_METAL_MODELSCOPE_CACHE":
-        lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
+    "VLLM_METAL_MODELSCOPE_CACHE": lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
 }
 
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -16,7 +16,18 @@ environment variable" warnings.
 
 import os
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    VLLM_METAL_MEMORY_FRACTION: str = "auto"
+    VLLM_METAL_USE_MLX: bool = True
+    VLLM_MLX_DEVICE: str = "gpu"
+    VLLM_METAL_BLOCK_SIZE: int = 16
+    VLLM_METAL_DEBUG: bool = False
+    VLLM_METAL_USE_PAGED_ATTENTION: bool = True
+    VLLM_METAL_PREFIX_CACHE: bool = False
+    VLLM_METAL_PREFIX_CACHE_FRACTION: str = ""
+    VLLM_METAL_MODELSCOPE_CACHE: str | None = None
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the

--- a/vllm_metal/utils.py
+++ b/vllm_metal/utils.py
@@ -34,7 +34,9 @@ def get_model_download_path(model_repo_name: str) -> str:
         try:
             from modelscope.hub.snapshot_download import snapshot_download
 
-            model_cache_dir = os.environ.get("VLLM_METAL_MODELSCOPE_CACHE")
+            import vllm_metal.envs as envs
+
+            model_cache_dir = envs.VLLM_METAL_MODELSCOPE_CACHE
 
             logger.info(f"Downloading model {model_repo_name} from ModelScope...")
             model_path = snapshot_download(model_repo_name, cache_dir=model_cache_dir)

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -9,7 +9,6 @@ in contrast to the fixed-block layout used by paged attention.
 
 import hashlib
 import math
-import os
 from array import array
 from dataclasses import dataclass
 from typing import Any, TypeAlias
@@ -24,6 +23,8 @@ from mlx_lm.models.cache import (
     make_prompt_cache,
 )
 from vllm.logger import init_logger
+
+import vllm_metal.envs as envs
 
 logger = init_logger(__name__)
 
@@ -46,7 +47,7 @@ AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
 
 def _prefix_cache_enabled() -> bool:
     """Check whether prefix caching is enabled via environment variable."""
-    return "VLLM_METAL_PREFIX_CACHE" in os.environ
+    return envs.VLLM_METAL_PREFIX_CACHE
 
 
 _PREFIX_CACHE_ENABLED = _prefix_cache_enabled()
@@ -55,7 +56,7 @@ _PREFIX_CACHE_DEFAULT_FRACTION = 0.05  # 5% of MLX working set
 
 def _get_prefix_cache_max_bytes() -> int:
     """Get prefix cache memory limit based on MLX recommended working set."""
-    fraction_str = os.environ.get("VLLM_METAL_PREFIX_CACHE_FRACTION", "")
+    fraction_str = envs.VLLM_METAL_PREFIX_CACHE_FRACTION
     if fraction_str:
         try:
             fraction = float(fraction_str)


### PR DESCRIPTION
similar fix to my upstream PR: https://github.com/vllm-project/vllm/pull/35007

* register all env vars in a vllm way
* dedicated `envs.py`
* update relevant unit tests


### The problem

**before**: unregistered envs warning
<img width="1168" height="259" alt="image" src="https://github.com/user-attachments/assets/e447e7cc-d3bc-446e-9f5f-22850223f62b" />

**after**: the warning disappeared.  
