### PR TITLE
Enforce per-layer sliding window for Gemma4 attention 

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -43,6 +43,7 @@ def make_stub_runner(
         "_model_adapter": DefaultModelAdapter(),
         "kv_heads_per_layer": None,
         "head_dim_per_layer": None,
+        "sliding_window_per_layer": None,
         "use_async_scheduling": True,
         "device": torch.device("cpu"),
         "_sampler": None,

--- a/tests/test_gemma4_sliding_window_dispatch.py
+++ b/tests/test_gemma4_sliding_window_dispatch.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end kernel-dispatch verification for Gemma4 sliding window.
+
+Spies on the Metal ``paged_attention_primitive`` op during a real vLLM
+inference and asserts the per-layer ``sliding_window`` values reach the
+kernel with the correct split between sliding-attention and
+full-attention layers.  Complements ``test_sliding_window_wiring.py``
+which exercises the same wiring without running the Metal kernel.
+
+Gemma4 E2B is used (not 31B) because:
+- E2B has uniform KV heads, so the paged-attention guard in
+  ``require_uniform_kv_heads`` admits it today.  31B support unblocks
+  after upstream PR #279 lands.
+- E2B has YOCO (``num_kv_shared_layers=20``), so every model forward
+  exercises the shared-layer cache-index retrieval -- shared layers
+  must still receive a sliding_window matching their own attention
+  type, via ``cache_idx_map``.
+
+Run:
+    GEMMA4_MODEL_PATH=/path/to/gemma-4-E2B-it \\
+        pytest tests/test_gemma4_sliding_window_dispatch.py -v -s -m slow
+"""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+
+import pytest
+
+MODEL_ENV = "GEMMA4_MODEL_PATH"
+
+# --- Gemma4 E2B text_config invariants ---
+# Verified against mlx-community/gemma-4-E2B-it config.json.  Every 5th
+# layer (indices 4, 9, 14, 19, 24, 29, 34) is ``full_attention``; the
+# other 28 are ``sliding_attention``.
+_E2B_SLIDING_WINDOW = 512
+_E2B_NUM_SLIDING_LAYERS = 28
+_E2B_NUM_FULL_LAYERS = 7
+_E2B_TOTAL_LAYERS = _E2B_NUM_SLIDING_LAYERS + _E2B_NUM_FULL_LAYERS
+
+_NO_WINDOW = -1
+
+# Position of ``sliding_window`` in ``paged_attention_primitive``'s
+# positional signature (see ``attention_sdpa.py:489-510``).
+_SLIDING_WINDOW_ARG_INDEX = 11
+
+# Ratio tolerance: layer_types is a config constant, but prefill and
+# decode may dispatch slightly different counts across forwards, so we
+# accept a 1% slack.
+_RATIO_TOLERANCE = 0.01
+
+
+@pytest.fixture(scope="module")
+def kernel_sliding_window_log() -> list[int]:
+    """Run one Gemma4 inference with a spy on ``paged_attention_primitive``.
+
+    Returns the list of ``sliding_window`` ints passed to every kernel
+    dispatch during the inference.  Skips if the model path env var is
+    unset.
+    """
+    model_path = os.environ.get(MODEL_ENV)
+    if not model_path:
+        pytest.skip(f"{MODEL_ENV} not set -- skipping slow kernel dispatch test")
+    if not os.path.isdir(model_path):
+        pytest.skip(f"{MODEL_ENV}={model_path} is not a directory")
+
+    with pytest.MonkeyPatch.context() as mp:
+        # Single-process mode for determinism (mirrors test_gemma4_golden.py).
+        mp.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+        # Install the spy BEFORE importing vllm or creating the LLM --
+        # ``get_ops()`` caches the module the first time it runs, so the
+        # patch must sit on the attribute before any forward pass starts.
+        from vllm_metal.metal import get_ops
+
+        ops = get_ops()
+        orig_fn = ops.paged_attention_primitive
+        captured: list[int] = []
+
+        def spy(*args, **kwargs):
+            sw = (
+                args[_SLIDING_WINDOW_ARG_INDEX]
+                if len(args) > _SLIDING_WINDOW_ARG_INDEX
+                else kwargs.get("sliding_window")
+            )
+            captured.append(sw)
+            return orig_fn(*args, **kwargs)
+
+        mp.setattr(ops, "paged_attention_primitive", spy)
+
+        from vllm import LLM, SamplingParams
+
+        llm = LLM(model=model_path, max_model_len=512, max_num_seqs=1)
+        sp = SamplingParams(temperature=0, max_tokens=5, ignore_eos=True)
+        llm.generate(["The capital of France is"], sp)
+
+        return captured
+
+
+@pytest.mark.slow
+class TestGemma4KernelReceivesPerLayerSlidingWindow:
+    """Kernel-level assertions on the sliding_window values dispatched."""
+
+    def test_only_expected_window_values_appear(
+        self, kernel_sliding_window_log: list[int]
+    ) -> None:
+        """No stray values leak from wiring errors."""
+        # Act
+        unexpected = {
+            w
+            for w in kernel_sliding_window_log
+            if w not in (_E2B_SLIDING_WINDOW, _NO_WINDOW)
+        }
+        # Assert
+        assert not unexpected, (
+            f"kernel received unexpected sliding_window values: {unexpected}"
+        )
+
+    def test_both_sliding_and_full_layers_dispatch(
+        self, kernel_sliding_window_log: list[int]
+    ) -> None:
+        """``sliding_window=512`` and ``-1`` both appear."""
+        # Act
+        counts = Counter(kernel_sliding_window_log)
+        # Assert
+        assert counts[_E2B_SLIDING_WINDOW] > 0, (
+            "sliding layers never received their window -- enforcement is "
+            "not reaching the kernel"
+        )
+        assert counts[_NO_WINDOW] > 0, (
+            "full layers never received -1 -- they may be incorrectly getting a window"
+        )
+
+    def test_ratio_matches_layer_types_config(
+        self, kernel_sliding_window_log: list[int]
+    ) -> None:
+        """Sliding/full dispatch ratio matches the 28:7 layer_types split.
+
+        Each model forward dispatches one kernel call per layer (YOCO
+        shared layers reuse the cache index of their same-type reference,
+        so the retrieved ``sliding_window`` still matches their own
+        attention type).  The aggregate ratio is therefore fixed by
+        ``layer_types`` and not stochastic.
+        """
+        # Act
+        counts = Counter(kernel_sliding_window_log)
+        sliding = counts[_E2B_SLIDING_WINDOW]
+        full = counts[_NO_WINDOW]
+        total = sliding + full
+        assert total > 0
+        actual_sliding = sliding / total
+        actual_full = full / total
+        expected_sliding = _E2B_NUM_SLIDING_LAYERS / _E2B_TOTAL_LAYERS
+        expected_full = _E2B_NUM_FULL_LAYERS / _E2B_TOTAL_LAYERS
+        # Assert
+        assert actual_sliding == pytest.approx(
+            expected_sliding, abs=_RATIO_TOLERANCE
+        ), f"sliding ratio {actual_sliding:.3f} != expected {expected_sliding:.3f}"
+        assert actual_full == pytest.approx(expected_full, abs=_RATIO_TOLERANCE), (
+            f"full ratio {actual_full:.3f} != expected {expected_full:.3f}"
+        )

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -272,3 +272,41 @@ class TestRequireUniformKvHeads:
         adapter = DefaultModelAdapter()
         with pytest.raises(ValueError, match="VLLM_METAL_USE_PAGED_ATTENTION=0"):
             adapter.require_uniform_kv_heads(args, num_kv_heads)
+
+
+class TestBuildSlidingWindowPerLayer:
+    """Tests for build_sliding_window_per_layer()."""
+
+    def test_returns_none_for_model_without_layer_types(self) -> None:
+        adapter = DefaultModelAdapter()
+        result = adapter.build_sliding_window_per_layer({}, num_layers=4)
+        assert result is None
+
+    def test_returns_none_without_sliding_window_config(self) -> None:
+        args = {"layer_types": ["sliding_attention", "full_attention"]}
+        adapter = DefaultModelAdapter()
+        result = adapter.build_sliding_window_per_layer(args, num_layers=2)
+        assert result is None
+
+    def test_gemma4_sliding_layers_get_window_full_layers_disabled(self) -> None:
+        args = {
+            "layer_types": [
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+                "sliding_attention",
+            ],
+            "sliding_window": 1024,
+        }
+        adapter = DefaultModelAdapter()
+        result = adapter.build_sliding_window_per_layer(args, num_layers=4)
+        assert result == [1024, 1024, -1, 1024]
+
+    def test_length_mismatch_returns_none(self) -> None:
+        args = {
+            "layer_types": ["sliding_attention"],
+            "sliding_window": 1024,
+        }
+        adapter = DefaultModelAdapter()
+        result = adapter.build_sliding_window_per_layer(args, num_layers=4)
+        assert result is None

--- a/tests/test_sliding_window_wiring.py
+++ b/tests/test_sliding_window_wiring.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end wiring tests for per-layer sliding window enforcement.
+
+Verifies the full chain from model config to Metal KV cache:
+
+    config.layer_types + config.sliding_window
+      -> DefaultModelAdapter.build_sliding_window_per_layer
+      -> MetalModelRunner.sliding_window_per_layer
+      -> ModelCachePolicy._build_mha_backend (slice to num_cache_layers)
+      -> MHAPagedAttentionBackend (kwarg)
+      -> MetalPagedKVCache.sliding_window_per_layer
+
+Kernel-level correctness (that a ``sliding_window`` value actually
+masks out-of-window tokens) is separately validated by
+``test_metal_unified_attn`` in ``test_metal_unified_attention.py``;
+both the production ``paged_attention_primitive`` and the test helper
+``metal_unified_attention`` dispatch to the same
+``paged_attention_v2_online`` kernel (see ``paged_ops.cpp``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.v1.model_adapter import DefaultModelAdapter
+
+# --- Test parameters (kept small for fast execution) ---
+_SLIDING_WINDOW = 64
+_BLOCK_SIZE = 16
+_NUM_BLOCKS = 2
+_NUM_KV_HEADS = 4
+_HEAD_DIM = 64
+_KV_CACHE_DTYPE = mx.bfloat16
+
+# Sentinel used by the Metal kernel to mean "no window enforcement".
+# Must match ``MetalPagedKVCache`` default and the kernel-side
+# ``if (sliding_window >= 0)`` guard in ``pagedattention.metal``.
+_NO_WINDOW = -1
+
+
+# ===
+# Non-YOCO: every model layer has its own cache entry.
+# ===
+
+
+class TestNonYocoSlidingWindowWiring:
+    """Config -> cache with identity layer-to-cache mapping."""
+
+    def test_gemma4_like_config_lands_in_kv_cache(self) -> None:
+        """Mixed sliding/full config produces matching per-layer list in cache."""
+        # Arrange: 4-layer model mixing sliding and full attention, mirroring
+        # Gemma4's ``layer_types`` pattern.
+        layer_types = [
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+        ]
+        num_layers = len(layer_types)
+        expected = [
+            _SLIDING_WINDOW,
+            _NO_WINDOW,
+            _SLIDING_WINDOW,
+            _SLIDING_WINDOW,
+        ]
+        model_args = {
+            "layer_types": layer_types,
+            "sliding_window": _SLIDING_WINDOW,
+            "num_hidden_layers": num_layers,
+        }
+        adapter = DefaultModelAdapter()
+        sw_list = adapter.build_sliding_window_per_layer(model_args, num_layers)
+
+        runner = make_stub_runner(
+            model_args=model_args,
+            num_layers=num_layers,
+            num_kv_cache_layers=num_layers,
+            num_kv_heads=_NUM_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            kv_cache_dtype=_KV_CACHE_DTYPE,
+            cache_config=SimpleNamespace(block_size=_BLOCK_SIZE),
+            sliding_window_per_layer=sw_list,
+            _yoco_cache_mapping=None,
+        )
+
+        # Act: build the backend, which constructs the KV cache with the
+        # per-layer window list sliced by the cache policy.
+        backend = runner.build_paged_attention_backend(block_size=_BLOCK_SIZE)
+        backend.initialize(num_blocks=_NUM_BLOCKS)
+
+        # Assert
+        assert backend._cache is not None
+        assert backend._cache.sliding_window_per_layer == expected
+
+    def test_model_without_sliding_window_defaults_to_disabled(self) -> None:
+        """Non-Gemma config (Qwen3/Llama) yields all-disabled windows.
+
+        Regression guard: adding the sliding-window plumbing must not
+        accidentally enforce a window on models that never had one.
+        """
+        # Arrange: no ``layer_types`` or ``sliding_window`` in the config.
+        num_layers = 4
+        model_args = {"num_hidden_layers": num_layers}
+
+        adapter = DefaultModelAdapter()
+        sw_list = adapter.build_sliding_window_per_layer(model_args, num_layers)
+        assert sw_list is None
+
+        runner = make_stub_runner(
+            model_args=model_args,
+            num_layers=num_layers,
+            num_kv_cache_layers=num_layers,
+            num_kv_heads=_NUM_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            kv_cache_dtype=_KV_CACHE_DTYPE,
+            cache_config=SimpleNamespace(block_size=_BLOCK_SIZE),
+            sliding_window_per_layer=sw_list,
+            _yoco_cache_mapping=None,
+        )
+
+        # Act
+        backend = runner.build_paged_attention_backend(block_size=_BLOCK_SIZE)
+        backend.initialize(num_blocks=_NUM_BLOCKS)
+
+        # Assert: all disabled (preserves pre-PR behaviour for non-sliding models)
+        assert backend._cache is not None
+        assert backend._cache.sliding_window_per_layer == [_NO_WINDOW] * num_layers
+
+
+# ===
+# YOCO: shared cache layers indexed via ``cache_idx_map``.
+# ===
+
+
+class TestYocoSlidingWindowWiring:
+    """YOCO shared layers resolve to the correct reference-layer window."""
+
+    def test_shared_layer_cache_idx_retrieves_correct_window(self) -> None:
+        """Every model layer (unique + shared) resolves to the right window.
+
+        Gemma4 YOCO: the last ``num_kv_shared_layers`` layers do not own a
+        cache entry; instead their ``cache_idx_map`` points back to the
+        most recent unique layer of the same attention type.  In
+        ``sdpa_forward`` the retrieval key is
+        ``kv_cache.sliding_window_per_layer[cache_idx]``, so for correctness
+        each shared layer must resolve to a window matching its own type.
+        """
+        # Arrange: 5 layers, last 2 shared with earlier same-type unique layers.
+        # Unique segment: indices 0..2; shared segment: indices 3..4.
+        layer_types = [
+            "sliding_attention",  # unique, cache 0  -> sliding
+            "full_attention",  # unique, cache 1  -> full
+            "sliding_attention",  # unique, cache 2  -> sliding
+            "full_attention",  # shared, cache_idx = 1 (last full)
+            "sliding_attention",  # shared, cache_idx = 2 (last sliding)
+        ]
+        num_layers = len(layer_types)
+        num_kv_shared = 2
+        num_unique = num_layers - num_kv_shared
+        model_args = {
+            "layer_types": layer_types,
+            "sliding_window": _SLIDING_WINDOW,
+            "num_hidden_layers": num_layers,
+            "num_kv_shared_layers": num_kv_shared,
+        }
+
+        adapter = DefaultModelAdapter()
+        sw_list = adapter.build_sliding_window_per_layer(model_args, num_layers)
+        yoco = adapter.build_yoco_cache_mapping(model_args)
+        assert yoco is not None
+        _, cache_idx_map = yoco
+
+        runner = make_stub_runner(
+            model_args=model_args,
+            num_layers=num_layers,
+            num_kv_cache_layers=num_unique,
+            num_kv_heads=_NUM_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            kv_cache_dtype=_KV_CACHE_DTYPE,
+            cache_config=SimpleNamespace(block_size=_BLOCK_SIZE),
+            sliding_window_per_layer=sw_list,
+            _yoco_cache_mapping=yoco,
+        )
+
+        # Act
+        backend = runner.build_paged_attention_backend(block_size=_BLOCK_SIZE)
+        backend.initialize(num_blocks=_NUM_BLOCKS)
+
+        # Assert #1: cache stores one entry per unique layer, matching the
+        # identity segment of the YOCO map.
+        cache = backend._cache
+        assert cache is not None
+        assert cache.sliding_window_per_layer == [
+            _SLIDING_WINDOW,
+            _NO_WINDOW,
+            _SLIDING_WINDOW,
+        ]
+
+        # Assert #2: every model layer (unique + shared) retrieves a window
+        # matching its own attention type -- this is the invariant that
+        # ``sdpa_forward`` relies on when indexing by ``cache_idx``.
+        for model_layer_idx, lt in enumerate(layer_types):
+            cache_idx = cache_idx_map[model_layer_idx]
+            retrieved = cache.sliding_window_per_layer[cache_idx]
+            expected = _SLIDING_WINDOW if lt == "sliding_attention" else _NO_WINDOW
+            assert retrieved == expected, (
+                f"layer {model_layer_idx} ({lt}): "
+                f"cache_idx={cache_idx}, got {retrieved}, expected {expected}"
+            )

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -349,9 +349,10 @@ def sdpa_forward(
     n_heads = queries.shape[1]
     head_dim = queries.shape[3]
 
-    # Per-layer cache shape: each layer may have its own (kv_heads, head_dim).
+    # Per-layer cache properties: shape and sliding window.
     cache_kv_heads = kv_cache.kv_heads_per_layer[layer_idx]
     cache_head_dim = kv_cache.head_dim_per_layer[layer_idx]
+    layer_sliding_window = kv_cache.sliding_window_per_layer[layer_idx]
     actual_head_dim = head_dim
     queries, keys, values = pad_qkv_to_cache_head_dim(
         queries, keys, values, head_dim, cache_head_dim
@@ -497,7 +498,7 @@ def sdpa_forward(
             cu_seqlens_q,
             kernel_block_size,
             max_seq_len,
-            -1,  # sliding_window (-1 = disabled)
+            layer_sliding_window,
             out,
             key_scale_cache=kernel_key_scale,
             value_scale_cache=kernel_value_scale,
@@ -520,7 +521,7 @@ def sdpa_forward(
             cu_seqlens_q,
             kernel_block_size,
             max_seq_len,
-            -1,  # sliding_window (-1 = disabled)
+            layer_sliding_window,
             out,
         )
 

--- a/vllm_metal/metal_kernel_backend/cache.py
+++ b/vllm_metal/metal_kernel_backend/cache.py
@@ -53,6 +53,7 @@ class MetalPagedKVCache:
         *,
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
+        sliding_window_per_layer: list[int] | None = None,
     ) -> None:
         self.num_layers = num_layers
         self.num_kv_heads = num_kv_heads
@@ -108,6 +109,7 @@ class MetalPagedKVCache:
 
         self.kv_heads_per_layer = kv_heads_per_layer or [num_kv_heads] * num_layers
         self.head_dim_per_layer = head_dim_per_layer or [head_dim] * num_layers
+        self.sliding_window_per_layer = sliding_window_per_layer or [-1] * num_layers
 
         if len(self.kv_heads_per_layer) != num_layers:
             raise ValueError(
@@ -118,6 +120,11 @@ class MetalPagedKVCache:
             raise ValueError(
                 f"head_dim_per_layer length {len(self.head_dim_per_layer)} "
                 f"!= num_layers {num_layers}"
+            )
+        if len(self.sliding_window_per_layer) != num_layers:
+            raise ValueError(
+                f"sliding_window_per_layer length "
+                f"{len(self.sliding_window_per_layer)} != num_layers {num_layers}"
             )
 
         if dtype not in (mx.float16, mx.bfloat16, mx.float32):

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -79,6 +79,7 @@ class MHAPagedAttentionBackend:
         cache_idx_map: dict[int, int] | None = None,
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
+        sliding_window_per_layer: list[int] | None = None,
     ) -> None:
         self._num_layers = num_layers
         self._num_kv_heads = num_kv_heads
@@ -92,6 +93,7 @@ class MHAPagedAttentionBackend:
         self._cache_idx_map = cache_idx_map
         self._kv_heads_per_layer = kv_heads_per_layer
         self._head_dim_per_layer = head_dim_per_layer
+        self._sliding_window_per_layer = sliding_window_per_layer
 
     def _require_initialized(self, caller: str) -> MetalPagedKVCache:
         if self._cache is None:
@@ -113,6 +115,7 @@ class MHAPagedAttentionBackend:
             v_quant=self._v_quant,
             kv_heads_per_layer=self._kv_heads_per_layer,
             head_dim_per_layer=self._head_dim_per_layer,
+            sliding_window_per_layer=self._sliding_window_per_layer,
         )
 
     def patch_model(self, model: Any) -> int:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -441,6 +441,14 @@ class ModelCachePolicy:
         num_layers, cache_idx_map = self._mha_cache_layout()
         config = get_config()
         kv_heads, head_dims = self._cache_layer_shapes(num_layers)
+        # YOCO's ``build_yoco_cache_mapping`` assigns the first
+        # ``num_cache_layers`` model layers identity-style (``mapping[i] = i``),
+        # so slicing the first ``num_cache_layers`` entries of the full
+        # per-model-layer list yields the correct window for each cache slot.
+        # Shared layers then retrieve the right window via ``cache_idx_map``,
+        # which points back to a same-type unique layer by construction.
+        sw = self._runner.sliding_window_per_layer
+        sw_list = sw[:num_layers] if sw is not None else None
         return MHAPagedAttentionBackend(
             num_layers=num_layers,
             num_kv_heads=self._runner.num_kv_heads,
@@ -453,6 +461,7 @@ class ModelCachePolicy:
             cache_idx_map=cache_idx_map,
             kv_heads_per_layer=kv_heads,
             head_dim_per_layer=head_dims,
+            sliding_window_per_layer=sw_list,
         )
 
     def _cache_layer_shapes(self, num_cache_layers: int) -> tuple[list[int], list[int]]:

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -44,6 +44,11 @@ class ModelAdapter(Protocol):
     ) -> tuple[int, dict[int, int]] | None:
         """Build YOCO layer→cache_idx mapping, or None if not applicable."""
 
+    def build_sliding_window_per_layer(
+        self, args: dict[str, Any], num_layers: int
+    ) -> list[int] | None:
+        """Return per-layer sliding window sizes, or None for no enforcement."""
+
 
 # Models that vLLM flags as multimodal but must be loaded via mlx_lm.
 # gemma4: mlx_vlm forward path produces garbled output vs mlx_lm.
@@ -170,3 +175,22 @@ class DefaultModelAdapter(ModelAdapter):
                 mapping[i] = type_to_cache_idx[layer_types[i]]
 
         return num_unique, mapping
+
+    def build_sliding_window_per_layer(
+        self, args: dict[str, Any], num_layers: int
+    ) -> list[int] | None:
+        """Return per-layer sliding window sizes for Gemma4, else None.
+
+        Gemma4 sliding-attention layers enforce a local window
+        (``config.sliding_window``); full-attention layers attend to the
+        entire context (represented as ``-1``).  Models without
+        ``layer_types`` or ``sliding_window`` in their config return
+        ``None``, keeping the current disabled-everywhere behavior.
+        """
+        layer_types: list[str] = args.get("layer_types", [])
+        sliding_window = args.get("sliding_window")
+        if len(layer_types) != num_layers or not sliding_window:
+            return None
+
+        sw = int(sliding_window)
+        return [sw if lt == "sliding_attention" else -1 for lt in layer_types]

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -186,6 +186,12 @@ class ModelLifecycle:
             yoco[0] if yoco is not None else self._runner.num_layers
         )
 
+        self._runner.sliding_window_per_layer = (
+            self._model_adapter.build_sliding_window_per_layer(
+                args, self._runner.num_layers
+            )
+        )
+
         if self._runner.is_hybrid:
             fai = int(args["full_attention_interval"])
             self._runner.full_attention_interval = fai

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -251,9 +251,11 @@ class MetalModelRunner:
         self._paged_request_seq_lens: dict[str, int] = {}  # req_id → seq_len
         self.kv_cache_dtype: mx.Dtype | None = None
 
-        # Per-layer KV shapes (None = uniform)
+        # Per-layer KV cache shapes (None = uniform across layers)
         self.kv_heads_per_layer: list[int] | None = None
         self.head_dim_per_layer: list[int] | None = None
+        # Per-layer attention metadata (None = enforcement disabled)
+        self.sliding_window_per_layer: list[int] | None = None
 
         # Async forward state: stashed by execute_model, consumed by
         # sample_tokens (mirrors upstream's execute_model_state pattern).


### PR DESCRIPTION
Problem

`sdpa_forward` hardcoded `sliding_window=-1` on every `paged_attention_primitive` call, so Gemma4 `sliding_attention` layers silently attend beyond their configured window (E2B: 512, 31B: 1024). Metal kernel already has the mask (`pagedattention.metal:1065-1067`) — just never enabled.

Silent: short prompts unaffected; long context drifts from mlx_lm / upstream.

Fix

Thread per-layer window from `config.layer_types` + `config.sliding_window` through adapter → lifecycle → runner → cache_policy → MHA backend → KV cache, and read `kv_cache.sliding_window_per_layer[layer_idx]` in `sdpa_forward`.
Non-Gemma configs return `None` → cache defaults to `[-1] * N`, zero behaviour change for Qwen3 / Llama / hybrid Qwen3.5.

Testing

- Adapter unit (4 tests): None fallbacks, exact match, length mismatch.
- Wiring integration (3 tests): config → `MetalPagedKVCache`, incl. YOCO
  shared-layer cache-idx retrieval.
- Kernel dispatch, slow (3 tests): real Gemma4 E2B with a spy on
  `paged_attention_primitive`; asserts only `{512, -1}` appear and ratio
  matches `layer_types` exactly (28:7). Needs `GEMMA4_MODEL_PATH`.
- `test_gemma4_golden.py` still matches mlx_lm on E2B.