### PR TITLE
Rewrite block table bookeeping, from python to mlx

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -38,6 +38,7 @@ def make_stub_runner(
         "_gdn_needs_materialize": False,
         "_request_states": {},
         "_paged_request_seq_lens": {},
+        "_paged_prep_buffers": None,
         "_prefix_cache": None,
         "_pending_output": None,
         "_execute_model_state": None,

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -62,7 +62,7 @@ class _RaisingLinear:
 
 def _make_ctx(seq_len: int) -> PagedAttentionContext:
     """Return a minimal paged context sufficient for apply_packed_rope."""
-    return PagedAttentionContext(
+    return PagedAttentionContext.from_lists(
         slot_mapping=list(range(seq_len)),
         block_tables=[[0]],
         context_lens=[seq_len],

--- a/tests/test_block_size_translation.py
+++ b/tests/test_block_size_translation.py
@@ -8,6 +8,7 @@ kernel-compatible block sizes (8, 16, 32).
 
 from __future__ import annotations
 
+import mlx.core as mx
 import pytest
 
 from vllm_metal.metal_kernel_backend.attention_sdpa import (
@@ -15,6 +16,15 @@ from vllm_metal.metal_kernel_backend.attention_sdpa import (
     _build_block_tables,
     _pick_kernel_block_size,
 )
+
+
+def _pad_to_mx(raw: list[list[int]]) -> mx.array:
+    """Pad + convert to int32 MLX tensor — mirrors PagedAttentionContext.block_tables_mx."""
+    if not raw:
+        return mx.zeros((0, 0), dtype=mx.int32)
+    max_blocks = max(len(bt) for bt in raw)
+    padded = [bt + [0] * (max_blocks - len(bt)) for bt in raw]
+    return mx.array(padded, dtype=mx.int32)
 
 
 class TestPickKernelBlockSize:
@@ -45,13 +55,13 @@ class TestBuildBlockTables:
     """Tests for _build_block_tables."""
 
     def test_no_translation_for_supported_sizes(self):
-        bt, kbs = _build_block_tables([[0, 1], [2]], 16)
+        bt, kbs = _build_block_tables(_pad_to_mx([[0, 1], [2]]), 16)
         assert kbs == 16
         assert bt.tolist() == [[0, 1], [2, 0]]
 
     def test_translation_single_block(self):
         # 544 -> 32, ratio=17
-        bt, kbs = _build_block_tables([[0], [1]], 544)
+        bt, kbs = _build_block_tables(_pad_to_mx([[0], [1]]), 544)
         assert kbs == 32
         ratio = 544 // 32  # 17
         # block 0 -> [0, 1, ..., 16]
@@ -60,7 +70,7 @@ class TestBuildBlockTables:
         assert bt[1].tolist() == list(range(ratio, 2 * ratio))
 
     def test_translation_multi_block(self):
-        bt, kbs = _build_block_tables([[0, 2]], 544)
+        bt, kbs = _build_block_tables(_pad_to_mx([[0, 2]]), 544)
         ratio = 544 // 32
         expected = list(range(0, ratio)) + list(range(2 * ratio, 3 * ratio))
         assert bt[0].tolist() == expected
@@ -69,7 +79,7 @@ class TestBuildBlockTables:
         # Unequal block table lengths — shorter rows are zero-padded before
         # expansion, so padding block_id=0 expands to [0, 1, …, ratio-1].
         # The kernel never reads these entries (bounded by context_len).
-        bt, kbs = _build_block_tables([[0, 1], [2]], 544)
+        bt, kbs = _build_block_tables(_pad_to_mx([[0, 1], [2]]), 544)
         ratio = 544 // 32
         assert bt.shape[0] == 2
         assert bt.shape[1] == 2 * ratio
@@ -79,16 +89,16 @@ class TestBuildBlockTables:
         assert row1[ratio:] == list(range(0, ratio))
 
     def test_output_shape(self):
-        bt, kbs = _build_block_tables([[0, 1, 2]], 544)
+        bt, kbs = _build_block_tables(_pad_to_mx([[0, 1, 2]]), 544)
         ratio = 544 // 32
         assert bt.shape == (1, 3 * ratio)
 
     def test_empty_block_tables(self):
-        bt, kbs = _build_block_tables([], 16)
+        bt, kbs = _build_block_tables(_pad_to_mx([]), 16)
         assert bt.shape == (0, 0)
         assert kbs == 16
 
     def test_empty_block_tables_hybrid(self):
-        bt, kbs = _build_block_tables([], 544)
+        bt, kbs = _build_block_tables(_pad_to_mx([]), 544)
         assert bt.shape == (0, 0)
         assert kbs == 544

--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -18,6 +18,9 @@ from vllm_metal.paged_attention_backend.mla import (
 )
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 
+_np_ctx = pac.PagedAttentionContext.from_lists
+
+
 # Fixture dimensions matching GLM/DeepSeek-V2 defaults
 _KV_LORA_RANK = 512
 _QK_ROPE_HEAD_DIM = 64
@@ -280,7 +283,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
         wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
 
         pac.set_context(
-            pac.PagedAttentionContext(
+            _np_ctx(
                 slot_mapping=[3],
                 block_tables=[[0]],
                 context_lens=[4],
@@ -303,7 +306,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
         wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
 
         pac.set_context(
-            pac.PagedAttentionContext(
+            _np_ctx(
                 slot_mapping=[0, 1, 2, 3],
                 block_tables=[[0]],
                 context_lens=[4],
@@ -326,7 +329,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
         wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
 
         pac.set_context(
-            pac.PagedAttentionContext(
+            _np_ctx(
                 slot_mapping=[2],
                 block_tables=[[0]],
                 context_lens=[3],
@@ -355,7 +358,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
         # Request A: 2 past tokens, decode token at slot 2 in block 0
         # Request B: 1 past token,  decode token at slot 5 in block 1
         pac.set_context(
-            pac.PagedAttentionContext(
+            _np_ctx(
                 slot_mapping=[2, 5],
                 block_tables=[[0], [1]],
                 context_lens=[3, 2],
@@ -379,7 +382,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
         cache_a = self._make_cache()
         wrapper_a = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache_a)
         pac.set_context(
-            pac.PagedAttentionContext(
+            _np_ctx(
                 slot_mapping=[0, 1, 2, 3],
                 block_tables=[[0]],
                 context_lens=[4],
@@ -400,7 +403,7 @@ class TestMLAPagedAttentionWrapperPagedPath:
         cache_b = self._make_cache()
         wrapper_b = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache_b)
         pac.set_context(
-            pac.PagedAttentionContext(
+            _np_ctx(
                 slot_mapping=[0, 1, 2, 3],
                 block_tables=[[0]],
                 context_lens=[4],

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -40,7 +40,7 @@ class TestPrepare:
 
         # block 10: slots 40,41,42,43; block 11: slot 44
         assert ctx is not None
-        assert ctx.slot_mapping == [40, 41, 42, 43, 44]
+        assert ctx.slot_mapping_mx.tolist() == [40, 41, 42, 43, 44]
         assert ctx.block_tables == [[10, 11]]
         assert ctx.context_lens == [5]
         assert ctx.cu_seqlens == [0, 5]
@@ -54,7 +54,7 @@ class TestPrepare:
         assert ctx is not None
         # Request 0: block 10, slots 40,41,42
         # Request 1: block 20, slots 80,81
-        assert ctx.slot_mapping == [40, 41, 42, 80, 81]
+        assert ctx.slot_mapping_mx.tolist() == [40, 41, 42, 80, 81]
         assert ctx.cu_seqlens == [0, 3, 5]
         assert ctx.block_tables == [[10], [20]]
         assert ctx.context_lens == [3, 2]
@@ -68,7 +68,7 @@ class TestPrepare:
         assert ctx is not None
         assert ctx.cu_seqlens == [0, 5]
         # block 5: slots 20,21,22,23; block 6: slot 24
-        assert ctx.slot_mapping == [20, 21, 22, 23, 24]
+        assert ctx.slot_mapping_mx.tolist() == [20, 21, 22, 23, 24]
         assert ctx.block_tables == [[5, 6]]
         assert ctx.context_lens == [5]
 
@@ -83,7 +83,7 @@ class TestPrepare:
         # Only 3 tokens in the query (positions 4, 5, 6)
         assert ctx.cu_seqlens == [0, 3]
         # Slots for positions 4, 5, 6: block 11 slots 44, 45, 46
-        assert ctx.slot_mapping == [44, 45, 46]
+        assert ctx.slot_mapping_mx.tolist() == [44, 45, 46]
         assert ctx.block_tables == [[10, 11]]
         # Total context = start_pos + num_tokens = 4 + 3 = 7
         assert ctx.context_lens == [7]
@@ -98,7 +98,7 @@ class TestPrepare:
 
         # new_pos=7, block_ids[7//4]=block_ids[1]=6, slot=6*4+(7%4)=27
         assert ctx is not None
-        assert ctx.slot_mapping == [27]
+        assert ctx.slot_mapping_mx.tolist() == [27]
         assert ctx.context_lens == [8]
         assert ctx.offsets == [7]
         assert ctx.cu_seqlens == [0, 1]
@@ -114,7 +114,7 @@ class TestPrepare:
         assert ctx is not None
         # Decode slot: pos=7, block 6, slot=6*4+3=27
         # Prefill slots: block 10 slots 40,41,42,43; block 11 slot 44
-        assert ctx.slot_mapping == [27, 40, 41, 42, 43, 44]
+        assert ctx.slot_mapping_mx.tolist() == [27, 40, 41, 42, 43, 44]
         assert ctx.cu_seqlens == [0, 1, 6]
         assert ctx.offsets == [7, 0]
         assert ctx.context_lens == [8, 5]

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -40,11 +40,11 @@ class TestPrepare:
 
         # block 10: slots 40,41,42,43; block 11: slot 44
         assert ctx is not None
-        assert ctx.slot_mapping == [40, 41, 42, 43, 44]
-        assert ctx.block_tables == [[10, 11]]
-        assert ctx.context_lens == [5]
-        assert ctx.cu_seqlens == [0, 5]
-        assert ctx.offsets == [0]
+        assert ctx.slot_mapping.tolist() == [40, 41, 42, 43, 44]
+        assert ctx.block_tables.tolist() == [[10, 11]]
+        assert ctx.context_lens.tolist() == [5]
+        assert ctx.cu_seqlens.tolist() == [0, 5]
+        assert ctx.offsets.tolist() == [0]
 
     def test_prepare_unified_prefill_packed(self):
         # Two prefill requests packed together
@@ -54,11 +54,11 @@ class TestPrepare:
         assert ctx is not None
         # Request 0: block 10, slots 40,41,42
         # Request 1: block 20, slots 80,81
-        assert ctx.slot_mapping == [40, 41, 42, 80, 81]
-        assert ctx.cu_seqlens == [0, 3, 5]
-        assert ctx.block_tables == [[10], [20]]
-        assert ctx.context_lens == [3, 2]
-        assert ctx.offsets == [0, 0]
+        assert ctx.slot_mapping.tolist() == [40, 41, 42, 80, 81]
+        assert ctx.cu_seqlens.tolist() == [0, 3, 5]
+        assert ctx.block_tables.tolist() == [[10], [20]]
+        assert ctx.context_lens.tolist() == [3, 2]
+        assert ctx.offsets.tolist() == [0, 0]
 
     def test_prepare_unified_prefill_multiblock(self):
         # Single prefill spanning two blocks
@@ -66,11 +66,11 @@ class TestPrepare:
         ctx = get_context()
 
         assert ctx is not None
-        assert ctx.cu_seqlens == [0, 5]
+        assert ctx.cu_seqlens.tolist() == [0, 5]
         # block 5: slots 20,21,22,23; block 6: slot 24
-        assert ctx.slot_mapping == [20, 21, 22, 23, 24]
-        assert ctx.block_tables == [[5, 6]]
-        assert ctx.context_lens == [5]
+        assert ctx.slot_mapping.tolist() == [20, 21, 22, 23, 24]
+        assert ctx.block_tables.tolist() == [[5, 6]]
+        assert ctx.context_lens.tolist() == [5]
 
     def test_prepare_unified_continuation_chunk(self):
         # Continuation chunk: 3 new tokens starting at position 4
@@ -81,14 +81,14 @@ class TestPrepare:
 
         assert ctx is not None
         # Only 3 tokens in the query (positions 4, 5, 6)
-        assert ctx.cu_seqlens == [0, 3]
+        assert ctx.cu_seqlens.tolist() == [0, 3]
         # Slots for positions 4, 5, 6: block 11 slots 44, 45, 46
-        assert ctx.slot_mapping == [44, 45, 46]
-        assert ctx.block_tables == [[10, 11]]
+        assert ctx.slot_mapping.tolist() == [44, 45, 46]
+        assert ctx.block_tables.tolist() == [[10, 11]]
         # Total context = start_pos + num_tokens = 4 + 3 = 7
-        assert ctx.context_lens == [7]
+        assert ctx.context_lens.tolist() == [7]
         # RoPE offset = start_pos
-        assert ctx.offsets == [4]
+        assert ctx.offsets.tolist() == [4]
 
     def test_prepare_unified_decode_only(self):
         # Single decode request via prepare_unified
@@ -98,10 +98,10 @@ class TestPrepare:
 
         # new_pos=7, block_ids[7//4]=block_ids[1]=6, slot=6*4+(7%4)=27
         assert ctx is not None
-        assert ctx.slot_mapping == [27]
-        assert ctx.context_lens == [8]
-        assert ctx.offsets == [7]
-        assert ctx.cu_seqlens == [0, 1]
+        assert ctx.slot_mapping.tolist() == [27]
+        assert ctx.context_lens.tolist() == [8]
+        assert ctx.offsets.tolist() == [7]
+        assert ctx.cu_seqlens.tolist() == [0, 1]
 
     def test_prepare_unified_mixed(self):
         # 1 decode + 1 prefill
@@ -114,11 +114,13 @@ class TestPrepare:
         assert ctx is not None
         # Decode slot: pos=7, block 6, slot=6*4+3=27
         # Prefill slots: block 10 slots 40,41,42,43; block 11 slot 44
-        assert ctx.slot_mapping == [27, 40, 41, 42, 43, 44]
-        assert ctx.cu_seqlens == [0, 1, 6]
-        assert ctx.offsets == [7, 0]
-        assert ctx.context_lens == [8, 5]
-        assert ctx.block_tables == [[5, 6], [10, 11]]
+        assert ctx.slot_mapping.tolist() == [27, 40, 41, 42, 43, 44]
+        assert ctx.cu_seqlens.tolist() == [0, 1, 6]
+        assert ctx.offsets.tolist() == [7, 0]
+        assert ctx.context_lens.tolist() == [8, 5]
+        # Block tables are dense-padded to max blocks across requests (=2 here);
+        # the shorter row gets a trailing zero. Kernels mask via context_lens.
+        assert ctx.block_tables.tolist() == [[5, 6], [10, 11]]
 
 
 class TestPackedRoPE:

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -40,7 +40,7 @@ class TestPrepare:
 
         # block 10: slots 40,41,42,43; block 11: slot 44
         assert ctx is not None
-        assert ctx.slot_mapping_mx.tolist() == [40, 41, 42, 43, 44]
+        assert ctx.slot_mapping == [40, 41, 42, 43, 44]
         assert ctx.block_tables == [[10, 11]]
         assert ctx.context_lens == [5]
         assert ctx.cu_seqlens == [0, 5]
@@ -54,7 +54,7 @@ class TestPrepare:
         assert ctx is not None
         # Request 0: block 10, slots 40,41,42
         # Request 1: block 20, slots 80,81
-        assert ctx.slot_mapping_mx.tolist() == [40, 41, 42, 80, 81]
+        assert ctx.slot_mapping == [40, 41, 42, 80, 81]
         assert ctx.cu_seqlens == [0, 3, 5]
         assert ctx.block_tables == [[10], [20]]
         assert ctx.context_lens == [3, 2]
@@ -68,7 +68,7 @@ class TestPrepare:
         assert ctx is not None
         assert ctx.cu_seqlens == [0, 5]
         # block 5: slots 20,21,22,23; block 6: slot 24
-        assert ctx.slot_mapping_mx.tolist() == [20, 21, 22, 23, 24]
+        assert ctx.slot_mapping == [20, 21, 22, 23, 24]
         assert ctx.block_tables == [[5, 6]]
         assert ctx.context_lens == [5]
 
@@ -83,7 +83,7 @@ class TestPrepare:
         # Only 3 tokens in the query (positions 4, 5, 6)
         assert ctx.cu_seqlens == [0, 3]
         # Slots for positions 4, 5, 6: block 11 slots 44, 45, 46
-        assert ctx.slot_mapping_mx.tolist() == [44, 45, 46]
+        assert ctx.slot_mapping == [44, 45, 46]
         assert ctx.block_tables == [[10, 11]]
         # Total context = start_pos + num_tokens = 4 + 3 = 7
         assert ctx.context_lens == [7]
@@ -98,7 +98,7 @@ class TestPrepare:
 
         # new_pos=7, block_ids[7//4]=block_ids[1]=6, slot=6*4+(7%4)=27
         assert ctx is not None
-        assert ctx.slot_mapping_mx.tolist() == [27]
+        assert ctx.slot_mapping == [27]
         assert ctx.context_lens == [8]
         assert ctx.offsets == [7]
         assert ctx.cu_seqlens == [0, 1]
@@ -114,7 +114,7 @@ class TestPrepare:
         assert ctx is not None
         # Decode slot: pos=7, block 6, slot=6*4+3=27
         # Prefill slots: block 10 slots 40,41,42,43; block 11 slot 44
-        assert ctx.slot_mapping_mx.tolist() == [27, 40, 41, 42, 43, 44]
+        assert ctx.slot_mapping == [27, 40, 41, 42, 43, 44]
         assert ctx.cu_seqlens == [0, 1, 6]
         assert ctx.offsets == [7, 0]
         assert ctx.context_lens == [8, 5]

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -545,7 +545,7 @@ class TestPrepareUnifiedSlotMapping:
 
         assert len(captured) == 1
         ctx = captured[0]
-        assert ctx.slot_mapping_mx.tolist() == [0, 1, 2, 3]
+        assert ctx.slot_mapping == [0, 1, 2, 3]
         assert ctx.offsets == [0]
         assert ctx.context_lens == [4]
 
@@ -580,6 +580,6 @@ class TestPrepareUnifiedSlotMapping:
 
         assert len(captured) == 1
         ctx = captured[0]
-        assert ctx.slot_mapping_mx.tolist() == [2, 3]  # positions 2-3 in block 0
+        assert ctx.slot_mapping == [2, 3]  # positions 2-3 in block 0
         assert ctx.offsets == [2]
         assert ctx.context_lens == [4]  # start_pos + num_tokens = 2 + 2

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -545,9 +545,9 @@ class TestPrepareUnifiedSlotMapping:
 
         assert len(captured) == 1
         ctx = captured[0]
-        assert ctx.slot_mapping == [0, 1, 2, 3]
-        assert ctx.offsets == [0]
-        assert ctx.context_lens == [4]
+        assert ctx.slot_mapping.tolist() == [0, 1, 2, 3]
+        assert ctx.offsets.tolist() == [0]
+        assert ctx.context_lens.tolist() == [4]
 
     def test_prefix_hit_slot_mapping_starts_at_start_pos(self):
         """start_pos == 2: slots cover positions 2-3, RoPE offset is 2."""
@@ -580,6 +580,6 @@ class TestPrepareUnifiedSlotMapping:
 
         assert len(captured) == 1
         ctx = captured[0]
-        assert ctx.slot_mapping == [2, 3]  # positions 2-3 in block 0
-        assert ctx.offsets == [2]
-        assert ctx.context_lens == [4]  # start_pos + num_tokens = 2 + 2
+        assert ctx.slot_mapping.tolist() == [2, 3]  # positions 2-3 in block 0
+        assert ctx.offsets.tolist() == [2]
+        assert ctx.context_lens.tolist() == [4]  # start_pos + num_tokens = 2 + 2

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -545,7 +545,7 @@ class TestPrepareUnifiedSlotMapping:
 
         assert len(captured) == 1
         ctx = captured[0]
-        assert ctx.slot_mapping == [0, 1, 2, 3]
+        assert ctx.slot_mapping_mx.tolist() == [0, 1, 2, 3]
         assert ctx.offsets == [0]
         assert ctx.context_lens == [4]
 
@@ -580,6 +580,6 @@ class TestPrepareUnifiedSlotMapping:
 
         assert len(captured) == 1
         ctx = captured[0]
-        assert ctx.slot_mapping == [2, 3]  # positions 2-3 in block 0
+        assert ctx.slot_mapping_mx.tolist() == [2, 3]  # positions 2-3 in block 0
         assert ctx.offsets == [2]
         assert ctx.context_lens == [4]  # start_pos + num_tokens = 2 + 2

--- a/tests/test_paged_prefix_caching_e2e.py
+++ b/tests/test_paged_prefix_caching_e2e.py
@@ -76,10 +76,10 @@ def _run_prefix_cache_correctness() -> None:
     seen_start_pos: list[int] = []
     orig_prepare = pac.prepare_unified
 
-    def patched_prepare(decode_requests, prefill_requests, block_size):
+    def patched_prepare(decode_requests, prefill_requests, block_size, buffers=None):
         for _, _, start_pos in prefill_requests:
             seen_start_pos.append(start_pos)
-        return orig_prepare(decode_requests, prefill_requests, block_size)
+        return orig_prepare(decode_requests, prefill_requests, block_size, buffers)
 
     pac.prepare_unified = patched_prepare
 

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -175,7 +175,6 @@ class GDNPagedAttentionWrapper(nn.Module):
         g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
         beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv).astype(kernel_dtype))
 
-        # Cached MLX views — built once per forward pass, reused across layers.
         cu_seqlens_arr = ctx.cu_seqlens_mx
         # Stable request → slot mapping from model_runner's allocator.
         if ctx.gdn_slot_mapping is not None:

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -175,10 +175,11 @@ class GDNPagedAttentionWrapper(nn.Module):
         g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
         beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv).astype(kernel_dtype))
 
-        cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
+        # Cached MLX views — built once per forward pass, reused across layers.
+        cu_seqlens_arr = ctx.cu_seqlens_mx
         # Stable request → slot mapping from model_runner's allocator.
         if ctx.gdn_slot_mapping is not None:
-            slot_mapping = mx.array(ctx.gdn_slot_mapping, dtype=mx.int32)
+            slot_mapping = ctx.gdn_slot_mapping_mx
         else:
             slot_mapping = mx.arange(num_requests, dtype=mx.int32)
 

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -75,7 +75,7 @@ class GDNPagedAttentionWrapper(nn.Module):
         cache_idx: int = self._gdn_cache_idx
         state_cache: GDNPagedStateCache = self._gdn_state_cache
 
-        cu_seqlens = ctx.cu_seqlens
+        cu_seqlens = ctx.cu_seqlens_list
         if cu_seqlens is None or len(cu_seqlens) < 2:
             raise RuntimeError("GDN wrapper requires cu_seqlens in context")
 

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -71,10 +71,15 @@ def _pick_kernel_block_size(cache_block_size: int) -> int:
 
 
 def _build_block_tables(
-    raw_block_tables: list[list[int]],
+    padded_block_tables: mx.array,
     cache_block_size: int,
 ) -> tuple[mx.array, int]:
-    """Build kernel-compatible block tables, translating if necessary.
+    """Translate block tables to the kernel's block size, if needed.
+
+    Takes an already-padded ``[num_reqs, max_blocks]`` int32 MLX tensor built
+    once per forward pass (see ``PagedAttentionContext.block_tables_mx``).
+    When ``cache_block_size`` is already kernel-compatible this is a no-op
+    and returns the input unchanged.
 
     When ``cache_block_size`` exceeds the kernel's compiled block sizes,
     each vLLM block ``b`` is expanded into ``ratio`` kernel blocks
@@ -84,28 +89,22 @@ def _build_block_tables(
     Returns:
         (block_tables, kernel_block_size)
     """
-    if not raw_block_tables:
-        return mx.zeros((0, 0), dtype=mx.int32), cache_block_size
+    if padded_block_tables.size == 0:
+        return padded_block_tables, cache_block_size
 
     if cache_block_size in _KERNEL_BLOCK_SIZES:
         # Fast path — no translation needed.
-        max_blocks = max(len(bt) for bt in raw_block_tables)
-        padded = [bt + [0] * (max_blocks - len(bt)) for bt in raw_block_tables]
-        return mx.array(padded, dtype=mx.int32), cache_block_size
+        return padded_block_tables, cache_block_size
 
     # Hybrid path — translate large block_size to a kernel-compatible one.
     # Vectorized: each vLLM block b → [b*ratio, b*ratio+1, …, b*ratio+ratio-1].
     kernel_bs = _pick_kernel_block_size(cache_block_size)
     ratio = cache_block_size // kernel_bs
-
-    max_blocks = max(len(bt) for bt in raw_block_tables)
-    padded = [bt + [0] * (max_blocks - len(bt)) for bt in raw_block_tables]
-    bt_arr = mx.array(padded, dtype=mx.int32)  # [num_seqs, max_blocks]
     offsets = mx.arange(ratio, dtype=mx.int32)  # [ratio]
     # [num_seqs, max_blocks, 1] * ratio + [1, 1, ratio] → [num_seqs, max_blocks, ratio]
-    expanded = (bt_arr[:, :, None] * ratio + offsets[None, None, :]).reshape(
-        bt_arr.shape[0], -1
-    )
+    expanded = (
+        padded_block_tables[:, :, None] * ratio + offsets[None, None, :]
+    ).reshape(padded_block_tables.shape[0], -1)
     return expanded, kernel_bs
 
 
@@ -364,9 +363,10 @@ def sdpa_forward(
     k_3d = mx.contiguous(keys[0].transpose(1, 0, 2).astype(kv_cache.dtype))
     v_3d = mx.contiguous(values[0].transpose(1, 0, 2).astype(kv_cache.dtype))
 
-    slot_mapping = mx.array(ctx.slot_mapping, dtype=mx.int64)
-    seq_lens = mx.array(ctx.context_lens, dtype=mx.int32)
-    cu_seqlens_q = mx.array(ctx.cu_seqlens, dtype=mx.int32)
+    # Cached MLX views — built once per forward pass, reused across all layers.
+    slot_mapping = ctx.slot_mapping_mx
+    seq_lens = ctx.context_lens_mx
+    cu_seqlens_q = ctx.cu_seqlens_mx
     max_seq_len = max(ctx.context_lens)
 
     # --- Block tables (with hybrid block-size translation) ---
@@ -376,7 +376,7 @@ def sdpa_forward(
     # it expands each vLLM block into multiple kernel blocks and returns the
     # kernel-compatible block_size.  The cache is reshaped to match (zero-copy).
     block_tables, kernel_block_size = _build_block_tables(
-        ctx.block_tables, kv_cache.block_size
+        ctx.block_tables_mx, kv_cache.block_size
     )
 
     if shared_kv is not None:

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -183,8 +183,8 @@ def prepare_sdpa_qkv(
             inner,
             queries,
             keys,
-            ctx.cu_seqlens,
-            offsets=ctx.offsets if ctx.offsets else None,
+            ctx.cu_seqlens_list,
+            offsets=ctx.offsets_list if len(ctx.offsets) > 0 else None,
             apply_keys=False,
         )
     else:
@@ -217,8 +217,8 @@ def prepare_sdpa_qkv(
             inner,
             queries,
             keys,
-            ctx.cu_seqlens,
-            offsets=ctx.offsets if ctx.offsets else None,
+            ctx.cu_seqlens_list,
+            offsets=ctx.offsets_list if len(ctx.offsets) > 0 else None,
         )
 
     kv_for_sharing = (keys, values)
@@ -366,7 +366,8 @@ def sdpa_forward(
     slot_mapping = ctx.slot_mapping_mx
     seq_lens = ctx.context_lens_mx
     cu_seqlens_q = ctx.cu_seqlens_mx
-    max_seq_len = max(ctx.context_lens)
+    # int() so downstream nanobind primitives don't see a numpy scalar.
+    max_seq_len = int(ctx.context_lens.max())
 
     # --- Block tables (with hybrid block-size translation) ---
     # vLLM may inflate block_size (e.g. 544) to align attention pages with

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -363,7 +363,6 @@ def sdpa_forward(
     k_3d = mx.contiguous(keys[0].transpose(1, 0, 2).astype(kv_cache.dtype))
     v_3d = mx.contiguous(values[0].transpose(1, 0, 2).astype(kv_cache.dtype))
 
-    # Cached MLX views — built once per forward pass, reused across all layers.
     slot_mapping = ctx.slot_mapping_mx
     seq_lens = ctx.context_lens_mx
     cu_seqlens_q = ctx.cu_seqlens_mx

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -112,8 +112,6 @@ class MLAPagedAttentionWrapper(nn.Module):
             latent_cache.num_blocks, latent_cache.block_size, latent_cache.latent_dim
         )
 
-        # Dense padded block tables, built once per forward pass and reused
-        # across layers (see PagedAttentionContext.block_tables_mx).
         block_tables_mx = ctx.block_tables_mx
 
         outputs = []

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -54,7 +54,7 @@ class MLAPagedAttentionWrapper(nn.Module):
         ctx = get_context()
         if ctx is None:
             return self._inner(x, mask=mask, cache=cache)
-        if not ctx.block_tables:
+        if ctx.block_tables.shape[0] == 0:
             raise RuntimeError(
                 "MLAPagedAttentionWrapper called with empty block_tables"
             )
@@ -88,8 +88,8 @@ class MLAPagedAttentionWrapper(nn.Module):
             inner,
             q_pe,
             k_pe,
-            ctx.cu_seqlens,
-            offsets=ctx.offsets or None,
+            ctx.cu_seqlens_list,
+            offsets=ctx.offsets_list if len(ctx.offsets) > 0 else None,
         )
 
         # Concatenate kv_norm and the roped k_pe into a single per-token latent,
@@ -114,10 +114,12 @@ class MLAPagedAttentionWrapper(nn.Module):
 
         block_tables_mx = ctx.block_tables_mx
 
+        cu_list = ctx.cu_seqlens_list
+        ctx_lens_list = ctx.context_lens.tolist()
         outputs = []
-        for req_idx, ctx_len in enumerate(ctx.context_lens):
-            req_start = ctx.cu_seqlens[req_idx]
-            req_end = ctx.cu_seqlens[req_idx + 1]
+        for req_idx, ctx_len in enumerate(ctx_lens_list):
+            req_start = cu_list[req_idx]
+            req_end = cu_list[req_idx + 1]
             num_new = req_end - req_start
             past_len = ctx_len - num_new  # tokens cached before this step
 

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -107,13 +107,14 @@ class MLAPagedAttentionWrapper(nn.Module):
         flat = latent_cache.latent_caches[layer_idx].reshape(
             -1, latent_cache.latent_dim
         )
-        flat[mx.array(ctx.slot_mapping, dtype=mx.int64)] = latent_flat
+        flat[ctx.slot_mapping_mx] = latent_flat
         latent_cache.latent_caches[layer_idx] = flat.reshape(
             latent_cache.num_blocks, latent_cache.block_size, latent_cache.latent_dim
         )
 
-        # Pre-convert block tables once to avoid a new mx.array allocation per request
-        block_tables_mx = [mx.array(bt, dtype=mx.int32) for bt in ctx.block_tables]
+        # Dense padded block tables, built once per forward pass and reused
+        # across layers (see PagedAttentionContext.block_tables_mx).
+        block_tables_mx = ctx.block_tables_mx
 
         outputs = []
         for req_idx, ctx_len in enumerate(ctx.context_lens):
@@ -125,7 +126,7 @@ class MLAPagedAttentionWrapper(nn.Module):
             # Gather this request's full context from the paged cache.
             # Block indexing: each block holds block_size contiguous token slots.
             n_blocks = math.ceil(ctx_len / latent_cache.block_size)
-            blocks = block_tables_mx[req_idx][:n_blocks]
+            blocks = block_tables_mx[req_idx, :n_blocks]
             all_latent = latent_cache.latent_caches[layer_idx][blocks].reshape(
                 -1, latent_cache.latent_dim
             )[:ctx_len]

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -54,9 +54,6 @@ class PagedAttentionContext:
     # Populated by model_runner for hybrid models; None for non-hybrid.
     gdn_slot_mapping: list[int] | None = None
 
-    # Lazy MLX views — converted once per forward pass on first access, then
-    # reused across all attention layers. Eliminates the N-layer redundancy of
-    # re-converting the same Python lists on every attention wrapper call.
     _slot_mapping_mx: mx.array | None = field(default=None, init=False, repr=False)
     _block_tables_mx: mx.array | None = field(default=None, init=False, repr=False)
     _context_lens_mx: mx.array | None = field(default=None, init=False, repr=False)
@@ -75,9 +72,8 @@ class PagedAttentionContext:
     def block_tables_mx(self) -> mx.array:
         """Dense padded [num_reqs, max_blocks] int32 tensor.
 
-        Rows shorter than max_blocks are right-padded with 0. Callers that need
-        a per-request length should read from ``context_lens`` or derive from
-        ``block_tables``.
+        Rows shorter than max_blocks are right-padded with 0; kernels mask
+        off the tail via the per-request length array.
         """
         if self._block_tables_mx is None:
             if not self.block_tables:

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -112,6 +112,53 @@ class PagedAttentionContext:
             )
         return self._gdn_slot_mapping_mx
 
+    def _compute_slot_mapping_mx(self, block_size: int) -> None:
+        """Populate ``_slot_mapping_mx`` via vectorized MLX ops.
+
+        Upstream reference:
+        ``vllm/v1/worker/gpu/block_table.py::_compute_slot_mappings_kernel``
+        (Triton, ~line 213). Upstream runs the same math on-GPU per step;
+        we express it via MLX broadcast/indexing so MLX's scheduler runs
+        it on Metal. Avoids the per-token Python loop that
+        ``prepare_unified`` would otherwise execute for every prefill token.
+
+        MLX lacks ``searchsorted`` as of 0.31.x, so ``per_token_req`` is
+        derived via a broadcast compare + sum instead of the single
+        ``tl.load`` upstream does from ``idx_mapping``. Equivalent result.
+        """
+        if (
+            self.cu_seqlens is None
+            or not self.block_tables
+            or self.cu_seqlens[-1] == 0
+        ):
+            self._slot_mapping_mx = mx.zeros((0,), dtype=mx.int64)
+            return
+
+        total_tokens = self.cu_seqlens[-1]
+        cu = self.cu_seqlens_mx                         # [num_reqs + 1]
+        offs = mx.array(self.offsets, dtype=mx.int32)   # [num_reqs]
+        bt = self.block_tables_mx                       # [num_reqs, max_blocks]
+
+        positions = mx.arange(total_tokens, dtype=mx.int32)
+        cu_starts = cu[:-1]                             # [num_reqs]
+        # per_token_req: index of the request each packed token belongs to.
+        # Upstream reads this directly from idx_mapping; we count how many
+        # cu_seqlens boundaries each position has crossed.
+        per_token_req = (
+            (positions[:, None] >= cu_starts[None, :]).sum(axis=1) - 1
+        )
+        # Absolute sequence position within the request:
+        #   batch_pos − req_start + rope_offset
+        local_pos = (
+            positions - cu_starts[per_token_req] + offs[per_token_req]
+        )
+        block_indices = local_pos // block_size
+        block_offsets = local_pos % block_size
+        block_numbers = bt[per_token_req, block_indices]
+        self._slot_mapping_mx = (
+            block_numbers * block_size + block_offsets
+        ).astype(mx.int64)
+
 
 def set_context(ctx: PagedAttentionContext) -> None:
     _thread_local.paged_ctx = ctx
@@ -231,40 +278,35 @@ def prepare_unified(
             chunk (0 for a fresh prefill, >0 for continuation chunks).
         block_size: tokens per KV cache block.
     """
-    slot_mapping: list[int] = []
     cu_seqlens: list[int] = [0]
     block_tables: list[list[int]] = []
     context_lens: list[int] = []
     offsets: list[int] = []
 
-    # Decode requests first (1 token each)
+    # Decode requests first (1 token each).
     for block_ids, seq_len in decode_requests:
-        new_pos = seq_len
-        block_idx = block_ids[new_pos // block_size]
-        slot = block_idx * block_size + (new_pos % block_size)
-        slot_mapping.append(slot)
         cu_seqlens.append(cu_seqlens[-1] + 1)
         block_tables.append(block_ids)
         context_lens.append(seq_len + 1)  # including new token
         offsets.append(seq_len)  # RoPE position
 
-    # Prefill requests (variable tokens each, starting at start_pos)
+    # Prefill requests (variable tokens each, starting at start_pos).
     for block_ids, num_tokens, start_pos in prefill_requests:
-        for pos in range(start_pos, start_pos + num_tokens):
-            block_idx = block_ids[pos // block_size]
-            slot = block_idx * block_size + (pos % block_size)
-            slot_mapping.append(slot)
         cu_seqlens.append(cu_seqlens[-1] + num_tokens)
         block_tables.append(block_ids)
         context_lens.append(start_pos + num_tokens)
         offsets.append(start_pos)
 
-    set_context(
-        PagedAttentionContext(
-            slot_mapping=slot_mapping,
-            block_tables=block_tables,
-            context_lens=context_lens,
-            cu_seqlens=cu_seqlens,
-            offsets=offsets,
-        )
+    # slot_mapping is computed via vectorized MLX ops in
+    # ``_compute_slot_mapping_mx`` — see upstream
+    # ``vllm/v1/worker/gpu/block_table.py::_compute_slot_mappings_kernel``.
+    # The Python list stays empty; consumers read ``ctx.slot_mapping_mx``.
+    ctx = PagedAttentionContext(
+        slot_mapping=[],
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens=cu_seqlens,
+        offsets=offsets,
     )
+    ctx._compute_slot_mapping_mx(block_size)
+    set_context(ctx)

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -112,53 +112,6 @@ class PagedAttentionContext:
             )
         return self._gdn_slot_mapping_mx
 
-    def _compute_slot_mapping_mx(self, block_size: int) -> None:
-        """Populate ``_slot_mapping_mx`` via vectorized MLX ops.
-
-        Upstream reference:
-        ``vllm/v1/worker/gpu/block_table.py::_compute_slot_mappings_kernel``
-        (Triton, ~line 213). Upstream runs the same math on-GPU per step;
-        we express it via MLX broadcast/indexing so MLX's scheduler runs
-        it on Metal. Avoids the per-token Python loop that
-        ``prepare_unified`` would otherwise execute for every prefill token.
-
-        MLX lacks ``searchsorted`` as of 0.31.x, so ``per_token_req`` is
-        derived via a broadcast compare + sum instead of the single
-        ``tl.load`` upstream does from ``idx_mapping``. Equivalent result.
-        """
-        if (
-            self.cu_seqlens is None
-            or not self.block_tables
-            or self.cu_seqlens[-1] == 0
-        ):
-            self._slot_mapping_mx = mx.zeros((0,), dtype=mx.int64)
-            return
-
-        total_tokens = self.cu_seqlens[-1]
-        cu = self.cu_seqlens_mx                         # [num_reqs + 1]
-        offs = mx.array(self.offsets, dtype=mx.int32)   # [num_reqs]
-        bt = self.block_tables_mx                       # [num_reqs, max_blocks]
-
-        positions = mx.arange(total_tokens, dtype=mx.int32)
-        cu_starts = cu[:-1]                             # [num_reqs]
-        # per_token_req: index of the request each packed token belongs to.
-        # Upstream reads this directly from idx_mapping; we count how many
-        # cu_seqlens boundaries each position has crossed.
-        per_token_req = (
-            (positions[:, None] >= cu_starts[None, :]).sum(axis=1) - 1
-        )
-        # Absolute sequence position within the request:
-        #   batch_pos − req_start + rope_offset
-        local_pos = (
-            positions - cu_starts[per_token_req] + offs[per_token_req]
-        )
-        block_indices = local_pos // block_size
-        block_offsets = local_pos % block_size
-        block_numbers = bt[per_token_req, block_indices]
-        self._slot_mapping_mx = (
-            block_numbers * block_size + block_offsets
-        ).astype(mx.int64)
-
 
 def set_context(ctx: PagedAttentionContext) -> None:
     _thread_local.paged_ctx = ctx
@@ -278,35 +231,40 @@ def prepare_unified(
             chunk (0 for a fresh prefill, >0 for continuation chunks).
         block_size: tokens per KV cache block.
     """
+    slot_mapping: list[int] = []
     cu_seqlens: list[int] = [0]
     block_tables: list[list[int]] = []
     context_lens: list[int] = []
     offsets: list[int] = []
 
-    # Decode requests first (1 token each).
+    # Decode requests first (1 token each)
     for block_ids, seq_len in decode_requests:
+        new_pos = seq_len
+        block_idx = block_ids[new_pos // block_size]
+        slot = block_idx * block_size + (new_pos % block_size)
+        slot_mapping.append(slot)
         cu_seqlens.append(cu_seqlens[-1] + 1)
         block_tables.append(block_ids)
         context_lens.append(seq_len + 1)  # including new token
         offsets.append(seq_len)  # RoPE position
 
-    # Prefill requests (variable tokens each, starting at start_pos).
+    # Prefill requests (variable tokens each, starting at start_pos)
     for block_ids, num_tokens, start_pos in prefill_requests:
+        for pos in range(start_pos, start_pos + num_tokens):
+            block_idx = block_ids[pos // block_size]
+            slot = block_idx * block_size + (pos % block_size)
+            slot_mapping.append(slot)
         cu_seqlens.append(cu_seqlens[-1] + num_tokens)
         block_tables.append(block_ids)
         context_lens.append(start_pos + num_tokens)
         offsets.append(start_pos)
 
-    # slot_mapping is computed via vectorized MLX ops in
-    # ``_compute_slot_mapping_mx`` — see upstream
-    # ``vllm/v1/worker/gpu/block_table.py::_compute_slot_mappings_kernel``.
-    # The Python list stays empty; consumers read ``ctx.slot_mapping_mx``.
-    ctx = PagedAttentionContext(
-        slot_mapping=[],
-        block_tables=block_tables,
-        context_lens=context_lens,
-        cu_seqlens=cu_seqlens,
-        offsets=offsets,
+    set_context(
+        PagedAttentionContext(
+            slot_mapping=slot_mapping,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens=cu_seqlens,
+            offsets=offsets,
+        )
     )
-    ctx._compute_slot_mapping_mx(block_size)
-    set_context(ctx)

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -17,6 +17,7 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any
 
+import mlx.core as mx
 from mlx_lm.models.base import create_causal_mask
 
 # ---------------------------------------------------------------------------
@@ -52,6 +53,64 @@ class PagedAttentionContext:
     # GDN state pool slot mapping: request batch position → stable slot ID.
     # Populated by model_runner for hybrid models; None for non-hybrid.
     gdn_slot_mapping: list[int] | None = None
+
+    # Lazy MLX views — converted once per forward pass on first access, then
+    # reused across all attention layers. Eliminates the N-layer redundancy of
+    # re-converting the same Python lists on every attention wrapper call.
+    _slot_mapping_mx: mx.array | None = field(default=None, init=False, repr=False)
+    _block_tables_mx: mx.array | None = field(default=None, init=False, repr=False)
+    _context_lens_mx: mx.array | None = field(default=None, init=False, repr=False)
+    _cu_seqlens_mx: mx.array | None = field(default=None, init=False, repr=False)
+    _gdn_slot_mapping_mx: mx.array | None = field(
+        default=None, init=False, repr=False
+    )
+
+    @property
+    def slot_mapping_mx(self) -> mx.array:
+        if self._slot_mapping_mx is None:
+            self._slot_mapping_mx = mx.array(self.slot_mapping, dtype=mx.int64)
+        return self._slot_mapping_mx
+
+    @property
+    def block_tables_mx(self) -> mx.array:
+        """Dense padded [num_reqs, max_blocks] int32 tensor.
+
+        Rows shorter than max_blocks are right-padded with 0. Callers that need
+        a per-request length should read from ``context_lens`` or derive from
+        ``block_tables``.
+        """
+        if self._block_tables_mx is None:
+            if not self.block_tables:
+                self._block_tables_mx = mx.zeros((0, 0), dtype=mx.int32)
+            else:
+                max_blocks = max(len(bt) for bt in self.block_tables)
+                padded = [
+                    bt + [0] * (max_blocks - len(bt)) for bt in self.block_tables
+                ]
+                self._block_tables_mx = mx.array(padded, dtype=mx.int32)
+        return self._block_tables_mx
+
+    @property
+    def context_lens_mx(self) -> mx.array:
+        if self._context_lens_mx is None:
+            self._context_lens_mx = mx.array(self.context_lens, dtype=mx.int32)
+        return self._context_lens_mx
+
+    @property
+    def cu_seqlens_mx(self) -> mx.array:
+        if self._cu_seqlens_mx is None:
+            self._cu_seqlens_mx = mx.array(self.cu_seqlens, dtype=mx.int32)
+        return self._cu_seqlens_mx
+
+    @property
+    def gdn_slot_mapping_mx(self) -> mx.array | None:
+        if self.gdn_slot_mapping is None:
+            return None
+        if self._gdn_slot_mapping_mx is None:
+            self._gdn_slot_mapping_mx = mx.array(
+                self.gdn_slot_mapping, dtype=mx.int32
+            )
+        return self._gdn_slot_mapping_mx
 
 
 def set_context(ctx: PagedAttentionContext) -> None:

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import mlx.core as mx
+import numpy as np
 from mlx_lm.models.base import create_causal_mask
 
 # ---------------------------------------------------------------------------
@@ -33,6 +34,39 @@ from mlx_lm.models.base import create_causal_mask
 _thread_local = threading.local()
 
 
+class PagedPrepBuffers:
+    """Private working storage for ``prepare_unified`` — do not access fields
+    from outside this module.
+
+    The dense ``block_table`` is sized to the worst case once at runner
+    init; per-step the active slice ``[:nreqs, :max_blocks]`` is a
+    rectangle with short rows right-padded by 0, and kernels mask off the
+    tail via ``context_lens``. The other four arrays are 1D contiguous.
+    """
+
+    __slots__ = (
+        "slot_mapping",
+        "block_table",
+        "cu_seqlens",
+        "context_lens",
+        "offsets",
+    )
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_num_blocks_per_req: int,
+        max_num_batched_tokens: int,
+    ) -> None:
+        self.slot_mapping = np.zeros(max_num_batched_tokens, dtype=np.int64)
+        self.block_table = np.zeros(
+            (max_num_reqs, max_num_blocks_per_req), dtype=np.int32
+        )
+        self.cu_seqlens = np.zeros(max_num_reqs + 1, dtype=np.int32)
+        self.context_lens = np.zeros(max_num_reqs, dtype=np.int32)
+        self.offsets = np.zeros(max_num_reqs, dtype=np.int32)
+
+
 @dataclass
 class PagedAttentionContext:
     """Context set before each forward pass, read by patched attention.
@@ -40,62 +74,55 @@ class PagedAttentionContext:
     All forward passes use the varlen kernel with ``cu_seqlens`` to handle
     variable-length subsequences (both prefill and decode tokens packed
     into a single flat sequence).
+
+    Each numpy field is a view into a ``PagedPrepBuffers`` slice for the
+    current step's active extent. The view does not own memory; the
+    underlying buffer outlives the context.
     """
 
-    slot_mapping: list[int]
-    block_tables: list[list[int]] = field(default_factory=list)
-    context_lens: list[int] = field(default_factory=list)
+    slot_mapping: np.ndarray  # int64, shape [total_tokens]
+    block_tables: np.ndarray  # int32, shape [num_reqs, max_blocks_this_step]
+    context_lens: np.ndarray  # int32, shape [num_reqs]
     # Per-segment RoPE offsets: 0 for fresh prefill, seq_len for decode.
-    offsets: list[int] = field(default_factory=list)
+    offsets: np.ndarray  # int32, shape [num_reqs]
     # Cumulative sequence length array: [0, len0, len0+len1, ...]
     # (length = num_requests + 1).
-    cu_seqlens: list[int] | None = None
+    cu_seqlens: np.ndarray  # int32, shape [num_reqs + 1]
     # GDN state pool slot mapping: request batch position → stable slot ID.
     # Populated by model_runner for hybrid models; None for non-hybrid.
+    # Tiny (one int per request) so a Python list is fine.
     gdn_slot_mapping: list[int] | None = None
 
     _slot_mapping_mx: mx.array | None = field(default=None, init=False, repr=False)
     _block_tables_mx: mx.array | None = field(default=None, init=False, repr=False)
     _context_lens_mx: mx.array | None = field(default=None, init=False, repr=False)
     _cu_seqlens_mx: mx.array | None = field(default=None, init=False, repr=False)
-    _gdn_slot_mapping_mx: mx.array | None = field(
-        default=None, init=False, repr=False
-    )
+    _gdn_slot_mapping_mx: mx.array | None = field(default=None, init=False, repr=False)
+    _cu_seqlens_list: list[int] | None = field(default=None, init=False, repr=False)
+    _offsets_list: list[int] | None = field(default=None, init=False, repr=False)
 
     @property
     def slot_mapping_mx(self) -> mx.array:
         if self._slot_mapping_mx is None:
-            self._slot_mapping_mx = mx.array(self.slot_mapping, dtype=mx.int64)
+            self._slot_mapping_mx = mx.array(self.slot_mapping)
         return self._slot_mapping_mx
 
     @property
     def block_tables_mx(self) -> mx.array:
-        """Dense padded [num_reqs, max_blocks] int32 tensor.
-
-        Rows shorter than max_blocks are right-padded with 0; kernels mask
-        off the tail via the per-request length array.
-        """
         if self._block_tables_mx is None:
-            if not self.block_tables:
-                self._block_tables_mx = mx.zeros((0, 0), dtype=mx.int32)
-            else:
-                max_blocks = max(len(bt) for bt in self.block_tables)
-                padded = [
-                    bt + [0] * (max_blocks - len(bt)) for bt in self.block_tables
-                ]
-                self._block_tables_mx = mx.array(padded, dtype=mx.int32)
+            self._block_tables_mx = mx.array(self.block_tables)
         return self._block_tables_mx
 
     @property
     def context_lens_mx(self) -> mx.array:
         if self._context_lens_mx is None:
-            self._context_lens_mx = mx.array(self.context_lens, dtype=mx.int32)
+            self._context_lens_mx = mx.array(self.context_lens)
         return self._context_lens_mx
 
     @property
     def cu_seqlens_mx(self) -> mx.array:
         if self._cu_seqlens_mx is None:
-            self._cu_seqlens_mx = mx.array(self.cu_seqlens, dtype=mx.int32)
+            self._cu_seqlens_mx = mx.array(self.cu_seqlens)
         return self._cu_seqlens_mx
 
     @property
@@ -103,10 +130,58 @@ class PagedAttentionContext:
         if self.gdn_slot_mapping is None:
             return None
         if self._gdn_slot_mapping_mx is None:
-            self._gdn_slot_mapping_mx = mx.array(
-                self.gdn_slot_mapping, dtype=mx.int32
-            )
+            self._gdn_slot_mapping_mx = mx.array(self.gdn_slot_mapping, dtype=mx.int32)
         return self._gdn_slot_mapping_mx
+
+    @property
+    def cu_seqlens_list(self) -> list[int]:
+        """Python ints for per-request loops in attention wrappers.
+
+        MLX slice indices reject ``np.int32``; the per-layer per-request
+        ``int(cu_seqlens[i])`` coercion is hot enough at high batch/layer
+        counts to matter, so cache one ``tolist()`` per forward pass.
+        """
+        if self._cu_seqlens_list is None:
+            self._cu_seqlens_list = self.cu_seqlens.tolist()
+        return self._cu_seqlens_list
+
+    @property
+    def offsets_list(self) -> list[int]:
+        if self._offsets_list is None:
+            self._offsets_list = self.offsets.tolist()
+        return self._offsets_list
+
+    @classmethod
+    def from_lists(
+        cls,
+        *,
+        slot_mapping: list[int],
+        block_tables: list[list[int]],
+        context_lens: list[int],
+        cu_seqlens: list[int],
+        offsets: list[int],
+        gdn_slot_mapping: list[int] | None = None,
+    ) -> PagedAttentionContext:
+        """Build a context from raw Python lists — for tests and ad-hoc use.
+
+        Mirrors the dense-padding ``prepare_unified`` applies to
+        ``block_tables``: shorter rows get trailing zeros so the result is a
+        contiguous rectangle.
+        """
+        if not block_tables:
+            bt = np.zeros((0, 0), dtype=np.int32)
+        else:
+            max_blocks = max(len(b) for b in block_tables)
+            padded = [b + [0] * (max_blocks - len(b)) for b in block_tables]
+            bt = np.array(padded, dtype=np.int32)
+        return cls(
+            slot_mapping=np.array(slot_mapping, dtype=np.int64),
+            block_tables=bt,
+            context_lens=np.array(context_lens, dtype=np.int32),
+            cu_seqlens=np.array(cu_seqlens, dtype=np.int32),
+            offsets=np.array(offsets, dtype=np.int32),
+            gdn_slot_mapping=gdn_slot_mapping,
+        )
 
 
 def set_context(ctx: PagedAttentionContext) -> None:
@@ -211,6 +286,7 @@ def prepare_unified(
     decode_requests: list[tuple[list[int], int]],
     prefill_requests: list[tuple[list[int], int, int]],
     block_size: int,
+    buffers: PagedPrepBuffers | None = None,
 ) -> None:
     """Compute metadata for a unified prefill + decode forward pass.
 
@@ -219,6 +295,12 @@ def prepare_unified(
     the varlen kernel handles both decode (length-1) and prefill (length-N)
     subsequences in one dispatch.
 
+    Writes are slice-assignments into ``buffers`` (persistent across steps).
+    The constructed context holds *views* of the active extent; the buffer
+    must outlive the context. When ``buffers`` is ``None`` an ad-hoc
+    instance is allocated, sized to this call's inputs — used by tests; in
+    production the runner passes a persistent buffer.
+
     Args:
         decode_requests: list of ``(block_ids, seq_len)`` for decode requests.
             ``seq_len`` = tokens already cached before this step.
@@ -226,41 +308,74 @@ def prepare_unified(
             prefill.  ``start_pos`` is the position of the first token in this
             chunk (0 for a fresh prefill, >0 for continuation chunks).
         block_size: tokens per KV cache block.
+        buffers: persistent storage; auto-allocated when ``None``.
     """
-    slot_mapping: list[int] = []
-    cu_seqlens: list[int] = [0]
-    block_tables: list[list[int]] = []
-    context_lens: list[int] = []
-    offsets: list[int] = []
+    num_decode = len(decode_requests)
+    num_reqs = num_decode + len(prefill_requests)
 
-    # Decode requests first (1 token each)
+    total_tokens = num_decode + sum(num for _, num, _ in prefill_requests)
+    max_blocks = 0
+    for block_ids, _ in decode_requests:
+        if len(block_ids) > max_blocks:
+            max_blocks = len(block_ids)
+    for block_ids, _, _ in prefill_requests:
+        if len(block_ids) > max_blocks:
+            max_blocks = len(block_ids)
+
+    if buffers is None:
+        buffers = PagedPrepBuffers(
+            max_num_reqs=max(num_reqs, 1),
+            max_num_blocks_per_req=max(max_blocks, 1),
+            max_num_batched_tokens=max(total_tokens, 1),
+        )
+
+    # Buffer rows are reused across steps. A long row from step N would
+    # leak stale tail entries into step N+1's shorter row through the
+    # dense slice — clear the active rectangle once per step.
+    if num_reqs > 0 and max_blocks > 0:
+        buffers.block_table[:num_reqs, :max_blocks] = 0
+
+    buffers.cu_seqlens[0] = 0
+    cu = 0
+    req_idx = 0
+
     for block_ids, seq_len in decode_requests:
         new_pos = seq_len
         block_idx = block_ids[new_pos // block_size]
         slot = block_idx * block_size + (new_pos % block_size)
-        slot_mapping.append(slot)
-        cu_seqlens.append(cu_seqlens[-1] + 1)
-        block_tables.append(block_ids)
-        context_lens.append(seq_len + 1)  # including new token
-        offsets.append(seq_len)  # RoPE position
+        buffers.slot_mapping[cu] = slot
+        n_blocks = len(block_ids)
+        if n_blocks:
+            buffers.block_table[req_idx, :n_blocks] = block_ids
+        buffers.context_lens[req_idx] = seq_len + 1
+        buffers.offsets[req_idx] = seq_len
+        cu += 1
+        buffers.cu_seqlens[req_idx + 1] = cu
+        req_idx += 1
 
-    # Prefill requests (variable tokens each, starting at start_pos)
     for block_ids, num_tokens, start_pos in prefill_requests:
-        for pos in range(start_pos, start_pos + num_tokens):
-            block_idx = block_ids[pos // block_size]
-            slot = block_idx * block_size + (pos % block_size)
-            slot_mapping.append(slot)
-        cu_seqlens.append(cu_seqlens[-1] + num_tokens)
-        block_tables.append(block_ids)
-        context_lens.append(start_pos + num_tokens)
-        offsets.append(start_pos)
+        if num_tokens > 0:
+            positions = np.arange(start_pos, start_pos + num_tokens, dtype=np.int64)
+            block_idx = positions // block_size
+            offset_in_block = positions % block_size
+            block_arr = np.asarray(block_ids, dtype=np.int64)
+            slots = block_arr[block_idx] * block_size + offset_in_block
+            buffers.slot_mapping[cu : cu + num_tokens] = slots
+        n_blocks = len(block_ids)
+        if n_blocks:
+            buffers.block_table[req_idx, :n_blocks] = block_ids
+        buffers.context_lens[req_idx] = start_pos + num_tokens
+        buffers.offsets[req_idx] = start_pos
+        cu += num_tokens
+        buffers.cu_seqlens[req_idx + 1] = cu
+        req_idx += 1
 
     set_context(
         PagedAttentionContext(
-            slot_mapping=slot_mapping,
-            block_tables=block_tables,
-            context_lens=context_lens,
-            cu_seqlens=cu_seqlens,
-            offsets=offsets,
+            slot_mapping=buffers.slot_mapping[:cu],
+            block_tables=buffers.block_table[:num_reqs, :max_blocks],
+            context_lens=buffers.context_lens[:num_reqs],
+            offsets=buffers.offsets[:num_reqs],
+            cu_seqlens=buffers.cu_seqlens[: num_reqs + 1],
         )
     )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -22,6 +22,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
+from vllm.utils.math_utils import cdiv
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.core.sched.output import (
     CachedRequestData,
@@ -41,6 +42,7 @@ from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.paged_attention_common import (
     OffsetCache,
+    PagedPrepBuffers,
     clear_context,
     prepare_unified,
 )
@@ -250,6 +252,9 @@ class MetalModelRunner:
         self._paged_attention_backend: PagedAttentionBackend | None = None
         self._paged_block_size: int = 0
         self._paged_request_seq_lens: dict[str, int] = {}  # req_id → seq_len
+        # Persistent host-side buffers for prepare_unified — allocated lazily
+        # after _paged_block_size is known (worker-side init).
+        self._paged_prep_buffers: PagedPrepBuffers | None = None
         self.kv_cache_dtype: mx.Dtype | None = None
 
         # Per-layer KV cache shapes (None = uniform across layers)
@@ -479,6 +484,20 @@ class MetalModelRunner:
     ) -> PagedAttentionBackend:
         """Build the paged-attention backend for the loaded model."""
         return self._cache_policy.build_paged_attention_backend(block_size=block_size)
+
+    def _build_prep_buffers(self) -> PagedPrepBuffers:
+        """Allocate the persistent host-side buffers for ``prepare_unified``.
+
+        Sized to the worst-case batch shape that the scheduler can hand us.
+        Lazy because ``_paged_block_size`` is only known after the worker
+        has built the paged attention backend.
+        """
+        block_size = self._paged_block_size or 1
+        return PagedPrepBuffers(
+            max_num_reqs=self.scheduler_config.max_num_seqs,
+            max_num_blocks_per_req=cdiv(self.model_config.max_model_len, block_size),
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
+        )
 
     def estimate_one_sequence_kv_bytes(
         self, *, max_model_len: int, block_size: int
@@ -766,7 +785,16 @@ class MetalModelRunner:
         for pr in prefill_reqs:
             prefill_info.append((pr.block_ids, len(pr.token_ids), pr.start_pos))
 
-        prepare_unified(decode_info, prefill_info, self._paged_block_size)
+        if self._paged_prep_buffers is None and hasattr(self, "scheduler_config"):
+            # Stub runners bypass __init__ and lack scheduler_config; in that
+            # case prepare_unified will allocate an ad-hoc per-call buffer.
+            self._paged_prep_buffers = self._build_prep_buffers()
+        prepare_unified(
+            decode_info,
+            prefill_info,
+            self._paged_block_size,
+            self._paged_prep_buffers,
+        )
 
         # ---- GDN slot mapping (hybrid models) ----
         if self.is_hybrid:


### PR DESCRIPTION
### Benchmark (sonnet 1024+128, 100 prompts, concurrency 32)

Branch `memory_mlock` caches per-forward-pass MLX views of
`PagedAttentionContext` and pads `block_tables` into a dense
`[num_reqs, max_blocks]` tensor (matching upstream vLLM's pattern).
Eliminates the N-layer redundancy of re-converting the same Python
lists inside every attention wrapper.

| Metric | main | this PR | Change |
|---|---:|---:|---:|
| Benchmark duration (s) | 183.42 | 180.59 | **−1.54%** |
| Output tok/s | 69.79 | 70.88 | **+1.56%** |
| Total tok/s | 621.70 | 631.42 | **+1.56%** |
| Mean TTFT (ms) | 11425.79 | 10990.28 | **−3.81%** |
| Median TTFT (ms) | 6382.78 | 6572.80 | +2.98% |
| P99 TTFT (ms) | 38940.91 | 37294.19 | **−4.23%** |
| Mean TPOT (ms) | 352.34 | 348.94 | **−0.96%** |
| Median TPOT (ms) | 389.12 | 385.51 | **−0.93%** |
| P99 TPOT (ms) | 434.69 | 426.70 | **−1.84%** |
| Mean ITL (ms) | 352.34 | 348.94 | **−0.96%** |
| Median ITL (ms) | 138.17 | 133.41 | **−3.44%** |
| P99 ITL (ms) | 3159.27 | 3164.68 | +0.17% |

Small but consistent improvements across throughput and all TPOT/ITL
percentiles. 

<details>
<summary>Full benchmark output</summary>

**main**

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             32
Request rate configured (RPS):           10.00
Benchmark duration (s):                  183.42
Total input tokens:                      101230
Total generated tokens:                  12800
Request throughput (req/s):              0.55
Output token throughput (tok/s):         69.79
Peak output token throughput (tok/s):    256.00
Peak concurrent requests:                35.00
Total token throughput (tok/s):          621.70
---------------Time to First Token----------------
Mean TTFT (ms):                          11425.79
Median TTFT (ms):                        6382.78
P99 TTFT (ms):                           38940.91
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          352.34
Median TPOT (ms):                        389.12
P99 TPOT (ms):                           434.69
---------------Inter-token Latency----------------
Mean ITL (ms):                           352.34
Median ITL (ms):                         138.17
P99 ITL (ms):                            3159.27
==================================================
```

**this PR (`memory_mlock` @ `b9889dc`)**

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Maximum request concurrency:             32
Request rate configured (RPS):           10.00
Benchmark duration (s):                  180.59
Total input tokens:                      101230
Total generated tokens:                  12800
Request throughput (req/s):              0.55
Output token throughput (tok/s):         70.88
Peak output token throughput (tok/s):    256.00
Peak concurrent requests:                35.00
Total token throughput (tok/s):          631.42
---------------Time to First Token----------------
Mean TTFT (ms):                          10990.28
Median TTFT (ms):                        6572.80
P99 TTFT (ms):                           37294.19
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          348.94
Median TPOT (ms):                        385.51
P99 TPOT (ms):                           426.70
---------------Inter-token Latency----------------
Mean ITL (ms):                           348.94
Median ITL (ms):                         133.41
P99 ITL (ms):                            3164.68
==================================================
```

</details>

<details>
<summary>Benchmark config</summary>

- Model: `Qwen/Qwen3-0.6B`
- Dataset: sonnet (1024 input + 128 output)
- Prompts: 100, rate: 10 RPS, concurrency: 32
- `VLLM_METAL_USE_PAGED_ATTENTION=1`, `VLLM_METAL_MEMORY_FRACTION=0.3`
- Max model len: 2048
- Hardware: Apple M1 Pro · 32 GB unified memory
- Baseline commit: `77c3e1b` (origin/main)
- This PR commit: `b9889dc` on `memory_mlock`

</details>