### PR TITLE
feat: implement grammar/structured output support for Metal paged path

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -10,6 +10,7 @@ import torch
 import vllm_metal.v1.model_runner as mr
 from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1.model_adapter import DefaultModelAdapter
+from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
 
 def make_stub_runner(
@@ -45,6 +46,7 @@ def make_stub_runner(
         "device": torch.device("cpu"),
         "_sampler": None,
         "_logitsprocs": None,
+        "_structured_output_applier": MetalStructuredOutputApplier(),
         "model_args": _model_args,
     }
 

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for _apply_grammar_bitmask_metal, _apply_grammar_bitmask_paged,
-and grammar integration in sample_tokens."""
+"""Tests for _apply_grammar_bitmask_paged and grammar integration in
+execute_model / sample_tokens."""
 
 from __future__ import annotations
 
@@ -11,14 +11,14 @@ from unittest.mock import patch
 import mlx.core as mx
 import numpy as np
 import pytest
+from vllm.sampling_params import SamplingParams
 from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.sample.sampler import Sampler
 
 import vllm_metal.v1.model_runner as mr
+import vllm_metal.v1.structured_output as so
 from tests.stub_runner import make_stub_runner
-from vllm_metal.v1.model_runner import (
-    _apply_grammar_bitmask_metal,
-    _apply_grammar_bitmask_paged,
-)
+from vllm_metal.v1.structured_output import _apply_grammar_bitmask_paged
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,6 +67,7 @@ def _make_scheduler_output(req_ids: list[str]) -> SimpleNamespace:
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
         preempted_req_ids=set(),
+        has_structured_output_requests=False,
     )
 
 
@@ -130,239 +131,6 @@ def _build_cu_seqlens(num_decode: int, prefill_lens: list[int]) -> list[int]:
     for length in prefill_lens:
         cu.append(cu[-1] + length)
     return cu
-
-
-# ---------------------------------------------------------------------------
-# _apply_grammar_bitmask_metal — 2D helper
-# ---------------------------------------------------------------------------
-
-
-class TestApplyGrammarBitmaskMetal:
-    def test_forbidden_tokens_set_to_neg_inf(self) -> None:
-        """Tokens forbidden by the bitmask must become -inf after masking."""
-        allowed_token = 5
-        logits = _uniform_logits_2d(1)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(
-            ["r0"], _make_single_token_bitmask(allowed_token)
-        )
-
-        result = _to_numpy(_apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits))
-
-        assert np.isfinite(result[0, allowed_token])
-        for tok in range(VOCAB_SIZE):
-            if tok != allowed_token:
-                assert result[0, tok] == float("-inf"), (
-                    f"Token {tok} should be forbidden but got {result[0, tok]}"
-                )
-
-    def test_all_allowed_bitmask_leaves_logits_unchanged(self) -> None:
-        """A full bitmask must not change logit values."""
-        data = np.random.randn(1, VOCAB_SIZE).astype(np.float32)
-        logits = mx.array(data)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(["r0"], _make_full_bitmask())
-
-        result = _to_numpy(_apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits))
-
-        np.testing.assert_allclose(result, data, rtol=1e-5)
-
-    def test_non_structured_rows_unaffected(self) -> None:
-        """Rows without grammar constraints must be unchanged."""
-        logits = mx.array(
-            np.array([[10.0] * VOCAB_SIZE, [10.0] * VOCAB_SIZE], dtype=np.float32)
-        )
-        allowed_token = 3
-        sched = _make_scheduler_output(["plain", "structured"])
-        grammar = _make_grammar_output(
-            ["structured"], _make_single_token_bitmask(allowed_token)
-        )
-
-        result = _to_numpy(
-            _apply_grammar_bitmask_metal(
-                sched, grammar, ["plain", "structured"], logits
-            )
-        )
-
-        np.testing.assert_allclose(
-            result[0], 10.0, err_msg="Plain row must be bit-identical to input"
-        )
-        assert np.isfinite(result[1, allowed_token])
-        for tok in range(VOCAB_SIZE):
-            if tok != allowed_token:
-                assert result[1, tok] == float("-inf")
-
-    def test_batch_order_independent_of_grammar_output_order(self) -> None:
-        """Bitmask must be applied to the correct request even when order differs."""
-        allowed_in_r0 = 7
-        allowed_in_r1 = 13
-        bitmask = np.vstack(
-            [
-                _make_single_token_bitmask(allowed_in_r1),  # listed first, but is r1
-                _make_single_token_bitmask(allowed_in_r0),  # listed second, but is r0
-            ]
-        )
-        logits = _uniform_logits_2d(2)
-        sched = _make_scheduler_output(["r0", "r1"])
-        grammar = _make_grammar_output(["r1", "r0"], bitmask)
-
-        result = _to_numpy(
-            _apply_grammar_bitmask_metal(sched, grammar, ["r0", "r1"], logits)
-        )
-
-        assert np.isfinite(result[0, allowed_in_r0])
-        assert result[0, (allowed_in_r0 + 1) % VOCAB_SIZE] == float("-inf")
-        assert np.isfinite(result[1, allowed_in_r1])
-        assert result[1, (allowed_in_r1 + 1) % VOCAB_SIZE] == float("-inf")
-
-    def test_dtype_preserved_for_float16(self) -> None:
-        logits = mx.zeros((1, VOCAB_SIZE), dtype=mx.float16)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
-
-        result = _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
-
-        assert result.dtype == mx.float16, f"Expected float16, got {result.dtype}"
-
-    def test_dtype_preserved_for_bfloat16(self) -> None:
-        logits = mx.zeros((1, VOCAB_SIZE), dtype=mx.bfloat16)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
-
-        result = _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
-
-        assert result.dtype == mx.bfloat16
-
-    def test_raises_if_xgrammar_missing(self) -> None:
-        logits = _uniform_logits_2d(1)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
-
-        with patch.object(mr, "xgr", None):
-            with pytest.raises(RuntimeError, match="xgrammar is required"):
-                _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
-
-    def test_rejects_3d_logits(self) -> None:
-        """The 2D helper must reject 3D (paged-path) logits with a clear assertion."""
-        logits_3d = _uniform_logits_3d(2)  # shape (1, 2, vocab)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
-
-        with pytest.raises(AssertionError, match="2D"):
-            _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits_3d)
-
-    def test_greedy_argmax_picks_only_allowed_token(self) -> None:
-        allowed_token = 17
-        data = np.random.randn(1, VOCAB_SIZE).astype(np.float32)
-        logits = mx.array(data)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(
-            ["r0"], _make_single_token_bitmask(allowed_token)
-        )
-
-        result = _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
-        sampled = int(mx.argmax(result[0]).item())
-
-        assert sampled == allowed_token
-
-    def test_input_array_not_mutated(self) -> None:
-        """Caller-held input mx.array must be unchanged after the call."""
-        rng = np.random.default_rng(42)
-        data = rng.standard_normal((1, VOCAB_SIZE)).astype(np.float32)
-        logits = mx.array(data)
-        sched = _make_scheduler_output(["r0"])
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
-
-        _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
-
-        np.testing.assert_array_equal(_to_numpy(logits), data)
-
-    def test_spec_decode_rows_all_constrained(self) -> None:
-        """With spec-decode tokens, every position (base + speculative) is masked."""
-        # r0 plain, r1 structured with 2 spec tokens:
-        # logits rows: 0=r0, 1=r1-base, 2=r1-spec0, 3=r1-spec1
-        allowed_base = 5
-        allowed_spec0 = 11
-        allowed_spec1 = 21
-        logits = _uniform_logits_2d(4)
-        sched = SimpleNamespace(
-            scheduled_spec_decode_tokens={"r1": [100, 101]},
-            num_scheduled_tokens={"r0": 1, "r1": 3},
-            total_num_scheduled_tokens=4,
-            finished_req_ids=set(),
-        )
-        # grammar_bitmask has 3 rows for r1 (base + 2 spec)
-        bitmask = np.vstack(
-            [
-                _make_single_token_bitmask(allowed_base),
-                _make_single_token_bitmask(allowed_spec0),
-                _make_single_token_bitmask(allowed_spec1),
-            ]
-        )
-        grammar = _make_grammar_output(["r1"], bitmask)
-
-        result = _to_numpy(
-            _apply_grammar_bitmask_metal(sched, grammar, ["r0", "r1"], logits)
-        )
-
-        # r0 row 0: unconstrained
-        assert np.all(np.isfinite(result[0]))
-        # r1 base row 1: constrained to allowed_base
-        assert np.isfinite(result[1, allowed_base])
-        assert result[1, (allowed_base + 1) % VOCAB_SIZE] == float("-inf")
-        # r1 spec rows 2, 3: each constrained to their respective allowed token
-        assert np.isfinite(result[2, allowed_spec0])
-        assert result[2, (allowed_spec0 + 1) % VOCAB_SIZE] == float("-inf")
-        assert np.isfinite(result[3, allowed_spec1])
-        assert result[3, (allowed_spec1 + 1) % VOCAB_SIZE] == float("-inf")
-
-    def test_empty_structured_output_request_ids_returns_unchanged(self) -> None:
-        """Empty structured_output_request_ids must return logits unchanged."""
-        data = np.random.randn(2, VOCAB_SIZE).astype(np.float32)
-        logits = mx.array(data)
-        sched = _make_scheduler_output(["r0", "r1"])
-        grammar = _make_grammar_output([], np.zeros((0, NUM_BITMASK_WORDS), dtype=np.int32))
-
-        result = _to_numpy(
-            _apply_grammar_bitmask_metal(sched, grammar, ["r0", "r1"], logits)
-        )
-
-        np.testing.assert_array_equal(result, data)
-
-    def test_absent_structured_output_req_cumulative_index_correct(self) -> None:
-        """A structured-output req absent from the batch must not desync cumulative_index.
-
-        r0 is absent (preempted), r1 is present. The bitmask has r0's row first,
-        then r1's row. cumulative_index must skip r0's row correctly so r1 gets
-        the right bitmask.
-        """
-        allowed_token = 42
-        logits = _uniform_logits_2d(1)  # only r1 is in this batch
-        sched = _make_scheduler_output(["r1"])
-        bitmask = np.vstack(
-            [
-                _make_single_token_bitmask(0),   # r0's bitmask (not in batch)
-                _make_single_token_bitmask(allowed_token),  # r1's bitmask
-            ]
-        )
-        grammar = _make_grammar_output(["r0", "r1"], bitmask)
-
-        result = _to_numpy(
-            _apply_grammar_bitmask_metal(sched, grammar, ["r1"], logits)
-        )
-
-        # r1's bitmask (row 1) allows only allowed_token — verify the full row.
-        # If cumulative_index were wrong and r0's bitmask (allows token 0) were
-        # applied instead, token 0 would be finite and allowed_token would be -inf.
-        assert np.isfinite(result[0, allowed_token]), (
-            f"allowed_token {allowed_token} should be finite"
-        )
-        assert np.all(result[0, :allowed_token] == float("-inf")), (
-            "all tokens before allowed_token must be forbidden"
-        )
-        assert np.all(result[0, allowed_token + 1:] == float("-inf")), (
-            "all tokens after allowed_token must be forbidden"
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -530,7 +298,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
-        with patch.object(mr, "xgr", None):
+        with patch.object(so, "xgr", None):
             with pytest.raises(RuntimeError, match="xgrammar is required"):
                 _apply_grammar_bitmask_paged(
                     sched, grammar, decode_reqs, [], cu, 1, logits
@@ -726,7 +494,7 @@ class TestApplyGrammarBitmaskPaged:
 
 
 # ---------------------------------------------------------------------------
-# sample_tokens — non-paged path raises NotImplementedError
+# execute_model — non-paged path raises early for structured output
 # ---------------------------------------------------------------------------
 
 
@@ -734,23 +502,15 @@ class TestSampleTokensGrammarNonPagedPath:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner()
 
-    def test_non_paged_path_raises_for_grammar_output(self) -> None:
-        """Non-paged path must raise NotImplementedError when grammar_output is set."""
+    def test_non_paged_path_raises_early_in_execute_model(self) -> None:
+        """Non-paged path must raise NotImplementedError in execute_model before
+        any forward pass runs, when structured output is requested."""
         runner = self._make_runner()
-        runner._pending_output = ModelRunnerOutput(
-            req_ids=["r0"],
-            req_id_to_index={"r0": 0},
-            sampled_token_ids=[[5]],
-            logprobs=None,
-            prompt_logprobs_dict={},
-            pooler_output=[None],
-        )
-        runner._execute_model_state = None
-
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+        scheduler_output = _make_scheduler_output([])
+        scheduler_output.has_structured_output_requests = True
 
         with pytest.raises(NotImplementedError, match="non-paged"):
-            runner.sample_tokens(grammar_output=grammar)
+            runner.execute_model(scheduler_output)
 
     def test_non_paged_path_no_raise_without_grammar(self) -> None:
         """Non-paged path with grammar_output=None must return output normally."""
@@ -767,3 +527,65 @@ class TestSampleTokensGrammarNonPagedPath:
 
         out = runner.sample_tokens(grammar_output=None)
         assert out is pending
+
+
+# ---------------------------------------------------------------------------
+# sample_tokens — paged path applies grammar bitmask before sampling
+# ---------------------------------------------------------------------------
+
+
+class TestSampleTokensGrammarPagedPath:
+    """Integration tests for the paged decode path: execute_model → sample_tokens."""
+
+    def test_grammar_constraint_applied_on_paged_decode(self) -> None:
+        """Grammar bitmask must constrain greedy sampling on the paged path.
+
+        Injects _execute_model_state directly (no live model available in unit
+        tests) to isolate the sample_tokens bitmask-then-sample ordering.
+        Covers the state that execute_model leaves behind after a paged forward.
+        """
+        vocab = 64
+        allowed_token = 5
+
+        runner = make_stub_runner(
+            model_args={"vocab_size": vocab},
+            _paged_request_seq_lens={},
+        )
+        runner._sampler = Sampler()
+
+        req_state = mr.RequestState(
+            token_ids=[1],
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(temperature=0.0),
+            generator=None,
+            generated_tokens=0,
+        )
+        decode_reqs = [("r0", req_state)]
+
+        # Uniform logits: without bitmask, greedy argmax = token 0.
+        logits = mx.zeros((1, 1, vocab))
+
+        scheduler_output = _make_scheduler_output(["r0"])
+        grammar_output = _make_grammar_output(
+            ["r0"], _make_single_token_bitmask(allowed_token)
+        )
+
+        # Simulate the paged forward state that execute_model leaves behind.
+        batch = mr._ExecutionBatch()
+        batch.paged_decode_reqs = decode_reqs
+
+        runner._execute_model_state = mr._PagedForwardState(
+            batch=batch,
+            prefill_reqs=[],
+            decode_reqs=decode_reqs,
+            scheduler_output=scheduler_output,
+            logits=logits,
+            cu_seqlens=[0, 1],
+            num_decode=1,
+        )
+
+        output = runner.sample_tokens(grammar_output=grammar_output)
+
+        assert output is not None
+        assert output.sampled_token_ids[0][0] == allowed_token

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -46,7 +46,11 @@ def _make_single_token_bitmask(
     return bitmask
 
 
-def _make_scheduler_output(req_ids: list[str]) -> SimpleNamespace:
+def _make_scheduler_output(
+    req_ids: list[str],
+    *,
+    has_structured_output_requests: bool = False,
+) -> SimpleNamespace:
     """Minimal SchedulerOutput stub — no spec-decode tokens."""
     return SimpleNamespace(
         scheduled_spec_decode_tokens={},
@@ -67,7 +71,7 @@ def _make_scheduler_output(req_ids: list[str]) -> SimpleNamespace:
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
         preempted_req_ids=set(),
-        has_structured_output_requests=False,
+        has_structured_output_requests=has_structured_output_requests,
     )
 
 
@@ -506,8 +510,9 @@ class TestSampleTokensGrammarNonPagedPath:
         """Non-paged path must raise NotImplementedError in execute_model before
         any forward pass runs, when structured output is requested."""
         runner = self._make_runner()
-        scheduler_output = _make_scheduler_output([])
-        scheduler_output.has_structured_output_requests = True
+        scheduler_output = _make_scheduler_output(
+            [], has_structured_output_requests=True
+        )
 
         with pytest.raises(NotImplementedError, match="non-paged"):
             runner.execute_model(scheduler_output)

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -316,6 +316,54 @@ class TestApplyGrammarBitmaskMetal:
         assert np.isfinite(result[3, allowed_spec1])
         assert result[3, (allowed_spec1 + 1) % VOCAB_SIZE] == float("-inf")
 
+    def test_empty_structured_output_request_ids_returns_unchanged(self) -> None:
+        """Empty structured_output_request_ids must return logits unchanged."""
+        data = np.random.randn(2, VOCAB_SIZE).astype(np.float32)
+        logits = mx.array(data)
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output([], np.zeros((0, NUM_BITMASK_WORDS), dtype=np.int32))
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_metal(sched, grammar, ["r0", "r1"], logits)
+        )
+
+        np.testing.assert_array_equal(result, data)
+
+    def test_absent_structured_output_req_cumulative_index_correct(self) -> None:
+        """A structured-output req absent from the batch must not desync cumulative_index.
+
+        r0 is absent (preempted), r1 is present. The bitmask has r0's row first,
+        then r1's row. cumulative_index must skip r0's row correctly so r1 gets
+        the right bitmask.
+        """
+        allowed_token = 42
+        logits = _uniform_logits_2d(1)  # only r1 is in this batch
+        sched = _make_scheduler_output(["r1"])
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(0),   # r0's bitmask (not in batch)
+                _make_single_token_bitmask(allowed_token),  # r1's bitmask
+            ]
+        )
+        grammar = _make_grammar_output(["r0", "r1"], bitmask)
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_metal(sched, grammar, ["r1"], logits)
+        )
+
+        # r1's bitmask (row 1) allows only allowed_token — verify the full row.
+        # If cumulative_index were wrong and r0's bitmask (allows token 0) were
+        # applied instead, token 0 would be finite and allowed_token would be -inf.
+        assert np.isfinite(result[0, allowed_token]), (
+            f"allowed_token {allowed_token} should be finite"
+        )
+        assert np.all(result[0, :allowed_token] == float("-inf")), (
+            "all tokens before allowed_token must be forbidden"
+        )
+        assert np.all(result[0, allowed_token + 1:] == float("-inf")), (
+            "all tokens after allowed_token must be forbidden"
+        )
+
 
 # ---------------------------------------------------------------------------
 # _apply_grammar_bitmask_paged — 3D paged-path helper
@@ -645,13 +693,14 @@ class TestApplyGrammarBitmaskPaged:
         with pytest.raises(NotImplementedError, match="speculative decoding"):
             _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
 
-    def test_spec_decode_raises_even_when_plain_req_has_spec_tokens(self) -> None:
-        """Guard is coarse: any spec-decode in the batch raises, not just on structured reqs.
+    def test_spec_decode_plain_req_does_not_block_structured_req(self) -> None:
+        """Plain req with spec tokens must not block a structured-output req.
 
-        Pins the intended conservative behavior: r1 (plain) has spec tokens, but
-        r0 (structured) does not — batch is still rejected.  Update this test if
-        the guard is ever tightened to per-request granularity.
+        r1 (plain) has spec tokens; r0 (structured) does not.
+        The guard must allow this batch — only raise when the structured-output
+        request itself overlaps with spec-decode.
         """
+        allowed_token = 5
         logits = _uniform_logits_3d(3)
         decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
         cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
@@ -661,10 +710,19 @@ class TestApplyGrammarBitmaskPaged:
             total_num_scheduled_tokens=3,
             finished_req_ids=set(),
         )
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(allowed_token))
 
