### PR TITLE
Per-layer KV cache shapes for heterogeneous attention

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -41,6 +41,8 @@ def make_stub_runner(
         "_pending_output": None,
         "_execute_model_state": None,
         "_model_adapter": DefaultModelAdapter(),
+        "kv_heads_per_layer": None,
+        "head_dim_per_layer": None,
         "use_async_scheduling": True,
         "device": torch.device("cpu"),
         "_sampler": None,

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -108,7 +108,9 @@ class TestMHABackendPerLayer:
         assert cache.key_caches[0].shape[-2:] == (16, 256)
         assert cache.key_caches[1].shape[-2:] == (4, 512)
 
-    def test_warm_up_uses_layer_zero_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_warm_up_uses_layer_zero_shape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Kernel warm-up should compile against the concrete layer-0 shape."""
         cache = MetalPagedKVCache(
             num_layers=2,

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for per-layer KV cache shape support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
+from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
+
+
+class TestMetalPagedKVCachePerLayer:
+    """MetalPagedKVCache with heterogeneous per-layer shapes."""
+
+    def test_heterogeneous_shapes_allocate_correctly(self) -> None:
+        """Each layer's cache tensor matches its requested shape."""
+        kv_heads = [16, 4]
+        head_dims = [256, 512]
+        num_blocks = 4
+        block_size = 16
+
+        cache = MetalPagedKVCache(
+            num_layers=2,
+            num_kv_heads=kv_heads[0],
+            head_dim=head_dims[0],
+            num_blocks=num_blocks,
+            block_size=block_size,
+            dtype=mx.bfloat16,
+            kv_heads_per_layer=kv_heads,
+            head_dim_per_layer=head_dims,
+        )
+
+        assert cache.key_caches[0].shape == (num_blocks, block_size, 16, 256)
+        assert cache.key_caches[1].shape == (num_blocks, block_size, 4, 512)
+        assert cache.value_caches[0].shape == (num_blocks, block_size, 16, 256)
+        assert cache.value_caches[1].shape == (num_blocks, block_size, 4, 512)
+
+    def test_uniform_per_layer_matches_scalar(self) -> None:
+        """Uniform per-layer lists produce identical shapes to scalar params."""
+        num_layers = 4
+        num_kv_heads = 8
+        head_dim = 128
+        num_blocks = 2
+        block_size = 16
+
+        scalar_cache = MetalPagedKVCache(
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            num_blocks=num_blocks,
+            block_size=block_size,
+        )
+        per_layer_cache = MetalPagedKVCache(
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            num_blocks=num_blocks,
+            block_size=block_size,
+            kv_heads_per_layer=[num_kv_heads] * num_layers,
+            head_dim_per_layer=[head_dim] * num_layers,
+        )
+
+        for i in range(num_layers):
+            assert (
+                scalar_cache.key_caches[i].shape == per_layer_cache.key_caches[i].shape
+            )
+
+    def test_length_mismatch_raises(self) -> None:
+        """Mismatched list lengths are caught early."""
+        with pytest.raises(ValueError, match="kv_heads_per_layer length"):
+            MetalPagedKVCache(
+                num_layers=2,
+                num_kv_heads=8,
+                head_dim=128,
+                num_blocks=1,
+                block_size=16,
+                kv_heads_per_layer=[8, 8, 8],
+            )
+
+
+class TestMHABackendPerLayer:
+    """MHAPagedAttentionBackend passes per-layer shapes to cache."""
+
+    def test_backend_propagates_per_layer_shapes(self) -> None:
+        kv_heads = [16, 4]
+        head_dims = [256, 512]
+
+        backend = MHAPagedAttentionBackend(
+            num_layers=2,
+            num_kv_heads=kv_heads[0],
+            head_dim=head_dims[0],
+            block_size=16,
+            dtype=mx.bfloat16,
+            kv_heads_per_layer=kv_heads,
+            head_dim_per_layer=head_dims,
+        )
+        backend.initialize(num_blocks=4)
+
+        cache = backend._cache
+        assert cache is not None
+        assert cache.key_caches[0].shape[-2:] == (16, 256)
+        assert cache.key_caches[1].shape[-2:] == (4, 512)
+
+
+class TestCachePolicyPerLayerBytes:
+    """Block-size-bytes and one-sequence-bytes with per-layer shapes."""
+
+    _BLOCK_SIZE = 16
+    _DTYPE = mx.bfloat16
+
+    def _make_runner(
+        self,
+        *,
+        num_layers: int,
+        num_kv_heads: int,
+        head_dim: int,
+        kv_heads_per_layer: list[int] | None = None,
+        head_dim_per_layer: list[int] | None = None,
+    ) -> object:
+        return make_stub_runner(
+            num_layers=num_layers,
+            num_kv_cache_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            kv_cache_dtype=self._DTYPE,
+            cache_config=SimpleNamespace(block_size=self._BLOCK_SIZE),
+            kv_heads_per_layer=kv_heads_per_layer,
+            head_dim_per_layer=head_dim_per_layer,
+        )
+
+    def test_uniform_per_layer_matches_scalar_block_bytes(self) -> None:
+        """Uniform per-layer lists give identical block bytes to scalar path."""
+        num_layers = 4
+        num_kv_heads = 8
+        head_dim = 128
+
+        scalar_runner = self._make_runner(
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+        )
+        per_layer_runner = self._make_runner(
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            kv_heads_per_layer=[num_kv_heads] * num_layers,
+            head_dim_per_layer=[head_dim] * num_layers,
+        )
+
+        assert (
+            scalar_runner.get_cache_block_size_bytes()
+            == per_layer_runner.get_cache_block_size_bytes()
+        )
+
+    def test_heterogeneous_block_bytes_equals_hand_computed_sum(self) -> None:
+        """Per-layer bytes sum matches hand computation."""
+        kv_heads = [16, 4]
+        head_dims = [256, 512]
+        dtype_size = self._DTYPE.size
+        kv_factor = 2
+
+        runner = self._make_runner(
+            num_layers=2,
+            num_kv_heads=kv_heads[0],
+            head_dim=head_dims[0],
+            kv_heads_per_layer=kv_heads,
+            head_dim_per_layer=head_dims,
+        )
+
+        expected = (
+            kv_factor
+            * self._BLOCK_SIZE
+            * dtype_size
+            * sum(h * d for h, d in zip(kv_heads, head_dims, strict=True))
+        )
+        assert runner.get_cache_block_size_bytes() == expected

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -10,7 +10,10 @@ import pytest
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
-from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
+from vllm_metal.paged_attention_backend.mha import (
+    MHAPagedAttentionBackend,
+    warm_up_paged_cache,
+)
 
 
 class TestMetalPagedKVCachePerLayer:
@@ -105,6 +108,46 @@ class TestMHABackendPerLayer:
         assert cache.key_caches[0].shape[-2:] == (16, 256)
         assert cache.key_caches[1].shape[-2:] == (4, 512)
 
+    def test_warm_up_uses_layer_zero_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Kernel warm-up should compile against the concrete layer-0 shape."""
+        cache = MetalPagedKVCache(
+            num_layers=2,
+            num_kv_heads=8,
+            head_dim=128,
+            num_blocks=1,
+            block_size=16,
+            dtype=mx.bfloat16,
+            kv_heads_per_layer=[16, 4],
+            head_dim_per_layer=[256, 512],
+        )
+        seen: dict[str, tuple[int, ...]] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self,
+                dummy_k: mx.array,
+                dummy_v: mx.array,
+                key_cache: mx.array,
+                value_cache: mx.array,
+                dummy_slot: mx.array,
+            ) -> None:
+                seen["dummy_k"] = dummy_k.shape
+                seen["dummy_v"] = dummy_v.shape
+                seen["key_cache"] = key_cache.shape
+                seen["value_cache"] = value_cache.shape
+
+        monkeypatch.setattr(
+            "vllm_metal.paged_attention_backend.mha.get_ops",
+            lambda: _FakeOps(),
+        )
+
+        warm_up_paged_cache(cache)
+
+        assert seen["dummy_k"] == (1, 16, 256)
+        assert seen["dummy_v"] == (1, 16, 256)
+        assert seen["key_cache"] == (1, 16, 16, 256)
+        assert seen["value_cache"] == (1, 16, 16, 256)
+
 
 class TestCachePolicyPerLayerBytes:
     """Block-size-bytes and one-sequence-bytes with per-layer shapes."""
@@ -120,8 +163,10 @@ class TestCachePolicyPerLayerBytes:
         head_dim: int,
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
+        model_args: dict | None = None,
     ) -> object:
         return make_stub_runner(
+            model_args=model_args,
             num_layers=num_layers,
             num_kv_cache_layers=num_layers,
             num_kv_heads=num_kv_heads,
@@ -178,3 +223,24 @@ class TestCachePolicyPerLayerBytes:
             * sum(h * d for h, d in zip(kv_heads, head_dims, strict=True))
         )
         assert runner.get_cache_block_size_bytes() == expected
+
+    def test_hybrid_per_layer_shapes_raise_early(self) -> None:
+        """Unsupported hybrid + per-layer combos should fail at public APIs."""
+        runner = self._make_runner(
+            num_layers=4,
+            num_kv_heads=4,
+            head_dim=256,
+            kv_heads_per_layer=[4, 4, 4, 4],
+            head_dim_per_layer=[256, 256, 256, 256],
+            model_args={"full_attention_interval": 2},
+        )
+
+        with pytest.raises(
+            NotImplementedError, match="Per-layer KV shapes with hybrid models"
+        ):
+            runner.get_kv_cache_spec()
+
+        with pytest.raises(
+            NotImplementedError, match="Per-layer KV shapes with hybrid models"
+        ):
+            runner.build_paged_attention_backend(block_size=self._BLOCK_SIZE)

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -348,9 +348,9 @@ def sdpa_forward(
     n_heads = queries.shape[1]
     head_dim = queries.shape[3]
 
-    # Variable head_dim models (e.g. Gemma4): pad Q/K/V to the cache's
-    # allocated head_dim.  Output is truncated back before o_proj.
-    cache_head_dim = kv_cache.head_dim
+    # Per-layer cache shape: each layer may have its own (kv_heads, head_dim).
+    cache_kv_heads = kv_cache.kv_heads_per_layer[layer_idx]
+    cache_head_dim = kv_cache.head_dim_per_layer[layer_idx]
     actual_head_dim = head_dim
     queries, keys, values = pad_qkv_to_cache_head_dim(
         queries, keys, values, head_dim, cache_head_dim
@@ -396,15 +396,11 @@ def sdpa_forward(
         new_k_cache = kv_cache.key_caches[layer_idx]
         new_v_cache = kv_cache.value_caches[layer_idx]
     else:
-        flat_k = kv_cache.key_caches[layer_idx].reshape(
-            -1, kv_cache.num_kv_heads, head_dim
-        )
+        flat_k = kv_cache.key_caches[layer_idx].reshape(-1, cache_kv_heads, head_dim)
         flat_k[slot_mapping] = k_3d
         new_k_cache = flat_k.reshape(kv_cache.key_caches[layer_idx].shape)
 
-        flat_v = kv_cache.value_caches[layer_idx].reshape(
-            -1, kv_cache.num_kv_heads, head_dim
-        )
+        flat_v = kv_cache.value_caches[layer_idx].reshape(-1, cache_kv_heads, head_dim)
         flat_v[slot_mapping] = v_3d
         new_v_cache = flat_v.reshape(kv_cache.value_caches[layer_idx].shape)
 
@@ -426,10 +422,10 @@ def sdpa_forward(
     kernel_v_cache = new_v_cache
     if kernel_block_size != kv_cache.block_size:
         kernel_k_cache = new_k_cache.reshape(
-            -1, kernel_block_size, kv_cache.num_kv_heads, head_dim
+            -1, kernel_block_size, cache_kv_heads, head_dim
         )
         kernel_v_cache = new_v_cache.reshape(
-            -1, kernel_block_size, kv_cache.num_kv_heads, head_dim
+            -1, kernel_block_size, cache_kv_heads, head_dim
         )
 
     ops = get_ops()
@@ -438,7 +434,7 @@ def sdpa_forward(
         q_3d,
         kernel_k_cache,
         kernel_v_cache,
-        kv_cache.num_kv_heads,
+        cache_kv_heads,
         inner.scale,
         0.0,  # softcap (0 = disabled)
         block_tables,

--- a/vllm_metal/metal_kernel_backend/cache.py
+++ b/vllm_metal/metal_kernel_backend/cache.py
@@ -51,6 +51,10 @@ class MetalPagedKVCache:
         self.kv_heads_per_layer = kv_heads_per_layer or [num_kv_heads] * num_layers
         self.head_dim_per_layer = head_dim_per_layer or [head_dim] * num_layers
 
+        # Canonical scalars for warm_up_paged_cache (layer-0 shape)
+        self.num_kv_heads = self.kv_heads_per_layer[0]
+        self.head_dim = self.head_dim_per_layer[0]
+
         if len(self.kv_heads_per_layer) != num_layers:
             raise ValueError(
                 f"kv_heads_per_layer length {len(self.kv_heads_per_layer)} "

--- a/vllm_metal/metal_kernel_backend/cache.py
+++ b/vllm_metal/metal_kernel_backend/cache.py
@@ -20,7 +20,14 @@ import mlx.core as mx
 
 
 class MetalPagedKVCache:
-    """Per-layer MLX arrays for native Metal paged attention."""
+    """Per-layer MLX arrays for native Metal paged attention.
+
+    Supports heterogeneous per-layer shapes: when ``kv_heads_per_layer``
+    and ``head_dim_per_layer`` are provided, each cache layer is allocated
+    with its own ``(num_kv_heads, head_dim)`` pair.  When omitted, all
+    layers share the scalar ``num_kv_heads`` / ``head_dim`` (backward
+    compat for MLA, Hybrid, and uniform MHA models).
+    """
 
     def __init__(
         self,
@@ -30,6 +37,9 @@ class MetalPagedKVCache:
         num_blocks: int,
         block_size: int,
         dtype: mx.Dtype = mx.float16,
+        *,
+        kv_heads_per_layer: list[int] | None = None,
+        head_dim_per_layer: list[int] | None = None,
     ) -> None:
         self.num_layers = num_layers
         self.num_kv_heads = num_kv_heads
@@ -38,25 +48,35 @@ class MetalPagedKVCache:
         self.block_size = block_size
         self.dtype = dtype
 
+        self.kv_heads_per_layer = kv_heads_per_layer or [num_kv_heads] * num_layers
+        self.head_dim_per_layer = head_dim_per_layer or [head_dim] * num_layers
+
+        if len(self.kv_heads_per_layer) != num_layers:
+            raise ValueError(
+                f"kv_heads_per_layer length {len(self.kv_heads_per_layer)} "
+                f"!= num_layers {num_layers}"
+            )
+        if len(self.head_dim_per_layer) != num_layers:
+            raise ValueError(
+                f"head_dim_per_layer length {len(self.head_dim_per_layer)} "
+                f"!= num_layers {num_layers}"
+            )
+
         if dtype not in (mx.float16, mx.bfloat16, mx.float32):
             raise ValueError(f"Unsupported dtype for paged KV cache: {dtype}")
 
-        # Per-layer caches — unified layout for both K and V
+        # Per-layer caches — each layer sized by its own (kv_heads, head_dim)
         self.key_caches: list[mx.array] = []
         self.value_caches: list[mx.array] = []
-        for _ in range(num_layers):
-            self.key_caches.append(
-                mx.zeros(
-                    (num_blocks, block_size, num_kv_heads, head_dim),
-                    dtype=dtype,
-                )
+        for i in range(num_layers):
+            shape = (
+                num_blocks,
+                block_size,
+                self.kv_heads_per_layer[i],
+                self.head_dim_per_layer[i],
             )
-            self.value_caches.append(
-                mx.zeros(
-                    (num_blocks, block_size, num_kv_heads, head_dim),
-                    dtype=dtype,
-                )
-            )
+            self.key_caches.append(mx.zeros(shape, dtype=dtype))
+            self.value_caches.append(mx.zeros(shape, dtype=dtype))
 
         # Force allocation so Metal buffers exist before kernel dispatch
         mx.eval(*self.key_caches, *self.value_caches)

--- a/vllm_metal/metal_kernel_backend/cache.py
+++ b/vllm_metal/metal_kernel_backend/cache.py
@@ -51,10 +51,6 @@ class MetalPagedKVCache:
         self.kv_heads_per_layer = kv_heads_per_layer or [num_kv_heads] * num_layers
         self.head_dim_per_layer = head_dim_per_layer or [head_dim] * num_layers
 
-        # Canonical scalars for warm_up_paged_cache (layer-0 shape)
-        self.num_kv_heads = self.kv_heads_per_layer[0]
-        self.head_dim = self.head_dim_per_layer[0]
-
         if len(self.kv_heads_per_layer) != num_layers:
             raise ValueError(
                 f"kv_heads_per_layer length {len(self.kv_heads_per_layer)} "

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -70,6 +70,8 @@ class MHAPagedAttentionBackend:
         block_size: int,
         dtype: mx.Dtype,
         cache_idx_map: dict[int, int] | None = None,
+        kv_heads_per_layer: list[int] | None = None,
+        head_dim_per_layer: list[int] | None = None,
     ) -> None:
         self._num_layers = num_layers
         self._num_kv_heads = num_kv_heads
@@ -78,6 +80,8 @@ class MHAPagedAttentionBackend:
         self._dtype = dtype
         self._cache: MetalPagedKVCache | None = None
         self._cache_idx_map = cache_idx_map
+        self._kv_heads_per_layer = kv_heads_per_layer
+        self._head_dim_per_layer = head_dim_per_layer
 
     def _require_initialized(self, caller: str) -> MetalPagedKVCache:
         if self._cache is None:
@@ -94,6 +98,8 @@ class MHAPagedAttentionBackend:
             num_blocks=num_blocks,
             block_size=self._block_size,
             dtype=self._dtype,
+            kv_heads_per_layer=self._kv_heads_per_layer,
+            head_dim_per_layer=self._head_dim_per_layer,
         )
 
     def patch_model(self, model: Any) -> int:

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -36,8 +36,12 @@ def warm_up_paged_cache(cache: MetalPagedKVCache) -> None:
         ) from e
 
     try:
-        dummy_k = mx.zeros((1, cache.num_kv_heads, cache.head_dim), dtype=cache.dtype)
-        dummy_v = mx.zeros((1, cache.num_kv_heads, cache.head_dim), dtype=cache.dtype)
+        # Warm up against the concrete layer-0 cache shape. Per-layer cache
+        # allocation may differ from the scalar constructor fallback.
+        warmup_kv_heads = cache.kv_heads_per_layer[0]
+        warmup_head_dim = cache.head_dim_per_layer[0]
+        dummy_k = mx.zeros((1, warmup_kv_heads, warmup_head_dim), dtype=cache.dtype)
+        dummy_v = mx.zeros((1, warmup_kv_heads, warmup_head_dim), dtype=cache.dtype)
         dummy_slot = mx.zeros((1,), dtype=mx.int64)
         mx.eval(dummy_k, dummy_v, dummy_slot)
         ops.reshape_and_cache(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -93,6 +93,7 @@ class ModelCachePolicy:
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
         kv_heads_list = self._runner.kv_heads_per_layer
         head_dim_list = self._runner.head_dim_per_layer
+        has_per_layer = kv_heads_list is not None and head_dim_list is not None
         specs: dict[str, KVCacheSpec] = {}
         for layer_idx in range(self._runner.num_layers):
             if (
@@ -113,11 +114,11 @@ class ModelCachePolicy:
             else:
                 kv_h = (
                     kv_heads_list[layer_idx]
-                    if kv_heads_list
+                    if has_per_layer
                     else self._runner.num_kv_heads
                 )
                 hd = (
-                    head_dim_list[layer_idx] if head_dim_list else self._runner.head_dim
+                    head_dim_list[layer_idx] if has_per_layer else self._runner.head_dim
                 )
                 layer_name = f"layers.{layer_idx}.self_attn"
                 specs[layer_name] = FullAttentionSpec(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -91,6 +91,8 @@ class ModelCachePolicy:
 
         block_size = self._runner.cache_config.block_size
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
+        kv_heads_list = self._runner.kv_heads_per_layer
+        head_dim_list = self._runner.head_dim_per_layer
         specs: dict[str, KVCacheSpec] = {}
         for layer_idx in range(self._runner.num_layers):
             if (
@@ -109,11 +111,19 @@ class ModelCachePolicy:
                     block_size=block_size,
                 )
             else:
+                kv_h = (
+                    kv_heads_list[layer_idx]
+                    if kv_heads_list
+                    else self._runner.num_kv_heads
+                )
+                hd = (
+                    head_dim_list[layer_idx] if head_dim_list else self._runner.head_dim
+                )
                 layer_name = f"layers.{layer_idx}.self_attn"
                 specs[layer_name] = FullAttentionSpec(
                     block_size=block_size,
-                    num_kv_heads=self._runner.num_kv_heads,
-                    head_size=self._runner.head_dim,
+                    num_kv_heads=kv_h,
+                    head_size=hd,
                     dtype=torch_dtype,
                 )
 
@@ -127,26 +137,18 @@ class ModelCachePolicy:
         )
 
     def get_cache_block_size_bytes(self) -> int:
-        """Return the byte size of one cache block."""
+        """Return the byte size of one cache block.
+
+        For per-layer shapes, sums each layer's contribution individually.
+        For uniform shapes, reduces to the existing product formula.
+        """
         if self._runner._is_stt:
             return STT_SCHED_BLOCK_BYTES
 
         block_size = self._runner.cache_config.block_size
         dtype_size = self._require_kv_cache_dtype().size
-        num_kv_layers = (
-            self._runner.num_sdpa_layers
-            if self._runner.is_hybrid
-            else self._runner.num_kv_cache_layers
-        )
         kv_factor = 1 if self._runner.is_mla else 2
-        return (
-            kv_factor
-            * num_kv_layers
-            * block_size
-            * self._runner.num_kv_heads
-            * self._runner.head_dim
-            * dtype_size
-        )
+        return kv_factor * block_size * dtype_size * self._kv_layer_size_sum()
 
     def linear_cache_bytes_per_slot(self) -> int:
         """Return bytes for one request's linear-attention state."""
@@ -183,19 +185,9 @@ class ModelCachePolicy:
         """Estimate bytes for one max-length sequence of cache state."""
         dtype_size = self._require_kv_cache_dtype().size
         aligned_tokens = -(-max_model_len // block_size) * block_size
-        num_kv_layers = (
-            self._runner.num_sdpa_layers
-            if self._runner.is_hybrid
-            else self._runner.num_kv_cache_layers
-        )
         kv_factor = 1 if self._runner.is_mla else 2
         sdpa_kv_bytes = (
-            kv_factor
-            * num_kv_layers
-            * aligned_tokens
-            * self._runner.num_kv_heads
-            * self._runner.head_dim
-            * dtype_size
+            kv_factor * aligned_tokens * dtype_size * self._kv_layer_size_sum()
         )
         if self._runner.is_hybrid:
             return sdpa_kv_bytes + self.linear_cache_bytes_per_slot()
@@ -227,6 +219,7 @@ class ModelCachePolicy:
 
     def _build_mha_backend(self, block_size: int) -> MHAPagedAttentionBackend:
         num_layers, cache_idx_map = self._mha_cache_layout()
+        kv_heads, head_dims = self._cache_layer_shapes(num_layers)
         return MHAPagedAttentionBackend(
             num_layers=num_layers,
             num_kv_heads=self._runner.num_kv_heads,
@@ -234,7 +227,42 @@ class ModelCachePolicy:
             block_size=block_size,
             dtype=self._require_kv_cache_dtype(),
             cache_idx_map=cache_idx_map,
+            kv_heads_per_layer=kv_heads,
+            head_dim_per_layer=head_dims,
         )
+
+    def _cache_layer_shapes(self, num_cache_layers: int) -> tuple[list[int], list[int]]:
+        """Build per-cache-layer ``(kv_heads, head_dim)`` lists.
+
+        When the runner has per-layer shape lists (populated by the model
+        adapter in a later PR), extract the first ``num_cache_layers`` entries
+        (which correspond to the unique layers for YOCO models).  Otherwise
+        replicate the scalar values for backward-compat uniform allocation.
+        """
+        kv_heads = self._runner.kv_heads_per_layer
+        head_dims = self._runner.head_dim_per_layer
+        if kv_heads is not None and head_dims is not None:
+            return kv_heads[:num_cache_layers], head_dims[:num_cache_layers]
+        return (
+            [self._runner.num_kv_heads] * num_cache_layers,
+            [self._runner.head_dim] * num_cache_layers,
+        )
+
+    def _kv_layer_size_sum(self) -> int:
+        """Sum of ``kv_heads × head_dim`` across KV cache layers.
+
+        For uniform models this equals ``num_kv_layers × kv_heads × head_dim``.
+        """
+        num_kv_layers = (
+            self._runner.num_sdpa_layers
+            if self._runner.is_hybrid
+            else self._runner.num_kv_cache_layers
+        )
+        kv_heads = self._runner.kv_heads_per_layer
+        head_dims = self._runner.head_dim_per_layer
+        if kv_heads is not None and head_dims is not None:
+            return sum(kv_heads[i] * head_dims[i] for i in range(num_kv_layers))
+        return num_kv_layers * self._runner.num_kv_heads * self._runner.head_dim
 
     def _mha_cache_layout(self) -> tuple[int, list[int] | None]:
         if self._runner._yoco_cache_mapping is None:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -262,6 +262,11 @@ class ModelCachePolicy:
         kv_heads = self._runner.kv_heads_per_layer
         head_dims = self._runner.head_dim_per_layer
         if kv_heads is not None and head_dims is not None:
+            if self._runner.is_hybrid:
+                raise NotImplementedError(
+                    "Per-layer KV shapes with hybrid models require "
+                    "SDPA-layer index remapping, which is not yet implemented."
+                )
             return sum(kv_heads[i] * head_dims[i] for i in range(num_kv_layers))
         return num_kv_layers * self._runner.num_kv_heads * self._runner.head_dim
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -235,10 +235,10 @@ class ModelCachePolicy:
     def _cache_layer_shapes(self, num_cache_layers: int) -> tuple[list[int], list[int]]:
         """Build per-cache-layer ``(kv_heads, head_dim)`` lists.
 
-        When the runner has per-layer shape lists (populated by the model
-        adapter in a later PR), extract the first ``num_cache_layers`` entries
-        (which correspond to the unique layers for YOCO models).  Otherwise
-        replicate the scalar values for backward-compat uniform allocation.
+        When the runner has per-layer shape lists, extract the first
+        ``num_cache_layers`` entries (which correspond to the unique
+        layers for YOCO models).  Otherwise replicate the scalar values
+        for backward-compat uniform allocation.
         """
         kv_heads = self._runner.kv_heads_per_layer
         head_dims = self._runner.head_dim_per_layer

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -62,6 +62,7 @@ class ModelCachePolicy:
 
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
+        self._require_supported_per_layer_shapes()
         self._model_adapter.require_uniform_kv_heads(
             self._runner.model_args,
             self._runner.num_kv_heads,
@@ -89,6 +90,7 @@ class ModelCachePolicy:
                 ),
             }
 
+        self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
         kv_heads_list = self._runner.kv_heads_per_layer
@@ -146,6 +148,7 @@ class ModelCachePolicy:
         if self._runner._is_stt:
             return STT_SCHED_BLOCK_BYTES
 
+        self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         dtype_size = self._require_kv_cache_dtype().size
         kv_factor = 1 if self._runner.is_mla else 2
@@ -174,6 +177,7 @@ class ModelCachePolicy:
         self, *, block_size: int
     ) -> PagedAttentionBackend:
         """Create the paged-attention backend for the loaded model."""
