### PR TITLE
[Paged KV] Enable prefix caching on the unified paged path

### DIFF
--- a/tests/test_paged_deterministic.py
+++ b/tests/test_paged_deterministic.py
@@ -200,12 +200,19 @@ class TestPagedDeterministic:
 
 @pytest.fixture(scope="module")
 def vllm_prefix_cached_outputs(_paged_llm, vllm_outputs):
-    """Second pass — cache populated by ``vllm_outputs``, cache hits expected.
+    """Second pass — cache populated by the ``vllm_outputs`` priming pass.
 
-    Depends on ``vllm_outputs`` so pytest orders the priming pass first.
-    The upstream scheduler should report ``num_computed_tokens > 0`` here,
-    exercising the ``start_pos > 0`` path in the model_runner (issue #182).
+    ``vllm_outputs`` is declared as a dependency only so pytest orders the
+    priming pass first; its return value is intentionally unused.
+
+    Upstream invariant: a ``generate`` call repeating the same prompt
+    triggers the prefix-cache lookup (block hashes match), so the second
+    pass walks the ``start_pos > 0`` path inside the model_runner
+    (issue #182).  We do not assert ``num_computed_tokens > 0`` directly
+    — that contract belongs to upstream's own tests.  This fixture's job
+    is to confirm vllm-metal's cache-hit code path produces correct output.
     """
+    del vllm_outputs  # ordering-only dependency
     if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") != "1":
         pytest.skip("Prefix caching e2e test only meaningful on the paged path")
     sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
@@ -221,10 +228,30 @@ class TestPagedPrefixCacheCorrectness:
     def test_prefix_cached_matches_golden(self, vllm_prefix_cached_outputs, prompt):
         output = vllm_prefix_cached_outputs[prompt]
         token_ids = list(output.outputs[0].token_ids)
+        text = output.outputs[0].text
+
         mlx_expected = GOLDEN_MLX[prompt]
         paged_expected = GOLDEN_PAGED[prompt]
-        assert token_ids == mlx_expected or token_ids == paged_expected, (
-            f"Prefix-cached output for {prompt!r} matched neither golden set.\n"
+
+        mlx_match = token_ids == mlx_expected
+        paged_match = token_ids == paged_expected
+        print(
+            f"VLLM_METAL_USE_PAGED_ATTENTION: {os.environ.get('VLLM_METAL_USE_PAGED_ATTENTION')}"
+        )
+        print(f"\n  prompt: {prompt!r}  (prefix-cached)")
+        print(f"  output: {text!r}")
+        print(f"  ids:    {token_ids}")
+        if mlx_match:
+            print("  result: MATCHED mlx-cache golden")
+        elif paged_match:
+            print("  result: MATCHED paged-cache golden")
+        else:
+            print("  result: NO MATCH")
+            print(f"  expected (mlx):   {mlx_expected}")
+            print(f"  expected (paged): {paged_expected}")
+
+        assert mlx_match or paged_match, (
+            f"Output for {prompt!r} (prefix-cached) matched neither golden set.\n"
             f"Got:            {token_ids}\n"
             f"Expected (mlx): {mlx_expected}\n"
             f"Expected (pgd): {paged_expected}"

--- a/tests/test_paged_deterministic.py
+++ b/tests/test_paged_deterministic.py
@@ -118,27 +118,20 @@ def _set_env():
 
 
 @pytest.fixture(scope="module")
-def _paged_llm():
-    """Single LLM shared across both test classes.
+def vllm_outputs():
+    """Run vLLM offline inference once for all prompts.
 
-    A second module-scope LLM cannot fit alongside this one — Metal
-    memory held by the first LLM is not released by Python gc, so the
-    second initialisation hits ``kv_budget=0`` and aborts.  Both the
-    cache-off baseline test and the prefix-cache-hit e2e test reuse
-    this instance.
-
-    ``enable_prefix_caching=True`` is safe for the baseline test because
-    the first ``generate`` pass walks an empty cache and produces output
-    identical to a cache-off run.  Subsequent passes hit the cache.
+    Pinned to ``enable_prefix_caching=False`` so the golden token IDs
+    (cache-off reference) remain the invariant under test regardless of
+    upstream default changes.
     """
     llm = LLM(
         model=MODEL_NAME,
         max_model_len=512,
         max_num_seqs=1,
-        enable_prefix_caching=True,
+        enable_prefix_caching=False,
     )
 
-    # Verify paged KV path is active when requested
     if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") == "1":
         runner = llm.llm_engine.model_executor.driver_worker.model_runner
         assert runner._paged_attention_backend is not None, (
@@ -151,14 +144,8 @@ def _paged_llm():
         attn = runner.model.model.layers[0].self_attn
         assert isinstance(attn, MetalKernelPagedAttentionWrapper)
 
-    return llm
-
-
-@pytest.fixture(scope="module")
-def vllm_outputs(_paged_llm):
-    """First pass — empty cache, output equals cache-off baseline."""
     sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
-    outputs = _paged_llm.generate(PROMPTS, sp)
+    outputs = llm.generate(PROMPTS, sp)
     return {o.prompt: o for o in outputs}
 
 
@@ -192,66 +179,6 @@ class TestPagedDeterministic:
 
         assert mlx_match or paged_match, (
             f"Output for {prompt!r} matched neither golden set.\n"
-            f"Got:            {token_ids}\n"
-            f"Expected (mlx): {mlx_expected}\n"
-            f"Expected (pgd): {paged_expected}"
-        )
-
-
-@pytest.fixture(scope="module")
-def vllm_prefix_cached_outputs(_paged_llm, vllm_outputs):
-    """Second pass — cache populated by the ``vllm_outputs`` priming pass.
-
-    ``vllm_outputs`` is declared as a dependency only so pytest orders the
-    priming pass first; its return value is intentionally unused.
-
-    Upstream invariant: a ``generate`` call repeating the same prompt
-    triggers the prefix-cache lookup (block hashes match), so the second
-    pass walks the ``start_pos > 0`` path inside the model_runner
-    (issue #182).  We do not assert ``num_computed_tokens > 0`` directly
-    — that contract belongs to upstream's own tests.  This fixture's job
-    is to confirm vllm-metal's cache-hit code path produces correct output.
-    """
-    del vllm_outputs  # ordering-only dependency
-    if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") != "1":
-        pytest.skip("Prefix caching e2e test only meaningful on the paged path")
-    sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
-    outputs = _paged_llm.generate(PROMPTS, sp)
-    return {o.prompt: o for o in outputs}
-
-
-class TestPagedPrefixCacheCorrectness:
-    """End-to-end correctness of paged prefix caching (issue #182)."""
-
-    @pytest.mark.slow
-    @pytest.mark.parametrize("prompt", PROMPTS)
-    def test_prefix_cached_matches_golden(self, vllm_prefix_cached_outputs, prompt):
-        output = vllm_prefix_cached_outputs[prompt]
-        token_ids = list(output.outputs[0].token_ids)
-        text = output.outputs[0].text
-
-        mlx_expected = GOLDEN_MLX[prompt]
-        paged_expected = GOLDEN_PAGED[prompt]
-
-        mlx_match = token_ids == mlx_expected
-        paged_match = token_ids == paged_expected
-        print(
-            f"VLLM_METAL_USE_PAGED_ATTENTION: {os.environ.get('VLLM_METAL_USE_PAGED_ATTENTION')}"
-        )
-        print(f"\n  prompt: {prompt!r}  (prefix-cached)")
-        print(f"  output: {text!r}")
-        print(f"  ids:    {token_ids}")
-        if mlx_match:
-            print("  result: MATCHED mlx-cache golden")
-        elif paged_match:
-            print("  result: MATCHED paged-cache golden")
-        else:
-            print("  result: NO MATCH")
-            print(f"  expected (mlx):   {mlx_expected}")
-            print(f"  expected (paged): {paged_expected}")
-
-        assert mlx_match or paged_match, (
-            f"Output for {prompt!r} (prefix-cached) matched neither golden set.\n"
             f"Got:            {token_ids}\n"
             f"Expected (mlx): {mlx_expected}\n"
             f"Expected (pgd): {paged_expected}"

--- a/tests/test_paged_deterministic.py
+++ b/tests/test_paged_deterministic.py
@@ -118,12 +118,25 @@ def _set_env():
 
 
 @pytest.fixture(scope="module")
-def vllm_outputs():
-    """Run vLLM offline inference once for all prompts.
+def _paged_llm():
+    """Single LLM shared across both test classes.
 
-    Uses max_num_seqs=1 to avoid batch-invariance non-determinism on Metal.
+    A second module-scope LLM cannot fit alongside this one — Metal
+    memory held by the first LLM is not released by Python gc, so the
+    second initialisation hits ``kv_budget=0`` and aborts.  Both the
+    cache-off baseline test and the prefix-cache-hit e2e test reuse
+    this instance.
+
+    ``enable_prefix_caching=True`` is safe for the baseline test because
+    the first ``generate`` pass walks an empty cache and produces output
+    identical to a cache-off run.  Subsequent passes hit the cache.
     """
-    llm = LLM(model=MODEL_NAME, max_model_len=512, max_num_seqs=1)
+    llm = LLM(
+        model=MODEL_NAME,
+        max_model_len=512,
+        max_num_seqs=1,
+        enable_prefix_caching=True,
+    )
 
     # Verify paged KV path is active when requested
     if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") == "1":
@@ -138,8 +151,14 @@ def vllm_outputs():
         attn = runner.model.model.layers[0].self_attn
         assert isinstance(attn, MetalKernelPagedAttentionWrapper)
 
+    return llm
+
+
+@pytest.fixture(scope="module")
+def vllm_outputs(_paged_llm):
+    """First pass — empty cache, output equals cache-off baseline."""
     sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
-    outputs = llm.generate(PROMPTS, sp)
+    outputs = _paged_llm.generate(PROMPTS, sp)
     return {o.prompt: o for o in outputs}
 
 
@@ -173,6 +192,39 @@ class TestPagedDeterministic:
 
         assert mlx_match or paged_match, (
             f"Output for {prompt!r} matched neither golden set.\n"
+            f"Got:            {token_ids}\n"
+            f"Expected (mlx): {mlx_expected}\n"
+            f"Expected (pgd): {paged_expected}"
+        )
+
+
+@pytest.fixture(scope="module")
+def vllm_prefix_cached_outputs(_paged_llm, vllm_outputs):
+    """Second pass — cache populated by ``vllm_outputs``, cache hits expected.
+
+    Depends on ``vllm_outputs`` so pytest orders the priming pass first.
+    The upstream scheduler should report ``num_computed_tokens > 0`` here,
+    exercising the ``start_pos > 0`` path in the model_runner (issue #182).
+    """
+    if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") != "1":
+        pytest.skip("Prefix caching e2e test only meaningful on the paged path")
+    sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
+    outputs = _paged_llm.generate(PROMPTS, sp)
+    return {o.prompt: o for o in outputs}
+
+
+class TestPagedPrefixCacheCorrectness:
+    """End-to-end correctness of paged prefix caching (issue #182)."""
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("prompt", PROMPTS)
+    def test_prefix_cached_matches_golden(self, vllm_prefix_cached_outputs, prompt):
+        output = vllm_prefix_cached_outputs[prompt]
+        token_ids = list(output.outputs[0].token_ids)
+        mlx_expected = GOLDEN_MLX[prompt]
+        paged_expected = GOLDEN_PAGED[prompt]
+        assert token_ids == mlx_expected or token_ids == paged_expected, (
+            f"Prefix-cached output for {prompt!r} matched neither golden set.\n"
             f"Got:            {token_ids}\n"
             f"Expected (mlx): {mlx_expected}\n"
             f"Expected (pgd): {paged_expected}"

--- a/tests/test_paged_prefix_caching_e2e.py
+++ b/tests/test_paged_prefix_caching_e2e.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end correctness of paged prefix caching (issue #182).
+
+Fires the deterministic-test prompts twice through ``vllm.LLM`` with
+prefix caching enabled.  The first pass primes the cache; the second
+pass exercises the model_runner's ``start_pos > 0`` path because the
+upstream scheduler reports ``num_computed_tokens > 0``.  The asserted
+token sequence is the existing cache-off golden, so a broken cache-hit
+path surfaces as a token mismatch.
+
+The LLM body runs in a spawned child process (``multiprocessing`` with
+the ``spawn`` start method) so Metal device init happens in a fresh
+interpreter.  This is required on the Metal platform because:
+  - ``fork`` inherits the parent's Metal context and segfaults in the
+    child (Metal is not fork-safe).
+  - Running in the parent pytest process alongside the cache-off
+    baseline fixture in ``test_paged_deterministic`` causes
+    ``kv_budget=0`` — MLX wired buffers aren't released by Python gc.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+
+import pytest
+
+from tests.test_paged_deterministic import (
+    DEFAULT_PAGED_MEMORY_FRACTION,
+    DEFAULT_USE_PAGED_ATTENTION,
+)
+
+
+def _setenv_default(key: str, default: str) -> None:
+    if os.environ.get(key) is None:
+        os.environ[key] = default
+
+
+def _run_prefix_cache_correctness() -> None:
+    """Body of the e2e test — runs in a spawned child process.
+
+    Imports happen lazily inside the child so vllm / MLX init is not
+    inherited from the parent process.
+    """
+    _setenv_default("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    _setenv_default("VLLM_METAL_USE_PAGED_ATTENTION", DEFAULT_USE_PAGED_ATTENTION)
+    _setenv_default("VLLM_METAL_MEMORY_FRACTION", DEFAULT_PAGED_MEMORY_FRACTION)
+
+    if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") != "1":
+        return  # non-paged path: nothing to test
+
+    from vllm import LLM, SamplingParams
+
+    from tests.test_paged_deterministic import (
+        GOLDEN_MLX,
+        GOLDEN_PAGED,
+        MAX_TOKENS,
+        MODEL_NAME,
+        PROMPTS,
+    )
+
+    llm = LLM(
+        model=MODEL_NAME,
+        max_model_len=512,
+        max_num_seqs=1,
+        enable_prefix_caching=True,
+    )
+    sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
+    llm.generate(PROMPTS, sp)  # prime the cache
+    outputs = llm.generate(PROMPTS, sp)  # cache hits expected
+    by_prompt = {o.prompt: o for o in outputs}
+
+    mismatches = []
+    for prompt in PROMPTS:
+        output = by_prompt[prompt]
+        token_ids = list(output.outputs[0].token_ids)
+        mlx_expected = GOLDEN_MLX[prompt]
+        paged_expected = GOLDEN_PAGED[prompt]
+        if token_ids != mlx_expected and token_ids != paged_expected:
+            mismatches.append(
+                f"  {prompt!r}\n"
+                f"    got:        {token_ids}\n"
+                f"    mlx golden: {mlx_expected}\n"
+                f"    pgd golden: {paged_expected}"
+            )
+
+    if mismatches:
+        raise AssertionError(
+            "Prefix-cached output matched neither golden set for some prompts:\n"
+            + "\n".join(mismatches)
+        )
+
+
+@pytest.mark.slow
+def test_prefix_cached_matches_golden() -> None:
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(target=_run_prefix_cache_correctness)
+    proc.start()
+    proc.join()
+    if proc.exitcode != 0:
+        raise AssertionError(
+            f"Prefix-cache e2e test failed in spawned child "
+            f"(exit code: {proc.exitcode})"
+        )

--- a/tests/test_paged_prefix_caching_e2e.py
+++ b/tests/test_paged_prefix_caching_e2e.py
@@ -1,18 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """End-to-end correctness of paged prefix caching (issue #182).
 
-Fires the deterministic-test prompts twice through ``vllm.LLM`` with
-prefix caching enabled.  The first pass primes the cache; the second
-pass exercises the model_runner's ``start_pos > 0`` path because the
-upstream scheduler reports ``num_computed_tokens > 0``.  The asserted
-token sequence is the existing cache-off golden, so a broken cache-hit
-path surfaces as a token mismatch.
+Sends a batch of prompts that share a long prefix (>= one KV block of
+16 tokens) twice through ``vllm.LLM`` with prefix caching enabled.  The
+first ``generate`` populates the cache; the second triggers cache hits
+that walk the model_runner's ``start_pos > 0`` path because the upstream
+scheduler reports ``num_computed_tokens > 0``.
+
+Two assertions (in code order):
+  1. Cache-hit reach — at least one prefill in the second pass is issued
+     with ``start_pos > 0``.  Verified by spying on ``prepare_unified``
+     (which receives per-prefill ``start_pos`` tuples).  Fails fast if
+     the cache-hit branch was never taken.
+  2. Determinism — second pass produces identical tokens to the first
+     (greedy, same prompts).  A broken cache-hit path that still
+     reaches the branch surfaces as a token mismatch.
 
 The LLM body runs in a spawned child process (``multiprocessing`` with
 the ``spawn`` start method) so Metal device init happens in a fresh
-interpreter.  This is required on the Metal platform because:
-  - ``fork`` inherits the parent's Metal context and segfaults in the
-    child (Metal is not fork-safe).
+interpreter.  Required on Metal because:
+  - ``fork`` inherits the parent's Metal context and segfaults
+    (Metal is not fork-safe).
   - Running in the parent pytest process alongside the cache-off
     baseline fixture in ``test_paged_deterministic`` causes
     ``kv_budget=0`` — MLX wired buffers aren't released by Python gc.
@@ -28,7 +36,23 @@ import pytest
 from tests.test_paged_deterministic import (
     DEFAULT_PAGED_MEMORY_FRACTION,
     DEFAULT_USE_PAGED_ATTENTION,
+    MODEL_NAME,
 )
+
+# Long shared prefix (~30 tokens — comfortably more than the 16-token
+# Metal block size, so the upstream scheduler hashes at least one block
+# and prefix cache lookups can succeed).
+SHARED_PREFIX = (
+    "Once upon a time in a far away kingdom there was a great king "
+    "named Aragorn who ruled the land of Gondor with wisdom and "
+    "grace, and his people loved him dearly because "
+)
+PROMPTS = [
+    SHARED_PREFIX + "the queen agreed.",
+    SHARED_PREFIX + "the people prospered.",
+    SHARED_PREFIX + "the ravens watched silently.",
+]
+MAX_TOKENS = 10
 
 
 def _setenv_default(key: str, default: str) -> None:
@@ -37,11 +61,7 @@ def _setenv_default(key: str, default: str) -> None:
 
 
 def _run_prefix_cache_correctness() -> None:
-    """Body of the e2e test — runs in a spawned child process.
-
-    Imports happen lazily inside the child so vllm / MLX init is not
-    inherited from the parent process.
-    """
+    """Body of the e2e test — runs in a spawned child process."""
     _setenv_default("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
     _setenv_default("VLLM_METAL_USE_PAGED_ATTENTION", DEFAULT_USE_PAGED_ATTENTION)
     _setenv_default("VLLM_METAL_MEMORY_FRACTION", DEFAULT_PAGED_MEMORY_FRACTION)
@@ -51,48 +71,62 @@ def _run_prefix_cache_correctness() -> None:
 
     from vllm import LLM, SamplingParams
 
-    from tests.test_paged_deterministic import (
-        GOLDEN_MLX,
-        GOLDEN_PAGED,
-        MAX_TOKENS,
-        MODEL_NAME,
-        PROMPTS,
-    )
+    import vllm_metal.paged_attention_common as pac
 
-    llm = LLM(
-        model=MODEL_NAME,
-        max_model_len=512,
-        max_num_seqs=1,
-        enable_prefix_caching=True,
-    )
-    sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
-    llm.generate(PROMPTS, sp)  # prime the cache
-    outputs = llm.generate(PROMPTS, sp)  # cache hits expected
-    by_prompt = {o.prompt: o for o in outputs}
+    seen_start_pos: list[int] = []
+    orig_prepare = pac.prepare_unified
 
+    def patched_prepare(decode_requests, prefill_requests, block_size):
+        for _, _, start_pos in prefill_requests:
+            seen_start_pos.append(start_pos)
+        return orig_prepare(decode_requests, prefill_requests, block_size)
+
+    pac.prepare_unified = patched_prepare
+
+    try:
+        llm = LLM(
+            model=MODEL_NAME,
+            max_model_len=512,
+            max_num_seqs=1,
+            enable_prefix_caching=True,
+        )
+        sp = SamplingParams(temperature=0, max_tokens=MAX_TOKENS)
+        out_first = llm.generate(PROMPTS, sp)
+        prime_count = len(seen_start_pos)
+        out_second = llm.generate(PROMPTS, sp)
+    finally:
+        pac.prepare_unified = orig_prepare
+
+    # Cache-hit reach: at least one prefill in the second pass must
+    # advance past the cached prefix.
+    second_pass = seen_start_pos[prime_count:]
+    if not any(sp > 0 for sp in second_pass):
+        raise AssertionError(
+            f"Second pass should issue at least one prefill with start_pos "
+            f"> 0 (cache-hit path), but saw start_pos values: {second_pass}"
+        )
+
+    # Determinism: greedy decode of the same prompts must produce the
+    # same tokens whether or not the prefix was served from cache.
     mismatches = []
-    for prompt in PROMPTS:
-        output = by_prompt[prompt]
-        token_ids = list(output.outputs[0].token_ids)
-        mlx_expected = GOLDEN_MLX[prompt]
-        paged_expected = GOLDEN_PAGED[prompt]
-        if token_ids != mlx_expected and token_ids != paged_expected:
+    for o1, o2 in zip(out_first, out_second, strict=True):
+        toks1 = list(o1.outputs[0].token_ids)
+        toks2 = list(o2.outputs[0].token_ids)
+        if toks1 != toks2:
             mismatches.append(
-                f"  {prompt!r}\n"
-                f"    got:        {token_ids}\n"
-                f"    mlx golden: {mlx_expected}\n"
-                f"    pgd golden: {paged_expected}"
+                f"  prompt: {o1.prompt!r}\n"
+                f"    first  pass tokens: {toks1}\n"
+                f"    second pass tokens: {toks2}"
             )
-
     if mismatches:
         raise AssertionError(
-            "Prefix-cached output matched neither golden set for some prompts:\n"
+            "Cache-hit path produced different tokens than the priming pass:\n"
             + "\n".join(mismatches)
         )
 
 
 @pytest.mark.slow
-def test_prefix_cached_matches_golden() -> None:
+def test_prefix_cache_hit_path_correctness() -> None:
     ctx = mp.get_context("spawn")
     proc = ctx.Process(target=_run_prefix_cache_correctness)
     proc.start()

--- a/tools/README.md
+++ b/tools/README.md
@@ -65,8 +65,9 @@ python -m tools.benchmark.attention_benchmark --mode varlen --q-lens 1,4,16,64 -
 
 ## Prefix Caching Benchmark
 
-Measures TTFT with shared-prefix workloads using `prefix_repetition` dataset.
-Establishes a baseline before prefix caching is implemented (#159).
+Measures TTFT / TPOT / E2EL with shared-prefix workloads using the
+upstream `prefix_repetition` dataset.  Compare cache-off baseline vs
+cache-on by toggling `--enable-prefix-caching` / `--no-enable-prefix-caching`.
 
 **1. Start the server:**
 
@@ -74,7 +75,8 @@ Establishes a baseline before prefix caching is implemented (#159).
 # Adjust MEMORY_FRACTION based on available RAM (lower if OOM).
 VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION=0.7 \
   vllm serve Qwen/Qwen3-0.6B \
-    --port 8000 --max-model-len 2048 --max-num-seqs 8
+    --port 8000 --max-model-len 2048 --max-num-seqs 8 \
+    --enable-prefix-caching
 ```
 
 **2. Run the benchmark:**
@@ -93,8 +95,8 @@ vllm bench serve \
   --request-rate inf \
   --percentile-metrics ttft,tpot,e2el \
   --metric-percentiles 50,99 \
-  --save-result --label baseline
+  --save-result --label cache-on
 ```
 
-Key metric is **TTFT** — with prefix caching enabled, requests sharing
-the same prefix should show lower TTFT on cache hits.
+For a cache-off baseline, restart the server with
+`--no-enable-prefix-caching` and re-run with `--label baseline`.

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -275,15 +275,6 @@ class MetalPlatform(Platform):
                     scheduler_config.max_num_batched_tokens,
                 )
 
-        if config.use_paged_attention and getattr(
-            cache_config, "enable_prefix_caching", False
-        ):
-            # The unified paged path does not yet safely support vLLM core
-            # prefix-cache hits for new requests. Disable the feature at the
-            # platform layer until that path is fully supported.
-            cache_config.enable_prefix_caching = False
-            logger.info("Metal: disabled prefix caching")
-
         # Configure cache — ensure block_size is at least the Metal kernel
         # minimum.  With chunked prefill enabled, upstream may default to
         # block_size=1 for fine-grained scheduling, but our Metal paged


### PR DESCRIPTION
Summary
Removes the platform-layer force-disable that was blocking`enable_prefix_caching` on the paged path. The unified prefill code already handles `num_computed_tokens > 0` (#195, #207, #208, #211); the only remaining gap was that `platform.py:278-285` overrode it.

Adds an end-to-end correctness test that fires identical prompts twice through `vllm.LLM(enable_prefix_caching=True)` — the second pass walks the `start_pos > 0` path; tokens still match the cache-off golden.

Both test classes share a single `LLM` fixture: Metal memory held by a released `LLM` is not freed by Python gc, so a second module-scope `LLM` would hit `kv_budget=0`.

## Hybrid models
Upstream `ModelConfig.is_prefix_caching_supported` already returns False for hybrid/Mamba models, so the `default_prefix_caching` resolution in `vllm/engine/arg_utils.py` keeps cache off unless the user explicitly forces it. No vllm-metal-side guard needed.

## Benchmark
<img width="3119" height="1181" alt="benchmark_182" src="https://github.com/user-attachments/assets/4b1bc629-a7bb-4983-b5d0-f6481774cad0" />




Closes #182.