-        with pytest.raises(NotImplementedError, match="speculative decoding"):
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        # Must not raise — r0 (structured) has no spec tokens.
+        result = _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+
+        result_np = _to_numpy(result)
+        # r0 (row 0) is constrained to allowed_token
+        assert np.isfinite(result_np[0, 0, allowed_token])
+        assert result_np[0, 0, (allowed_token + 1) % VOCAB_SIZE] == float("-inf")
+        # r1 (row 1) is unconstrained — all logits finite
+        assert np.all(np.isfinite(result_np[0, 1]))
+        # row 2 is r1's spec-token slot; it is outside grammar_output.structured_output_request_ids
+        # so it receives no masking — intentionally not asserted here.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -1,0 +1,711 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for _apply_grammar_bitmask_metal, _apply_grammar_bitmask_paged,
+and grammar integration in sample_tokens."""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.v1.outputs import ModelRunnerOutput
+
+import vllm_metal.v1.model_runner as mr
+from tests.stub_runner import make_stub_runner
+from vllm_metal.v1.model_runner import (
+    _apply_grammar_bitmask_metal,
+    _apply_grammar_bitmask_paged,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VOCAB_SIZE = 64
+NUM_BITMASK_WORDS = math.ceil(VOCAB_SIZE / 32)  # 2 int32 words for vocab=64
+
+
+def _make_full_bitmask(num_rows: int = 1, vocab_size: int = VOCAB_SIZE) -> np.ndarray:
+    """All tokens allowed (all bits = 1, i.e. fill_value=-1 == 0xFFFFFFFF)."""
+    words = math.ceil(vocab_size / 32)
+    return np.full((num_rows, words), fill_value=-1, dtype=np.int32)
+
+
+def _make_single_token_bitmask(
+    token_id: int, vocab_size: int = VOCAB_SIZE
+) -> np.ndarray:
+    """Bitmask that allows only `token_id`, forbids everything else."""
+    words = math.ceil(vocab_size / 32)
+    bitmask = np.zeros((1, words), dtype=np.int32)
+    word_idx = token_id // 32
+    bit_idx = token_id % 32
+    bitmask[0, word_idx] = 1 << bit_idx
+    return bitmask
+
+
+def _make_scheduler_output(req_ids: list[str]) -> SimpleNamespace:
+    """Minimal SchedulerOutput stub — no spec-decode tokens."""
+    return SimpleNamespace(
+        scheduled_spec_decode_tokens={},
+        num_scheduled_tokens=dict.fromkeys(req_ids, 1),
+        total_num_scheduled_tokens=len(req_ids),
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
+            new_block_ids=[],
+            num_computed_tokens=[],
+            num_output_tokens=[],
+        ),
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+        preempted_req_ids=set(),
+    )
+
+
+def _make_grammar_output(
+    req_ids: list[str],
+    bitmask: np.ndarray,
+) -> SimpleNamespace:
+    """Minimal GrammarOutput stub."""
+    return SimpleNamespace(
+        structured_output_request_ids=req_ids,
+        grammar_bitmask=bitmask,
+    )
+
+
+def _uniform_logits_2d(batch: int, vocab: int = VOCAB_SIZE) -> mx.array:
+    return mx.zeros((batch, vocab))
+
+
+def _uniform_logits_3d(total_tokens: int, vocab: int = VOCAB_SIZE) -> mx.array:
+    """Paged-path logits: shape (1, total_tokens, vocab)."""
+    return mx.zeros((1, total_tokens, vocab))
+
+
+def _to_numpy(arr: mx.array) -> np.ndarray:
+    """Materialise an MLX array to numpy (triggers lazy evaluation)."""
+    return np.array(arr)
+
+
+def _make_decode_req(req_id: str) -> tuple[str, SimpleNamespace]:
+    """Minimal (req_id, RequestState) pair for a decode request."""
+    state = SimpleNamespace(
+        token_ids=[1, 2, 3],
+        prompt_len=2,
+        cache=[],
+        sampling_params=None,
+        generator=None,
+        generated_tokens=1,
+    )
+    return (req_id, state)
+
+
+def _make_prefill_req(req_id: str, num_tokens: int) -> SimpleNamespace:
+    """Minimal PrefillRequest for a prefill request."""
+    return SimpleNamespace(
+        req_id=req_id,
+        token_ids=list(range(num_tokens)),
+        block_ids=[],
+        start_pos=0,
+        prompt_len=num_tokens,
+        full_prompt_token_ids=None,
+        generator=None,
+        sampling_params=None,
+    )
+
+
+def _build_cu_seqlens(num_decode: int, prefill_lens: list[int]) -> list[int]:
+    """Build cumulative sequence lengths matching _start_paged_forward logic."""
+    cu = [0]
+    for _ in range(num_decode):
+        cu.append(cu[-1] + 1)
+    for length in prefill_lens:
+        cu.append(cu[-1] + length)
+    return cu
+
+
+# ---------------------------------------------------------------------------
+# _apply_grammar_bitmask_metal — 2D helper
+# ---------------------------------------------------------------------------
+
+
+class TestApplyGrammarBitmaskMetal:
+    def test_forbidden_tokens_set_to_neg_inf(self) -> None:
+        """Tokens forbidden by the bitmask must become -inf after masking."""
+        allowed_token = 5
+        logits = _uniform_logits_2d(1)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(
+            ["r0"], _make_single_token_bitmask(allowed_token)
+        )
+
+        result = _to_numpy(_apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits))
+
+        assert np.isfinite(result[0, allowed_token])
+        for tok in range(VOCAB_SIZE):
+            if tok != allowed_token:
+                assert result[0, tok] == float("-inf"), (
+                    f"Token {tok} should be forbidden but got {result[0, tok]}"
+                )
+
+    def test_all_allowed_bitmask_leaves_logits_unchanged(self) -> None:
+        """A full bitmask must not change logit values."""
+        data = np.random.randn(1, VOCAB_SIZE).astype(np.float32)
+        logits = mx.array(data)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_full_bitmask())
+
+        result = _to_numpy(_apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits))
+
+        np.testing.assert_allclose(result, data, rtol=1e-5)
+
+    def test_non_structured_rows_unaffected(self) -> None:
+        """Rows without grammar constraints must be unchanged."""
+        logits = mx.array(
+            np.array([[10.0] * VOCAB_SIZE, [10.0] * VOCAB_SIZE], dtype=np.float32)
+        )
+        allowed_token = 3
+        sched = _make_scheduler_output(["plain", "structured"])
+        grammar = _make_grammar_output(
+            ["structured"], _make_single_token_bitmask(allowed_token)
+        )
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_metal(
+                sched, grammar, ["plain", "structured"], logits
+            )
+        )
+
+        np.testing.assert_allclose(
+            result[0], 10.0, err_msg="Plain row must be bit-identical to input"
+        )
+        assert np.isfinite(result[1, allowed_token])
+        for tok in range(VOCAB_SIZE):
+            if tok != allowed_token:
+                assert result[1, tok] == float("-inf")
+
+    def test_batch_order_independent_of_grammar_output_order(self) -> None:
+        """Bitmask must be applied to the correct request even when order differs."""
+        allowed_in_r0 = 7
+        allowed_in_r1 = 13
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(allowed_in_r1),  # listed first, but is r1
+                _make_single_token_bitmask(allowed_in_r0),  # listed second, but is r0
+            ]
+        )
+        logits = _uniform_logits_2d(2)
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output(["r1", "r0"], bitmask)
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_metal(sched, grammar, ["r0", "r1"], logits)
+        )
+
+        assert np.isfinite(result[0, allowed_in_r0])
+        assert result[0, (allowed_in_r0 + 1) % VOCAB_SIZE] == float("-inf")
+        assert np.isfinite(result[1, allowed_in_r1])
+        assert result[1, (allowed_in_r1 + 1) % VOCAB_SIZE] == float("-inf")
+
+    def test_dtype_preserved_for_float16(self) -> None:
+        logits = mx.zeros((1, VOCAB_SIZE), dtype=mx.float16)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        result = _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
+
+        assert result.dtype == mx.float16, f"Expected float16, got {result.dtype}"
+
+    def test_dtype_preserved_for_bfloat16(self) -> None:
+        logits = mx.zeros((1, VOCAB_SIZE), dtype=mx.bfloat16)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        result = _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
+
+        assert result.dtype == mx.bfloat16
+
+    def test_raises_if_xgrammar_missing(self) -> None:
+        logits = _uniform_logits_2d(1)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        with patch.object(mr, "xgr", None):
+            with pytest.raises(RuntimeError, match="xgrammar is required"):
+                _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
+
+    def test_rejects_3d_logits(self) -> None:
+        """The 2D helper must reject 3D (paged-path) logits with a clear assertion."""
+        logits_3d = _uniform_logits_3d(2)  # shape (1, 2, vocab)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        with pytest.raises(AssertionError, match="2D"):
+            _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits_3d)
+
+    def test_greedy_argmax_picks_only_allowed_token(self) -> None:
+        allowed_token = 17
+        data = np.random.randn(1, VOCAB_SIZE).astype(np.float32)
+        logits = mx.array(data)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(
+            ["r0"], _make_single_token_bitmask(allowed_token)
+        )
+
+        result = _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
+        sampled = int(mx.argmax(result[0]).item())
+
+        assert sampled == allowed_token
+
+    def test_input_array_not_mutated(self) -> None:
+        """Caller-held input mx.array must be unchanged after the call."""
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal((1, VOCAB_SIZE)).astype(np.float32)
+        logits = mx.array(data)
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        _apply_grammar_bitmask_metal(sched, grammar, ["r0"], logits)
+
+        np.testing.assert_array_equal(_to_numpy(logits), data)
+
+    def test_spec_decode_rows_all_constrained(self) -> None:
+        """With spec-decode tokens, every position (base + speculative) is masked."""
+        # r0 plain, r1 structured with 2 spec tokens:
+        # logits rows: 0=r0, 1=r1-base, 2=r1-spec0, 3=r1-spec1
+        allowed_base = 5
+        allowed_spec0 = 11
+        allowed_spec1 = 21
+        logits = _uniform_logits_2d(4)
+        sched = SimpleNamespace(
+            scheduled_spec_decode_tokens={"r1": [100, 101]},
+            num_scheduled_tokens={"r0": 1, "r1": 3},
+            total_num_scheduled_tokens=4,
+            finished_req_ids=set(),
+        )
+        # grammar_bitmask has 3 rows for r1 (base + 2 spec)
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(allowed_base),
+                _make_single_token_bitmask(allowed_spec0),
+                _make_single_token_bitmask(allowed_spec1),
+            ]
+        )
+        grammar = _make_grammar_output(["r1"], bitmask)
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_metal(sched, grammar, ["r0", "r1"], logits)
+        )
+
+        # r0 row 0: unconstrained
+        assert np.all(np.isfinite(result[0]))
+        # r1 base row 1: constrained to allowed_base
+        assert np.isfinite(result[1, allowed_base])
+        assert result[1, (allowed_base + 1) % VOCAB_SIZE] == float("-inf")
+        # r1 spec rows 2, 3: each constrained to their respective allowed token
+        assert np.isfinite(result[2, allowed_spec0])
+        assert result[2, (allowed_spec0 + 1) % VOCAB_SIZE] == float("-inf")
+        assert np.isfinite(result[3, allowed_spec1])
+        assert result[3, (allowed_spec1 + 1) % VOCAB_SIZE] == float("-inf")
+
+
+# ---------------------------------------------------------------------------
+# _apply_grammar_bitmask_paged — 3D paged-path helper
+# ---------------------------------------------------------------------------
+
+
+class TestApplyGrammarBitmaskPaged:
+    def test_decode_only_forbidden_tokens_neg_inf(self) -> None:
+        """Decode request: forbidden tokens become -inf in the correct row."""
+        allowed_token = 5
+        # 2 decode requests → logits shape (1, 2, vocab)
+        logits = _uniform_logits_3d(2)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output(
+            ["r0"], _make_single_token_bitmask(allowed_token)
+        )
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        )
+
+        # Row 0 (r0): only allowed_token survives
+        assert np.isfinite(result[0, 0, allowed_token])
+        assert result[0, 0, (allowed_token + 1) % VOCAB_SIZE] == float("-inf")
+        # Row 1 (r1): unconstrained — all finite
+        assert np.all(np.isfinite(result[0, 1]))
+
+    def test_decode_row_mapping_correct(self) -> None:
+        """Grammar is applied to the correct decode row (not always row 0)."""
+        allowed_in_r1 = 11
+        logits = _uniform_logits_3d(2)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output(
+            ["r1"], _make_single_token_bitmask(allowed_in_r1)
+        )
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        )
+
+        # Row 0 (r0): unconstrained
+        assert np.all(np.isfinite(result[0, 0]))
+        # Row 1 (r1): constrained
+        assert np.isfinite(result[0, 1, allowed_in_r1])
+        assert result[0, 1, (allowed_in_r1 + 1) % VOCAB_SIZE] == float("-inf")
+
+    def test_prefill_last_token_row_constrained(self) -> None:
+        """Grammar bitmask is applied to the last token row of a prefill request."""
+        allowed_token = 9
+        prefill_len = 4  # tokens at rows 0,1,2,3 in logits[0]
+        # Only prefill, no decode. total_tokens = 4.
+        logits = _uniform_logits_3d(prefill_len)
+        prefill_reqs = [_make_prefill_req("p0", prefill_len)]
+        cu = _build_cu_seqlens(num_decode=0, prefill_lens=[prefill_len])
+        sched = _make_scheduler_output(["p0"])
+        grammar = _make_grammar_output(
+            ["p0"], _make_single_token_bitmask(allowed_token)
+        )
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(
+                sched, grammar, [], prefill_reqs, cu, 0, logits
+            )
+        )
+
+        # Only the LAST row (row 3) should be constrained
+        last_row = prefill_len - 1
+        assert np.isfinite(result[0, last_row, allowed_token])
+        assert result[0, last_row, (allowed_token + 1) % VOCAB_SIZE] == float("-inf")
+        # Earlier rows untouched
+        for row in range(last_row):
+            assert np.all(np.isfinite(result[0, row]))
+
+    def test_mixed_decode_and_prefill(self) -> None:
+        """Grammar constraints work correctly across decode + prefill in one batch."""
+        allowed_decode = 7
+        allowed_prefill = 15
+        # 1 decode (row 0) + 1 prefill of 3 tokens (rows 1,2,3)
+        logits = _uniform_logits_3d(4)
+        decode_reqs = [_make_decode_req("d0")]
+        prefill_reqs = [_make_prefill_req("p0", 3)]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[3])
+        sched = _make_scheduler_output(["d0", "p0"])
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(allowed_decode),
+                _make_single_token_bitmask(allowed_prefill),
+            ]
+        )
+        grammar = _make_grammar_output(["d0", "p0"], bitmask)
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(
+                sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
+            )
+        )
+
+        # Decode row 0 (d0)
+        assert np.isfinite(result[0, 0, allowed_decode])
+        assert result[0, 0, (allowed_decode + 1) % VOCAB_SIZE] == float("-inf")
+        # Prefill last token row 3 (p0)
+        assert np.isfinite(result[0, 3, allowed_prefill])
+        assert result[0, 3, (allowed_prefill + 1) % VOCAB_SIZE] == float("-inf")
+        # Prefill intermediate rows 1,2 untouched
+        for row in [1, 2]:
+            assert np.all(np.isfinite(result[0, row]))
+
+    def test_no_constrained_requests_returns_unchanged_logits(self) -> None:
+        """If no scheduled request has grammar constraints, logits are returned as-is."""
+        data = np.random.randn(1, 2, VOCAB_SIZE).astype(np.float32)
+        logits = mx.array(data)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        # Grammar output references a request not in this batch
+        grammar = _make_grammar_output(["absent"], _make_single_token_bitmask(0))
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        )
+
+        np.testing.assert_allclose(result, data, rtol=1e-5)
+
+    def test_empty_structured_output_request_ids_returns_unchanged(self) -> None:
+        """GrammarOutput with empty request list must not touch logits."""
+        data = np.random.randn(1, 1, VOCAB_SIZE).astype(np.float32)
+        logits = mx.array(data)
+        decode_reqs = [_make_decode_req("r0")]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
+        sched = _make_scheduler_output(["r0"])
+        # empty structured_output_request_ids — grammar engine sent a no-op
+        grammar = _make_grammar_output(
+            [], np.zeros((0, NUM_BITMASK_WORDS), dtype=np.int32)
+        )
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
+        )
+
+        np.testing.assert_allclose(result, data, rtol=1e-5)
+
+    def test_dtype_preserved(self) -> None:
+        """Output dtype must match the input dtype."""
+        logits = mx.zeros((1, 1, VOCAB_SIZE), dtype=mx.float16)
+        decode_reqs = [_make_decode_req("r0")]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        result = _apply_grammar_bitmask_paged(
+            sched, grammar, decode_reqs, [], cu, 1, logits
+        )
+
+        assert result.dtype == mx.float16
+
+    def test_raises_if_xgrammar_missing(self) -> None:
+        logits = _uniform_logits_3d(1)
+        decode_reqs = [_make_decode_req("r0")]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        with patch.object(mr, "xgr", None):
+            with pytest.raises(RuntimeError, match="xgrammar is required"):
+                _apply_grammar_bitmask_paged(
+                    sched, grammar, decode_reqs, [], cu, 1, logits
+                )
+
+    def test_rejects_2d_logits(self) -> None:
+        """The paged helper must reject 2D logits with a clear assertion."""
+        logits_2d = _uniform_logits_2d(2)
+        decode_reqs = [_make_decode_req("r0")]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        with pytest.raises(AssertionError):
+            _apply_grammar_bitmask_paged(
+                sched, grammar, decode_reqs, [], cu, 1, logits_2d
+            )
+
+    def test_batch_order_independent_of_grammar_output_order(self) -> None:
+        """Bitmask must reach the correct row even when grammar_output order differs."""
+        allowed_r0 = 3
+        allowed_r1 = 19
+        # bitmask is ordered [r1, r0] but batch is [r0, r1]
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(allowed_r1),
+                _make_single_token_bitmask(allowed_r0),
+            ]
+        )
+        logits = _uniform_logits_3d(2)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output(["r1", "r0"], bitmask)
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        )
+
+        assert np.isfinite(result[0, 0, allowed_r0])
+        assert result[0, 0, (allowed_r0 + 1) % VOCAB_SIZE] == float("-inf")
+        assert np.isfinite(result[0, 1, allowed_r1])
+        assert result[0, 1, (allowed_r1 + 1) % VOCAB_SIZE] == float("-inf")
+
+    def test_dtype_preserved_for_bfloat16(self) -> None:
+        logits = mx.zeros((1, 1, VOCAB_SIZE), dtype=mx.bfloat16)
+        decode_reqs = [_make_decode_req("r0")]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
+        sched = _make_scheduler_output(["r0"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        result = _apply_grammar_bitmask_paged(
+            sched, grammar, decode_reqs, [], cu, 1, logits
+        )
+
+        assert result.dtype == mx.bfloat16
+
+    def test_input_array_not_mutated(self) -> None:
+        """Caller-held input mx.array must be unchanged after the call."""
+        rng = np.random.default_rng(42)
+        data = rng.standard_normal((1, 2, VOCAB_SIZE)).astype(np.float32)
+        logits = mx.array(data)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
+
+        _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+
+        np.testing.assert_array_equal(_to_numpy(logits), data)
+
+    def test_non_constrained_rows_unchanged_at_float16(self) -> None:
+        """Non-constrained rows must round-trip bit-identically at fp16."""
+        rng = np.random.default_rng(7)
+        data = rng.standard_normal((1, 2, VOCAB_SIZE)).astype(np.float16)
+        logits = mx.array(data)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        # Only r0 is constrained; r1 (row 1) must come back unchanged.
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        )
+
+        np.testing.assert_array_equal(result[0, 1], data[0, 1])
+
+    def test_non_constrained_rows_unchanged_at_bfloat16(self) -> None:
+        """Non-constrained rows must round-trip bit-identically at bfloat16."""
+        rng = np.random.default_rng(13)
+        data_fp32 = rng.standard_normal((1, 2, VOCAB_SIZE)).astype(np.float32)
+        logits = mx.array(data_fp32).astype(mx.bfloat16)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = _make_scheduler_output(["r0", "r1"])
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
+
+        result = _apply_grammar_bitmask_paged(
+            sched, grammar, decode_reqs, [], cu, 2, logits
+        )
+
+        # Row 1 (r1) is unconstrained — values must match the input row exactly.
+        np.testing.assert_array_equal(
+            np.array(result[0, 1].astype(mx.float32)),
+            np.array(logits[0, 1].astype(mx.float32)),
+        )
+
+    def test_multiple_prefill_requests_correct_last_row(self) -> None:
+        """cu_seqlens index must identify the last row for each prefill correctly."""
+        # 1 decode (row 0) + prefill-0 of 3 tokens (rows 1,2,3)
+        #                   + prefill-1 of 5 tokens (rows 4,5,6,7,8)
+        allowed_p0 = 7
+        allowed_p1 = 13
+        total_tokens = 1 + 3 + 5
+        logits = _uniform_logits_3d(total_tokens)
+        decode_reqs = [_make_decode_req("d0")]
+        prefill_reqs = [_make_prefill_req("p0", 3), _make_prefill_req("p1", 5)]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[3, 5])
+        sched = _make_scheduler_output(["d0", "p0", "p1"])
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(allowed_p0),
+                _make_single_token_bitmask(allowed_p1),
+            ]
+        )
+        grammar = _make_grammar_output(["p0", "p1"], bitmask)
+
+        result = _to_numpy(
+            _apply_grammar_bitmask_paged(
+                sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
+            )
+        )
+
+        # d0 row 0: unconstrained
+        assert np.all(np.isfinite(result[0, 0]))
+        # p0 last row = 1 + 3 - 1 = 3
+        assert np.isfinite(result[0, 3, allowed_p0])
+        assert result[0, 3, (allowed_p0 + 1) % VOCAB_SIZE] == float("-inf")
+        # p1 last row = 1 + 3 + 5 - 1 = 8
+        assert np.isfinite(result[0, 8, allowed_p1])
+        assert result[0, 8, (allowed_p1 + 1) % VOCAB_SIZE] == float("-inf")
+        # intermediate rows untouched
+        for row in [1, 2, 4, 5, 6, 7]:
+            assert np.all(np.isfinite(result[0, row]))
+
+    def test_spec_decode_raises_when_constrained_req_has_spec_tokens(self) -> None:
+        """Paged helper must raise when a structured-output request has spec-decode."""
+        logits = _uniform_logits_3d(2)
+        decode_reqs = [_make_decode_req("r0")]
+        cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
+        sched = SimpleNamespace(
+            scheduled_spec_decode_tokens={"r0": [9]},
+            num_scheduled_tokens={"r0": 2},
+            total_num_scheduled_tokens=2,
+            finished_req_ids=set(),
+        )
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        with pytest.raises(NotImplementedError, match="speculative decoding"):
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
+
+    def test_spec_decode_raises_even_when_plain_req_has_spec_tokens(self) -> None:
+        """Guard is coarse: any spec-decode in the batch raises, not just on structured reqs.
+
+        Pins the intended conservative behavior: r1 (plain) has spec tokens, but
+        r0 (structured) does not — batch is still rejected.  Update this test if
+        the guard is ever tightened to per-request granularity.
+        """
+        logits = _uniform_logits_3d(3)
+        decode_reqs = [_make_decode_req("r0"), _make_decode_req("r1")]
+        cu = _build_cu_seqlens(num_decode=2, prefill_lens=[])
+        sched = SimpleNamespace(
+            scheduled_spec_decode_tokens={"r1": [99]},
+            num_scheduled_tokens={"r0": 1, "r1": 2},
+            total_num_scheduled_tokens=3,
+            finished_req_ids=set(),
+        )
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
+
+        with pytest.raises(NotImplementedError, match="speculative decoding"):
+            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+
+
+# ---------------------------------------------------------------------------
+# sample_tokens — non-paged path raises NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+class TestSampleTokensGrammarNonPagedPath:
+    def _make_runner(self) -> mr.MetalModelRunner:
+        return make_stub_runner()
+
+    def test_non_paged_path_raises_for_grammar_output(self) -> None:
+        """Non-paged path must raise NotImplementedError when grammar_output is set."""
+        runner = self._make_runner()
+        runner._pending_output = ModelRunnerOutput(
+            req_ids=["r0"],
+            req_id_to_index={"r0": 0},
+            sampled_token_ids=[[5]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[None],
+        )
+        runner._execute_model_state = None
+
+        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
+
+        with pytest.raises(NotImplementedError, match="non-paged"):
+            runner.sample_tokens(grammar_output=grammar)
+
+    def test_non_paged_path_no_raise_without_grammar(self) -> None:
+        """Non-paged path with grammar_output=None must return output normally."""
+        runner = self._make_runner()
+        pending = ModelRunnerOutput(
+            req_ids=["r0"],
+            req_id_to_index={"r0": 0},
+            sampled_token_ids=[[5]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[None],
+        )
+        runner._pending_output = pending
+
+        out = runner.sample_tokens(grammar_output=None)
+        assert out is pending

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -203,9 +203,7 @@ class TestApplyGrammarBitmaskPaged:
         )
 
         result = _to_numpy(
-            _applier.apply_paged(
-                sched, grammar, [], prefill_reqs, cu, 0, logits
-            )
+            _applier.apply_paged(sched, grammar, [], prefill_reqs, cu, 0, logits)
         )
 
         # Only the LAST row (row 3) should be constrained
@@ -292,9 +290,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
-        result = _applier.apply_paged(
-            sched, grammar, decode_reqs, [], cu, 1, logits
-        )
+        result = _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
 
         assert result.dtype == mx.float16
 
@@ -307,9 +303,7 @@ class TestApplyGrammarBitmaskPaged:
 
         with patch.object(so, "xgr", None):
             with pytest.raises(RuntimeError, match="xgrammar is required"):
-                _applier.apply_paged(
-                    sched, grammar, decode_reqs, [], cu, 1, logits
-                )
+                _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
 
     def test_rejects_2d_logits(self) -> None:
         """The paged helper must reject 2D logits with a clear assertion."""
@@ -320,9 +314,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
         with pytest.raises(AssertionError):
-            _applier.apply_paged(
-                sched, grammar, decode_reqs, [], cu, 1, logits_2d
-            )
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits_2d)
 
     def test_batch_order_independent_of_grammar_output_order(self) -> None:
         """Bitmask must reach the correct row even when grammar_output order differs."""
@@ -357,9 +349,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
-        result = _applier.apply_paged(
-            sched, grammar, decode_reqs, [], cu, 1, logits
-        )
+        result = _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
 
         assert result.dtype == mx.bfloat16
 
@@ -404,9 +394,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0", "r1"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
 
-        result = _applier.apply_paged(
-            sched, grammar, decode_reqs, [], cu, 2, logits
-        )
+        result = _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
 
         # Row 1 (r1) is unconstrained — values must match the input row exactly.
         np.testing.assert_array_equal(
@@ -485,7 +473,9 @@ class TestApplyGrammarBitmaskPaged:
             total_num_scheduled_tokens=3,
             finished_req_ids=set(),
         )
-        grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(allowed_token))
+        grammar = _make_grammar_output(
+            ["r0"], _make_single_token_bitmask(allowed_token)
+        )
 
         # Must not raise — r0 (structured) has no spec tokens.
         result = _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for _apply_grammar_bitmask_paged and grammar integration in
+"""Tests for MetalStructuredOutputApplier.apply_paged and grammar integration in
 execute_model / sample_tokens."""
 
 from __future__ import annotations
@@ -18,7 +18,10 @@ from vllm.v1.sample.sampler import Sampler
 import vllm_metal.v1.model_runner as mr
 import vllm_metal.v1.structured_output as so
 from tests.stub_runner import make_stub_runner
-from vllm_metal.v1.structured_output import _apply_grammar_bitmask_paged
+from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
+
+# Shared instance used by unit tests that call apply_paged directly.
+_applier = MetalStructuredOutputApplier()
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -138,7 +141,7 @@ def _build_cu_seqlens(num_decode: int, prefill_lens: list[int]) -> list[int]:
 
 
 # ---------------------------------------------------------------------------
-# _apply_grammar_bitmask_paged — 3D paged-path helper
+# MetalStructuredOutputApplier.apply_paged — 3D paged-path helper
 # ---------------------------------------------------------------------------
 
 
@@ -156,7 +159,7 @@ class TestApplyGrammarBitmaskPaged:
         )
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
         )
 
         # Row 0 (r0): only allowed_token survives
@@ -177,7 +180,7 @@ class TestApplyGrammarBitmaskPaged:
         )
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
         )
 
         # Row 0 (r0): unconstrained
@@ -200,7 +203,7 @@ class TestApplyGrammarBitmaskPaged:
         )
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(
+            _applier.apply_paged(
                 sched, grammar, [], prefill_reqs, cu, 0, logits
             )
         )
@@ -232,7 +235,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["d0", "p0"], bitmask)
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(
+            _applier.apply_paged(
                 sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
             )
         )
@@ -258,7 +261,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["absent"], _make_single_token_bitmask(0))
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
         )
 
         np.testing.assert_allclose(result, data, rtol=1e-5)
@@ -276,7 +279,7 @@ class TestApplyGrammarBitmaskPaged:
         )
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
         )
 
         np.testing.assert_allclose(result, data, rtol=1e-5)
@@ -289,7 +292,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
-        result = _apply_grammar_bitmask_paged(
+        result = _applier.apply_paged(
             sched, grammar, decode_reqs, [], cu, 1, logits
         )
 
@@ -304,7 +307,7 @@ class TestApplyGrammarBitmaskPaged:
 
         with patch.object(so, "xgr", None):
             with pytest.raises(RuntimeError, match="xgrammar is required"):
-                _apply_grammar_bitmask_paged(
+                _applier.apply_paged(
                     sched, grammar, decode_reqs, [], cu, 1, logits
                 )
 
@@ -317,7 +320,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
         with pytest.raises(AssertionError):
-            _apply_grammar_bitmask_paged(
+            _applier.apply_paged(
                 sched, grammar, decode_reqs, [], cu, 1, logits_2d
             )
 
@@ -339,7 +342,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["r1", "r0"], bitmask)
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
         )
 
         assert np.isfinite(result[0, 0, allowed_r0])
@@ -354,7 +357,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
-        result = _apply_grammar_bitmask_paged(
+        result = _applier.apply_paged(
             sched, grammar, decode_reqs, [], cu, 1, logits
         )
 
@@ -370,7 +373,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0", "r1"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
 
-        _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
 
         np.testing.assert_array_equal(_to_numpy(logits), data)
 
@@ -386,7 +389,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
         )
 
         np.testing.assert_array_equal(result[0, 1], data[0, 1])
@@ -401,7 +404,7 @@ class TestApplyGrammarBitmaskPaged:
         sched = _make_scheduler_output(["r0", "r1"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(5))
 
-        result = _apply_grammar_bitmask_paged(
+        result = _applier.apply_paged(
             sched, grammar, decode_reqs, [], cu, 2, logits
         )
 
@@ -432,7 +435,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["p0", "p1"], bitmask)
 
         result = _to_numpy(
-            _apply_grammar_bitmask_paged(
+            _applier.apply_paged(
                 sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
             )
         )
@@ -463,7 +466,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
         with pytest.raises(NotImplementedError, match="speculative decoding"):
-            _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
 
     def test_spec_decode_plain_req_does_not_block_structured_req(self) -> None:
         """Plain req with spec tokens must not block a structured-output req.
