### PR TITLE
[TurboQuant] Add 512-dim FWHT support

### DIFF
--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 TurboQuant KV Cache — Comprehensive Test Suite
 

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -33,12 +33,15 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
+from types import SimpleNamespace
 
 import mlx.core as mx
 import numpy as np
 import pytest
 import torch
 
+from tests.stub_runner import make_stub_runner
+from vllm_metal.config import get_config, reset_config
 from vllm_metal.metal import get_ops
 from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 from vllm_metal.metal_kernel_backend.turboquant import (
@@ -2002,6 +2005,39 @@ def test_turboquant_512_head_dim_matches_python_reference() -> None:
     relative_error_percent = mean_abs_diff / ref_mean_abs * 100.0
 
     assert relative_error_percent < 5.0
+
+
+def test_turboquant_per_layer_shapes_raise_early() -> None:
+    """TurboQuant must keep rejecting per-layer KV shapes until PR2 lands."""
+    reset_config()
+    config = get_config()
+    config.turboquant = True
+    config.k_quant = "q8_0"
+    config.v_quant = "q3_0"
+
+    try:
+        runner = make_stub_runner(
+            num_layers=2,
+            num_kv_cache_layers=2,
+            num_kv_heads=16,
+            head_dim=256,
+            kv_cache_dtype=mx.bfloat16,
+            cache_config=SimpleNamespace(block_size=16),
+            kv_heads_per_layer=[16, 4],
+            head_dim_per_layer=[256, 512],
+        )
+
+        with pytest.raises(
+            NotImplementedError, match="TurboQuant with per-layer KV shapes"
+        ):
+            runner.get_kv_cache_spec()
+
+        with pytest.raises(
+            NotImplementedError, match="TurboQuant with per-layer KV shapes"
+        ):
+            runner.build_paged_attention_backend(block_size=16)
+    finally:
+        reset_config()
 
 
 # --- TurboQuantAttentionSpec (replacement for head_size_v hack) ------------

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -41,8 +41,8 @@ import torch
 from vllm_metal.metal import get_ops
 from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 from vllm_metal.metal_kernel_backend.turboquant import (
-    _FWHT_SUPPORTED_DIMS,
     BLOCK_SIZE,
+    FWHT_SUPPORTED_HEAD_DIMS,
     QUANT_PARAMS,
     V_QUANT_PARAMS,
     fwht,
@@ -354,14 +354,14 @@ def section_python_roundtrip_mse() -> int:
 def _fill_cache(cache, k_packed, v_packed, k_scale, v_scale, k_zero, slot):
     """Scatter-write packed K/V/scales/zero into the paged cache at `slot`."""
     layer = 0
-    nkv = U_NUM_KV_HEADS
-    sg = U_HEAD_DIM // 32
+    num_kv_heads = k_packed.shape[1]
+    scale_group_count = k_scale.shape[-1]
 
-    flat_k = cache.key_caches[layer].reshape(-1, nkv, cache.k_packed_dim)
+    flat_k = cache.key_caches[layer].reshape(-1, num_kv_heads, cache.k_packed_dim)
     flat_k[slot] = k_packed
     cache.key_caches[layer] = flat_k.reshape(cache.key_caches[layer].shape)
 
-    flat_v = cache.value_caches[layer].reshape(-1, nkv, cache.v_packed_dim)
+    flat_v = cache.value_caches[layer].reshape(-1, num_kv_heads, cache.v_packed_dim)
     flat_v[slot] = v_packed
     cache.value_caches[layer] = flat_v.reshape(cache.value_caches[layer].shape)
 
@@ -371,7 +371,7 @@ def _fill_cache(cache, k_packed, v_packed, k_scale, v_scale, k_zero, slot):
         ("key_zero_caches", k_zero),
     ]:
         arr = getattr(cache, attr)[layer]
-        flat = arr.reshape(-1, nkv, sg)
+        flat = arr.reshape(-1, num_kv_heads, scale_group_count)
         flat[slot] = data
         getattr(cache, attr)[layer] = flat.reshape(arr.shape)
 
@@ -1770,7 +1770,7 @@ def main() -> int:
 # TurboQuant's FWHT rotation uses random signs generated Python-side via
 # ``mx.random.randint(0, 2, shape=(N,), key=mx.random.key(42))``. The Metal
 # kernel stores byte-identical copies as compile-time constants
-# (``FWHT_SIGNS_64`` / ``_128`` / ``_256`` in ``turboquant.metal``).  If
+# (``FWHT_SIGNS_64`` / ``_128`` / ``_256`` / ``_512`` in ``turboquant.metal``).  If
 # either side drifts — different RNG key, MLX PRNG change, or manual edits
 # to the Metal tables — encode/decode silently disagree and produce garbage.
 
@@ -1811,7 +1811,7 @@ def _python_signs(head_size: int) -> np.ndarray:
     return np.asarray(signs)
 
 
-@pytest.mark.parametrize("head_size", _FWHT_SUPPORTED_DIMS)
+@pytest.mark.parametrize("head_size", FWHT_SUPPORTED_HEAD_DIMS)
 def test_metal_sign_table_matches_python_rng(head_size: int) -> None:
     """Metal constant table must equal the Python-generated signs element-wise."""
     metal_signs = _parse_metal_sign_table(head_size)
@@ -1828,7 +1828,7 @@ def test_metal_sign_table_matches_python_rng(head_size: int) -> None:
     )
 
 
