### PR TITLE
Flatten Gemma4 text_config on mlx-lm load

### DIFF
--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -161,6 +161,42 @@ class TestModelLifecycle:
         assert runner.num_layers == 32
         assert runner.head_dim == 128
 
+    def test_load_merges_nested_text_config_from_mlx_lm_args(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """mlx-lm Gemma4 exposes .args with dims nested inside text_config.
+
+        Pin that model arg extraction flattens text_config onto the top level
+        on the .args path as well, so every dim key sits at the top level for
+        models whose mlx-lm ModelArgs only declares
+        ``{model_type, text_config, vocab_size}`` at the top level.
+        """
+        args = SimpleNamespace(
+            model_type="gemma4",
+            vocab_size=_TEXT_MODEL_ARGS["vocab_size"],
+            text_config=dict(_TEXT_MODEL_ARGS),
+        )
+        fake_model = SimpleNamespace(args=args)
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {"stub-model": (fake_model, object())},
+        )
+        lifecycle, runner = _make_lifecycle()
+
+        lifecycle.load()
+
+        assert runner.model is fake_model
+        assert runner.num_layers == _TEXT_MODEL_ARGS["num_hidden_layers"]
+        assert runner.num_kv_heads == _TEXT_MODEL_ARGS["num_key_value_heads"]
+        assert runner.hidden_size == _TEXT_MODEL_ARGS["hidden_size"]
+        assert runner.head_dim == (
+            _TEXT_MODEL_ARGS["hidden_size"] // _TEXT_MODEL_ARGS["num_attention_heads"]
+        )
+        assert runner.model_args["model_type"] == "gemma4"
+        assert runner.model_args["vocab_size"] == _TEXT_MODEL_ARGS["vocab_size"]
+
     def test_load_extracts_vlm_text_config_with_inherited_slots(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -208,26 +208,28 @@ class ModelLifecycle:
             )
 
     def _extract_model_args(self, model: Any, is_vlm: bool) -> dict[str, Any]:
-        # mlx-lm exposes .args while HF-backed models expose .config.
+        # Both the .args (mlx-lm) and .config (HF) paths may expose a nested
+        # ``text_config`` (e.g. Gemma4 via mlx-lm); the merge below flattens
+        # its keys onto the top level so every key sits in one flat dict.
         model_args = getattr(model, "args", None)
         if model_args is not None:
-            return self._config_to_mapping(model_args, label="model.args")
-
-        config = getattr(model, "config", None)
-        if config is None:
-            raise ValueError(
-                "Cannot extract model config: model has neither .args nor .config "
-                "attribute."
-            )
-
-        config_values = self._config_to_mapping(config, label="config")
-        if is_vlm and "text_config" in config_values:
-            model_values = self._config_to_mapping(
-                config_values["text_config"],
-                label="text_config",
-            )
+            model_values = self._config_to_mapping(model_args, label="model.args")
         else:
-            model_values = config_values
+            config = getattr(model, "config", None)
+            if config is None:
+                raise ValueError(
+                    "Cannot extract model config: model has neither .args nor "
+                    ".config attribute."
+                )
+
+            config_values = self._config_to_mapping(config, label="config")
+            if is_vlm and "text_config" in config_values:
+                model_values = self._config_to_mapping(
+                    config_values["text_config"],
+                    label="text_config",
+                )
+            else:
+                model_values = config_values
 
         text_config = model_values.get("text_config")
         if text_config is None:


### PR DESCRIPTION
Summary
- To restore the nested `text_config` flatten on the mlx-lm `.args` load path.
- To unblock Gemma4 variants whose mlx-lm `ModelArgs` expose only `{model_type, text_config, vocab_size}` at the top level.

Problem:
After #271 extracted `_extract_model_args` into `ModelLifecycle`, the `.args` branch early-returned without running the nested
`text_config` setdefault merge that both paths previously shared. Gemma4 variants then die at startup in `resolve_model_dims()` with
`Cannot resolve model dimensions: num_layers, num_kv_heads, head_dim. Available keys: ['model_type', 'text_config', 'vocab_size']`.

Fix:
- Both `.args` and `.config` branches now fall through to the existing bottom `setdefault` merge, flattening nested `text_config` keys
onto the top level.
- Load-path behavior is identical to pre-#271 on both paths.
- This is a regression fix only; it does not yet enable Gemma4 26B/31B on paged attention (per-layer KV cache shapes will land in
follow-ups). After this fix, 31B loads successfully and then hits the existing `require_uniform_kv_heads` guard, which is the expected
boundary.

Related: #274