### PR TITLE
Fix per-layer KV head count in SDPA dispatch

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -4,6 +4,7 @@
 Covers:
 - ``pad_qkv_to_cache_head_dim`` / ``truncate_padded_output`` pure helpers.
 - ``prepare_sdpa_qkv`` branches (K-eq-V fallback, v_norm, YOCO shared_kv).
+- ``sdpa_forward`` propagation of per-layer ``num_kv_heads`` to the kernel.
 
 The ``prepare_sdpa_qkv`` tests use minimal fake attention modules rather
 than real mlx_lm Attention modules so they stay fast and deterministic.
@@ -12,15 +13,19 @@ not here.
 """
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import mlx.core as mx
 import pytest
 
+import vllm_metal.metal_kernel_backend.attention_sdpa as sdpa_mod
 from vllm_metal.metal_kernel_backend.attention_sdpa import (
     pad_qkv_to_cache_head_dim,
     prepare_sdpa_qkv,
+    sdpa_forward,
     truncate_padded_output,
 )
+from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 from vllm_metal.paged_attention_common import PagedAttentionContext
 
 # === Test fixtures (shared shapes) ===
@@ -317,3 +322,71 @@ class TestPrepareSDPAQKV:
                 _N_KV_HEADS,
                 shared_kv=(shared_k, shared_v),
             )
+
+
+class TestSDPAForward:
+    """Tests for ``sdpa_forward`` runtime argument propagation."""
+
+    def test_kernel_receives_per_layer_kv_heads(self) -> None:
+        """Heterogeneous layers must pass their concrete KV-head count.
+
+        Regression guard for Gemma4-style mixed KV layouts: ``sdpa_forward``
+        resolves the layer's actual cache shape from ``kv_heads_per_layer``
+        and must pass that same count to ``paged_attention_primitive``.
+        """
+        actual_kv_heads = 1
+        cache = MetalPagedKVCache(
+            num_layers=2,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+            kv_heads_per_layer=[_N_KV_HEADS, actual_kv_heads],
+            head_dim_per_layer=[_HEAD_DIM, _HEAD_DIM],
+        )
+
+        inner = SimpleNamespace(
+            n_heads=_N_HEADS,
+            n_kv_heads=actual_kv_heads,
+            scale=_HEAD_DIM**-0.5,
+            o_proj=lambda out: out,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        queries = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM))
+        keys = mx.ones((_BATCH, actual_kv_heads, _SEQ_LEN, _HEAD_DIM))
+        values = mx.ones((_BATCH, actual_kv_heads, _SEQ_LEN, _HEAD_DIM))
+        kv_for_sharing = (keys, values)
+
+        captured: dict[str, int] = {}
+
+        class _FakeOps:
+            def paged_attention_primitive(
+                self,
+                _query,
+                _key_cache,
+                _value_cache,
+                num_kv_heads,
+                *_args,
+                **_kwargs,
+            ) -> None:
+                captured["num_kv_heads"] = num_kv_heads
+
+        with (
+            patch.object(
+                sdpa_mod,
+                "prepare_sdpa_qkv",
+                return_value=(queries, keys, values, None, kv_for_sharing),
+            ),
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)),
+            ),
+        ):
+            sdpa_forward(inner, x, ctx, cache, layer_idx=1)
+
+        assert captured["num_kv_heads"] == actual_kv_heads

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -9,6 +9,7 @@ import mlx.core as mx
 import pytest
 
 from tests.stub_runner import make_stub_runner
+from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
 from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 from vllm_metal.paged_attention_backend.mha import (
     MHAPagedAttentionBackend,
@@ -246,3 +247,38 @@ class TestCachePolicyPerLayerBytes:
             NotImplementedError, match="Per-layer KV shapes with hybrid models"
         ):
             runner.build_paged_attention_backend(block_size=self._BLOCK_SIZE)
+
+    def test_turboquant_per_layer_shapes_raise_early(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unsupported TurboQuant + per-layer combos should fail at public APIs."""
+        runner = self._make_runner(
+            num_layers=2,
+            num_kv_heads=4,
+            head_dim=256,
+            kv_heads_per_layer=[4, 2],
+            head_dim_per_layer=[256, 512],
+        )
+        monkeypatch.setattr(
+            "vllm_metal.v1.cache_policy.get_config",
+            lambda: MetalConfig(
+                memory_fraction=AUTO_MEMORY_FRACTION,
+                use_mlx=True,
+                mlx_device="gpu",
+                block_size=self._BLOCK_SIZE,
+                debug=False,
+                turboquant=True,
+            ),
+        )
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Per-layer KV shapes with TurboQuant are not yet implemented",
+        ):
+            runner.validate_paged_attention_support()
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Per-layer KV shapes with TurboQuant are not yet implemented",
+        ):
+            runner.get_kv_cache_spec()

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -502,7 +502,7 @@ def sdpa_forward(
             q_3d,
             kernel_k_cache,
             kernel_v_cache,
-            kv_cache.num_kv_heads,
+            cache_kv_heads,
             inner.scale,
             0.0,  # softcap (0 = disabled)
             block_tables,
@@ -525,7 +525,7 @@ def sdpa_forward(
             q_3d,
             kernel_k_cache,
             kernel_v_cache,
-            kv_cache.num_kv_heads,
+            cache_kv_heads,
             inner.scale,
             0.0,  # softcap (0 = disabled)
             block_tables,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -505,6 +505,10 @@ class ModelCachePolicy:
                 "Per-layer KV shapes with hybrid models require "
                 "SDPA-layer index remapping, which is not yet implemented."
             )
+        if get_config().turboquant:
+            raise NotImplementedError(
+                "Per-layer KV shapes with TurboQuant are not yet implemented."
+            )
 
     def _kv_layer_size_sum(self) -> int:
         """Sum of ``kv_heads × head_dim`` across KV cache layers.


### PR DESCRIPTION
This PR is:
- To pass the layer-specific KV head count to the Metal paged-attention kernel.
- To keep heterogeneous cache layout and kernel indexing consistent.
- To add a regression test for the host→kernel argument contract.

Note: 

`sdpa_forward()` already resolves the correct per-layer KV head count from `kv_cache.kv_heads_per_layer[layer_idx]`, but it was still passing the scalar `kv_cache.num_kv_heads` to `paged_attention_primitive()`.

That is wrong for heterogeneous models such as Gemma4 26B/31B. The Metal kernel uses `num_kv_heads` for grouping and cache stride, so the kernel must receive the current layer's KV head count, not the model-wide scalar default.
