### PR TITLE
Add TurboQuant KV cache compression for MHA

### DIFF
--- a/docs/turboquant.md
+++ b/docs/turboquant.md
@@ -1,0 +1,104 @@
+# TurboQuant KV Cache Compression
+
+vllm-metal supports TurboQuant-based KV cache compression: a Walsh–Hadamard rotation followed by per-block quantization that shrinks the KV cache by 2.5x–5x with minimal quality loss. Quantize/dequantize runs natively on Apple Silicon via MLX + a Metal kernel.
+
+## Quick Start
+
+```bash
+VLLM_METAL_USE_PAGED_ATTENTION=1 vllm serve meta-llama/Llama-3.2-1B-Instruct \
+  --dtype bfloat16 \
+  --max-model-len 32768 \
+  --additional-config '{"turboquant": true, "k_quant": "q8_0", "v_quant": "q3_0"}'
+```
+
+TurboQuant is controlled via vLLM's `--additional-config` JSON, not a separate environment variable. Paged attention (`VLLM_METAL_USE_PAGED_ATTENTION=1`) is required.
+
+## Configuration
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `turboquant` | `false` | Enable TurboQuant KV cache compression |
+| `k_quant` | `"q8_0"` | Key quantization type (see table below) |
+| `v_quant` | `"q3_0"` | Value quantization type (Lloyd-Max) |
+
+### Supported Key Quant Types
+
+K uses per-block affine quantization with a Walsh–Hadamard rotation.
+
+| `k_quant` | Bits | Notes |
+|-----------|------|-------|
+| `q8_0`, `int8`, `uint8` | 8 | Near-lossless |
+| `q5_0` | 5 | Good quality / size trade-off |
+| `q4_0`, `int4`, `uint4` | 4 | Matches TurboQuant paper config |
+| `int2`, `uint2` | 2 | Aggressive; noticeable quality loss |
+
+### Supported Value Quant Types
+
+V uses Lloyd-Max (non-uniform) quantization with a Walsh–Hadamard rotation. Values are mapped to precomputed centroids per bitwidth.
+
+| `v_quant` | Bits |
+|-----------|------|
+| `q2_0` | 2 |
+| `q3_0` | 3 |
+| `q4_0` | 4 |
+| `q5_0` | 5 |
+| `q8_0` | 8 |
+
+## Compression
+
+Measured on a Qwen3-0.6B-shaped KV cache (28 layers, 4 KV heads, head_dim=128, block_size=16) vs fp16:
+
+| Config | Compression | K mse | V mse |
+|--------|-------------|-------|-------|
+| `k_quant=q8_0`, `v_quant=q3_0` (default) | **2.56x** | 0.00002 | 0.03241 |
+| `k_quant=q5_0`, `v_quant=q3_0` | 3.37x | 0.00154 | 0.03241 |
+| `k_quant=q4_0`, `v_quant=q3_0` | 3.76x | 0.00658 | 0.03241 |
+| `k_quant=uint2`, `v_quant=q3_0` | 4.92x | 0.16639 | 0.03241 |
+
+At `max_model_len=32768` on Llama-3.2-1B, the default `q8_0/q3_0` configuration frees roughly 2.5x more context for the same KV memory budget.
+
+## Requirements and Caveats
+
+- **Paged attention is required** (`VLLM_METAL_USE_PAGED_ATTENTION=1`). TurboQuant cannot run on the MLX KV cache path.
+- **MHA and hybrid (SDPA + GDN linear attention) models are supported.** In hybrid models, only the SDPA layers are compressed; GDN recurrent state stays at fp16 (it has no paged KV cache to quantize).
+- **MLA models are not supported.** Enabling `turboquant` on an MLA model raises `NotImplementedError` at startup rather than silently falling back.
+- **Head dim must be 64, 128, or 256** — sizes supported by the FWHT Metal kernel. Models outside this set are not supported yet.
+- Quality is model-dependent. For production use, spot-check perplexity with your target config before rolling out aggressive settings (`int2`, `q2_0`).
+
+## Known Quality Floors
+
+Not every supported `(k_quant, v_quant)` combination is production-grade. K precision is load-bearing in a way V precision is not — K participates in the softmax, so quantization error gets **exponentially** amplified by `exp(QK^T)`, while V errors get **linearly** averaged across the context and largely wash out. This asymmetry means aggressive K quantization fails long before aggressive V quantization does.
+
+Observed behavior:
+
+| Config | Compression | Qualitative quality | Recommended use |
+|--------|-------------|---------------------|-----------------|
+| `q8_0` / `q3_0` | 2.56x | Matches bf16 within noise | **Default** |
+| `q8_0` / `q2_0` | ~2.9x | Usable; minor fluency dip | Tight-memory serving |
+| `q4_0` / `q3_0` | 3.76x | Paper-validated config; mild quality regression | Memory-bound workloads |
+| `int2` / `q3_0` | ~4.1x | **Degraded**: semi-coherent, topic-drift, numeric artefacts ("2018 2018") | Capacity benchmarks only |
+| `int2` / `q2_0` | ~4.8x | **Broken**: degenerate repetition loops ("concept concept concept…") | Not for serving |
+
+## Examples
+
+### Normal Compression
+
+For production use with minimal quality impact:
+
+```bash
+VLLM_METAL_USE_PAGED_ATTENTION=1 vllm serve meta-llama/Llama-3.2-1B-Instruct \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --additional-config '{"turboquant": true, "k_quant": "q8_0", "v_quant": "q3_0"}'
+```
+
+### Aggressive Compression
+
+For memory-bound workloads where some quality loss is acceptable:
+
+```bash
+VLLM_METAL_USE_PAGED_ATTENTION=1 vllm serve meta-llama/Llama-3.2-1B-Instruct \
+  --dtype bfloat16 \
+  --max-model-len 65536 \
+  --additional-config '{"turboquant": true, "k_quant": "q4_0", "v_quant": "q3_0"}'
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -67,4 +67,5 @@ nav:
     - Configuration: configuration.md
   - Features:
     - Speech-to-Text: stt.md
+    - Turboquant: turboquant.md
   - Contributing: CONTRIBUTING.md

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,3 +140,53 @@ class TestMetalConfig:
                     debug=False,
                     use_paged_attention=True,
                 )
+
+    def test_turboquant_defaults(self) -> None:
+        """Test default TurboQuant config values."""
+        config = MetalConfig.from_env()
+        assert config.turboquant is False
+        assert config.k_quant == "q8_0"
+        assert config.v_quant == "q3_0"
+
+    def test_turboquant_requires_paged_attention(self) -> None:
+        """Test that turboquant=True without paged attention is rejected."""
+        with pytest.raises(ValueError, match="turboquant requires paged attention"):
+            MetalConfig(
+                memory_fraction=AUTO_MEMORY_FRACTION,
+                use_mlx=False,
+                mlx_device="gpu",
+                block_size=16,
+                debug=False,
+                use_paged_attention=False,
+                turboquant=True,
+                k_quant="uint8",
+            )
+
+    def test_turboquant_invalid_k_quant_rejected(self) -> None:
+        """Test that invalid k_quant values are rejected."""
+        with pytest.raises(ValueError, match="Invalid k_quant"):
+            MetalConfig(
+                memory_fraction=AUTO_MEMORY_FRACTION,
+                use_mlx=False,
+                mlx_device="gpu",
+                block_size=16,
+                debug=False,
+                use_paged_attention=True,
+                turboquant=True,
+                k_quant="fp16",
+            )
+
+    def test_turboquant_invalid_v_quant_rejected(self) -> None:
+        """Test that invalid v_quant values are rejected."""
+        with pytest.raises(ValueError, match="Invalid v_quant"):
+            MetalConfig(
+                memory_fraction=AUTO_MEMORY_FRACTION,
+                use_mlx=False,
+                mlx_device="gpu",
+                block_size=16,
+                debug=False,
+                use_paged_attention=True,
+                turboquant=True,
+                k_quant="q8_0",
+                v_quant="fp16",
+            )

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -1,0 +1,2006 @@
+"""
+TurboQuant KV Cache — Comprehensive Test Suite
+
+Sections (all run by default unless noted):
+  0. Quant Type Validation     — K/V quant type acceptance/rejection tests
+  1. Pack/Unpack Roundtrip     — bit-packing correctness, no Metal
+  2. Python Roundtrip MSE      — quantization quality per quant type, no Metal
+  3. Metal Kernel Dequant      — Metal kernel vs Python reference per quant type
+  4. Metal E2E Correctness     — cache write → paged attention (Qwen3-0.6B shape)
+  5. Memory Capacity Analysis  — theoretical compression table
+  6. Published Comparison      — vs KIVI / KVQuant / QJL numbers
+  7. Quantization Latency      — encode + cache-write overhead
+  8. True Memory Usage         — RSS + Metal active memory (Llama-3.2-1B shape)
+  9. Serve Benchmark           — bf16 vs q8_0 via live vllm serve (opt-in: --serve)
+
+Run:
+    uv run python tests/test_turboquant.py           # sections 0-8
+    uv run python tests/test_turboquant.py --serve   # all sections including 9
+"""
+
+import gc
+import json
+import math
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+
+from vllm_metal.metal import get_ops
+from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
+from vllm_metal.metal_kernel_backend.turboquant import (
+    _FWHT_SUPPORTED_DIMS,
+    BLOCK_SIZE,
+    QUANT_PARAMS,
+    V_QUANT_PARAMS,
+    fwht,
+    get_v_centroids,
+    pack_bits,
+    packed_dim,
+    turbo_quant_decode,
+    turbo_quant_encode,
+    unpack_bits,
+)
+from vllm_metal.v1.cache_policy import (
+    TurboQuantAttentionSpec,
+    _build_turboquant_attention_spec,
+    _turboquant_page_size_bytes,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared config
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Qwen3-0.6B shape — used for correctness / latency / capacity sections.
+Q_NUM_KV_HEADS = 4
+Q_HEAD_DIM = 128
+Q_NUM_LAYERS = 28
+Q_BLOCK_SIZE = 16
+Q_GQA_RATIO = 4  # 16 Q heads / 4 KV heads
+
+# Qwen3-0.6B unpack test shape (smaller, one-block fits in NUM_BLOCKS=4).
+U_NUM_KV_HEADS = 4
+U_HEAD_DIM = 64
+U_BLOCK_SIZE = 16
+U_NUM_BLOCKS = 4
+U_GQA_RATIO = 4
+
+# Llama-3.2-1B shape — used for true memory usage section.
+L_NUM_LAYERS = 16
+L_NUM_KV_HEADS = 8
+L_HEAD_DIM = 64
+L_BLOCK_SIZE = 16
+
+# Quant types exercised by sections 3 and 2.
+QUANTS = ["q8_0", "int8", "q5_0", "q4_0", "uint2"]
+
+# Serve benchmark config (section 9).
+SERVE_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
+SERVE_HOST = "127.0.0.1"
+SERVE_PORT = 8765
+# Each config is (label, additional_config_dict or None).
+# TQ configs sweep the (k_quant, v_quant) cross-product that matters in
+# practice: q8_0 (lossless-ish K) vs int2 (aggressive K) crossed with
+# q3_0 (balanced V) vs q2_0 (aggressive V).  bf16 is the uncompressed
+# baseline every TQ config is judged against.
+SERVE_CONFIGS = [
+    ("bf16", None),
+    ("q8q3", {"turboquant": True, "k_quant": "q8_0", "v_quant": "q3_0"}),
+    ("q8q2", {"turboquant": True, "k_quant": "q8_0", "v_quant": "q2_0"}),
+    ("i2q3", {"turboquant": True, "k_quant": "int2", "v_quant": "q3_0"}),
+    ("i2q2", {"turboquant": True, "k_quant": "int2", "v_quant": "q2_0"}),
+]
+SERVE_BASE_ENV = {
+    "VLLM_METAL_USE_PAGED_ATTENTION": "1",
+    "VLLM_METAL_USE_MLX": "1",
+    "VLLM_METAL_MEMORY_FRACTION": "0.80",
+}
+SERVE_READY_TIMEOUT = 600
+SERVE_COOLDOWN = 30
+SERVE_QUALITY_PROMPT = (
+    "Explain the concept of attention in transformer neural networks "
+    "in exactly three sentences."
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def sep(title: str) -> None:
+    w = 72
+    print(f"\n{'═' * w}")
+    print(f"  {title}")
+    print(f"{'═' * w}")
+
+
+def cos_sim(a: mx.array, b: mx.array) -> float:
+    a_f = a.reshape(-1, a.shape[-1]).astype(mx.float32)
+    b_f = b.reshape(-1, b.shape[-1]).astype(mx.float32)
+    dot = mx.sum(a_f * b_f, axis=-1)
+    na = mx.sqrt(mx.sum(a_f**2, axis=-1))
+    nb = mx.sqrt(mx.sum(b_f**2, axis=-1))
+    return mx.mean(dot / (na * nb + 1e-8)).item()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 0: Quant Type Validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def section_quant_type_validation() -> int:
+    """Verify valid K/V quant types are accepted and invalid ones are rejected."""
+    sep("Section 0: Quant Type Validation")
+    failures = 0
+
+    # Valid K quant types
+    valid_k_quants = [
+        "q8_0",
+        "int8",
+        "uint8",
+        "q5_0",
+        "q4_0",
+        "int4",
+        "uint4",
+        "int2",
+        "uint2",
+    ]
+    # Valid V quant types
+    valid_v_quants = ["q2_0", "q3_0", "q4_0", "q5_0", "q8_0"]
+    # Invalid quant types (should be rejected)
+    invalid_k_quants = ["q3_0", "uint3", "fp16", "bf16", "invalid", ""]
+    invalid_v_quants = ["uint3", "int3", "fp16", "invalid", ""]
+
+    print("  K quant types:")
+    for k_quant in valid_k_quants:
+        if k_quant in QUANT_PARAMS:
+            print(f"    {k_quant:8s}  [OK] accepted")
+        else:
+            print(f"    {k_quant:8s}  [FAIL] should be accepted but rejected")
+            failures += 1
+
+    for k_quant in invalid_k_quants:
+        if k_quant not in QUANT_PARAMS:
+            print(f"    {k_quant or '(empty)':8s}  [OK] rejected")
+        else:
+            print(
+                f"    {k_quant or '(empty)':8s}  [FAIL] should be rejected but accepted"
+            )
+            failures += 1
+
+    print("\n  V quant types:")
+    for v_quant in valid_v_quants:
+        if v_quant in V_QUANT_PARAMS:
+            print(f"    {v_quant:8s}  [OK] accepted")
+        else:
+            print(f"    {v_quant:8s}  [FAIL] should be accepted but rejected")
+            failures += 1
+
+    for v_quant in invalid_v_quants:
+        if v_quant not in V_QUANT_PARAMS:
+            print(f"    {v_quant or '(empty)':8s}  [OK] rejected")
+        else:
+            print(
+                f"    {v_quant or '(empty)':8s}  [FAIL] should be rejected but accepted"
+            )
+            failures += 1
+
+    # Test MetalPagedKVCache validation
+    print("\n  MetalPagedKVCache validation:")
+    # Valid combo
+    try:
+        _ = MetalPagedKVCache(
+            num_layers=1,
+            num_blocks=4,
+            block_size=16,
+            num_kv_heads=4,
+            head_dim=64,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant="q8_0",
+            v_quant="q3_0",
+        )
+        print("    k=q8_0, v=q3_0  [OK] accepted")
+    except ValueError as e:
+        print(f"    k=q8_0, v=q3_0  [FAIL] rejected: {e}")
+        failures += 1
+
+    # Invalid K quant
+    try:
+        MetalPagedKVCache(
+            num_layers=1,
+            num_blocks=4,
+            block_size=16,
+            num_kv_heads=4,
+            head_dim=64,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant="invalid",
+            v_quant="q3_0",
+        )
+        print("    k=invalid       [FAIL] should be rejected")
+        failures += 1
+    except ValueError:
+        print("    k=invalid       [OK] rejected")
+
+    # Invalid V quant
+    try:
+        MetalPagedKVCache(
+            num_layers=1,
+            num_blocks=4,
+            block_size=16,
+            num_kv_heads=4,
+            head_dim=64,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant="q8_0",
+            v_quant="uint3",
+        )
+        print("    v=uint3         [FAIL] should be rejected")
+        failures += 1
+    except ValueError:
+        print("    v=uint3         [OK] rejected")
+
+    # Test get_v_centroids for valid bit widths
+    print("\n  get_v_centroids validation:")
+    for v_quant, params in V_QUANT_PARAMS.items():
+        bits = params["bits"]
+        try:
+            centroids = get_v_centroids(bits)
+            expected_len = 1 << bits
+            if len(centroids) == expected_len:
+                print(f"    {v_quant} ({bits}-bit)  [OK] {expected_len} centroids")
+            else:
+                print(
+                    f"    {v_quant} ({bits}-bit)  [FAIL] expected {expected_len}, got {len(centroids)}"
+                )
+                failures += 1
+        except Exception as e:
+            print(f"    {v_quant} ({bits}-bit)  [FAIL] {e}")
+            failures += 1
+
+    return failures
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 1: Pack / Unpack Roundtrip
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def section_pack_unpack_roundtrip() -> int:
+    """Verify pack_bits → unpack_bits identity for all sub-8-bit widths."""
+    sep("Section 1: Pack/Unpack Roundtrip")
+    failures = 0
+    orig_dim = 64  # divisible by 8 (3-bit group) and 4 (2-bit group)
+
+    for bits in [2, 3, 4, 5]:
+        max_val = (1 << bits) - 1
+        vals = mx.array([i % (max_val + 1) for i in range(orig_dim)], dtype=mx.uint8)
+        mx.eval(vals)
+
+        packed = pack_bits(vals, bits)
+        mx.eval(packed)
+        unpacked = unpack_bits(packed, bits, orig_dim)
+        mx.eval(unpacked)
+
+        mismatch = mx.any(unpacked != vals).item()
+        mark = "FAIL" if mismatch else "OK"
+        print(f"  bits={bits}  [{mark}]")
+        if mismatch:
+            failures += 1
+            bad = [i for i in range(orig_dim) if unpacked[i].item() != vals[i].item()]
+            print(f"    first mismatch indices: {bad[:8]}")
+
+    return failures
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 2: Python Roundtrip MSE
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def section_python_roundtrip_mse() -> int:
+    """Quantization roundtrip quality — no Metal required."""
+    sep("Section 2: Python Roundtrip MSE (no Metal)")
+    np.random.seed(42)
+    n_tokens = 32
+    k = mx.array(
+        np.random.randn(n_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    v = mx.array(
+        np.random.randn(n_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    mx.eval(k, v)
+
+    for quant in QUANTS:
+        k_q, v_q = turbo_quant_encode(k, v, quant)
+        k_hat, v_hat = turbo_quant_decode(
+            k_q, v_q, output_dtype=mx.float16, key_quant_type=quant
+        )
+        mx.eval(k_hat, v_hat)
+
+        k_mse = mx.mean((k.astype(mx.float32) - k_hat.astype(mx.float32)) ** 2).item()
+        v_mse = mx.mean((v.astype(mx.float32) - v_hat.astype(mx.float32)) ** 2).item()
+        k_cos = cos_sim(k, k_hat)
+        v_cos = cos_sim(v, v_hat)
+        bits = QUANT_PARAMS[quant]["bits"]
+        print(
+            f"  {quant:6s} ({bits}-bit K / 3-bit V)  "
+            f"K mse={k_mse:.5f} cos={k_cos:.4f}  "
+            f"V mse={v_mse:.5f} cos={v_cos:.4f}"
+        )
+
+    return 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 3: Metal Kernel Dequant
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _fill_cache(cache, k_packed, v_packed, k_scale, v_scale, k_zero, slot):
+    """Scatter-write packed K/V/scales/zero into the paged cache at `slot`."""
+    layer = 0
+    nkv = U_NUM_KV_HEADS
+    sg = U_HEAD_DIM // 32
+
+    flat_k = cache.key_caches[layer].reshape(-1, nkv, cache.k_packed_dim)
+    flat_k[slot] = k_packed
+    cache.key_caches[layer] = flat_k.reshape(cache.key_caches[layer].shape)
+
+    flat_v = cache.value_caches[layer].reshape(-1, nkv, cache.v_packed_dim)
+    flat_v[slot] = v_packed
+    cache.value_caches[layer] = flat_v.reshape(cache.value_caches[layer].shape)
+
+    for attr, data in [
+        ("key_scale_caches", k_scale),
+        ("value_scale_caches", v_scale),
+        ("key_zero_caches", k_zero),
+    ]:
+        arr = getattr(cache, attr)[layer]
+        flat = arr.reshape(-1, nkv, sg)
+        flat[slot] = data
+        getattr(cache, attr)[layer] = flat.reshape(arr.shape)
+
+
+def _python_attention_reference(q, k, v, scale):
+    """Single-sequence multihead attention with GQA replication."""
+    nkv = k.shape[1]
+    nq = q.shape[1]
+    rep = nq // nkv
+    k_rep = mx.repeat(k, rep, axis=1).astype(mx.float32)
+    v_rep = mx.repeat(v, rep, axis=1).astype(mx.float32)
+    q_f = q.astype(mx.float32)
+    scores = mx.einsum("qhd,khd->qhk", q_f, k_rep) * scale
+    p = mx.softmax(scores, axis=-1)
+    return mx.einsum("qhk,khd->qhd", p, v_rep)
+
+
+def section_metal_kernel_dequant() -> int:
+    """Metal paged attention output vs Python dequant reference."""
+    sep("Section 3: Metal Kernel Dequant (Metal vs Python reference)")
+    print(f"  heads={U_NUM_KV_HEADS}  head_dim={U_HEAD_DIM}  block_size={U_BLOCK_SIZE}")
+    print()
+    ops = get_ops()
+    failures = 0
+
+    for quant in QUANTS:
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_blocks=U_NUM_BLOCKS,
+            block_size=U_BLOCK_SIZE,
+            num_kv_heads=U_NUM_KV_HEADS,
+            head_dim=U_HEAD_DIM,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant=quant,
+        )
+
+        n_tokens = U_BLOCK_SIZE
+        k = mx.random.normal(
+            shape=(n_tokens, U_NUM_KV_HEADS, U_HEAD_DIM), key=mx.random.key(1)
+        ).astype(mx.float16)
+        v = mx.random.normal(
+            shape=(n_tokens, U_NUM_KV_HEADS, U_HEAD_DIM), key=mx.random.key(2)
+        ).astype(mx.float16)
+        q = mx.random.normal(
+            shape=(1, U_NUM_KV_HEADS * U_GQA_RATIO, U_HEAD_DIM), key=mx.random.key(3)
+        ).astype(mx.float16)
+        mx.eval(k, v, q)
+
+        (k_packed, k_scale, k_zero), (v_packed, v_scale) = turbo_quant_encode(
+            k, v, quant
+        )
+        mx.eval(k_packed, k_scale, k_zero, v_packed, v_scale)
+
+        k_ref, v_ref = turbo_quant_decode(
+            (k_packed, k_scale, k_zero),
+            (v_packed, v_scale),
+            output_dtype=mx.float16,
+            key_quant_type=quant,
+        )
+        mx.eval(k_ref, v_ref)
+
+        slot = mx.array(list(range(n_tokens)), dtype=mx.int64)
+        mx.eval(slot)
+        _fill_cache(cache, k_packed, v_packed, k_scale, v_scale, k_zero, slot)
+        mx.eval(
+            cache.key_caches[0],
+            cache.value_caches[0],
+            cache.key_scale_caches[0],
+            cache.value_scale_caches[0],
+            cache.key_zero_caches[0],
+        )
+
+        block_tables = mx.array([[0]], dtype=mx.int32)
+        seq_lens = mx.array([n_tokens], dtype=mx.int32)
+        cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+        out_metal = mx.zeros(
+            (1, U_NUM_KV_HEADS * U_GQA_RATIO, U_HEAD_DIM), dtype=mx.float16
+        )
+        mx.eval(block_tables, seq_lens, cu_seqlens_q, out_metal)
+
+        attn_scale = 1.0 / math.sqrt(U_HEAD_DIM)
+        v_centroids = get_v_centroids(cache.v_bits)
+        ops.paged_attention_primitive(
+            q,
+            cache.key_caches[0],
+            cache.value_caches[0],
+            U_NUM_KV_HEADS,
+            attn_scale,
+            0.0,
+            block_tables,
+            seq_lens,
+            cu_seqlens_q,
+            U_BLOCK_SIZE,
+            n_tokens,
+            -1,
+            out_metal,
+            key_scale_cache=cache.key_scale_caches[0],
+            value_scale_cache=cache.value_scale_caches[0],
+            key_zero_cache=cache.key_zero_caches[0],
+            v_centroids=v_centroids,
+            use_turboquant=True,
+            quant_type=quant,
+            v_bits=cache.v_bits,
+        )
+        mx.eval(out_metal)
+
+        out_ref = _python_attention_reference(q, k_ref, v_ref, attn_scale)
+        mx.eval(out_ref)
+
+        diff = out_metal.astype(mx.float32) - out_ref.astype(mx.float32)
+        mad = mx.mean(mx.abs(diff)).item()
+        denom = mx.mean(mx.abs(out_ref.astype(mx.float32))).item() + 1e-8
+        rel = mad / denom * 100.0
+
+        ok = rel < 5.0
+        mark = "OK" if ok else "FAIL"
+        print(f"  {quant:6s}  mean_abs_diff={mad:.4f}  rel_err={rel:6.2f}%  [{mark}]")
+        if not ok:
+            failures += 1
+
+    return failures
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 4: Metal E2E Correctness
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _scatter_tq(cache, layer, packed_k, k_scale, k_zero, packed_v, v_scale, slot):
+    """Scatter TurboQuant tensors into the 5 paged cache arrays for `layer`."""
+    nkv = cache.num_kv_heads
+    sg = cache.head_dim // BLOCK_SIZE
+
+    def sc(arr, data, d):
+        flat = arr.reshape(-1, nkv, d)
+        flat[slot] = data
+        return flat.reshape(arr.shape)
+
+    cache.key_caches[layer] = sc(cache.key_caches[layer], packed_k, cache.k_packed_dim)
+    cache.value_caches[layer] = sc(
+        cache.value_caches[layer], packed_v, cache.v_packed_dim
+    )
+    cache.key_scale_caches[layer] = sc(cache.key_scale_caches[layer], k_scale, sg)
+    cache.value_scale_caches[layer] = sc(cache.value_scale_caches[layer], v_scale, sg)
+    cache.key_zero_caches[layer] = sc(cache.key_zero_caches[layer], k_zero, sg)
+
+
+def _scatter_fp16(cache, layer, k, v, slot, head_dim):
+    """Scatter FP16 K/V into the paged cache arrays for `layer`."""
+    nkv = cache.num_kv_heads
+    flat_k = cache.key_caches[layer].reshape(-1, nkv, head_dim)
+    flat_k[slot] = k
+    cache.key_caches[layer] = flat_k.reshape(cache.key_caches[layer].shape)
+    flat_v = cache.value_caches[layer].reshape(-1, nkv, head_dim)
+    flat_v[slot] = v
+    cache.value_caches[layer] = flat_v.reshape(cache.value_caches[layer].shape)
+
+
+def section_metal_e2e() -> int:
+    """Cache write → paged attention correctness at multiple sequence lengths."""
+    sep("Section 4: Metal E2E Correctness (Qwen3-0.6B shape)")
+    ops = get_ops()
+    failures = 0
+
+    for quant in ["q8_0"]:
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=10,
+            block_size=Q_BLOCK_SIZE,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant=quant,
+        )
+
+        for n_tokens in [1, 5, 15]:
+            k = mx.random.normal(
+                shape=(n_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM),
+                key=mx.random.key(n_tokens),
+            ).astype(mx.float16)
+            v = mx.random.normal(
+                shape=(n_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM),
+                key=mx.random.key(n_tokens + 100),
+            ).astype(mx.float16)
+            q = mx.random.normal(
+                shape=(n_tokens, Q_NUM_KV_HEADS * Q_GQA_RATIO, Q_HEAD_DIM),
+                key=mx.random.key(n_tokens + 200),
+            ).astype(mx.float16)
+            mx.eval(k, v, q)
+
+            (packed_k, k_scale, k_zero), (packed_v, v_scale) = turbo_quant_encode(
+                k, v, quant, value_bits=cache.v_bits
+            )
+            mx.eval(packed_k, k_scale, k_zero, packed_v, v_scale)
+
+            _, v_hat_py = turbo_quant_decode(
+                (packed_k, k_scale, k_zero),
+                (packed_v, v_scale),
+                output_dtype=mx.float16,
+                key_quant_type=quant,
+            )
+            mx.eval(v_hat_py)
+
+            slot = mx.array(list(range(n_tokens)), dtype=mx.int64)
+            mx.eval(slot)
+            _scatter_tq(cache, 0, packed_k, k_scale, k_zero, packed_v, v_scale, slot)
+            mx.eval(
+                cache.key_caches[0],
+                cache.value_caches[0],
+                cache.key_scale_caches[0],
+                cache.value_scale_caches[0],
+                cache.key_zero_caches[0],
+            )
+
+            block_tables = mx.array([[0]], dtype=mx.int32)
+            seq_lens = mx.array([n_tokens], dtype=mx.int32)
+            cu_seqlens = mx.array([0, n_tokens], dtype=mx.int32)
+            out = mx.zeros(
+                (n_tokens, Q_NUM_KV_HEADS * Q_GQA_RATIO, Q_HEAD_DIM), dtype=mx.float16
+            )
+            mx.eval(block_tables, seq_lens, cu_seqlens, out)
+
+            scale = 1.0 / (Q_HEAD_DIM**0.5)
+            v_centroids = get_v_centroids(cache.v_bits)
+            ops.paged_attention_primitive(
+                q,
+                cache.key_caches[0],
+                cache.value_caches[0],
+                Q_NUM_KV_HEADS,
+                scale,
+                0.0,
+                block_tables,
+                seq_lens,
+                cu_seqlens,
+                Q_BLOCK_SIZE,
+                n_tokens,
+                -1,
+                out,
+                key_scale_cache=cache.key_scale_caches[0],
+                value_scale_cache=cache.value_scale_caches[0],
+                key_zero_cache=cache.key_zero_caches[0],
+                v_centroids=v_centroids,
+                use_turboquant=True,
+                quant_type=quant,
+                v_bits=cache.v_bits,
+            )
+            mx.eval(out)
+
+            if n_tokens == 1:
+                v_mse = mx.mean(
+                    (out[0, 0].astype(mx.float32) - v_hat_py[0, 0].astype(mx.float32))
+                    ** 2
+                ).item()
+                ok = v_mse < 1e-4
+                mark = "OK" if ok else "FAIL"
+                print(
+                    f"  n_tokens={n_tokens:2d} {quant}  single-tok V mse={v_mse:.2e}  [{mark}]"
+                )
+            else:
+                finite = mx.all(mx.isfinite(out)).item()
+                max_ab = mx.max(mx.abs(out)).item()
+                ok = finite and max_ab < 100
+                mark = "OK" if ok else "FAIL"
+                print(
+                    f"  n_tokens={n_tokens:2d} {quant}  finite={finite}  max_abs={max_ab:.2f}  [{mark}]"
+                )
+
+            if not ok:
+                failures += 1
+
+    return failures
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 5: Memory Capacity Analysis
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def section_memory_capacity() -> int:
+    """Theoretical compression table and live cache population sanity check."""
+    sep("Section 5: Memory Capacity Analysis (Qwen3-0.6B shape)")
+    ops = get_ops()
+
+    def fp16_block_bytes():
+        return 2 * Q_NUM_LAYERS * Q_BLOCK_SIZE * Q_NUM_KV_HEADS * Q_HEAD_DIM * 2
+
+    def tq_block_bytes(k_quant: str = "q8_0") -> int:
+        # K packed at k_bits, V packed at 3 bits, 3x float32 scales (k_scale, v_scale, k_zero)
+        k_bits = QUANT_PARAMS[k_quant]["bits"]
+        k_bytes = packed_dim(Q_HEAD_DIM, k_bits)
+        v_bytes = packed_dim(Q_HEAD_DIM, 3)
+        s_bytes = (
+            (Q_HEAD_DIM // BLOCK_SIZE) * 2 * 3
+        )  # float16: k_scale + v_scale + k_zero
+        return (
+            Q_NUM_LAYERS * Q_BLOCK_SIZE * Q_NUM_KV_HEADS * (k_bytes + v_bytes + s_bytes)
+        )
+
+    fp16_blk = fp16_block_bytes()
+    tq_blk = tq_block_bytes()
+    compress = fp16_blk / tq_blk
+    print(
+        f"\n  Qwen3-0.6B: {Q_NUM_LAYERS}L  {Q_NUM_KV_HEADS}kv  hd={Q_HEAD_DIM}  bs={Q_BLOCK_SIZE}"
+    )
+    print(
+        f"  FP16 per block:  {fp16_blk:>10,} B   TQ per block: {tq_blk:>10,} B   ({compress:.2f}x)"
+    )
+
+    print(
+        f"\n  {'Budget':>8}  {'FP16 blocks':>12}  {'FP16 tokens':>12}  {'TQ blocks':>10}  {'TQ tokens':>10}  {'Gain':>6}"
+    )
+    print(f"  {'─' * 8}  {'─' * 12}  {'─' * 12}  {'─' * 10}  {'─' * 10}  {'─' * 6}")
+    for mb in [64, 128, 256, 512, 1024]:
+        budget = mb * 1024 * 1024
+        fp16_b = budget // fp16_blk
+        fp16_tok = fp16_b * Q_BLOCK_SIZE
+        tq_b = budget // tq_blk
+        tq_tok = tq_b * Q_BLOCK_SIZE
+        gain = tq_tok / max(fp16_tok, 1)
+        print(
+            f"  {mb:>6} MB  {fp16_b:>12,}  {fp16_tok:>12,}  {tq_b:>10,}  {tq_tok:>10,}  {gain:>5.2f}x"
+        )
+
+    # Live population sanity check (1 layer, single block each)
+    n_fp16 = 32
+    n_tq = int(n_fp16 * compress)
+    tok_fp16 = n_fp16 * Q_BLOCK_SIZE
+    tok_tq = n_tq * Q_BLOCK_SIZE
+    print(
+        f"\n  Live check: fp16={n_fp16} blocks ({tok_fp16} tok)  tq={n_tq} blocks ({tok_tq} tok)"
+    )
+
+    np.random.seed(7)
+    ops = get_ops()
+    scale = 1.0 / (Q_HEAD_DIM**0.5)
+
+    cache_fp16 = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=Q_NUM_KV_HEADS,
+        head_dim=Q_HEAD_DIM,
+        num_blocks=n_fp16,
+        block_size=Q_BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=False,
+    )
+    k16 = mx.array(
+        np.random.randn(tok_fp16, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    v16 = mx.array(
+        np.random.randn(tok_fp16, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    sl16 = mx.array(list(range(tok_fp16)), dtype=mx.int64)
+    mx.eval(k16, v16, sl16)
+    _scatter_fp16(cache_fp16, 0, k16, v16, sl16, Q_HEAD_DIM)
+    mx.eval(cache_fp16.key_caches[0], cache_fp16.value_caches[0])
+
+    q16 = mx.random.normal(
+        shape=(1, Q_NUM_KV_HEADS * Q_GQA_RATIO, Q_HEAD_DIM), key=mx.random.key(99)
+    ).astype(mx.float16)
+    o16 = mx.zeros((1, Q_NUM_KV_HEADS * Q_GQA_RATIO, Q_HEAD_DIM), dtype=mx.float16)
+    bt16 = mx.arange(n_fp16, dtype=mx.int32).reshape(1, -1)
+    s16 = mx.array([tok_fp16], dtype=mx.int32)
+    cu16 = mx.array([0, 1], dtype=mx.int32)
+    mx.eval(q16, o16, bt16, s16, cu16)
+    ops.paged_attention_primitive(
+        q16,
+        cache_fp16.key_caches[0],
+        cache_fp16.value_caches[0],
+        Q_NUM_KV_HEADS,
+        scale,
+        0.0,
+        bt16,
+        s16,
+        cu16,
+        Q_BLOCK_SIZE,
+        tok_fp16,
+        -1,
+        o16,
+    )
+    mx.eval(o16)
+    fp16_ok = mx.all(mx.isfinite(o16)).item()
+    print(
+        f"  FP16 attention output: finite={fp16_ok}  [{('OK' if fp16_ok else 'FAIL')}]"
+    )
+
+    cache_tq = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=Q_NUM_KV_HEADS,
+        head_dim=Q_HEAD_DIM,
+        num_blocks=n_tq,
+        block_size=Q_BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant="q8_0",
+    )
+    ktq = mx.array(
+        np.random.randn(tok_tq, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    vtq = mx.array(
+        np.random.randn(tok_tq, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    mx.eval(ktq, vtq)
+    (pk, ks, kz), (pv, vs) = turbo_quant_encode(
+        ktq, vtq, "q8_0", value_bits=cache_tq.v_bits
+    )
+    sl_tq = mx.array(list(range(tok_tq)), dtype=mx.int64)
+    mx.eval(pk, ks, kz, pv, vs, sl_tq)
+    _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, sl_tq)
+    mx.eval(
+        cache_tq.key_caches[0],
+        cache_tq.value_caches[0],
+        cache_tq.key_scale_caches[0],
+        cache_tq.value_scale_caches[0],
+        cache_tq.key_zero_caches[0],
+    )
+
+    qtq = mx.random.normal(
+        shape=(1, Q_NUM_KV_HEADS * Q_GQA_RATIO, Q_HEAD_DIM), key=mx.random.key(99)
+    ).astype(mx.float16)
+    otq = mx.zeros((1, Q_NUM_KV_HEADS * Q_GQA_RATIO, Q_HEAD_DIM), dtype=mx.float16)
+    bttq = mx.arange(n_tq, dtype=mx.int32).reshape(1, -1)
+    stq = mx.array([tok_tq], dtype=mx.int32)
+    cutq = mx.array([0, 1], dtype=mx.int32)
+    mx.eval(qtq, otq, bttq, stq, cutq)
+    v_centroids = get_v_centroids(cache_tq.v_bits)
+    ops.paged_attention_primitive(
+        qtq,
+        cache_tq.key_caches[0],
+        cache_tq.value_caches[0],
+        Q_NUM_KV_HEADS,
+        scale,
+        0.0,
+        bttq,
+        stq,
+        cutq,
+        Q_BLOCK_SIZE,
+        tok_tq,
+        -1,
+        otq,
+        key_scale_cache=cache_tq.key_scale_caches[0],
+        value_scale_cache=cache_tq.value_scale_caches[0],
+        key_zero_cache=cache_tq.key_zero_caches[0],
+        v_centroids=v_centroids,
+        use_turboquant=True,
+        quant_type="q8_0",
+        v_bits=cache_tq.v_bits,
+    )
+    mx.eval(otq)
+    tq_ok = mx.all(mx.isfinite(otq)).item()
+    print(
+        f"  TQ attention output:   finite={tq_ok}   [{('OK' if tq_ok else 'FAIL')}]"
+        f"  ({tok_tq} tokens, {tok_tq - tok_fp16} more than fp16)"
+    )
+
+    return 0 if (fp16_ok and tq_ok) else 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 6: Published Comparison
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def section_published_comparison() -> int:
+    """Compare our NRMSE and compression to published TurboQuant / KIVI / QJL."""
+    sep("Section 6: Comparison to Published Numbers")
+    np.random.seed(0)
+    n_tokens = 256
+    k = mx.array(
+        np.random.randn(n_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    v = mx.array(
+        np.random.randn(n_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+    )
+    mx.eval(k, v)
+
+    k_std = mx.sqrt(mx.mean(k.astype(mx.float32) ** 2)).item()
+    v_std = mx.sqrt(mx.mean(v.astype(mx.float32) ** 2)).item()
+
+    for quant in ["q8_0", "q4_0"]:
+        kq, vq = turbo_quant_encode(k, v, quant)
+        k_hat, v_hat = turbo_quant_decode(
+            kq, vq, output_dtype=mx.float16, key_quant_type=quant
+        )
+        mx.eval(k_hat, v_hat)
+
+        k_mse = mx.mean((k.astype(mx.float32) - k_hat.astype(mx.float32)) ** 2).item()
+        v_mse = mx.mean((v.astype(mx.float32) - v_hat.astype(mx.float32)) ** 2).item()
+        k_nrmse = (k_mse**0.5) / k_std
+        v_nrmse = (v_mse**0.5) / v_std
+        k_cos = cos_sim(k, k_hat)
+        v_cos = cos_sim(v, v_hat)
+        print(f"\n  Ours ({quant} K / 3-bit V):")
+        print(f"    K: mse={k_mse:.5f}  nrmse={k_nrmse:.4f}  cos={k_cos:.6f}")
+        print(f"    V: mse={v_mse:.5f}  nrmse={v_nrmse:.4f}  cos={v_cos:.6f}")
+
+    fp16_per_tok = Q_HEAD_DIM * 2 * 2  # K + V at fp16 (2 bytes each)
+
+    def _tq_per_tok(k_quant: str) -> int:
+        k_bits = QUANT_PARAMS[k_quant]["bits"]
+        k_bytes = packed_dim(Q_HEAD_DIM, k_bits)
+        v_bytes = packed_dim(Q_HEAD_DIM, 3)
+        s_bytes = (
+            (Q_HEAD_DIM // BLOCK_SIZE) * 2 * 3
+        )  # float16: k_scale + v_scale + k_zero
+        return k_bytes + v_bytes + s_bytes
+
+    ratio_q8 = fp16_per_tok / _tq_per_tok("q8_0")
+    ratio_q4 = fp16_per_tok / _tq_per_tok("q4_0")
+    print(f"""
+  Published reference (head_dim={Q_HEAD_DIM}):
+  ───────────────────────────────────────────────────────
+  Method          | K    | V    | Compression | Notes
+  ─────────────────────────────────────────────────────
+  KIVI (2024)     | 2bit | 2bit | ~8x         | per-channel K / per-token V
+  KVQuant (2024)  | 2-4b | 2-4b | 3-8x        | NF quant + rotation
+  QJL (2024)      | 3bit | 3bit | ~4.5x       | JL projection for K
+  TurboQuant      | 4bit | 3bit | ~4.6x       | WHT + Lloyd-Max V
+  Ours (K=8,V=3)  | 8bit | 3bit | {ratio_q8:.1f}x         | conservative K, aggressive V
+  Ours (K=4,V=3)  | 4bit | 3bit | {ratio_q4:.1f}x         | same storage, lower K quality
+    """)
+    return 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 7: Quantization Latency
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def section_latency() -> int:
+    """Encode + cache-write overhead per decode token."""
+    sep("Section 7: Quantization Latency")
+
+    k = mx.random.normal(shape=(1, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(mx.float16)
+    v = mx.random.normal(shape=(1, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(mx.float16)
+    mx.eval(k, v)
+
+    cache_tq = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=Q_NUM_KV_HEADS,
+        head_dim=Q_HEAD_DIM,
+        num_blocks=10,
+        block_size=Q_BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant="q8_0",
+    )
+    cache_fp = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=Q_NUM_KV_HEADS,
+        head_dim=Q_HEAD_DIM,
+        num_blocks=10,
+        block_size=Q_BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=False,
+    )
+    slot = mx.array([0], dtype=mx.int64)
+    mx.eval(slot)
+
+    # Warm up
+    for _ in range(10):
+        kq, vq = turbo_quant_encode(k, v, "q8_0")
+        mx.eval(*kq, *vq)
+
+    n = 200
+
+    # Benchmark encode
+    t0 = time.perf_counter()
+    for _ in range(n):
+        kq, vq = turbo_quant_encode(k, v, "q8_0")
+        mx.eval(*kq, *vq)
+    encode_us = (time.perf_counter() - t0) / n * 1e6
+
+    # Pre-encode once for write benchmarks
+    (pk, ks, kz), (pv, vs) = turbo_quant_encode(
+        k, v, "q8_0", value_bits=cache_tq.v_bits
+    )
+    mx.eval(pk, ks, kz, pv, vs)
+
+    # Benchmark TQ cache write (scatter 5 arrays)
+    for _ in range(10):
+        _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, slot)
+        mx.eval(
+            cache_tq.key_caches[0],
+            cache_tq.value_caches[0],
+            cache_tq.key_scale_caches[0],
+            cache_tq.value_scale_caches[0],
+            cache_tq.key_zero_caches[0],
+        )
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, slot)
+        mx.eval(
+            cache_tq.key_caches[0],
+            cache_tq.value_caches[0],
+            cache_tq.key_scale_caches[0],
+            cache_tq.value_scale_caches[0],
+            cache_tq.key_zero_caches[0],
+        )
+    tq_write_us = (time.perf_counter() - t0) / n * 1e6
+
+    # Benchmark FP16 cache write (scatter K+V)
+    for _ in range(10):
+        _scatter_fp16(cache_fp, 0, k, v, slot, Q_HEAD_DIM)
+        mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _scatter_fp16(cache_fp, 0, k, v, slot, Q_HEAD_DIM)
+        mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
+    fp16_write_us = (time.perf_counter() - t0) / n * 1e6
+
+    overhead_us = encode_us + tq_write_us - fp16_write_us
+    tok_budget = 1e6 / 60  # ~16,700 µs at 60 tok/s
+    print(f"\n  Single-token ({Q_NUM_KV_HEADS} KV heads, hd={Q_HEAD_DIM}):")
+    print(f"    TQ encode (Python):    {encode_us:>8.1f} µs")
+    print(f"    TQ cache write:        {tq_write_us:>8.1f} µs")
+    print(f"    FP16 cache write:      {fp16_write_us:>8.1f} µs")
+    print(
+        f"    TQ overhead:           {overhead_us:>8.1f} µs  "
+        f"({overhead_us / tok_budget * 100:.1f}% of 60tok/s budget)"
+    )
+    return 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 8: Peak Memory During Attention (heap + on-chip SRAM breakdown)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Memory taxonomy for one decode step:
+#
+#   Metal heap (tracked by mx.metal.get_active_memory / get_peak_memory):
+#     - KV cache arrays (persistent, dominant at large context)
+#     - Output array (1 token * nq_heads * head_dim * dtype_bytes)
+#     - Control arrays: block_tables, seq_lens, cu_seqlens (negligible)
+#
+#   On-chip threadgroup SRAM (NOT in Metal heap, calculated below):
+#     - Standard attn workspace: max(NUM_WARPS*block_size, 2*NUM_WARPS + NUM_WARPS*head_dim) * 4B
+#     - TurboQuant extra: NUM_WARPS * head_dim * 4B  (per-warp FWHT buffer)
+#     - Per CTA dispatch, freed on completion — never shows in get_active_memory()
+#
+# Protocol:
+#   1. gc.collect() + mx.metal.clear_cache() for clean baseline
+#   2. Create + eval cache → measure static heap delta
+#   3. Create attention inputs → record pre-attn active
+#   4. mx.metal.reset_peak_memory()
+#   5. Run paged_attention_primitive + mx.eval(out)
+#   6. peak = mx.metal.get_peak_memory()       # max heap during forward pass
+#   7. post = mx.metal.get_active_memory()     # steady-state after (intermediates freed)
+#   8. lazy_intermediates = peak - post        # MLX lazy-graph temporaries
+#   9. attn_heap_delta = peak - pre_attn   # net heap delta from cache state
+#
+# Key result: attn_heap_delta ≈ output_size + lazy intermediates (~tiny).
+# The dequant is inline in Metal SRAM — zero hidden heap overhead for TQ.
+
+
+_MB = 1024 * 1024
+
+# Metal kernel constants (must match paged_ops.cpp)
+_NUM_THREADS = 256
+_NUM_SIMD_LANES = 32
+_NUM_WARPS = _NUM_THREADS // _NUM_SIMD_LANES  # 8
+
+
+def _shmem_bytes(block_size: int, head_dim: int, turboquant: bool) -> int:
+    """Threadgroup SRAM per CTA dispatch (on-chip, not in Metal heap)."""
+    warp_scores = _NUM_WARPS * block_size * 4
+    if turboquant:
+        # TQ path uses warp_scores slot for both scores and FWHT buffer
+        warp_scores += _NUM_WARPS * head_dim * 4
+    merge = (2 * _NUM_WARPS + _NUM_WARPS * head_dim) * 4
+    return max(warp_scores, merge)
+
+
+def _theoretical_cache_bytes(
+    num_layers: int,
+    num_tokens: int,
+    num_kv_heads: int,
+    head_dim: int,
+    turboquant: bool,
+    k_quant: str | None = None,
+) -> int:
+    """Exact formula for cache heap allocation, matching MetalPagedKVCache."""
+    if not turboquant:
+        return num_layers * num_tokens * num_kv_heads * head_dim * 2 * 2  # fp16 K+V
+    k_bits = QUANT_PARAMS[k_quant]["bits"]
+    k_bytes = packed_dim(head_dim, k_bits)
+    v_bytes = packed_dim(head_dim, 3)
+    sg = head_dim // BLOCK_SIZE
+    scale_bytes = sg * 2 * 3  # float16: k_scale, v_scale, k_zero
+    return num_layers * num_tokens * num_kv_heads * (k_bytes + v_bytes + scale_bytes)
+
+
+def _measure_one(
+    ops,
+    num_layers: int,
+    num_kv_heads: int,
+    head_dim: int,
+    num_blocks: int,
+    block_size: int,
+    seq_len: int,
+    turboquant: bool,
+    k_quant: str | None,
+) -> dict:
+    """
+    Full measurement for one (config, seq_len) pair.
+
+    Returns:
+        cache_heap_mb       — Metal heap consumed by cache arrays alone
+        pre_attn_heap_mb    — heap just before attention dispatch (cache + q/control)
+        peak_heap_mb        — peak heap captured by get_peak_memory() during eval
+        post_attn_heap_mb   — heap after eval (lazy intermediates freed)
+        lazy_intermediates_mb — peak - post (MLX graph temporary overhead)
+        attn_heap_delta_mb  — peak - pre_attn (net heap added by attention call)
+        shmem_kb            — on-chip SRAM per CTA (calculated, not from Metal API)
+        theoretical_cache_mb — formula cross-check vs measured cache_heap_mb
+    """
+    gc.collect()
+    mx.clear_cache()
+    mx.eval()  # drain lazy graph before baseline
+
+    base_active = mx.get_active_memory()
+
+    # ── Allocate cache ──────────────────────────────────────────────────────
+    cache = MetalPagedKVCache(
+        num_layers=num_layers,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        dtype=mx.float16,
+        turboquant=turboquant,
+        k_quant=k_quant,
+    )
+    if turboquant:
+        mx.eval(
+            *cache.key_caches,
+            *cache.value_caches,
+            *cache.key_scale_caches,
+            *cache.value_scale_caches,
+            *cache.key_zero_caches,
+        )
+    else:
+        mx.eval(*cache.key_caches, *cache.value_caches)
+
+    after_alloc = mx.get_active_memory()
+    cache_heap_mb = (after_alloc - base_active) / _MB
+
+    # ── Fill layer 0 with seq_len tokens ────────────────────────────────────
+    layer = 0
+    key = mx.random.normal(
+        shape=(seq_len, num_kv_heads, head_dim), key=mx.random.key(1)
+    ).astype(mx.float16)
+    val = mx.random.normal(
+        shape=(seq_len, num_kv_heads, head_dim), key=mx.random.key(2)
+    ).astype(mx.float16)
+    mx.eval(key, val)
+
+    if turboquant:
+        (pk, ks, kz), (pv, vs) = turbo_quant_encode(
+            key, val, k_quant, value_bits=cache.v_bits
+        )
+        mx.eval(pk, ks, kz, pv, vs)
+        sl = mx.array(list(range(seq_len)), dtype=mx.int64)
+        mx.eval(sl)
+        _scatter_tq(cache, layer, pk, ks, kz, pv, vs, sl)
+        mx.eval(
+            cache.key_caches[layer],
+            cache.value_caches[layer],
+            cache.key_scale_caches[layer],
+            cache.value_scale_caches[layer],
+            cache.key_zero_caches[layer],
+        )
+        del pk, ks, kz, pv, vs, sl
+    else:
+        sl = mx.array(list(range(seq_len)), dtype=mx.int64)
+        mx.eval(sl)
+        _scatter_fp16(cache, layer, key, val, sl, head_dim)
+        mx.eval(cache.key_caches[layer], cache.value_caches[layer])
+        del sl
+    del key, val
+    gc.collect()
+    mx.eval()
+
+    # ── Build attention inputs ───────────────────────────────────────────────
+    # Decode scenario: 1 new query token against seq_len cached tokens.
+    # GQA ratio 4 (matches Qwen3-0.6B: 16 Q / 4 KV).
+    nq = num_kv_heads * 4
+    q = mx.random.normal(shape=(1, nq, head_dim), key=mx.random.key(3)).astype(
+        mx.float16
+    )
+    num_blks = math.ceil(seq_len / block_size)
+    block_tables = mx.arange(num_blks, dtype=mx.int32).reshape(1, -1)
+    seq_lens_arr = mx.array([seq_len], dtype=mx.int32)
+    cu_seqlens = mx.array([0, 1], dtype=mx.int32)
+    out_arr = mx.zeros((1, nq, head_dim), dtype=mx.float16)
+    mx.eval(q, block_tables, seq_lens_arr, cu_seqlens, out_arr)
+
+    attn_scale = 1.0 / math.sqrt(head_dim)
+
+    # ── Peak measurement ─────────────────────────────────────────────────────
+    # Drain lazy graph; record stable heap before reset.
+    mx.eval()
+    pre_attn_active = mx.get_active_memory()
+    mx.reset_peak_memory()
+
+    if turboquant:
+        v_centroids = get_v_centroids(cache.v_bits)
+        ops.paged_attention_primitive(
+            q,
+            cache.key_caches[layer],
+            cache.value_caches[layer],
+            num_kv_heads,
+            attn_scale,
+            0.0,
+            block_tables,
+            seq_lens_arr,
+            cu_seqlens,
+            block_size,
+            seq_len,
+            -1,
+            out_arr,
+            key_scale_cache=cache.key_scale_caches[layer],
+            value_scale_cache=cache.value_scale_caches[layer],
+            key_zero_cache=cache.key_zero_caches[layer],
+            v_centroids=v_centroids,
+            use_turboquant=True,
+            quant_type=k_quant,
+            v_bits=cache.v_bits,
+        )
+    else:
+        ops.paged_attention_primitive(
+            q,
+            cache.key_caches[layer],
+            cache.value_caches[layer],
+            num_kv_heads,
+            attn_scale,
+            0.0,
+            block_tables,
+            seq_lens_arr,
+            cu_seqlens,
+            block_size,
+            seq_len,
+            -1,
+            out_arr,
+        )
+    mx.eval(out_arr)
+
+    peak_active = mx.get_peak_memory()
+    post_attn_active = mx.get_active_memory()
+
+    # ── Derived metrics ──────────────────────────────────────────────────────
+    shmem_b = _shmem_bytes(block_size, head_dim, turboquant)
+    # Dispatch one threadgroup per (nq_heads, decode_tokens=1) = nq dispatches.
+    total_shmem_kb = shmem_b * nq / 1024
+
+    theoretical = _theoretical_cache_bytes(
+        num_layers,
+        num_blocks * block_size,
+        num_kv_heads,
+        head_dim,
+        turboquant,
+        k_quant,
+    )
+
+    return {
+        "cache_heap_mb": cache_heap_mb,
+        "pre_attn_heap_mb": pre_attn_active / _MB,
+        "peak_heap_mb": peak_active / _MB,
+        "post_attn_heap_mb": post_attn_active / _MB,
+        "lazy_intermediates_mb": max(0.0, (peak_active - post_attn_active) / _MB),
+        "attn_heap_delta_mb": (peak_active - pre_attn_active) / _MB,
+        "shmem_per_cta_kb": shmem_b / 1024,
+        "total_shmem_kb": total_shmem_kb,
+        "theoretical_cache_mb": theoretical / _MB,
+    }
+
+
+def section_peak_memory_analysis() -> int:
+    """
+    Section 8: Peak Metal memory during attention — heap + on-chip SRAM.
+
+    Three sub-reports:
+
+      8a. Formula cross-check
+          Confirm measured cache allocation matches the theoretical formula.
+          Catches any hidden allocations or size regressions.
+
+      8b. Static footprint + peak during decode
+          For each quant type, at realistic token counts (Qwen3-0.6B shape):
+            - Cache heap (persistent)
+            - Peak heap during one decode attention call
+            - Lazy intermediates (MLX graph temporaries, freed after eval)
+            - On-chip SRAM (calculated; invisible to Metal heap APIs)
+          Proves TQ's advantage holds during computation, not just at rest.
+
+      8c. Seq-len sweep
+          Absolute heap savings and compression ratio as context grows.
+          Identifies the token count where TQ pays off.
+
+    Failure conditions:
+      - Measured cache diverges from formula by > 1% (hidden allocation)
+      - TQ peak exceeds FP16 peak at any tested seq_len (unexpected overhead)
+      - TQ lazy intermediates exceed FP16 lazy intermediates by > 10 MB
+        (would indicate dequant escaped to heap)
+    """
+    sep("Section 8: Peak Memory During Attention (heap + on-chip SRAM)")
+    ops = get_ops()
+    failures = 0
+
+    # ── 8a. Formula cross-check ──────────────────────────────────────────────
+    print("\n  8a. Formula cross-check (measured cache vs theoretical)")
+    print(
+        f"  {'config':8s}  {'measured MB':>12s}  {'formula MB':>10s}  {'Δ MB':>7s}  {'Δ %':>7s}  status"
+    )
+    print(f"  {'─' * 8}  {'─' * 12}  {'─' * 10}  {'─' * 7}  {'─' * 7}  {'─' * 6}")
+    # Threshold: allow up to 0.25 MB absolute overhead. Metal's allocator rounds
+    # each buffer to 4 KB page boundaries; for 5 small TQ arrays this adds ~50 KB
+    # of fixed overhead that does NOT grow with sequence length or layer count.
+    # The guard catches large unexpected heap allocations (e.g. a dequant
+    # temp-buffer materialised on the heap), which would appear as > 1 MB.
+    _formula_abs_tol_mb = 0.25
+
+    check_seq = 512
+    check_blks = math.ceil(check_seq / Q_BLOCK_SIZE)
+    check_cfgs = [
+        ("fp16", False, None),
+        ("q8_0", True, "q8_0"),
+        ("q4_0", True, "q4_0"),
+        ("uint2", True, "uint2"),
+    ]
+    for label, tq, kq in check_cfgs:
+        m = _measure_one(
+            ops,
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=check_blks,
+            block_size=Q_BLOCK_SIZE,
+            seq_len=check_seq,
+            turboquant=tq,
+            k_quant=kq,
+        )
+        measured = m["cache_heap_mb"]
+        formula = m["theoretical_cache_mb"]
+        delta_mb = measured - formula
+        delta_pct = delta_mb / (formula + 1e-6) * 100
+        ok = delta_mb < _formula_abs_tol_mb
+        mark = "OK" if ok else "FAIL"
+        print(
+            f"  {label:8s}  {measured:>12.3f}  {formula:>10.3f}  {delta_mb:>7.3f}  {delta_pct:>6.1f}%  [{mark}]"
+        )
+        if not ok:
+            failures += 1
+
+    # ── 8b. Static footprint + peak during decode ────────────────────────────
+    decode_seq_len = 2048
+    decode_num_blks = math.ceil(decode_seq_len / Q_BLOCK_SIZE)
+
+    print(
+        f"\n  8b. Static footprint + peak during decode  "
+        f"(Qwen3-0.6B shape, 1 layer, {decode_seq_len} tokens)"
+    )
+    print("\n  Legend:")
+    print("    cache heap    — persistent Metal heap for KV cache arrays")
+    print("    peak heap     — Metal heap peak captured during mx.eval(out)")
+    print("    lazy intermed — peak minus post-eval active (MLX graph temps)")
+    print("    SRAM/CTA      — on-chip threadgroup memory per dispatch (not in heap)")
+    print()
+    hdr = (
+        f"  {'config':8s}  {'cache MB':>10s}  {'peak MB':>10s}  "
+        f"{'lazy MB':>9s}  {'SRAM/CTA KB':>11s}  peak/fp16"
+    )
+    print(hdr)
+    print(f"  {'─' * 8}  {'─' * 10}  {'─' * 10}  {'─' * 9}  {'─' * 11}  {'─' * 8}")
+
+    bench_cfgs = [
+        ("fp16", False, None),
+        ("q8_0", True, "q8_0"),
+        ("q5_0", True, "q5_0"),
+        ("q4_0", True, "q4_0"),
+        ("uint2", True, "uint2"),
+    ]
+    results_8b = {}
+    for label, tq, kq in bench_cfgs:
+        m = _measure_one(
+            ops,
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=decode_num_blks,
+            block_size=Q_BLOCK_SIZE,
+            seq_len=decode_seq_len,
+            turboquant=tq,
+            k_quant=kq,
+        )
+        results_8b[label] = m
+
+    fp16_peak = results_8b["fp16"]["peak_heap_mb"]
+    for label, _tq, _kq in bench_cfgs:
+        m = results_8b[label]
+        ratio = m["peak_heap_mb"] / fp16_peak if fp16_peak > 0 else 1.0
+        print(
+            f"  {label:8s}  {m['cache_heap_mb']:>10.2f}  {m['peak_heap_mb']:>10.2f}  "
+            f"{m['lazy_intermediates_mb']:>9.3f}  {m['shmem_per_cta_kb']:>11.2f}  {ratio:>8.3f}"
+        )
+
+    # Assert: TQ peak must be strictly smaller than FP16 peak
+    for label, tq, _ in bench_cfgs:
+        if not tq:
+            continue
+        tq_peak = results_8b[label]["peak_heap_mb"]
+        lazy_diff = (
+            results_8b[label]["lazy_intermediates_mb"]
+            - results_8b["fp16"]["lazy_intermediates_mb"]
+        )
+        if tq_peak >= fp16_peak:
+            print(
+                f"  FAIL: {label} peak ({tq_peak:.2f} MB) >= fp16 peak ({fp16_peak:.2f} MB)"
+            )
+            failures += 1
+        if lazy_diff > 10.0:
+            print(
+                f"  FAIL: {label} lazy intermediates {lazy_diff:+.2f} MB above fp16 "
+                f"(dequant may have escaped to heap)"
+            )
+            failures += 1
+
+    # ── 8c. Seq-len sweep ────────────────────────────────────────────────────
+    sweep_quants = [("q8_0", True, "q8_0"), ("q4_0", True, "q4_0")]
+    sweep_seqlens = [128, 256, 512, 1024, 2048, 4096]
+
+    print("\n  8c. Heap savings vs seq_len  (Qwen3-0.6B shape, 1 layer)")
+    print(f"\n  {'seq_len':>8s}  {'fp16 MB':>9s}  ", end="")
+    for label, _, _ in sweep_quants:
+        print(f"  {label + ' MB':>10s}  {'saved MB':>9s}  {'ratio':>6s}", end="")
+    print()
+    print(f"  {'─' * 8}  {'─' * 9}  ", end="")
+    for _ in sweep_quants:
+        print(f"  {'─' * 10}  {'─' * 9}  {'─' * 6}", end="")
+    print()
+
+    for seq_len in sweep_seqlens:
+        num_blks = math.ceil(seq_len / Q_BLOCK_SIZE)
+        fp16_m = _measure_one(
+            ops,
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=num_blks,
+            block_size=Q_BLOCK_SIZE,
+            seq_len=seq_len,
+            turboquant=False,
+            k_quant=None,
+        )
+        fp16_peak_mb = fp16_m["peak_heap_mb"]
+        print(f"  {seq_len:>8d}  {fp16_peak_mb:>9.2f}  ", end="")
+
+        for _label, tq, kq in sweep_quants:
+            tq_m = _measure_one(
+                ops,
+                num_layers=1,
+                num_kv_heads=Q_NUM_KV_HEADS,
+                head_dim=Q_HEAD_DIM,
+                num_blocks=num_blks,
+                block_size=Q_BLOCK_SIZE,
+                seq_len=seq_len,
+                turboquant=tq,
+                k_quant=kq,
+            )
+            tq_peak = tq_m["peak_heap_mb"]
+            saved = fp16_peak_mb - tq_peak
+            ratio = fp16_peak_mb / tq_peak if tq_peak > 0 else float("inf")
+            print(f"  {tq_peak:>10.2f}  {saved:>9.2f}  {ratio:>6.2f}x", end="")
+        print()
+
+    # ── Full-model projection (all 28 layers) ─────────────────────────────────
+    print(f"\n  Full-model projection ({Q_NUM_LAYERS} layers, Qwen3-0.6B):")
+    print(f"  (Scales linearly: multiply 1-layer numbers by {Q_NUM_LAYERS})")
+    for seq_len in [2048, 8192]:
+        fp16_total = (
+            _theoretical_cache_bytes(
+                Q_NUM_LAYERS, seq_len, Q_NUM_KV_HEADS, Q_HEAD_DIM, False
+            )
+            / _MB
+        )
+        for label, tq, kq in sweep_quants:
+            tq_total = (
+                _theoretical_cache_bytes(
+                    Q_NUM_LAYERS, seq_len, Q_NUM_KV_HEADS, Q_HEAD_DIM, tq, kq
+                )
+                / _MB
+            )
+            saved = fp16_total - tq_total
+            ratio = fp16_total / tq_total if tq_total > 0 else float("inf")
+            print(
+                f"  seq={seq_len:5d}  {label:6s}  "
+                f"fp16={fp16_total:7.1f} MB  tq={tq_total:7.1f} MB  "
+                f"saved={saved:7.1f} MB  ({ratio:.2f}x)"
+            )
+
+    return failures
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 9: Serve Benchmark (opt-in via --serve)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _wait_dead(pid: int, timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.5)
+
+
+def _kill_server(proc: subprocess.Popen) -> None:
+    pid = proc.pid
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        return
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+    subprocess.run(
+        ["pkill", "-9", "-f", f"vllm serve.*--port {SERVE_PORT}"], capture_output=True
+    )
+    _wait_dead(pid, timeout=15)
+
+
+def _parse_max_tokens(log_path: str) -> int | None:
+    pat = re.compile(r"max_tokens_cached=(\d+)")
+    try:
+        with open(log_path) as f:
+            for line in f:
+                m = pat.search(line)
+                if m:
+                    return int(m.group(1))
+    except FileNotFoundError:
+        pass
+    return None
+
+
+def _send_chat(prompt: str, max_tokens: int) -> dict:
+    body = json.dumps(
+        {
+            "model": SERVE_MODEL,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"http://{SERVE_HOST}:{SERVE_PORT}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    t0 = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        return {"ok": False, "error": str(e)[:300], "elapsed": time.monotonic() - t0}
+    elapsed = time.monotonic() - t0
+    usage = data.get("usage", {})
+    c_toks = usage.get("completion_tokens", 0)
+    return {
+        "ok": True,
+        "text": data["choices"][0]["message"]["content"],
+        "prompt_tokens": usage.get("prompt_tokens", 0),
+        "completion_tokens": c_toks,
+        "elapsed": elapsed,
+        "tok_per_s": c_toks / elapsed if elapsed > 0 else 0.0,
+    }
+
+
+def _rss_mb(pid: int | None = None) -> float:
+    """Return RSS memory in MB for the given pid (default: current process)."""
+    try:
+        import psutil
+
+        p = psutil.Process(pid)
+        return p.memory_info().rss / (1024 * 1024)
+    except Exception:
+        return 0.0
+
+
+def _run_serve_config(label: str, additional_config: dict | None, log_dir: str) -> dict:
+    result = {
+        "label": label,
+        "ready": False,
+        "max_tokens": 0,
+        "idle_rss": 0.0,
+        "peak_rss": 0.0,
+        "chat": {},
+    }
+    env = os.environ.copy()
+    env.update(SERVE_BASE_ENV)
+
+    cmd = [
+        "vllm",
+        "serve",
+        SERVE_MODEL,
+        "--host",
+        SERVE_HOST,
+        "--port",
+        str(SERVE_PORT),
+        "--max-model-len",
+        "auto",
+        "--enforce-eager",
+    ]
+    if additional_config:
+        import json
+
+        cmd.extend(["--additional-config", json.dumps(additional_config)])
+    log_path = os.path.join(log_dir, f"{label}.log")
+    print(f"\n  ── {label} ──")
+    print(f"     {shlex.join(cmd)}")
+    if additional_config:
+        print(f"     additional_config: {additional_config}")
+
+    log_f = open(log_path, "w")
+    proc = subprocess.Popen(
+        cmd, env=env, stdout=log_f, stderr=subprocess.STDOUT, preexec_fn=os.setsid
+    )
+    try:
+        deadline = time.monotonic() + SERVE_READY_TIMEOUT
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                print(f"     FAIL: vllm exited (rc={proc.returncode}); see {log_path}")
+                return result
+            try:
+                with urllib.request.urlopen(
+                    f"http://{SERVE_HOST}:{SERVE_PORT}/v1/models", timeout=1.5
+                ) as r:
+                    if r.status == 200:
+                        result["ready"] = True
+                        break
+            except (urllib.error.URLError, ConnectionError, TimeoutError):
+                pass
+            time.sleep(1.0)
+
+        if not result["ready"]:
+            print("     FAIL: ready timeout")
+            return result
+
+        log_f.flush()
+        result["max_tokens"] = _parse_max_tokens(log_path) or 0
+        print(f"     ready.  max_tokens_cached = {result['max_tokens']:,}")
+
+        time.sleep(3)
+        idle = [_rss_mb(proc.pid) for _ in range(6)]
+        result["idle_rss"] = max(idle) if idle else 0.0
+        print(f"     idle RSS = {result['idle_rss']:.0f} MB")
+
+        print("     warm-up request...")
+        warmup = _send_chat("Hello", 16)
+        if not warmup.get("ok"):
+            print(f"     warm-up FAILED: {warmup.get('error', '?')}")
+            result["chat"] = warmup
+            return result
+        time.sleep(1)
+
+        print(f'     quality prompt: "{SERVE_QUALITY_PROMPT[:60]}..."')
+        active_samples: list[float] = []
+        holder: dict = {}
+
+        def _req():
+            holder["r"] = _send_chat(SERVE_QUALITY_PROMPT, 256)
+
+        t = threading.Thread(target=_req, daemon=True)
+        t.start()
+        while t.is_alive():
+            active_samples.append(_rss_mb(proc.pid))
+            time.sleep(0.3)
+        t.join()
+
+        chat = holder.get("r", {"ok": False, "error": "no result"})
+        result["chat"] = chat
+        result["peak_rss"] = (
+            max(active_samples) if active_samples else result["idle_rss"]
+        )
+
+        if chat.get("ok"):
+            print(
+                f"     tok/s={chat['tok_per_s']:.1f}  peak RSS={result['peak_rss']:.0f} MB"
+            )
+            print("     ─── response ───")
+            for line in chat["text"].split("\n"):
+                print(f"     | {line}")
+        else:
+            print(f"     request FAILED: {chat.get('error', '?')}")
+
+    finally:
+        _kill_server(proc)
+        log_f.close()
+        print(f"     cooling down {SERVE_COOLDOWN}s...")
+        time.sleep(SERVE_COOLDOWN)
+
+    return result
+
+
+def section_serve_benchmark() -> int:
+    """Compare bf16 against the TQ (k_quant, v_quant) sweep via live vllm serve."""
+    tq_labels = ", ".join(label for label, cfg in SERVE_CONFIGS if cfg is not None)
+    sep(f"Section 9: Serve Benchmark (bf16 vs TQ sweep: {tq_labels})")
+    print(f"  Model: {SERVE_MODEL}")
+    log_dir = "/tmp/tq-serve-bench"
+    os.makedirs(log_dir, exist_ok=True)
+
+    results = [_run_serve_config(label, env, log_dir) for label, env in SERVE_CONFIGS]
+
+    print()
+    sep("Serve Results")
+    bf16 = next((r for r in results if r["label"] == "bf16"), None)
+    hdr = f"  {'config':8s} {'max_ctx':>10s} {'idle MB':>8s} {'peak MB':>8s} {'tok/s':>7s}  status"
+    print(hdr)
+    print(f"  {'─' * 8} {'─' * 10} {'─' * 8} {'─' * 8} {'─' * 7}  {'─' * 6}")
+    for r in results:
+        chat = r.get("chat", {})
+        tps = f"{chat['tok_per_s']:.1f}" if chat.get("ok") else "—"
+        status = "ok" if chat.get("ok") else ("load" if r["ready"] else "FAIL")
+        print(
+            f"  {r['label']:8s} {r['max_tokens']:>10,} "
+            f"{r['idle_rss']:>8.0f} {r['peak_rss']:>8.0f} {tps:>7s}  {status}"
+        )
+
+    if bf16 and bf16["max_tokens"] > 0:
+        for r in results:
+            if r["label"] == "bf16" or r["max_tokens"] <= 0:
+                continue
+            ratio = r["max_tokens"] / bf16["max_tokens"]
+            print(
+                f"\n  {r['label']} context unlock: {ratio:.2f}x "
+                f"({r['max_tokens']:,} vs {bf16['max_tokens']:,} tokens)"
+            )
+    return 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    run_serve = "--serve" in sys.argv
+
+    print("╔══════════════════════════════════════════════════════════════════════╗")
+    print("║         TurboQuant KV Cache — Comprehensive Test Suite              ║")
+    print("╚══════════════════════════════════════════════════════════════════════╝")
+
+    failures = 0
+    failures += section_quant_type_validation()
+    failures += section_pack_unpack_roundtrip()
+    failures += section_python_roundtrip_mse()
+    failures += section_metal_kernel_dequant()
+    failures += section_metal_e2e()
+    failures += section_memory_capacity()
+    failures += section_published_comparison()
+    failures += section_latency()
+    failures += section_peak_memory_analysis()
+
+    if run_serve:
+        failures += section_serve_benchmark()
+    else:
+        print("\n  (skipping section 9 — serve benchmark; pass --serve to enable)")
+
+    sep("DONE")
+    if failures:
+        print(f"  {failures} section(s) FAILED.\n")
+        return 1
+    print("  All sections passed.\n")
+    return 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pytest-native unit tests (collected by `pytest tests/test_turboquant.py`).
+# Not run by the script `main()` path above.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- FWHT Python/Metal sign-table parity -----------------------------------
+#
+# TurboQuant's FWHT rotation uses random signs generated Python-side via
+# ``mx.random.randint(0, 2, shape=(N,), key=mx.random.key(42))``. The Metal
+# kernel stores byte-identical copies as compile-time constants
+# (``FWHT_SIGNS_64`` / ``_128`` / ``_256`` in ``turboquant.metal``).  If
+# either side drifts — different RNG key, MLX PRNG change, or manual edits
+# to the Metal tables — encode/decode silently disagree and produce garbage.
+
+_METAL_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "vllm_metal"
+    / "metal"
+    / "kernels_v2"
+    / "turboquant.metal"
+)
+
+
+def _parse_metal_sign_table(head_size: int) -> np.ndarray:
+    """Extract ``FWHT_SIGNS_<head_size>`` from the Metal source as a numpy array."""
+    source = _METAL_SOURCE.read_text()
+    pattern = re.compile(
+        rf"constant\s+float\s+FWHT_SIGNS_{head_size}\[{head_size}\]\s*=\s*\{{([^}}]*)\}}",
+        re.DOTALL,
+    )
+    match = pattern.search(source)
+    if match is None:
+        raise AssertionError(f"FWHT_SIGNS_{head_size} not found in {_METAL_SOURCE}")
+    values = re.findall(r"-?\d+\.?\d*f?", match.group(1))
+    signs = np.array([float(v.rstrip("f")) for v in values], dtype=np.float32)
+    if signs.shape != (head_size,):
+        raise AssertionError(
+            f"FWHT_SIGNS_{head_size} expected length {head_size}, got {signs.shape[0]}"
+        )
+    return signs
+
+
+def _python_signs(head_size: int) -> np.ndarray:
+    """Reproduce the Python sign vector using the same RNG recipe as ``fwht``."""
+    from vllm_metal.metal_kernel_backend.turboquant import _RNG_KEY
+
+    sign01 = mx.random.randint(0, 2, shape=(head_size,), key=_RNG_KEY)
+    signs = (1 - 2 * sign01).astype(mx.float32)
+    return np.asarray(signs)
+
+
+@pytest.mark.parametrize("head_size", _FWHT_SUPPORTED_DIMS)
+def test_metal_sign_table_matches_python_rng(head_size: int) -> None:
+    """Metal constant table must equal the Python-generated signs element-wise."""
+    metal_signs = _parse_metal_sign_table(head_size)
+    python_signs = _python_signs(head_size)
+    np.testing.assert_array_equal(
+        python_signs,
+        metal_signs,
+        err_msg=(
+            f"FWHT_SIGNS_{head_size} drift between Python RNG and Metal tables. "
+            "If this fails, either the _RNG_KEY changed, MLX's PRNG trajectory "
+            "shifted, or turboquant.metal was edited manually. Regenerate both "
+            "sides together."
+        ),
+    )
+
+
+@pytest.mark.parametrize("head_size", _FWHT_SUPPORTED_DIMS)
+def test_fwht_roundtrips_exactly_with_current_signs(head_size: int) -> None:
+    """Sanity check: encode then decode recovers the input (signs cancel)."""
+    rng = np.random.default_rng(seed=0)
+    x_np = rng.standard_normal((4, head_size)).astype(np.float32)
+    x = mx.array(x_np)
+    encoded = fwht(x, encode=True)
+    decoded = fwht(encoded, encode=False)
+    np.testing.assert_allclose(
+        np.asarray(decoded),
+        x_np,
+        rtol=1e-5,
+        atol=1e-5,
+        err_msg=(
+            f"FWHT encode/decode round-trip failed at head_size={head_size}. "
+            "This indicates a bug in the Python FWHT itself, not a Python/Metal "
+            "parity issue."
+        ),
+    )
+
+
+# --- TurboQuantAttentionSpec (replacement for head_size_v hack) ------------
+#
+# ``TurboQuantAttentionSpec`` subclasses ``FullAttentionSpec`` and overrides
+# ``real_page_size_bytes`` so the scheduler sees the true compressed page size
+# without synthesising a bogus ``head_size_v`` (which used to go negative for
+# aggressive 2-bit configs).
+
+# Last config is the 2-bit edge case that used to produce a negative
+# ``head_size_v`` under the pre-subclass strategy.
+_TQ_SPEC_CONFIGS = [
+    # (label,          block_size, num_kv_heads, head_dim, k_quant, v_quant)
+    ("default_q8_q3", 16, 4, 128, "q8_0", "q3_0"),
+    ("q4_q3_gqa", 16, 8, 128, "q4_0", "q3_0"),
+    ("wide_head_256", 16, 2, 256, "q8_0", "q3_0"),
+    ("narrow_head_64", 16, 8, 64, "q8_0", "q3_0"),
+    ("aggressive_2b", 16, 8, 128, "int2", "q2_0"),
+]
+
+
+@pytest.mark.parametrize(
+    "_label, block_size, num_kv_heads, head_dim, k_quant, v_quant",
+    _TQ_SPEC_CONFIGS,
+    ids=[c[0] for c in _TQ_SPEC_CONFIGS],
+)
+def test_tq_spec_real_page_size_bytes_matches_helper(
+    _label, block_size, num_kv_heads, head_dim, k_quant, v_quant
+):
+    spec = TurboQuantAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_dim,
+        dtype=torch.int8,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+    expected = _turboquant_page_size_bytes(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+    assert spec.real_page_size_bytes == expected
+    assert spec.page_size_bytes == expected
+
+
+@pytest.mark.parametrize(
+    "_label, block_size, num_kv_heads, head_dim, k_quant, v_quant",
+    _TQ_SPEC_CONFIGS,
+    ids=[c[0] for c in _TQ_SPEC_CONFIGS],
+)
+def test_tq_spec_head_size_stays_honest(
+    _label, block_size, num_kv_heads, head_dim, k_quant, v_quant
+):
+    """``head_size`` must equal the real model head_dim — no reverse-engineering.
+
+    The old factory set ``head_size_v`` to a synthesised value which went
+    negative for 2-bit K.  The subclass keeps ``head_size`` intact.
+    """
+    spec = TurboQuantAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_dim,
+        dtype=torch.int8,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+    assert spec.head_size == head_dim
+    # head_size_v defaults to head_size via FullAttentionSpec.__post_init__.
+    assert spec.head_size_v == head_dim
+    assert spec.page_size_bytes > 0
+
+
+def test_tq_spec_aggressive_2bit_config_does_not_go_negative():
+    """Regression: ``int2/q2_0`` used to produce negative ``head_size_v``."""
+    spec = _build_turboquant_attention_spec(
+        block_size=16,
+        num_kv_heads=8,
+        head_dim=128,
+        k_quant="int2",
+        v_quant="q2_0",
+    )
+    assert isinstance(spec, TurboQuantAttentionSpec)
+    assert spec.head_size == 128
+    assert spec.head_size_v == 128
+    assert spec.page_size_bytes > 0
+    # 2-bit compression should be notably smaller than an fp16 K+V calc.
+    fp16_page_bytes = 2 * 16 * 8 * 128 * 2
+    assert spec.page_size_bytes < fp16_page_bytes
+
+
+def test_tq_spec_factory_returns_subclass_instance():
+    spec = _build_turboquant_attention_spec(
+        block_size=16,
+        num_kv_heads=4,
+        head_dim=128,
+        k_quant="q8_0",
+        v_quant="q3_0",
+    )
+    assert isinstance(spec, TurboQuantAttentionSpec)
+    assert spec.k_quant == "q8_0"
+    assert spec.v_quant == "q3_0"
+
+
+def test_tq_spec_merge_uniform_specs():
+    specs = [
+        _build_turboquant_attention_spec(
+            block_size=16,
+            num_kv_heads=4,
+            head_dim=128,
+            k_quant="q8_0",
+            v_quant="q3_0",
+        )
+        for _ in range(3)
+    ]
+    merged = TurboQuantAttentionSpec.merge(specs)
+    assert isinstance(merged, TurboQuantAttentionSpec)
+    assert merged.k_quant == "q8_0"
+    assert merged.v_quant == "q3_0"
+    assert merged.page_size_bytes == specs[0].page_size_bytes
+
+
+def test_tq_spec_registered_in_vllm_spec_manager_map():
+    """Importing ``cache_policy`` must register our subclass with vLLM.
+
+    vLLM's ``get_manager_for_kv_cache_spec`` uses strict-type lookup
+    (``spec_manager_map[type(spec)]``), not isinstance. If this assertion
+    fails the engine-core will crash at startup with ``KeyError:
+    TurboQuantAttentionSpec`` the moment TurboQuant is enabled.
+    """
+    from vllm.v1.core.single_type_kv_cache_manager import (
+        FullAttentionManager,
+        spec_manager_map,
+    )
+
+    assert TurboQuantAttentionSpec in spec_manager_map, (
+        "TurboQuantAttentionSpec missing from vLLM's spec_manager_map — "
+        "engine-core will KeyError at startup."
+    )
+    assert spec_manager_map[TurboQuantAttentionSpec] is FullAttentionManager
+
+
+def test_tq_spec_merge_rejects_mixed_quant():
+    a = _build_turboquant_attention_spec(
+        block_size=16, num_kv_heads=4, head_dim=128, k_quant="q8_0", v_quant="q3_0"
+    )
+    b = _build_turboquant_attention_spec(
+        block_size=16, num_kv_heads=4, head_dim=128, k_quant="q4_0", v_quant="q3_0"
+    )
+    with pytest.raises(AssertionError, match="same .k_quant, v_quant."):
+        TurboQuantAttentionSpec.merge([a, b])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -16,6 +16,18 @@ PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION = 0.9
 # Minimum blocks required for paged attention to be usable.
 PAGED_ATTENTION_MIN_BLOCKS = 16
 
+# Valid key quantization types for TurboQuant (mirrors QUANT_PARAMS in turboquant.py).
+# Kept here as a plain set so config can be imported without MLX.
+TURBOQUANT_VALID_K_QUANTS: frozenset[str] = frozenset(
+    {"q8_0", "int8", "uint8", "q5_0", "q4_0", "int4", "uint4", "int2", "uint2"}
+)
+
+# Valid value quantization types for TurboQuant.
+# V uses Lloyd-Max quantization with FWHT rotation.
+TURBOQUANT_VALID_V_QUANTS: frozenset[str] = frozenset(
+    {"q2_0", "q3_0", "q4_0", "q5_0", "q8_0"}
+)
+
 
 @dataclass
 class MetalConfig:
@@ -27,6 +39,9 @@ class MetalConfig:
     block_size: int
     debug: bool
     use_paged_attention: bool = True
+    turboquant: bool = False  # Enable TurboQuant KV cache compression
+    k_quant: str = "q8_0"  # Key quantization type: q8_0, q4_0, int8, uint8, etc.
+    v_quant: str = "q3_0"  # Value quantization type: q2_0, q3_0, q4_0, q5_0 (Lloyd-Max)
 
     def __post_init__(self) -> None:
         if self.block_size <= 0:
@@ -50,6 +65,29 @@ class MetalConfig:
                 raise ValueError(
                     f"Invalid VLLM_METAL_MEMORY_FRACTION={self.memory_fraction}. "
                     "Must be a finite value in (0, 1] when paged attention is enabled."
+                )
+
+        self._validate_turboquant()
+
+    def _validate_turboquant(self) -> None:
+        """Validate TurboQuant configuration."""
+        if self.turboquant:
+            if not self.use_paged_attention:
+                raise ValueError(
+                    "turboquant requires paged attention. "
+                    "TurboQuant KV cache compression only works with paged attention."
+                )
+            if self.k_quant not in TURBOQUANT_VALID_K_QUANTS:
+                available = ", ".join(sorted(TURBOQUANT_VALID_K_QUANTS))
+                raise ValueError(
+                    f"Invalid k_quant={self.k_quant!r}. "
+                    f"Available quantization types: {available}"
+                )
+            if self.v_quant not in TURBOQUANT_VALID_V_QUANTS:
+                available = ", ".join(sorted(TURBOQUANT_VALID_V_QUANTS))
+                raise ValueError(
+                    f"Invalid v_quant={self.v_quant!r}. "
+                    f"Available quantization types: {available}"
                 )
 
     @property
@@ -81,6 +119,8 @@ class MetalConfig:
                 "Must be a positive integer."
             ) from e
 
+        # TurboQuant config is set via --additional-config, not env vars.
+        # See MetalPlatform.check_and_update_config() for how it's applied.
         return cls(
             memory_fraction=memory_fraction,
             use_mlx=envs.VLLM_METAL_USE_MLX,

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -64,11 +64,12 @@ def _build_paged_attention_source() -> str:
 
 
 def _build_v2_paged_attention_source() -> str:
-    """Concatenate float8 + utils + v2 paged_attention (online softmax)."""
+    """Concatenate float8 + utils + turboquant + v2 paged_attention (online softmax)."""
     parts = [
         f"#define VLLM_METAL_PARTITION_SIZE {PARTITION_SIZE}",
         _read_metal_source(_KERNELS_V2_DIR / "float8.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "turboquant.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "pagedattention.metal"),
     ]
     return "\n".join(parts)

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -15,9 +15,8 @@
 using namespace metal;
 
 // ========================================== Generic vector types
-
-// A vector type to store Q, K, V elements.
-template <typename T, int VEC_SIZE> struct Vec {};
+// NOTE: Vec<T, VEC_SIZE> is declared in utils.metal.
+// Specializations for char are in turboquant.metal.
 
 // A vector type to store FP32 accumulators.
 template <typename T> struct FloatVec {};
@@ -784,12 +783,19 @@ inline int find_seq_idx(const device int32_t *cu_seqlens_q,
   return lo;
 }
 
+// ========================================== Function constants
+// NOTE: TurboQuant helpers (Char8_, Vec<char>, is_char, tq_load_k_vec, etc.)
+// are in turboquant.metal, concatenated before this file by the build system.
+
 constant bool use_partitioning [[function_constant(10)]];
 constant bool use_alibi [[function_constant(20)]];
 constant bool use_fp8_scales [[function_constant(30)]];
 constant bool use_sinks [[function_constant(40)]];
+constant bool use_turboquant [[function_constant(50)]];
+constant int k_bits [[function_constant(60)]];
+constant int v_bits [[function_constant(70)]];  // V quantization bit width (default 3)
 
-template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
+template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
           int NUM_THREADS, int NUM_SIMD_LANES, int PARTITION_SIZE = 0>
 [[kernel]] void paged_attention(
     device float *exp_sums
@@ -801,9 +807,9 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
     device T *out
     [[buffer(2)]], // [num_seqs, num_heads, max_num_partitions, head_size]
     device const T *q [[buffer(3)]], // [num_seqs, num_heads, head_size]
-    device const CACHE_T *k_cache
+    device const K_CACHE_T *k_cache
     [[buffer(4)]], // [num_blocks, block_size, num_kv_heads, head_size]
-    device const CACHE_T *v_cache
+    device const V_CACHE_T *v_cache
     [[buffer(5)]], // [num_blocks, block_size, num_kv_heads, head_size]
     const device float *__restrict__ k_scale
     [[buffer(6), function_constant(use_fp8_scales)]], // [1]
@@ -826,6 +832,18 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
     device const int32_t *cu_seqlens_q [[buffer(19)]],  // [num_seqs + 1]
     const constant int &num_seqs [[buffer(20)]],
     const constant int &sliding_window [[buffer(21)]],  // -1 = disabled
+    const device half *key_scale_cache
+    [[buffer(22), function_constant(use_turboquant)]], // [num_blocks, block_size, num_kv_heads, head_size/32]
+    const device half *value_scale_cache
+    [[buffer(23), function_constant(use_turboquant)]], // [num_blocks, block_size, num_kv_heads, head_size/32]
+    const constant int &v_block_stride
+    [[buffer(24), function_constant(use_turboquant)]],
+    const constant int &v_head_stride
+    [[buffer(25), function_constant(use_turboquant)]],
+    const device half *key_zero_cache
+    [[buffer(26), function_constant(use_turboquant)]], // [num_blocks, block_size, num_kv_heads, head_size/32]
+    const device float *v_centroids
+    [[buffer(27), function_constant(use_turboquant)]], // [2^v_bits] Lloyd-Max centroids for V
     threadgroup char *shared_mem [[threadgroup(0)]],
     uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
     uint3 threadgroups_per_grid [[threadgroups_per_grid]],
@@ -899,7 +917,7 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
   constexpr int VEC_SIZE = MAX(16 / (THREAD_GROUP_SIZE * sizeof(T)), 1);
   using K_vec = typename Vec<T, VEC_SIZE>::Type;
   using Q_vec = typename Vec<T, VEC_SIZE>::Type;
-  using Quant_vec = typename Vec<CACHE_T, VEC_SIZE>::Type;
+  using Quant_vec = typename Vec<K_CACHE_T, VEC_SIZE>::Type;
 
   constexpr int NUM_ELEMS_PER_THREAD = HEAD_SIZE / THREAD_GROUP_SIZE;
   constexpr int NUM_VECS_PER_THREAD = NUM_ELEMS_PER_THREAD / VEC_SIZE;
@@ -928,8 +946,11 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
   // for the tree reduction of O accumulators.
   threadgroup float red_smem[2 * NUM_WARPS];
 
-  // Token stride within a block: num_kv_heads * HEAD_SIZE
-  const int kv_token_stride = num_kv_heads * HEAD_SIZE;
+  // Token stride within a block: num_kv_heads * (stride between adjacent KV heads).
+  // For non-TQ / 8-bit K, kv_head_stride == HEAD_SIZE.
+  // For sub-8-bit TQ K, kv_head_stride == k_packed_dim (head_size * k_bits / 8),
+  // so using kv_head_stride here keeps K pointer arithmetic correct in both cases.
+  const int kv_token_stride = num_kv_heads * kv_head_stride;
 
   // ========== Online softmax: per-warp state ==========
   // Each warp maintains its own running (m, l, O) across its KV blocks.
@@ -960,6 +981,11 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
   threadgroup float *warp_scores =
       reinterpret_cast<threadgroup float *>(shared_mem) +
       warp_idx * BLOCK_SIZE;
+  // TurboQuant: per-warp FWHT workspace for V dequantization.
+  // Allocated after warp_scores. Host must provide the extra shmem when use_turboquant.
+  threadgroup float *fwht_buf =
+      reinterpret_cast<threadgroup float *>(shared_mem) +
+      NUM_WARPS * BLOCK_SIZE + warp_idx * HEAD_SIZE;
 
   const device uint32_t *block_table =
       block_tables + seq_idx * max_num_blocks_per_seq;
@@ -981,16 +1007,41 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
 
 #pragma unroll
       for (int j = 0; j < NUM_VECS_PER_THREAD; j++) {
-        const device CACHE_T *k_ptr =
+        const device K_CACHE_T *k_ptr =
             k_cache + physical_block_number * kv_block_stride +
             physical_block_offset * kv_token_stride +
             kv_head_idx * kv_head_stride;
         const int vec_idx = thread_group_offset + j * THREAD_GROUP_SIZE;
 
-        if constexpr (is_uchar<CACHE_T>()) {
-          Quant_vec k_vec_quant = *reinterpret_cast<const device Quant_vec *>(
-              k_ptr + vec_idx * VEC_SIZE);
-          k_vecs[j] = fp8_convert<K_vec, Quant_vec>(k_vec_quant, *k_scale);
+        if constexpr (is_uchar<K_CACHE_T>()) {
+          // uchar K: FP8 (non-TQ) or TurboQuant uint8 / sub-8-bit K path.
+          if (use_turboquant) {
+            constexpr int SCALE_GROUP_SIZE = 32;
+            constexpr int SCALE_GROUPS = HEAD_SIZE / SCALE_GROUP_SIZE;
+            const int64_t k_scale_base_offset =
+                physical_block_number * (int64_t)(BLOCK_SIZE * num_kv_heads * SCALE_GROUPS) +
+                physical_block_offset * (num_kv_heads * SCALE_GROUPS) +
+                kv_head_idx * SCALE_GROUPS;
+            tq_load_k_vec<T, K_CACHE_T, VEC_SIZE>(
+                k_vecs[j], k_ptr, key_scale_cache, key_zero_cache,
+                k_scale_base_offset, vec_idx, k_bits);
+          } else {
+            // FP8 path
+            Quant_vec k_vec_quant = *reinterpret_cast<const device Quant_vec *>(
+                k_ptr + vec_idx * VEC_SIZE);
+            k_vecs[j] = fp8_convert<K_vec, Quant_vec>(k_vec_quant, *k_scale);
+          }
+        } else if constexpr (is_char<K_CACHE_T>()) {
+          // char K: TQ int8 K — always asymmetric dequant (no FP8 for char)
+          constexpr int SCALE_GROUP_SIZE = 32;
+          constexpr int SCALE_GROUPS = HEAD_SIZE / SCALE_GROUP_SIZE;
+          const int64_t k_scale_base_offset =
+              physical_block_number * (int64_t)(BLOCK_SIZE * num_kv_heads * SCALE_GROUPS) +
+              physical_block_offset * (num_kv_heads * SCALE_GROUPS) +
+              kv_head_idx * SCALE_GROUPS;
+          tq_load_k_vec<T, K_CACHE_T, VEC_SIZE>(
+              k_vecs[j], k_ptr, key_scale_cache, key_zero_cache,
+              k_scale_base_offset, vec_idx, k_bits);
         } else {
           k_vecs[j] = *reinterpret_cast<const device K_vec *>(
               k_ptr + vec_idx * VEC_SIZE);
@@ -1071,22 +1122,39 @@ template <typename T, typename CACHE_T, int HEAD_SIZE, int BLOCK_SIZE,
       warp_l += w;
 
       // Load V and accumulate: O += w * V
-      const device CACHE_T *v_ptr =
-          v_cache + physical_block_number * kv_block_stride +
-          tok * kv_token_stride +
-          kv_head_idx * kv_head_stride;
-
+      if (use_turboquant) {
+        // TurboQuant V: 3-bit Lloyd-Max + FWHT dequantization.
+        const device uchar *v_ptr =
+            reinterpret_cast<const device uchar *>(v_cache) +
+            (int64_t)physical_block_number * v_block_stride +
+            tok * (num_kv_heads * v_head_stride) +
+            kv_head_idx * v_head_stride;
+        constexpr int SCALE_GROUP_SIZE = 32;
+        constexpr int SCALE_GROUPS = HEAD_SIZE / SCALE_GROUP_SIZE;
+        const int64_t v_scale_base_offset =
+            physical_block_number * (int64_t)(BLOCK_SIZE * num_kv_heads * SCALE_GROUPS) +
+            tok * (num_kv_heads * SCALE_GROUPS) +
+            kv_head_idx * SCALE_GROUPS;
+        tq_load_and_accumulate_v<HEAD_SIZE, NUM_SIMD_LANES>(
+            v_accs, fwht_buf, v_ptr, value_scale_cache, v_scale_base_offset, w, lane,
+            v_centroids, v_bits);
+      } else {
+        const device V_CACHE_T *v_ptr =
+            v_cache + physical_block_number * kv_block_stride +
+            tok * kv_token_stride +
+            kv_head_idx * kv_head_stride;
 #pragma unroll
-      for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
-        const int d = lane + i * NUM_SIMD_LANES;
-        if (d < HEAD_SIZE) {
-          float v_val;
-          if constexpr (is_uchar<CACHE_T>()) {
-            v_val = fp8_e4m3_to_float(v_ptr[d]) * (*v_scale);
-          } else {
-            v_val = float(v_ptr[d]);
+        for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
+          const int d = lane + i * NUM_SIMD_LANES;
+          if (d < HEAD_SIZE) {
+            float v_val;
+            if constexpr (is_uchar<V_CACHE_T>()) {
+              v_val = fp8_e4m3_to_float(v_ptr[d]) * (*v_scale);
+            } else {
+              v_val = float(v_ptr[d]);
+            }
+            v_accs[i] += w * v_val;
           }
-          v_accs[i] += w * v_val;
         }
       }
     }
@@ -1340,22 +1408,23 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   }
 }
 
-#define instantiate_paged_attention_inner(type, cache_type, head_size,         \
-                                          block_size, num_threads,             \
+#define instantiate_paged_attention_inner(type, k_cache_type, v_cache_type,    \
+                                          head_size, block_size, num_threads,  \
                                           num_simd_lanes, partition_size)      \
-  template [[host_name("paged_attention_" #type "_cache_" #cache_type          \
+  template [[host_name("paged_attention_" #type "_cache_" #k_cache_type        \
+                       "_" #v_cache_type                                       \
                        "_hs" #head_size "_bs" #block_size "_nt" #num_threads   \
                        "_nsl" #num_simd_lanes                                  \
                        "_ps" #partition_size)]] [[kernel]] void                \
-  paged_attention<type, cache_type, head_size, block_size, num_threads,        \
-                  num_simd_lanes, partition_size>(                             \
+  paged_attention<type, k_cache_type, v_cache_type, head_size, block_size,     \
+                  num_threads, num_simd_lanes, partition_size>(                \
       device float *exp_sums                                                   \
       [[buffer(0), function_constant(use_partitioning)]],                      \
       device float *max_logits                                                 \
       [[buffer(1), function_constant(use_partitioning)]],                      \
       device type *out [[buffer(2)]], device const type *q [[buffer(3)]],      \
-      device const cache_type *k_cache [[buffer(4)]],                          \
-      device const cache_type *v_cache [[buffer(5)]],                          \
+      device const k_cache_type *k_cache [[buffer(4)]],                        \
+      device const v_cache_type *v_cache [[buffer(5)]],                        \
       device const float *k_scale                                              \
       [[buffer(6), function_constant(use_fp8_scales)]],                        \
       device const float *v_scale                                              \
@@ -1375,6 +1444,18 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
       device const int32_t *cu_seqlens_q [[buffer(19)]],                       \
       const constant int &num_seqs [[buffer(20)]],                             \
       const constant int &sliding_window [[buffer(21)]],                       \
+      const device half *key_scale_cache                                       \
+      [[buffer(22), function_constant(use_turboquant)]],                       \
+      const device half *value_scale_cache                                     \
+      [[buffer(23), function_constant(use_turboquant)]],                       \
+      const constant int &v_block_stride                                       \
+      [[buffer(24), function_constant(use_turboquant)]],                       \
+      const constant int &v_head_stride                                        \
+      [[buffer(25), function_constant(use_turboquant)]],                       \
+      const device half *key_zero_cache                                        \
+      [[buffer(26), function_constant(use_turboquant)]],                       \
+      const device float *v_centroids                                          \
+      [[buffer(27), function_constant(use_turboquant)]],                       \
       threadgroup char *shared_mem [[threadgroup(0)]],                         \
       uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],     \
       uint3 threadgroups_per_grid [[threadgroups_per_grid]],                   \
@@ -1407,30 +1488,31 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
       uint simd_lid [[thread_index_in_simdgroup]]);
 
 #define instantiate_paged_attention_heads(                                     \
-    type, cache_type, block_size, num_threads, num_simd_lanes, partition_size) \
-  instantiate_paged_attention_inner(type, cache_type, 64, block_size,          \
-                                    num_threads, num_simd_lanes,               \
+    type, k_cache_type, v_cache_type, block_size, num_threads,                 \
+    num_simd_lanes, partition_size)                                            \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 64,      \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 80, block_size,          \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 80,      \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 96, block_size,          \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 96,      \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 112, block_size,         \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 112,     \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 128, block_size,         \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 128,     \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 192, block_size,         \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 192,     \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 256, block_size,         \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 256,     \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);                           \
-  instantiate_paged_attention_inner(type, cache_type, 512, block_size,         \
-                                    num_threads, num_simd_lanes,               \
+  instantiate_paged_attention_inner(type, k_cache_type, v_cache_type, 512,     \
+                                    block_size, num_threads, num_simd_lanes,   \
                                     partition_size);
 
 #define instantiate_paged_attention_v2_reduce_heads(                           \
@@ -1452,26 +1534,32 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   instantiate_paged_attention_v2_reduce_inner(type, 512, num_threads,          \
                                               num_simd_lanes, partition_size);
 
-#define instantiate_paged_attention_block_size(type, cache_type, num_threads,  \
+#define instantiate_paged_attention_block_size(type, k_cache_type,             \
+                                               v_cache_type, num_threads,      \
                                                num_simd_lanes, partition_size) \
-  instantiate_paged_attention_heads(type, cache_type, 8, num_threads,          \
-                                    num_simd_lanes, partition_size);           \
-  instantiate_paged_attention_heads(type, cache_type, 16, num_threads,         \
-                                    num_simd_lanes, partition_size);           \
-  instantiate_paged_attention_heads(type, cache_type, 32, num_threads,         \
-                                    num_simd_lanes, partition_size);
+  instantiate_paged_attention_heads(type, k_cache_type, v_cache_type, 8,       \
+                                    num_threads, num_simd_lanes,               \
+                                    partition_size);                           \
+  instantiate_paged_attention_heads(type, k_cache_type, v_cache_type, 16,      \
+                                    num_threads, num_simd_lanes,               \
+                                    partition_size);                           \
+  instantiate_paged_attention_heads(type, k_cache_type, v_cache_type, 32,      \
+                                    num_threads, num_simd_lanes,               \
+                                    partition_size);
 
 // TODO: tune num_threads = 256
 // NOTE: partition_size = 0
-#define instantiate_paged_attention_v1(type, cache_type, num_simd_lanes)       \
-  instantiate_paged_attention_block_size(type, cache_type, 256,                \
-                                         num_simd_lanes, 0);
+#define instantiate_paged_attention_v1(type, k_cache_type, v_cache_type,       \
+                                       num_simd_lanes)                         \
+  instantiate_paged_attention_block_size(type, k_cache_type, v_cache_type,     \
+                                         256, num_simd_lanes, 0);
 
 // TODO: tune num_threads = 256
 // NOTE: partition_size = VLLM_METAL_PARTITION_SIZE
-#define instantiate_paged_attention_v2(type, cache_type, num_simd_lanes)       \
-  instantiate_paged_attention_block_size(type, cache_type, 256,                \
-                                         num_simd_lanes,                        \
+#define instantiate_paged_attention_v2(type, k_cache_type, v_cache_type,       \
+                                       num_simd_lanes)                         \
+  instantiate_paged_attention_block_size(type, k_cache_type, v_cache_type,     \
+                                         256, num_simd_lanes,                  \
                                          VLLM_METAL_PARTITION_SIZE);
 
 // TODO: tune num_threads = 256
@@ -1480,22 +1568,34 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   instantiate_paged_attention_v2_reduce_heads(                                  \
       type, 256, num_simd_lanes, VLLM_METAL_PARTITION_SIZE);
 
-instantiate_paged_attention_v1(float, float, 32);
-instantiate_paged_attention_v1(bfloat16_t, bfloat16_t, 32);
-instantiate_paged_attention_v1(half, half, 32);
+// Non-TQ: same K/V cache type (kernel name: paged_attention_<T>_cache_<CT>_<CT>_hs...)
+instantiate_paged_attention_v1(float, float, float, 32);
+instantiate_paged_attention_v1(bfloat16_t, bfloat16_t, bfloat16_t, 32);
+instantiate_paged_attention_v1(half, half, half, 32);
 
-instantiate_paged_attention_v1(float, uchar, 32);
-instantiate_paged_attention_v1(bfloat16_t, uchar, 32);
-instantiate_paged_attention_v1(half, uchar, 32);
+// FP8 non-TQ (uchar K + uchar V)
+instantiate_paged_attention_v1(float, uchar, uchar, 32);
+instantiate_paged_attention_v1(bfloat16_t, uchar, uchar, 32);
+instantiate_paged_attention_v1(half, uchar, uchar, 32);
 
 instantiate_paged_attention_v2_reduce(float, 32);
 instantiate_paged_attention_v2_reduce(bfloat16_t, 32);
 instantiate_paged_attention_v2_reduce(half, 32);
 
-instantiate_paged_attention_v2(float, float, 32);
-instantiate_paged_attention_v2(bfloat16_t, bfloat16_t, 32);
-instantiate_paged_attention_v2(half, half, 32);
+instantiate_paged_attention_v2(float, float, float, 32);
+instantiate_paged_attention_v2(bfloat16_t, bfloat16_t, bfloat16_t, 32);
+instantiate_paged_attention_v2(half, half, half, 32);
 
-instantiate_paged_attention_v2(float, uchar, 32);
-instantiate_paged_attention_v2(bfloat16_t, uchar, 32);
-instantiate_paged_attention_v2(half, uchar, 32);
+// FP8 non-TQ (uchar K + uchar V) — also used for TQ uint8 K (differentiated by use_turboquant FC)
+instantiate_paged_attention_v2(float, uchar, uchar, 32);
+instantiate_paged_attention_v2(bfloat16_t, uchar, uchar, 32);
+instantiate_paged_attention_v2(half, uchar, uchar, 32);
+
+// TurboQuant: int8 K (char) + 3-bit V (uchar) — both non-partitioned (ps0) and partitioned
+instantiate_paged_attention_v1(float, char, uchar, 32);
+instantiate_paged_attention_v1(bfloat16_t, char, uchar, 32);
+instantiate_paged_attention_v1(half, char, uchar, 32);
+
+instantiate_paged_attention_v2(float, char, uchar, 32);
+instantiate_paged_attention_v2(bfloat16_t, char, uchar, 32);
+instantiate_paged_attention_v2(half, char, uchar, 32);

--- a/vllm_metal/metal/kernels_v2/turboquant.metal
+++ b/vllm_metal/metal/kernels_v2/turboquant.metal
@@ -1,0 +1,316 @@
+// TurboQuant KV cache compression helpers for Metal paged attention.
+// This file is included by pagedattention.metal after Vec<> is declared.
+//
+// TurboQuant uses:
+// - K: Asymmetric uniform quantization (int8/uint8 or sub-8-bit packed)
+// - V: 3-bit Lloyd-Max quantization with FWHT rotation
+//
+// Copyright contributors to the vLLM project
+// Licensed under the Apache License 2.0
+
+#pragma once
+
+// NOTE: This header is included by pagedattention.metal which already has:
+//   #include <metal_stdlib>
+//   #include <metal_simdgroup>
+//   using namespace metal;
+//   template <typename T, int VEC_SIZE> struct Vec {};
+
+// ========================================== int8 (char) vector data types
+// Used by TurboQuant int8 K cache (K_CACHE_T = char).
+
+struct Char8_ {
+    char4 x;
+    char4 y;
+};
+
+template <> struct Vec<char, 1> { using Type = char; };
+template <> struct Vec<char, 2> { using Type = char2; };
+template <> struct Vec<char, 4> { using Type = char4; };
+template <> struct Vec<char, 8> { using Type = Char8_; };
+
+// ========================================== Type trait for signed char
+
+template <typename T> inline constexpr bool is_char() { return false; }
+template <> inline constexpr bool is_char<char>() { return true; }
+
+// ========================================== Sub-8-bit unpacking
+
+// Generic sub-8-bit unpack from a packed byte stream.
+// Layout: element i occupies bits [i*bits, i*bits + bits) in the packed
+// byte stream (little-endian within each byte). A value spans at most
+// two consecutive bytes for any bits <= 8.
+inline uint unpack_k_bits(const device uchar* bytes, int elem_idx, int bits) {
+    int bit_pos = elem_idx * bits;
+    int byte_idx = bit_pos >> 3;        // bit_pos / 8
+    int bit_offset = bit_pos & 7;       // bit_pos % 8
+    uint raw = uint(bytes[byte_idx]);
+    if (bit_offset + bits > 8) {
+        raw |= uint(bytes[byte_idx + 1]) << 8;
+    }
+    return (raw >> bit_offset) & ((1u << bits) - 1u);
+}
+
+// Unpack a single 3-bit value from packed bytes (8 values per 3 bytes).
+// Used for V cache.
+inline uchar unpack_3bit(const device uchar* packed, int elem_idx) {
+    int group = elem_idx / 8;
+    int pos = elem_idx % 8;
+    int byte_base = group * 3;
+    uint b0 = packed[byte_base];
+    uint b1 = packed[byte_base + 1];
+    uint b2 = packed[byte_base + 2];
+    uint combined = b0 | (b1 << 8) | (b2 << 16);
+    return uchar((combined >> (pos * 3)) & 0x7);
+}
+
+// ========================================== FWHT random sign tables
+// Deterministic random signs — matches Python: key=mx.random.key(42)
+// Generated via: signs = 1 - 2 * mx.random.randint(0, 2, shape=(N,), key=mx.random.key(42))
+
+constant float FWHT_SIGNS_64[64] = {
+     1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,
+    -1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f,
+     1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,
+     1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f
+};
+
+constant float FWHT_SIGNS_128[128] = {
+    -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,
+    -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f,
+     1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,
+     1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f,
+    -1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,
+    -1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,
+     1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f, -1.f,  1.f,
+     1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f
+};
+
+constant float FWHT_SIGNS_256[256] = {
+     1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,
+     1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,
+    -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,
+    -1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
+    -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
+    -1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,
+    -1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,
+     1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f,
+    -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f, -1.f,
+    -1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f,
+    -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,
+    -1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f, -1.f,
+    -1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f,
+     1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,
+    -1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,
+    -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f, -1.f, -1.f
+};
+
+// ========================================== K dequantization
+
+// TurboQuant K dequant: asymmetric uniform quantization — (idx + zp) * scale
+// Uchar overload for uint8 and sub-8-bit raw values (unsigned).
+inline float tq_dequant_k(uchar index, float scale, float zero_point) {
+    return (float(index) + zero_point) * scale;
+}
+
+// Char overload for int8 / q8_0 (signed).
+inline float tq_dequant_k(char index, float scale, float zero_point) {
+    return (float(index) + zero_point) * scale;
+}
+
+// Explicit uint overload for sub-8-bit raw values returned by unpack_k_bits.
+inline float tq_dequant_k_raw(uint index, float scale, float zero_point) {
+    return (float(index) + zero_point) * scale;
+}
+
+// ========================================== V dequantization
+
+// TurboQuant V dequant: Lloyd-Max centroid lookup (arbitrary bit width)
+// centroids: pointer to 2^bits centroid values (passed from Python)
+// v_bits: quantization bit width (used to mask index)
+inline float tq_dequant_v_centroid(uchar index, float scale, const device float* centroids, int v_bits) {
+    uint mask = (1u << v_bits) - 1u;
+    return centroids[index & mask] * scale;
+}
+
+// ========================================== FWHT sign lookup
+
+// FWHT sign lookup by HEAD_SIZE — supported for 64, 128, and 256.
+// The primary template returns 1.f and is never called for TQ-enabled kernels
+// (runtime guard in MetalPagedKVCache enforces valid sizes), but must exist
+// to satisfy the compiler for non-TQ specializations of other head sizes.
+template<int HEAD_SIZE> inline float get_fwht_sign(uint idx) { return 1.f; }
+template<> inline float get_fwht_sign<64>(uint idx)  { return FWHT_SIGNS_64[idx]; }
+template<> inline float get_fwht_sign<128>(uint idx) { return FWHT_SIGNS_128[idx]; }
+template<> inline float get_fwht_sign<256>(uint idx) { return FWHT_SIGNS_256[idx]; }
+
+// ========================================== Inverse FWHT
+
+// In-place inverse FWHT for HEAD_SIZE elements using threadgroup memory.
+// Supports HEAD_SIZE = 64 (6 stages), 128 (7 stages), or 256 (8 stages).
+// Each SIMD lane owns HEAD_SIZE/32 elements (lane i → indices i, i+32, i+64, ...).
+template<int HEAD_SIZE>
+inline void threadgroup_inverse_fwht(threadgroup float* fwht_buf, uint lane) {
+    constexpr int NUM_STAGES = (HEAD_SIZE == 64) ? 6 : (HEAD_SIZE == 128) ? 7 : 8;
+    constexpr int ELEMS_PER_LANE = HEAD_SIZE / 32;
+    float vals[ELEMS_PER_LANE];
+
+    #pragma unroll
+    for (int stage = 0; stage < NUM_STAGES; stage++) {
+        uint mask = 1u << stage;
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+            vals[e] = fwht_buf[lane + e * 32];
+        }
+        if (mask < 32) {
+            // Partners in different lanes — safe to read from threadgroup memory
+            #pragma unroll
+            for (int e = 0; e < ELEMS_PER_LANE; e++) {
+                uint idx = lane + e * 32;
+                float partner_val = fwht_buf[idx ^ mask];
+                fwht_buf[idx] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
+            }
+        } else {
+            // Partner owned by this thread at a different e offset
+            float results[ELEMS_PER_LANE];
+            #pragma unroll
+            for (int e = 0; e < ELEMS_PER_LANE; e++) {
+                uint idx = lane + e * 32;
+                uint partner_idx = idx ^ mask;
+                int partner_e = static_cast<int>((partner_idx - lane) / 32);
+                float partner_val = vals[partner_e];
+                results[e] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
+            }
+            #pragma unroll
+            for (int e = 0; e < ELEMS_PER_LANE; e++) {
+                fwht_buf[lane + e * 32] = results[e];
+            }
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    // Normalisation: 1/sqrt(HEAD_SIZE) + random sign flip
+    constexpr float INV_SQRT_N = (HEAD_SIZE == 64) ? 0.125f : (HEAD_SIZE == 128) ? 0.08838834764831843f : 0.0625f;
+    #pragma unroll
+    for (int e = 0; e < ELEMS_PER_LANE; e++) {
+        uint idx = lane + e * 32;
+        fwht_buf[idx] *= INV_SQRT_N * get_fwht_sign<HEAD_SIZE>(idx);
+    }
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+// ========================================== High-level K/V load helpers
+
+// Load and dequantize a K vector for TurboQuant.
+// Handles both 8-bit (char/uchar) and sub-8-bit packed formats.
+template <typename T, typename K_CACHE_T, int VEC_SIZE>
+inline void tq_load_k_vec(
+    thread typename Vec<T, VEC_SIZE>::Type& k_vec_out,
+    const device K_CACHE_T* k_ptr,
+    const device half* key_scale_cache,
+    const device half* key_zero_cache,
+    int64_t k_scale_base_offset,
+    int vec_idx,
+    int k_bits
+) {
+    constexpr int SCALE_GROUP_SIZE = 32;
+    using K_vec = typename Vec<T, VEC_SIZE>::Type;
+    K_vec k_vec_result;
+    thread T* result_ptr = reinterpret_cast<thread T*>(&k_vec_result);
+
+    if constexpr (is_char<K_CACHE_T>()) {
+        // int8 K path (signed)
+        const device K_CACHE_T* k_elem_ptr = k_ptr + vec_idx * VEC_SIZE;
+        #pragma unroll
+        for (int e = 0; e < VEC_SIZE; e++) {
+            int elem_idx = vec_idx * VEC_SIZE + e;
+            int group_idx = elem_idx / SCALE_GROUP_SIZE;
+            float s = key_scale_cache[k_scale_base_offset + group_idx];
+            float z = key_zero_cache[k_scale_base_offset + group_idx];
+            result_ptr[e] = T(tq_dequant_k(k_elem_ptr[e], s, z));
+        }
+    } else {
+        // uchar K path (uint8 or sub-8-bit packed)
+        if (k_bits >= 8) {
+            // 8-bit unsigned: one byte per element
+            const device uchar* k_elem_ptr = reinterpret_cast<const device uchar*>(k_ptr) + vec_idx * VEC_SIZE;
+            #pragma unroll
+            for (int e = 0; e < VEC_SIZE; e++) {
+                int elem_idx = vec_idx * VEC_SIZE + e;
+                int group_idx = elem_idx / SCALE_GROUP_SIZE;
+                float s = key_scale_cache[k_scale_base_offset + group_idx];
+                float z = key_zero_cache[k_scale_base_offset + group_idx];
+                result_ptr[e] = T(tq_dequant_k(k_elem_ptr[e], s, z));
+            }
+        } else {
+            // Sub-8-bit packed: unpack k_bits bits per logical element
+            const device uchar* k_bytes = reinterpret_cast<const device uchar*>(k_ptr);
+            #pragma unroll
+            for (int e = 0; e < VEC_SIZE; e++) {
+                int elem_idx = vec_idx * VEC_SIZE + e;
+                int group_idx = elem_idx / SCALE_GROUP_SIZE;
+                float s = key_scale_cache[k_scale_base_offset + group_idx];
+                float z = key_zero_cache[k_scale_base_offset + group_idx];
+                uint raw = unpack_k_bits(k_bytes, elem_idx, k_bits);
+                result_ptr[e] = T(tq_dequant_k_raw(raw, s, z));
+            }
+        }
+    }
+    k_vec_out = k_vec_result;
+}
+
+// Generic sub-v_bits unpack from a packed byte stream (mirrors unpack_k_bits).
+inline uint unpack_v_bits(const device uchar* bytes, int elem_idx, int bits) {
+    int bit_pos = elem_idx * bits;
+    int byte_idx = bit_pos >> 3;        // bit_pos / 8
+    int bit_offset = bit_pos & 7;       // bit_pos % 8
+    uint raw = uint(bytes[byte_idx]);
+    if (bit_offset + bits > 8) {
+        raw |= uint(bytes[byte_idx + 1]) << 8;
+    }
+    return (raw >> bit_offset) & ((1u << bits) - 1u);
+}
+
+// Load, dequantize, inverse-FWHT, and accumulate a V vector for TurboQuant.
+// This handles the full V pipeline: unpack v_bits → centroid lookup → FWHT → accumulate.
+// v_bits: quantization bit width (passed as function constant from kernel)
+// v_centroids: pointer to 2^v_bits centroid values
+template <int HEAD_SIZE, int NUM_SIMD_LANES>
+inline void tq_load_and_accumulate_v(
+    thread float* v_accs,
+    threadgroup float* fwht_buf,
+    const device uchar* v_ptr,
+    const device half* value_scale_cache,
+    int64_t v_scale_base_offset,
+    float weight,
+    uint lane,
+    const device float* v_centroids,
+    int v_bits
+) {
+    constexpr int SCALE_GROUP_SIZE = 32;
+    constexpr int V_ELEMS_PER_THREAD = (HEAD_SIZE + NUM_SIMD_LANES - 1) / NUM_SIMD_LANES;
+
+    // Load packed v_bits V, dequantize via centroid lookup, write to fwht_buf
+    #pragma unroll
+    for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
+        const int d = lane + i * NUM_SIMD_LANES;
+        if (d < HEAD_SIZE) {
+            int group_idx = d / SCALE_GROUP_SIZE;
+            float vs = value_scale_cache[v_scale_base_offset + group_idx];
+            uchar v_idx = (v_bits == 3) ? unpack_3bit(v_ptr, d) : uchar(unpack_v_bits(v_ptr, d, v_bits));
+            fwht_buf[d] = tq_dequant_v_centroid(v_idx, vs, v_centroids, v_bits);
+        }
+    }
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Apply inverse FWHT to reconstruct the original V vector
+    threadgroup_inverse_fwht<HEAD_SIZE>(fwht_buf, lane);
+
+    // Accumulate: O += weight * V_reconstructed
+    #pragma unroll
+    for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
+        const int d = lane + i * NUM_SIMD_LANES;
+        if (d < HEAD_SIZE) {
+            v_accs[i] += weight * fwht_buf[d];
+        }
+    }
+}

--- a/vllm_metal/metal/kernels_v2/utils.metal
+++ b/vllm_metal/metal/kernels_v2/utils.metal
@@ -5,8 +5,14 @@
 
 #include "float8.metal"
 #include <metal_stdlib>
+#include <metal_simdgroup>
 
 using namespace metal;
+
+// ========================================== Generic vector types
+// Forward declaration for Vec template, specialized in pagedattention.metal
+// and turboquant.metal for various types.
+template <typename T, int VEC_SIZE> struct Vec {};
 
 #if defined(__HAVE_BFLOAT__)
 

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <string>
+#include <unordered_map>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
@@ -66,10 +67,26 @@ static std::string dtype_to_metal(Dtype dt) {
     case float16:   return "half";
     case bfloat16:  return "bfloat16_t";
     case float32:   return "float";
+    case int8:      return "char";
+    case uint8:     return "uchar";
     default:
       throw std::runtime_error(
           "Unsupported dtype for paged attention kernel");
   }
+}
+
+static int get_bits(const std::string& quant_type) {
+  static const std::unordered_map<std::string, int> BITS = {
+      {"q8_0", 8}, {"int8", 8}, {"uint8", 8},
+      {"q5_0", 5},
+      {"q4_0", 4}, {"int4", 4}, {"uint4", 4},
+      {"int2", 2}, {"uint2", 2},
+  };
+  auto it = BITS.find(quant_type);
+  if (it == BITS.end()) {
+    throw std::runtime_error("Unknown quant_type: " + quant_type);
+  }
+  return it->second;
 }
 
 // ---------------------------------------------------------------------------
@@ -270,7 +287,15 @@ static void dispatch_paged_attention_v2_online(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window, Stream s,
-    bool from_primitive = false) {
+    bool from_primitive = false,
+    // TurboQuant (optional, all nullptr when disabled):
+    const array* key_scale_cache = nullptr,
+    const array* value_scale_cache = nullptr,
+    const array* key_zero_cache = nullptr,
+    const array* v_centroids = nullptr,
+    bool use_turboquant = false,
+    int k_bits = 8,
+    int v_bits = 3) {
   auto& d = metal::device(s.device);
 
   int total_q_tokens = static_cast<int>(query.shape(0));
@@ -279,25 +304,42 @@ static void dispatch_paged_attention_v2_online(
   int max_blocks = static_cast<int>(block_tables.shape(1));
   int num_seqs   = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
 
-  auto dt = dtype_to_metal(query.dtype());
+  // 3-part kernel name: paged_attention_<T>_cache_<K>_<V>_hs...
+  auto dt        = dtype_to_metal(query.dtype());
+  auto k_cache_dt = dtype_to_metal(key_cache.dtype());
+  auto v_cache_dt = dtype_to_metal(value_cache.dtype());
   std::string kname =
-      "paged_attention_" + dt + "_cache_" + dt +
+      "paged_attention_" + dt + "_cache_" + k_cache_dt + "_" + v_cache_dt +
       "_hs" + std::to_string(head_size) +
       "_bs" + std::to_string(block_size) +
       "_nt256_nsl32_ps0";
 
-  bool use_partitioning = false;
-  bool use_alibi        = false;
-  bool use_fp8          = false;
-  bool use_sinks        = false;
+  bool use_partitioning  = false;
+  bool use_alibi         = false;
+  bool use_fp8           = false;
+  bool use_sinks         = false;
+  bool use_tq_fc         = use_turboquant;
+  int  k_bits_i          = k_bits;
+  int  v_bits_i          = v_bits;
+
+  // The hash name is MLX's cache key. It MUST encode every function-constant
+  // value that varies across calls — otherwise the first compilation wins and
+  // subsequent calls with different constants silently reuse the wrong kernel.
+  std::string hash_name = kname + "_v2"
+      + "_tq" + (use_tq_fc ? "1" : "0")
+      + "_kb" + std::to_string(k_bits_i)
+      + "_vb" + std::to_string(v_bits_i);
 
   auto* lib = d.get_library("paged_attention_v2_kern");
   auto* kernel = d.get_kernel(
-      kname, lib, kname + "_v2",
+      kname, lib, hash_name,
       {{&use_partitioning, MTL::DataType::DataTypeBool, NS::UInteger(10)},
        {&use_alibi,        MTL::DataType::DataTypeBool, NS::UInteger(20)},
        {&use_fp8,          MTL::DataType::DataTypeBool, NS::UInteger(30)},
-       {&use_sinks,        MTL::DataType::DataTypeBool, NS::UInteger(40)}});
+       {&use_sinks,        MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_tq_fc,        MTL::DataType::DataTypeBool, NS::UInteger(50)},
+       {&k_bits_i,         MTL::DataType::DataTypeInt,  NS::UInteger(60)},
+       {&v_bits_i,         MTL::DataType::DataTypeInt,  NS::UInteger(70)}});
 
   constexpr int NUM_THREADS    = 256;
   constexpr int NUM_SIMD_LANES = 32;
@@ -306,6 +348,10 @@ static void dispatch_paged_attention_v2_online(
                           * static_cast<int>(sizeof(float));
   int merge_bytes = (2 * NUM_WARPS + NUM_WARPS * head_size)
                     * static_cast<int>(sizeof(float));
+  // TurboQuant: add per-warp FWHT buffer (NUM_WARPS * head_size floats)
+  if (use_turboquant) {
+    warp_scores_bytes += NUM_WARPS * head_size * static_cast<int>(sizeof(float));
+  }
   size_t shmem = static_cast<size_t>(std::max(warp_scores_bytes, merge_bytes));
 
   auto& enc = d.get_command_encoder(s.index);
@@ -342,6 +388,19 @@ static void dispatch_paged_attention_v2_online(
   int32_t sliding_window_i = static_cast<int32_t>(sliding_window);
   enc.set_bytes(sliding_window_i, 21);
 
+  // TurboQuant buffers (slots 22-27, only bound when use_turboquant)
+  if (use_turboquant) {
+    enc.set_input_array(*key_scale_cache,   22);
+    enc.set_input_array(*value_scale_cache, 23);
+    // v_block_stride = value_cache.strides()[0], v_head_stride = value_cache.strides()[2]
+    int32_t v_block_stride_i = static_cast<int32_t>(value_cache.strides()[0]);
+    int32_t v_head_stride_i  = static_cast<int32_t>(value_cache.strides()[2]);
+    enc.set_bytes(v_block_stride_i, 24);
+    enc.set_bytes(v_head_stride_i,  25);
+    enc.set_input_array(*key_zero_cache, 26);
+    enc.set_input_array(*v_centroids, 27);
+  }
+
   enc.dispatch_threadgroups(
       MTL::Size::Make(num_heads, total_q_tokens, 1),
       MTL::Size::Make(NUM_THREADS, 1, 1));
@@ -354,6 +413,12 @@ static void dispatch_paged_attention_v2_online(
     d.add_temporary(block_tables, s.index);
     d.add_temporary(seq_lens, s.index);
     d.add_temporary(cu_seqlens_q, s.index);
+    if (use_turboquant) {
+      d.add_temporary(*key_scale_cache, s.index);
+      d.add_temporary(*value_scale_cache, s.index);
+      d.add_temporary(*key_zero_cache, s.index);
+      d.add_temporary(*v_centroids, s.index);
+    }
   }
 }
 
@@ -414,9 +479,11 @@ void paged_attention_v2_online_impl_common(
   bool use_partitioning =
       kPartitionSize % block_size == 0 && max_num_partitions > 1;
 
-  auto dt = dtype_to_metal(query.dtype());
+  auto dt        = dtype_to_metal(query.dtype());
+  auto k_cache_dt = dtype_to_metal(key_cache.dtype());
+  auto v_cache_dt = dtype_to_metal(value_cache.dtype());
   std::string kname =
-      "paged_attention_" + dt + "_cache_" + dt +
+      "paged_attention_" + dt + "_cache_" + k_cache_dt + "_" + v_cache_dt +
       "_hs" + std::to_string(head_size) +
       "_bs" + std::to_string(block_size) +
       "_nt256_nsl32_ps" +
@@ -425,14 +492,23 @@ void paged_attention_v2_online_impl_common(
   bool use_alibi        = false;
   bool use_fp8          = false;
   bool use_sinks        = sinks != nullptr;
+  bool use_tq_fc        = false;
+  int  k_bits_i         = 8;
+
+  // Same hash-name discipline as v2: encode every varying function constant
+  // (use_sinks here) so MLX doesn't reuse a stale specialization.
+  std::string hash_name = kname + "_v2"
+      + "_sinks" + (use_sinks ? "1" : "0");
 
   auto* lib = d.get_library("paged_attention_v2_kern");
   auto* kernel = d.get_kernel(
-      kname, lib, kname + "_v2",
+      kname, lib, hash_name,
       {{&use_partitioning, MTL::DataType::DataTypeBool, NS::UInteger(10)},
        {&use_alibi,        MTL::DataType::DataTypeBool, NS::UInteger(20)},
        {&use_fp8,          MTL::DataType::DataTypeBool, NS::UInteger(30)},
-       {&use_sinks,        MTL::DataType::DataTypeBool, NS::UInteger(40)}});
+       {&use_sinks,        MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_tq_fc,        MTL::DataType::DataTypeBool, NS::UInteger(50)},
+       {&k_bits_i,         MTL::DataType::DataTypeInt,  NS::UInteger(60)}});
 
   constexpr int NUM_THREADS    = 256;
   constexpr int NUM_SIMD_LANES = 32;
@@ -553,11 +629,13 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
  public:
   PagedAttentionPrimitive(
       Stream stream, int num_kv_heads, float scale, float softcap,
-      int block_size, int max_seq_len, int sliding_window)
+      int block_size, int max_seq_len, int sliding_window,
+      bool use_turboquant = false, int k_bits = 8, int v_bits = 3)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
-        sliding_window_(sliding_window) {}
+        sliding_window_(sliding_window),
+        use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -565,9 +643,14 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   }
 
   void eval_gpu(const std::vector<array>& inputs, array& out) override {
-    // inputs: [query, key_cache, value_cache, block_tables, seq_lens,
-    //          cu_seqlens_q]
+    // Non-TQ inputs: [query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q]
+    // TQ inputs:     [query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q,
+    //                 key_scale_cache, value_scale_cache, key_zero_cache, v_centroids]
     out.set_data(allocator::malloc(out.nbytes()));
+    const array* ks = use_turboquant_ ? &inputs[6] : nullptr;
+    const array* vs = use_turboquant_ ? &inputs[7] : nullptr;
+    const array* kz = use_turboquant_ ? &inputs[8] : nullptr;
+    const array* vc = use_turboquant_ ? &inputs[9] : nullptr;
     dispatch_paged_attention_v2_online(
         out,
         inputs[0],               // query
@@ -576,7 +659,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_,
         stream(),
-        /*from_primitive=*/true);
+        /*from_primitive=*/true,
+        ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_);
   }
 
   const char* name() const override { return "PagedAttention"; }
@@ -587,7 +671,10 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->scale_ == scale_ && rhs->softcap_ == softcap_
         && rhs->block_size_ == block_size_
         && rhs->max_seq_len_ == max_seq_len_
-        && rhs->sliding_window_ == sliding_window_;
+        && rhs->sliding_window_ == sliding_window_
+        && rhs->use_turboquant_ == use_turboquant_
+        && rhs->k_bits_ == k_bits_
+        && rhs->v_bits_ == v_bits_;
   }
 
  private:
@@ -597,6 +684,9 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int block_size_;
   int max_seq_len_;
   int sliding_window_;
+  bool use_turboquant_;
+  int k_bits_;
+  int v_bits_;
 };
 
 static array paged_attention_primitive_fn(
@@ -605,11 +695,25 @@ static array paged_attention_primitive_fn(
     int num_kv_heads, float scale, float softcap,
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
-    int block_size, int max_seq_len, int sliding_window) {
+    int block_size, int max_seq_len, int sliding_window,
+    bool use_turboquant = false, const std::string& quant_type = "",
+    const array* key_scale_cache = nullptr,
+    const array* value_scale_cache = nullptr,
+    const array* key_zero_cache = nullptr,
+    const array* v_centroids = nullptr,
+    int v_bits = 3) {
+  int k_bits = use_turboquant ? get_bits(quant_type) : 8;
   auto prim = std::make_shared<PagedAttentionPrimitive>(
       default_stream(Device::gpu),
       num_kv_heads, scale, softcap,
-      block_size, max_seq_len, sliding_window);
+      block_size, max_seq_len, sliding_window,
+      use_turboquant, k_bits, v_bits);
+  if (use_turboquant) {
+    return array(
+        query.shape(), query.dtype(), std::move(prim),
+        {query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q,
+         *key_scale_cache, *value_scale_cache, *key_zero_cache, *v_centroids});
+  }
   return array(
       query.shape(), query.dtype(), std::move(prim),
       {query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q});
@@ -840,7 +944,22 @@ NB_MODULE(_paged_ops, m) {
            nb::handle block_tables_h, nb::handle seq_lens_h,
            nb::handle cu_seqlens_q_h,
            int block_size, int max_seq_len, int sliding_window,
-           nb::handle out_h) {
+           nb::handle out_h,
+           nb::object key_scale_cache_h,
+           nb::object value_scale_cache_h,
+           nb::object key_zero_cache_h,
+           nb::object v_centroids_h,
+           bool use_turboquant,
+           const std::string& quant_type,
+           int v_bits) {
+          const array* ks = use_turboquant
+              ? nb::inst_ptr<array>(key_scale_cache_h) : nullptr;
+          const array* vs = use_turboquant
+              ? nb::inst_ptr<array>(value_scale_cache_h) : nullptr;
+          const array* kz = use_turboquant
+              ? nb::inst_ptr<array>(key_zero_cache_h) : nullptr;
+          const array* vc = use_turboquant
+              ? nb::inst_ptr<array>(v_centroids_h) : nullptr;
           auto result = paged_attention_primitive_fn(
               *nb::inst_ptr<array>(query_h),
               *nb::inst_ptr<array>(key_cache_h),
@@ -849,7 +968,8 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(block_tables_h),
               *nb::inst_ptr<array>(seq_lens_h),
               *nb::inst_ptr<array>(cu_seqlens_q_h),
-              block_size, max_seq_len, sliding_window);
+              block_size, max_seq_len, sliding_window,
+              use_turboquant, quant_type, ks, vs, kz, vc, v_bits);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -860,6 +980,13 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("block_size"), nb::arg("max_seq_len"),
         nb::arg("sliding_window"),
         nb::arg("out"),
+        nb::arg("key_scale_cache") = nb::none(),
+        nb::arg("value_scale_cache") = nb::none(),
+        nb::arg("key_zero_cache") = nb::none(),
+        nb::arg("v_centroids") = nb::none(),
+        nb::arg("use_turboquant") = false,
+        nb::arg("quant_type") = "",
+        nb::arg("v_bits") = 3,
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.");
 

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -35,6 +35,7 @@ from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 from vllm_metal.metal_kernel_backend.packed_prefill_compat import (
     apply_packed_rope,
 )
+from vllm_metal.metal_kernel_backend.turboquant import turbo_quant_encode
 from vllm_metal.paged_attention_common import PagedAttentionContext
 
 # === Metal kernel block-size support ===
@@ -377,24 +378,52 @@ def sdpa_forward(
         ctx.block_tables, kv_cache.block_size
     )
 
-    # --- Cache write: MLX-native scatter (pure functional, graph-tracked) ---
-    # YOCO shared layers (shared_kv is not None) skip the write — their K/V
-    # is already in the reference layer's cache.  Only unique layers scatter.
-    #
-    # Flatten cache to [num_slots, num_kv_heads, head_dim], scatter new K/V
-    # by slot_mapping, then reshape back.  This creates proper graph nodes
-    # that MLX's evaluator can track for dependency ordering and buffer
-    # donation — no in-place mutation, no copy_shared_buffer, no const_cast.
-    #
-    # DONATION INVARIANT: the rebind (below) must drop the list's reference
-    # to the old cache *before* mx.eval runs.  At eval time the old cache
-    # must have use_count == 1 (only the graph) for MLX to donate its
-    # buffer to the scatter output.  Do NOT insert mx.eval between the
-    # scatter and the rebind, or hold extra references to the old cache.
     if shared_kv is not None:
-        # YOCO shared layer: K/V already written by the reference layer.
+        # YOCO shared layer: the reference layer already scattered the
+        # authoritative K/V (and, under TurboQuant, the scale/zero caches
+        # too).  Skip the write to avoid (a) redundant compute and (b)
+        # silent byte-drift if this layer's raw K/V differs marginally
+        # from the reference's — re-encoding would produce non-identical
+        # packed bytes.
         new_k_cache = kv_cache.key_caches[layer_idx]
         new_v_cache = kv_cache.value_caches[layer_idx]
+        if kv_cache.turboquant:
+            new_key_scale_cache = kv_cache.key_scale_caches[layer_idx]
+            new_value_scale_cache = kv_cache.value_scale_caches[layer_idx]
+            new_key_zero_cache = kv_cache.key_zero_caches[layer_idx]
+    elif kv_cache.turboquant:
+        # --- TurboQuant cache write: Python quantize → MLX scatter ---
+        # Quantize K/V, then scatter each of the 5 caches independently.
+        (packed_k, k_scale, k_zero), (packed_v, v_scale) = turbo_quant_encode(
+            k_3d, v_3d, kv_cache.k_quant, value_bits=kv_cache.v_bits
+        )
+
+        def _scatter(cache_arr, data):
+            flat = cache_arr.reshape(-1, kv_cache.num_kv_heads, data.shape[-1])
+            flat[slot_mapping] = data
+            return flat.reshape(cache_arr.shape)
+
+        kv_cache.key_caches[layer_idx] = _scatter(
+            kv_cache.key_caches[layer_idx], packed_k
+        )
+        kv_cache.value_caches[layer_idx] = _scatter(
+            kv_cache.value_caches[layer_idx], packed_v
+        )
+        kv_cache.key_scale_caches[layer_idx] = _scatter(
+            kv_cache.key_scale_caches[layer_idx], k_scale
+        )
+        kv_cache.value_scale_caches[layer_idx] = _scatter(
+            kv_cache.value_scale_caches[layer_idx], v_scale
+        )
+        kv_cache.key_zero_caches[layer_idx] = _scatter(
+            kv_cache.key_zero_caches[layer_idx], k_zero
+        )
+
+        new_k_cache = kv_cache.key_caches[layer_idx]
+        new_v_cache = kv_cache.value_caches[layer_idx]
+        new_key_scale_cache = kv_cache.key_scale_caches[layer_idx]
+        new_value_scale_cache = kv_cache.value_scale_caches[layer_idx]
+        new_key_zero_cache = kv_cache.key_zero_caches[layer_idx]
     else:
         flat_k = kv_cache.key_caches[layer_idx].reshape(-1, cache_kv_heads, head_dim)
         flat_k[slot_mapping] = k_3d
@@ -421,30 +450,79 @@ def sdpa_forward(
     kernel_k_cache = new_k_cache
     kernel_v_cache = new_v_cache
     if kernel_block_size != kv_cache.block_size:
+        # Use the cache's actual last-axis size rather than the logical
+        # ``head_dim``.  Under TurboQuant the K/V caches are stored in
+        # packed form (``packed_head_dim = packed_dim(head_dim, bits)``)
+        # which differs from ``head_dim`` for all bitwidths except 8-bit K.
+        # Mirrors the ``sg = ...shape[-1]`` idiom used for the scale/zero
+        # reshape below.
         kernel_k_cache = new_k_cache.reshape(
-            -1, kernel_block_size, cache_kv_heads, head_dim
+            -1, kernel_block_size, cache_kv_heads, new_k_cache.shape[-1]
         )
         kernel_v_cache = new_v_cache.reshape(
-            -1, kernel_block_size, cache_kv_heads, head_dim
+            -1, kernel_block_size, cache_kv_heads, new_v_cache.shape[-1]
         )
 
     ops = get_ops()
     out = mx.array(0)
-    ops.paged_attention_primitive(
-        q_3d,
-        kernel_k_cache,
-        kernel_v_cache,
-        cache_kv_heads,
-        inner.scale,
-        0.0,  # softcap (0 = disabled)
-        block_tables,
-        seq_lens,
-        cu_seqlens_q,
-        kernel_block_size,
-        max_seq_len,
-        -1,  # sliding_window (-1 = disabled)
-        out,
-    )
+    if kv_cache.turboquant:
+        # Reshape scale/zero caches for kernel block size
+        kernel_key_scale = new_key_scale_cache
+        kernel_value_scale = new_value_scale_cache
+        kernel_key_zero = new_key_zero_cache
+        if kernel_block_size != kv_cache.block_size:
+            sg = new_key_scale_cache.shape[-1]
+            kernel_key_scale = new_key_scale_cache.reshape(
+                -1, kernel_block_size, kv_cache.num_kv_heads, sg
+            )
+            kernel_value_scale = new_value_scale_cache.reshape(
+                -1, kernel_block_size, kv_cache.num_kv_heads, sg
+            )
+            kernel_key_zero = new_key_zero_cache.reshape(
+                -1, kernel_block_size, kv_cache.num_kv_heads, sg
+            )
+        # Get Lloyd-Max centroids for V quantization (lazily computed, cached)
+        from vllm_metal.metal_kernel_backend.turboquant import get_v_centroids
+
+        v_centroids = get_v_centroids(kv_cache.v_bits)
+        ops.paged_attention_primitive(
+            q_3d,
+            kernel_k_cache,
+            kernel_v_cache,
+            kv_cache.num_kv_heads,
+            inner.scale,
+            0.0,  # softcap (0 = disabled)
+            block_tables,
+            seq_lens,
+            cu_seqlens_q,
+            kernel_block_size,
+            max_seq_len,
+            -1,  # sliding_window (-1 = disabled)
+            out,
+            key_scale_cache=kernel_key_scale,
+            value_scale_cache=kernel_value_scale,
+            key_zero_cache=kernel_key_zero,
+            v_centroids=v_centroids,
+            use_turboquant=True,
+            quant_type=kv_cache.k_quant,
+            v_bits=kv_cache.v_bits,
+        )
+    else:
+        ops.paged_attention_primitive(
+            q_3d,
+            kernel_k_cache,
+            kernel_v_cache,
+            kv_cache.num_kv_heads,
+            inner.scale,
+            0.0,  # softcap (0 = disabled)
+            block_tables,
+            seq_lens,
+            cu_seqlens_q,
+            kernel_block_size,
+            max_seq_len,
+            -1,  # sliding_window (-1 = disabled)
+            out,
+        )
 
     # Reshape + strip padding back to actual head_dim before o_proj.
     out = truncate_padded_output(out, B, L, n_heads, cache_head_dim, actual_head_dim)

--- a/vllm_metal/metal_kernel_backend/cache.py
+++ b/vllm_metal/metal_kernel_backend/cache.py
@@ -17,6 +17,16 @@ Block allocation is managed externally by the scheduler's KV cache manager.
 from __future__ import annotations
 
 import mlx.core as mx
+from vllm.logger import init_logger
+
+from vllm_metal.metal_kernel_backend.turboquant import (
+    BLOCK_SIZE,
+    QUANT_PARAMS,
+    V_QUANT_PARAMS,
+    packed_dim,
+)
+
+logger = init_logger(__name__)
 
 
 class MetalPagedKVCache:
@@ -37,6 +47,9 @@ class MetalPagedKVCache:
         num_blocks: int,
         block_size: int,
         dtype: mx.Dtype = mx.float16,
+        turboquant: bool = False,
+        k_quant: str | None = None,
+        v_quant: str | None = None,
         *,
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
@@ -47,6 +60,51 @@ class MetalPagedKVCache:
         self.num_blocks = num_blocks
         self.block_size = block_size
         self.dtype = dtype
+        self.turboquant = turboquant
+        self.k_quant = k_quant
+        self.v_quant = v_quant
+
+        if turboquant:
+            if k_quant is None or k_quant not in QUANT_PARAMS:
+                available = ", ".join(sorted(QUANT_PARAMS.keys()))
+                raise ValueError(
+                    f"turboquant requires valid k_quant, got {k_quant!r}. "
+                    f"Available: {available}"
+                )
+            # Default v_quant to "q3_0" (3-bit Lloyd-Max)
+            if v_quant is None:
+                v_quant = "q3_0"
+                self.v_quant = v_quant
+            if v_quant not in V_QUANT_PARAMS:
+                available = ", ".join(sorted(V_QUANT_PARAMS.keys()))
+                raise ValueError(
+                    f"turboquant requires valid v_quant, got {v_quant!r}. "
+                    f"Available: {available}"
+                )
+            if head_dim % 32 != 0:
+                raise ValueError(
+                    f"TurboQuant requires head_dim divisible by 32, got {head_dim}"
+                )
+            if head_dim not in (64, 128, 256):
+                raise ValueError(
+                    f"TurboQuant V FWHT only supports head_dim 64, 128, or 256, got {head_dim}"
+                )
+
+        self.k_size = QUANT_PARAMS[k_quant]["dtype"] if turboquant else None
+
+        # Bit-packed dimensions for sub-8-bit quant types
+        if turboquant:
+            k_bits = QUANT_PARAMS[k_quant]["bits"]
+            v_bits = V_QUANT_PARAMS[v_quant]["bits"]
+            self.k_bits = k_bits
+            self.v_bits = v_bits
+            self.k_packed_dim = packed_dim(head_dim, k_bits)
+            self.v_packed_dim = packed_dim(head_dim, v_bits)
+        else:
+            self.k_bits = 0
+            self.v_bits = 0
+            self.k_packed_dim = head_dim
+            self.v_packed_dim = head_dim
 
         self.kv_heads_per_layer = kv_heads_per_layer or [num_kv_heads] * num_layers
         self.head_dim_per_layer = head_dim_per_layer or [head_dim] * num_layers
@@ -68,15 +126,112 @@ class MetalPagedKVCache:
         # Per-layer caches — each layer sized by its own (kv_heads, head_dim)
         self.key_caches: list[mx.array] = []
         self.value_caches: list[mx.array] = []
-        for i in range(num_layers):
-            shape = (
-                num_blocks,
-                block_size,
-                self.kv_heads_per_layer[i],
-                self.head_dim_per_layer[i],
-            )
-            self.key_caches.append(mx.zeros(shape, dtype=dtype))
-            self.value_caches.append(mx.zeros(shape, dtype=dtype))
+        self.key_scale_caches: list[mx.array] = []
+        self.value_scale_caches: list[mx.array] = []
+        self.key_zero_caches: list[mx.array] = []  # asymmetric K zero_point
+        if not turboquant:
+            for i in range(num_layers):
+                shape = (
+                    num_blocks,
+                    block_size,
+                    self.kv_heads_per_layer[i],
+                    self.head_dim_per_layer[i],
+                )
+                self.key_caches.append(mx.zeros(shape, dtype=dtype))
+                self.value_caches.append(mx.zeros(shape, dtype=dtype))
+            mx.eval(*self.key_caches, *self.value_caches)
 
-        # Force allocation so Metal buffers exist before kernel dispatch
-        mx.eval(*self.key_caches, *self.value_caches)
+            # Log KV cache memory usage
+            kv_bytes = (
+                num_layers
+                * num_blocks
+                * block_size
+                * num_kv_heads
+                * head_dim
+                * 2
+                * self._dtype_size(dtype)
+            )
+            logger.info(
+                f"KV cache: {kv_bytes / 1e6:.1f} MB "
+                f"({num_layers} layers, {num_blocks} blocks, {block_size} tokens/block)"
+            )
+        else:
+            for _ in range(num_layers):
+                self.key_caches.append(
+                    mx.zeros(
+                        (num_blocks, block_size, num_kv_heads, self.k_packed_dim),
+                        dtype=self.k_size,
+                    )
+                )
+                self.value_caches.append(
+                    mx.zeros(
+                        (num_blocks, block_size, num_kv_heads, self.v_packed_dim),
+                        dtype=mx.uint8,
+                    )
+                )
+                self.key_scale_caches.append(
+                    mx.zeros(
+                        (num_blocks, block_size, num_kv_heads, head_dim // BLOCK_SIZE),
+                        dtype=mx.float16,
+                    )
+                )
+                self.value_scale_caches.append(
+                    mx.zeros(
+                        (num_blocks, block_size, num_kv_heads, head_dim // BLOCK_SIZE),
+                        dtype=mx.float16,
+                    )
+                )
+                self.key_zero_caches.append(
+                    mx.zeros(
+                        (num_blocks, block_size, num_kv_heads, head_dim // BLOCK_SIZE),
+                        dtype=mx.float16,
+                    )
+                )
+            mx.eval(
+                *self.key_caches,
+                *self.value_caches,
+                *self.key_scale_caches,
+                *self.value_scale_caches,
+                *self.key_zero_caches,
+            )
+
+            # Log TurboQuant KV cache memory usage with comparison.
+            # Single source of truth: _turboquant_page_size_bytes in cache_policy.
+            from vllm_metal.v1.cache_policy import _turboquant_page_size_bytes
+
+            per_block_bytes = _turboquant_page_size_bytes(
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                k_quant=k_quant,
+                v_quant=v_quant,
+            )
+            tq_total = num_layers * num_blocks * per_block_bytes
+            fp16_equivalent = (
+                num_layers * num_blocks * block_size * num_kv_heads * head_dim * 2 * 2
+            )  # fp16 K+V
+            compression = fp16_equivalent / tq_total if tq_total > 0 else float("inf")
+            logger.info(
+                f"TurboQuant KV cache (packed): {tq_total / 1e6:.1f} MB "
+                f"(K: {self.k_bits}b->{self.k_packed_dim}d, V: {self.v_bits}b->{self.v_packed_dim}d, "
+                f"vs {fp16_equivalent / 1e6:.1f} MB fp16, {compression:.2f}x compression)"
+            )
+
+    _DTYPE_SIZES = {
+        mx.float16: 2,
+        mx.bfloat16: 2,
+        mx.float32: 4,
+        mx.int8: 1,
+        mx.uint8: 1,
+    }
+
+    @staticmethod
+    def _dtype_size(dtype: mx.Dtype) -> int:
+        """Return size in bytes for an MLX dtype."""
+        size = MetalPagedKVCache._DTYPE_SIZES.get(dtype)
+        if size is None:
+            raise ValueError(
+                f"Unknown dtype {dtype} in _dtype_size. "
+                f"Supported: {list(MetalPagedKVCache._DTYPE_SIZES.keys())}"
+            )
+        return size

--- a/vllm_metal/metal_kernel_backend/turboquant.py
+++ b/vllm_metal/metal_kernel_backend/turboquant.py
@@ -1,0 +1,549 @@
+import mlx.core as mx
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_RNG_KEY = mx.random.key(42)
+
+# === Pre-computed Lloyd-Max tables for 3-bit (fast path for Metal V dequant) ===
+# These match the Metal kernel's CENTROIDS_3BIT table and are used directly
+# without going through the dynamic Lloyd-Max iteration.
+CENTROIDS_3BIT = mx.array(
+    [
+        -2.15195,
+        -1.34391,
+        -0.75601,
+        -0.24509,
+        0.24509,
+        0.75601,
+        1.34391,
+        2.15195,
+    ],
+    dtype=mx.float32,
+)
+
+BOUNDARIES_3BIT = mx.array(
+    [
+        -1.74793,
+        -1.04996,
+        -0.50055,
+        0.0,
+        0.50055,
+        1.04996,
+        1.74793,
+    ],
+    dtype=mx.float32,
+)
+
+# Quantization block size: number of elements per scale group.
+# Must match the Metal kernel's compile-time SCALE_GROUP_SIZE constant (also 32)
+# and the scale cache allocation in cache.py (head_dim // 32 groups).
+BLOCK_SIZE = 32
+
+# === Quantization parameters ===
+# - "signed":  True  → stored as int8 (char in Metal), idx in [-max, max]
+#              False → stored as uint8 (uchar in Metal), idx in [0, max]
+# - "bits":    storage bit width (sub-8-bit types are bit-packed into uint8)
+# - Sub-8-bit types are always unsigned: bit packing only works on unsigned bytes
+#   and the Metal kernel unpacks them as unsigned raw values.
+# Key quantization params (used with --turboquant-k-quant)
+QUANT_PARAMS = {
+    # Signed 8-bit (no packing)
+    "q8_0": {"signed": True, "bits": 8, "dtype": mx.int8, "block_size": 32},
+    "int8": {"signed": True, "bits": 8, "dtype": mx.int8, "block_size": 32},
+    # Unsigned 8-bit (no packing)
+    "uint8": {"signed": False, "bits": 8, "dtype": mx.uint8, "block_size": 32},
+    # Sub-8-bit unsigned (bit-packed into uint8 bytes)
+    "q5_0": {"signed": False, "bits": 5, "dtype": mx.uint8, "block_size": 32},
+    "q4_0": {"signed": False, "bits": 4, "dtype": mx.uint8, "block_size": 32},
+    "int4": {"signed": False, "bits": 4, "dtype": mx.uint8, "block_size": 32},
+    "uint4": {"signed": False, "bits": 4, "dtype": mx.uint8, "block_size": 32},
+    "int2": {"signed": False, "bits": 2, "dtype": mx.uint8, "block_size": 32},
+    "uint2": {"signed": False, "bits": 2, "dtype": mx.uint8, "block_size": 32},
+}
+
+# Value quantization params (used with --turboquant-v-quant)
+# V uses Lloyd-Max quantization with FWHT rotation.
+# Centroids are lazily computed for arbitrary bit widths.
+V_QUANT_PARAMS = {
+    "q2_0": {"signed": False, "bits": 2, "dtype": mx.uint8, "block_size": 32},
+    "q3_0": {"signed": False, "bits": 3, "dtype": mx.uint8, "block_size": 32},
+    "q4_0": {"signed": False, "bits": 4, "dtype": mx.uint8, "block_size": 32},
+    "q5_0": {"signed": False, "bits": 5, "dtype": mx.uint8, "block_size": 32},
+    "q8_0": {"signed": False, "bits": 8, "dtype": mx.uint8, "block_size": 32},
+}
+
+
+def searchsorted(boundaries, x):
+    return (x[..., None] > boundaries).sum(axis=-1)
+
+
+_FWHT_SUPPORTED_DIMS = (64, 128, 256)
+
+
+def fwht(x: mx.array, encode: bool) -> mx.array:
+    dim = x.shape[-1]
+    if dim not in _FWHT_SUPPORTED_DIMS:
+        raise ValueError(
+            f"FWHT only supports head_dim in {_FWHT_SUPPORTED_DIMS}, got {dim}. "
+            "The Metal kernel has hardcoded sign tables only for these sizes."
+        )
+    sign01 = mx.random.randint(0, 2, shape=(dim,), key=_RNG_KEY)
+    signs = 1 - 2 * sign01
+    if encode:
+        x = x * signs
+        x = mx.hadamard_transform(x)
+    else:
+        x = mx.hadamard_transform(x)
+        x *= signs
+    return x
+
+
+# === Lloyd-Max dynamic centroid computation (pure MLX) ===
+# For bits != 3, centroids/boundaries are computed via iterative Lloyd-Max
+# on unit-normal samples (FWHT output is approximately unit normal).
+# Results are cached per bit width; the first call pays the iteration cost.
+_LLOYD_MAX_CACHE: dict[int, tuple[mx.array, mx.array]] = {}
+
+
+def _compute_lloyd_max_normal(bits: int) -> tuple[mx.array, mx.array]:
+    """Iterative Lloyd-Max for unit-normal source at given bit width.
+
+    Runs entirely on MLX (no numpy). Uses one-hot masking to compute
+    per-cluster means without Python loops over clusters.
+    """
+    if bits < 1:
+        raise ValueError(f"bits must be >= 1, got {bits}")
+    n = 1 << bits
+    samples = mx.random.normal(shape=(200_000,), key=mx.random.key(0)).astype(
+        mx.float32
+    )
+    # Uniform init over the observed range.
+    lo = mx.min(samples)
+    hi = mx.max(samples)
+    centroids = mx.linspace(lo.item(), hi.item(), num=n).astype(mx.float32)
+
+    cluster_ids = mx.arange(n, dtype=mx.int32)
+    converged = False
+    max_diff = 0.0
+    # Relax threshold for higher bit widths where centroids are densely packed
+    threshold = 1e-4 if bits >= 5 else 1e-6
+    for _ in range(500):
+        boundaries = (centroids[:-1] + centroids[1:]) * 0.5
+        # assign[i] = cluster index for sample[i] (in [0, n))
+        assign = searchsorted(boundaries, samples).astype(mx.int32)
+        # one_hot: (N, n)
+        one_hot = (assign[:, None] == cluster_ids[None, :]).astype(mx.float32)
+        counts = one_hot.sum(axis=0)  # (n,)
+        sums = (one_hot * samples[:, None]).sum(axis=0)  # (n,)
+        # Empty clusters keep their old centroid to avoid divide-by-zero.
+        new_centroids = mx.where(counts > 0, sums / mx.maximum(counts, 1.0), centroids)
+        diff = mx.abs(new_centroids - centroids).max().item()
+        if diff < threshold:
+            centroids = new_centroids
+            converged = True
+            break
+        max_diff = diff
+        centroids = new_centroids
+    if not converged:
+        logger.warning(
+            "Lloyd-Max did not converge in 500 iterations for bits=%d; "
+            "quantization quality may be suboptimal. Current convergence=%s",
+            bits,
+            f"{max_diff:.20f}",
+        )
+    boundaries = (centroids[:-1] + centroids[1:]) * 0.5
+    return centroids, boundaries
+
+
+def lloyd_max_centroids(bits: int) -> tuple[mx.array, mx.array]:
+    """Return (centroids, boundaries) for Lloyd-Max quantization of unit normal.
+
+    For bits == 3, returns the precomputed lookup used by the Metal kernel.
+    For other bit widths, computes via iterative Lloyd-Max (cached per width).
+    """
+    if bits == 3:
+        return CENTROIDS_3BIT, BOUNDARIES_3BIT
+    if bits not in _LLOYD_MAX_CACHE:
+        _LLOYD_MAX_CACHE[bits] = _compute_lloyd_max_normal(bits)
+    return _LLOYD_MAX_CACHE[bits]
+
+
+def get_v_centroids(bits: int) -> mx.array:
+    """Get Lloyd-Max centroids for V quantization at given bit width.
+
+    Returns a float32 array of 2^bits centroids, suitable for passing to
+    the Metal kernel as a buffer parameter. Results are cached.
+
+    Args:
+        bits: Quantization bit width (1-8).
+
+    Returns:
+        mx.array of shape (2^bits,) with float32 centroids.
+    """
+    centroids, _ = lloyd_max_centroids(bits)
+    return centroids.astype(mx.float32)
+
+
+def lm_quant(x: mx.array, bits: int = 3) -> tuple[mx.array, mx.array]:
+    """Lloyd-Max quantize ``x`` along its last dim.
+
+    Args:
+        x:    Input tensor, last dim must be divisible by BLOCK_SIZE.
+        bits: Target bit width. 3 uses the precomputed lookup; other
+              widths compute centroids dynamically via Lloyd-Max.
+
+    Returns:
+        (indices, scale) where ``indices`` are uint8 values in [0, 2^bits - 1]
+        and ``scale`` is the per-block RMS normalizer.
+    """
+    _, boundaries = lloyd_max_centroids(bits)
+    shape = x.shape
+    x = x.reshape(*shape[:-1], -1, BLOCK_SIZE)
+    scale = mx.sqrt(mx.mean(x**2, axis=-1, keepdims=True))
+    x_norm = x / (scale + 1e-8)
+    indices = searchsorted(boundaries, x_norm).reshape(shape)
+    return indices.astype(mx.uint8), scale.squeeze(-1).astype(mx.float16)
+
+
+def lm_de_quant(
+    indices: mx.array,
+    scale: mx.array,
+    bits: int = 3,
+    block_size: int = 32,
+) -> mx.array:
+    """Lloyd-Max dequantize (centroid lookup + block-wise rescale)."""
+    centroids, _ = lloyd_max_centroids(bits)
+    shape = indices.shape
+    idx_r = indices.reshape(*shape[:-1], -1, block_size)
+    x_norm = centroids[idx_r.astype(mx.int32)]
+    x = x_norm * scale[..., None]
+    return x.reshape(shape)
+
+
+def packed_dim(head_dim: int, bits: int) -> int:
+    """Packed byte count for head_dim elements at given bit width."""
+    if (head_dim * bits) % 8 != 0:
+        raise ValueError(
+            f"head_dim={head_dim} * bits={bits} = {head_dim * bits} is not divisible by 8; "
+            "choose a head_dim and bit width whose product is byte-aligned"
+        )
+    return head_dim * bits // 8
+
+
+def _pack_2bit(vals: mx.array) -> mx.array:
+    shape = vals.shape
+    g = vals.reshape(*shape[:-1], -1, 4).astype(mx.uint8)
+    packed = (
+        (g[..., 0] & 0x3)
+        | ((g[..., 1] & 0x3) << 2)
+        | ((g[..., 2] & 0x3) << 4)
+        | ((g[..., 3] & 0x3) << 6)
+    )
+    return packed.reshape(*shape[:-1], -1)
+
+
+def _unpack_2bit(packed: mx.array, orig_dim: int) -> mx.array:
+    shape = packed.shape
+    g = packed.reshape(*shape[:-1], -1, 1)
+    v0 = g & 0x3
+    v1 = (g >> 2) & 0x3
+    v2 = (g >> 4) & 0x3
+    v3 = (g >> 6) & 0x3
+    unpacked = mx.concatenate([v0, v1, v2, v3], axis=-1)
+    return unpacked.reshape(*shape[:-1], orig_dim).astype(mx.uint8)
+
+
+def _pack_3bit(vals: mx.array) -> mx.array:
+    shape = vals.shape
+    g = vals.reshape(*shape[:-1], -1, 8).astype(mx.uint32)
+    v = [g[..., i] for i in range(8)]
+    b0 = (v[0] & 0x7) | ((v[1] & 0x7) << 3) | ((v[2] & 0x7) << 6)
+    b1 = (
+        ((v[2] & 0x7) >> 2)
+        | ((v[3] & 0x7) << 1)
+        | ((v[4] & 0x7) << 4)
+        | ((v[5] & 0x7) << 7)
+    )
+    b2 = ((v[5] & 0x7) >> 1) | ((v[6] & 0x7) << 2) | ((v[7] & 0x7) << 5)
+    packed = mx.stack([b0, b1, b2], axis=-1).astype(mx.uint8)
+    return packed.reshape(*shape[:-1], -1)
+
+
+def _unpack_3bit(packed: mx.array, orig_dim: int) -> mx.array:
+    shape = packed.shape
+    g = packed.reshape(*shape[:-1], -1, 3).astype(mx.uint32)
+    b0, b1, b2 = g[..., 0], g[..., 1], g[..., 2]
+    combined = b0 | (b1 << 8) | (b2 << 16)
+    vals = []
+    for i in range(8):
+        vals.append((combined >> (i * 3)) & 0x7)
+    unpacked = mx.stack(vals, axis=-1).astype(mx.uint8)
+    return unpacked.reshape(*shape[:-1], orig_dim)
+
+
+def _pack_4bit(vals: mx.array) -> mx.array:
+    shape = vals.shape
+    g = vals.reshape(*shape[:-1], -1, 2).astype(mx.uint8)
+    packed = (g[..., 0] & 0xF) | ((g[..., 1] & 0xF) << 4)
+    return packed.reshape(*shape[:-1], -1)
+
+
+def _unpack_4bit(packed: mx.array, orig_dim: int) -> mx.array:
+    shape = packed.shape
+    g = packed.reshape(*shape[:-1], -1, 1)
+    lo = g & 0xF
+    hi = (g >> 4) & 0xF
+    unpacked = mx.concatenate([lo, hi], axis=-1)
+    return unpacked.reshape(*shape[:-1], orig_dim).astype(mx.uint8)
+
+
+def _pack_5bit(vals: mx.array) -> mx.array:
+    shape = vals.shape
+    g = vals.reshape(*shape[:-1], -1, 8).astype(mx.uint64)
+    combined = g[..., 0] & 0x1F
+    for i in range(1, 8):
+        combined = combined | ((g[..., i] & 0x1F) << (i * 5))
+    # Extract 5 bytes from the 40-bit combined value
+    b = [(combined >> (i * 8)) & 0xFF for i in range(5)]
+    packed = mx.stack(b, axis=-1).astype(mx.uint8)
+    return packed.reshape(*shape[:-1], -1)
+
+
+def _unpack_5bit(packed: mx.array, orig_dim: int) -> mx.array:
+    shape = packed.shape
+    g = packed.reshape(*shape[:-1], -1, 5).astype(mx.uint64)
+    combined = (
+        g[..., 0]
+        | (g[..., 1] << 8)
+        | (g[..., 2] << 16)
+        | (g[..., 3] << 24)
+        | (g[..., 4] << 32)
+    )
+    vals = []
+    for i in range(8):
+        vals.append((combined >> (i * 5)) & 0x1F)
+    unpacked = mx.stack(vals, axis=-1).astype(mx.uint8)
+    return unpacked.reshape(*shape[:-1], orig_dim)
+
+
+_PACK_FNS = {2: _pack_2bit, 3: _pack_3bit, 4: _pack_4bit, 5: _pack_5bit}
+_UNPACK_FNS = {2: _unpack_2bit, 3: _unpack_3bit, 4: _unpack_4bit, 5: _unpack_5bit}
+
+
+def pack_bits(values: mx.array, bits: int) -> mx.array:
+    """Pack sub-8-bit values into bytes.
+
+    values: [..., dim] uint8 with each element using only `bits` bits.
+    Returns: [..., dim * bits // 8] uint8.
+    """
+    if bits == 8:
+        return values
+    if bits not in _PACK_FNS:
+        raise ValueError(f"Unsupported bit width for packing: {bits}")
+    return _PACK_FNS[bits](values)
+
+
+def unpack_bits(packed: mx.array, bits: int, orig_dim: int) -> mx.array:
+    """Unpack packed bytes back to per-element uint8.
+
+    packed: [..., packed_dim] uint8.
+    Returns: [..., orig_dim] uint8.
+    """
+    if bits == 8:
+        return packed
+    if bits not in _UNPACK_FNS:
+        raise ValueError(f"Unsupported bit width for unpacking: {bits}")
+    return _UNPACK_FNS[bits](packed, orig_dim)
+
+
+def quantize(
+    x: mx.array, output_type: str = "int8"
+) -> tuple[mx.array, mx.array, mx.array]:
+    """Asymmetric block-wise quantization.
+
+    Handles both signed (int8) and unsigned (uint8 / sub-8-bit) types.
+    All variants share the same dequantization formula:
+
+        ``x_hat = (indices + zero_point) * scale``
+
+    Args:
+        x:           Input tensor, last dim must be divisible by block_size.
+        output_type: Key from QUANT_PARAMS.
+
+    Returns:
+        (indices, scale, zero_point).  ``scale`` and ``zero_point`` have shape
+        ``(..., head_dim // block_size)`` (one per block). Indices are stored
+        in the dtype declared by QUANT_PARAMS — unsigned for sub-8-bit so they
+        can be bit-packed directly.
+    """
+    if output_type not in QUANT_PARAMS:
+        available = ", ".join(sorted(QUANT_PARAMS.keys()))
+        raise ValueError(
+            f"Unsupported quantization type: {output_type}. Available: {available}"
+        )
+
+    params = QUANT_PARAMS[output_type]
+    bits: int = params["bits"]
+    signed = params["signed"]
+    dtype = params["dtype"]
+    block_size = params["block_size"]
+
+    shape = x.shape
+    x = x.reshape(*shape[:-1], -1, block_size)
+
+    x_min = mx.min(x, axis=-1, keepdims=True)
+    x_max = mx.max(x, axis=-1, keepdims=True)
+
+    if signed:
+        # Signed asymmetric: idx in [-max_val, max_val], max_val = 2^(bits-1) - 1.
+        # scale * (max_val - (-max_val)) = x_max - x_min  →  scale = (x_max-x_min)/(2*max_val)
+        # Zero-point centers the quantization grid on the block midpoint.
+        max_val = (1 << (bits - 1)) - 1
+        scale = (x_max - x_min) / (2.0 * max_val)
+        zero_point = mx.round((x_max + x_min) / (2.0 * (scale + 1e-8)))
+        indices = mx.clip(
+            mx.round(x / (scale + 1e-8) - zero_point),
+            -max_val,
+            max_val,
+        ).astype(dtype)
+    else:
+        # Unsigned asymmetric: idx in [0, max_val], max_val = 2^bits - 1.
+        # x_min corresponds to idx=0 (via zero_point offset). This keeps all
+        # indices non-negative, which is required for correct bit packing.
+        max_val = (1 << bits) - 1
+        scale = (x_max - x_min) / max_val
+        zero_point = mx.round(x_min / (scale + 1e-8))
+        indices = mx.clip(
+            mx.round(x / (scale + 1e-8) - zero_point),
+            0,
+            max_val,
+        ).astype(dtype)
+
+    indices = indices.reshape(shape)
+    return (
+        indices,
+        scale.squeeze(-1).astype(mx.float16),
+        zero_point.squeeze(-1).astype(mx.float16),
+    )
+
+
+def dequantize(
+    indices: mx.array, scale: mx.array, zero_point: mx.array, block_size: int = 32
+) -> mx.array:
+    """Asymmetric uniform dequantization: ``x = (indices + zero_point) * scale``.
+
+    Args:
+        indices: Quantized indices (flattened).
+        scale: Scale factors per block.
+        zero_point: Zero-point offsets per block.
+        block_size: Number of elements per scale block.
+    Returns:
+        Dequantized tensor.
+    """
+    shape = indices.shape
+    indices_reshaped = indices.reshape(*shape[:-1], -1, block_size)
+    x = (indices_reshaped.astype(mx.float32) + zero_point[..., None]) * scale[..., None]
+    return x.reshape(shape)
+
+
+def turbo_quant_encode_value(x: mx.array, bits: int = 3) -> tuple[mx.array, mx.array]:
+    """Encode V with FWHT and Lloyd-Max quantization at the given bit width.
+
+    Args:
+        x:    Input tensor. Last dim must be a power of two (FWHT) and divisible
+              by BLOCK_SIZE (Lloyd-Max scale grouping).
+        bits: Target bit width. 3 uses the precomputed lookup (fast path, also
+              what the Metal kernel consumes); other widths compute centroids
+              dynamically via Lloyd-Max.
+
+    Returns:
+        (indices, scale). ``indices`` are uint8 values in [0, 2^bits - 1]
+        (not yet bit-packed).
+    """
+    x = fwht(x, True)
+    return lm_quant(x, bits)
+
+
+def turbo_quant_encode_key(
+    x: mx.array, quant_type: str = "q8_0"
+) -> tuple[mx.array, mx.array, mx.array]:
+    """Key quantization — asymmetric uniform (no FWHT)."""
+    return quantize(x, quant_type)
+
+
+def turbo_quant_decode_value(
+    indices: mx.array,
+    scale: mx.array,
+    output_dtype: mx.Dtype = mx.float32,
+    block_size: int = 32,
+    bits: int = 3,
+) -> mx.array:
+    """Decode V with Lloyd-Max dequantization and inverse FWHT."""
+    x = lm_de_quant(indices, scale, bits=bits, block_size=block_size)
+    x = fwht(x, False)
+    return x.astype(output_dtype)
+
+
+def turbo_quant_decode_key(
+    indices: mx.array,
+    scale: mx.array,
+    zero_point: mx.array,
+    output_dtype: mx.Dtype = mx.float32,
+    block_size: int = 32,
+) -> mx.array:
+    """Decode K with asymmetric dequantization: ``x = (indices + zero_point) * scale``."""
+    return dequantize(indices, scale, zero_point, block_size).astype(output_dtype)
+
+
+def turbo_quant_encode(
+    key: mx.array,
+    value: mx.array,
+    key_quant: str = "q8_0",
+    value_bits: int = 3,
+) -> tuple:
+    """Encode key and value arrays for TurboQuant storage.
+
+    Returns:
+        ``(k_quant, v_quant)`` where
+        ``k_quant = (packed_indices, scale, zero_point)`` and
+        ``v_quant = (packed_indices, scale)``. Sub-8-bit indices are bit-packed.
+    """
+    indices_k, scale_k, zero_k = turbo_quant_encode_key(key, key_quant)
+    indices_v, scale_v = turbo_quant_encode_value(value, bits=value_bits)
+
+    k_bits: int = QUANT_PARAMS[key_quant]["bits"]
+    if k_bits < 8:
+        indices_k = pack_bits(indices_k.astype(mx.uint8), k_bits)
+    if value_bits < 8:
+        indices_v = pack_bits(indices_v, value_bits)
+
+    return (indices_k, scale_k, zero_k), (indices_v, scale_v)
+
+
+def turbo_quant_decode(
+    k_quant: tuple,
+    v_quant: tuple,
+    output_dtype: mx.Dtype = mx.float32,
+    block_size: int = 32,
+    key_quant_type: str = "q8_0",
+    value_bits: int = 3,
+) -> tuple[mx.array, mx.array]:
+    """Decode TurboQuant-encoded key/value pairs."""
+    k_indices, k_scale, k_zero = k_quant
+    v_indices, v_scale = v_quant
+
+    k_bits: int = QUANT_PARAMS[key_quant_type]["bits"]
+    orig_k_dim = k_scale.shape[-1] * block_size
+    orig_v_dim = v_scale.shape[-1] * block_size
+
+    if k_bits < 8:
+        k_indices = unpack_bits(k_indices, k_bits, orig_k_dim)
+    if value_bits < 8:
+        v_indices = unpack_bits(v_indices, value_bits, orig_v_dim)
+
+    k = turbo_quant_decode_key(k_indices, k_scale, k_zero, output_dtype, block_size)
+    v = turbo_quant_decode_value(
+        v_indices, v_scale, output_dtype, block_size, bits=value_bits
+    )
+    return k, v

--- a/vllm_metal/paged_attention_backend/hybrid.py
+++ b/vllm_metal/paged_attention_backend/hybrid.py
@@ -89,6 +89,10 @@ class HybridPagedAttentionBackend:
         # Common
         block_size: int,
         dtype: mx.Dtype,
+        # TurboQuant (SDPA layers only)
+        turboquant: bool = False,
+        k_quant: str | None = None,
+        v_quant: str | None = None,
     ) -> None:
         self._max_num_seqs = max_num_seqs
         self._block_size = block_size
@@ -104,6 +108,11 @@ class HybridPagedAttentionBackend:
         self._linear_value_head_dim = linear_value_head_dim
         self._linear_conv_kernel_dim = linear_conv_kernel_dim
         self._linear_conv_dim = linear_conv_dim
+
+        # TurboQuant params (only applies to SDPA layers)
+        self._turboquant = turboquant
+        self._k_quant = k_quant
+        self._v_quant = v_quant
 
         # Classify layers
         self._sdpa_indices: list[int] = []
@@ -130,6 +139,9 @@ class HybridPagedAttentionBackend:
             num_blocks=num_blocks,
             block_size=self._block_size,
             dtype=self._dtype,
+            turboquant=self._turboquant,
+            k_quant=self._k_quant,
+            v_quant=self._v_quant,
         )
 
         self._state_cache = GDNPagedStateCache(

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -73,6 +73,9 @@ class MHAPagedAttentionBackend:
         head_dim: int,
         block_size: int,
         dtype: mx.Dtype,
+        turboquant: bool = False,
+        k_quant: str | None = None,
+        v_quant: str | None = None,
         cache_idx_map: dict[int, int] | None = None,
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
@@ -83,6 +86,9 @@ class MHAPagedAttentionBackend:
         self._block_size = block_size
         self._dtype = dtype
         self._cache: MetalPagedKVCache | None = None
+        self._turboquant = turboquant
+        self._k_quant = k_quant
+        self._v_quant = v_quant
         self._cache_idx_map = cache_idx_map
         self._kv_heads_per_layer = kv_heads_per_layer
         self._head_dim_per_layer = head_dim_per_layer
@@ -102,6 +108,9 @@ class MHAPagedAttentionBackend:
             num_blocks=num_blocks,
             block_size=self._block_size,
             dtype=self._dtype,
+            turboquant=self._turboquant,
+            k_quant=self._k_quant,
+            v_quant=self._v_quant,
             kv_heads_per_layer=self._kv_heads_per_layer,
             head_dim_per_layer=self._head_dim_per_layer,
         )

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -209,6 +209,19 @@ class MetalPlatform(Platform):
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
 
+        # Apply TurboQuant config from --additional-config
+        # Example: --additional-config '{"turboquant": true, "k_quant": "q4_0"}'
+        add = getattr(vllm_config, "additional_config", None) or {}
+        if add.get("turboquant"):
+            config.turboquant = True
+            config.k_quant = add.get("k_quant", "q8_0")
+            config.v_quant = add.get("v_quant", "q3_0")
+            config._validate_turboquant()
+            logger.info(
+                f"TurboQuant enabled via --additional-config: "
+                f"k_quant={config.k_quant}, v_quant={config.v_quant}"
+            )
+
         if config.debug:
             logger.info(f"Metal config: {config}")
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -14,6 +14,15 @@ from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCache
 from vllm_metal.config import (
     PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION,
     PAGED_ATTENTION_MIN_BLOCKS,
+    get_config,
+)
+from vllm_metal.metal_kernel_backend.turboquant import (
+    BLOCK_SIZE as TQ_BLOCK_SIZE,
+)
+from vllm_metal.metal_kernel_backend.turboquant import (
+    QUANT_PARAMS,
+    V_QUANT_PARAMS,
+    packed_dim,
 )
 from vllm_metal.paged_attention_backend.hybrid import (
     HybridPagedAttentionBackend,
@@ -35,6 +44,132 @@ if TYPE_CHECKING:
     from vllm_metal.v1.worker import MetalWorker
 
 logger = init_logger(__name__)
+
+
+def _turboquant_page_size_bytes(
+    block_size: int, num_kv_heads: int, head_dim: int, k_quant: str, v_quant: str
+) -> int:
+    """Calculate TurboQuant-compressed page size for one layer."""
+    k_bits = QUANT_PARAMS[k_quant]["bits"]
+    v_bits = V_QUANT_PARAMS[v_quant]["bits"]
+    k_packed = packed_dim(head_dim, k_bits)
+    v_packed = packed_dim(head_dim, v_bits)
+    kv_bytes = block_size * num_kv_heads * (k_packed + v_packed)
+    scale_groups = head_dim // TQ_BLOCK_SIZE
+    scale_bytes = 3 * block_size * num_kv_heads * scale_groups * 2
+    return kv_bytes + scale_bytes
+
+
+@dataclass(frozen=True, kw_only=True)
+class TurboQuantAttentionSpec(FullAttentionSpec):
+    """FullAttentionSpec for TurboQuant-compressed KV cache.
+
+    Reports the true packed byte count per page via an override of
+    ``real_page_size_bytes`` so vLLM's scheduler can budget more blocks
+    than the FP16 formula would allow — without lying about ``head_size``
+    (the ``head_size_v`` reverse-engineering trick the previous version
+    used produced negative values for aggressive 2-bit configs).
+
+    Mirrors the upstream pattern of :class:`MLAAttentionSpec` which
+    overrides ``real_page_size_bytes`` for its ``fp8_ds_mla`` cache layout.
+    """
+
+    k_quant: str
+    v_quant: str
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        return _turboquant_page_size_bytes(
+            block_size=self.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_dim=self.head_size,
+            k_quant=self.k_quant,
+            v_quant=self.v_quant,
+        )
+
+    @classmethod
+    def merge(cls, specs):
+        assert all(isinstance(s, TurboQuantAttentionSpec) for s in specs), (
+            "All attention layers in the same KV cache group must be "
+            "TurboQuantAttentionSpec."
+        )
+        k_set = {s.k_quant for s in specs}
+        v_set = {s.v_quant for s in specs}
+        assert len(k_set) == 1 and len(v_set) == 1, (
+            "All TurboQuant layers in the same cache group must share the "
+            "same (k_quant, v_quant); mixed-quant groups are not supported."
+        )
+        return cls(
+            block_size=specs[0].block_size,
+            num_kv_heads=specs[0].num_kv_heads,
+            head_size=specs[0].head_size,
+            head_size_v=specs[0].head_size_v,
+            dtype=specs[0].dtype,
+            page_size_padded=specs[0].page_size_padded,
+            sliding_window=cls.merge_window_sizes(
+                {s.sliding_window for s in specs if s.sliding_window is not None}
+            ),
+            attention_chunk_size=cls.merge_window_sizes(
+                {
+                    s.attention_chunk_size
+                    for s in specs
+                    if s.attention_chunk_size is not None
+                }
+            ),
+            k_quant=k_set.pop(),
+            v_quant=v_set.pop(),
+        )
+
+
+def _build_turboquant_attention_spec(
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    k_quant: str,
+    v_quant: str,
+) -> TurboQuantAttentionSpec:
+    """Build a TurboQuantAttentionSpec for a single attention layer.
+
+    Reports the real compressed page size via ``real_page_size_bytes``
+    override, so the scheduler allocates the right number of blocks and
+    ``head_size`` stays equal to the model's real head_dim.
+    """
+    return TurboQuantAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_dim,
+        dtype=torch.int8,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+
+
+def _register_turboquant_spec_manager() -> None:
+    """Register ``TurboQuantAttentionSpec`` in vLLM's spec→manager map.
+
+    vLLM's ``get_manager_for_kv_cache_spec`` uses strict-type lookup
+    (``spec_manager_map[type(spec)]``), not ``isinstance``, so the
+    ``FullAttentionSpec`` entry does not cover subclasses.  We reuse
+    ``FullAttentionManager`` because a TurboQuant cache is accessed
+    like a regular KV page from the scheduler's POV — block indexing,
+    no special slot math (per-element byte layout is handled entirely
+    inside the Metal kernel).
+
+    Mirrors the upstream registration for ``MLAAttentionSpec`` (which
+    vLLM also maps to ``FullAttentionManager``).
+    """
+    try:
+        from vllm.v1.core.single_type_kv_cache_manager import (
+            FullAttentionManager,
+            spec_manager_map,
+        )
+    except ImportError:
+        # vLLM shape changed; let the scheduler raise its own clearer error.
+        return
+    spec_manager_map.setdefault(TurboQuantAttentionSpec, FullAttentionManager)
+
+
+_register_turboquant_spec_manager()
 
 
 @dataclass(frozen=True)
@@ -93,6 +228,11 @@ class ModelCachePolicy:
         self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
+        config = get_config()
+        use_turboquant = (
+            config.turboquant and not self._runner.is_hybrid and not self._runner.is_mla
+        )
+
         kv_heads_list = self._runner.kv_heads_per_layer
         head_dim_list = self._runner.head_dim_per_layer
         has_per_layer = kv_heads_list is not None and head_dim_list is not None
@@ -112,6 +252,15 @@ class ModelCachePolicy:
                     torch_dtype=torch_dtype,
                     page_size_padded=self._runner.cache_config.mamba_page_size_padded,
                     block_size=block_size,
+                )
+            elif use_turboquant:
+                layer_name = f"layers.{layer_idx}.self_attn"
+                specs[layer_name] = _build_turboquant_attention_spec(
+                    block_size=block_size,
+                    num_kv_heads=self._runner.num_kv_heads,
+                    head_dim=self._runner.head_dim,
+                    k_quant=config.k_quant,
+                    v_quant=config.v_quant,
                 )
             else:
                 kv_h = (
@@ -151,6 +300,23 @@ class ModelCachePolicy:
         self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         dtype_size = self._require_kv_cache_dtype().size
+        num_kv_layers = (
+            self._runner.num_sdpa_layers
+            if self._runner.is_hybrid
+            else self._runner.num_kv_cache_layers
+        )
+
+        # TurboQuant uses quantized KV cache with different byte layout
+        config = get_config()
+        if config.turboquant and not self._runner.is_hybrid and not self._runner.is_mla:
+            return num_kv_layers * _turboquant_page_size_bytes(
+                block_size=block_size,
+                num_kv_heads=self._runner.num_kv_heads,
+                head_dim=self._runner.head_dim,
+                k_quant=config.k_quant,
+                v_quant=config.v_quant,
+            )
+
         kv_factor = 1 if self._runner.is_mla else 2
         return kv_factor * block_size * dtype_size * self._kv_layer_size_sum()
 
@@ -191,6 +357,25 @@ class ModelCachePolicy:
         self._require_supported_per_layer_shapes()
         dtype_size = self._require_kv_cache_dtype().size
         aligned_tokens = -(-max_model_len // block_size) * block_size
+        num_kv_layers = (
+            self._runner.num_sdpa_layers
+            if self._runner.is_hybrid
+            else self._runner.num_kv_cache_layers
+        )
+
+        # TurboQuant uses quantized KV cache with different byte layout
+        config = get_config()
+        if config.turboquant and not self._runner.is_hybrid and not self._runner.is_mla:
+            # _turboquant_page_size_bytes is parameterised by tokens (block_size);
+            # pass aligned_tokens to get the per-sequence byte total directly.
+            return num_kv_layers * _turboquant_page_size_bytes(
+                block_size=aligned_tokens,
+                num_kv_heads=self._runner.num_kv_heads,
+                head_dim=self._runner.head_dim,
+                k_quant=config.k_quant,
+                v_quant=config.v_quant,
+            )
+
         kv_factor = 1 if self._runner.is_mla else 2
         sdpa_kv_bytes = (
             kv_factor * aligned_tokens * dtype_size * self._kv_layer_size_sum()
@@ -200,6 +385,25 @@ class ModelCachePolicy:
         return sdpa_kv_bytes
 
     def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionBackend:
+        config = get_config()
+        if config.turboquant:
+            return HybridPagedAttentionBackend(
+                num_layers=self._runner.num_layers,
+                full_attention_interval=self._runner.full_attention_interval,
+                max_num_seqs=self._runner.scheduler_config.max_num_seqs,
+                num_kv_heads=self._runner.num_kv_heads,
+                head_dim=self._runner.head_dim,
+                linear_num_v_heads=self._runner.linear_num_v_heads,
+                linear_key_head_dim=self._runner.linear_key_head_dim,
+                linear_value_head_dim=self._runner.linear_value_head_dim,
+                linear_conv_kernel_dim=self._runner.linear_conv_kernel_dim,
+                linear_conv_dim=self._runner.linear_conv_dim,
+                block_size=block_size,
+                dtype=self._require_kv_cache_dtype(),
+                turboquant=True,
+                k_quant=config.k_quant,
+                v_quant=config.v_quant,
+            )
         return HybridPagedAttentionBackend(
             num_layers=self._runner.num_layers,
             full_attention_interval=self._runner.full_attention_interval,
@@ -213,9 +417,19 @@ class ModelCachePolicy:
             linear_conv_dim=self._runner.linear_conv_dim,
             block_size=block_size,
             dtype=self._require_kv_cache_dtype(),
+            turboquant=False,
+            k_quant=None,
+            v_quant=None,
         )
 
     def _build_mla_backend(self, block_size: int) -> MLAPagedAttentionBackend:
+        config = get_config()
+        if config.turboquant:
+            raise NotImplementedError(
+                "TurboQuant is not supported for MLA models. "
+                "Disable `turboquant` in --additional-config or select a "
+                "non-MLA model."
+            )
         return MLAPagedAttentionBackend(
             num_layers=self._runner.num_layers,
             latent_dim=self._runner.mla_latent_dim,
@@ -225,6 +439,7 @@ class ModelCachePolicy:
 
     def _build_mha_backend(self, block_size: int) -> MHAPagedAttentionBackend:
         num_layers, cache_idx_map = self._mha_cache_layout()
+        config = get_config()
         kv_heads, head_dims = self._cache_layer_shapes(num_layers)
         return MHAPagedAttentionBackend(
             num_layers=num_layers,
@@ -232,6 +447,9 @@ class ModelCachePolicy:
             head_dim=self._runner.head_dim,
             block_size=block_size,
             dtype=self._require_kv_cache_dtype(),
+            turboquant=config.turboquant,
+            k_quant=config.k_quant if config.turboquant else None,
+            v_quant=config.v_quant if config.turboquant else None,
             cache_idx_map=cache_idx_map,
             kv_heads_per_layer=kv_heads,
             head_dim_per_layer=head_dims,
@@ -346,13 +564,16 @@ class WorkerCachePlanner:
         )
         backend.initialize(plan.num_blocks)
         n_patched = backend.patch_model(self._worker.model_runner.model)
+        config = get_config()
         logger.info(
             "Paged attention enabled: %d layers patched, "
-            "%d blocks allocated (block_size=%d, mla=%s)",
+            "%d blocks allocated (block_size=%d, mla=%s, turboquant=%s, k_quant=%s)",
             n_patched,
             plan.num_blocks,
             plan.block_size,
             self._worker.model_runner.is_mla,
+            config.turboquant,
+            config.k_quant if config.turboquant else "N/A",
         )
 
         self._worker.model_runner._paged_attention_backend = backend

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -83,6 +83,16 @@ class MetalWorker(WorkerBase):
         )
         self.metal_config = get_config()
 
+        # Apply TurboQuant config from --additional-config (needed because worker
+        # runs in a separate process and doesn't inherit the config singleton
+        # state set in MetalPlatform.check_and_update_config).
+        add = vllm_config.additional_config
+        if isinstance(add, dict) and add.get("turboquant"):
+            self.metal_config.turboquant = True
+            self.metal_config.k_quant = add.get("k_quant", "q8_0")
+            self.metal_config.v_quant = add.get("v_quant", "q3_0")
+            self.metal_config._validate_turboquant()
+
         # Disable custom all reduce (not supported on Metal)
         self.parallel_config.disable_custom_all_reduce = True
 
@@ -257,6 +267,10 @@ class MetalWorker(WorkerBase):
             The loaded model
         """
         return self.model_runner.model
+
+    def update_max_model_len(self, max_model_len: int) -> None:
+        """Update max_model_len after engine auto-fits context to GPU memory."""
+        self.model_config.max_model_len = max_model_len
 
     def get_cache_block_size_bytes(self) -> int:
         """Get the size of a single cache block in bytes.


### PR DESCRIPTION
**What**

Adds opt-in quantized KV cache for MHA paged attention, controlled by two env vars:

 `VLLM_METAL_TURBOQUANT=1`        # enables TQ
 `--turboquant-k-quant`      # key quant type (q8_0 / q5_0 / q4_0 / uint2 / int8 / uint8 / etc.)
 `--turboquant-v-quant`       # value quant type (q8_0 / q5_0 / q4_0 / q3_0 / q2_0)

  - Key quantization — block-wise scalar quant (configurable: 2–8 bit). WHT-based grouping, per-block scale stored alongside the packed data.
  - Value quantization — Lloyd-Max quantization from dynamically computed centroids (range: 2-8bit)
  - Metal dequant kernel — single-pass V lookup + K unpack fused into the paged attention decode path. No separate dequant pass.
  - Block size accounting — get_cache_block_size_bytes reports the correct compressed size so the engine allocates proportionally more blocks
  - TurboQuant is **MHA and hybrid-only** (is_mla=False). MLA models will throw a NotImplementedError if used with TurboQuant

  **Why**

  Unlocks free context length increases with smarter KV cache compression on memory-constrained Apple Silicon (e.g. 8 GB M1 MBA).

|Metric|bf16|K-q8_0; V-3bit TQ|
|-------|--------|--------|
|Max Context Length (Llama 3.2 1B, M1 8GB MBA)|38,768 tok|99,280 tok|
|Compression|1.0x|2.56x|
|Tok/s|19.2 tok/s|16.8 tok/s (Small model - compute bound not memory bound)|

**3.7x theoretical compression** of KV cache (q4_0 quantization vs. bf16)

  **Quantization quality**

  Measured on random bf16 tensors (head_dim=128):

  |Quantisation|Bits|Cos Sim.|
|----|----|----|
|q8_0|8|0.999989|
|q5_0|5|0.999206|
|q4_0|4|0.996761|
|uint2|2|0.926900|

  **Overhead**

  Single-token encode + cache write on Qwen3-0.6B shape (4 KV heads, hd=128):

  - TQ encode (Python): ~610 µs
  - TQ cache write: ~360 µs (vs 340 µs fp16 — near-zero write overhead)
  - Net TQ overhead: ~640 µs ≈ 4% of a 60 tok/s decode budget

  **Future work**

  - Move TurboQuantEncode to a Metal kernel to eliminate the ~610 µs Python encode overhead