### PR TITLE
Fix hybrid model prefill hang and GDN slot overflow

### DIFF
--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -143,6 +143,201 @@ class TestGDNFreeSlotZeroing:
             assert sc.recurrent_states[layer_idx].dtype == mx.float32
 
 
+class TestGDNAllocSlotZeroing:
+    """Verify that _gdn_alloc_slot zeros state for reused slots."""
+
+    def _make_runner_stub(self, max_seqs: int = 2):
+        """Build a minimal stub with GDN slot management wired up."""
+        from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
+
+        sc = GDNPagedStateCache(
+            num_layers=2,
+            max_seqs=max_seqs,
+            conv_kernel_dim=4,
+            conv_dim=64,
+            num_v_heads=4,
+            value_head_dim=16,
+            key_head_dim=16,
+            dtype=mx.float16,
+        )
+        backend = MagicMock()
+        backend._state_cache = sc
+
+        runner = MagicMock()
+        runner._gdn_req_to_slot = {}
+        runner._gdn_free_slots = []
+        runner._paged_attention_backend = backend
+        return runner, sc
+
+    def test_reused_slot_is_zeroed(self):
+        """A slot returned to the free list and re-allocated must have
+        zeroed conv and recurrent state."""
+        from vllm_metal.v1.model_runner import MetalModelRunner
+
+        runner, sc = self._make_runner_stub()
+
+        # Allocate slot 0 for req-A
+        slot = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        assert slot == 0
+
+        # Write non-zero data to slot 0
+        for layer_idx in range(sc.num_layers):
+            sc.conv_states[layer_idx] = mx.ones_like(sc.conv_states[layer_idx])
+            sc.recurrent_states[layer_idx] = mx.ones_like(
+                sc.recurrent_states[layer_idx]
+            )
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Free slot 0 (bare pop+append, no zeroing — matches early release path)
+        runner._gdn_req_to_slot.pop("req-A")
+        runner._gdn_free_slots.append(slot)
+
+        # Re-allocate — should trigger alloc-time zeroing
+        slot2 = MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        assert slot2 == 0  # reused
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Slot 0 must be zeroed
+        for layer_idx in range(sc.num_layers):
+            assert mx.array_equal(
+                sc.conv_states[layer_idx][0],
+                mx.zeros_like(sc.conv_states[layer_idx][0]),
+            )
+            assert mx.array_equal(
+                sc.recurrent_states[layer_idx][0],
+                mx.zeros_like(sc.recurrent_states[layer_idx][0]),
+            )
+
+    def test_reused_slot_preserves_other_slots(self):
+        """Alloc-time zeroing of slot 0 must not affect slot 1."""
+        from vllm_metal.v1.model_runner import MetalModelRunner
+
+        runner, sc = self._make_runner_stub()
+
+        # Allocate slots 0 and 1
+        MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+
+        # Write ones everywhere
+        for layer_idx in range(sc.num_layers):
+            sc.conv_states[layer_idx] = mx.ones_like(sc.conv_states[layer_idx])
+            sc.recurrent_states[layer_idx] = mx.ones_like(
+                sc.recurrent_states[layer_idx]
+            )
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Free slot 0, re-allocate
+        runner._gdn_req_to_slot.pop("req-A")
+        runner._gdn_free_slots.append(0)
+        MetalModelRunner._gdn_alloc_slot(runner, "req-C")
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Slot 1 must still be ones
+        assert mx.allclose(sc.conv_states[0][1], mx.ones((3, 64), dtype=mx.float16))
+        assert mx.allclose(
+            sc.recurrent_states[0][1], mx.ones((4, 16, 16), dtype=mx.float32)
+        )
+
+    def test_new_slot_not_zeroed(self):
+        """A brand-new slot (not from free list) should not trigger zeroing."""
+        from vllm_metal.v1.model_runner import MetalModelRunner
+
+        runner, sc = self._make_runner_stub()
+        slot = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        assert slot == 0
+        # No crash, no zeroing needed — state was already initialized to zero
+
+    def test_double_free_is_safe(self):
+        """Calling _gdn_free_slot twice for the same req_id must not crash."""
+        from vllm_metal.v1.model_runner import MetalModelRunner
+
+        runner, sc = self._make_runner_stub()
+        MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+
+        MetalModelRunner._gdn_free_slot(runner, "req-A")
+        MetalModelRunner._gdn_free_slot(runner, "req-A")  # no-op, no crash
+
+    def test_slot_reuse_after_early_release(self):
+        """Slot freed via bare pop+append (early release) should be
+        available for immediate reallocation with zeroed state."""
+        from vllm_metal.v1.model_runner import MetalModelRunner
+
+        runner, sc = self._make_runner_stub(max_seqs=1)
+
+        slot0 = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        assert slot0 == 0
+
+        # Write non-zero data to slot 0
+        for layer_idx in range(sc.num_layers):
+            sc.conv_states[layer_idx] = mx.ones_like(sc.conv_states[layer_idx])
+            sc.recurrent_states[layer_idx] = mx.ones_like(
+                sc.recurrent_states[layer_idx]
+            )
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Early release (bare pop+append, as in execute_model)
+        runner._gdn_req_to_slot.pop("req-A")
+        runner._gdn_free_slots.append(slot0)
+
+        # Same-step allocation should reuse slot 0
+        slot1 = MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        assert slot1 == 0
+
+        # Alloc-time zeroing must have cleared the state
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+        for layer_idx in range(sc.num_layers):
+            assert mx.array_equal(
+                sc.conv_states[layer_idx][0],
+                mx.zeros_like(sc.conv_states[layer_idx][0]),
+            ), f"conv_states[{layer_idx}][0] not zeroed after early-release reuse"
+            assert mx.array_equal(
+                sc.recurrent_states[layer_idx][0],
+                mx.zeros_like(sc.recurrent_states[layer_idx][0]),
+            ), f"recurrent_states[{layer_idx}][0] not zeroed after early-release reuse"
+
+    def test_early_release_then_alloc_full_cycle(self):
+        """Simulate the full execute_model early-release → alloc cycle
+        with 2 slots: finish req-A, start req-C while req-B still active."""
+        from vllm_metal.v1.model_runner import MetalModelRunner
+
+        runner, sc = self._make_runner_stub(max_seqs=2)
+
+        # Allocate 2 requests
+        slot_a = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        slot_b = MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        assert slot_a == 0
+        assert slot_b == 1
+
+        # Write distinct data to each slot
+        for layer_idx in range(sc.num_layers):
+            sc.conv_states[layer_idx] = mx.ones_like(sc.conv_states[layer_idx]) * 5.0
+            sc.recurrent_states[layer_idx] = (
+                mx.ones_like(sc.recurrent_states[layer_idx]) * 3.0
+            )
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Early-release req-A (bare pop+append, no zeroing)
+        runner._gdn_req_to_slot.pop("req-A")
+        runner._gdn_free_slots.append(slot_a)
+
+        # Allocate req-C — should reuse slot 0 with zeroed state
+        slot_c = MetalModelRunner._gdn_alloc_slot(runner, "req-C")
+        assert slot_c == 0  # reused slot
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+        # Slot 0 (req-C) must be zeroed
+        assert mx.array_equal(sc.conv_states[0][0], mx.zeros_like(sc.conv_states[0][0]))
+        assert mx.array_equal(
+            sc.recurrent_states[0][0], mx.zeros_like(sc.recurrent_states[0][0])
+        )
+
+        # Slot 1 (req-B) must still have its data (5.0 / 3.0)
+        assert sc.conv_states[0][1].sum().item() != 0, "req-B conv state was corrupted"
+        assert sc.recurrent_states[0][1].sum().item() != 0, (
+            "req-B recurrent state was corrupted"
+        )
+
+
 class TestSyncMLXInTensorBridge:
     """Verify sync_mlx is called before MPS tensor transfer."""
 

