### PR TITLE
Refactor model runner legacy cache [1/n]

### DIFF
--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock
 import mlx.core as mx
 import pytest
 
-import vllm_metal.v1.legacy_cache as lc
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
+from vllm_metal.v1 import contiguous_cache
 
 
 class StubArraysCache:
@@ -116,8 +116,12 @@ class TestPrefixCacheRestoreOffset:
         def fake_make_prompt_cache(_model):
             return [self._KVCacheWithoutOffsetSideEffect()]
 
-        monkeypatch.setattr(lc, "KVCache", self._KVCacheWithoutOffsetSideEffect)
-        monkeypatch.setattr(lc, "make_prompt_cache", fake_make_prompt_cache)
+        monkeypatch.setattr(
+            contiguous_cache, "KVCache", self._KVCacheWithoutOffsetSideEffect
+        )
+        monkeypatch.setattr(
+            contiguous_cache, "make_prompt_cache", fake_make_prompt_cache
+        )
 
         k = mx.zeros((1, 2, 7, 8), dtype=mx.float32)
         v = mx.zeros((1, 2, 7, 8), dtype=mx.float32)

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import mlx.core as mx
 import pytest
 
+import vllm_metal.v1.legacy_cache as lc
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
 
@@ -115,8 +116,8 @@ class TestPrefixCacheRestoreOffset:
         def fake_make_prompt_cache(_model):
             return [self._KVCacheWithoutOffsetSideEffect()]
 
-        monkeypatch.setattr(mr, "KVCache", self._KVCacheWithoutOffsetSideEffect)
-        monkeypatch.setattr(mr, "make_prompt_cache", fake_make_prompt_cache)
+        monkeypatch.setattr(lc, "KVCache", self._KVCacheWithoutOffsetSideEffect)
+        monkeypatch.setattr(lc, "make_prompt_cache", fake_make_prompt_cache)
 
         k = mx.zeros((1, 2, 7, 8), dtype=mx.float32)
         v = mx.zeros((1, 2, 7, 8), dtype=mx.float32)

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -24,7 +24,7 @@ class TestPrefixCacheHybridGuard:
             model_args={"vocab_size": 100},
             model=MagicMock(),
             _is_vlm=False,
-            _prefix_cache=mr.PrefixCacheManager(max_bytes=1024 * 1024),
+            _prefix_cache=contiguous_cache.PrefixCacheManager(max_bytes=1024 * 1024),
             _sampler=MagicMock(),
         )
 
@@ -33,13 +33,15 @@ class TestPrefixCacheHybridGuard:
         insert_spy = MagicMock()
 
         def fake_make_prompt_cache(model):
-            kv = mr.KVCache()
+            kv = contiguous_cache.KVCache()
             kv.keys = mx.zeros((1, 8, 0, 64))
             kv.values = mx.zeros((1, 8, 0, 64))
             kv.offset = 0
             return [kv, StubArraysCache(), kv]
 
-        monkeypatch.setattr(mr, "make_prompt_cache", fake_make_prompt_cache)
+        monkeypatch.setattr(
+            contiguous_cache, "make_prompt_cache", fake_make_prompt_cache
+        )
 
         runner = self._make_runner()
         monkeypatch.setattr(runner._prefix_cache, "lookup", lookup_spy)
@@ -68,11 +70,13 @@ class TestPrefixCacheHybridGuard:
         insert_spy = MagicMock()
 
         def fake_make_prompt_cache(model):
-            kv = mr.KVCache()
+            kv = contiguous_cache.KVCache()
             kv.state = [mx.zeros((1, 4, 8, 64)), mx.zeros((1, 4, 8, 64))]
             return [kv, kv]
 
-        monkeypatch.setattr(mr, "make_prompt_cache", fake_make_prompt_cache)
+        monkeypatch.setattr(
+            contiguous_cache, "make_prompt_cache", fake_make_prompt_cache
+        )
 
         runner = self._make_runner()
         monkeypatch.setattr(runner._prefix_cache, "lookup", lookup_spy)
@@ -125,9 +129,11 @@ class TestPrefixCacheRestoreOffset:
 
         k = mx.zeros((1, 2, 7, 8), dtype=mx.float32)
         v = mx.zeros((1, 2, 7, 8), dtype=mx.float32)
-        cached = mr.CachedPrefix(token_ids=[1, 2, 3], cache_state=[(k, v)])
+        cached = contiguous_cache.CachedPrefix(
+            token_ids=[1, 2, 3], cache_state=[(k, v)]
+        )
 
-        manager = mr.PrefixCacheManager(max_bytes=1024 * 1024)
+        manager = contiguous_cache.PrefixCacheManager(max_bytes=1024 * 1024)
         restored = manager.restore_cache(cached, model=MagicMock(), is_vlm=False)
 
         restored_layer = restored[0]
@@ -155,16 +161,18 @@ class TestHybridCacheMergeExtract:
     _KV_NUM_HEADS = 1
     _KV_HEAD_DIM = 2
 
-    def _make_arrays_cache(self, v0: float | None, v1: float | None) -> mr.ArraysCache:
-        cache = mr.ArraysCache(self._ARRAYS_CACHE_ENTRIES)
+    def _make_arrays_cache(
+        self, v0: float | None, v1: float | None
+    ) -> contiguous_cache.ArraysCache:
+        cache = contiguous_cache.ArraysCache(self._ARRAYS_CACHE_ENTRIES)
         if v0 is not None:
             cache[0] = mx.full((1, self._ARRAYS_CACHE_FEATURES), v0, dtype=mx.float32)
         if v1 is not None:
             cache[1] = mx.full((1, self._ARRAYS_CACHE_FEATURES), v1, dtype=mx.float32)
         return cache
 
-    def _make_kv_cache(self, seq_len: int, value: float) -> mr.KVCache:
-        kv = mr.KVCache()
+    def _make_kv_cache(self, seq_len: int, value: float) -> contiguous_cache.KVCache:
+        kv = contiguous_cache.KVCache()
         kv.keys = mx.full(
             (1, self._KV_NUM_HEADS, seq_len, self._KV_HEAD_DIM),
             value,
@@ -180,8 +188,8 @@ class TestHybridCacheMergeExtract:
 
     def _make_rotating_kv_cache(
         self, *, max_size: int, total_tokens: int, value: float
-    ) -> mr.RotatingKVCache:
-        cache = mr.RotatingKVCache(max_size=max_size)
+    ) -> contiguous_cache.RotatingKVCache:
+        cache = contiguous_cache.RotatingKVCache(max_size=max_size)
         keys = mx.full(
             (1, self._KV_NUM_HEADS, 1, self._KV_HEAD_DIM),
             value,
@@ -201,13 +209,15 @@ class TestHybridCacheMergeExtract:
         arrays_cache_req0 = self._make_arrays_cache(1.0, 11.0)
         arrays_cache_req1 = self._make_arrays_cache(2.0, 22.0)
 
-        merged = mr._merge_kv_caches([[arrays_cache_req0], [arrays_cache_req1]])
-        extracted_req0 = mr._extract_kv_cache(merged, 0)[0]
-        extracted_req1 = mr._extract_kv_cache(merged, 1)[0]
+        merged = contiguous_cache._merge_kv_caches(
+            [[arrays_cache_req0], [arrays_cache_req1]]
+        )
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)[0]
+        extracted_req1 = contiguous_cache._extract_kv_cache(merged, 1)[0]
 
-        assert isinstance(merged[0], mr.ArraysCache)
-        assert isinstance(extracted_req0, mr.ArraysCache)
-        assert isinstance(extracted_req1, mr.ArraysCache)
+        assert isinstance(merged[0], contiguous_cache.ArraysCache)
+        assert isinstance(extracted_req0, contiguous_cache.ArraysCache)
+        assert isinstance(extracted_req1, contiguous_cache.ArraysCache)
         assert bool(mx.allclose(extracted_req0.state[0], arrays_cache_req0.state[0]))
         assert bool(mx.allclose(extracted_req0.state[1], arrays_cache_req0.state[1]))
         assert bool(mx.allclose(extracted_req1.state[0], arrays_cache_req1.state[0]))