@@ -485,7 +488,7 @@ class TestApplyGrammarBitmaskPaged:
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(allowed_token))
 
         # Must not raise — r0 (structured) has no spec tokens.
-        result = _apply_grammar_bitmask_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
+        result = _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 2, logits)
 
         result_np = _to_numpy(result)
         # r0 (row 0) is constrained to allowed_token

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -130,6 +130,7 @@ class TestV1MetalModelRunnerExecuteModel:
             finished_req_ids=set(),
             free_encoder_mm_hashes=[],
             preempted_req_ids=set(),
+            has_structured_output_requests=False,
         )
 
     def test_returns_empty_output_directly_for_empty_batch(self) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1267,18 +1267,18 @@ class MetalModelRunner:
             )
             return None
 
-        # Paged backend is present but produced no work this step, OR legacy
-        # non-paged path.  Either way, no logits are available to apply grammar
-        # constraints — fail fast rather than silently dropping the constraint.
-        if scheduler_output.has_structured_output_requests:
-            raise NotImplementedError(
-                "Grammar/structured-output constraints are not supported on "
-                "the non-paged (legacy) Metal path. "
-                "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
-                "to use structured output."
-            )
-
         if self._paged_attention_backend is None:
+            # Fail fast: grammar constraints require the paged path so we can
+            # apply them before sampling.  Raise here, before any forward work
+            # runs, rather than in sample_tokens() after tokens are already
+            # sampled and RequestState has been mutated.
+            if scheduler_output.has_structured_output_requests:
+                raise NotImplementedError(
+                    "Grammar/structured-output constraints are not supported on "
+                    "the non-paged (legacy) Metal path. "
+                    "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
+                    "to use structured output."
+                )
             self._run_non_paged_decode_batch(batch)
 
         # Non-paged path: complete synchronously

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1281,6 +1281,19 @@ class MetalModelRunner:
             )
             return None
 