+        self._require_supported_per_layer_shapes()
         if self._runner.is_hybrid:
             return self._build_hybrid_backend(block_size)
         if self._runner.is_mla:
@@ -184,6 +188,7 @@ class ModelCachePolicy:
         self, *, max_model_len: int, block_size: int
     ) -> int:
         """Estimate bytes for one max-length sequence of cache state."""
+        self._require_supported_per_layer_shapes()
         dtype_size = self._require_kv_cache_dtype().size
         aligned_tokens = -(-max_model_len // block_size) * block_size
         kv_factor = 1 if self._runner.is_mla else 2
@@ -249,6 +254,22 @@ class ModelCachePolicy:
             [self._runner.head_dim] * num_cache_layers,
         )
 
+    def _require_supported_per_layer_shapes(self) -> None:
+        """Reject unsupported per-layer KV shape combinations early."""
+        kv_heads = self._runner.kv_heads_per_layer
+        head_dims = self._runner.head_dim_per_layer
+        if (kv_heads is None) != (head_dims is None):
+            raise ValueError(
+                "kv_heads_per_layer and head_dim_per_layer must be set together."
+            )
+        if kv_heads is None:
+            return
+        if self._runner.is_hybrid:
+            raise NotImplementedError(
+                "Per-layer KV shapes with hybrid models require "
+                "SDPA-layer index remapping, which is not yet implemented."
+            )
+
     def _kv_layer_size_sum(self) -> int:
         """Sum of ``kv_heads × head_dim`` across KV cache layers.
 
@@ -262,11 +283,6 @@ class ModelCachePolicy:
         kv_heads = self._runner.kv_heads_per_layer
         head_dims = self._runner.head_dim_per_layer
         if kv_heads is not None and head_dims is not None:
-            if self._runner.is_hybrid:
-                raise NotImplementedError(
-                    "Per-layer KV shapes with hybrid models require "
-                    "SDPA-layer index remapping, which is not yet implemented."
-                )
             return sum(kv_heads[i] * head_dims[i] for i in range(num_kv_layers))
         return num_kv_layers * self._runner.num_kv_heads * self._runner.head_dim
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -251,6 +251,10 @@ class MetalModelRunner:
         self._paged_request_seq_lens: dict[str, int] = {}  # req_id → seq_len
         self.kv_cache_dtype: mx.Dtype | None = None
 
+        # Per-layer KV shapes (None = uniform; populated by model adapter)
+        self.kv_heads_per_layer: list[int] | None = None
+        self.head_dim_per_layer: list[int] | None = None
+
         # Async forward state: stashed by execute_model, consumed by
         # sample_tokens (mirrors upstream's execute_model_state pattern).
         self._execute_model_state: _PagedForwardState | None = None

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -251,7 +251,7 @@ class MetalModelRunner:
         self._paged_request_seq_lens: dict[str, int] = {}  # req_id → seq_len
         self.kv_cache_dtype: mx.Dtype | None = None
 
-        # Per-layer KV shapes (None = uniform; populated by model adapter)
+        # Per-layer KV shapes (None = uniform)
         self.kv_heads_per_layer: list[int] | None = None
         self.head_dim_per_layer: list[int] | None = None
 


### PR DESCRIPTION
Summary
- To let `MetalPagedKVCache` allocate each layer with its own `(num_kv_heads, head_dim)` shape.
- To prepare the paged-attention pipeline for Gemma4 26B/31B, which mix sliding layers (16 heads, 256 dim) with full-attention layers (4 heads, 512 dim).
- To keep every existing model on the identical uniform code path with identical memory numbers.

Problem:
`MetalPagedKVCache` allocated all layers with a single `(num_kv_heads, head_dim)` pair. Gemma4 26B/31B need per-layer shapes, and
forcing the uniform max wastes ~2.18× KV memory. This PR adds the mechanism; a follow-up PR wires the Gemma4 adapter and removes the
`require_uniform_kv_heads` guard.

Fix:
- `MetalPagedKVCache` accepts optional keyword-only `kv_heads_per_layer` / `head_dim_per_layer` lists. When omitted, derives uniform
lists from the scalar params — MLA, Hybrid, and all existing MHA callers are unchanged.
- `MHAPagedAttentionBackend` propagates per-layer lists to the cache.
- `sdpa_forward` reads `kv_cache.kv_heads_per_layer[layer_idx]` / `kv_cache.head_dim_per_layer[layer_idx]` instead of scalar globals.
- `ModelCachePolicy.get_cache_block_size_bytes()` / `estimate_one_sequence_kv_bytes()` sum per-layer `kv_heads × head_dim` via a shared
`_kv_layer_size_sum()` helper. For uniform models this reduces to the existing product formula.
- `ModelCachePolicy.get_kv_cache_spec()` emits per-layer `FullAttentionSpec` from runner attributes when available.
- `MetalModelRunner` gains `kv_heads_per_layer` / `head_dim_per_layer` (default `None`, populated by the model adapter in the follow-up
PR).