### PR TITLE
Fix GDN slot release and enforce hybrid backend state cache

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -33,6 +33,7 @@ def make_stub_runner(
         "_paged_attention_backend": None,
         "_gdn_req_to_slot": {},
         "_gdn_free_slots": [],
+        "_gdn_needs_materialize": False,
         "_request_states": {},
         "_paged_request_seq_lens": {},
         "_finished_request_count": 0,

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -31,6 +31,8 @@ def make_stub_runner(
         "_is_stt": False,
         "_is_vlm": False,
         "_paged_attention_backend": None,
+        "_gdn_req_to_slot": {},
+        "_gdn_free_slots": [],
         "_request_states": {},
         "_paged_request_seq_lens": {},
         "_finished_request_count": 0,

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -20,6 +20,7 @@ Run golden token test (requires model download):
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
@@ -252,22 +253,68 @@ class TestGDNSlotLifecycle:
         runner._gdn_release_slots({"req-A"})
 
         assert runner._gdn_free_slots == [slot]
+        assert runner._gdn_needs_materialize is True
 
-    def test_release_slots_materializes_once_per_batch(self):
+    def test_materialize_pending_state_cache_clears_flag_once(self):
         runner, _ = self._make_runner_stub()
         runner._gdn_alloc_slot("req-A")
         runner._gdn_alloc_slot("req-B")
+        runner._gdn_release_slots({"req-A", "req-B", "req-C"})
 
         with patch.object(
             runner,
             "_gdn_materialize_state_cache",
             wraps=runner._gdn_materialize_state_cache,
         ) as mock_materialize:
-            runner._gdn_release_slots({"req-A", "req-B", "req-C"})
+            runner._gdn_materialize_pending_state_cache()
+            runner._gdn_materialize_pending_state_cache()
 
         assert runner._gdn_req_to_slot == {}
         assert sorted(runner._gdn_free_slots) == [0, 1]
         mock_materialize.assert_called_once()
+        assert runner._gdn_needs_materialize is False
+
+    def test_execute_model_recycles_slots_without_materializing(self):
+        from vllm_metal.v1.model_runner import _ExecutionBatch
+
+        runner, _ = self._make_runner_stub()
+        runner.model = object()
+        runner.model_args = {"full_attention_interval": 2}
+        runner._gdn_req_to_slot = {"req-A": 0}
+        runner._paged_attention_backend = _HybridBackendStub(
+            runner._paged_attention_backend._state_cache
+        )
+        scheduler_output = SimpleNamespace(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=SimpleNamespace(
+                req_ids=[],
+                new_block_ids=[],
+                resumed_req_ids=set(),
+                num_computed_tokens=[],
+            ),
+            num_scheduled_tokens={},
+            total_num_scheduled_tokens=0,
+            finished_req_ids={"req-A"},
+            preempted_req_ids=set(),
+            grammar_bitmask=None,
+        )
+
+        with (
+            patch.object(runner, "_handle_new_requests"),
+            patch.object(runner, "_update_cached_request_blocks"),
+            patch.object(runner, "_collect_cached_requests"),
+            patch.object(_ExecutionBatch, "has_paged_work", return_value=True),
+            patch.object(runner, "_build_prefill_pack", return_value=[]),
+            patch.object(runner, "_start_paged_forward"),
+            patch.object(runner, "_gdn_materialize_state_cache") as mock_materialize,
+        ):
+            result = runner.execute_model(scheduler_output)
+
+        assert result is None
+        assert runner._gdn_req_to_slot == {}
+        assert runner._gdn_free_slots == [0]
+        assert runner._gdn_needs_materialize is True
+        mock_materialize.assert_not_called()
 
     def test_slot_reuse_after_early_release(self):
         """Slot freed via _gdn_release_slots should be

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -281,9 +281,6 @@ class TestGDNSlotLifecycle:
         runner.model = object()
         runner.model_args = {"full_attention_interval": 2}
         runner._gdn_req_to_slot = {"req-A": 0}
-        runner._paged_attention_backend = _HybridBackendStub(
-            runner._paged_attention_backend._state_cache
-        )
         scheduler_output = SimpleNamespace(
             scheduled_new_reqs=[],
             scheduled_cached_reqs=SimpleNamespace(
@@ -315,6 +312,20 @@ class TestGDNSlotLifecycle:
         assert runner._gdn_free_slots == [0]
         assert runner._gdn_needs_materialize is True
         mock_materialize.assert_not_called()
+
+    def test_cleanup_finished_requests_drains_pending_materialization(self):
+        runner, _ = self._make_runner_stub()
+        runner._gdn_needs_materialize = True
+
+        with patch.object(
+            runner,
+            "_gdn_materialize_state_cache",
+            wraps=runner._gdn_materialize_state_cache,
+        ) as mock_materialize:
+            runner._cleanup_finished_requests(set())
+
+        mock_materialize.assert_called_once()
+        assert runner._gdn_needs_materialize is False
 
     def test_slot_reuse_after_early_release(self):
         """Slot freed via _gdn_release_slots should be

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -25,6 +25,12 @@ from unittest.mock import MagicMock, patch
 import mlx.core as mx
 
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
+from vllm_metal.paged_attention_backend.hybrid import HybridPagedAttentionBackend
+
+
+class _HybridBackendStub(HybridPagedAttentionBackend):
+    def __init__(self, state_cache: GDNPagedStateCache) -> None:
+        self._state_cache = state_cache
 
 
 class TestGDNProjectionDispatch:
@@ -160,8 +166,7 @@ class TestGDNAllocSlotZeroing:
             key_head_dim=16,
             dtype=mx.float16,
         )
-        backend = MagicMock()
-        backend._state_cache = sc
+        backend = _HybridBackendStub(sc)
 
         runner = MagicMock()
         runner._gdn_req_to_slot = {}

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -3,7 +3,7 @@
 
 Covers:
   - GDNPagedAttentionWrapper projection dispatch (in_proj_qkvz vs in_proj_qkv)
-  - _gdn_free_slot state zeroing (slot-only, preserves other slots)
+  - GDN release and alloc-time slot reuse
   - sync_mlx insertion in mlx_to_torch for MPS safety
   - Golden token deterministic test for Qwen3-Next (slow, requires model)
 
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 
+from tests.stub_runner import make_stub_runner
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_backend.hybrid import HybridPagedAttentionBackend
 
@@ -51,8 +52,8 @@ class TestGDNProjectionDispatch:
         assert not hasattr(module, "in_proj_qkvz")
 
 
-class TestGDNFreeSlotZeroing:
-    """Verify that _gdn_free_slot zeros only the freed slot."""
+class TestGDNStateZeroing:
+    """Verify that slot zeroing only affects the released slot."""
 
     def _make_cache(self, num_layers: int = 2, max_seqs: int = 2) -> GDNPagedStateCache:
         return GDNPagedStateCache(
@@ -78,7 +79,7 @@ class TestGDNFreeSlotZeroing:
             )
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
-        # Simulate _gdn_free_slot for slot 0 only
+        # Zero slot 0 only.
         slot = 0
         mx.eval(*sc.conv_states, *sc.recurrent_states)
         for layer_idx in range(sc.num_layers):
@@ -149,8 +150,8 @@ class TestGDNFreeSlotZeroing:
             assert sc.recurrent_states[layer_idx].dtype == mx.float32
 
 
-class TestGDNAllocSlotZeroing:
-    """Verify that _gdn_alloc_slot zeros state for reused slots."""
+class TestGDNSlotLifecycle:
+    """Verify GDN slot release and alloc-time reuse behavior."""
 
     def _make_runner_stub(self, max_seqs: int = 2):
         """Build a minimal stub with GDN slot management wired up."""
@@ -168,21 +169,16 @@ class TestGDNAllocSlotZeroing:
         )
         backend = _HybridBackendStub(sc)
 