+        # Defensive invariant: any active structured-output request on the paged
+        # path contributes a paged decode or prefill entry, so if the paged
+        # backend is present, has_paged_work() must be True whenever SO requests
+        # are scheduled. If this fires, the scheduler routed an SO request to the
+        # synchronous tail where no bitmask is applied.
+        assert not (
+            self._paged_attention_backend is not None
+            and scheduler_output.has_structured_output_requests
+        ), (
+            "Structured-output request present but no paged work was scheduled — "
+            "invariant violated."
+        )
+
         if self._paged_attention_backend is None:
             self._run_non_paged_decode_batch(batch)
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1243,6 +1243,20 @@ class MetalModelRunner:
         if self._is_stt:
             return self._execute_stt(scheduler_output)
 
+        # Fail fast before any model work runs.  On the non-paged path,
+        # _handle_new_requests immediately calls _prefill_single for new
+        # requests, so the guard must come before it — not after.
+        if (
+            self._paged_attention_backend is None
+            and scheduler_output.has_structured_output_requests
+        ):
+            raise NotImplementedError(
+                "Grammar/structured-output constraints are not supported on "
+                "the non-paged (legacy) Metal path. "
+                "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
+                "to use structured output."
+            )
+
         batch = _ExecutionBatch()
         self._handle_new_requests(
             batch, scheduler_output.scheduled_new_reqs, scheduler_output
@@ -1268,17 +1282,6 @@ class MetalModelRunner:
             return None
 
         if self._paged_attention_backend is None:
-            # Fail fast: grammar constraints require the paged path so we can
-            # apply them before sampling.  Raise here, before any forward work
-            # runs, rather than in sample_tokens() after tokens are already
-            # sampled and RequestState has been mutated.
-            if scheduler_output.has_structured_output_requests:
-                raise NotImplementedError(
-                    "Grammar/structured-output constraints are not supported on "
-                    "the non-paged (legacy) Metal path. "
-                    "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
-                    "to use structured output."
-                )
             self._run_non_paged_decode_batch(batch)
 
         # Non-paged path: complete synchronously

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -16,13 +16,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
-import numpy as np
 import torch
-
-try:
-    import xgrammar as xgr
-except ImportError:
-    xgr = None  # type: ignore[assignment]
 from mlx_lm import stream_generate
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -50,7 +44,6 @@ from vllm_metal.paged_attention_common import (
     clear_context,
     prepare_unified,
 )
-from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.v1 import contiguous_cache
@@ -73,6 +66,7 @@ from vllm_metal.v1.sampling_batch import (
     sample_from_logits,
     sample_prefill_tokens,
 )
+from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
 logger = init_logger(__name__)
 
@@ -178,202 +172,6 @@ class _PagedForwardState(NamedTuple):
     logits: mx.array
     cu_seqlens: list[int]
     num_decode: int
-
-
-def _apply_grammar_bitmask_metal(
-    scheduler_output: SchedulerOutput,
-    grammar_output: GrammarOutput,
-    req_ids: list[str],
-    logits: mx.array,
-) -> mx.array:
-    """Apply grammar bitmask to logits for structured output on Metal.
-
-    Replicates the upstream GPU logic but bridges mx.array logits through
-    a CPU torch tensor so the xgrammar CPU kernel can apply the bitmask.
-    Non-fp32 logits are upcasted for the kernel and restored afterwards.
-
-    Args:
-        scheduler_output: Scheduler output containing spec-decode token counts.
-        grammar_output: Grammar bitmask and request IDs from the scheduler.
-        req_ids: Ordered list of request IDs in this batch.
-        logits: MLX logits array of shape (batch, vocab_size).
-
-    Returns:
-        Logits with forbidden tokens set to -inf, same dtype as input.
-    """
-    if xgr is None:
-        raise RuntimeError(
-            "xgrammar is required for structured output. "
-            "Install it with: pip install xgrammar"
-        )
-
-    grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
-    spec_tokens = scheduler_output.scheduled_spec_decode_tokens
-
-    # Invariant: this helper operates on 2D logits (batch, vocab).
-    assert logits.ndim == 2, (
-        f"_apply_grammar_bitmask_metal expects 2D logits, got shape {logits.shape}"
-    )
-
-    # Map each structured-output request to its logit row index,
-    # accounting for any speculative-decode token offsets.
-    struct_out_req_batch_indices: dict[str, int] = {}
-    cumulative_offset = 0
-    struct_out_req_ids = set(grammar_output.structured_output_request_ids)
-    for batch_index, req_id in enumerate(req_ids):
-        logit_index = batch_index + cumulative_offset
-        cumulative_offset += len(spec_tokens.get(req_id, ()))
-        if req_id in struct_out_req_ids:
-            struct_out_req_batch_indices[req_id] = logit_index
-
-    # Re-order the bitmask rows to match this runner's batch order.
-    # fill_value=-1 means "all bits set" which xgrammar treats as unconstrained;
-    # only structured-output rows are overwritten with real bitmask data.
-    # cumulative_index tracks position in grammar_output.grammar_bitmask which
-    # is ordered by structured_output_request_ids (may differ from batch order).
-    out_indices: list[int] = []
-    sorted_bitmask = np.full(
-        shape=(logits.shape[0], grammar_bitmask.shape[1]),
-        fill_value=-1,
-        dtype=grammar_bitmask.dtype,
-    )
-    cumulative_index = 0
-    for req_id in grammar_output.structured_output_request_ids:
-        num_spec_tokens = len(spec_tokens.get(req_id, ()))
-        if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
-            for i in range(1 + num_spec_tokens):
-                bitmask_index = logit_idx + i
-                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
-                out_indices.append(bitmask_index)
-        cumulative_index += 1 + num_spec_tokens
-
-    # No structured-output requests are present in this batch; return unchanged.
-    if not out_indices:
-        return logits
-
-    # xgrammar's CPU kernel requires a CPU torch tensor in float32.
-    # np.array() forces MLX evaluation and produces an independent owned copy —
-    # we explicitly avoid mlx_to_torch here because its output aliases MLX storage,
-    # so in-place xgrammar mutation would desync the MLX side.
-    original_dtype = logits.dtype
-    logits_np = np.array(logits.astype(mx.float32))  # always float32, always a copy
-    logits_torch = torch.from_numpy(logits_np)  # writable; shares np buffer (safe)
-    bitmask_torch = torch.from_numpy(sorted_bitmask)
-
-    # Pass indices=None when every row is constrained (cheaper xgrammar path).
-    # Use set equality — out_indices may contain duplicates when spec-decode adds
-    # multiple rows per request (one per speculative token); set() deduplicates.
-    # A length coincidence must not trigger the shortcut when coverage is incomplete.
-    indices = None if set(out_indices) == set(range(logits.shape[0])) else out_indices
-    xgr.apply_token_bitmask_inplace(logits_torch, bitmask_torch, indices=indices)
-
-    # logits_np already reflects the in-place xgrammar mutation (shares torch buffer).
-    # logits_np is kept alive for the function scope — mx.array() copies the buffer
-    # eagerly, but this assumption must hold if MLX construction ever becomes lazy.
-    result = mx.array(logits_np)
-    return result.astype(original_dtype) if original_dtype != mx.float32 else result
-
-
-def _apply_grammar_bitmask_paged(
-    scheduler_output: SchedulerOutput,
-    grammar_output: GrammarOutput,
-    decode_reqs: list[tuple[str, Any]],
-    prefill_reqs: list[Any],
-    cu_seqlens: list[int],
-    num_decode: int,
-    logits: mx.array,  # shape (1, total_tokens, vocab)
-) -> mx.array:
-    """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
-
-    Applies constraints only to the sample positions:
-    - Decode request i  → row i of logits[0]
-    - Prefill request j → last-token row per sequence (from cu_seqlens)
-
-    Args:
-        scheduler_output: Used to guard against spec-decode requests, which are
-            not yet supported with grammar constraints on the paged path.
-        grammar_output: Grammar bitmask and structured-output request IDs.
-        decode_reqs: (req_id, RequestState) pairs in decode-batch order.
-        prefill_reqs: PrefillRequest objects in prefill order.
-        cu_seqlens: Cumulative token counts: [0, 1, …, num_decode,
-            num_decode+len(pr0), …].  Used to locate last-token rows.
-        num_decode: Number of decode requests (prefix of the token dimension).
-        logits: Full paged logits, shape (1, total_tokens, vocab).
-
-    Returns:
-        Logits with forbidden token positions set to -inf, same shape and dtype.
-    """
-    if xgr is None:
-        raise RuntimeError(
-            "xgrammar is required for structured output. "
-            "Install it with: pip install xgrammar"
-        )
-
-    assert logits.ndim == 3 and logits.shape[0] == 1, (
-        f"_apply_grammar_bitmask_paged expects shape (1, T, V), got {logits.shape}"
-    )
-
-    # Spec-decode expands the token dimension with verification positions that
-    # don't map 1:1 to grammar_bitmask rows — guard until that's implemented.
-    # Only raise when a structured-output request overlaps with spec-decode;
-    # plain requests with spec tokens can co-exist in the same batch safely.
-    spec_req_ids = {
-        req_id
-        for req_id, tokens in scheduler_output.scheduled_spec_decode_tokens.items()
-        if tokens
-    }
-    if spec_req_ids & set(grammar_output.structured_output_request_ids):
-        raise NotImplementedError(
-            "Grammar/structured-output constraints are not yet supported "
-            "when speculative decoding is active on the paged Metal path."
-        )
-
-    grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
-
-    # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
-    # per decode token plus one per prefill sequence, plus the leading zero.
-    assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
-        f"cu_seqlens length {len(cu_seqlens)} != "
-        f"num_decode({num_decode}) + len(prefill_reqs)({len(prefill_reqs)}) + 1"
-    )
-
-    # Build req_id → sample row index in logits[0].
-    req_id_to_row: dict[str, int] = {}
-    for i, (req_id, _) in enumerate(decode_reqs):
-        req_id_to_row[req_id] = i
-    for j, pr in enumerate(prefill_reqs):
-        # cu_seqlens[num_decode + j + 1] - 1 is the last token of prefill seq j.
-        last_row = cu_seqlens[num_decode + j + 1] - 1
-        req_id_to_row[pr.req_id] = last_row
-
-    # Determine which structured-output requests are present in this batch.
-    constrained: list[tuple[int, int]] = []  # (logit_row, bitmask_row)
-    for bitmask_row, req_id in enumerate(grammar_output.structured_output_request_ids):
-        if req_id in req_id_to_row:
-            constrained.append((req_id_to_row[req_id], bitmask_row))
-
-    if not constrained:
-        return logits
-
-    # Convert the 2D token-logits slice to a CPU torch tensor for xgrammar.
-    # Explicit float32 cast before numpy: numpy has no bfloat16 dtype, and
-    # np.array() forces MLX evaluation, producing an independent writable copy.
-    original_dtype = logits.dtype
-    logits_np = np.array(logits[0].astype(mx.float32))  # (total_tokens, vocab)
-    logits_torch = torch.from_numpy(logits_np)
-
-    # Apply per constrained row. xgrammar's indices= parameter selects rows from
-    # a full-batch bitmask — it does not support a sub-sampled bitmask paired
-    # with target logit indices, so we apply row-by-row here.
-    for logit_row, bitmask_row in constrained:
-        row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
-        # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
-        xgr.apply_token_bitmask_inplace(
-            logits_torch[logit_row : logit_row + 1], row_bitmask, indices=None
-        )
-
-    result_2d = torch_to_mlx(logits_torch).astype(original_dtype)
-    return result_2d[None]  # Restore (1, total_tokens, vocab) shape
 
 
 class MetalModelRunner:
