### PR TITLE
Bump vllm minimum version to 0.19.1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,7 @@ main() {
 
   ensure_venv "$venv"
 
-  local vllm_v="0.19.0"
+  local vllm_v="0.19.1"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   curl -OL $url_base/v$vllm_v/$filename
@@ -137,12 +137,6 @@ main() {
   CXXFLAGS="-Wno-parentheses" uv pip install .
   cd -
   rm -rf vllm-$vllm_v*
-
-  # Upgrade transformers beyond vllm's <5 pin.
-  # mlx-lm 0.30+ and mlx-vlm 0.3.10+ require transformers>=5.0.0 for newer
-  # model architectures (Qwen3.5, Nemotron, etc.). vllm works fine with v5 —
-  # upstream is tracking the official upgrade in vllm-project/vllm#30566.
-  uv pip install 'transformers>=5.0.0'
 
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
     uv pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "mlx-lm>=0.31.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-vlm>=0.4.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
     # Model loading and weights
-    "transformers>=5.0.0",
+    # Lower bound aligned with vllm 0.19.1's exclude list in requirements/common.txt
+    "transformers>=5.5.1",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
     # Native Metal extension JIT build


### PR DESCRIPTION
Pick up vllm 0.19.1, which ships transformers v5 officially upstream (#30566).                                                      
Drops the post-install override from #169 and aligns pyproject's transformers pin to >=5.5.1.