### PR TITLE
Clear multimodal_config for text-backbone-override models

### DIFF
--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -30,6 +30,41 @@ class TestShouldForceTextBackbone:
         assert result is False
 
 
+class TestNormalizeModelConfig:
+    """Tests for normalize_model_config()."""
+
+    def test_clears_multimodal_config_for_gemma4(self) -> None:
+        model_config = SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=False),
+            hf_config=SimpleNamespace(model_type="gemma4"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is None
+
+    def test_preserves_multimodal_config_for_other_models(self) -> None:
+        sentinel = SimpleNamespace(language_model_only=False)
+        model_config = SimpleNamespace(
+            multimodal_config=sentinel,
+            hf_config=SimpleNamespace(model_type="qwen3_vl"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is sentinel
+
+    def test_noop_when_multimodal_config_already_none(self) -> None:
+        model_config = SimpleNamespace(
+            multimodal_config=None,
+            hf_config=SimpleNamespace(model_type="gemma4"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is None
+
+
 class TestTextModel:
     def test_returns_language_model_when_present(self) -> None:
         language_model = object()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -192,6 +192,8 @@ class TestMetalPlatform:
                     disable_cascade_attn=False,
                     tokenizer=None,
                     max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
                 ),
                 scheduler_config=SimpleNamespace(
                     async_scheduling=True,
@@ -240,6 +242,8 @@ class TestMetalPlatform:
                     disable_cascade_attn=False,
                     tokenizer=None,
                     max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
                 ),
                 scheduler_config=SimpleNamespace(
                     async_scheduling=True,
@@ -282,6 +286,8 @@ class TestMetalPlatform:
                     disable_cascade_attn=False,
                     tokenizer=None,
                     max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
                 ),
                 scheduler_config=SimpleNamespace(
                     async_scheduling=True,
@@ -323,6 +329,8 @@ class TestMetalPlatform:
                     disable_cascade_attn=False,
                     tokenizer=None,
                     max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
                 ),
                 scheduler_config=SimpleNamespace(
                     async_scheduling=True,
@@ -368,6 +376,8 @@ class TestMetalPlatform:
                     disable_cascade_attn=False,
                     tokenizer=None,
                     max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
                 ),
                 scheduler_config=SimpleNamespace(
                     async_scheduling=True,
@@ -404,6 +414,8 @@ class TestMetalPlatform:
                 model="openai/whisper-tiny",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                multimodal_config=None,
+                hf_config=SimpleNamespace(model_type="whisper"),
             ),
             scheduler_config=SimpleNamespace(
                 async_scheduling=True,
@@ -432,6 +444,8 @@ class TestMetalPlatform:
                 model="openai/whisper-tiny",
                 disable_cascade_attn=False,
                 tokenizer="custom-tokenizer",
+                multimodal_config=None,
+                hf_config=SimpleNamespace(model_type="whisper"),
             ),
             scheduler_config=SimpleNamespace(
                 async_scheduling=True,
@@ -443,6 +457,96 @@ class TestMetalPlatform:
 
         assert vllm_config.model_config.tokenizer == "custom-tokenizer"
         assert vllm_config.scheduler_config.async_scheduling is False
+
+    def test_check_and_update_config_clears_multimodal_for_text_backbone_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Gemma4-style multimodal configs must be cleared for the text-only path.
+
+        Gemma4 MLX checkpoints are flagged multimodal in the HF config but
+        ship without the vision/audio preprocessor files that vLLM's input
+        processor tries to load. Clearing ``multimodal_config`` at the
+        platform layer makes ``is_multimodal_model`` False so the input
+        processor skips feature-extractor loading.
+        """
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            model_config = SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=128,
+                multimodal_config=SimpleNamespace(language_model_only=False),
+                hf_config=SimpleNamespace(model_type="gemma4"),
+            )
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=model_config,
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert model_config.multimodal_config is None
+
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_preserves_multimodal_for_non_gemma4_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-overridden multimodal models must keep multimodal_config set."""
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            sentinel = SimpleNamespace(language_model_only=False)
+            model_config = SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=128,
+                multimodal_config=sentinel,
+                hf_config=SimpleNamespace(model_type="qwen3_vl"),
+            )
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=model_config,
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert model_config.multimodal_config is sentinel
+
+        finally:
+            reset_config()
 
     def test_synchronize_runs_mlx_barrier(
         self, monkeypatch: pytest.MonkeyPatch

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -281,9 +281,15 @@ class MetalPlatform(Platform):
         ):
             cache_config.block_size = config.block_size
 
-        # Disable cascade attention (not supported)
+        # Disable cascade attention (not supported), then let the adapter
+        # apply any model-specific normalisations (e.g. clearing
+        # ``multimodal_config`` for model types served on the text-only
+        # backbone — see ``DefaultModelAdapter.normalize_model_config``).
         if model_config is not None:
             model_config.disable_cascade_attn = True
+            from vllm_metal.v1.model_adapter import DefaultModelAdapter
+
+            DefaultModelAdapter().normalize_model_config(model_config)
 
         # STT model detection — set tokenizer fallback if not already configured.
         # Lazy imports to avoid circular import: platform.py is loaded during

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -3,7 +3,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import ModelConfig
+
+logger = init_logger(__name__)
 
 
 class ModelAdapter(Protocol):
@@ -11,6 +18,13 @@ class ModelAdapter(Protocol):
 
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether a multimodal config should run on the text-only path."""
+
+    def normalize_model_config(self, model_config: ModelConfig) -> None:
+        """Apply model-specific normalisations to ``model_config`` in place.
+
+        Called early during platform setup so the engine sees a consistent
+        view of the model before constructing input processors, etc.
+        """
 
     def resolve_max_head_dim(
         self, args: dict[str, Any], head_dim: int | None
@@ -48,6 +62,34 @@ class DefaultModelAdapter(ModelAdapter):
         """
         model_type = getattr(hf_config, "model_type", "")
         return model_type in _TEXT_BACKBONE_OVERRIDE_TYPES
+
+    def normalize_model_config(self, model_config: ModelConfig) -> None:
+        """Clear ``multimodal_config`` for models served on the text backbone.
+
+        For model types in :data:`_TEXT_BACKBONE_OVERRIDE_TYPES` the runner
+        executes the language-model forward via mlx_lm, even though the HF
+        config marks the architecture as multimodal. Leaving the engine's
+        ``multimodal_config`` populated triggers eager loading of the
+        multimodal feature extractor at engine startup, which crashes on MLX
+        checkpoints that ship neither ``preprocessor_config.json`` nor a
+        ``feature_extractor`` section in ``processor_config.json`` (e.g.
+        ``mlx-community/gemma-4-31b-8bit``).
+
+        Clearing it here makes ``is_multimodal_model`` ``False`` so the
+        input processor skips that path. The ``should_force_text_backbone``
+        predicate is the single source of truth for which model types apply.
+        """
+        if model_config.multimodal_config is None:
+            return
+        if not self.should_force_text_backbone(model_config.hf_config):
+            return
+
+        model_config.multimodal_config = None
+        logger.info(
+            "Metal: forcing text-only backbone for model_type=%s "
+            "(cleared multimodal_config)",
+            model_config.hf_config.model_type,
+        )
 
     def resolve_max_head_dim(
         self, args: dict[str, Any], head_dim: int | None


### PR DESCRIPTION
## Summary

Gemma4 MLX checkpoints are registered as multimodal in the HF config but are served via the text-only `mlx_lm` path by vllm-metal. vLLM's `InputProcessor` eagerly instantiates the multimodal feature extractor during engine startup and crashes on MLX checkpoints that ship neither `preprocessor_config.json` nor a `feature_extractor` section in `processor_config.json` — which is the case for the [Gemma4 31B MLX release](https://huggingface.co/mlx-community/gemma-4-31b-8bit).

Repro on current `main`:

```
GEMMA4_31B_MODEL_PATH=/path/to/gemma-4-31b-8bit \
  VLLM_ENABLE_V1_MULTIPROCESSING=0 VLLM_METAL_MEMORY_FRACTION=0.62 \
  python -c "from vllm import LLM; LLM(model='${GEMMA4_31B_MODEL_PATH}', max_model_len=128, max_num_seqs=1)"
# OSError: Can't load feature extractor for '…/gemma-4-31b-8bit'. … directory containing a preprocessor_config.json file
```

## Changes

- `vllm_metal/platform.py:check_and_update_config`: clear `model_config.multimodal_config` for any model type in `_TEXT_BACKBONE_OVERRIDE_TYPES` so `is_multimodal_model` returns `False` before the input processor runs. Uses the same `should_force_text_backbone` predicate as `ModelLifecycle.load`, keeping the two decisions in sync.
- `tests/test_platform.py`: two new cases — `gemma4` clears the config, `qwen3_vl` preserves it.

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy vllm_metal` clean
- [x] `pytest -m "not slow" tests/` — 462 passed
- [x] Manual: `LLM(model='mlx-community/gemma-4-31b-8bit', …)` now starts cleanly (end-to-end validation covered by the companion #276 follow-up)

## Notes

This fix is a prerequisite for running the Gemma4 31B MLX checkpoint end-to-end on the paged attention path (issue #276), but it is an independent bugfix against any Gemma4 MLX checkpoint whose `processor_config.json` lacks a `feature_extractor` section.