@@ -1034,7 +832,7 @@ class MetalModelRunner:
 
         # ---- apply structured output bitmask if present ----
         if grammar_output is not None:
-            logits = _apply_grammar_bitmask_paged(
+            logits = MetalStructuredOutputApplier.apply_paged(
                 scheduler_output,
                 grammar_output,
                 decode_reqs,
@@ -1469,6 +1267,17 @@ class MetalModelRunner:
             )
             return None
 
+        # Paged backend is present but produced no work this step, OR legacy
+        # non-paged path.  Either way, no logits are available to apply grammar
+        # constraints — fail fast rather than silently dropping the constraint.
+        if scheduler_output.has_structured_output_requests:
+            raise NotImplementedError(
+                "Grammar/structured-output constraints are not supported on "
+                "the non-paged (legacy) Metal path. "
+                "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
+                "to use structured output."
+            )
+
         if self._paged_attention_backend is None:
             self._run_non_paged_decode_batch(batch)
 
@@ -1496,18 +1305,6 @@ class MetalModelRunner:
             self._validate_scheduled_outputs(batch, scheduler_output)
             self._cleanup_finished_requests(scheduler_output.finished_req_ids)
             return self._build_output(batch)
-
-        # Non-paged path: sampling already happened inside execute_model, so
-        # grammar constraints cannot be applied here.  Raising is intentional:
-        # silently returning unconstrained tokens when the caller requested a
-        # grammar/JSON schema is a correctness violation, not a degraded mode.
-        if grammar_output is not None:
-            raise NotImplementedError(
-                "Grammar/structured-output constraints are not supported on "
-                "the non-paged (legacy) Metal path. "
-                "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
-                "to use structured output."
-            )
 
         # Non-paged path: return output built by execute_model
         if self._pending_output is not None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1290,13 +1290,14 @@ class MetalModelRunner:
         # contribute a paged decode or prefill entry, so has_paged_work() must be
         # True. If this fires, a scheduler change broke that contract and the
         # bitmask would have been silently skipped on the synchronous tail.
-        assert not (
+        if (
             self._paged_attention_backend is not None
             and scheduler_output.has_structured_output_requests
-        ), (
-            "Structured-output request present but no paged work was scheduled — "
-            "invariant violated."
-        )
+        ):
+            raise RuntimeError(
+                "Structured-output request present but no paged work was scheduled — "
+                "invariant violated."
+            )
 
         if self._paged_attention_backend is None:
             self._run_non_paged_decode_batch(batch)

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -16,7 +16,13 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
+import numpy as np
 import torch
+
+try:
+    import xgrammar as xgr
+except ImportError:
+    xgr = None  # type: ignore[assignment]
 from mlx_lm import stream_generate
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -44,6 +50,7 @@ from vllm_metal.paged_attention_common import (
     clear_context,
     prepare_unified,
 )
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.v1 import contiguous_cache
@@ -171,6 +178,184 @@ class _PagedForwardState(NamedTuple):
     logits: mx.array
     cu_seqlens: list[int]
     num_decode: int
+
+
+def _apply_grammar_bitmask_metal(
+    scheduler_output: SchedulerOutput,
+    grammar_output: GrammarOutput,
+    req_ids: list[str],
+    logits: mx.array,
+) -> mx.array:
+    """Apply grammar bitmask to logits for structured output on Metal.
+
+    Replicates the upstream GPU logic but bridges mx.array logits through
+    a CPU torch tensor so the xgrammar CPU kernel can apply the bitmask.
+    Non-fp32 logits are upcasted for the kernel and restored afterwards.
+
+    Args:
+        scheduler_output: Scheduler output containing spec-decode token counts.
+        grammar_output: Grammar bitmask and request IDs from the scheduler.
+        req_ids: Ordered list of request IDs in this batch.
+        logits: MLX logits array of shape (batch, vocab_size).
+
+    Returns:
+        Logits with forbidden tokens set to -inf, same dtype as input.
+    """
+    if xgr is None:
+        raise RuntimeError(
+            "xgrammar is required for structured output. "
+            "Install it with: pip install xgrammar"
+        )
+
+    grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
+    spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+
+    # Invariant: this helper operates on 2D logits (batch, vocab).
+    assert logits.ndim == 2, (
+        f"_apply_grammar_bitmask_metal expects 2D logits, got shape {logits.shape}"
+    )
+
+    # Map each structured-output request to its logit row index,
+    # accounting for any speculative-decode token offsets.
+    struct_out_req_batch_indices: dict[str, int] = {}
+    cumulative_offset = 0
+    struct_out_req_ids = set(grammar_output.structured_output_request_ids)
+    for batch_index, req_id in enumerate(req_ids):
+        logit_index = batch_index + cumulative_offset
+        cumulative_offset += len(spec_tokens.get(req_id, ()))
+        if req_id in struct_out_req_ids:
+            struct_out_req_batch_indices[req_id] = logit_index
+
+    # Re-order the bitmask rows to match this runner's batch order.
+    # fill_value=-1 means "all bits set" which xgrammar treats as unconstrained;
+    # only structured-output rows are overwritten with real bitmask data.
+    # cumulative_index tracks position in grammar_output.grammar_bitmask which
+    # is ordered by structured_output_request_ids (may differ from batch order).
+    out_indices: list[int] = []
+    sorted_bitmask = np.full(
+        shape=(logits.shape[0], grammar_bitmask.shape[1]),
+        fill_value=-1,
+        dtype=grammar_bitmask.dtype,
+    )
+    cumulative_index = 0
+    for req_id in grammar_output.structured_output_request_ids:
+        num_spec_tokens = len(spec_tokens.get(req_id, ()))
+        if (logit_idx := struct_out_req_batch_indices.get(req_id)) is not None:
+            for i in range(1 + num_spec_tokens):
+                bitmask_index = logit_idx + i
+                sorted_bitmask[bitmask_index] = grammar_bitmask[cumulative_index + i]
+                out_indices.append(bitmask_index)
+        cumulative_index += 1 + num_spec_tokens
+
+    # No structured-output requests are present in this batch; return unchanged.
+    if not out_indices:
+        return logits
+
+    # xgrammar's CPU kernel requires a CPU torch tensor in float32.
+    # np.array() forces MLX evaluation and produces an independent owned copy —
+    # we explicitly avoid mlx_to_torch here because its output aliases MLX storage,
+    # so in-place xgrammar mutation would desync the MLX side.
+    original_dtype = logits.dtype
+    logits_np = np.array(logits.astype(mx.float32))  # always float32, always a copy
+    logits_torch = torch.from_numpy(logits_np)  # writable; shares np buffer (safe)
+    bitmask_torch = torch.from_numpy(sorted_bitmask)
+
+    # Pass indices=None when every row is constrained (cheaper xgrammar path).
+    # Use set equality — a length coincidence (e.g. with spec-decode offsets) must
+    # not trigger the all-rows shortcut when coverage is actually incomplete.
+    indices = None if set(out_indices) == set(range(logits.shape[0])) else out_indices
+    xgr.apply_token_bitmask_inplace(logits_torch, bitmask_torch, indices=indices)
+
+    result = torch_to_mlx(logits_torch)
+    return result.astype(original_dtype) if original_dtype != mx.float32 else result
+
+
+def _apply_grammar_bitmask_paged(
+    scheduler_output: SchedulerOutput,
+    grammar_output: GrammarOutput,
+    decode_reqs: list[tuple[str, Any]],
+    prefill_reqs: list[Any],
+    cu_seqlens: list[int],
+    num_decode: int,
+    logits: mx.array,  # shape (1, total_tokens, vocab)
+) -> mx.array:
+    """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
+
+    Applies constraints only to the sample positions:
+    - Decode request i  → row i of logits[0]
+    - Prefill request j → last-token row per sequence (from cu_seqlens)
+
+    Args:
+        scheduler_output: Used to guard against spec-decode requests, which are
+            not yet supported with grammar constraints on the paged path.
+        grammar_output: Grammar bitmask and structured-output request IDs.
+        decode_reqs: (req_id, RequestState) pairs in decode-batch order.
+        prefill_reqs: PrefillRequest objects in prefill order.
+        cu_seqlens: Cumulative token counts: [0, 1, …, num_decode,
+            num_decode+len(pr0), …].  Used to locate last-token rows.
+        num_decode: Number of decode requests (prefix of the token dimension).
+        logits: Full paged logits, shape (1, total_tokens, vocab).
+
+    Returns:
+        Logits with forbidden token positions set to -inf, same shape and dtype.
+    """
+    if xgr is None:
+        raise RuntimeError(
+            "xgrammar is required for structured output. "
+            "Install it with: pip install xgrammar"
+        )
+
+    assert logits.ndim == 3 and logits.shape[0] == 1, (
+        f"_apply_grammar_bitmask_paged expects shape (1, T, V), got {logits.shape}"
+    )
+
+    # Spec-decode expands the token dimension with verification positions that
+    # don't map 1:1 to grammar_bitmask rows — guard until that's implemented.
+    if any(scheduler_output.scheduled_spec_decode_tokens.values()):
+        raise NotImplementedError(
+            "Grammar/structured-output constraints are not yet supported "
+            "when speculative decoding is active on the paged Metal path."
+        )
+
+    grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
+
+    # Build req_id → sample row index in logits[0].
+    req_id_to_row: dict[str, int] = {}
+    for i, (req_id, _) in enumerate(decode_reqs):
+        req_id_to_row[req_id] = i
+    for j, pr in enumerate(prefill_reqs):
+        # cu_seqlens[num_decode + j + 1] - 1 is the last token of prefill seq j.
+        last_row = cu_seqlens[num_decode + j + 1] - 1
+        req_id_to_row[pr.req_id] = last_row
+
+    # Determine which structured-output requests are present in this batch.
+    constrained: list[tuple[int, int]] = []  # (logit_row, bitmask_row)
+    for bitmask_row, req_id in enumerate(grammar_output.structured_output_request_ids):
+        if req_id in req_id_to_row:
+            constrained.append((req_id_to_row[req_id], bitmask_row))
+
+    if not constrained:
+        return logits
+
+    # Convert the 2D token-logits slice to a CPU torch tensor for xgrammar.
+    # Explicit float32 cast before numpy: numpy has no bfloat16 dtype, and
+    # np.array() forces MLX evaluation, producing an independent writable copy.
+    original_dtype = logits.dtype
+    logits_np = np.array(logits[0].astype(mx.float32))  # (total_tokens, vocab)
+    logits_torch = torch.from_numpy(logits_np)
+
+    # Apply per constrained row. xgrammar's indices= parameter selects rows from
+    # a full-batch bitmask — it does not support a sub-sampled bitmask paired
+    # with target logit indices, so we apply row-by-row here.
+    for logit_row, bitmask_row in constrained:
+        row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
+        # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
+        xgr.apply_token_bitmask_inplace(
+            logits_torch[logit_row : logit_row + 1], row_bitmask, indices=None
+        )
+
+    result_2d = torch_to_mlx(logits_torch).astype(original_dtype)
+    return result_2d[None]  # Restore (1, total_tokens, vocab) shape
 
 
 class MetalModelRunner:
@@ -806,7 +991,10 @@ class MetalModelRunner:
             num_decode=num_decode,
         )
 