--- a/tools/test_qwen3_next_golden.py
+++ b/tools/test_qwen3_next_golden.py
@@ -17,7 +17,7 @@ import os
 
 os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 os.environ.setdefault("VLLM_METAL_USE_PAGED_ATTENTION", "1")
-os.environ.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.9")
+os.environ.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.55")
 
 from vllm import LLM, SamplingParams
 
@@ -26,7 +26,7 @@ MAX_TOKENS = 10
 
 PROMPTS = [
     "The capital of France is",
-    "The weather today is not",
+    "The speed of light is approximately",
     "One plus one equals",
     "The largest planet in our solar system is",
     "Water boils at a temperature of",
@@ -34,16 +34,30 @@ PROMPTS = [
 ]
 
 # fmt: off
-# Golden token IDs from mlx_lm greedy decoding (argmax sampler).
+# Golden token IDs from mlx_lm greedy decoding (generate_step + argmax).
 # Model: mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit
 # Environment: mlx 0.31.1, mlx-lm 0.31.1
+# Regenerated 2026-04-10 via mlx_lm generate_step + argmax sampler.
+#
+# History:
+# - Original golden values (PR #240) had incorrect leading-space
+#   tokenization (e.g. token 59604 'Paris' instead of 12095 ' Paris').
+#   These never matched actual mlx_lm generate_step output.
+# - "The weather today is not" was replaced with "The speed of light is
+#   approximately" because the Qwen3-Next-80B model produces a perfect
+#   logit tie at token position 7: tokens 15920 (' Which', logit -1.875)
+#   and 42344 (' （', logit -1.875) are bitwise-equal IEEE 754 floats
+#   (hex bff00000). The argmax tie-break is implementation-dependent,
+#   making this prompt unsuitable for deterministic exact-token regression
+#   testing. All replacement candidates were verified tie-free across
+#   the full 9-token generation window.
 GOLDEN_MLX = {
-    "The capital of France is": [59604, 13, 576, 6722, 315, 9856, 374, 19846, 13, 576],
-    "The weather today is not": [1661, 438, 432, 572, 13671, 13, 42344, 40916, 64559],
-    "One plus one equals": [267, 1126, 13, 9043, 5519, 1378, 16819, 3040, 13, 13322],
-    "The largest planet in our solar system is": [41, 19519, 11, 448, 264, 23033, 315, 220, 23, 23],
-    "Water boils at a temperature of": [16, 15, 15, 30937, 13, 1913, 279, 68723, 5452],
-    "Machine learning is": [25993, 315, 20443, 11229, 429, 23497, 389, 11220, 25185],
+    "The capital of France is": [12095, 13, 576, 6722, 315, 9856, 374, 19846, 13],
+    "The speed of light is approximately": [400, 18, 1124, 15136, 220, 16, 15, 61, 20],
+    "One plus one equals": [1378, 13, 9043, 5519, 1378, 16819, 3040, 13, 13322],
+    "The largest planet in our solar system is": [49689, 11, 448, 264, 23033, 315, 220, 23, 23],
+    "Water boils at a temperature of": [220, 16, 15, 15, 30937, 13, 1913, 279, 68723],
+    "Machine learning is": [264, 25993, 315, 20443, 11229, 429, 23497, 389, 11220],
 }
 # fmt: on
 

--- a/vllm_metal/paged_attention_backend/hybrid.py
+++ b/vllm_metal/paged_attention_backend/hybrid.py
@@ -42,12 +42,16 @@ def _build_linear_layer_spec(
     key_head_dim: int,
     torch_dtype: torch.dtype,
     page_size_padded: int | None = None,
+    block_size: int = 1,
 ) -> MambaSpec:
     """Build a MambaSpec for one GDN linear attention layer.
 
     Args:
         page_size_padded: Optional padded page size from cache_config to
             align Mamba page size with attention page size in hybrid models.
+        block_size: Tokens per block.  Must match the SDPA block_size so
+            the scheduler's unified block pool can serve both layer types
+            without running out of blocks prematurely.
     """
     return MambaSpec(
         shapes=(
@@ -55,7 +59,7 @@ def _build_linear_layer_spec(
             (num_v_heads, value_head_dim, key_head_dim),
         ),
         dtypes=(torch_dtype, torch_dtype),
-        block_size=1,
+        block_size=block_size,
         page_size_padded=page_size_padded,
     )
 

--- a/vllm_metal/paged_attention_backend/hybrid.py
+++ b/vllm_metal/paged_attention_backend/hybrid.py
@@ -42,7 +42,7 @@ def _build_linear_layer_spec(
     key_head_dim: int,
     torch_dtype: torch.dtype,
     page_size_padded: int | None = None,
-    block_size: int = 1,
+    block_size: int,
 ) -> MambaSpec:
     """Build a MambaSpec for one GDN linear attention layer.
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1032,34 +1032,47 @@ class MetalModelRunner:
         """Allocate a stable GDN state pool slot for a request."""
         if req_id in self._gdn_req_to_slot:
             return self._gdn_req_to_slot[req_id]
+        reused = False
         if self._gdn_free_slots:
             slot = self._gdn_free_slots.pop()
+            reused = True
         else:
             slot = len(self._gdn_req_to_slot)
         self._gdn_req_to_slot[req_id] = slot
+        # Zero state for reused slots so the new request starts clean.
+        # Done at alloc time (inside the forward-pass graph) rather than
+        # at free time to avoid mx.eval synchronisation issues.
+        if reused:
+            backend = self._paged_attention_backend
+            if backend is not None and hasattr(backend, "_state_cache"):
+                sc = backend._state_cache
+                if sc is not None:
+                    for layer_idx in range(sc.num_layers):
+                        conv = sc.conv_states[layer_idx]
+                        conv[slot] = mx.zeros_like(conv[slot])
+                        sc.conv_states[layer_idx] = conv
+                        rec = sc.recurrent_states[layer_idx]
+                        rec[slot] = mx.zeros_like(rec[slot])
+                        sc.recurrent_states[layer_idx] = rec
         return slot
 
     def _gdn_free_slot(self, req_id: str) -> None:
-        """Release a GDN state pool slot and zero its state."""
+        """Release a GDN state pool slot.
+
+        Materializes conv/recurrent state arrays to detach them from the
+        previous request's lazy computation graph.  Actual zeroing is
+        deferred to ``_gdn_alloc_slot`` (alloc-time zeroing) so that
+        each slot is zeroed exactly once, right before reuse.
+        """
         slot = self._gdn_req_to_slot.pop(req_id, None)
         if slot is None:
             return
-        # Zero conv and recurrent state so the next request doesn't
-        # inherit the previous request's linear-attention history.
+        # Materialize state arrays so the lazy graph does not grow
+        # unboundedly across requests.
         backend = self._paged_attention_backend
         if backend is not None and hasattr(backend, "_state_cache"):
             sc = backend._state_cache
             if sc is not None:
-                # Materialize existing arrays to detach from previous
-                # request's computation graph, then zero only the freed slot.
-                mx.eval(*sc.conv_states, *sc.recurrent_states)
-                for layer_idx in range(sc.num_layers):
-                    conv = sc.conv_states[layer_idx]
-                    conv[slot] = 0
-                    sc.conv_states[layer_idx] = conv
-                    rec = sc.recurrent_states[layer_idx]
-                    rec[slot] = 0
-                    sc.recurrent_states[layer_idx] = rec
                 mx.eval(*sc.conv_states, *sc.recurrent_states)
         self._gdn_free_slots.append(slot)
 
@@ -1124,6 +1137,7 @@ class MetalModelRunner:
                     key_head_dim=self.linear_key_head_dim,
                     torch_dtype=torch_dtype,
                     page_size_padded=self.cache_config.mamba_page_size_padded,
+                    block_size=block_size,
                 )
             else:
                 layer_name = f"layers.{layer_idx}.self_attn"
@@ -1980,6 +1994,18 @@ class MetalModelRunner:
         self._collect_cached_requests(batch, cached_reqs, scheduler_output)
 
         if self._paged_attention_backend is not None and batch.has_paged_work():
+            # Free GDN slots for finished requests BEFORE allocating new
+            # ones, so slots can be reused within the same scheduling step.
+            # Conv/recurrent states are materialized per-layer in
+            # attention_linear.py, so the mx.eval in _gdn_free_slot is
+            # cheap (states already evaluated).  The _gdn_free_slot call
+            # in the later _cleanup_finished_requests is a no-op.
+            if self.is_hybrid and scheduler_output.finished_req_ids:
+                for req_id in scheduler_output.finished_req_ids:
+                    slot = self._gdn_req_to_slot.pop(req_id, None)
+                    if slot is not None:
+                        self._gdn_free_slots.append(slot)
+
             prefill_pack = self._build_prefill_pack(batch)
             self._start_paged_forward(
                 batch,


### PR DESCRIPTION
## Summary

Fix two critical bugs in the hybrid model (SDPA + GDN linear attention) paged attention path that prevented reliable serving on Apple Silicon:

1. **Long prefill hang**: Prompts over ~1145 tokens silently failed to schedule
2. **GDN slot overflow**: Concurrent request turnover caused slot exhaustion and crash

Also regenerates incorrect Qwen3-Next golden token values and adds unit tests.

## Problem

### 1. Prefill hang (block_size mismatch)

`_build_linear_layer_spec` hardcoded `MambaSpec(block_size=1)`, causing the scheduler to require one block per token for GDN layers. With the unified block pool divided into groups (~4580 blocks / 4 groups = ~1145 per group), any prompt exceeding ~1145 tokens could not be scheduled. The scheduler silently refused the request with no error.

### 2. Slot overflow (async scheduling race)

In the async paged path, `execute_model` allocates new request slots before `sample_tokens` frees finished request slots. With `max_num_seqs=1`, a finished request's slot was unavailable for the next request in the same scheduling step, causing an out-of-bounds slot access and crash.

## Changes

### `vllm_metal/paged_attention_backend/hybrid.py`
- Pass SDPA `block_size` through to `_build_linear_layer_spec` instead of hardcoding 1

### `vllm_metal/v1/model_runner.py`
- **Early slot release**: Pop finished request slot mappings in `execute_model` before `_start_paged_forward`, so slots can be reused within the same scheduling step
- **Alloc-time zeroing**: Zero conv/recurrent state in `_gdn_alloc_slot` using `mx.zeros_like` when reusing a slot from the free list, avoiding `mx.eval` synchronization issues that caused GPU hangs on large models
- **Simplify `_gdn_free_slot`**: Remove redundant zeroing, retain `mx.eval` to materialize state arrays and prevent lazy graph accumulation

### `tools/test_qwen3_next_golden.py`
- Regenerate golden token IDs via `mlx_lm generate_step` + argmax sampler — previous values had incorrect leading-space tokenization (e.g. token 59604 `'Paris'` instead of 12095 `' Paris'`)
- Replace `"The weather today is not"` with `"The speed of light is approximately"` — the original prompt produces a bitwise-equal logit tie (IEEE 754 `bff00000`, -1.875) at position 7, making argmax non-deterministic
- Set `VLLM_METAL_MEMORY_FRACTION=0.55` default for 80B model test

### `tests/test_qwen3_next_gdn.py`
- Add 5 unit tests: alloc-time zeroing, slot isolation, fresh allocation, double-free safety, early release reuse

## Test

**Environment**: M2 Ultra 192GB, mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit

| Test | Result |
|------|--------|
| `pytest -m "not slow" tests/` | 416 passed |
| Qwen3-0.6B golden (6/6) | passed |
| Qwen3-Next 80B golden (6/6) | passed |
| Qwen3-Next 80B serve 1K×15 batch | 93.3 TPS |
| Qwen3-Next 80B serve 4K×15 batch | 31.2 TPS |
| `ruff check` + `ruff format` | clean |

## Test plan

- [x] `pytest -m "not slow" tests/` — 416 passed
- [x] Qwen3-0.6B paged deterministic golden — 6/6 exact match
- [x] Qwen3-Next 80B golden token test — 6/6 exact match
- [x] Lint + format clean