-        runner = MagicMock()
-        runner._gdn_req_to_slot = {}
-        runner._gdn_free_slots = []
-        runner._paged_attention_backend = backend
+        runner = make_stub_runner(_paged_attention_backend=backend)
         return runner, sc
 
     def test_reused_slot_is_zeroed(self):
         """A slot returned to the free list and re-allocated must have
         zeroed conv and recurrent state."""
-        from vllm_metal.v1.model_runner import MetalModelRunner
-
         runner, sc = self._make_runner_stub()
 
         # Allocate slot 0 for req-A
-        slot = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        slot = runner._gdn_alloc_slot("req-A")
         assert slot == 0
 
         # Write non-zero data to slot 0
@@ -193,12 +189,12 @@ class TestGDNAllocSlotZeroing:
             )
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
-        # Free slot 0 (bare pop+append, no zeroing — matches early release path)
+        # Put slot 0 on the free list to isolate alloc-time zeroing.
         runner._gdn_req_to_slot.pop("req-A")
         runner._gdn_free_slots.append(slot)
 
         # Re-allocate — should trigger alloc-time zeroing
-        slot2 = MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        slot2 = runner._gdn_alloc_slot("req-B")
         assert slot2 == 0  # reused
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
@@ -215,13 +211,11 @@ class TestGDNAllocSlotZeroing:
 
     def test_reused_slot_preserves_other_slots(self):
         """Alloc-time zeroing of slot 0 must not affect slot 1."""