-    def _sample_paged_batch(self) -> tuple[_ExecutionBatch, SchedulerOutput]:
+    def _sample_paged_batch(
+        self,
+        grammar_output: GrammarOutput | None = None,
+    ) -> tuple[_ExecutionBatch, SchedulerOutput]:
         """Eval logits, sample tokens, and postprocess paged batch.
 
         Consumes state stashed by ``_start_paged_forward``.
@@ -823,8 +1011,20 @@ class MetalModelRunner:
         cu_seqlens = state.cu_seqlens
         num_decode = state.num_decode
 
-        # ---- wait for GPU forward to complete ----
+        # ---- wait for MLX forward to complete ----
         mx.eval(logits)
+
+        # ---- apply structured output bitmask if present ----
+        if grammar_output is not None:
+            logits = _apply_grammar_bitmask_paged(
+                scheduler_output,
+                grammar_output,
+                decode_reqs,
+                prefill_reqs,
+                cu_seqlens,
+                num_decode,
+                logits,
+            )
 
         # ---- sample tokens ----
         vocab_size = self._vocab_size
@@ -1272,14 +1472,24 @@ class MetalModelRunner:
         token sampling, and request state updates happen — allowing the
         scheduler to run while the GPU was computing the forward pass.
         """
-        del grammar_output
-
-        # Paged path: eval + sample + postprocess
+        # Paged path: wait for MLX forward, apply grammar bitmask, sample tokens.
         if self._execute_model_state is not None:
-            batch, scheduler_output = self._sample_paged_batch()
+            batch, scheduler_output = self._sample_paged_batch(grammar_output)
             self._validate_scheduled_outputs(batch, scheduler_output)
             self._cleanup_finished_requests(scheduler_output.finished_req_ids)
             return self._build_output(batch)
+
+        # Non-paged path: sampling already happened inside execute_model, so
+        # grammar constraints cannot be applied here.  Raising is intentional:
+        # silently returning unconstrained tokens when the caller requested a
+        # grammar/JSON schema is a correctness violation, not a degraded mode.
+        if grammar_output is not None:
+            raise NotImplementedError(
+                "Grammar/structured-output constraints are not supported on "
+                "the non-paged (legacy) Metal path. "
+                "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
+                "to use structured output."
+            )
 
         # Non-paged path: return output built by execute_model
         if self._pending_output is not None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -256,6 +256,9 @@ class MetalModelRunner:
         # sample_tokens (mirrors upstream's execute_model_state pattern).
         self._execute_model_state: _PagedForwardState | None = None
 