@@ -223,13 +233,15 @@ class TestHybridCacheMergeExtract:
         arrays_cache_req0 = self._make_arrays_cache(1.0, 11.0)
         arrays_cache_req1 = self._make_arrays_cache(2.0, None)
 
-        merged = mr._merge_kv_caches([[arrays_cache_req0], [arrays_cache_req1]])
+        merged = contiguous_cache._merge_kv_caches(
+            [[arrays_cache_req0], [arrays_cache_req1]]
+        )
 
-        extracted_req0 = mr._extract_kv_cache(merged, 0)[0]
-        extracted_req1 = mr._extract_kv_cache(merged, 1)[0]
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)[0]
+        extracted_req1 = contiguous_cache._extract_kv_cache(merged, 1)[0]
 
-        assert isinstance(extracted_req0, mr.ArraysCache)
-        assert isinstance(extracted_req1, mr.ArraysCache)
+        assert isinstance(extracted_req0, contiguous_cache.ArraysCache)
+        assert isinstance(extracted_req1, contiguous_cache.ArraysCache)
 
         assert bool(mx.allclose(extracted_req0.state[0], arrays_cache_req0.state[0]))
         assert bool(mx.allclose(extracted_req0.state[1], arrays_cache_req0.state[1]))
@@ -247,22 +259,22 @@ class TestHybridCacheMergeExtract:
         arrays_cache_req0 = self._make_arrays_cache(3.0, 33.0)
         arrays_cache_req1 = self._make_arrays_cache(4.0, 44.0)
 
-        merged = mr._merge_kv_caches(
+        merged = contiguous_cache._merge_kv_caches(
             [[kv_cache_req0, arrays_cache_req0], [kv_cache_req1, arrays_cache_req1]]
         )
-        extracted_req0 = mr._extract_kv_cache(merged, 0)
-        extracted_req1 = mr._extract_kv_cache(merged, 1)
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)
+        extracted_req1 = contiguous_cache._extract_kv_cache(merged, 1)
 
-        assert isinstance(merged[0], mr.BatchKVCache)
-        assert isinstance(merged[1], mr.ArraysCache)
+        assert isinstance(merged[0], contiguous_cache.BatchKVCache)
+        assert isinstance(merged[1], contiguous_cache.ArraysCache)
 
         kv_req0_out, arrays_req0_out = extracted_req0
         kv_req1_out, arrays_req1_out = extracted_req1
 
-        assert isinstance(kv_req0_out, mr.KVCache)
-        assert isinstance(kv_req1_out, mr.KVCache)
-        assert isinstance(arrays_req0_out, mr.ArraysCache)
-        assert isinstance(arrays_req1_out, mr.ArraysCache)
+        assert isinstance(kv_req0_out, contiguous_cache.KVCache)
+        assert isinstance(kv_req1_out, contiguous_cache.KVCache)
+        assert isinstance(arrays_req0_out, contiguous_cache.ArraysCache)
+        assert isinstance(arrays_req1_out, contiguous_cache.ArraysCache)
 
         assert kv_req0_out.offset == kv_cache_req0.offset
         assert kv_req1_out.offset == kv_cache_req1.offset
@@ -282,13 +294,13 @@ class TestHybridCacheMergeExtract:
         )
         cache_req1 = self._make_rotating_kv_cache(max_size=8, total_tokens=5, value=2.0)
 
-        merged = mr._merge_kv_caches([[cache_req0], [cache_req1]])
-        extracted_req0 = mr._extract_kv_cache(merged, 0)[0]
-        extracted_req1 = mr._extract_kv_cache(merged, 1)[0]
+        merged = contiguous_cache._merge_kv_caches([[cache_req0], [cache_req1]])
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)[0]
+        extracted_req1 = contiguous_cache._extract_kv_cache(merged, 1)[0]
 
-        assert isinstance(merged[0], mr.BatchRotatingKVCache)
-        assert isinstance(extracted_req0, mr.RotatingKVCache)
-        assert isinstance(extracted_req1, mr.RotatingKVCache)
+        assert isinstance(merged[0], contiguous_cache.BatchRotatingKVCache)
+        assert isinstance(extracted_req0, contiguous_cache.RotatingKVCache)
+        assert isinstance(extracted_req1, contiguous_cache.RotatingKVCache)
         assert extracted_req0.offset == cache_req0.offset
         assert extracted_req1.offset == cache_req1.offset
 
@@ -310,13 +322,13 @@ class TestHybridCacheMergeExtract:
         assert cache_req0.offset > cache_req0.max_size
         assert cache_req1.offset > cache_req1.max_size
 
-        merged = mr._merge_kv_caches([[cache_req0], [cache_req1]])
-        extracted_req0 = mr._extract_kv_cache(merged, 0)[0]
-        extracted_req1 = mr._extract_kv_cache(merged, 1)[0]
+        merged = contiguous_cache._merge_kv_caches([[cache_req0], [cache_req1]])
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)[0]
+        extracted_req1 = contiguous_cache._extract_kv_cache(merged, 1)[0]
 
-        assert isinstance(merged[0], mr.BatchRotatingKVCache)
-        assert isinstance(extracted_req0, mr.RotatingKVCache)
-        assert isinstance(extracted_req1, mr.RotatingKVCache)
+        assert isinstance(merged[0], contiguous_cache.BatchRotatingKVCache)
+        assert isinstance(extracted_req0, contiguous_cache.RotatingKVCache)
+        assert isinstance(extracted_req1, contiguous_cache.RotatingKVCache)
         assert extracted_req0.offset == cache_req0.offset
         assert extracted_req1.offset == cache_req1.offset
 