-        from vllm_metal.v1.model_runner import MetalModelRunner
-
         runner, sc = self._make_runner_stub()
 
         # Allocate slots 0 and 1
-        MetalModelRunner._gdn_alloc_slot(runner, "req-A")
-        MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        runner._gdn_alloc_slot("req-A")
+        runner._gdn_alloc_slot("req-B")
 
         # Write ones everywhere
         for layer_idx in range(sc.num_layers):
@@ -231,10 +225,10 @@ class TestGDNAllocSlotZeroing:
             )
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
-        # Free slot 0, re-allocate
+        # Put slot 0 on the free list, then re-allocate.
         runner._gdn_req_to_slot.pop("req-A")
         runner._gdn_free_slots.append(0)
-        MetalModelRunner._gdn_alloc_slot(runner, "req-C")
+        runner._gdn_alloc_slot("req-C")
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
         # Slot 1 must still be ones
@@ -245,31 +239,42 @@ class TestGDNAllocSlotZeroing:
 
     def test_new_slot_not_zeroed(self):
         """A brand-new slot (not from free list) should not trigger zeroing."""
-        from vllm_metal.v1.model_runner import MetalModelRunner
-
         runner, sc = self._make_runner_stub()
-        slot = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        slot = runner._gdn_alloc_slot("req-A")
         assert slot == 0
         # No crash, no zeroing needed — state was already initialized to zero
 
-    def test_double_free_is_safe(self):
-        """Calling _gdn_free_slot twice for the same req_id must not crash."""
-        from vllm_metal.v1.model_runner import MetalModelRunner
+    def test_release_slots_is_noop_when_already_released(self):
+        runner, _ = self._make_runner_stub()
+        slot = runner._gdn_alloc_slot("req-A")
 
-        runner, sc = self._make_runner_stub()
-        MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        runner._gdn_release_slots({"req-A"})
+        runner._gdn_release_slots({"req-A"})
 
-        MetalModelRunner._gdn_free_slot(runner, "req-A")
-        MetalModelRunner._gdn_free_slot(runner, "req-A")  # no-op, no crash
+        assert runner._gdn_free_slots == [slot]
+
+    def test_release_slots_materializes_once_per_batch(self):
+        runner, _ = self._make_runner_stub()
+        runner._gdn_alloc_slot("req-A")
+        runner._gdn_alloc_slot("req-B")
+
+        with patch.object(
+            runner,
+            "_gdn_materialize_state_cache",
+            wraps=runner._gdn_materialize_state_cache,
+        ) as mock_materialize:
+            runner._gdn_release_slots({"req-A", "req-B", "req-C"})
+
+        assert runner._gdn_req_to_slot == {}
+        assert sorted(runner._gdn_free_slots) == [0, 1]
+        mock_materialize.assert_called_once()
 
     def test_slot_reuse_after_early_release(self):