+        # Structured-output bitmask applier for the paged path.
+        self._structured_output_applier = MetalStructuredOutputApplier()
+
     @property
     def is_mla(self) -> bool:
         """Whether the model uses Multi-head Latent Attention (MLA).
@@ -832,7 +835,7 @@ class MetalModelRunner:
 
         # ---- apply structured output bitmask if present ----
         if grammar_output is not None:
-            logits = MetalStructuredOutputApplier.apply_paged(
+            logits = self._structured_output_applier.apply_paged(
                 scheduler_output,
                 grammar_output,
                 decode_reqs,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1281,11 +1281,12 @@ class MetalModelRunner:
             )
             return None
 
-        # Defensive invariant: any active structured-output request on the paged
-        # path contributes a paged decode or prefill entry, so if the paged
-        # backend is present, has_paged_work() must be True whenever SO requests
-        # are scheduled. If this fires, the scheduler routed an SO request to the
-        # synchronous tail where no bitmask is applied.
+        # Defensive invariant: the vLLM scheduler sets has_structured_output_requests
+        # only when at least one SO request is present in the *current* scheduled
+        # batch (not the global queue). Any such request on the paged path must
+        # contribute a paged decode or prefill entry, so has_paged_work() must be
+        # True. If this fires, a scheduler change broke that contract and the
+        # bitmask would have been silently skipped on the synchronous tail.
         assert not (
             self._paged_attention_backend is not None
             and scheduler_output.has_structured_output_requests

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -261,12 +261,16 @@ def _apply_grammar_bitmask_metal(
     bitmask_torch = torch.from_numpy(sorted_bitmask)
 
     # Pass indices=None when every row is constrained (cheaper xgrammar path).
-    # Use set equality — a length coincidence (e.g. with spec-decode offsets) must
-    # not trigger the all-rows shortcut when coverage is actually incomplete.
+    # Use set equality — out_indices may contain duplicates when spec-decode adds
+    # multiple rows per request (one per speculative token); set() deduplicates.
+    # A length coincidence must not trigger the shortcut when coverage is incomplete.
     indices = None if set(out_indices) == set(range(logits.shape[0])) else out_indices
     xgr.apply_token_bitmask_inplace(logits_torch, bitmask_torch, indices=indices)
 
-    result = torch_to_mlx(logits_torch)
+    # logits_np already reflects the in-place xgrammar mutation (shares torch buffer).
+    # logits_np is kept alive for the function scope — mx.array() copies the buffer
+    # eagerly, but this assumption must hold if MLX construction ever becomes lazy.
+    result = mx.array(logits_np)
     return result.astype(original_dtype) if original_dtype != mx.float32 else result
 
 
@@ -311,13 +315,27 @@ def _apply_grammar_bitmask_paged(
 
     # Spec-decode expands the token dimension with verification positions that
     # don't map 1:1 to grammar_bitmask rows — guard until that's implemented.
-    if any(scheduler_output.scheduled_spec_decode_tokens.values()):
+    # Only raise when a structured-output request overlaps with spec-decode;
+    # plain requests with spec tokens can co-exist in the same batch safely.
+    spec_req_ids = {
+        req_id
+        for req_id, tokens in scheduler_output.scheduled_spec_decode_tokens.items()
+        if tokens
+    }
+    if spec_req_ids & set(grammar_output.structured_output_request_ids):
         raise NotImplementedError(
             "Grammar/structured-output constraints are not yet supported "
             "when speculative decoding is active on the paged Metal path."
         )
 
     grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
+
+    # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
+    # per decode token plus one per prefill sequence, plus the leading zero.
+    assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
+        f"cu_seqlens length {len(cu_seqlens)} != "
+        f"num_decode({num_decode}) + len(prefill_reqs)({len(prefill_reqs)}) + 1"
+    )
 
     # Build req_id → sample row index in logits[0].
     req_id_to_row: dict[str, int] = {}

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Structured output (grammar / JSON-schema bitmask) support for the Metal paged path.
+
+Owns xgrammar bridging, bitmask application, and request-to-logit-row remapping.
+``model_runner.py`` stays orchestration-only and delegates here via
+``MetalStructuredOutputApplier``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+import torch
+
+try:
+    import xgrammar as xgr
+except ImportError:
+    xgr = None  # type: ignore[assignment]
+
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
+
+
+class MetalStructuredOutputApplier:
+    """Applies grammar/structured-output bitmask constraints to paged-path logits.
+
+    Currently a single-method class; the boundary is intentional so that future
+    extensions (e.g. apply_non_paged, xgrammar allocator caching) have a stable
+    home without touching model_runner.py.
+    """
+
+    @staticmethod
+    def apply_paged(
+        scheduler_output: SchedulerOutput,
+        grammar_output: GrammarOutput,
+        decode_reqs: list[tuple[str, Any]],
+        prefill_reqs: list[Any],
+        cu_seqlens: list[int],
+        num_decode: int,
+        logits: mx.array,
+    ) -> mx.array:
+        """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
+
+        Delegates to the module-level implementation; callers should use this
+        class as the stable interface.
+        """
+        return _apply_grammar_bitmask_paged(
+            scheduler_output,
+            grammar_output,
+            decode_reqs,
+            prefill_reqs,
+            cu_seqlens,
+            num_decode,
+            logits,
+        )
+
+
+def _apply_grammar_bitmask_paged(
+    scheduler_output: SchedulerOutput,
+    grammar_output: GrammarOutput,
+    decode_reqs: list[tuple[str, Any]],
+    prefill_reqs: list[Any],
+    cu_seqlens: list[int],
+    num_decode: int,
+    logits: mx.array,  # shape (1, total_tokens, vocab)
+) -> mx.array:
+    """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
+
+    Applies constraints only to the sample positions:
+    - Decode request i  → row i of logits[0]
+    - Prefill request j → last-token row per sequence (from cu_seqlens)
+
+    Args:
+        scheduler_output: Used to guard against spec-decode requests, which are
+            not yet supported with grammar constraints on the paged path.
+        grammar_output: Grammar bitmask and structured-output request IDs.
+        decode_reqs: (req_id, RequestState) pairs in decode-batch order.
+        prefill_reqs: PrefillRequest objects in prefill order.
+        cu_seqlens: Cumulative token counts: [0, 1, …, num_decode,
+            num_decode+len(pr0), …].  Used to locate last-token rows.
+        num_decode: Number of decode requests (prefix of the token dimension).
+        logits: Full paged logits, shape (1, total_tokens, vocab).
+
+    Returns:
+        Logits with forbidden token positions set to -inf, same shape and dtype.
+    """
+    if xgr is None:
+        raise RuntimeError(
+            "xgrammar is required for structured output. "
+            "Install it with: pip install xgrammar"
+        )
+
+    assert logits.ndim == 3 and logits.shape[0] == 1, (
+        f"_apply_grammar_bitmask_paged expects shape (1, T, V), got {logits.shape}"
+    )
+
+    # Spec-decode expands the token dimension with verification positions that
+    # don't map 1:1 to grammar_bitmask rows — guard until that's implemented.
+    # Only raise when a structured-output request overlaps with spec-decode;
+    # plain requests with spec tokens can co-exist in the same batch safely.
+    spec_req_ids = {
+        req_id
+        for req_id, tokens in scheduler_output.scheduled_spec_decode_tokens.items()
+        if tokens
+    }
+    if spec_req_ids & set(grammar_output.structured_output_request_ids):
+        raise NotImplementedError(
+            "Grammar/structured-output constraints are not yet supported "
+            "when speculative decoding is active on the paged Metal path."
+        )
+
+    grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
+
+    # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
+    # per decode token plus one per prefill sequence, plus the leading zero.
+    assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
+        f"cu_seqlens length {len(cu_seqlens)} != "
+        f"num_decode({num_decode}) + len(prefill_reqs)({len(prefill_reqs)}) + 1"
+    )
+
+    # Build req_id → sample row index in logits[0].
+    req_id_to_row: dict[str, int] = {}
+    for i, (req_id, _) in enumerate(decode_reqs):
+        req_id_to_row[req_id] = i
+    for j, pr in enumerate(prefill_reqs):
+        # cu_seqlens[num_decode + j + 1] - 1 is the last token of prefill seq j.
+        last_row = cu_seqlens[num_decode + j + 1] - 1
+        req_id_to_row[pr.req_id] = last_row
+
+    # Determine which structured-output requests are present in this batch.
+    constrained: list[tuple[int, int]] = []  # (logit_row, bitmask_row)
+    for bitmask_row, req_id in enumerate(grammar_output.structured_output_request_ids):
+        if req_id in req_id_to_row:
+            constrained.append((req_id_to_row[req_id], bitmask_row))
+
+    if not constrained:
+        return logits
+
+    # Convert the 2D token-logits slice to a CPU torch tensor for xgrammar.
+    # Explicit float32 cast before numpy: numpy has no bfloat16 dtype, and
+    # np.array() forces MLX evaluation, producing an independent writable copy.
+    original_dtype = logits.dtype
+    logits_np = np.array(logits[0].astype(mx.float32))  # (total_tokens, vocab)
+    logits_torch = torch.from_numpy(logits_np)
+
+    # Apply per constrained row. xgrammar's indices= parameter selects rows from
+    # a full-batch bitmask — it does not support a sub-sampled bitmask paired
+    # with target logit indices, so we apply row-by-row here.
+    for logit_row, bitmask_row in constrained:
+        row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
+        # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
+        xgr.apply_token_bitmask_inplace(
+            logits_torch[logit_row : logit_row + 1], row_bitmask, indices=None
+        )
+
+    # torch_to_mlx wraps the numpy buffer of logits_torch; xgrammar mutations
+    # are already complete at this point so the shared-memory read-back is safe.
+    result_2d = torch_to_mlx(logits_torch).astype(original_dtype)
+    return result_2d[None]  # Restore (1, total_tokens, vocab) shape

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -152,11 +152,16 @@ def _apply_grammar_bitmask_paged(
     for logit_row, bitmask_row in constrained:
         row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
         # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
+        # vocab_size is intentionally omitted; xgrammar auto-detects it as
+        # min(logits_width, bitmask_words * 32).  Phantom slots in the last
+        # bitmask word (real_vocab % 32 != 0) get -inf, but the downstream
+        # sampler clips to the real vocabulary so they are never sampled.
         xgr.apply_token_bitmask_inplace(
             logits_torch[logit_row : logit_row + 1], row_bitmask, indices=None
         )
 
-    # torch_to_mlx wraps the numpy buffer of logits_torch; xgrammar mutations
-    # are already complete at this point so the shared-memory read-back is safe.
+    # mx.array(np.ndarray) copies the buffer into MLX memory — all xgrammar
+    # mutations to logits_torch are captured by this copy.  The safety guarantee
+    # comes from mx.array's copy-on-creation semantics, not from mutation ordering.
     result_2d = torch_to_mlx(logits_torch).astype(original_dtype)
     return result_2d[None]  # Restore (1, total_tokens, vocab) shape

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -114,11 +114,23 @@ def _apply_grammar_bitmask_paged(
 
     grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
 
+    # Fast path: if none of the structured-output request IDs appear in this
+    # batch, skip row-map construction and cu_seqlens validation entirely.
+    batch_req_ids = (
+        {req_id for req_id, _ in decode_reqs}
+        | {pr.req_id for pr in prefill_reqs}
+    )
+    if not any(
+        rid in batch_req_ids
+        for rid in grammar_output.structured_output_request_ids
+    ):
+        return logits
+
     # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
     # per decode token plus one per prefill sequence, plus the leading zero.
     assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
-        f"cu_seqlens length {len(cu_seqlens)} != "
-        f"num_decode({num_decode}) + len(prefill_reqs)({len(prefill_reqs)}) + 1"
+        f"cu_seqlens length {len(cu_seqlens)}, "
+        f"expected num_decode={num_decode} + prefill_count={len(prefill_reqs)} + 1"
     )
 
     # Build req_id → sample row index in logits[0].
@@ -149,6 +161,7 @@ def _apply_grammar_bitmask_paged(
     # Apply per constrained row. xgrammar's indices= parameter selects rows from
     # a full-batch bitmask — it does not support a sub-sampled bitmask paired
     # with target logit indices, so we apply row-by-row here.
+    # TODO: batch via indices= once xgrammar supports non-contiguous bitmask selection.
     for logit_row, bitmask_row in constrained:
         row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
         # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
@@ -160,8 +173,8 @@ def _apply_grammar_bitmask_paged(
             logits_torch[logit_row : logit_row + 1], row_bitmask, indices=None
         )
 
-    # mx.array(np.ndarray) copies the buffer into MLX memory — all xgrammar
-    # mutations to logits_torch are captured by this copy.  The safety guarantee
-    # comes from mx.array's copy-on-creation semantics, not from mutation ordering.
+    # logits_torch is always CPU float32 (produced by torch.from_numpy above),
+    # so torch_to_mlx goes through numpy, which copies the buffer into MLX
+    # memory.  All xgrammar mutations are therefore captured before the copy.
     result_2d = torch_to_mlx(logits_torch).astype(original_dtype)
     return result_2d[None]  # Restore (1, total_tokens, vocab) shape

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -27,13 +27,13 @@ from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 class MetalStructuredOutputApplier:
     """Applies grammar/structured-output bitmask constraints to paged-path logits.
 
-    Currently a single-method class; the boundary is intentional so that future
-    extensions (e.g. apply_non_paged, xgrammar allocator caching) have a stable
-    home without touching model_runner.py.
+    Instantiate once on MetalModelRunner and call apply_paged() from
+    _sample_paged_batch(). The class boundary keeps future extensions
+    (e.g. non-paged path, xgrammar allocator caching) out of model_runner.py.
     """
 
-    @staticmethod
     def apply_paged(
+        self,
         scheduler_output: SchedulerOutput,
         grammar_output: GrammarOutput,
         decode_reqs: list[tuple[str, Any]],
@@ -44,137 +44,121 @@ class MetalStructuredOutputApplier:
     ) -> mx.array:
         """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
 
-        Delegates to the module-level implementation; callers should use this
-        class as the stable interface.
+        Only the sample positions are constrained:
+        - Decode request i  → row i of logits[0]
+        - Prefill request j → last-token row per sequence (from cu_seqlens)
+
+        The CPU/xgrammar bridge copies only the constrained rows (n_constrained × vocab)
+        rather than the full (total_tokens × vocab) plane, then scatters the
+        modified rows back into logits via MLX indexed assignment.
+
+        Args:
+            scheduler_output: Used to guard against spec-decode requests, which are
+                not yet supported with grammar constraints on the paged path.
+            grammar_output: Grammar bitmask and structured-output request IDs.
+            decode_reqs: (req_id, RequestState) pairs in decode-batch order.
+            prefill_reqs: PrefillRequest objects in prefill order.
+            cu_seqlens: Cumulative token counts: [0, 1, …, num_decode,
+                num_decode+len(pr0), …].  Used to locate last-token rows.
+            num_decode: Number of decode requests (prefix of the token dimension).
+            logits: Full paged logits, shape (1, total_tokens, vocab).
+
+        Returns:
+            Logits with forbidden token positions set to -inf, same shape and dtype.
         """
-        return _apply_grammar_bitmask_paged(
-            scheduler_output,
-            grammar_output,
-            decode_reqs,
-            prefill_reqs,
-            cu_seqlens,
-            num_decode,
-            logits,
+        if xgr is None:
+            raise RuntimeError(
+                "xgrammar is required for structured output. "
+                "Install it with: pip install xgrammar"
+            )
+
+        assert logits.ndim == 3 and logits.shape[0] == 1, (
+            f"apply_paged expects shape (1, T, V), got {logits.shape}"
         )
 
+        # Spec-decode expands the token dimension with verification positions that
+        # don't map 1:1 to grammar_bitmask rows — guard until that's implemented.
+        # Only raise when a structured-output request overlaps with spec-decode;
+        # plain requests with spec tokens can co-exist in the same batch safely.
+        spec_req_ids = {
+            req_id
+            for req_id, tokens in scheduler_output.scheduled_spec_decode_tokens.items()
+            if tokens
+        }
+        if spec_req_ids & set(grammar_output.structured_output_request_ids):
+            raise NotImplementedError(
+                "Grammar/structured-output constraints are not yet supported "
+                "when speculative decoding is active on the paged Metal path."
+            )
 
-def _apply_grammar_bitmask_paged(
-    scheduler_output: SchedulerOutput,
-    grammar_output: GrammarOutput,
-    decode_reqs: list[tuple[str, Any]],
-    prefill_reqs: list[Any],
-    cu_seqlens: list[int],
-    num_decode: int,
-    logits: mx.array,  # shape (1, total_tokens, vocab)
-) -> mx.array:
-    """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
+        grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
 
-    Applies constraints only to the sample positions:
-    - Decode request i  → row i of logits[0]
-    - Prefill request j → last-token row per sequence (from cu_seqlens)
+        # Fast path: if none of the structured-output request IDs appear in this
+        # batch, skip row-map construction and cu_seqlens validation entirely.
+        batch_req_ids = (
+            {req_id for req_id, _ in decode_reqs}
+            | {pr.req_id for pr in prefill_reqs}
+        )
+        if not any(
+            rid in batch_req_ids
+            for rid in grammar_output.structured_output_request_ids
+        ):
+            return logits
 
