### PR TITLE
Extract model lifecycle responsibility from runner

### DIFF
--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -138,6 +138,36 @@ class TestModelLifecycle:
         assert runner.hidden_size == 4096
         assert runner.kv_cache_dtype is not None
 
+    def test_load_merges_nested_text_config_for_non_vlm_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=32000,
+                text_config=SimpleNamespace(
+                    vocab_size=32000,
+                    num_hidden_layers=32,
+                    num_attention_heads=32,
+                    num_key_value_heads=8,
+                    hidden_size=4096,
+                ),
+            )
+        )
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {"stub-model": (fake_model, object())},
+        )
+        lifecycle, runner = _make_lifecycle(model=SimpleNamespace())
+
+        lifecycle.load()
+
+        assert runner._is_vlm is False
+        assert runner.model_args["hidden_size"] == 4096
+        assert runner.num_layers == 32
+        assert runner.head_dim == 128
+
     def test_load_extracts_vlm_text_config_with_inherited_slots(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for model lifecycle ownership and config normalization."""
+"""Tests for model lifecycle behavior."""
 
 from __future__ import annotations
 
@@ -14,11 +14,39 @@ from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 
 
-class _SlotConfig:
-    __slots__ = ("vocab_size", "hidden_size")
+class _BaseSlotTextConfig:
+    __slots__ = ("vocab_size", "num_hidden_layers", "num_attention_heads")
 
-    def __init__(self, *, vocab_size: int, hidden_size: int) -> None:
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        num_hidden_layers: int,
+        num_attention_heads: int,
+    ) -> None:
         self.vocab_size = vocab_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+
+
+class _SlotTextConfig(_BaseSlotTextConfig):
+    __slots__ = ("num_key_value_heads", "hidden_size")
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        num_hidden_layers: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        hidden_size: int,
+    ) -> None:
+        super().__init__(
+            vocab_size=vocab_size,
+            num_hidden_layers=num_hidden_layers,
+            num_attention_heads=num_attention_heads,
+        )
+        self.num_key_value_heads = num_key_value_heads
         self.hidden_size = hidden_size
 
 
@@ -48,63 +76,112 @@ def _make_lifecycle(
 
 
 class TestModelLifecycle:
-    def test_is_vlm_model_defaults_false_when_flag_missing(self) -> None:
-        lifecycle, _ = _make_lifecycle(
+    def test_load_uses_adapter_override_for_text_only_multimodal_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=32000,
+                num_hidden_layers=32,
+                num_attention_heads=32,
+                num_key_value_heads=8,
+                hidden_size=4096,
+            )
+        )
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {"stub-model": (fake_model, object())},
+        )
+        lifecycle, runner = _make_lifecycle(
             model=SimpleNamespace(),
             model_config=SimpleNamespace(
                 model="stub-model",
-                hf_config=None,
+                hf_config=SimpleNamespace(model_type="gemma4"),
+                is_multimodal_model=True,
                 trust_remote_code=False,
                 dtype=torch.float16,
             ),
         )
 
-        assert lifecycle.is_vlm_model() is False
+        lifecycle.load()
 
-    def test_text_model_args_falls_back_to_config(self) -> None:
-        lifecycle, _ = _make_lifecycle(
-            model=SimpleNamespace(
-                config=SimpleNamespace(vocab_size=32000, hidden_size=4096)
+        assert runner._is_vlm is False
+
+    def test_load_extracts_text_model_config_from_cached_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_model = SimpleNamespace(
+            config=SimpleNamespace(
+                vocab_size=32000,
+                num_hidden_layers=32,
+                num_attention_heads=32,
+                num_key_value_heads=8,
+                hidden_size=4096,
             )
         )
-
-        model_args = lifecycle._text_model_args()
-
-        assert model_args["vocab_size"] == 32000
-        assert model_args["hidden_size"] == 4096
-
-    def test_vlm_model_args_accepts_slot_backed_text_config(self) -> None:
-        lifecycle, _ = _make_lifecycle(
-            model=SimpleNamespace(
-                config=SimpleNamespace(
-                    text_config=_SlotConfig(vocab_size=32000, hidden_size=4096)
-                )
-            ),
-            is_vlm=True,
+        fake_tokenizer = object()
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {"stub-model": (fake_model, fake_tokenizer)},
         )
+        lifecycle, runner = _make_lifecycle(model=SimpleNamespace())
 
-        model_args = lifecycle._vlm_model_args()
+        lifecycle.load()
 
-        assert model_args["vocab_size"] == 32000
-        assert model_args["hidden_size"] == 4096
+        assert runner.model is fake_model
+        assert runner.tokenizer is fake_tokenizer
+        assert runner.model_args["vocab_size"] == 32000
+        assert runner.hidden_size == 4096
+        assert runner.kv_cache_dtype is not None
 
-    def test_merge_text_config_accepts_namespace(self) -> None:
-        lifecycle, _ = _make_lifecycle(model=SimpleNamespace())
-
-        merged = lifecycle._merge_text_config(
-            {
-                "hidden_size": 1024,
-                "text_config": SimpleNamespace(
-                    hidden_size=4096,
+    def test_load_extracts_vlm_text_config_with_inherited_slots(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_model = SimpleNamespace(
+            config=SimpleNamespace(
+                text_config=_SlotTextConfig(
                     vocab_size=32000,
-                ),
-            }
+                    num_hidden_layers=32,
+                    num_attention_heads=32,
+                    num_key_value_heads=8,
+                    hidden_size=4096,
+                )
+            )
+        )
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {"stub-model": (fake_model, object())},
+        )
+        lifecycle, runner = _make_lifecycle(
+            model=SimpleNamespace(),
+            is_vlm=True,
+            model_config=SimpleNamespace(
+                model="stub-model",
+                hf_config=None,
+                is_multimodal_model=True,
+                trust_remote_code=False,
+                dtype=torch.float16,
+            ),
         )
 
-        assert merged["hidden_size"] == 1024
-        assert merged["vocab_size"] == 32000
+        lifecycle.load()
 
-    def test_load_stt_reuses_cached_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert runner._is_vlm is True
+        assert runner.model_args["vocab_size"] == 32000
+        assert runner.model_args["hidden_size"] == 4096
+        assert runner.num_layers == 32
+        assert runner.head_dim == 128
+
+    def test_load_reuses_cached_stt_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         adapter = object()
         fake_model = SimpleNamespace(
             create_runtime_adapter=lambda model_name: (adapter, model_name)
@@ -112,12 +189,12 @@ class TestModelLifecycle:
         monkeypatch.setattr(
             model_lifecycle,
             "_MODEL_CACHE",
-            {"openai/whisper-tiny": (fake_model, None)},
+            {"stub-model": (fake_model, None)},
         )
-
+        monkeypatch.setattr(model_lifecycle, "is_stt_model", lambda _model_name: True)
         lifecycle, runner = _make_lifecycle(model=object())
 
-        lifecycle.load_stt("openai/whisper-tiny")
+        lifecycle.load()
 
         assert runner.model is fake_model
         assert runner.tokenizer is None
@@ -125,7 +202,7 @@ class TestModelLifecycle:
         assert runner.kv_cache_dtype is None
         assert runner._is_vlm is False
         assert runner._is_stt is True
-        assert runner._stt_runtime_adapter == (adapter, "openai/whisper-tiny")
+        assert runner._stt_runtime_adapter == (adapter, "stub-model")
 
 
 class TestResolveModelDims:

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for model lifecycle ownership and config normalization."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
+from vllm_metal.v1 import model_lifecycle
+from vllm_metal.v1.model_lifecycle import ModelLifecycle
+
+
+class _SlotConfig:
+    __slots__ = ("vocab_size", "hidden_size")
+
+    def __init__(self, *, vocab_size: int, hidden_size: int) -> None:
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+
+
+def _make_lifecycle(
+    *,
+    model: object,
+    model_args: dict[str, object] | None = None,
+    model_config: object | None = None,
+    is_vlm: bool = False,
+) -> tuple[ModelLifecycle, object]:
+    runner = make_stub_runner(
+        model=model,
+        model_args=model_args,
+        _is_vlm=is_vlm,
+        metal_config=SimpleNamespace(debug=False),
+        model_config=model_config
+        or SimpleNamespace(
+            model="stub-model",
+            hf_config=None,
+            is_multimodal_model=False,
+            trust_remote_code=False,
+            dtype=torch.float16,
+        ),
+    )
+    lifecycle = ModelLifecycle(runner, runner._model_adapter)
+    return lifecycle, runner
+
+
+class TestModelLifecycle:
+    def test_is_vlm_model_defaults_false_when_flag_missing(self) -> None:
+        lifecycle, _ = _make_lifecycle(
+            model=SimpleNamespace(),
+            model_config=SimpleNamespace(
+                model="stub-model",
+                hf_config=None,
+                trust_remote_code=False,
+                dtype=torch.float16,
+            ),
+        )
+
+        assert lifecycle.is_vlm_model() is False
+
+    def test_text_model_args_falls_back_to_config(self) -> None:
+        lifecycle, _ = _make_lifecycle(
+            model=SimpleNamespace(
+                config=SimpleNamespace(vocab_size=32000, hidden_size=4096)
+            )
+        )
+
+        model_args = lifecycle._text_model_args()
+
+        assert model_args["vocab_size"] == 32000
+        assert model_args["hidden_size"] == 4096
+
+    def test_vlm_model_args_accepts_slot_backed_text_config(self) -> None:
+        lifecycle, _ = _make_lifecycle(
+            model=SimpleNamespace(
+                config=SimpleNamespace(
+                    text_config=_SlotConfig(vocab_size=32000, hidden_size=4096)
+                )
+            ),
+            is_vlm=True,
+        )
+
+        model_args = lifecycle._vlm_model_args()
+
+        assert model_args["vocab_size"] == 32000
+        assert model_args["hidden_size"] == 4096
+
+    def test_merge_text_config_accepts_namespace(self) -> None:
+        lifecycle, _ = _make_lifecycle(model=SimpleNamespace())
+
+        merged = lifecycle._merge_text_config(
+            {
+                "hidden_size": 1024,
+                "text_config": SimpleNamespace(
+                    hidden_size=4096,
+                    vocab_size=32000,
+                ),
+            }
+        )
+
+        assert merged["hidden_size"] == 1024
+        assert merged["vocab_size"] == 32000
+
+    def test_load_stt_reuses_cached_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = object()
+        fake_model = SimpleNamespace(
+            create_runtime_adapter=lambda model_name: (adapter, model_name)
+        )
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {"openai/whisper-tiny": (fake_model, None)},
+        )
+
+        lifecycle, runner = _make_lifecycle(model=object())
+
+        lifecycle.load_stt("openai/whisper-tiny")
+
+        assert runner.model is fake_model
+        assert runner.tokenizer is None
+        assert runner.model_args == {}
+        assert runner.kv_cache_dtype is None
+        assert runner._is_vlm is False
+        assert runner._is_stt is True
+        assert runner._stt_runtime_adapter == (adapter, "openai/whisper-tiny")
+
+
+class TestResolveModelDims:
+    def _make_runner(self, args: dict[str, object]) -> tuple[ModelLifecycle, object]:
+        return _make_lifecycle(model=object(), model_args=args)
+
+    def test_standard_mha(self) -> None:
+        lifecycle, runner = self._make_runner(
+            {
+                "num_hidden_layers": 32,
+                "num_attention_heads": 32,
+                "num_key_value_heads": 8,
+                "hidden_size": 4096,
+            }
+        )
+
+        lifecycle.resolve_model_dims()
+
+        assert runner.num_layers == 32
+        assert runner.num_kv_heads == 8
+        assert runner.head_dim == 128
+
+    def test_mla_overrides_kv_heads_and_head_dim(self) -> None:
+        lifecycle, runner = self._make_runner(
+            {
+                "num_hidden_layers": 47,
+                "num_attention_heads": 20,
+                "num_key_value_heads": 20,
+                "hidden_size": 2048,
+                "kv_lora_rank": 512,
+                "qk_rope_head_dim": 64,
+            }
+        )
+
+        lifecycle.resolve_model_dims()
+
+        assert runner.num_kv_heads == 1
+        assert runner.head_dim == 576
+        assert runner.mla_latent_dim == 576
+
+    def test_mla_default_rope_head_dim(self) -> None:
+        lifecycle, runner = self._make_runner(
+            {
+                "num_hidden_layers": 28,
+                "num_attention_heads": 16,
+                "hidden_size": 2048,
+                "kv_lora_rank": 256,
+            }
+        )
+
+        lifecycle.resolve_model_dims()
+
+        assert runner.head_dim == 256 + MLA_DEFAULT_QK_ROPE_HEAD_DIM
+        assert runner.mla_latent_dim == 256 + MLA_DEFAULT_QK_ROPE_HEAD_DIM
+
+    def test_missing_dims_raise(self) -> None:
+        lifecycle, _ = self._make_runner({"num_hidden_layers": 32})
+
+        with pytest.raises(ValueError, match="Cannot resolve model dimensions"):
+            lifecycle.resolve_model_dims()

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -13,6 +13,14 @@ from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 
+_TEXT_MODEL_ARGS = {
+    "vocab_size": 32000,
+    "num_hidden_layers": 32,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "hidden_size": 4096,
+}
+
 
 class _BaseSlotTextConfig:
     __slots__ = ("vocab_size", "num_hidden_layers", "num_attention_heads")
@@ -50,26 +58,47 @@ class _SlotTextConfig(_BaseSlotTextConfig):
         self.hidden_size = hidden_size
 
 
+def _runner_model_config(**overrides: object) -> object:
+    values = {
+        "model": "stub-model",
+        "hf_config": None,
+        "is_multimodal_model": False,
+        "trust_remote_code": False,
+        "dtype": torch.float16,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _text_config(**overrides: object) -> SimpleNamespace:
+    return SimpleNamespace(**(_TEXT_MODEL_ARGS | overrides))
+
+
+def _cache_generation_model(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    config: object,
+    tokenizer: object | None = None,
+) -> tuple[object, object]:
+    fake_model = SimpleNamespace(config=config)
+    fake_tokenizer = object() if tokenizer is None else tokenizer
+    monkeypatch.setattr(
+        model_lifecycle,
+        "_MODEL_CACHE",
+        {"stub-model": (fake_model, fake_tokenizer)},
+    )
+    return fake_model, fake_tokenizer
+
+
 def _make_lifecycle(
     *,
-    model: object,
     model_args: dict[str, object] | None = None,
     model_config: object | None = None,
-    is_vlm: bool = False,
 ) -> tuple[ModelLifecycle, object]:
     runner = make_stub_runner(
-        model=model,
         model_args=model_args,
-        _is_vlm=is_vlm,
         metal_config=SimpleNamespace(debug=False),
-        model_config=model_config
-        or SimpleNamespace(
-            model="stub-model",
-            hf_config=None,
-            is_multimodal_model=False,
-            trust_remote_code=False,
-            dtype=torch.float16,
-        ),
+        model_config=model_config or _runner_model_config(),
     )
     lifecycle = ModelLifecycle(runner, runner._model_adapter)
     return lifecycle, runner
@@ -80,29 +109,12 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        fake_model = SimpleNamespace(
-            config=SimpleNamespace(
-                vocab_size=32000,
-                num_hidden_layers=32,
-                num_attention_heads=32,
-                num_key_value_heads=8,
-                hidden_size=4096,
-            )
-        )
-        monkeypatch.setattr(
-            model_lifecycle,
-            "_MODEL_CACHE",
-            {"stub-model": (fake_model, object())},
-        )
+        _cache_generation_model(monkeypatch, config=_text_config())
         lifecycle, runner = _make_lifecycle(
-            model=SimpleNamespace(),
-            model_config=SimpleNamespace(
-                model="stub-model",
+            model_config=_runner_model_config(
                 hf_config=SimpleNamespace(model_type="gemma4"),
                 is_multimodal_model=True,
-                trust_remote_code=False,
-                dtype=torch.float16,
-            ),
+            )
         )
 
         lifecycle.load()
@@ -113,22 +125,13 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        fake_model = SimpleNamespace(
-            config=SimpleNamespace(
-                vocab_size=32000,
-                num_hidden_layers=32,
-                num_attention_heads=32,
-                num_key_value_heads=8,
-                hidden_size=4096,
-            )
-        )
         fake_tokenizer = object()
-        monkeypatch.setattr(
-            model_lifecycle,
-            "_MODEL_CACHE",
-            {"stub-model": (fake_model, fake_tokenizer)},
+        fake_model, _ = _cache_generation_model(
+            monkeypatch,
+            config=_text_config(),
+            tokenizer=fake_tokenizer,
         )
-        lifecycle, runner = _make_lifecycle(model=SimpleNamespace())
+        lifecycle, runner = _make_lifecycle()
 
         lifecycle.load()
 
@@ -142,24 +145,14 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        fake_model = SimpleNamespace(
+        _cache_generation_model(
+            monkeypatch,
             config=SimpleNamespace(
-                vocab_size=32000,
-                text_config=SimpleNamespace(
-                    vocab_size=32000,
-                    num_hidden_layers=32,
-                    num_attention_heads=32,
-                    num_key_value_heads=8,
-                    hidden_size=4096,
-                ),
-            )
+                vocab_size=_TEXT_MODEL_ARGS["vocab_size"],
+                text_config=_text_config(),
+            ),
         )
-        monkeypatch.setattr(
-            model_lifecycle,
-            "_MODEL_CACHE",
-            {"stub-model": (fake_model, object())},
-        )
-        lifecycle, runner = _make_lifecycle(model=SimpleNamespace())
+        lifecycle, runner = _make_lifecycle()
 
         lifecycle.load()
 
@@ -172,32 +165,18 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        fake_model = SimpleNamespace(
+        _cache_generation_model(
+            monkeypatch,
             config=SimpleNamespace(
                 text_config=_SlotTextConfig(
-                    vocab_size=32000,
-                    num_hidden_layers=32,
-                    num_attention_heads=32,
-                    num_key_value_heads=8,
-                    hidden_size=4096,
+                    **_TEXT_MODEL_ARGS,
                 )
-            )
-        )
-        monkeypatch.setattr(
-            model_lifecycle,
-            "_MODEL_CACHE",
-            {"stub-model": (fake_model, object())},
+            ),
         )
         lifecycle, runner = _make_lifecycle(
-            model=SimpleNamespace(),
-            is_vlm=True,
-            model_config=SimpleNamespace(
-                model="stub-model",
-                hf_config=None,
+            model_config=_runner_model_config(
                 is_multimodal_model=True,
-                trust_remote_code=False,
-                dtype=torch.float16,
-            ),
+            )
         )
 
         lifecycle.load()
@@ -222,7 +201,7 @@ class TestModelLifecycle:
             {"stub-model": (fake_model, None)},
         )
         monkeypatch.setattr(model_lifecycle, "is_stt_model", lambda _model_name: True)
-        lifecycle, runner = _make_lifecycle(model=object())
+        lifecycle, runner = _make_lifecycle()
 
         lifecycle.load()
 
@@ -236,11 +215,13 @@ class TestModelLifecycle:
 
 
 class TestResolveModelDims:
-    def _make_runner(self, args: dict[str, object]) -> tuple[ModelLifecycle, object]:
-        return _make_lifecycle(model=object(), model_args=args)
+    def _resolve(self, args: dict[str, object]) -> object:
+        lifecycle, runner = _make_lifecycle(model_args=args)
+        lifecycle.resolve_model_dims()
+        return runner
 
     def test_standard_mha(self) -> None:
-        lifecycle, runner = self._make_runner(
+        runner = self._resolve(
             {
                 "num_hidden_layers": 32,
                 "num_attention_heads": 32,
@@ -249,47 +230,48 @@ class TestResolveModelDims:
             }
         )
 
-        lifecycle.resolve_model_dims()
-
         assert runner.num_layers == 32
         assert runner.num_kv_heads == 8
         assert runner.head_dim == 128
 
-    def test_mla_overrides_kv_heads_and_head_dim(self) -> None:
-        lifecycle, runner = self._make_runner(
-            {
-                "num_hidden_layers": 47,
-                "num_attention_heads": 20,
-                "num_key_value_heads": 20,
-                "hidden_size": 2048,
-                "kv_lora_rank": 512,
-                "qk_rope_head_dim": 64,
-            }
-        )
-
-        lifecycle.resolve_model_dims()
+    @pytest.mark.parametrize(
+        ("args", "expected_head_dim"),
+        [
+            (
+                {
+                    "num_hidden_layers": 47,
+                    "num_attention_heads": 20,
+                    "num_key_value_heads": 20,
+                    "hidden_size": 2048,
+                    "kv_lora_rank": 512,
+                    "qk_rope_head_dim": 64,
+                },
+                576,
+            ),
+            (
+                {
+                    "num_hidden_layers": 28,
+                    "num_attention_heads": 16,
+                    "hidden_size": 2048,
+                    "kv_lora_rank": 256,
+                },
+                256 + MLA_DEFAULT_QK_ROPE_HEAD_DIM,
+            ),
+        ],
+    )
+    def test_mla_sets_expected_head_dim(
+        self,
+        args: dict[str, object],
+        expected_head_dim: int,
+    ) -> None:
+        runner = self._resolve(args)
 
         assert runner.num_kv_heads == 1
-        assert runner.head_dim == 576
-        assert runner.mla_latent_dim == 576
-
-    def test_mla_default_rope_head_dim(self) -> None:
-        lifecycle, runner = self._make_runner(
-            {
-                "num_hidden_layers": 28,
-                "num_attention_heads": 16,
-                "hidden_size": 2048,
-                "kv_lora_rank": 256,
-            }
-        )
-
-        lifecycle.resolve_model_dims()
-
-        assert runner.head_dim == 256 + MLA_DEFAULT_QK_ROPE_HEAD_DIM
-        assert runner.mla_latent_dim == 256 + MLA_DEFAULT_QK_ROPE_HEAD_DIM
+        assert runner.head_dim == expected_head_dim
+        assert runner.mla_latent_dim == expected_head_dim
 
     def test_missing_dims_raise(self) -> None:
-        lifecycle, _ = self._make_runner({"num_hidden_layers": 32})
+        lifecycle, _ = _make_lifecycle(model_args={"num_hidden_layers": 32})
 
         with pytest.raises(ValueError, match="Cannot resolve model dimensions"):
             lifecycle.resolve_model_dims()

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -246,7 +246,7 @@ class TestResolveModelDims:
                     "kv_lora_rank": 512,
                     "qk_rope_head_dim": 64,
                 },
-                576,
+                512 + 64,
             ),
             (
                 {

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import pytest
 from vllm.v1.outputs import ModelRunnerOutput
 
 import vllm_metal.v1.model_runner as mr
@@ -158,56 +157,12 @@ class TestV1MetalModelRunnerExecuteModel:
         assert runner._pending_output is None
 
 
-class TestResolveModelDims:
+class TestRunnerMlaProperties:
     def _make_runner(self, args: dict) -> mr.MetalModelRunner:
         return make_stub_runner(model_args=args)
 
-    def test_standard_mha(self) -> None:
-        r = self._make_runner(
-            {
-                "num_hidden_layers": 32,
-                "num_attention_heads": 32,
-                "num_key_value_heads": 8,
-                "hidden_size": 4096,
-            }
-        )
-        r._resolve_model_dims()
-        assert r.num_layers == 32
-        assert r.num_kv_heads == 8
-        assert r.head_dim == 128  # 4096 // 32
-
-    def test_mla_overrides_kv_heads_and_head_dim(self) -> None:
-        # GLM-4.7-Flash: kv_lora_rank=512, qk_rope_head_dim=64
-        r = self._make_runner(
-            {
-                "num_hidden_layers": 47,
-                "num_attention_heads": 20,
-                "num_key_value_heads": 20,
-                "hidden_size": 2048,
-                "kv_lora_rank": 512,
-                "qk_rope_head_dim": 64,
-            }
-        )
-        r._resolve_model_dims()
-        assert r.num_kv_heads == 1
-        assert r.head_dim == 576  # 512 + 64
-        assert r.mla_latent_dim == 576
-
-    def test_mla_default_rope_head_dim(self) -> None:
-        r = self._make_runner(
-            {
-                "num_hidden_layers": 28,
-                "num_attention_heads": 16,
-                "hidden_size": 2048,
-                "kv_lora_rank": 256,
-            }
-        )
-        r._resolve_model_dims()
-        assert r.head_dim == 320  # 256 + default 64
-        assert r.mla_latent_dim == 320  # default qk_rope_head_dim applied
-
     def test_mla_latent_dim_does_not_require_resolve_model_dims(self) -> None:
-        r = self._make_runner(
+        runner = self._make_runner(
             {
                 "num_hidden_layers": 4,
                 "num_attention_heads": 8,
@@ -217,19 +172,14 @@ class TestResolveModelDims:
             }
         )
 
-        assert r.mla_latent_dim == 576
-
-    def test_missing_dims_raise(self) -> None:
-        r = self._make_runner({"num_hidden_layers": 32})
-        with pytest.raises(ValueError, match="Cannot resolve model dimensions"):
-            r._resolve_model_dims()
+        assert runner.mla_latent_dim == 576
 
     def test_is_mla_true_when_kv_lora_rank_present(self) -> None:
-        r = self._make_runner({"kv_lora_rank": 512})
-        assert r.is_mla is True
+        runner = self._make_runner({"kv_lora_rank": 512})
+        assert runner.is_mla is True
 
     def test_is_mla_false_for_standard_mha(self) -> None:
-        r = self._make_runner(
+        runner = self._make_runner(
             {"num_hidden_layers": 32, "num_attention_heads": 32, "hidden_size": 4096}
         )
-        assert r.is_mla is False
+        assert runner.is_mla is False

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -45,10 +45,6 @@ class _StubRunner:
         self._pending_output = None
         self._stt_runtime_adapter = runtime_adapter
 
-    @property
-    def is_stt(self) -> bool:
-        return self._is_stt
-
 
 def _make_whisper_runtime_adapter() -> STTRuntimeAdapter:
     model = MagicMock()
@@ -432,28 +428,6 @@ class TestWhisperRuntimeAdapterTranscriberCaching:
         t1 = adapter.transcriber
         t2 = adapter.transcriber
         assert t1 is t2
-
-
-class TestIsSTTProperty:
-    """Tests for the public is_stt property on MetalModelRunner."""
-
-    def test_is_stt_default_false(self) -> None:
-        """is_stt should be False before STT model loading."""
-        runner = MagicMock()
-        runner._is_stt = False
-
-        prop = MetalModelRunner.is_stt.fget(runner)  # type: ignore[attr-defined]
-
-        assert prop is False
-
-    def test_is_stt_true_after_loading(self) -> None:
-        """is_stt should be True after STT model loading."""
-        runner = MagicMock()
-        runner._is_stt = True
-
-        prop = MetalModelRunner.is_stt.fget(runner)  # type: ignore[attr-defined]
-
-        assert prop is True
 
 
 @pytest.mark.slow

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Model lifecycle coordination for MetalModelRunner."""
+"""Model load and metadata derivation for MetalModelRunner."""
 
 from __future__ import annotations
 
 import time
 from collections.abc import Mapping
-from dataclasses import dataclass
 from threading import Lock
 from typing import TYPE_CHECKING, Any
 
@@ -29,20 +28,7 @@ _MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
 _MODEL_CACHE_LOCK = Lock()
 
 
-@dataclass(frozen=True)
-class ResolvedModelDims:
-    """Normalized runtime dimensions derived from model config."""
-
-    num_layers: int
-    num_attention_heads: int | None
-    num_kv_heads: int
-    hidden_size: int | None
-    head_dim: int
-
-
 class ModelLifecycle:
-    """Owns model load and metadata extraction for MetalModelRunner."""
-
     def __init__(
         self,
         runner: MetalModelRunner,
@@ -51,40 +37,53 @@ class ModelLifecycle:
         self._runner = runner
         self._model_adapter = model_adapter
 
-    def is_vlm_model(self) -> bool:
-        """Whether the configured model should load through mlx-vlm."""
-        hf_config = getattr(self._runner.model_config, "hf_config", None)
+    def load(self) -> None:
+        runner = self._runner
+        model_name = get_model_download_path(runner.model_config.model)
+        if is_stt_model(model_name):
+            self._load_stt(model_name)
+            return
+
+        model_config = runner.model_config
+        # vLLM model_config shape varies across backends.
+        hf_config = getattr(model_config, "hf_config", None)
+        is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
         if hf_config is not None and self._model_adapter.should_force_text_backbone(
             hf_config
         ):
-            return False
-        return bool(getattr(self._runner.model_config, "is_multimodal_model", False))
+            is_vlm = False
 
-    def load(self) -> None:
-        """Load the configured model and derive runtime metadata."""
-        model_name = get_model_download_path(self._runner.model_config.model)
+        model, tokenizer = self._load_generation_model(model_name, is_vlm)
 
-        if is_stt_model(model_name):
-            self.load_stt(model_name)
-            return
+        runner.model = model
+        runner.tokenizer = tokenizer
+        runner._is_vlm = is_vlm
+        runner._is_stt = False
+        runner._stt_runtime_adapter = None
 
-        is_vlm = self.is_vlm_model()
+        model_args = self._extract_model_args(model, is_vlm)
+        runner.model_args = model_args
+        runner._vocab_size = int(model_args["vocab_size"])
+        if runner.metal_config.debug:
+            logger.info("Model args: %s", model_args)
+        self.resolve_model_dims()
+        runner.kv_cache_dtype = torch_to_mlx(
+            torch.empty(0, dtype=model_config.dtype)
+        ).dtype
+
+    def _load_generation_model(self, model_name: str, is_vlm: bool) -> tuple[Any, Any]:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
 
         with _MODEL_CACHE_LOCK:
             cached = _MODEL_CACHE.get(model_name)
         if cached is not None:
-            self._runner.model, self._runner.tokenizer = cached
-            self._runner._is_vlm = is_vlm
-            self._runner._is_stt = False
-            self._runner._stt_runtime_adapter = None
-            load_time = time.time() - start_time
             logger.info(
-                "Model loaded from cache in %.3fs: %s", load_time, model_name
+                "Model loaded from cache in %.3fs: %s",
+                time.time() - start_time,
+                model_name,
             )
-            self._finalize_load()
-            return
+            return cached
 
         if is_vlm:
             logger.info("Using mlx-vlm for vision-language model")
@@ -92,35 +91,27 @@ class ModelLifecycle:
                 "VLM loaded in text-only mode: multimodal (image) inputs are "
                 "not yet supported. Vision encoder will be bypassed."
             )
-            self._runner.model, self._runner.tokenizer = mlx_vlm_load(model_name)
-            self._runner._is_vlm = True
+            model, tokenizer = mlx_vlm_load(model_name)
         else:
-            self._runner.model, self._runner.tokenizer = mlx_lm_load(
+            model, tokenizer = mlx_lm_load(
                 model_name,
                 tokenizer_config={
                     "trust_remote_code": self._runner.model_config.trust_remote_code
                 },
             )
-            self._runner._is_vlm = False
-
-        self._runner._is_stt = False
-        self._runner._stt_runtime_adapter = None
 
         with _MODEL_CACHE_LOCK:
-            _MODEL_CACHE[model_name] = (self._runner.model, self._runner.tokenizer)
+            _MODEL_CACHE[model_name] = (model, tokenizer)
+        logger.info("Model loaded in %.2fs: %s", time.time() - start_time, model_name)
+        return model, tokenizer
 
-        self._finalize_load()
-        load_time = time.time() - start_time
-        logger.info("Model loaded in %.2fs: %s", load_time, model_name)
-
-    def load_stt(self, model_name: str) -> None:
-        """Load a Speech-to-Text model and create its runtime adapter."""
+    def _load_stt(self, model_name: str) -> None:
         start_time = time.time()
 
         with _MODEL_CACHE_LOCK:
             cached = _MODEL_CACHE.get(model_name)
         if cached is not None:
-            self._runner.model, _ = cached
+            model, _ = cached
             load_time = time.time() - start_time
             logger.info(
                 "STT model loaded from cache in %.3fs: %s",
@@ -131,148 +122,22 @@ class ModelLifecycle:
             from vllm_metal.stt.loader import load_model as stt_load_model
 
             logger.info("Loading STT model: %s", model_name)
-            self._runner.model = stt_load_model(model_name)
+            model = stt_load_model(model_name)
             with _MODEL_CACHE_LOCK:
-                _MODEL_CACHE[model_name] = (self._runner.model, None)
+                _MODEL_CACHE[model_name] = (model, None)
             load_time = time.time() - start_time
             logger.info("STT model loaded in %.2fs: %s", load_time, model_name)
 
+        self._runner.model = model
         self._runner.tokenizer = None
         self._runner.model_args = {}
         self._runner.kv_cache_dtype = None
         self._runner._is_vlm = False
         self._runner._is_stt = True
-        self._runner._stt_runtime_adapter = self._runner.model.create_runtime_adapter(
-            model_name
-        )
-
-    def initialize_kv_cache_dtype(self) -> None:
-        """Resolve the MLX KV cache dtype from the configured torch dtype."""
-        self._runner.kv_cache_dtype = torch_to_mlx(
-            torch.empty(0, dtype=self._runner.model_config.dtype)
-        ).dtype
-
-    def extract_model_args(self) -> None:
-        """Normalize model config into the runner's shared mapping shape."""
-        if self._runner._is_vlm:
-            model_args = self._vlm_model_args()
-        else:
-            model_args = self._text_model_args()
-
-        merged_args = self._merge_text_config(model_args)
-        self._runner.model_args = merged_args
-        self._runner._vocab_size = int(merged_args["vocab_size"])
-
-        if self._runner.metal_config.debug:
-            logger.info("Model args: %s", merged_args)
+        self._runner._stt_runtime_adapter = model.create_runtime_adapter(model_name)
 
     def resolve_model_dims(self) -> None:
-        """Derive validated runtime dimensions from ``runner.model_args``."""
         args = self._runner.model_args
-        dims = self._resolve_base_dims(args)
-
-        self._runner.num_layers = dims.num_layers
-        self._runner.num_attention_heads = dims.num_attention_heads
-        self._runner.num_kv_heads = dims.num_kv_heads
-        self._runner.hidden_size = dims.hidden_size
-        self._runner.head_dim = dims.head_dim
-
-        if self._runner.is_mla:
-            self._apply_mla_dims(args)
-
-        yoco = self._model_adapter.build_yoco_cache_mapping(args)
-        self._runner._yoco_cache_mapping = yoco
-        self._runner.num_kv_cache_layers = (
-            yoco[0] if yoco is not None else self._runner.num_layers
-        )
-
-        if self._runner.is_hybrid:
-            self._apply_hybrid_dims(args)
-
-    def _finalize_load(self) -> None:
-        self.extract_model_args()
-        self.resolve_model_dims()
-        self.initialize_kv_cache_dtype()
-
-    def _text_model_args(self) -> dict[str, Any]:
-        model_args = getattr(self._runner.model, "args", None)
-        if model_args is not None:
-            return self._config_to_mapping(model_args, label="model.args")
-
-        config = getattr(self._runner.model, "config", None)
-        if config is not None:
-            return self._config_to_mapping(config, label="config")
-
-        raise ValueError(
-            "Cannot extract model config: model has neither .args nor .config "
-            "attribute."
-        )
-
-    def _vlm_model_args(self) -> dict[str, Any]:
-        config = getattr(self._runner.model, "config", None)
-        if config is None:
-            raise ValueError("Cannot extract VLM config: model has no .config.")
-
-        config_dict = self._config_to_mapping(config, label="config")
-        text_config = config_dict.get("text_config")
-        if text_config is None:
-            return config_dict
-        return self._config_to_mapping(text_config, label="text_config")
-
-    def _merge_text_config(self, model_args: dict[str, Any]) -> dict[str, Any]:
-        merged = dict(model_args)
-        text_config = merged.get("text_config")
-        if text_config is None:
-            return merged
-
-        if isinstance(text_config, Mapping):
-            text_values = dict(text_config)
-        else:
-            text_values = self._config_to_mapping(text_config, label="text_config")
-
-        for key, value in text_values.items():
-            merged.setdefault(key, value)
-        return merged
-
-    def _config_to_mapping(self, config: Any, *, label: str) -> dict[str, Any]:
-        if isinstance(config, Mapping):
-            return dict(config)
-
-        to_dict = getattr(config, "to_dict", None)
-        if callable(to_dict):
-            values = to_dict()
-            if isinstance(values, Mapping):
-                return dict(values)
-            raise TypeError(f"{label}.to_dict() must return a mapping.")
-
-        instance_dict = getattr(config, "__dict__", None)
-        if instance_dict is not None:
-            return dict(instance_dict)
-
-        slot_values = self._slots_to_mapping(config)
-        if slot_values is not None:
-            return slot_values
-
-        raise TypeError(
-            f"{label} must expose a mapping, to_dict(), __dict__, or __slots__."
-        )
-
-    def _slots_to_mapping(self, config: Any) -> dict[str, Any] | None:
-        slots = getattr(type(config), "__slots__", ())
-        if isinstance(slots, str):
-            slots = (slots,)
-        if not slots:
-            return None
-
-        values: dict[str, Any] = {}
-        for name in slots:
-            if not isinstance(name, str) or name.startswith("__"):
-                continue
-            if hasattr(config, name):
-                values[name] = getattr(config, name)
-        return values
-
-    def _resolve_base_dims(self, args: dict[str, Any]) -> ResolvedModelDims:
         num_layers = args.get("num_hidden_layers") or args.get("n_layers")
         num_attention_heads = args.get("num_attention_heads")
         num_kv_heads = (
@@ -301,38 +166,110 @@ class ModelLifecycle:
                 f"Available keys: {sorted(args.keys())}"
             )
 
-        return ResolvedModelDims(
-            num_layers=int(num_layers),
-            num_attention_heads=(
-                int(num_attention_heads) if num_attention_heads is not None else None
-            ),
-            num_kv_heads=int(num_kv_heads),
-            hidden_size=int(hidden_size) if hidden_size is not None else None,
-            head_dim=int(head_dim),
+        self._runner.num_layers = int(num_layers)
+        self._runner.num_attention_heads = (
+            int(num_attention_heads) if num_attention_heads is not None else None
+        )
+        self._runner.num_kv_heads = int(num_kv_heads)
+        self._runner.hidden_size = int(hidden_size) if hidden_size is not None else None
+        self._runner.head_dim = int(head_dim)
+
+        if self._runner.is_mla:
+            self._runner.num_kv_heads = 1
+            self._runner.head_dim = int(args["kv_lora_rank"]) + int(
+                args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
+            )
+
+        yoco = self._model_adapter.build_yoco_cache_mapping(args)
+        self._runner._yoco_cache_mapping = yoco
+        self._runner.num_kv_cache_layers = (
+            yoco[0] if yoco is not None else self._runner.num_layers
         )
 
-    def _apply_mla_dims(self, args: dict[str, Any]) -> None:
-        self._runner.num_kv_heads = 1
-        self._runner.head_dim = int(args["kv_lora_rank"]) + int(
-            args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
-        )
+        if self._runner.is_hybrid:
+            fai = int(args["full_attention_interval"])
+            self._runner.full_attention_interval = fai
+            self._runner.sdpa_layer_indices = frozenset(
+                i for i in range(self._runner.num_layers) if (i + 1) % fai == 0
+            )
+            self._runner.num_sdpa_layers = len(self._runner.sdpa_layer_indices)
+            self._runner.num_linear_layers = (
+                self._runner.num_layers - self._runner.num_sdpa_layers
+            )
+            self._runner.linear_num_k_heads = int(args["linear_num_key_heads"])
+            self._runner.linear_num_v_heads = int(args["linear_num_value_heads"])
+            self._runner.linear_key_head_dim = int(args["linear_key_head_dim"])
+            self._runner.linear_value_head_dim = int(args["linear_value_head_dim"])
+            self._runner.linear_conv_kernel_dim = int(args["linear_conv_kernel_dim"])
+            # Qwen3.5 GDN packs q/k at key_dim and v at value_dim.
+            self._runner.linear_conv_dim = (
+                self._runner.linear_num_k_heads * self._runner.linear_key_head_dim * 2
+                + self._runner.linear_num_v_heads * self._runner.linear_value_head_dim
+            )
 
-    def _apply_hybrid_dims(self, args: dict[str, Any]) -> None:
-        fai = int(args["full_attention_interval"])
-        self._runner.full_attention_interval = fai
-        self._runner.sdpa_layer_indices = frozenset(
-            i for i in range(self._runner.num_layers) if (i + 1) % fai == 0
-        )
-        self._runner.num_sdpa_layers = len(self._runner.sdpa_layer_indices)
-        self._runner.num_linear_layers = (
-            self._runner.num_layers - self._runner.num_sdpa_layers
-        )
-        self._runner.linear_num_k_heads = int(args["linear_num_key_heads"])
-        self._runner.linear_num_v_heads = int(args["linear_num_value_heads"])
-        self._runner.linear_key_head_dim = int(args["linear_key_head_dim"])
-        self._runner.linear_value_head_dim = int(args["linear_value_head_dim"])
-        self._runner.linear_conv_kernel_dim = int(args["linear_conv_kernel_dim"])
-        self._runner.linear_conv_dim = (
-            self._runner.linear_num_k_heads * self._runner.linear_key_head_dim * 2
-            + self._runner.linear_num_v_heads * self._runner.linear_value_head_dim
+    def _extract_model_args(self, model: Any, is_vlm: bool) -> dict[str, Any]:
+        # mlx-lm exposes .args while HF-backed models expose .config.
+        model_args = getattr(model, "args", None)
+        if model_args is not None:
+            return self._config_to_mapping(model_args, label="model.args")
+
+        config = getattr(model, "config", None)
+        if config is None:
+            raise ValueError(
+                "Cannot extract model config: model has neither .args nor .config "
+                "attribute."
+            )
+
+        config_values = self._config_to_mapping(config, label="config")
+        if is_vlm and "text_config" in config_values:
+            model_values = self._config_to_mapping(
+                config_values["text_config"],
+                label="text_config",
+            )
+        else:
+            model_values = config_values
+
+        text_config = model_values.get("text_config")
+        if text_config is None:
+            return model_values
+
+        merged_values = dict(model_values)
+        text_values = self._config_to_mapping(text_config, label="text_config")
+        for key, value in text_values.items():
+            merged_values.setdefault(key, value)
+        return merged_values
+
+    def _config_to_mapping(self, config: Any, *, label: str) -> dict[str, Any]:
+        missing = object()
+
+        if isinstance(config, Mapping):
+            return dict(config)
+
+        to_dict = getattr(config, "to_dict", None)
+        if callable(to_dict):
+            values = to_dict()
+            if isinstance(values, Mapping):
+                return dict(values)
+            raise TypeError(f"{label}.to_dict() must return a mapping.")
+
+        instance_dict = getattr(config, "__dict__", None)
+        if instance_dict is not None:
+            return dict(instance_dict)
+
+        slot_values: dict[str, Any] = {}
+        for cls in type(config).__mro__:
+            slots = cls.__dict__.get("__slots__", ())
+            if isinstance(slots, str):
+                slots = (slots,)
+            for name in slots:
+                if not isinstance(name, str) or name.startswith("__"):
+                    continue
+                value = getattr(config, name, missing)
+                if value is not missing:
+                    slot_values[name] = value
+        if slot_values:
+            return slot_values
+
+        raise TypeError(
+            f"{label} must expose a mapping, to_dict(), __dict__, or __slots__."
         )

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model lifecycle coordination for MetalModelRunner."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
+import torch
+from mlx_lm import load as mlx_lm_load
+from mlx_vlm import load as mlx_vlm_load
+from vllm.logger import init_logger
+
+from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
+from vllm_metal.stt.detection import is_stt_model
+from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.model_adapter import ModelAdapter
+
+if TYPE_CHECKING:
+    from vllm_metal.v1.model_runner import MetalModelRunner
+
+logger = init_logger(__name__)
+
+_MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
+_MODEL_CACHE_LOCK = Lock()
+
+
+@dataclass(frozen=True)
+class ResolvedModelDims:
+    """Normalized runtime dimensions derived from model config."""
+
+    num_layers: int
+    num_attention_heads: int | None
+    num_kv_heads: int
+    hidden_size: int | None
+    head_dim: int
+
+
+class ModelLifecycle:
+    """Owns model load and metadata extraction for MetalModelRunner."""
+
+    def __init__(
+        self,
+        runner: MetalModelRunner,
+        model_adapter: ModelAdapter,
+    ) -> None:
+        self._runner = runner
+        self._model_adapter = model_adapter
+
+    def is_vlm_model(self) -> bool:
+        """Whether the configured model should load through mlx-vlm."""
+        hf_config = getattr(self._runner.model_config, "hf_config", None)
+        if hf_config is not None and self._model_adapter.should_force_text_backbone(
+            hf_config
+        ):
+            return False
+        return bool(getattr(self._runner.model_config, "is_multimodal_model", False))
+
+    def load(self) -> None:
+        """Load the configured model and derive runtime metadata."""
+        model_name = get_model_download_path(self._runner.model_config.model)
+
+        if is_stt_model(model_name):
+            self.load_stt(model_name)
+            return
+
+        is_vlm = self.is_vlm_model()
+        logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
+        start_time = time.time()
+
+        with _MODEL_CACHE_LOCK:
+            cached = _MODEL_CACHE.get(model_name)
+        if cached is not None:
+            self._runner.model, self._runner.tokenizer = cached
+            self._runner._is_vlm = is_vlm
+            self._runner._is_stt = False
+            self._runner._stt_runtime_adapter = None
+            load_time = time.time() - start_time
+            logger.info(
+                "Model loaded from cache in %.3fs: %s", load_time, model_name
+            )
+            self._finalize_load()
+            return
+
+        if is_vlm:
+            logger.info("Using mlx-vlm for vision-language model")
+            logger.warning(
+                "VLM loaded in text-only mode: multimodal (image) inputs are "
+                "not yet supported. Vision encoder will be bypassed."
+            )
+            self._runner.model, self._runner.tokenizer = mlx_vlm_load(model_name)
+            self._runner._is_vlm = True
+        else:
+            self._runner.model, self._runner.tokenizer = mlx_lm_load(
+                model_name,
+                tokenizer_config={
+                    "trust_remote_code": self._runner.model_config.trust_remote_code
+                },
+            )
+            self._runner._is_vlm = False
+
+        self._runner._is_stt = False
+        self._runner._stt_runtime_adapter = None
+
+        with _MODEL_CACHE_LOCK:
+            _MODEL_CACHE[model_name] = (self._runner.model, self._runner.tokenizer)
+
+        self._finalize_load()
+        load_time = time.time() - start_time
+        logger.info("Model loaded in %.2fs: %s", load_time, model_name)
+
+    def load_stt(self, model_name: str) -> None:
+        """Load a Speech-to-Text model and create its runtime adapter."""
+        start_time = time.time()
+
+        with _MODEL_CACHE_LOCK:
+            cached = _MODEL_CACHE.get(model_name)
+        if cached is not None:
+            self._runner.model, _ = cached
+            load_time = time.time() - start_time
+            logger.info(
+                "STT model loaded from cache in %.3fs: %s",
+                load_time,
+                model_name,
+            )
+        else:
+            from vllm_metal.stt.loader import load_model as stt_load_model
+
+            logger.info("Loading STT model: %s", model_name)
+            self._runner.model = stt_load_model(model_name)
+            with _MODEL_CACHE_LOCK:
+                _MODEL_CACHE[model_name] = (self._runner.model, None)
+            load_time = time.time() - start_time
+            logger.info("STT model loaded in %.2fs: %s", load_time, model_name)
+
+        self._runner.tokenizer = None
+        self._runner.model_args = {}
+        self._runner.kv_cache_dtype = None
+        self._runner._is_vlm = False
+        self._runner._is_stt = True
+        self._runner._stt_runtime_adapter = self._runner.model.create_runtime_adapter(
+            model_name
+        )
+
+    def initialize_kv_cache_dtype(self) -> None:
+        """Resolve the MLX KV cache dtype from the configured torch dtype."""
+        self._runner.kv_cache_dtype = torch_to_mlx(
+            torch.empty(0, dtype=self._runner.model_config.dtype)
+        ).dtype
+
+    def extract_model_args(self) -> None:
+        """Normalize model config into the runner's shared mapping shape."""
+        if self._runner._is_vlm:
+            model_args = self._vlm_model_args()
+        else:
+            model_args = self._text_model_args()
+
+        merged_args = self._merge_text_config(model_args)
+        self._runner.model_args = merged_args
+        self._runner._vocab_size = int(merged_args["vocab_size"])
+
+        if self._runner.metal_config.debug:
+            logger.info("Model args: %s", merged_args)
+
+    def resolve_model_dims(self) -> None:
+        """Derive validated runtime dimensions from ``runner.model_args``."""
+        args = self._runner.model_args
+        dims = self._resolve_base_dims(args)
+
+        self._runner.num_layers = dims.num_layers
+        self._runner.num_attention_heads = dims.num_attention_heads
+        self._runner.num_kv_heads = dims.num_kv_heads
+        self._runner.hidden_size = dims.hidden_size
+        self._runner.head_dim = dims.head_dim
+
+        if self._runner.is_mla:
+            self._apply_mla_dims(args)
+
+        yoco = self._model_adapter.build_yoco_cache_mapping(args)
+        self._runner._yoco_cache_mapping = yoco
+        self._runner.num_kv_cache_layers = (
+            yoco[0] if yoco is not None else self._runner.num_layers
+        )
+
+        if self._runner.is_hybrid:
+            self._apply_hybrid_dims(args)
+
+    def _finalize_load(self) -> None:
+        self.extract_model_args()
+        self.resolve_model_dims()
+        self.initialize_kv_cache_dtype()
+
+    def _text_model_args(self) -> dict[str, Any]:
+        model_args = getattr(self._runner.model, "args", None)
+        if model_args is not None:
+            return self._config_to_mapping(model_args, label="model.args")
+
+        config = getattr(self._runner.model, "config", None)
+        if config is not None:
+            return self._config_to_mapping(config, label="config")
+
+        raise ValueError(
+            "Cannot extract model config: model has neither .args nor .config "
+            "attribute."
+        )
+
+    def _vlm_model_args(self) -> dict[str, Any]:
+        config = getattr(self._runner.model, "config", None)
+        if config is None:
+            raise ValueError("Cannot extract VLM config: model has no .config.")
+
+        config_dict = self._config_to_mapping(config, label="config")
+        text_config = config_dict.get("text_config")
+        if text_config is None:
+            return config_dict
+        return self._config_to_mapping(text_config, label="text_config")
+
+    def _merge_text_config(self, model_args: dict[str, Any]) -> dict[str, Any]:
+        merged = dict(model_args)
+        text_config = merged.get("text_config")
+        if text_config is None:
+            return merged
+
+        if isinstance(text_config, Mapping):
+            text_values = dict(text_config)
+        else:
+            text_values = self._config_to_mapping(text_config, label="text_config")
+
+        for key, value in text_values.items():
+            merged.setdefault(key, value)
+        return merged
+
+    def _config_to_mapping(self, config: Any, *, label: str) -> dict[str, Any]:
+        if isinstance(config, Mapping):
+            return dict(config)
+
+        to_dict = getattr(config, "to_dict", None)
+        if callable(to_dict):
+            values = to_dict()
+            if isinstance(values, Mapping):
+                return dict(values)
+            raise TypeError(f"{label}.to_dict() must return a mapping.")
+
+        instance_dict = getattr(config, "__dict__", None)
+        if instance_dict is not None:
+            return dict(instance_dict)
+
+        slot_values = self._slots_to_mapping(config)
+        if slot_values is not None:
+            return slot_values
+
+        raise TypeError(
+            f"{label} must expose a mapping, to_dict(), __dict__, or __slots__."
+        )
+
+    def _slots_to_mapping(self, config: Any) -> dict[str, Any] | None:
+        slots = getattr(type(config), "__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        if not slots:
+            return None
+
+        values: dict[str, Any] = {}
+        for name in slots:
+            if not isinstance(name, str) or name.startswith("__"):
+                continue
+            if hasattr(config, name):
+                values[name] = getattr(config, name)
+        return values
+
+    def _resolve_base_dims(self, args: dict[str, Any]) -> ResolvedModelDims:
+        num_layers = args.get("num_hidden_layers") or args.get("n_layers")
+        num_attention_heads = args.get("num_attention_heads")
+        num_kv_heads = (
+            args.get("num_key_value_heads")
+            or args.get("n_kv_heads")
+            or num_attention_heads
+        )
+        hidden_size = args.get("hidden_size")
+        head_dim = args.get("head_dim") or (
+            hidden_size // num_attention_heads
+            if hidden_size and num_attention_heads
+            else None
+        )
+        head_dim = self._model_adapter.resolve_max_head_dim(args, head_dim)
+
+        missing = []
+        if not num_layers:
+            missing.append("num_layers (num_hidden_layers / n_layers)")
+        if not num_kv_heads:
+            missing.append("num_kv_heads (num_key_value_heads / n_kv_heads)")
+        if not head_dim:
+            missing.append("head_dim")
+        if missing:
+            raise ValueError(
+                f"Cannot resolve model dimensions: {', '.join(missing)}. "
+                f"Available keys: {sorted(args.keys())}"
+            )
+
+        return ResolvedModelDims(
+            num_layers=int(num_layers),
+            num_attention_heads=(
+                int(num_attention_heads) if num_attention_heads is not None else None
+            ),
+            num_kv_heads=int(num_kv_heads),
+            hidden_size=int(hidden_size) if hidden_size is not None else None,
+            head_dim=int(head_dim),
+        )
+
+    def _apply_mla_dims(self, args: dict[str, Any]) -> None:
+        self._runner.num_kv_heads = 1
+        self._runner.head_dim = int(args["kv_lora_rank"]) + int(
+            args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
+        )
+
+    def _apply_hybrid_dims(self, args: dict[str, Any]) -> None:
+        fai = int(args["full_attention_interval"])
+        self._runner.full_attention_interval = fai
+        self._runner.sdpa_layer_indices = frozenset(
+            i for i in range(self._runner.num_layers) if (i + 1) % fai == 0
+        )
+        self._runner.num_sdpa_layers = len(self._runner.sdpa_layer_indices)
+        self._runner.num_linear_layers = (
+            self._runner.num_layers - self._runner.num_sdpa_layers
+        )
+        self._runner.linear_num_k_heads = int(args["linear_num_key_heads"])
+        self._runner.linear_num_v_heads = int(args["linear_num_value_heads"])
+        self._runner.linear_key_head_dim = int(args["linear_key_head_dim"])
+        self._runner.linear_value_head_dim = int(args["linear_value_head_dim"])
+        self._runner.linear_conv_kernel_dim = int(args["linear_conv_kernel_dim"])
+        self._runner.linear_conv_dim = (
+            self._runner.linear_num_k_heads * self._runner.linear_key_head_dim * 2
+            + self._runner.linear_num_v_heads * self._runner.linear_value_head_dim
+        )

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -45,7 +45,6 @@ class ModelLifecycle:
             return
 
         model_config = runner.model_config
-        # vLLM model_config shape varies across backends.
         hf_config = getattr(model_config, "hf_config", None)
         is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
         if hf_config is not None and self._model_adapter.should_force_text_backbone(
@@ -71,7 +70,9 @@ class ModelLifecycle:
             torch.empty(0, dtype=model_config.dtype)
         ).dtype
 
-    def _load_generation_model(self, model_name: str, is_vlm: bool) -> tuple[Any, Any]:
+    def _load_generation_model(
+        self, model_name: str, is_vlm: bool
+    ) -> tuple[Any, Any]:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
 

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -45,6 +45,7 @@ class ModelLifecycle:
             return
 
         model_config = runner.model_config
+        # vLLM model_config shape varies across backends.
         hf_config = getattr(model_config, "hf_config", None)
         is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
         if hf_config is not None and self._model_adapter.should_force_text_backbone(

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -71,9 +71,7 @@ class ModelLifecycle:
             torch.empty(0, dtype=model_config.dtype)
         ).dtype
 
-    def _load_generation_model(
-        self, model_name: str, is_vlm: bool
-    ) -> tuple[Any, Any]:
+    def _load_generation_model(self, model_name: str, is_vlm: bool) -> tuple[Any, Any]:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -264,11 +264,6 @@ class MetalModelRunner:
         self._execute_model_state: _PagedForwardState | None = None
 
     @property
-    def is_stt(self) -> bool:
-        """Whether the loaded model is a Speech-to-Text model."""
-        return self._is_stt
-
-    @property
     def is_mla(self) -> bool:
         """Whether the model uses Multi-head Latent Attention (MLA).
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -12,18 +12,13 @@ Key contracts:
 - Prefix-cache hits reconstruct full prompts for sampling metadata.
 """
 
-import time
 from dataclasses import dataclass, field
-from threading import Lock
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
 import torch
-from mlx_lm import load as mlx_lm_load
 from mlx_lm import stream_generate
 
-# mlx_vlm for vision-language models
-from mlx_vlm import load as mlx_vlm_load
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
@@ -53,12 +48,9 @@ from vllm_metal.paged_attention_common import (
     clear_context,
     prepare_unified,
 )
-from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
-from vllm_metal.stt.detection import is_stt_model
 from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
-from vllm_metal.utils import get_model_download_path
 from vllm_metal.v1 import contiguous_cache
 from vllm_metal.v1.contiguous_cache import (
     _MIN_BATCH_SIZE_FOR_BATCHING,
@@ -70,6 +62,7 @@ from vllm_metal.v1.contiguous_cache import (
     _merge_kv_caches,
 )
 from vllm_metal.v1.model_adapter import DefaultModelAdapter, ModelAdapter
+from vllm_metal.v1.model_lifecycle import ModelLifecycle
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
     SamplingBatch,
@@ -79,11 +72,6 @@ from vllm_metal.v1.sampling_batch import (
 )
 
 logger = init_logger(__name__)
-
-# Global model cache for fast repeated loads
-_model_cache: dict[str, tuple[Any, Any]] = {}  # model_name -> (model, tokenizer)
-_model_cache_lock = Lock()
-
 
 # Performance tuning
 _CACHE_CLEAR_INTERVAL = 50  # Clear cache every N finished requests
@@ -217,6 +205,7 @@ class MetalModelRunner:
         self.device = device
         self.metal_config = get_config()
         self._model_adapter: ModelAdapter = DefaultModelAdapter()
+        self._model_lifecycle = ModelLifecycle(self, self._model_adapter)
 
         self.model: Any = None
         self.tokenizer: Any = None
@@ -322,7 +311,7 @@ class MetalModelRunner:
         """Combined latent dimension for MLA cache: kv_lora_rank + qk_rope_head_dim.
 
         Only valid when is_mla is True. Derived directly from model_args so
-        callers do not depend on the _resolve_model_dims head_dim override.
+        callers do not depend on resolved runtime head_dim overrides.
         """
         if not self.is_mla:
             raise AttributeError("mla_latent_dim is only valid for MLA models")
@@ -362,270 +351,9 @@ class MetalModelRunner:
             return ("transcription",)
         return ("generate",)
 
-    def _is_vlm_model(self) -> bool:
-        """Check if the model is a vision-language model (VLM).
-
-        Returns:
-            True if the model is multimodal/VLM, False otherwise
-        """
-        hf_config = getattr(self.model_config, "hf_config", None)
-        if hf_config is not None and self._model_adapter.should_force_text_backbone(
-            hf_config
-        ):
-            return False
-        if hasattr(self.model_config, "is_multimodal_model"):
-            return self.model_config.is_multimodal_model
-        return False
-
     def load_model(self) -> None:
-        """Load the model using MLX with caching for fast repeated loads.
-
-        Uses mlx_vlm for vision-language models and mlx_lm for text-only models.
-        """
-        model_name = get_model_download_path(self.model_config.model)
-
-        # STT models use their own loading path — skip VLM/LM logic entirely.
-        if is_stt_model(model_name):
-            self._load_stt_model(model_name)
-            return
-
-        is_vlm = self._is_vlm_model()
-
-        logger.info(f"Loading model: {model_name} (VLM: {is_vlm})")
-        start_time = time.time()
-
-        # Check global cache first for fast repeated loads
-        with _model_cache_lock:
-            if model_name in _model_cache:
-                self.model, self.tokenizer = _model_cache[model_name]
-                self._is_vlm = is_vlm
-                load_time = time.time() - start_time
-                logger.info(
-                    f"Model loaded from cache in {load_time:.3f}s: {model_name}"
-                )
-                self._extract_model_args()
-                self._resolve_model_dims()
-                self._initialize_kv_cache_dtype()
-                return
-
-        # Load model using appropriate backend
-        if is_vlm:
-            logger.info("Using mlx-vlm for vision-language model")
-            # NOTE: Only text-only (language-model) inference is supported.
-            # Image inputs are not processed — the vision encoder is bypassed
-            # by routing all forward passes through model.language_model.
-            # Full multimodal inference (encode → fuse → forward) would follow
-            # the upstream decomposed encode/forward pattern and is a separate
-            # future effort.
-            logger.warning(
-                "VLM loaded in text-only mode: multimodal (image) inputs are "
-                "not yet supported. Vision encoder will be bypassed."
-            )
-            self.model, self.tokenizer = mlx_vlm_load(model_name)
-            self._is_vlm = True
-        else:
-            # Load model and tokenizer using mlx_lm for text-only models
-            self.model, self.tokenizer = mlx_lm_load(
-                model_name,
-                tokenizer_config={
-                    "trust_remote_code": self.model_config.trust_remote_code
-                },
-            )
-            self._is_vlm = False
-
-        # Cache for future loads
-        with _model_cache_lock:
-            _model_cache[model_name] = (self.model, self.tokenizer)
-
-        self._extract_model_args()
-        self._resolve_model_dims()
-        self._initialize_kv_cache_dtype()
-        load_time = time.time() - start_time
-        logger.info(f"Model loaded in {load_time:.2f}s: {model_name}")
-
-    def _load_stt_model(self, model_name: str) -> None:
-        """Load a Speech-to-Text model (e.g. Whisper) with caching."""
-        start_time = time.time()
-
-        with _model_cache_lock:
-            if model_name in _model_cache:
-                self.model, _ = _model_cache[model_name]
-                load_time = time.time() - start_time
-                logger.info(
-                    f"STT model loaded from cache in {load_time:.3f}s: {model_name}"
-                )
-                self.tokenizer = None  # Whisper manages its own tokenizer
-                self._is_stt = True
-                self._stt_runtime_adapter = self.model.create_runtime_adapter(
-                    model_name
-                )
-                return
-
-        # Local import: keep non-STT startup/import path light.
-        from vllm_metal.stt.loader import load_model as stt_load_model
-
-        logger.info(f"Loading STT model: {model_name}")
-        self.model = stt_load_model(model_name)
-        self.tokenizer = None  # Whisper manages its own tokenizer
-        self._is_stt = True
-        self._stt_runtime_adapter = self.model.create_runtime_adapter(model_name)
-
-        with _model_cache_lock:
-            _model_cache[model_name] = (self.model, None)
-
-        load_time = time.time() - start_time
-        logger.info(f"STT model loaded in {load_time:.2f}s: {model_name}")
-
-    def _initialize_kv_cache_dtype(self) -> None:
-        """Resolve the KV cache element dtype from model_config.dtype.
-
-        model_config.dtype is the authoritative compute dtype, set from
-        config.json torch_dtype at engine startup — the same source upstream
-        vLLM uses for kv_cache_dtype. Quantization changes weight storage
-        format but not compute precision, so this is correct for all model
-        families (dense, MoE, MLA) and quantisation levels.
-
-        torch_to_mlx on a zero-element probe tensor maps the torch.dtype to
-        its MLX equivalent without allocating memory.
-        """
-        self.kv_cache_dtype = torch_to_mlx(
-            torch.empty(0, dtype=self.model_config.dtype)
-        ).dtype
-
-    def _extract_model_args(self) -> None:
-        """Extract model configuration from loaded model.
-
-        Handles both text-only models and VLMs (which have nested text_config).
-        """
-        if hasattr(self.model, "args"):
-            # mlx-lm models (Qwen, Llama, etc.)
-            self.model_args = vars(self.model.args)
-        elif hasattr(self.model, "config"):
-            config = self.model.config
-            if self._is_vlm and hasattr(config, "text_config"):
-                # VLMs with nested text config (LLaVA, Pixtral via mlx-vlm)
-                text_config = config.text_config
-                if hasattr(text_config, "to_dict"):
-                    self.model_args = text_config.to_dict()
-                else:
-                    self.model_args = {
-                        k: getattr(text_config, k)
-                        for k in dir(text_config)
-                        if not k.startswith("_")
-                        and not callable(getattr(text_config, k))
-                    }
-            elif hasattr(config, "to_dict"):
-                # Standard HuggingFace config objects
-                self.model_args = config.to_dict()
-            else:
-                self.model_args = vars(config)
-        else:
-            raise ValueError(
-                "Cannot extract model config: model has neither .args nor "
-                ".config attribute."
-            )
-        # Merge nested text_config (Qwen3.5, VLMs) into top-level args.
-        # setdefault preserves any top-level keys that already exist.
-        tc = self.model_args.get("text_config")
-        if tc is not None:
-            if isinstance(tc, dict):
-                tc_dict = tc
-            elif hasattr(tc, "to_dict"):
-                tc_dict = tc.to_dict()
-            else:
-                tc_dict = vars(tc) if hasattr(tc, "__dict__") else {}
-            for k, v in tc_dict.items():
-                self.model_args.setdefault(k, v)
-
-        self._vocab_size: int = self.model_args["vocab_size"]
-
-        if self.metal_config.debug:
-            logger.info(f"Model args: {self.model_args}")
-
-    def _resolve_model_dims(self) -> None:
-        """Extract and validate model dimensions from ``self.model_args``.
-
-        Must be called after ``_extract_model_args()``.  Stores validated
-        dimensions as instance attributes so that every consumer reads from
-        one canonical source instead of repeating fallback chains.
-
-        Raises:
-            ValueError: If any critical dimension cannot be determined.
-        """
-        args = self.model_args
-
-        num_layers = args.get("num_hidden_layers") or args.get("n_layers")
-        num_attention_heads = args.get("num_attention_heads")
-        num_kv_heads = (
-            args.get("num_key_value_heads")
-            or args.get("n_kv_heads")
-            or num_attention_heads
-        )
-        hidden_size = args.get("hidden_size")
-        head_dim = args.get("head_dim") or (
-            hidden_size // num_attention_heads
-            if hidden_size and num_attention_heads
-            else None
-        )
-        head_dim = self._model_adapter.resolve_max_head_dim(args, head_dim)
-
-        # Fail fast if critical dims are missing
-        missing = []
-        if not num_layers:
-            missing.append("num_layers (num_hidden_layers / n_layers)")
-        if not num_kv_heads:
-            missing.append("num_kv_heads (num_key_value_heads / n_kv_heads)")
-        if not head_dim:
-            missing.append("head_dim")
-        if missing:
-            raise ValueError(
-                f"Cannot resolve model dimensions: {', '.join(missing)}. "
-                f"Available keys: {sorted(args.keys())}"
-            )
-
-        self.num_layers: int = int(num_layers)
-        self.num_attention_heads = num_attention_heads
-        self.num_kv_heads: int = int(num_kv_heads)
-        self.hidden_size = hidden_size
-        self.head_dim: int = int(head_dim)
-
-        # MLA (GLM/DeepSeek lineage): cache stores a joint latent vector per
-        # layer, not per-head K/V. Use one virtual head sized kv_lora_rank +
-        # qk_rope_head_dim so shared sizing paths can reuse head_dim/num_kv_heads
-        # while get_cache_block_size_bytes() applies an MLA-specific factor.
-        if self.is_mla:
-            self.num_kv_heads = 1
-            self.head_dim = int(args["kv_lora_rank"]) + int(
-                args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
-            )
-
-        # YOCO (Gemma4): shared layers reuse a reference layer's cache.
-        # Compute the mapping once here so get_cache_block_size_bytes()
-        # and worker._make_backend() both use the same layer count.
-        yoco = self._model_adapter.build_yoco_cache_mapping(args)
-        self._yoco_cache_mapping = yoco
-        self.num_kv_cache_layers: int = yoco[0] if yoco else self.num_layers
-
-        # Hybrid (Qwen3.5): mix of SDPA and GDN linear attention layers.
-        # Store per-type layer counts and GDN dimensions for cache allocation.
-        if self.is_hybrid:
-            fai = int(args["full_attention_interval"])
-            self.full_attention_interval: int = fai
-            self.sdpa_layer_indices: frozenset[int] = frozenset(
-                i for i in range(self.num_layers) if (i + 1) % fai == 0
-            )
-            self.num_sdpa_layers = len(self.sdpa_layer_indices)
-            self.num_linear_layers = self.num_layers - self.num_sdpa_layers
-            self.linear_num_k_heads: int = int(args["linear_num_key_heads"])
-            self.linear_num_v_heads: int = int(args["linear_num_value_heads"])
-            self.linear_key_head_dim: int = int(args["linear_key_head_dim"])
-            self.linear_value_head_dim: int = int(args["linear_value_head_dim"])
-            self.linear_conv_kernel_dim: int = int(args["linear_conv_kernel_dim"])
-            # Derived: total conv1d channel width (key_dim*2 + value_dim)
-            self.linear_conv_dim: int = (
-                self.linear_num_k_heads * self.linear_key_head_dim * 2
-                + self.linear_num_v_heads * self.linear_value_head_dim
-            )
+        """Load the configured model and derive runtime metadata."""
+        self._model_lifecycle.load()
 
     def _gdn_alloc_slot(self, req_id: str) -> int:
         """Allocate a stable GDN state pool slot for a request."""

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -18,7 +18,6 @@ from typing import Any, Literal, NamedTuple, TypeAlias
 import mlx.core as mx
 import torch
 from mlx_lm import stream_generate
-
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams


### PR DESCRIPTION
This PR is:
- To extract model loading, config normalization, and dimension resolution into `ModelLifecycle`.
- To keep `MetalModelRunner` focused on orchestration instead of startup/model-shape logic.
- To preserve the adapter boundary as the single place for model-specific rules.

Notes:
- This is a refactor only. Runtime behavior is intended to stay the same.
- `ModelLifecycle` now owns text/VLM/STT load flow, model arg extraction, KV cache dtype initialization, and resolved runtime dimensions.
- Tests move to the new ownership boundary in `tests/test_model_lifecycle.py` and cover the extracted lifecycle behavior directly.
- Next refactors will extract cache policy out of `MetalModelRunner` and move request-state / cleanup ownership into a dedicated boundary.
