### PR TITLE
Reduce KV cache allocation for YOCO shared layers

### DIFF
--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -98,10 +98,12 @@ class TestYocoCacheIntegration:
     _NUM_UNIQUE = _NUM_HIDDEN - _NUM_SHARED
     _NUM_KV_HEADS = 2
     _HEAD_DIM = 4
+    _BLOCK_SIZE = 16
+    _VOCAB_SIZE = 100
 
     def _gemma4_args(self) -> dict:
         return {
-            "vocab_size": 100,
+            "vocab_size": self._VOCAB_SIZE,
             "num_hidden_layers": self._NUM_HIDDEN,
             "num_kv_shared_layers": self._NUM_SHARED,
             "layer_types": list(self._LAYER_TYPES),
@@ -137,17 +139,16 @@ class TestYocoCacheIntegration:
         runner.num_kv_heads = self._NUM_KV_HEADS
         runner.head_dim = self._HEAD_DIM
         runner.kv_cache_dtype = mx.float16
-        runner.cache_config = SimpleNamespace(block_size=16)
+        runner.cache_config = SimpleNamespace(block_size=self._BLOCK_SIZE)
 
         block_bytes = runner.get_cache_block_size_bytes()
 
         # 2 (K+V) * num_unique * block_size * kv_heads * head_dim * dtype
         dtype_size = mx.float16.size
-        block_size = 16
         expected = (
             2
             * self._NUM_UNIQUE
-            * block_size
+            * self._BLOCK_SIZE
             * self._NUM_KV_HEADS
             * self._HEAD_DIM
             * dtype_size
@@ -178,7 +179,7 @@ class TestYocoCacheIntegration:
             num_kv_cache_layers=yoco[0],
         )
 
-        backend = MetalWorker._make_backend(runner, block_size=16)
+        backend = MetalWorker._make_backend(runner, block_size=self._BLOCK_SIZE)
 
         assert backend._num_layers == self._NUM_UNIQUE
         assert backend._cache_idx_map is not None

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -75,6 +75,141 @@ class TestResolveMaxHeadDim:
         assert result is None
 
 
+class TestYocoCacheIntegration:
+    """Integration tests for YOCO KV cache sharing.
+
+    Verifies reduced cache-byte accounting, _make_backend wiring, and
+    shared layers reusing the remapped cache slot.
+    """
+
+    # Gemma4-like config: 8 layers, 3 shared, alternating types
+    _LAYER_TYPES = [
+        "sliding",
+        "sliding",
+        "full",
+        "sliding",
+        "full",
+        "sliding",
+        "full",
+        "sliding",
+    ]
+    _NUM_HIDDEN = len(_LAYER_TYPES)
+    _NUM_SHARED = 3
+    _NUM_UNIQUE = _NUM_HIDDEN - _NUM_SHARED
+    _NUM_KV_HEADS = 2
+    _HEAD_DIM = 4
+
+    def _gemma4_args(self) -> dict:
+        return {
+            "vocab_size": 100,
+            "num_hidden_layers": self._NUM_HIDDEN,
+            "num_kv_shared_layers": self._NUM_SHARED,
+            "layer_types": list(self._LAYER_TYPES),
+            "num_key_value_heads": self._NUM_KV_HEADS,
+            "num_attention_heads": self._NUM_KV_HEADS,
+            "head_dim": self._HEAD_DIM,
+        }
+
+    def test_num_kv_cache_layers_reduced(self) -> None:
+        """Runner's num_kv_cache_layers uses unique count, not total."""
+        from tests.stub_runner import make_stub_runner
+
+        args = self._gemma4_args()
+        runner = make_stub_runner(model_args=args)
+        runner.num_layers = self._NUM_HIDDEN
+        runner._model_adapter = DefaultModelAdapter()
+
+        yoco = runner._model_adapter.build_yoco_cache_mapping(args)
+        assert yoco is not None
+        num_unique, _ = yoco
+        assert num_unique == self._NUM_UNIQUE
+
+    def test_cache_block_bytes_uses_unique_layers(self) -> None:
+        """get_cache_block_size_bytes should use num_kv_cache_layers, not num_layers."""
+        import mlx.core as mx
+
+        from tests.stub_runner import make_stub_runner
+
+        args = self._gemma4_args()
+        runner = make_stub_runner(model_args=args)
+        runner.num_layers = self._NUM_HIDDEN
+        runner.num_kv_cache_layers = self._NUM_UNIQUE
+        runner.num_kv_heads = self._NUM_KV_HEADS
+        runner.head_dim = self._HEAD_DIM
+        runner.kv_cache_dtype = mx.float16
+        runner.cache_config = SimpleNamespace(block_size=16)
+
+        block_bytes = runner.get_cache_block_size_bytes()
+
+        # 2 (K+V) * num_unique * block_size * kv_heads * head_dim * dtype
+        dtype_size = mx.float16.size
+        block_size = 16
+        expected = (
+            2
+            * self._NUM_UNIQUE
+            * block_size
+            * self._NUM_KV_HEADS
+            * self._HEAD_DIM
+            * dtype_size
+        )
+        assert block_bytes == expected
+
+    def test_make_backend_uses_compact_layer_count(self) -> None:
+        """_make_backend should create MHA backend with reduced num_layers."""
+        import mlx.core as mx
+
+        from vllm_metal.v1.worker import MetalWorker
+
+        adapter = DefaultModelAdapter()
+        args = self._gemma4_args()
+        yoco = adapter.build_yoco_cache_mapping(args)
+
+        # SimpleNamespace mock — avoids MetalModelRunner property issues
+        runner = SimpleNamespace(
+            model_args=args,
+            num_layers=self._NUM_HIDDEN,
+            num_kv_heads=self._NUM_KV_HEADS,
+            head_dim=self._HEAD_DIM,
+            kv_cache_dtype=mx.float16,
+            is_hybrid=False,
+            is_mla=False,
+            _model_adapter=adapter,
+            _yoco_cache_mapping=yoco,
+            num_kv_cache_layers=yoco[0],
+        )
+
+        backend = MetalWorker._make_backend(runner, block_size=16)
+
+        assert backend._num_layers == self._NUM_UNIQUE
+        assert backend._cache_idx_map is not None
+        # Shared layers map to a unique layer of same type
+        for i in range(self._NUM_UNIQUE, self._NUM_HIDDEN):
+            ref = backend._cache_idx_map[i]
+            assert ref < self._NUM_UNIQUE
+            assert self._LAYER_TYPES[ref] == self._LAYER_TYPES[i]
+
+    def test_shared_layer_reuses_cache_slot(self) -> None:
+        """Shared layers should get same cache_idx as their reference layer."""
+        adapter = DefaultModelAdapter()
+        args = self._gemma4_args()
+        result = adapter.build_yoco_cache_mapping(args)
+        assert result is not None
+        _, mapping = result
+
+        # Layer 5 (sliding, shared) should map to the same cache_idx as
+        # the last unique sliding layer in 0..4
+        shared_sliding = 5
+        ref = mapping[shared_sliding]
+        assert self._LAYER_TYPES[ref] == "sliding"
+        assert ref < self._NUM_UNIQUE
+
+        # Layer 6 (full, shared) → same cache_idx as last unique full layer
+        shared_full = 6
+        ref_full = mapping[shared_full]
+        assert self._LAYER_TYPES[ref_full] == "full"
+        assert ref_full < self._NUM_UNIQUE
+
+
 class TestRequireUniformKvHeads:
     """Tests for require_uniform_kv_heads()."""
 

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -378,6 +378,9 @@ def sdpa_forward(
     )
 
     # --- Cache write: MLX-native scatter (pure functional, graph-tracked) ---
+    # YOCO shared layers (shared_kv is not None) skip the write — their K/V
+    # is already in the reference layer's cache.  Only unique layers scatter.
+    #
     # Flatten cache to [num_slots, num_kv_heads, head_dim], scatter new K/V
     # by slot_mapping, then reshape back.  This creates proper graph nodes
     # that MLX's evaluator can track for dependency ordering and buffer
@@ -388,19 +391,26 @@ def sdpa_forward(
     # must have use_count == 1 (only the graph) for MLX to donate its
     # buffer to the scatter output.  Do NOT insert mx.eval between the
     # scatter and the rebind, or hold extra references to the old cache.
-    flat_k = kv_cache.key_caches[layer_idx].reshape(-1, kv_cache.num_kv_heads, head_dim)
-    flat_k[slot_mapping] = k_3d
-    new_k_cache = flat_k.reshape(kv_cache.key_caches[layer_idx].shape)
+    if shared_kv is not None:
+        # YOCO shared layer: K/V already written by the reference layer.
+        new_k_cache = kv_cache.key_caches[layer_idx]
+        new_v_cache = kv_cache.value_caches[layer_idx]
+    else:
+        flat_k = kv_cache.key_caches[layer_idx].reshape(
+            -1, kv_cache.num_kv_heads, head_dim
+        )
+        flat_k[slot_mapping] = k_3d
+        new_k_cache = flat_k.reshape(kv_cache.key_caches[layer_idx].shape)
 
-    flat_v = kv_cache.value_caches[layer_idx].reshape(
-        -1, kv_cache.num_kv_heads, head_dim
-    )
-    flat_v[slot_mapping] = v_3d
-    new_v_cache = flat_v.reshape(kv_cache.value_caches[layer_idx].shape)
+        flat_v = kv_cache.value_caches[layer_idx].reshape(
+            -1, kv_cache.num_kv_heads, head_dim
+        )
+        flat_v[slot_mapping] = v_3d
+        new_v_cache = flat_v.reshape(kv_cache.value_caches[layer_idx].shape)
 
-    # Rebind so next layer / decode step uses the updated cache
-    kv_cache.key_caches[layer_idx] = new_k_cache
-    kv_cache.value_caches[layer_idx] = new_v_cache
+        # Rebind so next layer / decode step uses the updated cache
+        kv_cache.key_caches[layer_idx] = new_k_cache
+        kv_cache.value_caches[layer_idx] = new_v_cache
 
     # --- Attention: paged attention primitive (read-only, fully lazy) ---
     # No per-layer eval or sync.  The primitive participates in MLX's lazy

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -69,6 +69,7 @@ class MHAPagedAttentionBackend:
         head_dim: int,
         block_size: int,
         dtype: mx.Dtype,
+        cache_idx_map: dict[int, int] | None = None,
     ) -> None:
         self._num_layers = num_layers
         self._num_kv_heads = num_kv_heads
@@ -76,6 +77,7 @@ class MHAPagedAttentionBackend:
         self._block_size = block_size
         self._dtype = dtype
         self._cache: MetalPagedKVCache | None = None
+        self._cache_idx_map = cache_idx_map
 
     def _require_initialized(self, caller: str) -> MetalPagedKVCache:
         if self._cache is None:
@@ -101,7 +103,9 @@ class MHAPagedAttentionBackend:
             patch_model_attention_metal_kernel,
         )
 