@@ -327,7 +339,7 @@ class TestHybridCacheMergeExtract:
         ``max_size``.  The merge must trim to the effective sliding-window length.
         """
         # Prefill 128 tokens into a cache with max_size=70
-        cache_req0 = mr.RotatingKVCache(max_size=70)
+        cache_req0 = contiguous_cache.RotatingKVCache(max_size=70)
         big_k = mx.full(
             (1, self._KV_NUM_HEADS, 128, self._KV_HEAD_DIM), 1.0, dtype=mx.float32
         )
@@ -340,13 +352,13 @@ class TestHybridCacheMergeExtract:
             max_size=70, total_tokens=30, value=2.0
         )
 
-        merged = mr._merge_kv_caches([[cache_req0], [cache_req1]])
-        extracted_req0 = mr._extract_kv_cache(merged, 0)[0]
-        extracted_req1 = mr._extract_kv_cache(merged, 1)[0]
+        merged = contiguous_cache._merge_kv_caches([[cache_req0], [cache_req1]])
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)[0]
+        extracted_req1 = contiguous_cache._extract_kv_cache(merged, 1)[0]
 
-        assert isinstance(merged[0], mr.BatchRotatingKVCache)
-        assert isinstance(extracted_req0, mr.RotatingKVCache)
-        assert isinstance(extracted_req1, mr.RotatingKVCache)
+        assert isinstance(merged[0], contiguous_cache.BatchRotatingKVCache)
+        assert isinstance(extracted_req0, contiguous_cache.RotatingKVCache)
+        assert isinstance(extracted_req1, contiguous_cache.RotatingKVCache)
         assert extracted_req0.offset == cache_req0.offset
         assert extracted_req1.offset == cache_req1.offset
 
@@ -362,9 +374,9 @@ class TestHybridCacheMergeExtract:
         )
         cache_req1 = self._make_rotating_kv_cache(max_size=8, total_tokens=5, value=2.0)
 
-        merged = mr._merge_kv_caches([[cache_req0], [cache_req1]])
+        merged = contiguous_cache._merge_kv_caches([[cache_req0], [cache_req1]])
         batch_cache = merged[0]
-        assert isinstance(batch_cache, mr.BatchRotatingKVCache)
+        assert isinstance(batch_cache, contiguous_cache.BatchRotatingKVCache)
 
         # Simulate one batched decode step (S=1)
         decode_k = mx.ones((2, self._KV_NUM_HEADS, 1, self._KV_HEAD_DIM))
@@ -375,8 +387,8 @@ class TestHybridCacheMergeExtract:
         extracted_req0 = batch_cache.extract(0)
         extracted_req1 = batch_cache.extract(1)
 
-        assert isinstance(extracted_req0, mr.RotatingKVCache)
-        assert isinstance(extracted_req1, mr.RotatingKVCache)
+        assert isinstance(extracted_req0, contiguous_cache.RotatingKVCache)
+        assert isinstance(extracted_req1, contiguous_cache.RotatingKVCache)
         assert extracted_req0.offset == cache_req0.offset + 1
         assert extracted_req1.offset == cache_req1.offset + 1
 
@@ -396,10 +408,10 @@ class TestHybridCacheMergeExtract:
             max_size=8, total_tokens=150, value=2.0
         )
 
-        merged = mr._merge_kv_caches([[cache_req0], [cache_req1]])
-        extracted_req0 = mr._extract_kv_cache(merged, 0)[0]
+        merged = contiguous_cache._merge_kv_caches([[cache_req0], [cache_req1]])
+        extracted_req0 = contiguous_cache._extract_kv_cache(merged, 0)[0]
 
-        assert isinstance(extracted_req0, mr.RotatingKVCache)
+        assert isinstance(extracted_req0, contiguous_cache.RotatingKVCache)
         assert extracted_req0.offset > extracted_req0.max_size
         assert extracted_req0.keys.shape[2] == extracted_req0.max_size
 
@@ -416,18 +428,18 @@ class TestHybridCacheMergeExtract:
 
     def test_merge_kv_caches_rejects_mixed_cache_types_within_layer(self) -> None:
         arrays_cache = self._make_arrays_cache(1.0, 2.0)
-        kv_cache = mr.KVCache()
+        kv_cache = contiguous_cache.KVCache()
         with pytest.raises(TypeError, match="Mixed cache types in a single layer"):
-            mr._merge_kv_caches([[arrays_cache], [kv_cache]])
+            contiguous_cache._merge_kv_caches([[arrays_cache], [kv_cache]])
 
 
 class TestPrefixCacheEviction:
     def test_eviction_under_max_bytes(self) -> None:
         # 1KB limit
-        mgr = mr.PrefixCacheManager(max_bytes=1024)
+        mgr = contiguous_cache.PrefixCacheManager(max_bytes=1024)
 
         # Create fake KVCache with known size
-        kv = mr.KVCache()
+        kv = contiguous_cache.KVCache()
         k = mx.zeros((1, 4, 8, 64))  # 8192 bytes (float32)
         v = mx.zeros((1, 4, 8, 64))
         kv.state = [k, v]
@@ -437,8 +449,8 @@ class TestPrefixCacheEviction:
         assert len(mgr._cache) == 0
         assert mgr._current_bytes == 0
 
-    def _make_kv(self, seq_len: int = 1) -> mr.KVCache:
-        kv = mr.KVCache()
+    def _make_kv(self, seq_len: int = 1) -> contiguous_cache.KVCache:
+        kv = contiguous_cache.KVCache()
         kv.state = [
             mx.zeros((1, 1, seq_len, 8)),
             mx.zeros((1, 1, seq_len, 8)),
@@ -448,7 +460,7 @@ class TestPrefixCacheEviction:
     def test_eviction_triggers_on_full(self) -> None:
         kv = self._make_kv()
         entry_bytes = kv.state[0].nbytes + kv.state[1].nbytes
-        mgr = mr.PrefixCacheManager(max_bytes=entry_bytes * 2 + 1)
+        mgr = contiguous_cache.PrefixCacheManager(max_bytes=entry_bytes * 2 + 1)
 
         mgr.insert([1], [self._make_kv()])
         mgr.insert([2], [self._make_kv()])
@@ -459,7 +471,7 @@ class TestPrefixCacheEviction:
         assert len(mgr._cache) == 2
 
     def test_duplicate_insert_skipped(self) -> None:
-        mgr = mr.PrefixCacheManager(max_bytes=1024 * 1024)
+        mgr = contiguous_cache.PrefixCacheManager(max_bytes=1024 * 1024)
 
         mgr.insert([1, 2], [self._make_kv()])
         bytes_after_first = mgr._current_bytes
@@ -473,11 +485,11 @@ class TestPrefixCacheEnableFlag:
 
     def test_enabled_when_env_set(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE", "1")
-        assert mr._prefix_cache_enabled() is True
+        assert contiguous_cache._prefix_cache_enabled() is True
 
     def test_disabled_when_env_unset(self, monkeypatch) -> None:
         monkeypatch.delenv("VLLM_METAL_PREFIX_CACHE", raising=False)
-        assert mr._prefix_cache_enabled() is False
+        assert contiguous_cache._prefix_cache_enabled() is False
 
 
 _TEN_GB = 10 * 1024**3
@@ -490,53 +502,53 @@ def _mock_device_info():
 class TestPrefixCacheFractionParsing:
     def test_valid_fraction(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE_FRACTION", "0.1")
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
         assert result == int(_TEN_GB * 0.1)
 
     def test_default_fraction(self, monkeypatch) -> None:
         monkeypatch.delenv("VLLM_METAL_PREFIX_CACHE_FRACTION", raising=False)
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
-        assert result == int(_TEN_GB * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
+        assert result == int(_TEN_GB * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)
 
     def test_invalid_string_uses_default(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE_FRACTION", "abc")
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
-        assert result == int(_TEN_GB * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
+        assert result == int(_TEN_GB * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)
 
     def test_out_of_range_zero_uses_default(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE_FRACTION", "0")
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
-        assert result == int(_TEN_GB * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
+        assert result == int(_TEN_GB * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)
 
     def test_out_of_range_above_one_uses_default(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE_FRACTION", "2")
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
-        assert result == int(_TEN_GB * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
+        assert result == int(_TEN_GB * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)
 
     def test_nan_uses_default(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE_FRACTION", "nan")
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
-        assert result == int(_TEN_GB * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
+        assert result == int(_TEN_GB * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)
 
     def test_inf_uses_default(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_PREFIX_CACHE_FRACTION", "inf")
-        monkeypatch.setattr(mr.mx, "device_info", _mock_device_info)
-        result = mr._get_prefix_cache_max_bytes()
-        assert result == int(_TEN_GB * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        monkeypatch.setattr(contiguous_cache.mx, "device_info", _mock_device_info)
+        result = contiguous_cache._get_prefix_cache_max_bytes()
+        assert result == int(_TEN_GB * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)
 
     def test_device_info_fallback(self, monkeypatch) -> None:
         monkeypatch.delenv("VLLM_METAL_PREFIX_CACHE_FRACTION", raising=False)
         monkeypatch.setattr(
-            mr.mx,
+            contiguous_cache.mx,
             "device_info",
             lambda: {},
         )
-        result = mr._get_prefix_cache_max_bytes()
+        result = contiguous_cache._get_prefix_cache_max_bytes()
         fallback = 8 * 1024**3
-        assert result == int(fallback * mr._PREFIX_CACHE_DEFAULT_FRACTION)
+        assert result == int(fallback * contiguous_cache._PREFIX_CACHE_DEFAULT_FRACTION)

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Legacy mlx_lm KV cache utilities.
+"""Contiguous KV cache utilities (non-paged code path).
 
 Prefix caching (PrefixCacheManager) and batched KV cache merge/extract