-    Args:
-        scheduler_output: Used to guard against spec-decode requests, which are
-            not yet supported with grammar constraints on the paged path.
-        grammar_output: Grammar bitmask and structured-output request IDs.
-        decode_reqs: (req_id, RequestState) pairs in decode-batch order.
-        prefill_reqs: PrefillRequest objects in prefill order.
-        cu_seqlens: Cumulative token counts: [0, 1, …, num_decode,
-            num_decode+len(pr0), …].  Used to locate last-token rows.
-        num_decode: Number of decode requests (prefix of the token dimension).
-        logits: Full paged logits, shape (1, total_tokens, vocab).
-
-    Returns:
-        Logits with forbidden token positions set to -inf, same shape and dtype.
-    """
-    if xgr is None:
-        raise RuntimeError(
-            "xgrammar is required for structured output. "
-            "Install it with: pip install xgrammar"
+        # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
+        # per decode token plus one per prefill sequence, plus the leading zero.
+        assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
+            f"cu_seqlens length {len(cu_seqlens)}, "
+            f"expected num_decode={num_decode} + prefill_count={len(prefill_reqs)} + 1"
         )
 
-    assert logits.ndim == 3 and logits.shape[0] == 1, (
-        f"_apply_grammar_bitmask_paged expects shape (1, T, V), got {logits.shape}"
-    )
+        # Build req_id → sample row index in logits[0].
+        req_id_to_row: dict[str, int] = {}
+        for i, (req_id, _) in enumerate(decode_reqs):
+            req_id_to_row[req_id] = i
+        for j, pr in enumerate(prefill_reqs):
+            # cu_seqlens[num_decode + j + 1] - 1 is the last token of prefill seq j.
+            last_row = cu_seqlens[num_decode + j + 1] - 1
+            req_id_to_row[pr.req_id] = last_row
 
-    # Spec-decode expands the token dimension with verification positions that
-    # don't map 1:1 to grammar_bitmask rows — guard until that's implemented.
-    # Only raise when a structured-output request overlaps with spec-decode;
-    # plain requests with spec tokens can co-exist in the same batch safely.
-    spec_req_ids = {
-        req_id
-        for req_id, tokens in scheduler_output.scheduled_spec_decode_tokens.items()
-        if tokens
-    }
-    if spec_req_ids & set(grammar_output.structured_output_request_ids):
-        raise NotImplementedError(
-            "Grammar/structured-output constraints are not yet supported "
-            "when speculative decoding is active on the paged Metal path."
-        )
+        # Determine which structured-output requests are present in this batch.
+        constrained: list[tuple[int, int]] = []  # (logit_row, bitmask_row)
+        for bitmask_row, req_id in enumerate(grammar_output.structured_output_request_ids):
+            if req_id in req_id_to_row:
+                constrained.append((req_id_to_row[req_id], bitmask_row))
 
-    grammar_bitmask: np.ndarray = grammar_output.grammar_bitmask
+        if not constrained:
+            return logits
 
-    # Fast path: if none of the structured-output request IDs appear in this
-    # batch, skip row-map construction and cu_seqlens validation entirely.
-    batch_req_ids = (
-        {req_id for req_id, _ in decode_reqs}
-        | {pr.req_id for pr in prefill_reqs}
-    )
-    if not any(
-        rid in batch_req_ids
-        for rid in grammar_output.structured_output_request_ids
-    ):
-        return logits
+        # --- CPU/xgrammar bridge: operate only on constrained rows ---
+        #
+        # Copy only the n_constrained rows (not total_tokens) to CPU float32.
+        # Explicit float32 cast: numpy has no bfloat16 dtype, and np.array()
+        # forces MLX evaluation, producing an independent writable copy.
+        original_dtype = logits.dtype
+        logit_rows = [logit_row for logit_row, _ in constrained]
+        rows_np = np.array(logits[0, logit_rows, :].astype(mx.float32))  # (n_constrained, vocab)
+        rows_torch = torch.from_numpy(rows_np)
 
-    # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
-    # per decode token plus one per prefill sequence, plus the leading zero.
-    assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
-        f"cu_seqlens length {len(cu_seqlens)}, "
-        f"expected num_decode={num_decode} + prefill_count={len(prefill_reqs)} + 1"
-    )
+        # Apply per constrained row. xgrammar's indices= parameter selects rows
+        # from a full-batch bitmask — it does not support a sub-sampled bitmask
+        # paired with non-contiguous logit indices, so we apply row-by-row here.
+        # TODO: batch via indices= once xgrammar supports non-contiguous bitmask selection.
+        for i, (_, bitmask_row) in enumerate(constrained):
+            row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
+            # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
+            # vocab_size is intentionally omitted; xgrammar auto-detects it as
+            # min(logits_width, bitmask_words * 32).  Phantom slots in the last
+            # bitmask word (real_vocab % 32 != 0) get -inf, but the downstream
+            # sampler clips to the real vocabulary so they are never sampled.
+            xgr.apply_token_bitmask_inplace(rows_torch[i : i + 1], row_bitmask)
 
-    # Build req_id → sample row index in logits[0].
-    req_id_to_row: dict[str, int] = {}
-    for i, (req_id, _) in enumerate(decode_reqs):
-        req_id_to_row[req_id] = i
-    for j, pr in enumerate(prefill_reqs):
-        # cu_seqlens[num_decode + j + 1] - 1 is the last token of prefill seq j.
-        last_row = cu_seqlens[num_decode + j + 1] - 1
-        req_id_to_row[pr.req_id] = last_row
+        # rows_torch is CPU float32 (from torch.from_numpy), so torch_to_mlx goes
+        # through numpy — all xgrammar mutations are captured before the copy.
+        rows_mlx = torch_to_mlx(rows_torch).astype(original_dtype)  # (n_constrained, vocab)
 
-    # Determine which structured-output requests are present in this batch.
-    constrained: list[tuple[int, int]] = []  # (logit_row, bitmask_row)
-    for bitmask_row, req_id in enumerate(grammar_output.structured_output_request_ids):
-        if req_id in req_id_to_row:
-            constrained.append((req_id_to_row[req_id], bitmask_row))
-
-    if not constrained:
-        return logits
-
-    # Convert the 2D token-logits slice to a CPU torch tensor for xgrammar.
-    # Explicit float32 cast before numpy: numpy has no bfloat16 dtype, and
-    # np.array() forces MLX evaluation, producing an independent writable copy.
-    original_dtype = logits.dtype
-    logits_np = np.array(logits[0].astype(mx.float32))  # (total_tokens, vocab)
-    logits_torch = torch.from_numpy(logits_np)
-
-    # Apply per constrained row. xgrammar's indices= parameter selects rows from
-    # a full-batch bitmask — it does not support a sub-sampled bitmask paired
-    # with target logit indices, so we apply row-by-row here.
-    # TODO: batch via indices= once xgrammar supports non-contiguous bitmask selection.
-    for logit_row, bitmask_row in constrained:
-        row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
-        # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
-        # vocab_size is intentionally omitted; xgrammar auto-detects it as
-        # min(logits_width, bitmask_words * 32).  Phantom slots in the last
-        # bitmask word (real_vocab % 32 != 0) get -inf, but the downstream
-        # sampler clips to the real vocabulary so they are never sampled.
-        xgr.apply_token_bitmask_inplace(
-            logits_torch[logit_row : logit_row + 1], row_bitmask
-        )
-
-    # logits_torch is always CPU float32 (produced by torch.from_numpy above),
-    # so torch_to_mlx goes through numpy, which copies the buffer into MLX
-    # memory.  All xgrammar mutations are therefore captured before the copy.
-    result_2d = torch_to_mlx(logits_torch).astype(original_dtype)
-    return result_2d[None]  # Restore (1, total_tokens, vocab) shape
+        # logits[0] produces a new lazy computation node (not a Python alias of
+        # logits), so __setitem__ here does not mutate the caller-held logits array.
+        result_2d = logits[0]
+        result_2d[logit_rows] = rows_mlx
+        return result_2d[None]  # Restore (1, total_tokens, vocab) shape

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -95,13 +95,11 @@ class MetalStructuredOutputApplier:
 
         # Fast path: if none of the structured-output request IDs appear in this
         # batch, skip row-map construction and cu_seqlens validation entirely.
-        batch_req_ids = (
-            {req_id for req_id, _ in decode_reqs}
-            | {pr.req_id for pr in prefill_reqs}
-        )
+        batch_req_ids = {req_id for req_id, _ in decode_reqs} | {
+            pr.req_id for pr in prefill_reqs
+        }
         if not any(
-            rid in batch_req_ids
-            for rid in grammar_output.structured_output_request_ids
+            rid in batch_req_ids for rid in grammar_output.structured_output_request_ids
         ):
             return logits
 
@@ -123,7 +121,9 @@ class MetalStructuredOutputApplier:
 
         # Determine which structured-output requests are present in this batch.
         constrained: list[tuple[int, int]] = []  # (logit_row, bitmask_row)
-        for bitmask_row, req_id in enumerate(grammar_output.structured_output_request_ids):
+        for bitmask_row, req_id in enumerate(
+            grammar_output.structured_output_request_ids
+        ):
             if req_id in req_id_to_row:
                 constrained.append((req_id_to_row[req_id], bitmask_row))
 
@@ -137,7 +137,9 @@ class MetalStructuredOutputApplier:
         # forces MLX evaluation, producing an independent writable copy.
         original_dtype = logits.dtype
         logit_rows = [logit_row for logit_row, _ in constrained]
-        rows_np = np.array(logits[0, logit_rows, :].astype(mx.float32))  # (n_constrained, vocab)
+        rows_np = np.array(
+            logits[0, logit_rows, :].astype(mx.float32)
+        )  # (n_constrained, vocab)
         rows_torch = torch.from_numpy(rows_np)
 
         # Apply per constrained row. xgrammar's indices= parameter selects rows
@@ -145,7 +147,9 @@ class MetalStructuredOutputApplier:
         # paired with non-contiguous logit indices, so we apply row-by-row here.
         # TODO: batch via indices= once xgrammar supports non-contiguous bitmask selection.
         for i, (_, bitmask_row) in enumerate(constrained):
-            row_bitmask = torch.from_numpy(grammar_bitmask[bitmask_row : bitmask_row + 1])
+            row_bitmask = torch.from_numpy(
+                grammar_bitmask[bitmask_row : bitmask_row + 1]
+            )
             # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
             # vocab_size is intentionally omitted; xgrammar auto-detects it as
             # min(logits_width, bitmask_words * 32).  Phantom slots in the last
@@ -155,7 +159,9 @@ class MetalStructuredOutputApplier:
 
         # rows_torch is CPU float32 (from torch.from_numpy), so torch_to_mlx goes
         # through numpy — all xgrammar mutations are captured before the copy.
-        rows_mlx = torch_to_mlx(rows_torch).astype(original_dtype)  # (n_constrained, vocab)
+        rows_mlx = torch_to_mlx(rows_torch).astype(
+            original_dtype
+        )  # (n_constrained, vocab)
 
         # logits[0] produces a new lazy computation node (not a Python alias of
         # logits), so __setitem__ here does not mutate the caller-held logits array.

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -170,7 +170,7 @@ def _apply_grammar_bitmask_paged(
         # bitmask word (real_vocab % 32 != 0) get -inf, but the downstream
         # sampler clips to the real vocabulary so they are never sampled.
         xgr.apply_token_bitmask_inplace(
-            logits_torch[logit_row : logit_row + 1], row_bitmask, indices=None
+            logits_torch[logit_row : logit_row + 1], row_bitmask
         )
 
     # logits_torch is always CPU float32 (produced by torch.from_numpy above),


### PR DESCRIPTION
implement grammar/structured output support for Metal paged path

Fixes: #238 

---

### Test
```bash
# PyTest
pytest tests/test_grammar_bitmask.py
```

```bash
# Reproduce
python reproduce_grammar_238.py
```

<details>
<summary>reproduce_grammar_238.py</summary>

```python
# SPDX-License-Identifier: Apache-2.0
"""Reproduction script for issue #238 — grammar/structured output on Metal paged path.

Goes through the real sample_tokens() → _sample_paged_batch() path so it
demonstrates the bug on `main` (grammar ignored, unconstrained token sampled)
and the fix on our branch (only the allowed token sampled).

Usage:
    source .venv-vllm-metal/bin/activate
    python reproduce_grammar_238.py
"""

import math
import sys
from types import SimpleNamespace

import mlx.core as mx
import numpy as np
import torch
from vllm.sampling_params import SamplingParams
from vllm.v1.sample.sampler import Sampler

import vllm_metal.v1.model_runner as mr
from vllm_metal.v1.model_runner import (
    RequestState,
    _ExecutionBatch,
    _PagedForwardState,
)

VOCAB = 128
# Token 90 is '{' in most LLaMA-family vocabularies — matches the issue evidence:
#   grammar_bitmask = [[0, 0, 67108864, ...]]
#   word 2, bit 26  →  90 // 32 == 2,  1 << (90 % 32) == 67108864
ALLOWED_TOKEN = 90


def _single_token_bitmask(token_id: int, vocab: int) -> np.ndarray:
    words = math.ceil(vocab / 32)
    bitmask = np.zeros((1, words), dtype=np.int32)
    bitmask[0, token_id // 32] = 1 << (token_id % 32)
    return bitmask


def run() -> None:
    # ---- build a minimal runner stub ----
    runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
    runner._sampler = Sampler()
    runner.device = torch.device("cpu")
    runner._vocab_size = VOCAB
    runner._logitsprocs = None
    runner._request_states = {}
    runner._paged_request_seq_lens = {}
    runner._pending_output = None
    runner._execute_model_state = None
    # Patch methods that touch scheduler/paged state we haven't set up
    runner._validate_scheduled_outputs = lambda batch, sched: None
    runner._cleanup_finished_requests = lambda req_ids: None

    # ---- one decode request, greedy sampling ----
    req_state = RequestState(
        token_ids=[1],
        prompt_len=1,
        cache=[],
        sampling_params=SamplingParams(temperature=0.0),
        generator=None,
        generated_tokens=0,
    )
    decode_reqs = [("r0", req_state)]

    # ---- uniform logits: without bitmask argmax == token 0 ----
    logits = mx.zeros((1, 1, VOCAB))

    # ---- scheduler_output stub ----
    scheduler_output = SimpleNamespace(
        scheduled_spec_decode_tokens={},
        num_scheduled_tokens={"r0": 1},
        total_num_scheduled_tokens=1,
        finished_req_ids=set(),
    )

    # ---- grammar: allow ONLY token ALLOWED_TOKEN ----
    grammar_output = SimpleNamespace(
        structured_output_request_ids=["r0"],
        grammar_bitmask=_single_token_bitmask(ALLOWED_TOKEN, VOCAB),
    )

    # ---- wire up _execute_model_state (paged forward already "done") ----
    batch = _ExecutionBatch()
    # _sample_paged_batch writes output via batch.paged_decode_reqs, not
    # decode_reqs directly — this mirrors what _collect_cached_requests does.
    batch.paged_decode_reqs = decode_reqs

    runner._execute_model_state = _PagedForwardState(
        batch=batch,
        prefill_reqs=[],
        decode_reqs=decode_reqs,
        scheduler_output=scheduler_output,
        logits=logits,
        cu_seqlens=[0, 1],
        num_decode=1,
    )

    # ---- call the real sample_tokens path ----
    output = runner.sample_tokens(grammar_output=grammar_output)

    sampled = output.sampled_token_ids[0][0]

    print(f"Vocab size      : {VOCAB}")
    print(f"Allowed token   : {ALLOWED_TOKEN}")
    print(f"Sampled token   : {sampled}")
    print()

    if sampled == ALLOWED_TOKEN:
        print("✓ PASS — grammar bitmask applied correctly")
    else:
        print(f"✗ FAIL — expected token {ALLOWED_TOKEN}, got {sampled}")
        sys.exit(1)


if __name__ == "__main__":
    run()

```
</details>

---

### Test Result

#### PyTest
```bash
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/name/Personal/vllm-metal
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 30 items

tests/test_grammar_bitmask.py ..............................                                                                                            [100%]

====================================================================== warnings summary =======================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv-vllm-metal/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /Users/name/Personal/vllm-metal/.venv-vllm-metal/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 30 passed, 16 warnings in 3.45s ===============================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

#### Reproduce

```bash
# Before
INFO 04-17 00:24:36 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 04-17 00:24:36 [__init__.py:46] - metal -> vllm_metal:register
INFO 04-17 00:24:36 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-17 00:24:37 [__init__.py:239] Platform plugin metal is activated
INFO 04-17 00:24:38 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
Vocab size      : 128
Allowed token   : 90
Sampled token   : 0

✗ FAIL — expected token 90, got 0
```

```bash
# After
INFO 04-17 00:23:46 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 04-17 00:23:46 [__init__.py:46] - metal -> vllm_metal:register
INFO 04-17 00:23:46 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 04-17 00:23:47 [__init__.py:239] Platform plugin metal is activated
INFO 04-17 00:23:48 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
Vocab size      : 128
Allowed token   : 90
Sampled token   : 90

✓ PASS — grammar bitmask applied correctly
```