-        return patch_model_attention_metal_kernel(model, cache, self._block_size)
+        return patch_model_attention_metal_kernel(
+            model, cache, self._block_size, cache_idx_map=self._cache_idx_map
+        )
 
     def warm_up(self) -> None:
         warm_up_paged_cache(self._require_initialized("warm_up"))

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -25,6 +25,11 @@ class ModelAdapter(Protocol):
     def text_model(self, model: Any) -> Any:
         """Return the callable model used for text-only execution."""
 
+    def build_yoco_cache_mapping(
+        self, args: dict[str, Any]
+    ) -> tuple[int, dict[int, int]] | None:
+        """Build YOCO layer→cache_idx mapping, or None if not applicable."""
+
 
 # Models that vLLM flags as multimodal but must be loaded via mlx_lm.
 # gemma4: mlx_vlm forward path produces garbled output vs mlx_lm.
@@ -80,3 +85,46 @@ class DefaultModelAdapter(ModelAdapter):
         if hasattr(model, "language_model"):
             return model.language_model
         return model
+
+    def build_yoco_cache_mapping(
+        self, args: dict[str, Any]
+    ) -> tuple[int, dict[int, int]] | None:
+        """Build the layer→cache_idx mapping for YOCO KV sharing.
+
+        Gemma4's "You Only Cache Once" architecture only caches K/V for
+        the first ``N - num_kv_shared_layers`` layers.  Shared layers
+        reuse the cache of the most recent unique layer of the same
+        attention type (sliding or full).
+
+        Follows the same logic as mlx_lm's ``Gemma4TextModel.previous_kvs``
+        mapping.
+
+        Returns:
+            ``(num_unique_cache_layers, {layer_idx: cache_idx})`` or
+            ``None`` if the model does not use KV sharing.
+        """
+        num_layers = args.get("num_hidden_layers", 0)
+        num_shared = args.get("num_kv_shared_layers", 0)
+        if not num_shared or not num_layers:
+            return None
+
+        layer_types: list[str] = args.get("layer_types", [])
+        if len(layer_types) != num_layers:
+            return None
+
+        num_unique = num_layers - num_shared
+
+        # Map each attention type to the LAST unique layer of that type,
+        # matching mlx_lm's ``kvs_by_type`` logic.
+        type_to_cache_idx: dict[str, int] = {}
+        for i in range(num_unique):
+            type_to_cache_idx[layer_types[i]] = i
+
+        mapping: dict[int, int] = {}
+        for i in range(num_layers):
+            if i < num_unique:
+                mapping[i] = i
+            else:
+                mapping[i] = type_to_cache_idx[layer_types[i]]
+
+        return num_unique, mapping

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -595,6 +595,13 @@ class MetalModelRunner:
                 args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
             )
 