-helpers used by the non-paged-attention code path.
+helpers for the contiguous KV cache path, used when paged attention is
+disabled. KV state is stored as contiguous mx.array tensors per request,
+in contrast to the fixed-block layout used by paged attention.
 """
 
 import hashlib

--- a/vllm_metal/v1/legacy_cache.py
+++ b/vllm_metal/v1/legacy_cache.py
@@ -1,0 +1,473 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Legacy mlx_lm KV cache utilities.
+
+Prefix caching (PrefixCacheManager) and batched KV cache merge/extract
+helpers used by the non-paged-attention code path.
+"""
+
+import hashlib
+import math
+import os
+from array import array
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import mlx.core as mx
+from mlx_lm.models.cache import (
+    ArraysCache,
+    BatchKVCache,
+    BatchRotatingKVCache,
+    KVCache,
+    RotatingKVCache,
+    make_prompt_cache,
+)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Minimum requests to use BatchKVCache for batched decode
+_MIN_BATCH_SIZE_FOR_BATCHING = 2
+
+# Type alias for any per-layer cache type supported by the model.
+#
+# Notes:
+# - Some models (e.g. gpt_oss) use `RotatingKVCache` for sliding-window attention.
+# - Hybrid models use `ArraysCache` for non-attention state.
+AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
+
+
+# ---------------------------------------------------------------------------
+# Prefix cache configuration — enabled by setting VLLM_METAL_PREFIX_CACHE
+# in the environment (any value; unset to disable).
+# ---------------------------------------------------------------------------
+
+
+def _prefix_cache_enabled() -> bool:
+    """Check whether prefix caching is enabled via environment variable."""
+    return "VLLM_METAL_PREFIX_CACHE" in os.environ
+
+
+_PREFIX_CACHE_ENABLED = _prefix_cache_enabled()
+_PREFIX_CACHE_DEFAULT_FRACTION = 0.05  # 5% of MLX working set
+
+
+def _get_prefix_cache_max_bytes() -> int:
+    """Get prefix cache memory limit based on MLX recommended working set."""
+    fraction_str = os.environ.get("VLLM_METAL_PREFIX_CACHE_FRACTION", "")
+    if fraction_str:
+        try:
+            fraction = float(fraction_str)
+            if not math.isfinite(fraction) or fraction <= 0 or fraction > 1:
+                logger.warning(
+                    "VLLM_METAL_PREFIX_CACHE_FRACTION=%r out of range (0, 1], "
+                    "using default %.2f",
+                    fraction_str,
+                    _PREFIX_CACHE_DEFAULT_FRACTION,
+                )
+                fraction = _PREFIX_CACHE_DEFAULT_FRACTION
+        except ValueError:
+            logger.warning(
+                "Invalid VLLM_METAL_PREFIX_CACHE_FRACTION=%r, using default %.2f",
+                fraction_str,
+                _PREFIX_CACHE_DEFAULT_FRACTION,
+            )
+            fraction = _PREFIX_CACHE_DEFAULT_FRACTION
+    else:
+        fraction = _PREFIX_CACHE_DEFAULT_FRACTION
+
+    fallback_bytes = 8 * 1024 * 1024 * 1024  # 8 GB
+    try:
+        device_info = mx.device_info()
+        total = int(device_info.get("max_recommended_working_set_size", 0))
+    except (AttributeError, RuntimeError):
+        total = 0
+
+    if total == 0:
+        total = fallback_bytes
+        logger.warning("Could not get MLX working set size, using 8GB fallback")
+
+    max_bytes = int(total * fraction)
+    logger.info(
+        "Prefix cache: %.1fGB limit (%.1f%% of %.1fGB MLX working set)",
+        max_bytes / (1024 * 1024 * 1024),
+        fraction * 100,
+        total / (1024 * 1024 * 1024),
+    )
+    return max_bytes
+
+
+def _compute_prefix_hash(token_ids: list[int]) -> bytes:
+    """Compute content hash for a token sequence."""
+    h = hashlib.sha256()
+    h.update(array("I", token_ids).tobytes())
+    return h.digest()
+
+
+def _compute_entry_bytes(cache_state: list[tuple[mx.array, mx.array] | None]) -> int:
+    """Compute memory usage of a cache entry in bytes."""
+    total = 0
+    for pair in cache_state:
+        if pair is not None:
+            total += pair[0].nbytes + pair[1].nbytes
+    return total
+
+
+@dataclass
+class CachedPrefix:
+    """Cached KV state for a token prefix.
+
+    cache_state contains (k, v) tuples for KVCache layers, or None for
+    ArraysCache layers in hybrid models.
+    """
+
+    token_ids: list[int]
+    cache_state: list[tuple[mx.array, mx.array] | None]
+    size_bytes: int = 0
+    ref_count: int = 0
+
+
+class PrefixCacheManager:
+    """Manager for prefix KV cache reuse with memory-based eviction."""
+
+    def __init__(self, max_bytes: int | None = None):
+        self._cache: dict[bytes, CachedPrefix] = {}
+        self._max_bytes = (
+            max_bytes if max_bytes is not None else _get_prefix_cache_max_bytes()
+        )
+        self._current_bytes = 0
+        self._hits = 0
+        self._misses = 0
+
+    def lookup(self, token_ids: list[int]) -> CachedPrefix | None:
+        """Look up cached prefix by token IDs."""
+        prefix_hash = _compute_prefix_hash(token_ids)
+        cached = self._cache.get(prefix_hash)
+        if cached is not None:
+            self._hits += 1
+            cached.ref_count += 1
+            logger.debug(
+                "Prefix cache HIT: %d hits, %d misses, rate=%.1f%%",
+                self._hits,
+                self._misses,
+                self.hit_rate * 100,
+            )
+            return cached
+        self._misses += 1
+        logger.debug(
+            "Prefix cache MISS: %d hits, %d misses, rate=%.1f%%",
+            self._hits,
+            self._misses,
+            self.hit_rate * 100,
+        )
+        return None
+
+    def _evict_until_fits(self, needed_bytes: int) -> None:
+        """Evict entries until we have room for needed_bytes."""
+        while self._current_bytes + needed_bytes > self._max_bytes and self._cache:
+            min_hash, min_entry = min(self._cache.items(), key=lambda x: x[1].ref_count)
+            self._current_bytes -= min_entry.size_bytes
+            del self._cache[min_hash]
+            logger.debug(
+                "Prefix cache eviction: freed %.1fMB",
+                min_entry.size_bytes / (1024 * 1024),
+            )
+
+    def insert(self, token_ids: list[int], cache: list[KVCache]) -> None:
+        """Insert a prefix cache entry with memory-based eviction.
+
+        Only KVCache layers are cached. ArraysCache layers are skipped (stored as
+        None) for hybrid model compatibility.
+        """
+        prefix_hash = _compute_prefix_hash(token_ids)
+        if prefix_hash in self._cache:
+            return
+
+        cache_state = []
+        for layer_cache in cache:
+            if isinstance(layer_cache, KVCache):
+                k = layer_cache.state[0]
+                v = layer_cache.state[1]
+                cache_state.append((mx.array(k), mx.array(v)))
+            else:
+                cache_state.append(None)
+
+        entry_bytes = _compute_entry_bytes(cache_state)
+
+        # Skip if single entry exceeds memory limit
+        if entry_bytes > self._max_bytes:
+            logger.debug(
+                "Prefix cache skip: entry %.1fMB exceeds limit %.1fGB",
+                entry_bytes / (1024 * 1024),
+                self._max_bytes / (1024 * 1024 * 1024),
+            )
+            return
+
+        self._evict_until_fits(entry_bytes)
+
+        self._cache[prefix_hash] = CachedPrefix(
+            token_ids=list(token_ids),
+            cache_state=cache_state,
+            size_bytes=entry_bytes,
+            ref_count=1,
+        )
+        self._current_bytes += entry_bytes
+
+    def restore_cache(
+        self, cached: CachedPrefix, model: Any, is_vlm: bool
+    ) -> list[AnyCache]:
+        """Restore a cached prefix to a fresh KVCache.
+
+        Only KVCache layers are restored. RotatingKVCache / ArraysCache layers
+        remain in their fresh state.
+        """
+        cache_model = (
+            model.language_model
+            if is_vlm and hasattr(model, "language_model")
+            else model
+        )
+        cache = make_prompt_cache(cache_model)
+        for i, layer_cache in enumerate(cache):
+            if i < len(cached.cache_state) and cached.cache_state[i] is not None:
+                if isinstance(layer_cache, KVCache):
+                    k, v = cached.cache_state[i]
+                    layer_cache.state = [mx.array(k), mx.array(v)]
+                    # Keep RoPE position correct even if KVCache.state setter
+                    # behavior changes in future mlx-lm versions.
+                    layer_cache.offset = int(k.shape[2])
+        return cache
+
+    @property
+    def hit_rate(self) -> float:
+        """Return prefix cache hit rate."""
+        total = self._hits + self._misses
+        return self._hits / total if total > 0 else 0.0
+
+    def get_stats(self) -> dict:
+        """Return prefix cache statistics."""
+        return {
+            "hits": self._hits,
+            "misses": self._misses,
+            "hit_rate": self.hit_rate,
+            "cached_entries": len(self._cache),
+            "current_bytes": self._current_bytes,
+            "max_bytes": self._max_bytes,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Batched KV cache merge / extract helpers (legacy non-paged decode path)
+# ---------------------------------------------------------------------------
+
+
+def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
+    """Merge per-request ArraysCache objects into a single batched ArraysCache.
+
+    This mirrors the behavior of `mlx_lm.models.cache.ArraysCache.merge` but is
+    implemented here for compatibility with older mlx-lm versions that do not
+    provide `merge()` / `extract()`.
+    """
+    if not caches:
+        raise ValueError("caches must be non-empty")
+
+    num_entries = len(caches[0].state)
+    batch_size = len(caches)
+
+    merged = ArraysCache(num_entries)
+    for entry_idx in range(num_entries):
+        values = [cache.state[entry_idx] for cache in caches]
+        template = next((value for value in values if value is not None), None)
+        if template is None:
+            continue
+
+        shape = list(template.shape)
+        shape[0] = batch_size
+        merged_state = mx.zeros(tuple(shape), template.dtype)
+        for batch_idx, value in enumerate(values):
+            if value is None:
+                continue
+            merged_state[batch_idx : batch_idx + 1] = value
+
+        merged[entry_idx] = merged_state
+
+    return merged
+
+
+def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
+    """Extract a single request's ArraysCache from a batched ArraysCache."""
+    state = batch_cache.state
+    extracted = ArraysCache(len(state))
+    extracted.state = [
+        None if value is None else value[idx : idx + 1] for value in state
+    ]
+    return extracted
+
+
+def _merge_rotating_kv_caches(
+    caches: list[RotatingKVCache],
+) -> BatchRotatingKVCache:
+    """Merge per-request RotatingKVCache objects into a single BatchRotatingKVCache.
+
+    This mirrors ``BatchRotatingKVCache.merge`` but pre-computes the temporal-ordered
+    keys/values, trims them to ``len(cache)`` (the effective sliding-window length),
+    and uses that length for the copy width.  The upstream implementation in
+    mlx-lm <= 0.29.1 uses ``c.offset`` which can exceed the underlying array size
+    after the cache has rotated, causing a broadcast shape error.
+
+    This workaround can be removed once vllm-metal can depend on an mlx-lm version
+    that includes the upstream fix (ml-explore/mlx-lm#738) and has been verified
+    to work with gpt-oss models end-to-end.
+    """
+    if not caches:
+        raise ValueError("caches must be non-empty")
+
+    if any(c.keys is None or c.values is None for c in caches):
+        raise ValueError(
+            "Cannot merge unpopulated RotatingKVCache (keys/values is None)"
+        )
+
+    if not all(c.max_size == caches[0].max_size for c in caches):
+        raise ValueError(
+            "BatchRotatingKVCache can only merge caches with the same maximum size"
+        )
+
+    # Pre-compute temporal-ordered keys/values and trim to the effective
+    # sliding-window length.  ``_temporal_order`` may return an array larger
+    # than ``len(cache)`` when the internal buffer has not been trimmed yet
+    # (e.g. after a large prefill), so we trim via ``_trim`` to preserve
+    # the ``keep`` prefix semantics used by RotatingKVCache internally.
+    ordered: list[tuple[mx.array, mx.array]] = []
+    for c in caches:
+        effective_len = c.size() if hasattr(c, "size") else len(c)
+        ordered_keys = c._temporal_order(c.keys)
+        ordered_values = c._temporal_order(c.values)
+        if ordered_keys.shape[2] > effective_len:
+            trim_size = ordered_keys.shape[2] - effective_len
+            ordered_keys = c._trim(trim_size, ordered_keys)
+            ordered_values = c._trim(trim_size, ordered_values)
+        else:
+            ordered_keys = ordered_keys[..., :effective_len, :]
+            ordered_values = ordered_values[..., :effective_len, :]
+        ordered.append((ordered_keys, ordered_values))
+
+    lengths = [k.shape[2] for k, _ in ordered]
+    max_length = max(lengths)
+    padding = [max_length - length for length in lengths]
+    batch_size = len(caches)
+    n_heads = max(k.shape[1] for k, _ in ordered)
+    k_dim = max(k.shape[3] for k, _ in ordered)
+    v_dim = max(v.shape[3] for _, v in ordered)
+    dtype = next(iter(k.dtype for k, _ in ordered))
+
+    keys = mx.zeros((batch_size, n_heads, max_length, k_dim), dtype=dtype)
+    values = mx.zeros((batch_size, n_heads, max_length, v_dim), dtype=dtype)
+    for i, (pad, (k, v)) in enumerate(zip(padding, ordered, strict=True)):
+        n = k.shape[2]
+        keys[i : i + 1, :, pad : pad + n] = k
+        values[i : i + 1, :, pad : pad + n] = v
+
+    cache = BatchRotatingKVCache(caches[0].max_size, padding)
+    cache.keys = keys
+    cache.values = values
+    cache.offset = mx.array([c.offset for c in caches])
+    cache._idx = keys.shape[2]
+    cache._offset = keys.shape[2]
+
+    return cache
+
+
+def _merge_kv_caches(
+    caches_list: list[list[AnyCache]],
+) -> list[BatchKVCache | BatchRotatingKVCache | ArraysCache]:
+    """Merge multiple per-request caches into batched caches.
+
+    Args:
+        caches_list: List of per-request caches, each is a list of per-layer caches
+
+    Returns:
+        List of batched caches, one per layer
+    """
+    if not caches_list:
+        return []
+
+    num_layers = len(caches_list[0])
+    merged: list[BatchKVCache | BatchRotatingKVCache | ArraysCache] = []
+
+    for layer_idx in range(num_layers):
+        layer_caches = [caches[layer_idx] for caches in caches_list]
+        if isinstance(layer_caches[0], ArraysCache):
+            arrays_caches: list[ArraysCache] = []
+            for cache in layer_caches:
+                if not isinstance(cache, ArraysCache):
+                    raise TypeError(
+                        "Mixed cache types in a single layer: expected ArraysCache"
+                    )
+                arrays_caches.append(cache)
+            batch_cache = _merge_arrays_caches(arrays_caches)
+        elif isinstance(layer_caches[0], RotatingKVCache):
+            rotating_caches: list[RotatingKVCache] = []
+            for cache in layer_caches:
+                if not isinstance(cache, RotatingKVCache):
+                    raise TypeError(
+                        "Mixed cache types in a single layer: expected RotatingKVCache"
+                    )
+                rotating_caches.append(cache)
+            batch_cache = _merge_rotating_kv_caches(rotating_caches)
+        elif isinstance(layer_caches[0], KVCache):
+            kv_caches: list[KVCache] = []
+            for cache in layer_caches:
+                if not isinstance(cache, KVCache):
+                    raise TypeError(
+                        "Mixed cache types in a single layer: expected KVCache"
+                    )
+                kv_caches.append(cache)
+            batch_cache = BatchKVCache.merge(kv_caches)
+        else:
+            cache_type = type(layer_caches[0]).__name__
+            raise TypeError(f"Unsupported cache type for batching: {cache_type}")
+        merged.append(batch_cache)
+
+    return merged
+
+
+def _extract_kv_cache(
+    batch_caches: list[BatchKVCache | BatchRotatingKVCache | ArraysCache], idx: int
+) -> list[AnyCache]:
+    """Extract a single request's cache from batched caches.
+
+    Args:
+        batch_caches: List of batched caches, one per layer
+        idx: Index of the request in the batch
+
+    Returns:
+        List of caches for the request, one per layer
+    """
+    extracted: list[AnyCache] = []
+    for cache in batch_caches:
+        if isinstance(cache, ArraysCache):
+            extracted.append(_extract_arrays_cache(cache, idx))
+        else:
+            c = cache.extract(idx)
+            # After extract, RotatingKVCache may have offset > max_size but
+            # keys.shape[2] < max_size (buffer was sliced).  Pad the buffer
+            # back to max_size so _update_in_place won't try to grow it
+            # (which would compute a negative new_size).  The padded region
+            # is dead space that will be overwritten on the next rotation.
+            if (
+                isinstance(c, RotatingKVCache)
+                and c.keys is not None
+                and c.offset > c.max_size
+                and c.keys.shape[2] < c.max_size
+            ):
+                pad = c.max_size - c.keys.shape[2]
+                z_k = mx.zeros(
+                    (1, c.keys.shape[1], pad, c.keys.shape[3]),
+                    dtype=c.keys.dtype,
+                )
+                z_v = mx.zeros(
+                    (1, c.values.shape[1], pad, c.values.shape[3]),
+                    dtype=c.values.dtype,
+                )
+                c.keys = mx.concatenate([c.keys, z_k], axis=2)
+                c.values = mx.concatenate([c.values, z_v], axis=2)
+            extracted.append(c)
+    return extracted

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -64,7 +64,7 @@ from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.utils import get_model_download_path
-from vllm_metal.v1.legacy_cache import (  # noqa: F401 — re-exported for tests
+from vllm_metal.v1.contiguous_cache import (  # noqa: F401 — re-exported for tests
     _MIN_BATCH_SIZE_FOR_BATCHING,
     _PREFIX_CACHE_DEFAULT_FRACTION,
     _PREFIX_CACHE_ENABLED,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1,19 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Metal Model Runner for vLLM v1 engine.
+"""
+NOTE: Coding style guide for this file:
+This model runner is shared by all models: text and multimodal, generative
+and embedding, public and private. As a result, this file must only contain
+code that is common to every model. Model-specific behavior belongs in the
+appropriate model-specific files.
 
-Optimized for performance with:
-- True batched decode using BatchKVCache for O(1) forward passes per batch
-- Async evaluation pipeline for pipelined computation
-- Pre-allocated input buffers to reduce allocation overhead
-- Global model cache for fast repeated loads
-- Content hash prefix caching for shared prompt reuse
+In other words:
+* Be paranoid about changing this file. It should remain stable.
+* Be even more paranoid about adding new lines. It should remain minimal.
+
+Even for shared features (for example, different parallelism modes), keep the
+complexity out of this path. The less common the feature, the more it should be
+hidden. Prefer utility functions defined elsewhere and call them from here,
+instead of embedding feature-specific logic directly.
 """
 
-import hashlib
-import math
-import os
 import time
-from array import array
 from dataclasses import dataclass, field
 from threading import Lock
 from typing import Any, Literal, NamedTuple, TypeAlias
@@ -23,11 +26,7 @@ import torch
 from mlx_lm import load as mlx_lm_load
 from mlx_lm import stream_generate
 from mlx_lm.models.cache import (
-    ArraysCache,
-    BatchKVCache,
-    BatchRotatingKVCache,
     KVCache,
-    RotatingKVCache,
     make_prompt_cache,
 )
 
@@ -65,6 +64,22 @@ from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.legacy_cache import (  # noqa: F401 — re-exported for tests
+    _MIN_BATCH_SIZE_FOR_BATCHING,
+    _PREFIX_CACHE_DEFAULT_FRACTION,
+    _PREFIX_CACHE_ENABLED,
+    AnyCache,
+    ArraysCache,
+    BatchKVCache,
+    BatchRotatingKVCache,
+    CachedPrefix,
+    PrefixCacheManager,
+    RotatingKVCache,
+    _extract_kv_cache,
+    _get_prefix_cache_max_bytes,
+    _merge_kv_caches,
+    _prefix_cache_enabled,
+)
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
     SamplingBatch,
@@ -80,357 +95,14 @@ _model_cache: dict[str, tuple[Any, Any]] = {}  # model_name -> (model, tokenizer
 _model_cache_lock = Lock()
 
 
-# Configuration for batched operations
-_MIN_BATCH_SIZE_FOR_BATCHING = 2  # Minimum requests to use BatchKVCache
-_MAX_BATCH_SIZE = 64  # Maximum batch size for decode
-
-
 # Performance tuning
 _CACHE_CLEAR_INTERVAL = 50  # Clear cache every N finished requests
 
-# Prefix cache configuration — enabled by setting VLLM_METAL_PREFIX_CACHE
-# in the environment (any value; unset to disable).
-
-
-def _prefix_cache_enabled() -> bool:
-    """Check whether prefix caching is enabled via environment variable."""
-    return "VLLM_METAL_PREFIX_CACHE" in os.environ
-
-
-_PREFIX_CACHE_ENABLED = _prefix_cache_enabled()
-_PREFIX_CACHE_DEFAULT_FRACTION = 0.05  # 5% of MLX working set
-
-
-def _get_prefix_cache_max_bytes() -> int:
-    """Get prefix cache memory limit based on MLX recommended working set."""
-    fraction_str = os.environ.get("VLLM_METAL_PREFIX_CACHE_FRACTION", "")
-    if fraction_str:
-        try:
-            fraction = float(fraction_str)
-            if not math.isfinite(fraction) or fraction <= 0 or fraction > 1:
-                logger.warning(
-                    "VLLM_METAL_PREFIX_CACHE_FRACTION=%r out of range (0, 1], "
-                    "using default %.2f",
-                    fraction_str,
-                    _PREFIX_CACHE_DEFAULT_FRACTION,
-                )
-                fraction = _PREFIX_CACHE_DEFAULT_FRACTION
-        except ValueError:
-            logger.warning(
-                "Invalid VLLM_METAL_PREFIX_CACHE_FRACTION=%r, using default %.2f",
-                fraction_str,
-                _PREFIX_CACHE_DEFAULT_FRACTION,
-            )
-            fraction = _PREFIX_CACHE_DEFAULT_FRACTION
-    else:
-        fraction = _PREFIX_CACHE_DEFAULT_FRACTION
-
-    fallback_bytes = 8 * 1024 * 1024 * 1024  # 8 GB
-    try:
-        device_info = mx.device_info()
-        total = int(device_info.get("max_recommended_working_set_size", 0))
-    except (AttributeError, RuntimeError):
-        total = 0
-
-    if total == 0:
-        total = fallback_bytes
-        logger.warning("Could not get MLX working set size, using 8GB fallback")
-
-    max_bytes = int(total * fraction)
-    logger.info(
-        "Prefix cache: %.1fGB limit (%.1f%% of %.1fGB MLX working set)",
-        max_bytes / (1024 * 1024 * 1024),
-        fraction * 100,
-        total / (1024 * 1024 * 1024),
-    )
-    return max_bytes
-
-
-def _compute_prefix_hash(token_ids: list[int]) -> bytes:
-    """Compute content hash for a token sequence."""
-    h = hashlib.sha256()
-    h.update(array("I", token_ids).tobytes())
-    return h.digest()
-
-
-def _compute_entry_bytes(cache_state: list[tuple[mx.array, mx.array] | None]) -> int:
-    """Compute memory usage of a cache entry in bytes."""
-    total = 0
-    for pair in cache_state:
-        if pair is not None:
-            total += pair[0].nbytes + pair[1].nbytes
-    return total
-
-
-@dataclass
-class CachedPrefix:
-    """Cached KV state for a token prefix.
-
-    cache_state contains (k, v) tuples for KVCache layers, or None for
-    ArraysCache layers in hybrid models.
-    """
-
-    token_ids: list[int]
-    cache_state: list[tuple[mx.array, mx.array] | None]
-    size_bytes: int = 0
-    ref_count: int = 0
-
-
-class PrefixCacheManager:
-    """Manager for prefix KV cache reuse with memory-based eviction."""
-
-    def __init__(self, max_bytes: int | None = None):
-        self._cache: dict[bytes, CachedPrefix] = {}
-        self._max_bytes = (
-            max_bytes if max_bytes is not None else _get_prefix_cache_max_bytes()
-        )
-        self._current_bytes = 0
-        self._hits = 0
-        self._misses = 0
-
-    def lookup(self, token_ids: list[int]) -> CachedPrefix | None:
-        """Look up cached prefix by token IDs."""
-        prefix_hash = _compute_prefix_hash(token_ids)
-        cached = self._cache.get(prefix_hash)
-        if cached is not None:
-            self._hits += 1
-            cached.ref_count += 1
-            logger.debug(
-                "Prefix cache HIT: %d hits, %d misses, rate=%.1f%%",
-                self._hits,
-                self._misses,
-                self.hit_rate * 100,
-            )
-            return cached
-        self._misses += 1
-        logger.debug(
-            "Prefix cache MISS: %d hits, %d misses, rate=%.1f%%",
-            self._hits,
-            self._misses,
-            self.hit_rate * 100,
-        )
-        return None
-
-    def _evict_until_fits(self, needed_bytes: int) -> None:
-        """Evict entries until we have room for needed_bytes."""
-        while self._current_bytes + needed_bytes > self._max_bytes and self._cache:
-            min_hash, min_entry = min(self._cache.items(), key=lambda x: x[1].ref_count)
-            self._current_bytes -= min_entry.size_bytes
-            del self._cache[min_hash]
-            logger.debug(
-                "Prefix cache eviction: freed %.1fMB",
-                min_entry.size_bytes / (1024 * 1024),
-            )
-
-    def insert(self, token_ids: list[int], cache: list[KVCache]) -> None:
-        """Insert a prefix cache entry with memory-based eviction.
-
-        Only KVCache layers are cached. ArraysCache layers are skipped (stored as
-        None) for hybrid model compatibility.
-        """
-        prefix_hash = _compute_prefix_hash(token_ids)
-        if prefix_hash in self._cache:
-            return
-
-        cache_state = []
-        for layer_cache in cache:
-            if isinstance(layer_cache, KVCache):
-                k = layer_cache.state[0]
-                v = layer_cache.state[1]
-                cache_state.append((mx.array(k), mx.array(v)))
-            else:
-                cache_state.append(None)
-
-        entry_bytes = _compute_entry_bytes(cache_state)
-
-        # Skip if single entry exceeds memory limit
-        if entry_bytes > self._max_bytes:
-            logger.debug(
-                "Prefix cache skip: entry %.1fMB exceeds limit %.1fGB",
-                entry_bytes / (1024 * 1024),
-                self._max_bytes / (1024 * 1024 * 1024),
-            )
-            return
-
-        self._evict_until_fits(entry_bytes)
-
-        self._cache[prefix_hash] = CachedPrefix(
-            token_ids=list(token_ids),
-            cache_state=cache_state,
-            size_bytes=entry_bytes,
-            ref_count=1,
-        )
-        self._current_bytes += entry_bytes
-
-    def restore_cache(
-        self, cached: CachedPrefix, model: Any, is_vlm: bool
-    ) -> list["AnyCache"]:
-        """Restore a cached prefix to a fresh KVCache.
-
-        Only KVCache layers are restored. RotatingKVCache / ArraysCache layers
-        remain in their fresh state.
-        """
-        cache_model = (
-            model.language_model
-            if is_vlm and hasattr(model, "language_model")
-            else model
-        )
-        cache = make_prompt_cache(cache_model)
-        for i, layer_cache in enumerate(cache):
-            if i < len(cached.cache_state) and cached.cache_state[i] is not None:
-                if isinstance(layer_cache, KVCache):
-                    k, v = cached.cache_state[i]
-                    layer_cache.state = [mx.array(k), mx.array(v)]
-                    # Keep RoPE position correct even if KVCache.state setter
-                    # behavior changes in future mlx-lm versions.
-                    layer_cache.offset = int(k.shape[2])
-        return cache
-
-    @property
-    def hit_rate(self) -> float:
-        """Return prefix cache hit rate."""
-        total = self._hits + self._misses
-        return self._hits / total if total > 0 else 0.0
-
-    def get_stats(self) -> dict:
-        """Return prefix cache statistics."""
-        return {
-            "hits": self._hits,
-            "misses": self._misses,
-            "hit_rate": self.hit_rate,
-            "cached_entries": len(self._cache),
-            "current_bytes": self._current_bytes,
-            "max_bytes": self._max_bytes,
-        }
-
-
-# Type alias for any per-layer cache type supported by the model.
-#
-# Notes:
-# - Some models (e.g. gpt_oss) use `RotatingKVCache` for sliding-window attention.
-# - Hybrid models use `ArraysCache` for non-attention state.
-AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
 SchedulerMemoryReportingMode: TypeAlias = Literal[
     "stt_nominal",
     "paged_attention_capacity",
     "single_sequence_estimate",
 ]
-
-
-def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
-    """Merge per-request ArraysCache objects into a single batched ArraysCache.
-
-    This mirrors the behavior of `mlx_lm.models.cache.ArraysCache.merge` but is
-    implemented here for compatibility with older mlx-lm versions that do not
-    provide `merge()` / `extract()`.
-    """
-    if not caches:
-        raise ValueError("caches must be non-empty")
-
-    num_entries = len(caches[0].state)
-    batch_size = len(caches)
-
-    merged = ArraysCache(num_entries)
-    for entry_idx in range(num_entries):
-        values = [cache.state[entry_idx] for cache in caches]
-        template = next((value for value in values if value is not None), None)
-        if template is None:
-            continue
-
-        shape = list(template.shape)
-        shape[0] = batch_size
-        merged_state = mx.zeros(tuple(shape), template.dtype)
-        for batch_idx, value in enumerate(values):
-            if value is None:
-                continue
-            merged_state[batch_idx : batch_idx + 1] = value
-
-        merged[entry_idx] = merged_state
-
-    return merged
-
-
-def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
-    """Extract a single request's ArraysCache from a batched ArraysCache."""
-    state = batch_cache.state
-    extracted = ArraysCache(len(state))
-    extracted.state = [
-        None if value is None else value[idx : idx + 1] for value in state
-    ]
-    return extracted
-
-
-def _merge_rotating_kv_caches(
-    caches: list[RotatingKVCache],
-) -> BatchRotatingKVCache:
-    """Merge per-request RotatingKVCache objects into a single BatchRotatingKVCache.
-
-    This mirrors ``BatchRotatingKVCache.merge`` but pre-computes the temporal-ordered
-    keys/values, trims them to ``len(cache)`` (the effective sliding-window length),
-    and uses that length for the copy width.  The upstream implementation in
-    mlx-lm <= 0.29.1 uses ``c.offset`` which can exceed the underlying array size
-    after the cache has rotated, causing a broadcast shape error.
-
-    This workaround can be removed once vllm-metal can depend on an mlx-lm version
-    that includes the upstream fix (ml-explore/mlx-lm#738) and has been verified
-    to work with gpt-oss models end-to-end.
-    """
-    if not caches:
-        raise ValueError("caches must be non-empty")
-
-    if any(c.keys is None or c.values is None for c in caches):
-        raise ValueError(
-            "Cannot merge unpopulated RotatingKVCache (keys/values is None)"
-        )
-
-    if not all(c.max_size == caches[0].max_size for c in caches):
-        raise ValueError(
-            "BatchRotatingKVCache can only merge caches with the same maximum size"
-        )
-
-    # Pre-compute temporal-ordered keys/values and trim to the effective
-    # sliding-window length.  ``_temporal_order`` may return an array larger
-    # than ``len(cache)`` when the internal buffer has not been trimmed yet
-    # (e.g. after a large prefill), so we trim via ``_trim`` to preserve
-    # the ``keep`` prefix semantics used by RotatingKVCache internally.
-    ordered: list[tuple[mx.array, mx.array]] = []
-    for c in caches:
-        effective_len = c.size() if hasattr(c, "size") else len(c)
-        ordered_keys = c._temporal_order(c.keys)
-        ordered_values = c._temporal_order(c.values)
-        if ordered_keys.shape[2] > effective_len:
-            trim_size = ordered_keys.shape[2] - effective_len
-            ordered_keys = c._trim(trim_size, ordered_keys)
-            ordered_values = c._trim(trim_size, ordered_values)
-        else:
-            ordered_keys = ordered_keys[..., :effective_len, :]
-            ordered_values = ordered_values[..., :effective_len, :]
-        ordered.append((ordered_keys, ordered_values))
-
-    lengths = [k.shape[2] for k, _ in ordered]
-    max_length = max(lengths)
-    padding = [max_length - length for length in lengths]
-    batch_size = len(caches)
-    n_heads = max(k.shape[1] for k, _ in ordered)
-    k_dim = max(k.shape[3] for k, _ in ordered)
-    v_dim = max(v.shape[3] for _, v in ordered)
-    dtype = next(iter(k.dtype for k, _ in ordered))
-
-    keys = mx.zeros((batch_size, n_heads, max_length, k_dim), dtype=dtype)
-    values = mx.zeros((batch_size, n_heads, max_length, v_dim), dtype=dtype)
-    for i, (pad, (k, v)) in enumerate(zip(padding, ordered, strict=True)):
-        n = k.shape[2]
-        keys[i : i + 1, :, pad : pad + n] = k
-        values[i : i + 1, :, pad : pad + n] = v
-
-    cache = BatchRotatingKVCache(caches[0].max_size, padding)
-    cache.keys = keys
-    cache.values = values
-    cache.offset = mx.array([c.offset for c in caches])
-    cache._idx = keys.shape[2]
-    cache._offset = keys.shape[2]
-
-    return cache
 
 
 def _create_request_generator(
@@ -449,14 +121,6 @@ def _create_request_generator(
     generator = torch.Generator(device=device)
     generator.manual_seed(sampling_params.seed)
     return generator
-
-
-@dataclass
-class SamplerOutput:
-    """Output from the sampler."""
-
-    token_ids: list[int]
-    logprobs: list[float] | None = None
 
 
 @dataclass
@@ -537,104 +201,6 @@ class _PagedForwardState(NamedTuple):
     num_decode: int
 
 
-def _merge_kv_caches(
-    caches_list: list[list[AnyCache]],
-) -> list[BatchKVCache | BatchRotatingKVCache | ArraysCache]:
-    """Merge multiple per-request caches into batched caches.
-
-    Args:
-        caches_list: List of per-request caches, each is a list of per-layer caches
-
-    Returns:
-        List of batched caches, one per layer
-    """
-    if not caches_list:
-        return []
-
-    num_layers = len(caches_list[0])
-    merged: list[BatchKVCache | BatchRotatingKVCache | ArraysCache] = []
-
-    for layer_idx in range(num_layers):
-        layer_caches = [caches[layer_idx] for caches in caches_list]
-        if isinstance(layer_caches[0], ArraysCache):
-            arrays_caches: list[ArraysCache] = []
-            for cache in layer_caches:
-                if not isinstance(cache, ArraysCache):
-                    raise TypeError(
-                        "Mixed cache types in a single layer: expected ArraysCache"
-                    )
-                arrays_caches.append(cache)
-            batch_cache = _merge_arrays_caches(arrays_caches)
-        elif isinstance(layer_caches[0], RotatingKVCache):
-            rotating_caches: list[RotatingKVCache] = []
-            for cache in layer_caches:
-                if not isinstance(cache, RotatingKVCache):
-                    raise TypeError(
-                        "Mixed cache types in a single layer: expected RotatingKVCache"
-                    )
-                rotating_caches.append(cache)
-            batch_cache = _merge_rotating_kv_caches(rotating_caches)
-        elif isinstance(layer_caches[0], KVCache):
-            kv_caches: list[KVCache] = []
-            for cache in layer_caches:
-                if not isinstance(cache, KVCache):
-                    raise TypeError(
-                        "Mixed cache types in a single layer: expected KVCache"
-                    )
-                kv_caches.append(cache)
-            batch_cache = BatchKVCache.merge(kv_caches)
-        else:
-            cache_type = type(layer_caches[0]).__name__
-            raise TypeError(f"Unsupported cache type for batching: {cache_type}")
-        merged.append(batch_cache)
-
-    return merged
-
-
-def _extract_kv_cache(
-    batch_caches: list[BatchKVCache | BatchRotatingKVCache | ArraysCache], idx: int
-) -> list[AnyCache]:
-    """Extract a single request's cache from batched caches.
-
-    Args:
-        batch_caches: List of batched caches, one per layer
-        idx: Index of the request in the batch
-
-    Returns:
-        List of caches for the request, one per layer
-    """
-    extracted: list[AnyCache] = []
-    for cache in batch_caches:
-        if isinstance(cache, ArraysCache):
-            extracted.append(_extract_arrays_cache(cache, idx))
-        else:
-            c = cache.extract(idx)
-            # After extract, RotatingKVCache may have offset > max_size but
-            # keys.shape[2] < max_size (buffer was sliced).  Pad the buffer
-            # back to max_size so _update_in_place won't try to grow it
-            # (which would compute a negative new_size).  The padded region
-            # is dead space that will be overwritten on the next rotation.
-            if (
-                isinstance(c, RotatingKVCache)
-                and c.keys is not None
-                and c.offset > c.max_size
-                and c.keys.shape[2] < c.max_size
-            ):
-                pad = c.max_size - c.keys.shape[2]
-                z_k = mx.zeros(
-                    (1, c.keys.shape[1], pad, c.keys.shape[3]),
-                    dtype=c.keys.dtype,
-                )
-                z_v = mx.zeros(
-                    (1, c.values.shape[1], pad, c.values.shape[3]),
-                    dtype=c.values.dtype,
-                )
-                c.keys = mx.concatenate([c.keys, z_k], axis=2)
-                c.values = mx.concatenate([c.values, z_v], axis=2)
-            extracted.append(c)
-    return extracted
-
-
 class MetalModelRunner:
     """Model runner for MLX-based inference on Metal.
 
@@ -677,9 +243,6 @@ class MetalModelRunner:
         # models so recurrent state survives request reordering/preemption.
         self._gdn_req_to_slot: dict[str, int] = {}
         self._gdn_free_slots: list[int] = []
-
-        # Pre-allocated buffer for decode input tokens
-        self._max_batch_size = _MAX_BATCH_SIZE
 
         # vLLM Sampler for token sampling with temperature, top_k, top_p support
         self._sampler = Sampler()

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -25,10 +25,6 @@ import mlx.core as mx
 import torch
 from mlx_lm import load as mlx_lm_load
 from mlx_lm import stream_generate
-from mlx_lm.models.cache import (
-    KVCache,
-    make_prompt_cache,
-)
 
 # mlx_vlm for vision-language models
 from mlx_vlm import load as mlx_vlm_load
@@ -64,21 +60,15 @@ from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.utils import get_model_download_path
-from vllm_metal.v1.contiguous_cache import (  # noqa: F401 — re-exported for tests
+from vllm_metal.v1 import contiguous_cache
+from vllm_metal.v1.contiguous_cache import (
     _MIN_BATCH_SIZE_FOR_BATCHING,
-    _PREFIX_CACHE_DEFAULT_FRACTION,
     _PREFIX_CACHE_ENABLED,
     AnyCache,
-    ArraysCache,
-    BatchKVCache,
-    BatchRotatingKVCache,
-    CachedPrefix,
+    KVCache,
     PrefixCacheManager,
-    RotatingKVCache,
     _extract_kv_cache,
-    _get_prefix_cache_max_bytes,
     _merge_kv_caches,
-    _prefix_cache_enabled,
 )
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
@@ -841,7 +831,7 @@ class MetalModelRunner:
         )
 
         # Create cache to check if model supports prefix caching
-        cache = make_prompt_cache(cache_model)
+        cache = contiguous_cache.make_prompt_cache(cache_model)
         # Prefix caching only safe for pure KVCache models (not Mamba/hybrid)
         supports_prefix_cache = all(isinstance(c, KVCache) for c in cache)
 


### PR DESCRIPTION
#122 

| Change | Details |
|--------|---------|
| **New file** | `v1/legacy_cache.py` (473 lines) — all legacy mlx_lm cache code |
| **Slimmed** | `v1/model_runner.py`: 2150 → 1707 lines (−463 lines, ~21% smaller) |
| **Dead code removed** | `SamplerOutput` class, `_MAX_BATCH_SIZE` / `self._max_batch_size` |
| **Backward compat** | All moved symbols re-exported from `model_runner.py` so `mr.PrefixCacheManager` etc. still work |

I didn't touch `_prefill_single, _batched_decode, _sequential_decode, _run_non_paged_decode_batch`, because they have deeper coupling. 