-        """Slot freed via bare pop+append (early release) should be
+        """Slot freed via _gdn_release_slots should be
         available for immediate reallocation with zeroed state."""
-        from vllm_metal.v1.model_runner import MetalModelRunner
-
         runner, sc = self._make_runner_stub(max_seqs=1)
 
-        slot0 = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
+        slot0 = runner._gdn_alloc_slot("req-A")
         assert slot0 == 0
 
         # Write non-zero data to slot 0
@@ -280,12 +285,10 @@ class TestGDNAllocSlotZeroing:
             )
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
-        # Early release (bare pop+append, as in execute_model)
-        runner._gdn_req_to_slot.pop("req-A")
-        runner._gdn_free_slots.append(slot0)
+        runner._gdn_release_slots({"req-A"})
 
         # Same-step allocation should reuse slot 0
-        slot1 = MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        slot1 = runner._gdn_alloc_slot("req-B")
         assert slot1 == 0
 
         # Alloc-time zeroing must have cleared the state
@@ -303,13 +306,11 @@ class TestGDNAllocSlotZeroing:
     def test_early_release_then_alloc_full_cycle(self):
         """Simulate the full execute_model early-release → alloc cycle
         with 2 slots: finish req-A, start req-C while req-B still active."""
-        from vllm_metal.v1.model_runner import MetalModelRunner
-
         runner, sc = self._make_runner_stub(max_seqs=2)
 
         # Allocate 2 requests
-        slot_a = MetalModelRunner._gdn_alloc_slot(runner, "req-A")
-        slot_b = MetalModelRunner._gdn_alloc_slot(runner, "req-B")
+        slot_a = runner._gdn_alloc_slot("req-A")
+        slot_b = runner._gdn_alloc_slot("req-B")
         assert slot_a == 0
         assert slot_b == 1
 
@@ -321,12 +322,10 @@ class TestGDNAllocSlotZeroing:
             )
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
-        # Early-release req-A (bare pop+append, no zeroing)
-        runner._gdn_req_to_slot.pop("req-A")
-        runner._gdn_free_slots.append(slot_a)
+        runner._gdn_release_slots({"req-A"})
 
         # Allocate req-C — should reuse slot 0 with zeroed state
-        slot_c = MetalModelRunner._gdn_alloc_slot(runner, "req-C")
+        slot_c = runner._gdn_alloc_slot("req-C")
         assert slot_c == 0  # reused slot
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1533,6 +1533,7 @@ class MetalModelRunner:
     ) -> None:
         """Evict finished request state and periodically clear MLX cache."""
         if not finished_req_ids:
+            self._gdn_materialize_pending_state_cache()
             return
 
         for req_id in finished_req_ids:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -647,10 +647,9 @@ class MetalModelRunner:
     def _gdn_free_slot(self, req_id: str, *, materialize_state: bool = True) -> None:
         """Release a GDN state pool slot.
 