+        # YOCO (Gemma4): shared layers reuse a reference layer's cache.
+        # Compute the mapping once here so get_cache_block_size_bytes()
+        # and worker._make_backend() both use the same layer count.
+        yoco = self._model_adapter.build_yoco_cache_mapping(args)
+        self._yoco_cache_mapping = yoco
+        self.num_kv_cache_layers: int = yoco[0] if yoco else self.num_layers
+
         # Hybrid (Qwen3.5): mix of SDPA and GDN linear attention layers.
         # Store per-type layer counts and GDN dimensions for cache allocation.
         if self.is_hybrid:
@@ -768,7 +775,9 @@ class MetalModelRunner:
         if self.kv_cache_dtype is None:
             raise RuntimeError("KV cache dtype not initialized; load_model() first")
         dtype_size = self.kv_cache_dtype.size
-        num_kv_layers = self.num_sdpa_layers if self.is_hybrid else self.num_layers
+        num_kv_layers = (
+            self.num_sdpa_layers if self.is_hybrid else self.num_kv_cache_layers
+        )
         kv_factor = 1 if self.is_mla else 2
         return (
             kv_factor

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -318,12 +318,29 @@ class MetalWorker(WorkerBase):
                 block_size=block_size,
                 dtype=runner.kv_cache_dtype,
             )
