### PR TITLE
Extract cache policy from runner and worker

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -8,6 +8,7 @@ from typing import Any
 import torch
 
 import vllm_metal.v1.model_runner as mr
+from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1.model_adapter import DefaultModelAdapter
 
 
@@ -51,6 +52,8 @@ def make_stub_runner(
         setattr(runner, k, v)
     for k, v in attrs.items():
         setattr(runner, k, v)
+
+    runner._cache_policy = ModelCachePolicy(runner, runner._model_adapter)
 
     # Derive _vocab_size from model_args — single source of truth.
     if "vocab_size" in _model_args:

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -159,21 +159,19 @@ class TestYocoCacheIntegration:
         """_make_backend should create MHA backend with reduced num_layers."""
         import mlx.core as mx
 
+        from tests.stub_runner import make_stub_runner
         from vllm_metal.v1.worker import MetalWorker
 
         adapter = DefaultModelAdapter()
         args = self._gemma4_args()
         yoco = adapter.build_yoco_cache_mapping(args)
 
-        # SimpleNamespace mock — avoids MetalModelRunner property issues
-        runner = SimpleNamespace(
+        runner = make_stub_runner(
             model_args=args,
             num_layers=self._NUM_HIDDEN,
             num_kv_heads=self._NUM_KV_HEADS,
             head_dim=self._HEAD_DIM,
             kv_cache_dtype=mx.float16,
-            is_hybrid=False,
-            is_mla=False,
             _model_adapter=adapter,
             _yoco_cache_mapping=yoco,
             num_kv_cache_layers=yoco[0],

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -25,6 +25,8 @@ from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.qwen3_asr.adapter import Qwen3ASRRuntimeAdapter
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.whisper.adapter import WhisperRuntimeAdapter
+from vllm_metal.v1.cache_policy import ModelCachePolicy
+from vllm_metal.v1.model_adapter import DefaultModelAdapter
 from vllm_metal.v1.model_runner import MetalModelRunner
 
 
@@ -44,6 +46,8 @@ class _StubRunner:
         self._request_states: dict = {}
         self._pending_output = None
         self._stt_runtime_adapter = runtime_adapter
+        self._model_adapter = DefaultModelAdapter()
+        self._cache_policy = ModelCachePolicy(self, self._model_adapter)
 
 
 def _make_whisper_runtime_adapter() -> STTRuntimeAdapter:

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -11,10 +11,11 @@ import pytest
 
 pytest.importorskip("vllm", reason="vllm not installed")
 
+from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402
+from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.cache_policy import ModelCachePolicy  # noqa: E402
 from vllm_metal.v1.model_adapter import DefaultModelAdapter  # noqa: E402
-from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.worker import MetalWorker  # noqa: E402
 
 
@@ -86,18 +87,15 @@ class TestWorkerRunnerBoundaryDelegation:
 
     def test_determine_available_memory_single_sequence_mode(self) -> None:
         """Test MLX path returns one max-length sequence estimate (PR #229)."""
-        import mlx.core as mx
-
-        model_runner = SimpleNamespace(
-            scheduler_memory_reporting_mode=MagicMock(
-                return_value="single_sequence_estimate"
-            ),
-            kv_cache_dtype=mx.float16,
-            is_hybrid=False,
-            is_mla=False,
+        model_runner = make_stub_runner(
             num_layers=16,
+            num_kv_cache_layers=16,
             num_kv_heads=8,
             head_dim=128,
+            kv_cache_dtype=mx.float16,
+        )
+        model_runner.scheduler_memory_reporting_mode = MagicMock(
+            return_value="single_sequence_estimate"
         )
         worker = _make_worker(model_runner, use_paged_attention=False)
         worker.model_config = SimpleNamespace(max_model_len=2048)
@@ -128,10 +126,9 @@ class TestOneSequenceKvBytes:
     """_one_sequence_kv_bytes must account for hybrid linear state and block alignment."""
 
     def test_non_hybrid_counts_all_layers(self) -> None:
-        model_runner = SimpleNamespace(
-            is_hybrid=False,
-            is_mla=False,
+        model_runner = make_stub_runner(
             num_layers=16,
+            num_kv_cache_layers=16,
             num_kv_heads=8,
             head_dim=64,
             kv_cache_dtype=mx.float16,
@@ -150,15 +147,18 @@ class TestOneSequenceKvBytes:
         assert result == 2 * 16 * 2048 * 8 * 64 * 2
 
     def test_hybrid_adds_linear_state(self) -> None:
-        linear_bytes = 1_000_000
-        model_runner = SimpleNamespace(
-            is_hybrid=True,
-            is_mla=False,
+        model_runner = make_stub_runner(
+            model_args={"full_attention_interval": 2},
             num_sdpa_layers=8,
             num_kv_heads=4,
             head_dim=256,
             kv_cache_dtype=mx.float16,
-            linear_cache_bytes_per_slot=MagicMock(return_value=linear_bytes),
+            linear_conv_kernel_dim=3,
+            linear_conv_dim=5,
+            linear_num_v_heads=2,
+            linear_value_head_dim=7,
+            linear_key_head_dim=11,
+            num_linear_layers=3,
         )
         worker = _make_worker(model_runner, use_paged_attention=False)
         worker.model_config = SimpleNamespace(max_model_len=2048)
@@ -171,6 +171,9 @@ class TestOneSequenceKvBytes:
 
         # Assert — SDPA bytes + linear state
         sdpa_bytes = 2 * 8 * 2048 * 4 * 256 * 2
+        conv_bytes = (3 - 1) * 5 * mx.float16.size
+        recurrent_bytes = 2 * 7 * 11 * mx.float32.size
+        linear_bytes = 3 * (conv_bytes + recurrent_bytes)
         assert result == sdpa_bytes + linear_bytes
 
     def test_linear_cache_bytes_uses_float32_recurrent(self) -> None:
@@ -210,10 +213,9 @@ class TestOneSequenceKvBytes:
         models (e.g. Granite 4.0-H) where the attention block_size is padded
         to 400 to match the mamba page size.
         """
-        model_runner = SimpleNamespace(
-            is_hybrid=False,
-            is_mla=False,
+        model_runner = make_stub_runner(
             num_layers=4,
+            num_kv_cache_layers=4,
             num_kv_heads=4,
             head_dim=64,
             kv_cache_dtype=mx.float16,
@@ -241,10 +243,10 @@ class TestOneSequenceKvBytes:
         head_dim=576 represents kv_lora_rank + qk_rope_head_dim (e.g. GLM-4).
         The 2x K/V factor must NOT be applied — kv_factor=1.
         """
-        model_runner = SimpleNamespace(
-            is_hybrid=False,
-            is_mla=True,
+        model_runner = make_stub_runner(
+            model_args={"kv_lora_rank": 512},
             num_layers=4,
+            num_kv_cache_layers=4,
             num_kv_heads=1,
             head_dim=576,
             kv_cache_dtype=mx.float16,
@@ -258,4 +260,23 @@ class TestOneSequenceKvBytes:
         result = MetalWorker._one_sequence_kv_bytes(worker)
 
         expected = 1 * 4 * 2048 * 1 * 576 * 2
+        assert result == expected
+
+    def test_yoco_uses_unique_cache_layers(self) -> None:
+        model_runner = make_stub_runner(
+            num_layers=28,
+            num_kv_cache_layers=24,
+            num_kv_heads=4,
+            head_dim=256,
+            kv_cache_dtype=mx.float16,
+        )
+        worker = _make_worker(model_runner, use_paged_attention=False)
+        worker.model_config = SimpleNamespace(max_model_len=2048)
+        worker.vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=16)
+        )
+
+        result = MetalWorker._one_sequence_kv_bytes(worker)
+
+        expected = 2 * 24 * 2048 * 4 * 256 * 2
         assert result == expected

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -12,6 +12,8 @@ import pytest
 pytest.importorskip("vllm", reason="vllm not installed")
 
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402
+from vllm_metal.v1.cache_policy import ModelCachePolicy  # noqa: E402
+from vllm_metal.v1.model_adapter import DefaultModelAdapter  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.worker import MetalWorker  # noqa: E402
 
@@ -174,6 +176,8 @@ class TestOneSequenceKvBytes:
     def test_linear_cache_bytes_uses_float32_recurrent(self) -> None:
         runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
         runner.model_args = {"full_attention_interval": 2}
+        runner._model_adapter = DefaultModelAdapter()
+        runner._cache_policy = ModelCachePolicy(runner, runner._model_adapter)
         runner.kv_cache_dtype = mx.float16
         runner.linear_conv_kernel_dim = 3
         runner.linear_conv_dim = 5

--- a/vllm_metal/stt/policy.py
+++ b/vllm_metal/stt/policy.py
@@ -12,6 +12,10 @@ STT_SCHED_AVAILABLE_BYTES = 1 << 30  # 1 GiB
 # Block size reported to vLLM for STT models (minimal, no real KV cache).
 STT_SCHED_BLOCK_BYTES = 1
 
+# Nominal head size for the placeholder KV spec used only to satisfy
+# vLLM scheduler initialization for STT models.
+STT_SCHED_NOMINAL_HEAD_SIZE = 64
+
 
 class _ModelConfigLike(Protocol):
     model: str

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -23,7 +23,11 @@ from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
 from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.pytorch_backend.tensor_bridge import MLX_TO_TORCH_DTYPE
-from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES, STT_SCHED_BLOCK_BYTES
+from vllm_metal.stt.policy import (
+    STT_SCHED_AVAILABLE_BYTES,
+    STT_SCHED_BLOCK_BYTES,
+    STT_SCHED_NOMINAL_HEAD_SIZE,
+)
 from vllm_metal.v1.model_adapter import ModelAdapter
 
 if TYPE_CHECKING:
@@ -80,7 +84,7 @@ class ModelCachePolicy:
                 "layers.0.self_attn": FullAttentionSpec(
                     block_size=self._runner.metal_config.block_size,
                     num_kv_heads=1,
-                    head_size=64,
+                    head_size=STT_SCHED_NOMINAL_HEAD_SIZE,
                     dtype=torch.float16,
                 ),
             }

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -93,7 +93,10 @@ class ModelCachePolicy:
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
         specs: dict[str, KVCacheSpec] = {}
         for layer_idx in range(self._runner.num_layers):
-            if self._runner.is_hybrid and layer_idx not in self._runner.sdpa_layer_indices:
+            if (
+                self._runner.is_hybrid
+                and layer_idx not in self._runner.sdpa_layer_indices
+            ):
                 layer_name = f"layers.{layer_idx}.linear_attn"
                 specs[layer_name] = _build_linear_layer_spec(
                     conv_kernel_dim=self._runner.linear_conv_kernel_dim,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cache-policy ownership for the v1 Metal runtime."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+import mlx.core as mx
+import torch
+from vllm.logger import init_logger
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
+
+from vllm_metal.paged_attention_backend.hybrid import (
+    HybridPagedAttentionBackend,
+    _build_linear_layer_spec,
+)
+from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
+from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
+from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
+from vllm_metal.pytorch_backend.tensor_bridge import MLX_TO_TORCH_DTYPE
+from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
+from vllm_metal.v1.model_adapter import ModelAdapter
+
+if TYPE_CHECKING:
+    from vllm_metal.v1.model_runner import MetalModelRunner
+
+logger = init_logger(__name__)
+
+
+class ModelCachePolicy:
+    """Cache shape, size, and backend-selection policy for one runner."""
+
+    def __init__(self, runner: MetalModelRunner, model_adapter: ModelAdapter) -> None:
+        self._runner = runner
+        self._model_adapter = model_adapter
+
+    def should_setup_paged_attention(self) -> bool:
+        """Whether worker-side paged-attention setup should run."""
+        return not self._runner._is_stt
+
+    def validate_paged_attention_support(self) -> None:
+        """Validate that the loaded model can run on the paged-attention path."""
+        self._model_adapter.require_uniform_kv_heads(
+            self._runner.model_args,
+            self._runner.num_kv_heads,
+        )
+
+    def scheduler_memory_reporting_mode(
+        self, *, paged_attention_enabled: bool
+    ) -> Literal["stt_nominal", "paged_attention_capacity", "single_sequence_estimate"]:
+        """Return which scheduler memory-reporting mode worker should use."""
+        if self._runner._is_stt:
+            return "stt_nominal"
+        if paged_attention_enabled:
+            return "paged_attention_capacity"
+        return "single_sequence_estimate"
+
+    def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
+        """Build the scheduler-visible KV cache specification."""
+        runner = self._runner
+        if runner._is_stt:
+            return {
+                "layers.0.self_attn": FullAttentionSpec(
+                    block_size=runner.metal_config.block_size,
+                    num_kv_heads=1,
+                    head_size=64,
+                    dtype=torch.float16,
+                ),
+            }
+
+        block_size = runner.cache_config.block_size
+        if runner.kv_cache_dtype is None:
+            raise RuntimeError("KV cache dtype not initialized; load_model() first")
+
+        torch_dtype = MLX_TO_TORCH_DTYPE[runner.kv_cache_dtype]
+        specs: dict[str, KVCacheSpec] = {}
+        for layer_idx in range(runner.num_layers):
+            if runner.is_hybrid and layer_idx not in runner.sdpa_layer_indices:
+                layer_name = f"layers.{layer_idx}.linear_attn"
+                specs[layer_name] = _build_linear_layer_spec(
+                    conv_kernel_dim=runner.linear_conv_kernel_dim,
+                    conv_dim=runner.linear_conv_dim,
+                    num_v_heads=runner.linear_num_v_heads,
+                    value_head_dim=runner.linear_value_head_dim,
+                    key_head_dim=runner.linear_key_head_dim,
+                    torch_dtype=torch_dtype,
+                    page_size_padded=runner.cache_config.mamba_page_size_padded,
+                    block_size=block_size,
+                )
+            else:
+                layer_name = f"layers.{layer_idx}.self_attn"
+                specs[layer_name] = FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=runner.num_kv_heads,
+                    head_size=runner.head_dim,
+                    dtype=torch_dtype,
+                )
+
+        return specs
+
+    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        """Accept engine KV cache config for API compatibility."""
+        logger.info(
+            "KV cache config received: %d blocks (MLX manages cache internally)",
+            kv_cache_config.num_blocks,
+        )
+
+    def get_cache_block_size_bytes(self) -> int:
+        """Return the byte size of one cache block."""
+        runner = self._runner
+        if runner._is_stt:
+            return STT_SCHED_BLOCK_BYTES
+
+        if runner.kv_cache_dtype is None:
+            raise RuntimeError("KV cache dtype not initialized; load_model() first")
+
+        block_size = runner.cache_config.block_size
+        dtype_size = runner.kv_cache_dtype.size
+        num_kv_layers = (
+            runner.num_sdpa_layers if runner.is_hybrid else runner.num_kv_cache_layers
+        )
+        kv_factor = 1 if runner.is_mla else 2
+        return (
+            kv_factor
+            * num_kv_layers
+            * block_size
+            * runner.num_kv_heads
+            * runner.head_dim
+            * dtype_size
+        )
+
+    def linear_cache_bytes_per_slot(self) -> int:
+        """Return bytes for one request's linear-attention state."""
+        runner = self._runner
+        if not runner.is_hybrid:
+            raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
+        if runner.kv_cache_dtype is None:
+            raise RuntimeError("KV cache dtype not initialized; load_model() first")
+
+        dtype_size = runner.kv_cache_dtype.size
+        recurrent_dtype_size = mx.float32.size
+        conv_bytes = (
+            (runner.linear_conv_kernel_dim - 1) * runner.linear_conv_dim * dtype_size
+        )
+        recurrent_bytes = (
+            runner.linear_num_v_heads
+            * runner.linear_value_head_dim
+            * runner.linear_key_head_dim
+            * recurrent_dtype_size
+        )
+        return runner.num_linear_layers * (conv_bytes + recurrent_bytes)
+
+    def build_paged_attention_backend(
+        self, *, block_size: int
+    ) -> PagedAttentionBackend:
+        """Create the paged-attention backend for the loaded model."""
+        runner = self._runner
+        if runner.is_hybrid:
+            return HybridPagedAttentionBackend(
+                num_layers=runner.num_layers,
+                full_attention_interval=runner.full_attention_interval,
+                max_num_seqs=runner.scheduler_config.max_num_seqs,
+                num_kv_heads=runner.num_kv_heads,
+                head_dim=runner.head_dim,
+                linear_num_v_heads=runner.linear_num_v_heads,
+                linear_key_head_dim=runner.linear_key_head_dim,
+                linear_value_head_dim=runner.linear_value_head_dim,
+                linear_conv_kernel_dim=runner.linear_conv_kernel_dim,
+                linear_conv_dim=runner.linear_conv_dim,
+                block_size=block_size,
+                dtype=runner.kv_cache_dtype,
+            )
+
+        if runner.is_mla:
+            return MLAPagedAttentionBackend(
+                num_layers=runner.num_layers,
+                latent_dim=runner.mla_latent_dim,
+                block_size=block_size,
+                dtype=runner.kv_cache_dtype,
+            )
+
+        yoco = runner._yoco_cache_mapping
+        if yoco is not None:
+            num_cache_layers, cache_idx_map = yoco
+            logger.info(
+                "YOCO KV sharing: %d unique cache layers (reduced from %d total)",
+                num_cache_layers,
+                runner.num_layers,
+            )
+        else:
+            num_cache_layers = runner.num_kv_cache_layers
+            cache_idx_map = None
+
+        return MHAPagedAttentionBackend(
+            num_layers=num_cache_layers,
+            num_kv_heads=runner.num_kv_heads,
+            head_dim=runner.head_dim,
+            block_size=block_size,
+            dtype=runner.kv_cache_dtype,
+            cache_idx_map=cache_idx_map,
+        )
+
+    def estimate_one_sequence_kv_bytes(
+        self, *, max_model_len: int, block_size: int
+    ) -> int:
+        """Estimate bytes for one max-length sequence of cache state."""
+        runner = self._runner
+        if runner.kv_cache_dtype is None:
+            raise RuntimeError("KV cache dtype not initialized; load_model() first")
+
+        dtype_size = runner.kv_cache_dtype.size
+        aligned_tokens = -(-max_model_len // block_size) * block_size
+        num_kv_layers = (
+            runner.num_sdpa_layers if runner.is_hybrid else runner.num_kv_cache_layers
+        )
+        kv_factor = 1 if runner.is_mla else 2
+        sdpa_kv_bytes = (
+            kv_factor
+            * num_kv_layers
+            * aligned_tokens
+            * runner.num_kv_heads
+            * runner.head_dim
+            * dtype_size
+        )
+        if runner.is_hybrid:
+            return sdpa_kv_bytes + self.linear_cache_bytes_per_slot()
+        return sdpa_kv_bytes

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -85,11 +85,8 @@ class ModelCachePolicy:
                 ),
             }
 
-        if self._runner.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-
         block_size = self._runner.cache_config.block_size
-        torch_dtype = MLX_TO_TORCH_DTYPE[self._runner.kv_cache_dtype]
+        torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
         specs: dict[str, KVCacheSpec] = {}
         for layer_idx in range(self._runner.num_layers):
             if self._runner.is_hybrid and layer_idx not in self._runner.sdpa_layer_indices:
@@ -127,11 +124,8 @@ class ModelCachePolicy:
         if self._runner._is_stt:
             return STT_SCHED_BLOCK_BYTES
 
-        if self._runner.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-
         block_size = self._runner.cache_config.block_size
-        dtype_size = self._runner.kv_cache_dtype.size
+        dtype_size = self._require_kv_cache_dtype().size
         num_kv_layers = (
             self._runner.num_sdpa_layers
             if self._runner.is_hybrid
@@ -151,10 +145,7 @@ class ModelCachePolicy:
         """Return bytes for one request's linear-attention state."""
         if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
-        if self._runner.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-
-        dtype_size = self._runner.kv_cache_dtype.size
+        dtype_size = self._require_kv_cache_dtype().size
         recurrent_dtype_size = mx.float32.size
         conv_bytes = (
             (self._runner.linear_conv_kernel_dim - 1)
@@ -183,10 +174,7 @@ class ModelCachePolicy:
         self, *, max_model_len: int, block_size: int
     ) -> int:
         """Estimate bytes for one max-length sequence of cache state."""
-        if self._runner.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-
-        dtype_size = self._runner.kv_cache_dtype.size
+        dtype_size = self._require_kv_cache_dtype().size
         aligned_tokens = -(-max_model_len // block_size) * block_size
         num_kv_layers = (
             self._runner.num_sdpa_layers
@@ -219,7 +207,7 @@ class ModelCachePolicy:
             linear_conv_kernel_dim=self._runner.linear_conv_kernel_dim,
             linear_conv_dim=self._runner.linear_conv_dim,
             block_size=block_size,
-            dtype=self._runner.kv_cache_dtype,
+            dtype=self._require_kv_cache_dtype(),
         )
 
     def _build_mla_backend(self, block_size: int) -> MLAPagedAttentionBackend:
@@ -227,7 +215,7 @@ class ModelCachePolicy:
             num_layers=self._runner.num_layers,
             latent_dim=self._runner.mla_latent_dim,
             block_size=block_size,
-            dtype=self._runner.kv_cache_dtype,
+            dtype=self._require_kv_cache_dtype(),
         )
 
     def _build_mha_backend(self, block_size: int) -> MHAPagedAttentionBackend:
@@ -237,7 +225,7 @@ class ModelCachePolicy:
             num_kv_heads=self._runner.num_kv_heads,
             head_dim=self._runner.head_dim,
             block_size=block_size,
-            dtype=self._runner.kv_cache_dtype,
+            dtype=self._require_kv_cache_dtype(),
             cache_idx_map=cache_idx_map,
         )
 
@@ -252,6 +240,11 @@ class ModelCachePolicy:
             self._runner.num_layers,
         )
         return num_cache_layers, cache_idx_map
+
+    def _require_kv_cache_dtype(self) -> mx.Dtype:
+        if self._runner.kv_cache_dtype is None:
+            raise RuntimeError("KV cache dtype not initialized; load_model() first")
+        return self._runner.kv_cache_dtype
 
 
 class WorkerCachePlanner:
@@ -311,16 +304,7 @@ class WorkerCachePlanner:
     def get_model_memory_usage(self) -> int:
         """Return current model memory usage in bytes."""
         mx.eval(mx.array([0]))
-
-        if hasattr(mx, "get_active_memory"):
-            return mx.get_active_memory()
-        if hasattr(mx, "metal") and hasattr(mx.metal, "get_active_memory"):
-            return mx.metal.get_active_memory()
-
-        hidden_size = getattr(self._worker.model_config, "hidden_size", 4096)
-        num_layers = getattr(self._worker.model_config, "num_hidden_layers", 32)
-        params = hidden_size * hidden_size * 4 * num_layers
-        return params * 2
+        return mx.get_active_memory()
 
     def determine_available_memory(self) -> int:
         """Return scheduler-visible available cache memory."""
@@ -337,7 +321,9 @@ class WorkerCachePlanner:
             self._worker._setup_paged_attention(overhead=overhead)
             backend = self._worker.model_runner._paged_attention_backend
             if backend is None:
-                raise RuntimeError("Paged attention backend not initialized")
+                raise RuntimeError(
+                    "Paged attention backend not initialized for capacity reporting"
+                )
             block_size_bytes = self._worker.get_cache_block_size_bytes()
             available = backend.num_blocks() * block_size_bytes
             logger.info(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 import mlx.core as mx
@@ -10,6 +11,10 @@ import torch
 from vllm.logger import init_logger
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
 
+from vllm_metal.config import (
+    PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION,
+    PAGED_ATTENTION_MIN_BLOCKS,
+)
 from vllm_metal.paged_attention_backend.hybrid import (
     HybridPagedAttentionBackend,
     _build_linear_layer_spec,
@@ -18,13 +23,26 @@ from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
 from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.pytorch_backend.tensor_bridge import MLX_TO_TORCH_DTYPE
-from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
+from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES, STT_SCHED_BLOCK_BYTES
 from vllm_metal.v1.model_adapter import ModelAdapter
 
 if TYPE_CHECKING:
     from vllm_metal.v1.model_runner import MetalModelRunner
+    from vllm_metal.v1.worker import MetalWorker
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class _PagedAttentionPlan:
+    block_size: int
+    fraction: float
+    metal_limit: int
+    usable_metal: int
+    model_memory: int
+    per_block_bytes: int
+    kv_budget: int
+    num_blocks: int
 
 
 class ModelCachePolicy:
@@ -57,42 +75,41 @@ class ModelCachePolicy:
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Build the scheduler-visible KV cache specification."""
-        runner = self._runner
-        if runner._is_stt:
+        if self._runner._is_stt:
             return {
                 "layers.0.self_attn": FullAttentionSpec(
-                    block_size=runner.metal_config.block_size,
+                    block_size=self._runner.metal_config.block_size,
                     num_kv_heads=1,
                     head_size=64,
                     dtype=torch.float16,
                 ),
             }
 
-        block_size = runner.cache_config.block_size
-        if runner.kv_cache_dtype is None:
+        if self._runner.kv_cache_dtype is None:
             raise RuntimeError("KV cache dtype not initialized; load_model() first")
 
-        torch_dtype = MLX_TO_TORCH_DTYPE[runner.kv_cache_dtype]
+        block_size = self._runner.cache_config.block_size
+        torch_dtype = MLX_TO_TORCH_DTYPE[self._runner.kv_cache_dtype]
         specs: dict[str, KVCacheSpec] = {}
-        for layer_idx in range(runner.num_layers):
-            if runner.is_hybrid and layer_idx not in runner.sdpa_layer_indices:
+        for layer_idx in range(self._runner.num_layers):
+            if self._runner.is_hybrid and layer_idx not in self._runner.sdpa_layer_indices:
                 layer_name = f"layers.{layer_idx}.linear_attn"
                 specs[layer_name] = _build_linear_layer_spec(
-                    conv_kernel_dim=runner.linear_conv_kernel_dim,
-                    conv_dim=runner.linear_conv_dim,
-                    num_v_heads=runner.linear_num_v_heads,
-                    value_head_dim=runner.linear_value_head_dim,
-                    key_head_dim=runner.linear_key_head_dim,
+                    conv_kernel_dim=self._runner.linear_conv_kernel_dim,
+                    conv_dim=self._runner.linear_conv_dim,
+                    num_v_heads=self._runner.linear_num_v_heads,
+                    value_head_dim=self._runner.linear_value_head_dim,
+                    key_head_dim=self._runner.linear_key_head_dim,
                     torch_dtype=torch_dtype,
-                    page_size_padded=runner.cache_config.mamba_page_size_padded,
+                    page_size_padded=self._runner.cache_config.mamba_page_size_padded,
                     block_size=block_size,
                 )
             else:
                 layer_name = f"layers.{layer_idx}.self_attn"
                 specs[layer_name] = FullAttentionSpec(
                     block_size=block_size,
-                    num_kv_heads=runner.num_kv_heads,
-                    head_size=runner.head_dim,
+                    num_kv_heads=self._runner.num_kv_heads,
+                    head_size=self._runner.head_dim,
                     dtype=torch_dtype,
                 )
 
@@ -107,121 +124,318 @@ class ModelCachePolicy:
 
     def get_cache_block_size_bytes(self) -> int:
         """Return the byte size of one cache block."""
-        runner = self._runner
-        if runner._is_stt:
+        if self._runner._is_stt:
             return STT_SCHED_BLOCK_BYTES
 
-        if runner.kv_cache_dtype is None:
+        if self._runner.kv_cache_dtype is None:
             raise RuntimeError("KV cache dtype not initialized; load_model() first")
 
-        block_size = runner.cache_config.block_size
-        dtype_size = runner.kv_cache_dtype.size
+        block_size = self._runner.cache_config.block_size
+        dtype_size = self._runner.kv_cache_dtype.size
         num_kv_layers = (
-            runner.num_sdpa_layers if runner.is_hybrid else runner.num_kv_cache_layers
+            self._runner.num_sdpa_layers
+            if self._runner.is_hybrid
+            else self._runner.num_kv_cache_layers
         )
-        kv_factor = 1 if runner.is_mla else 2
+        kv_factor = 1 if self._runner.is_mla else 2
         return (
             kv_factor
             * num_kv_layers
             * block_size
-            * runner.num_kv_heads
-            * runner.head_dim
+            * self._runner.num_kv_heads
+            * self._runner.head_dim
             * dtype_size
         )
 
     def linear_cache_bytes_per_slot(self) -> int:
         """Return bytes for one request's linear-attention state."""
-        runner = self._runner
-        if not runner.is_hybrid:
+        if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
-        if runner.kv_cache_dtype is None:
+        if self._runner.kv_cache_dtype is None:
             raise RuntimeError("KV cache dtype not initialized; load_model() first")
 
-        dtype_size = runner.kv_cache_dtype.size
+        dtype_size = self._runner.kv_cache_dtype.size
         recurrent_dtype_size = mx.float32.size
         conv_bytes = (
-            (runner.linear_conv_kernel_dim - 1) * runner.linear_conv_dim * dtype_size
+            (self._runner.linear_conv_kernel_dim - 1)
+            * self._runner.linear_conv_dim
+            * dtype_size
         )
         recurrent_bytes = (
-            runner.linear_num_v_heads
-            * runner.linear_value_head_dim
-            * runner.linear_key_head_dim
+            self._runner.linear_num_v_heads
+            * self._runner.linear_value_head_dim
+            * self._runner.linear_key_head_dim
             * recurrent_dtype_size
         )
-        return runner.num_linear_layers * (conv_bytes + recurrent_bytes)
+        return self._runner.num_linear_layers * (conv_bytes + recurrent_bytes)
 
     def build_paged_attention_backend(
         self, *, block_size: int
     ) -> PagedAttentionBackend:
         """Create the paged-attention backend for the loaded model."""
-        runner = self._runner
-        if runner.is_hybrid:
-            return HybridPagedAttentionBackend(
-                num_layers=runner.num_layers,
-                full_attention_interval=runner.full_attention_interval,
-                max_num_seqs=runner.scheduler_config.max_num_seqs,
-                num_kv_heads=runner.num_kv_heads,
-                head_dim=runner.head_dim,
-                linear_num_v_heads=runner.linear_num_v_heads,
-                linear_key_head_dim=runner.linear_key_head_dim,
-                linear_value_head_dim=runner.linear_value_head_dim,
-                linear_conv_kernel_dim=runner.linear_conv_kernel_dim,
-                linear_conv_dim=runner.linear_conv_dim,
-                block_size=block_size,
-                dtype=runner.kv_cache_dtype,
-            )
-
-        if runner.is_mla:
-            return MLAPagedAttentionBackend(
-                num_layers=runner.num_layers,
-                latent_dim=runner.mla_latent_dim,
-                block_size=block_size,
-                dtype=runner.kv_cache_dtype,
-            )
-
-        yoco = runner._yoco_cache_mapping
-        if yoco is not None:
-            num_cache_layers, cache_idx_map = yoco
-            logger.info(
-                "YOCO KV sharing: %d unique cache layers (reduced from %d total)",
-                num_cache_layers,
-                runner.num_layers,
-            )
-        else:
-            num_cache_layers = runner.num_kv_cache_layers
-            cache_idx_map = None
-
-        return MHAPagedAttentionBackend(
-            num_layers=num_cache_layers,
-            num_kv_heads=runner.num_kv_heads,
-            head_dim=runner.head_dim,
-            block_size=block_size,
-            dtype=runner.kv_cache_dtype,
-            cache_idx_map=cache_idx_map,
-        )
+        if self._runner.is_hybrid:
+            return self._build_hybrid_backend(block_size)
+        if self._runner.is_mla:
+            return self._build_mla_backend(block_size)
+        return self._build_mha_backend(block_size)
 
     def estimate_one_sequence_kv_bytes(
         self, *, max_model_len: int, block_size: int
     ) -> int:
         """Estimate bytes for one max-length sequence of cache state."""
-        runner = self._runner
-        if runner.kv_cache_dtype is None:
+        if self._runner.kv_cache_dtype is None:
             raise RuntimeError("KV cache dtype not initialized; load_model() first")
 
-        dtype_size = runner.kv_cache_dtype.size
+        dtype_size = self._runner.kv_cache_dtype.size
         aligned_tokens = -(-max_model_len // block_size) * block_size
         num_kv_layers = (
-            runner.num_sdpa_layers if runner.is_hybrid else runner.num_kv_cache_layers
+            self._runner.num_sdpa_layers
+            if self._runner.is_hybrid
+            else self._runner.num_kv_cache_layers
         )
-        kv_factor = 1 if runner.is_mla else 2
+        kv_factor = 1 if self._runner.is_mla else 2
         sdpa_kv_bytes = (
             kv_factor
             * num_kv_layers
             * aligned_tokens
-            * runner.num_kv_heads
-            * runner.head_dim
+            * self._runner.num_kv_heads
+            * self._runner.head_dim
             * dtype_size
         )
-        if runner.is_hybrid:
+        if self._runner.is_hybrid:
             return sdpa_kv_bytes + self.linear_cache_bytes_per_slot()
         return sdpa_kv_bytes
+
+    def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionBackend:
+        return HybridPagedAttentionBackend(
+            num_layers=self._runner.num_layers,
+            full_attention_interval=self._runner.full_attention_interval,
+            max_num_seqs=self._runner.scheduler_config.max_num_seqs,
+            num_kv_heads=self._runner.num_kv_heads,
+            head_dim=self._runner.head_dim,
+            linear_num_v_heads=self._runner.linear_num_v_heads,
+            linear_key_head_dim=self._runner.linear_key_head_dim,
+            linear_value_head_dim=self._runner.linear_value_head_dim,
+            linear_conv_kernel_dim=self._runner.linear_conv_kernel_dim,
+            linear_conv_dim=self._runner.linear_conv_dim,
+            block_size=block_size,
+            dtype=self._runner.kv_cache_dtype,
+        )
+
+    def _build_mla_backend(self, block_size: int) -> MLAPagedAttentionBackend:
+        return MLAPagedAttentionBackend(
+            num_layers=self._runner.num_layers,
+            latent_dim=self._runner.mla_latent_dim,
+            block_size=block_size,
+            dtype=self._runner.kv_cache_dtype,
+        )
+
+    def _build_mha_backend(self, block_size: int) -> MHAPagedAttentionBackend:
+        num_layers, cache_idx_map = self._mha_cache_layout()
+        return MHAPagedAttentionBackend(
+            num_layers=num_layers,
+            num_kv_heads=self._runner.num_kv_heads,
+            head_dim=self._runner.head_dim,
+            block_size=block_size,
+            dtype=self._runner.kv_cache_dtype,
+            cache_idx_map=cache_idx_map,
+        )
+
+    def _mha_cache_layout(self) -> tuple[int, list[int] | None]:
+        if self._runner._yoco_cache_mapping is None:
+            return self._runner.num_kv_cache_layers, None
+
+        num_cache_layers, cache_idx_map = self._runner._yoco_cache_mapping
+        logger.info(
+            "YOCO KV sharing: %d unique cache layers (reduced from %d total)",
+            num_cache_layers,
+            self._runner.num_layers,
+        )
+        return num_cache_layers, cache_idx_map
+
+
+class WorkerCachePlanner:
+    """Worker-owned cache budgeting and paged-attention setup."""
+
+    def __init__(self, worker: MetalWorker) -> None:
+        self._worker = worker
+
+    @staticmethod
+    def kv_budget_bytes(
+        metal_limit: int,
+        model_memory: int,
+        fraction: float,
+        overhead: int,
+    ) -> int:
+        """Return Metal-memory budget available for paged KV cache."""
+        return int(metal_limit * fraction) - model_memory - overhead
+
+    def setup_paged_attention(self, *, overhead: int) -> None:
+        """Allocate paged KV cache and patch the loaded model."""
+        self._worker.model_runner.validate_paged_attention_support()
+        plan = self._paged_attention_plan(overhead=overhead)
+        logger.info(
+            "Paged attention memory breakdown: "
+            "metal_limit=%.2fGB, fraction=%.2f, usable_metal=%.2fGB, "
+            "model_memory=%.2fGB, overhead=%.2fGB, "
+            "kv_budget=%.2fGB, per_block_bytes=%d, "
+            "num_blocks=%d, max_tokens_cached=%d",
+            plan.metal_limit / 1e9,
+            plan.fraction,
+            plan.usable_metal / 1e9,
+            plan.model_memory / 1e9,
+            overhead / 1e9,
+            plan.kv_budget / 1e9,
+            plan.per_block_bytes,
+            plan.num_blocks,
+            plan.num_blocks * plan.block_size,
+        )
+
+        backend = self._worker.model_runner.build_paged_attention_backend(
+            block_size=plan.block_size
+        )
+        backend.initialize(plan.num_blocks)
+        n_patched = backend.patch_model(self._worker.model_runner.model)
+        logger.info(
+            "Paged attention enabled: %d layers patched, "
+            "%d blocks allocated (block_size=%d, mla=%s)",
+            n_patched,
+            plan.num_blocks,
+            plan.block_size,
+            self._worker.model_runner.is_mla,
+        )
+
+        self._worker.model_runner._paged_attention_backend = backend
+        self._worker.model_runner._paged_block_size = plan.block_size
+
+    def get_model_memory_usage(self) -> int:
+        """Return current model memory usage in bytes."""
+        mx.eval(mx.array([0]))
+
+        if hasattr(mx, "get_active_memory"):
+            return mx.get_active_memory()
+        if hasattr(mx, "metal") and hasattr(mx.metal, "get_active_memory"):
+            return mx.metal.get_active_memory()
+
+        hidden_size = getattr(self._worker.model_config, "hidden_size", 4096)
+        num_layers = getattr(self._worker.model_config, "num_hidden_layers", 32)
+        params = hidden_size * hidden_size * 4 * num_layers
+        return params * 2
+
+    def determine_available_memory(self) -> int:
+        """Return scheduler-visible available cache memory."""
+        mode = self._worker.model_runner.scheduler_memory_reporting_mode(
+            paged_attention_enabled=self._worker.metal_config.use_paged_attention
+        )
+
+        if mode == "stt_nominal":
+            logger.info("STT model: reporting nominal memory for scheduler")
+            return STT_SCHED_AVAILABLE_BYTES
+
+        if mode == "paged_attention_capacity":
+            overhead = self._worker.model_runner.profile_run()
+            self._worker._setup_paged_attention(overhead=overhead)
+            backend = self._worker.model_runner._paged_attention_backend
+            if backend is None:
+                raise RuntimeError("Paged attention backend not initialized")
+            block_size_bytes = self._worker.get_cache_block_size_bytes()
+            available = backend.num_blocks() * block_size_bytes
+            logger.info(
+                "Paged attention: reporting MPS cache capacity "
+                "(%d blocks × %d bytes = %.2f GB)",
+                backend.num_blocks(),
+                block_size_bytes,
+                available / 1e9,
+            )
+            return available
+
+        available = self._worker._one_sequence_kv_bytes()
+        logger.info(
+            "MLX path: reporting %.2f GB for scheduler admission control "
+            "(one max-length sequence, max_model_len=%d)",
+            available / 1e9,
+            self._worker.model_config.max_model_len,
+        )
+        return available
+
+    def _paged_attention_plan(self, *, overhead: int) -> _PagedAttentionPlan:
+        block_size = self._worker.vllm_config.cache_config.block_size
+        fraction = self._memory_fraction()
+        metal_limit = self._metal_limit_bytes()
+        model_memory = self.get_model_memory_usage()
+        per_block_bytes = self._worker.get_cache_block_size_bytes()
+        usable_metal = int(metal_limit * fraction)
+        kv_budget = self.kv_budget_bytes(
+            metal_limit,
+            model_memory,
+            fraction,
+            overhead,
+        )
+
+        if self._worker.model_runner.is_hybrid:
+            kv_budget -= (
+                self._worker.model_runner.linear_cache_bytes_per_slot()
+                * self._worker.model_runner.scheduler_config.max_num_seqs
+            )
+
+        if kv_budget <= 0:
+            raise ValueError(
+                "Paged attention: not enough Metal memory for KV cache. "
+                f"metal_limit={metal_limit / 1e9:.2f}GB, "
+                f"fraction={fraction}, "
+                f"usable_metal={usable_metal / 1e9:.2f}GB, "
+                f"model_memory={model_memory / 1e9:.2f}GB, "
+                f"overhead={overhead / 1e9:.2f}GB, "
+                f"kv_budget={kv_budget / 1e9:.2f}GB. "
+                "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
+                "use a smaller or more quantized model."
+            )
+
+        num_blocks = kv_budget // per_block_bytes
+        if num_blocks < PAGED_ATTENTION_MIN_BLOCKS:
+            raise ValueError(
+                "Paged attention: computed num_blocks too low "
+                f"({num_blocks} < minimum {PAGED_ATTENTION_MIN_BLOCKS}). "
+                f"metal_limit={metal_limit / 1e9:.2f}GB, "
+                f"fraction={fraction}, "
+                f"usable_metal={usable_metal / 1e9:.2f}GB, "
+                f"model_memory={model_memory / 1e9:.2f}GB, "
+                f"overhead={overhead / 1e9:.2f}GB, "
+                f"kv_budget={kv_budget / 1e9:.2f}GB, "
+                f"per_block_bytes={per_block_bytes}. "
+                "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
+                "use a smaller or more quantized model."
+            )
+
+        return _PagedAttentionPlan(
+            block_size=block_size,
+            fraction=fraction,
+            metal_limit=metal_limit,
+            usable_metal=usable_metal,
+            model_memory=model_memory,
+            per_block_bytes=per_block_bytes,
+            kv_budget=kv_budget,
+            num_blocks=num_blocks,
+        )
+
+    def _memory_fraction(self) -> float:
+        if self._worker.metal_config.is_auto_memory:
+            logger.info(
+                "Paged attention: VLLM_METAL_MEMORY_FRACTION=auto, "
+                "defaulting to %.2f for paged path",
+                PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION,
+            )
+            return PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION
+        return self._worker.metal_config.memory_fraction
+
+    def _metal_limit_bytes(self) -> int:
+        device_info = mx.device_info()
+        metal_limit = int(device_info.get("max_recommended_working_set_size", 0))
+        if metal_limit <= 0:
+            raise RuntimeError(
+                "Paged attention: mx.device_info() did not return "
+                "max_recommended_working_set_size. "
+                "Ensure MLX is up to date and running on Apple Silicon. "
+                f"Reported device_info keys: {list(device_info.keys())}"
+            )
+        return metal_limit

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -313,6 +313,7 @@ class MetalModelRunner:
         cache path that the text/VLM runner uses.
         """
         return self._cache_policy.should_setup_paged_attention()
+
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
         self._cache_policy.validate_paged_attention_support()

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -46,8 +46,8 @@ from vllm_metal.paged_attention_common import (
 )
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
-from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1 import contiguous_cache
+from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1.contiguous_cache import (
     _MIN_BATCH_SIZE_FOR_BATCHING,
     _PREFIX_CACHE_ENABLED,
@@ -462,6 +462,21 @@ class MetalModelRunner:
         overhead = mx.get_cache_memory() - cache_before
         mx.set_cache_limit(overhead)
         return overhead
+
+    def build_paged_attention_backend(
+        self, *, block_size: int
+    ) -> PagedAttentionBackend:
+        """Build the paged-attention backend for the loaded model."""
+        return self._cache_policy.build_paged_attention_backend(block_size=block_size)
+
+    def estimate_one_sequence_kv_bytes(
+        self, *, max_model_len: int, block_size: int
+    ) -> int:
+        """Estimate bytes for one max-length sequence of cache state."""
+        return self._cache_policy.estimate_one_sequence_kv_bytes(
+            max_model_len=max_model_len,
+            block_size=block_size,
+        )
 
     def warm_up(self) -> None:
         """Warm up the model with a dummy forward pass.

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -29,17 +29,14 @@ from vllm.v1.core.sched.output import (
     NewRequestData,
     SchedulerOutput,
 )
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.config import get_config
-from vllm_metal.paged_attention_backend.hybrid import (
-    HybridPagedAttentionBackend,
-    _build_linear_layer_spec,
-)
+from vllm_metal.paged_attention_backend.hybrid import HybridPagedAttentionBackend
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.paged_attention_common import (
@@ -47,9 +44,9 @@ from vllm_metal.paged_attention_common import (
     clear_context,
     prepare_unified,
 )
-from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
+from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1 import contiguous_cache
 from vllm_metal.v1.contiguous_cache import (
     _MIN_BATCH_SIZE_FOR_BATCHING,
@@ -202,6 +199,7 @@ class MetalModelRunner:
         self.device = device
         self.metal_config = get_config()
         self._model_adapter: ModelAdapter = DefaultModelAdapter()
+        self._cache_policy = ModelCachePolicy(self, self._model_adapter)
         self._model_lifecycle = ModelLifecycle(self, self._model_adapter)
 
         self.model: Any = None
@@ -308,9 +306,16 @@ class MetalModelRunner:
             self.model_args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
         )
 
+    def should_setup_paged_attention(self) -> bool:
+        """Whether worker-side paged-attention setup should run.
+
+        STT models own their runtime path and do not use the paged-attention
+        cache path that the text/VLM runner uses.
+        """
+        return self._cache_policy.should_setup_paged_attention()
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
-        self._model_adapter.require_uniform_kv_heads(self.model_args, self.num_kv_heads)
+        self._cache_policy.validate_paged_attention_support()
 
     def scheduler_memory_reporting_mode(
         self, *, paged_attention_enabled: bool
@@ -320,11 +325,9 @@ class MetalModelRunner:
         Worker delegates this decision to the runner so STT-specific policy is
         not open-coded in `worker.py`.
         """
-        if self._is_stt:
-            return "stt_nominal"
-        if paged_attention_enabled:
-            return "paged_attention_capacity"
-        return "single_sequence_estimate"
+        return self._cache_policy.scheduler_memory_reporting_mode(
+            paged_attention_enabled=paged_attention_enabled
+        )
 
     def supported_worker_tasks(self) -> tuple[SupportedTask, ...]:
         """Return worker task capabilities for the loaded model."""
@@ -421,55 +424,7 @@ class MetalModelRunner:
         Returns:
             Dictionary mapping attention layer names to KV cache specs
         """
-        if self._is_stt:
-            # STT models manage their own KV cache internally.
-            # vLLM requires a non-empty spec for scheduler initialization,
-            # so we return a single minimal entry.
-            return {
-                "layers.0.self_attn": FullAttentionSpec(
-                    block_size=self.metal_config.block_size,
-                    num_kv_heads=1,
-                    head_size=64,
-                    dtype=torch.float16,
-                ),
-            }
-
-        # Use cache_config.block_size (not metal_config.block_size) because
-        # vLLM's hybrid alignment may have adjusted it to unify page sizes
-        # across SDPA and Mamba/GDN layers.
-        block_size = self.cache_config.block_size
-        if self.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-
-        # FullAttentionSpec (upstream vLLM) expects torch.dtype
-        from vllm_metal.pytorch_backend.tensor_bridge import MLX_TO_TORCH_DTYPE
-
-        torch_dtype = MLX_TO_TORCH_DTYPE[self.kv_cache_dtype]
-
-        specs: dict[str, KVCacheSpec] = {}
-        for layer_idx in range(self.num_layers):
-            if self.is_hybrid and layer_idx not in self.sdpa_layer_indices:
-                layer_name = f"layers.{layer_idx}.linear_attn"
-                specs[layer_name] = _build_linear_layer_spec(
-                    conv_kernel_dim=self.linear_conv_kernel_dim,
-                    conv_dim=self.linear_conv_dim,
-                    num_v_heads=self.linear_num_v_heads,
-                    value_head_dim=self.linear_value_head_dim,
-                    key_head_dim=self.linear_key_head_dim,
-                    torch_dtype=torch_dtype,
-                    page_size_padded=self.cache_config.mamba_page_size_padded,
-                    block_size=block_size,
-                )
-            else:
-                layer_name = f"layers.{layer_idx}.self_attn"
-                specs[layer_name] = FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=self.num_kv_heads,
-                    head_size=self.head_dim,
-                    dtype=torch_dtype,
-                )
-
-        return specs
+        return self._cache_policy.get_kv_cache_spec()
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """Accept KV cache config from engine (no-op for MLX path).
@@ -477,10 +432,7 @@ class MetalModelRunner:
         MLX manages its own KV cache via make_prompt_cache().
         This method exists to satisfy the engine's initialization protocol.
         """
-        logger.info(
-            "KV cache config received: %d blocks (MLX manages cache internally)",
-            kv_cache_config.num_blocks,
-        )
+        self._cache_policy.initialize_kv_cache(kv_cache_config)
 
     def get_cache_block_size_bytes(self) -> int:
         """Get the size of a single cache block in bytes.
@@ -488,51 +440,11 @@ class MetalModelRunner:
         Returns:
             Block size in bytes
         """
-        if self._is_stt:
-            return STT_SCHED_BLOCK_BYTES
-
-        # Use cache_config.block_size (not metal_config) because vLLM's
-        # hybrid alignment may have adjusted it to match mamba page size.
-        block_size = self.cache_config.block_size
-
-        # Each block stores key and value for SDPA layers only.
-        # Hybrid models (Qwen3.5) have linear attention layers that use
-        # fixed-size recurrent state, not paged KV — exclude them.
-        if self.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-        dtype_size = self.kv_cache_dtype.size
-        num_kv_layers = (
-            self.num_sdpa_layers if self.is_hybrid else self.num_kv_cache_layers
-        )
-        kv_factor = 1 if self.is_mla else 2
-        return (
-            kv_factor
-            * num_kv_layers
-            * block_size
-            * self.num_kv_heads
-            * self.head_dim
-            * dtype_size
-        )
+        return self._cache_policy.get_cache_block_size_bytes()
 
     def linear_cache_bytes_per_slot(self) -> int:
         """Bytes for one request's linear attention state across all GDN layers."""
-        if not self.is_hybrid:
-            raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
-        if self.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; load_model() first")
-        dtype_size = self.kv_cache_dtype.size
-        # GDN recurrent state is always float32 (see GDNPagedStateCache).
-        recurrent_dtype_size = mx.float32.size
-        conv_bytes = (
-            (self.linear_conv_kernel_dim - 1) * self.linear_conv_dim * dtype_size
-        )
-        recurrent_bytes = (
-            self.linear_num_v_heads
-            * self.linear_value_head_dim
-            * self.linear_key_head_dim
-            * recurrent_dtype_size
-        )
-        return self.num_linear_layers * (conv_bytes + recurrent_bytes)
+        return self._cache_policy.linear_cache_bytes_per_slot()
 
     def profile_run(self) -> int:
         """Measure MLX buffer-cache footprint of one forward pass and cap the allocator.

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -21,22 +21,13 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
 
-from vllm_metal.config import (
-    PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION,
-    PAGED_ATTENTION_MIN_BLOCKS,
-    get_config,
-)
-from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
-from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
+from vllm_metal.config import get_config
 from vllm_metal.platform import MetalPlatform
-from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES
 from vllm_metal.utils import set_wired_limit
+from vllm_metal.v1.cache_policy import WorkerCachePlanner
 
 if TYPE_CHECKING:
-    from vllm_metal.v1.model_runner import (
-        MetalModelRunner,
-        SchedulerMemoryReportingMode,
-    )
+    from vllm_metal.v1.model_runner import MetalModelRunner
 
 logger = init_logger(__name__)
 
@@ -152,7 +143,12 @@ class MetalWorker(WorkerBase):
         psutil.available is intentionally excluded — it reflects OS page-cache
         state and is blind to MLX wired buffers holding model weights.
         """
-        return int(metal_limit * fraction) - model_memory - overhead
+        return WorkerCachePlanner.kv_budget_bytes(
+            metal_limit,
+            model_memory,
+            fraction,
+            overhead,
+        )
 
     def _setup_paged_attention(self, overhead: int) -> None:
         """Allocate paged KV cache and patch model attention layers.
@@ -162,173 +158,12 @@ class MetalWorker(WorkerBase):
         max_model_len.  ``overhead`` is the measured intermediate-buffer
         footprint from :pymeth:`MetalModelRunner.profile_run`.
         """
-        runner = self.model_runner
-        runner.validate_paged_attention_support()
-
-        # Use cache_config.block_size (not metal_config) because vLLM's
-        # hybrid alignment may have adjusted it to match mamba page size.
-        block_size = self.vllm_config.cache_config.block_size
-
-        # --- Determine memory fraction ---
-        if self.metal_config.is_auto_memory:
-            fraction = PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION
-            logger.info(
-                "Paged attention: VLLM_METAL_MEMORY_FRACTION=auto, "
-                "defaulting to %.2f for paged path",
-                fraction,
-            )
-        else:
-            fraction = self.metal_config.memory_fraction
-
-        # --- Gather Metal memory numbers ---
-        # KV cache lives in Metal-managed (wired) memory. psutil.available
-        # reflects OS page-cache state and excludes MLX wired buffers, making
-        # it appear nearly zero when a large model is loaded. Use
-        # max_recommended_working_set_size — the OS-reported Metal headroom —
-        # as the budget ceiling instead.
-        device_info = mx.device_info()
-        metal_limit = int(device_info.get("max_recommended_working_set_size", 0))
-        if metal_limit <= 0:
-            raise RuntimeError(
-                "Paged attention: mx.device_info() did not return "
-                "max_recommended_working_set_size. "
-                "Ensure MLX is up to date and running on Apple Silicon. "
-                f"Reported device_info keys: {list(device_info.keys())}"
-            )
-        model_memory = self._get_model_memory_usage()
-        per_block_bytes = self.get_cache_block_size_bytes()
-
-        # --- Compute KV budget ---
-        usable_metal = int(metal_limit * fraction)
-        kv_budget = self._kv_budget_bytes(metal_limit, model_memory, fraction, overhead)
-
-        # For hybrid models, subtract the fixed linear state cost first.
-        if runner.is_hybrid:
-            kv_budget -= runner.linear_cache_bytes_per_slot() * (
-                runner.scheduler_config.max_num_seqs
-            )
-
-        if kv_budget <= 0:
-            raise ValueError(
-                "Paged attention: not enough Metal memory for KV cache. "
-                f"metal_limit={metal_limit / 1e9:.2f}GB, "
-                f"fraction={fraction}, "
-                f"usable_metal={usable_metal / 1e9:.2f}GB, "
-                f"model_memory={model_memory / 1e9:.2f}GB, "
-                f"overhead={overhead / 1e9:.2f}GB, "
-                f"kv_budget={kv_budget / 1e9:.2f}GB. "
-                "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
-                "use a smaller or more quantized model."
-            )
-
-        num_blocks = kv_budget // per_block_bytes
-
-        if num_blocks < PAGED_ATTENTION_MIN_BLOCKS:
-            raise ValueError(
-                "Paged attention: computed num_blocks too low "
-                f"({num_blocks} < minimum {PAGED_ATTENTION_MIN_BLOCKS}). "
-                f"metal_limit={metal_limit / 1e9:.2f}GB, "
-                f"fraction={fraction}, "
-                f"usable_metal={usable_metal / 1e9:.2f}GB, "
-                f"model_memory={model_memory / 1e9:.2f}GB, "
-                f"overhead={overhead / 1e9:.2f}GB, "
-                f"kv_budget={kv_budget / 1e9:.2f}GB, "
-                f"per_block_bytes={per_block_bytes}. "
-                "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
-                "use a smaller or more quantized model."
-            )
-
-        max_tokens_cached = num_blocks * block_size
-
-        logger.info(
-            "Paged attention memory breakdown: "
-            "metal_limit=%.2fGB, fraction=%.2f, usable_metal=%.2fGB, "
-            "model_memory=%.2fGB, overhead=%.2fGB (measured), "
-            "kv_budget=%.2fGB, per_block_bytes=%d, "
-            "num_blocks=%d, max_tokens_cached=%d",
-            metal_limit / 1e9,
-            fraction,
-            usable_metal / 1e9,
-            model_memory / 1e9,
-            overhead / 1e9,
-            kv_budget / 1e9,
-            per_block_bytes,
-            num_blocks,
-            max_tokens_cached,
-        )
-
-        # --- Create cache and patch model ---
-        if runner.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; runner.load_model()")
-
-        backend = self._make_backend(runner, block_size)
-        backend.initialize(num_blocks)
-        n_patched = backend.patch_model(runner.model)
-        logger.info(
-            "Paged attention enabled: %d layers patched, "
-            "%d blocks allocated (block_size=%d, mla=%s)",
-            n_patched,
-            num_blocks,
-            block_size,
-            runner.is_mla,
-        )
-
-        runner._paged_attention_backend = backend
-        runner._paged_block_size = block_size
+        WorkerCachePlanner(self).setup_paged_attention(overhead=overhead)
 
     @staticmethod
     def _make_backend(runner: MetalModelRunner, block_size: int) -> Any:
         """Create the right paged attention backend for the model type."""
-        if runner.is_hybrid:
-            from vllm_metal.paged_attention_backend.hybrid import (
-                HybridPagedAttentionBackend,
-            )
-
-            return HybridPagedAttentionBackend(
-                num_layers=runner.num_layers,
-                full_attention_interval=runner.full_attention_interval,
-                max_num_seqs=runner.scheduler_config.max_num_seqs,
-                num_kv_heads=runner.num_kv_heads,
-                head_dim=runner.head_dim,
-                linear_num_v_heads=runner.linear_num_v_heads,
-                linear_key_head_dim=runner.linear_key_head_dim,
-                linear_value_head_dim=runner.linear_value_head_dim,
-                linear_conv_kernel_dim=runner.linear_conv_kernel_dim,
-                linear_conv_dim=runner.linear_conv_dim,
-                block_size=block_size,
-                dtype=runner.kv_cache_dtype,
-            )
-        if runner.is_mla:
-            return MLAPagedAttentionBackend(
-                num_layers=runner.num_layers,
-                latent_dim=runner.mla_latent_dim,
-                block_size=block_size,
-                dtype=runner.kv_cache_dtype,
-            )
-        # YOCO (Gemma4): only allocate cache for unique layers;
-        # shared layers reuse a reference layer's cache via cache_idx_map.
-        # Mapping is pre-computed by model_runner._resolve_model_dims so that
-        # get_cache_block_size_bytes() also uses the correct layer count.
-        yoco = runner._yoco_cache_mapping
-        if yoco is not None:
-            num_cache_layers, cache_idx_map = yoco
-            logger.info(
-                "YOCO KV sharing: %d unique cache layers (reduced from %d total)",
-                num_cache_layers,
-                runner.num_layers,
-            )
-        else:
-            num_cache_layers = runner.num_kv_cache_layers
-            cache_idx_map = None
-
-        return MHAPagedAttentionBackend(
-            num_layers=num_cache_layers,
-            num_kv_heads=runner.num_kv_heads,
-            head_dim=runner.head_dim,
-            block_size=block_size,
-            dtype=runner.kv_cache_dtype,
-            cache_idx_map=cache_idx_map,
-        )
+        return runner.build_paged_attention_backend(block_size=block_size)
 
     def _get_model_memory_usage(self) -> int:
         """Get current model memory usage from MLX.
@@ -336,25 +171,7 @@ class MetalWorker(WorkerBase):
         Returns:
             Memory usage in bytes
         """
-        # Force evaluation of any pending computations
-        mx.eval(mx.array([0]))
-
-        # Get active memory usage - try new API first, then deprecated
-        if hasattr(mx, "get_active_memory"):
-            return mx.get_active_memory()
-        if hasattr(mx, "metal") and hasattr(mx.metal, "get_active_memory"):
-            return mx.metal.get_active_memory()
-
-        # Fallback: estimate from model config if available
-        if hasattr(self, "model_runner") and self.model_runner is not None:
-            model_config = self.model_config
-            hidden_size = getattr(model_config, "hidden_size", 4096)
-            num_layers = getattr(model_config, "num_hidden_layers", 32)
-            # Rough parameter count estimate
-            params = hidden_size * hidden_size * 4 * num_layers
-            return params * 2
-
-        return 0
+        return WorkerCachePlanner(self).get_model_memory_usage()
 
     def _one_sequence_kv_bytes(self) -> int:
         """Bytes for one max-length sequence of cache state.
@@ -364,32 +181,11 @@ class MetalWorker(WorkerBase):
         ``max_model_len`` up to the nearest ``block_size`` boundary via
         ``cdiv(max_model_len, block_size) * page_size_bytes``.
         """
-        runner = self.model_runner
-        if runner.kv_cache_dtype is None:
-            raise RuntimeError("KV cache dtype not initialized; runner.load_model()")
-        dtype_size = runner.kv_cache_dtype.size
-
-        num_kv_layers = (
-            runner.num_sdpa_layers if runner.is_hybrid else runner.num_layers
-        )
-
-        # Round token count up to block boundary to match the scheduler's
-        # block-aligned memory accounting.
         block_size = self.vllm_config.cache_config.block_size
-        max_tokens = -(-self.model_config.max_model_len // block_size) * block_size
-
-        kv_factor = 1 if runner.is_mla else 2
-        sdpa_kv_bytes = (
-            kv_factor
-            * num_kv_layers
-            * max_tokens
-            * runner.num_kv_heads
-            * runner.head_dim
-            * dtype_size
+        return self.model_runner.estimate_one_sequence_kv_bytes(
+            max_model_len=self.model_config.max_model_len,
+            block_size=block_size,
         )
-        if runner.is_hybrid:
-            return sdpa_kv_bytes + runner.linear_cache_bytes_per_slot()
-        return sdpa_kv_bytes
 
     def determine_available_memory(self) -> int:
         """Determine available memory for KV cache.
@@ -401,50 +197,7 @@ class MetalWorker(WorkerBase):
         Returns:
             Available memory in bytes
         """
-        mode: SchedulerMemoryReportingMode = (
-            self.model_runner.scheduler_memory_reporting_mode(
-                paged_attention_enabled=self.metal_config.use_paged_attention
-            )
-        )
-
-        if mode == "stt_nominal":
-            # STT models don't use vLLM's KV cache. Return a nominal value so
-            # scheduler minimum-memory checks pass.
-            logger.info("STT model: reporting nominal memory for scheduler")
-            return STT_SCHED_AVAILABLE_BYTES
-
-        if mode == "paged_attention_capacity":
-            # Profile intermediate-buffer footprint before sizing the cache, so
-            # the measured overhead drives KV budget math (issue #234).
-            overhead = self.model_runner.profile_run()
-            self._setup_paged_attention(overhead=overhead)
-            backend = self.model_runner._paged_attention_backend
-            assert backend is not None
-            num_blocks = backend.num_blocks()
-            block_size_bytes = self.get_cache_block_size_bytes()
-            available = num_blocks * block_size_bytes
-            logger.info(
-                "Paged attention: reporting MPS cache capacity "
-                "(%d blocks × %d bytes = %.2f GB)",
-                num_blocks,
-                block_size_bytes,
-                available / 1e9,
-            )
-            return available
-
-        # Default MLX path: report one max-length sequence for admission control.
-        # This matches the design from PR #229, which ensures the scheduler
-        # can admit at least one sequence without over-committing memory.
-        # MLX's make_prompt_cache() dynamically allocates KV cache per request,
-        # so we only need to report enough for one sequence.
-        available = self._one_sequence_kv_bytes()
-        logger.info(
-            "MLX path: reporting %.2f GB for scheduler admission control "
-            "(one max-length sequence, max_model_len=%d)",
-            available / 1e9,
-            self.model_config.max_model_len,
-        )
-        return available
+        return WorkerCachePlanner(self).determine_available_memory()
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Get KV cache specification.


### PR DESCRIPTION
This PR is:
- To move cache shape, size, and backend selection into a dedicated cache policy boundary.
- To keep `MetalModelRunner` and `MetalWorker` focused on orchestration instead of cache-specific branching and memory math.
- To make cache behavior consistent across MHA, MLA, hybrid, YOCO, and STT paths.

Notes:
- This is mostly a refactor, with one small correctness fix: one-sequence KV sizing now uses `num_kv_cache_layers` for YOCO/shared-KV models instead of `num_layers`.
- `ModelCachePolicy` now owns runner-side cache decisions such as KV cache spec, block size bytes, linear-state bytes, backend creation, and one-sequence cache sizing.
- `WorkerCachePlanner` now owns worker-side cache planning such as Metal memory budgeting, paged-attention setup, and available-memory reporting.
- STT scheduler placeholder values are now named constants instead of inline numbers.
- Tests were updated to cover the new boundary using real runner stubs where needed.