-        Materializes conv/recurrent state arrays to detach them from the
-        previous request's lazy computation graph.  Actual zeroing is
-        deferred to ``_gdn_alloc_slot`` (alloc-time zeroing) so that
-        each slot is zeroed exactly once, right before reuse.
+        If ``materialize_state`` is True, detaches conv/recurrent state
+        arrays from the lazy computation graph. Zeroing is deferred to
+        ``_gdn_alloc_slot`` right before reuse.
         """
         slot = self._gdn_req_to_slot.pop(req_id, None)
         if slot is None:
@@ -660,7 +659,7 @@ class MetalModelRunner:
         self._gdn_free_slots.append(slot)
 
     def _gdn_materialize_state_cache(self) -> None:
-        """Materialize GDN state arrays to detach lazy graphs."""
+        """Detach GDN state arrays from the lazy graph."""
         backend = self._paged_attention_backend
         if backend is None or not hasattr(backend, "_state_cache"):
             return

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -234,6 +234,7 @@ class MetalModelRunner:
         # models so recurrent state survives request reordering/preemption.
         self._gdn_req_to_slot: dict[str, int] = {}
         self._gdn_free_slots: list[int] = []
+        self._gdn_needs_materialize = False
 
         # vLLM Sampler for token sampling with temperature, top_k, top_p support
         self._sampler = Sampler()
@@ -660,7 +661,7 @@ class MetalModelRunner:
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
     def _gdn_release_slots(self, req_ids: set[str]) -> None:
-        """Release finished GDN slots, materializing state once if needed."""
+        """Release finished GDN slots and defer state materialization."""
         freed_slots: list[int] = []
         for req_id in req_ids:
             slot = self._gdn_req_to_slot.pop(req_id, None)
@@ -670,8 +671,15 @@ class MetalModelRunner:
         if not freed_slots:
             return
 
-        self._gdn_materialize_state_cache()
+        self._gdn_needs_materialize = True
         self._gdn_free_slots.extend(freed_slots)
+
+    def _gdn_materialize_pending_state_cache(self) -> None:
+        """Materialize GDN state after slot recycling if the step needs it."""
+        if not self._gdn_needs_materialize:
+            return
+        self._gdn_materialize_state_cache()
+        self._gdn_needs_materialize = False
 
     def _extract_logits(self, model_output: Any) -> mx.array:
         """Extract logits from model output.
@@ -1538,6 +1546,7 @@ class MetalModelRunner:
             self._paged_request_seq_lens.pop(req_id, None)
 
         self._gdn_release_slots(finished_req_ids)
+        self._gdn_materialize_pending_state_cache()
 
         self._finished_request_count += len(finished_req_ids)
         if self._finished_request_count < _CACHE_CLEAR_INTERVAL:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -661,11 +661,11 @@ class MetalModelRunner:
     def _gdn_materialize_state_cache(self) -> None:
         """Detach GDN state arrays from the lazy graph."""
         backend = self._paged_attention_backend
-        if backend is None or not hasattr(backend, "_state_cache"):
+        if backend is None:
             return
         sc = backend._state_cache
         if sc is None:
-            return
+            raise RuntimeError("GDN state cache is not initialized")
         mx.eval(*sc.conv_states, *sc.recurrent_states)
 
     def _extract_logits(self, model_output: Any) -> mx.array:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -644,7 +644,7 @@ class MetalModelRunner:
                         sc.recurrent_states[layer_idx] = rec
         return slot
 
-    def _gdn_free_slot(self, req_id: str) -> None:
+    def _gdn_free_slot(self, req_id: str, *, materialize_state: bool = True) -> None:
         """Release a GDN state pool slot.
 
         Materializes conv/recurrent state arrays to detach them from the
@@ -655,14 +655,19 @@ class MetalModelRunner:
         slot = self._gdn_req_to_slot.pop(req_id, None)
         if slot is None:
             return
-        # Materialize state arrays so the lazy graph does not grow
-        # unboundedly across requests.
-        backend = self._paged_attention_backend
-        if backend is not None and hasattr(backend, "_state_cache"):
-            sc = backend._state_cache
-            if sc is not None:
-                mx.eval(*sc.conv_states, *sc.recurrent_states)
+        if materialize_state:
+            self._gdn_materialize_state_cache()
         self._gdn_free_slots.append(slot)
+
+    def _gdn_materialize_state_cache(self) -> None:
+        """Materialize GDN state arrays to detach lazy graphs."""
+        backend = self._paged_attention_backend
+        if backend is None or not hasattr(backend, "_state_cache"):
+            return
+        sc = backend._state_cache
+        if sc is None:
+            return
+        mx.eval(*sc.conv_states, *sc.recurrent_states)
 
     def _extract_logits(self, model_output: Any) -> mx.array:
         """Extract logits from model output.

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -649,20 +649,6 @@ class MetalModelRunner:
                 sc.recurrent_states[layer_idx] = rec
         return slot
 