-@pytest.mark.parametrize("head_size", _FWHT_SUPPORTED_DIMS)
+@pytest.mark.parametrize("head_size", FWHT_SUPPORTED_HEAD_DIMS)
 def test_fwht_roundtrips_exactly_with_current_signs(head_size: int) -> None:
     """Sanity check: encode then decode recovers the input (signs cancel)."""
     rng = np.random.default_rng(seed=0)
@@ -1849,6 +1849,160 @@ def test_fwht_roundtrips_exactly_with_current_signs(head_size: int) -> None:
     )
 
 
+def test_turboquant_cache_accepts_head_dim_512() -> None:
+    """Regression: TurboQuant cache allocation should accept 512-dim heads."""
+    num_layers = 1
+    num_blocks = 2
+    block_size = 16
+    num_kv_heads = 2
+    head_dim = 512
+    k_quant = "q8_0"
+    v_quant = "q3_0"
+    key_bits = QUANT_PARAMS[k_quant]["bits"]
+    value_bits = V_QUANT_PARAMS[v_quant]["bits"]
+    scale_group_count = head_dim // BLOCK_SIZE
+    cache = MetalPagedKVCache(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+
+    assert cache.k_packed_dim == packed_dim(head_dim, key_bits)
+    assert cache.v_packed_dim == packed_dim(head_dim, value_bits)
+    assert cache.key_caches[0].shape == (
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        cache.k_packed_dim,
+    )
+    assert cache.value_caches[0].shape == (
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        cache.v_packed_dim,
+    )
+    assert cache.key_scale_caches[0].shape == (
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        scale_group_count,
+    )
+    assert cache.value_scale_caches[0].shape == (
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        scale_group_count,
+    )
+    assert cache.key_zero_caches[0].shape == (
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        scale_group_count,
+    )
+
+
+def test_turboquant_512_head_dim_matches_python_reference() -> None:
+    """The 512-dim TurboQuant kernel path should match Python dequant attention."""
+    num_blocks = 4
+    block_size = 16
+    num_tokens = block_size
+    num_kv_heads = 2
+    num_query_heads = 4
+    head_dim = 512
+    cache = MetalPagedKVCache(
+        num_layers=1,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant="q8_0",
+        v_quant="q3_0",
+    )
+    k = mx.random.normal(
+        shape=(num_tokens, num_kv_heads, head_dim), key=mx.random.key(11)
+    ).astype(mx.float16)
+    v = mx.random.normal(
+        shape=(num_tokens, num_kv_heads, head_dim), key=mx.random.key(12)
+    ).astype(mx.float16)
+    q = mx.random.normal(
+        shape=(1, num_query_heads, head_dim), key=mx.random.key(13)
+    ).astype(mx.float16)
+    mx.eval(k, v, q)
+
+    (k_packed, k_scale, k_zero), (v_packed, v_scale) = turbo_quant_encode(k, v, "q8_0")
+    mx.eval(k_packed, k_scale, k_zero, v_packed, v_scale)
+
+    k_ref, v_ref = turbo_quant_decode(
+        (k_packed, k_scale, k_zero),
+        (v_packed, v_scale),
+        output_dtype=mx.float16,
+        key_quant_type="q8_0",
+    )
+    mx.eval(k_ref, v_ref)
+
+    slot = mx.array(list(range(num_tokens)), dtype=mx.int64)
+    mx.eval(slot)
+    _fill_cache(cache, k_packed, v_packed, k_scale, v_scale, k_zero, slot)
+    mx.eval(
+        cache.key_caches[0],
+        cache.value_caches[0],
+        cache.key_scale_caches[0],
+        cache.value_scale_caches[0],
+        cache.key_zero_caches[0],
+    )
+
+    block_tables = mx.array([[0]], dtype=mx.int32)
+    seq_lens = mx.array([num_tokens], dtype=mx.int32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    out_metal = mx.zeros((1, num_query_heads, head_dim), dtype=mx.float16)
+    mx.eval(block_tables, seq_lens, cu_seqlens_q, out_metal)
+
+    attn_scale = 1.0 / math.sqrt(head_dim)
+    v_centroids = get_v_centroids(cache.v_bits)
+    ops = get_ops()
+    ops.paged_attention_primitive(
+        q,
+        cache.key_caches[0],
+        cache.value_caches[0],
+        num_kv_heads,
+        attn_scale,
+        0.0,
+        block_tables,
+        seq_lens,
+        cu_seqlens_q,
+        block_size,
+        num_tokens,
+        -1,
+        out_metal,
+        key_scale_cache=cache.key_scale_caches[0],
+        value_scale_cache=cache.value_scale_caches[0],
+        key_zero_cache=cache.key_zero_caches[0],
+        v_centroids=v_centroids,
+        use_turboquant=True,
+        quant_type="q8_0",
+        v_bits=cache.v_bits,
+    )
+    mx.eval(out_metal)
+
+    out_ref = _python_attention_reference(q, k_ref, v_ref, attn_scale)
+    mx.eval(out_ref)
+
+    diff = out_metal.astype(mx.float32) - out_ref.astype(mx.float32)
+    mean_abs_diff = mx.mean(mx.abs(diff)).item()
+    ref_mean_abs = mx.mean(mx.abs(out_ref.astype(mx.float32))).item() + 1e-8
+    relative_error_percent = mean_abs_diff / ref_mean_abs * 100.0
+
+    assert relative_error_percent < 5.0
+
+
 # --- TurboQuantAttentionSpec (replacement for head_size_v hack) ------------
 #
 # ``TurboQuantAttentionSpec`` subclasses ``FullAttentionSpec`` and overrides
@@ -1863,6 +2017,7 @@ _TQ_SPEC_CONFIGS = [
     ("default_q8_q3", 16, 4, 128, "q8_0", "q3_0"),
     ("q4_q3_gqa", 16, 8, 128, "q4_0", "q3_0"),
     ("wide_head_256", 16, 2, 256, "q8_0", "q3_0"),
+    ("wide_head_512", 16, 2, 512, "q8_0", "q3_0"),
     ("narrow_head_64", 16, 8, 64, "q8_0", "q3_0"),
     ("aggressive_2b", 16, 8, 128, "int2", "q2_0"),
 ]

--- a/vllm_metal/metal/kernels_v2/turboquant.metal
+++ b/vllm_metal/metal/kernels_v2/turboquant.metal
@@ -87,8 +87,8 @@ constant float FWHT_SIGNS_128[128] = {
 };
 
 constant float FWHT_SIGNS_256[256] = {
-     1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,
-     1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,
+    1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,
+    1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,
     -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,
     -1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
     -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
@@ -103,6 +103,41 @@ constant float FWHT_SIGNS_256[256] = {
      1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,
     -1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,
     -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f, -1.f, -1.f
+};
+
+constant float FWHT_SIGNS_512[512] = {
+    -1.f,  1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,
+     1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f,
+    -1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f, -1.f,
+    -1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,
+    -1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,
+    -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,
+    -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f,
+     1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,
+    -1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f,  1.f,
+    -1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f,
+    -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
+    -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f,
+     1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,
+     1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,
+     1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f,
+     1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f,
+     1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f,  1.f,  1.f,
+    -1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
+     1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
+     1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f,
+    -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,
+     1.f,  1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f,  1.f,  1.f,
+    -1.f, -1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f, -1.f, -1.f,  1.f,
+    -1.f,  1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,
+     1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f,
+     1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f,  1.f, -1.f,
+     1.f, -1.f,  1.f,  1.f,  1.f,  1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f,  1.f, -1.f,
+    -1.f, -1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f, -1.f,
+    -1.f, -1.f, -1.f, -1.f,  1.f, -1.f, -1.f, -1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f,
+     1.f, -1.f, -1.f, -1.f,  1.f,  1.f,  1.f,  1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,
+    -1.f,  1.f, -1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f, -1.f,  1.f,  1.f, -1.f,
+    -1.f, -1.f,  1.f, -1.f,  1.f, -1.f, -1.f,  1.f, -1.f,  1.f,  1.f, -1.f,  1.f, -1.f,  1.f,  1.f
 };
 
 // ========================================== K dequantization
@@ -135,7 +170,7 @@ inline float tq_dequant_v_centroid(uchar index, float scale, const device float*
 
 // ========================================== FWHT sign lookup
 
-// FWHT sign lookup by HEAD_SIZE — supported for 64, 128, and 256.
+// FWHT sign lookup by HEAD_SIZE — supported for 64, 128, 256, and 512.
 // The primary template returns 1.f and is never called for TQ-enabled kernels
 // (runtime guard in MetalPagedKVCache enforces valid sizes), but must exist
 // to satisfy the compiler for non-TQ specializations of other head sizes.
@@ -143,15 +178,29 @@ template<int HEAD_SIZE> inline float get_fwht_sign(uint idx) { return 1.f; }
 template<> inline float get_fwht_sign<64>(uint idx)  { return FWHT_SIGNS_64[idx]; }
 template<> inline float get_fwht_sign<128>(uint idx) { return FWHT_SIGNS_128[idx]; }
 template<> inline float get_fwht_sign<256>(uint idx) { return FWHT_SIGNS_256[idx]; }
+template<> inline float get_fwht_sign<512>(uint idx) { return FWHT_SIGNS_512[idx]; }
+
+template<int HEAD_SIZE> inline constexpr int fwht_num_stages() { return 0; }
+template<> inline constexpr int fwht_num_stages<64>() { return 6; }
+template<> inline constexpr int fwht_num_stages<128>() { return 7; }
+template<> inline constexpr int fwht_num_stages<256>() { return 8; }
+template<> inline constexpr int fwht_num_stages<512>() { return 9; }
+
+template<int HEAD_SIZE> inline constexpr float fwht_inv_sqrt_n() { return 1.f; }
+template<> inline constexpr float fwht_inv_sqrt_n<64>() { return 0.125f; }
+template<> inline constexpr float fwht_inv_sqrt_n<128>() { return 0.08838834764831843f; }
+template<> inline constexpr float fwht_inv_sqrt_n<256>() { return 0.0625f; }
+template<> inline constexpr float fwht_inv_sqrt_n<512>() { return 0.04419417382415922f; }
 
 // ========================================== Inverse FWHT
 
 // In-place inverse FWHT for HEAD_SIZE elements using threadgroup memory.
-// Supports HEAD_SIZE = 64 (6 stages), 128 (7 stages), or 256 (8 stages).
+// Supports HEAD_SIZE = 64 (6 stages), 128 (7 stages), 256 (8 stages),
+// or 512 (9 stages).
 // Each SIMD lane owns HEAD_SIZE/32 elements (lane i → indices i, i+32, i+64, ...).
 template<int HEAD_SIZE>
 inline void threadgroup_inverse_fwht(threadgroup float* fwht_buf, uint lane) {
-    constexpr int NUM_STAGES = (HEAD_SIZE == 64) ? 6 : (HEAD_SIZE == 128) ? 7 : 8;
+    constexpr int NUM_STAGES = fwht_num_stages<HEAD_SIZE>();
     constexpr int ELEMS_PER_LANE = HEAD_SIZE / 32;
     float vals[ELEMS_PER_LANE];
 
@@ -189,7 +238,7 @@ inline void threadgroup_inverse_fwht(threadgroup float* fwht_buf, uint lane) {
         simdgroup_barrier(mem_flags::mem_threadgroup);
     }
     // Normalisation: 1/sqrt(HEAD_SIZE) + random sign flip
-    constexpr float INV_SQRT_N = (HEAD_SIZE == 64) ? 0.125f : (HEAD_SIZE == 128) ? 0.08838834764831843f : 0.0625f;
+    constexpr float INV_SQRT_N = fwht_inv_sqrt_n<HEAD_SIZE>();
     #pragma unroll
     for (int e = 0; e < ELEMS_PER_LANE; e++) {
         uint idx = lane + e * 32;

--- a/vllm_metal/metal_kernel_backend/cache.py
+++ b/vllm_metal/metal_kernel_backend/cache.py
@@ -21,6 +21,7 @@ from vllm.logger import init_logger
 
 from vllm_metal.metal_kernel_backend.turboquant import (
     BLOCK_SIZE,
+    FWHT_SUPPORTED_HEAD_DIMS,
     QUANT_PARAMS,
     V_QUANT_PARAMS,
     packed_dim,
@@ -86,9 +87,13 @@ class MetalPagedKVCache:
                 raise ValueError(
                     f"TurboQuant requires head_dim divisible by 32, got {head_dim}"
                 )
-            if head_dim not in (64, 128, 256):
+            if head_dim not in FWHT_SUPPORTED_HEAD_DIMS:
+                supported_head_dims = ", ".join(
+                    str(dim) for dim in FWHT_SUPPORTED_HEAD_DIMS
+                )
                 raise ValueError(
-                    f"TurboQuant V FWHT only supports head_dim 64, 128, or 256, got {head_dim}"
+                    "TurboQuant V FWHT only supports "
+                    f"head_dim in ({supported_head_dims}), got {head_dim}"
                 )
 
         self.k_size = QUANT_PARAMS[k_quant]["dtype"] if turboquant else None

--- a/vllm_metal/metal_kernel_backend/turboquant.py
+++ b/vllm_metal/metal_kernel_backend/turboquant.py
@@ -78,14 +78,15 @@ def searchsorted(boundaries, x):
     return (x[..., None] > boundaries).sum(axis=-1)
 
 
-_FWHT_SUPPORTED_DIMS = (64, 128, 256)
+FWHT_SUPPORTED_HEAD_DIMS = (64, 128, 256, 512)
+_FWHT_SUPPORTED_DIMS = FWHT_SUPPORTED_HEAD_DIMS
 
 
 def fwht(x: mx.array, encode: bool) -> mx.array:
     dim = x.shape[-1]
-    if dim not in _FWHT_SUPPORTED_DIMS:
+    if dim not in FWHT_SUPPORTED_HEAD_DIMS:
         raise ValueError(
-            f"FWHT only supports head_dim in {_FWHT_SUPPORTED_DIMS}, got {dim}. "
+            f"FWHT only supports head_dim in {FWHT_SUPPORTED_HEAD_DIMS}, got {dim}. "
             "The Metal kernel has hardcoded sign tables only for these sizes."
         )
     sign01 = mx.random.randint(0, 2, shape=(dim,), key=_RNG_KEY)

--- a/vllm_metal/metal_kernel_backend/turboquant.py
+++ b/vllm_metal/metal_kernel_backend/turboquant.py
@@ -87,7 +87,6 @@ def searchsorted(boundaries, x):
 
 
 FWHT_SUPPORTED_HEAD_DIMS = (64, 128, 256, 512)
-_FWHT_SUPPORTED_DIMS = FWHT_SUPPORTED_HEAD_DIMS
 
 
 def fwht(x: mx.array, encode: bool) -> mx.array:

--- a/vllm_metal/metal_kernel_backend/turboquant.py
+++ b/vllm_metal/metal_kernel_backend/turboquant.py
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TurboQuant quantization helpers for Metal paged attention.
+
+Provides the Python-side encode/decode path for TurboQuant KV compression,
+including key/value quantization metadata, bit packing helpers, and the FWHT
+rotation/sign tables used by the Metal dequantization kernels.
+"""
+
 import mlx.core as mx
 from vllm.logger import init_logger
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -500,6 +500,10 @@ class ModelCachePolicy:
             )
         if kv_heads is None:
             return
+        if get_config().turboquant:
+            raise NotImplementedError(
+                "TurboQuant with per-layer KV shapes is not yet supported."
+            )
         if self._runner.is_hybrid:
             raise NotImplementedError(
                 "Per-layer KV shapes with hybrid models require "


### PR DESCRIPTION
This PR extends TurboQuant's generic FWHT path to support `head_dim=512`, which is required by models such as Gemma4 full-attention layers.

Changes in this PR:
- include `512` in the Python-side FWHT supported head sizes
- add `FWHT_SIGNS_512` and `get_fwht_sign<512>` in the Metal TurboQuant helper
- add focused tests for:
    - Python/Metal FWHT sign-table parity
    - FWHT round-trip at 512
    - TurboQuant cache allocation for `head_dim=512`
    - 512-dim TurboQuant kernel output vs Python reference attention
- add missing module/file headers for TurboQuant Python files for consistency with the rest of the repo

## Why

Paged-attention kernels already instantiate `HEAD_SIZE=512`, but TurboQuant's FWHT/sign-table path only supported `64/128/256`. That made `512`-dim value quantization fail
before the later Gemma4-specific runtime work could even matter.

This PR removes that blocker without mixing in the per-layer cache-sizing and runtime-dispatch changes that follow in later stacked PRs.