+        # YOCO (Gemma4): only allocate cache for unique layers;
+        # shared layers reuse a reference layer's cache via cache_idx_map.
+        # Mapping is pre-computed by model_runner._resolve_model_dims so that
+        # get_cache_block_size_bytes() also uses the correct layer count.
+        yoco = runner._yoco_cache_mapping
+        if yoco is not None:
+            num_cache_layers, cache_idx_map = yoco
+            logger.info(
+                "YOCO KV sharing: %d unique cache layers (reduced from %d total)",
+                num_cache_layers,
+                runner.num_layers,
+            )
+        else:
+            num_cache_layers = runner.num_kv_cache_layers
+            cache_idx_map = None
+
         return MHAPagedAttentionBackend(
-            num_layers=runner.num_layers,
+            num_layers=num_cache_layers,
             num_kv_heads=runner.num_kv_heads,
             head_dim=runner.head_dim,
             block_size=block_size,
             dtype=runner.kv_cache_dtype,
+            cache_idx_map=cache_idx_map,
         )
 
     def _get_model_memory_usage(self) -> int:


### PR DESCRIPTION
Fixes #264

Gemma4 YOCO shared layers (last 20 of 35) now reuse the reference layer's paged cache instead of allocating and writing their own.

- `model_adapter.build_yoco_cache_mapping()` computes layer→cache_idx mapping
- `MHAPagedAttentionBackend` allocates only unique cache layers (15 vs 35)
- `sdpa_forward` skips scatter write when `shared_kv` is provided
- Gemma4-E2B-it deterministic test: 5/5 token-exact match with mlx_lm

Related #251