-    def _gdn_free_slot(self, req_id: str, *, materialize_state: bool = True) -> None:
-        """Release a GDN state pool slot.
-
-        If ``materialize_state`` is True, detaches conv/recurrent state
-        arrays from the lazy computation graph. Pass False if the caller
-        already materialized in the same scheduling step.
-        """
-        slot = self._gdn_req_to_slot.pop(req_id, None)
-        if slot is None:
-            return
-        if materialize_state:
-            self._gdn_materialize_state_cache()
-        self._gdn_free_slots.append(slot)
-
     def _gdn_materialize_state_cache(self) -> None:
         """Detach GDN state arrays from the lazy graph to prevent growth."""
         backend = self._paged_attention_backend
@@ -672,6 +658,20 @@ class MetalModelRunner:
         if sc is None:
             raise RuntimeError("GDN state cache is not initialized")
         mx.eval(*sc.conv_states, *sc.recurrent_states)
+
+    def _gdn_release_slots(self, req_ids: set[str]) -> None:
+        """Release finished GDN slots, materializing state once if needed."""
+        freed_slots: list[int] = []
+        for req_id in req_ids:
+            slot = self._gdn_req_to_slot.pop(req_id, None)
+            if slot is not None:
+                freed_slots.append(slot)
+
+        if not freed_slots:
+            return
+
+        self._gdn_materialize_state_cache()
+        self._gdn_free_slots.extend(freed_slots)
 
     def _extract_logits(self, model_output: Any) -> mx.array:
         """Extract logits from model output.
@@ -1536,7 +1536,8 @@ class MetalModelRunner:
 
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
-            self._gdn_free_slot(req_id)
+
+        self._gdn_release_slots(finished_req_ids)
 
         self._finished_request_count += len(finished_req_ids)
         if self._finished_request_count < _CACHE_CLEAR_INTERVAL:
@@ -1589,14 +1590,7 @@ class MetalModelRunner:
             # Free GDN slots for finished requests BEFORE allocating new
             # ones, so slots can be reused within the same scheduling step.
             if self.is_hybrid and scheduler_output.finished_req_ids:
-                materialized = False
-                for req_id in scheduler_output.finished_req_ids:
-                    if req_id not in self._gdn_req_to_slot:
-                        continue
-                    if not materialized:
-                        self._gdn_materialize_state_cache()
-                        materialized = True
-                    self._gdn_free_slot(req_id, materialize_state=False)
+                self._gdn_release_slots(scheduler_output.finished_req_ids)
 
             prefill_pack = self._build_prefill_pack(batch)
             self._start_paged_forward(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -42,7 +42,10 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.config import get_config
-from vllm_metal.paged_attention_backend.hybrid import _build_linear_layer_spec
+from vllm_metal.paged_attention_backend.hybrid import (
+    HybridPagedAttentionBackend,
+    _build_linear_layer_spec,
+)
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.paged_attention_common import (
@@ -632,24 +635,26 @@ class MetalModelRunner:
         # at free time to avoid mx.eval synchronisation issues.
         if reused:
             backend = self._paged_attention_backend
-            if backend is not None and hasattr(backend, "_state_cache"):
-                sc = backend._state_cache
-                if sc is not None:
-                    for layer_idx in range(sc.num_layers):
-                        conv = sc.conv_states[layer_idx]
-                        conv[slot] = mx.zeros_like(conv[slot])
-                        sc.conv_states[layer_idx] = conv
-                        rec = sc.recurrent_states[layer_idx]
-                        rec[slot] = mx.zeros_like(rec[slot])
-                        sc.recurrent_states[layer_idx] = rec
+            if not isinstance(backend, HybridPagedAttentionBackend):
+                raise RuntimeError("GDN slot allocation requires hybrid paged backend")
+            sc = backend._state_cache
+            if sc is None:
+                raise RuntimeError("GDN state cache is not initialized")
+            for layer_idx in range(sc.num_layers):
+                conv = sc.conv_states[layer_idx]
+                conv[slot] = mx.zeros_like(conv[slot])
+                sc.conv_states[layer_idx] = conv
+                rec = sc.recurrent_states[layer_idx]
+                rec[slot] = mx.zeros_like(rec[slot])
+                sc.recurrent_states[layer_idx] = rec
         return slot
 
     def _gdn_free_slot(self, req_id: str, *, materialize_state: bool = True) -> None:
         """Release a GDN state pool slot.
 
         If ``materialize_state`` is True, detaches conv/recurrent state
-        arrays from the lazy computation graph. Zeroing is deferred to
-        ``_gdn_alloc_slot`` right before reuse.
+        arrays from the lazy computation graph. Pass False if the caller
+        already materialized in the same scheduling step.
         """
         slot = self._gdn_req_to_slot.pop(req_id, None)
         if slot is None:
@@ -659,10 +664,10 @@ class MetalModelRunner:
         self._gdn_free_slots.append(slot)
 
     def _gdn_materialize_state_cache(self) -> None:
-        """Detach GDN state arrays from the lazy graph."""
+        """Detach GDN state arrays from the lazy graph to prevent growth."""
         backend = self._paged_attention_backend
-        if backend is None:
-            return
+        if not isinstance(backend, HybridPagedAttentionBackend):
+            raise RuntimeError("GDN state cache requires hybrid paged backend")
         sc = backend._state_cache
         if sc is None:
             raise RuntimeError("GDN state cache is not initialized")

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1584,15 +1584,15 @@ class MetalModelRunner:
         if self._paged_attention_backend is not None and batch.has_paged_work():
             # Free GDN slots for finished requests BEFORE allocating new
             # ones, so slots can be reused within the same scheduling step.
-            # Conv/recurrent states are materialized per-layer in
-            # attention_linear.py, so the mx.eval in _gdn_free_slot is
-            # cheap (states already evaluated).  The _gdn_free_slot call
-            # in the later _cleanup_finished_requests is a no-op.
             if self.is_hybrid and scheduler_output.finished_req_ids:
+                materialized = False
                 for req_id in scheduler_output.finished_req_ids:
-                    slot = self._gdn_req_to_slot.pop(req_id, None)
-                    if slot is not None:
-                        self._gdn_free_slots.append(slot)
+                    if req_id not in self._gdn_req_to_slot:
+                        continue
+                    if not materialized:
+                        self._gdn_materialize_state_cache()
+                        materialized = True
+                    self._gdn_free_slot(req_id, materialize_state=False)
 
             prefill_pack = self._build_prefill_pack(batch)
             self._start_paged_forward(


### PR DESCRIPTION
This PR is:
- To unify GDN slot freeing so early release uses the same cleanup path.
- To materialize GDN state once per scheduling step to avoid repeated syncs.
- To enforce hybrid backend expectations and keep GDN tests aligned with runtime types.

Problem:
Early release bypassed `_gdn_free_slot`, skipping state materialization and creating two free paths. This could leave lazy MLX graphs attached to freed slots and made future cleanup changes inconsistent.

Fix:
- Centralized state materialization in `_gdn_materialize_state_cache`.
- Early release now materializes once per step and calls `_gdn_free_slot(..., materialize_state=False)`.
- Fail fast if the hybrid backend or state cache is missing.
- Tests now use a lightweight hybrid backend stub to match runtime expectations.

Tests:
- `python -m pytest tests/test_qwen3_next_gdn.py -v`
