### PR TITLE
Add text-only compatibility mode for multimodal FP8 checkpoints

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@
 ## Multimodal Serve Modes
 
 - `auto`: use native multimodal loading by default, but fall back to the text-only compatibility path for known-incompatible checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
-- `text-only-compat`: force multimodal models onto the text-only path when a checkpoint should still serve text generations but native multimodal loading is not ready.
+- `text-only-compat`: force the text-only compatibility path only for known-safe checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers. Other multimodal checkpoints stay on the native multimodal loader.
 - `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
 
 ## Paged KV vs MLX KV Memory Settings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,12 +8,25 @@
 | `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute (1=yes, 0=no) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_BLOCK_SIZE` | `16` | KV cache block size |
-| `VLLM_METAL_USE_PAGED_ATTENTION` | `0` | Enable experimental paged KV cache |
+| `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
+| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto`, `text-only-compat`, or `multimodal-native` |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |
 | `VLLM_METAL_PREFIX_CACHE` | (unset) | Set to enable prefix caching for shared prompt reuse |
 | `VLLM_METAL_PREFIX_CACHE_FRACTION` | `0.05` | Fraction of MLX working set for prefix cache (0, 1] |
+
+## Multimodal Serve Modes
+
+- `auto`: use native multimodal loading by default, but fall back to the
+  text-only compatibility path for known-incompatible checkpoints such as
+  Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
+- `text-only-compat`: force multimodal models onto the text-only path. This is
+  useful when a checkpoint should still serve text generations but native
+  multimodal loading is not ready.
+- `multimodal-native`: disable the compatibility fallback and keep the native
+  multimodal path active. Use this when validating or developing real
+  multimodal support.
 
 ## Paged KV vs MLX KV Memory Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,15 +18,9 @@
 
 ## Multimodal Serve Modes
 
-- `auto`: use native multimodal loading by default, but fall back to the
-  text-only compatibility path for known-incompatible checkpoints such as
-  Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
-- `text-only-compat`: force multimodal models onto the text-only path. This is
-  useful when a checkpoint should still serve text generations but native
-  multimodal loading is not ready.
-- `multimodal-native`: disable the compatibility fallback and keep the native
-  multimodal path active. Use this when validating or developing real
-  multimodal support.
+- `auto`: use native multimodal loading by default, but fall back to the text-only compatibility path for known-incompatible checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
+- `text-only-compat`: force multimodal models onto the text-only path when a checkpoint should still serve text generations but native multimodal loading is not ready.
+- `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
 
 ## Paged KV vs MLX KV Memory Settings
 
@@ -36,7 +30,7 @@
 
 | `VLLM_METAL_MEMORY_FRACTION` | `VLLM_METAL_USE_PAGED_ATTENTION` | Valid? | Notes |
 |--|--|--|--|
-| `auto` | `0` | Yes | MLX path (default) |
-| `auto` | `1` | Yes | Paged KV path; defaults to 0.9 internally |
+| `auto` | `0` | Yes | MLX path |
+| `auto` | `1` | Yes | Paged KV path (default); defaults to 0.9 internally |
 | `0.7` | `1` | Yes | Paged KV path with explicit memory budget |
 | `0.7` | `0` | No | Explicit fraction without paged KV is invalid |

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -3,11 +3,14 @@
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
+import os
 import sys
 from types import ModuleType
 
 import numpy as np
+import pytest
 
 import vllm_metal.compat as compat
 
@@ -62,6 +65,25 @@ def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):
 
 
 class TestQwen35Fp8CompatPatch:
+    def test_logs_when_mlx_core_is_unavailable(self, monkeypatch) -> None:
+        original_import = builtins.__import__
+        warnings = []
+
+        def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "mlx.core":
+                raise ImportError("missing mlx.core")
+            return original_import(name, globals, locals, fromlist, level)
+
+        def _record_warning(message, *args, **_kwargs):
+            warnings.append(message % args)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        monkeypatch.setattr(compat.logger, "warning", _record_warning)
+
+        compat._patch_mlx_lm_qwen35_fp8_sanitize()
+
+        assert any("mlx.core is unavailable" in warning for warning in warnings)
+
     def test_patches_dense_qwen35_even_when_moe_module_is_missing(
         self, monkeypatch
     ) -> None:
@@ -78,6 +100,62 @@ class TestQwen35Fp8CompatPatch:
 
         assert "language_model.layers.0.linear.weight_scale_inv" not in sanitized
         assert sanitized["language_model.layers.0.linear.weight"].shape == (128, 128)
+
+    def test_dequant_applies_scale_values_by_fp8_block(self, monkeypatch) -> None:
+        _install_fake_qwen35_modules(monkeypatch, include_moe=False)
+
+        weight = np.arange(129 * 130, dtype=np.float32).reshape(129, 130)
+        scale_inv = np.array(
+            [[2.0, 3.0], [5.0, 7.0]],
+            dtype=np.float32,
+        )
+        dequantized = compat._dequantize_qwen35_fp8_weight(
+            weight,
+            scale_inv,
+            sys.modules["mlx.core"],
+        )
+
+        expected = weight.copy()
+        expected[:128, :128] *= 2.0
+        expected[:128, 128:] *= 3.0
+        expected[128:, :128] *= 5.0
+        expected[128:, 128:] *= 7.0
+        assert dequantized.shape == (129, 130)
+        np.testing.assert_allclose(dequantized, expected)
+
+    def test_dequant_real_mlx_fp8_values_when_enabled(self) -> None:
+        if os.environ.get("VLLM_METAL_RUN_REAL_MLX_FP8_TESTS") != "1":
+            pytest.skip("VLLM_METAL_RUN_REAL_MLX_FP8_TESTS=1 not set")
+
+        import mlx.core as mx
+
+        fp8_dtype = getattr(mx, "float8_e4m3fn", None)
+        if fp8_dtype is None:
+            pytest.skip("mlx.core has no float8_e4m3fn dtype")
+
+        weight = mx.array([[1.0, -2.0], [0.5, 4.0]], dtype=mx.float32).astype(fp8_dtype)
+        scale_inv = mx.array([[2.0]], dtype=mx.float32)
+
+        dequantized = compat._dequantize_qwen35_fp8_weight(weight, scale_inv, mx)
+        mx.eval(dequantized)
+
+        np.testing.assert_allclose(
+            np.array(dequantized, dtype=np.float32),
+            np.array([[2.0, -4.0], [1.0, 8.0]], dtype=np.float32),
+        )
+
+    def test_rejects_unexpected_fp8_block_scale_shape(self, monkeypatch) -> None:
+        dense_module, _ = _install_fake_qwen35_modules(monkeypatch, include_moe=False)
+
+        compat._patch_mlx_lm_qwen35_fp8_sanitize()
+
+        with pytest.raises(ValueError, match="128x128 FP8 blocks"):
+            dense_module.Model().sanitize(
+                {
+                    "language_model.layers.0.linear.weight": np.ones((128, 128)),
+                    "language_model.layers.0.linear.weight_scale_inv": np.ones((2, 1)),
+                }
+            )
 
     def test_patches_higher_rank_weights_for_moe(self, monkeypatch) -> None:
         _, moe_module = _install_fake_qwen35_modules(monkeypatch, include_moe=True)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -79,9 +79,7 @@ class TestQwen35Fp8CompatPatch:
         assert "language_model.layers.0.linear.weight_scale_inv" not in sanitized
         assert sanitized["language_model.layers.0.linear.weight"].shape == (128, 128)
 
-    def test_patches_higher_rank_weights_for_moe(
-        self, monkeypatch
-    ) -> None:
+    def test_patches_higher_rank_weights_for_moe(self, monkeypatch) -> None:
         _, moe_module = _install_fake_qwen35_modules(monkeypatch, include_moe=True)
         gate_up_proj_prefix = "language_model.layers.0.mlp.experts.gate_up_proj"
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -83,33 +83,18 @@ class TestQwen35Fp8CompatPatch:
         self, monkeypatch
     ) -> None:
         _, moe_module = _install_fake_qwen35_modules(monkeypatch, include_moe=True)
+        gate_up_proj_prefix = "language_model.layers.0.mlp.experts.gate_up_proj"
 
         compat._patch_mlx_lm_qwen35_fp8_sanitize()
 
         sanitized = moe_module.Model().sanitize(
             {
-                "language_model.layers.0.mlp.experts.gate_up_proj.weight": np.ones(
-                    (2, 256, 128)
-                ),
-                "language_model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv": np.ones(
-                    (2, 2, 1)
-                ),
-                "language_model.layers.0.mlp.experts.gate_up_proj.activation_scale": np.ones(
-                    (2, 2, 1)
-                ),
+                f"{gate_up_proj_prefix}.weight": np.ones((2, 256, 128)),
+                f"{gate_up_proj_prefix}.weight_scale_inv": np.ones((2, 2, 1)),
+                f"{gate_up_proj_prefix}.activation_scale": np.ones((2, 2, 1)),
             }
         )
 
-        assert (
-            "language_model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv"
-            not in sanitized
-        )
-        assert (
-            "language_model.layers.0.mlp.experts.gate_up_proj.activation_scale"
-            not in sanitized
-        )
-        assert sanitized["language_model.layers.0.mlp.experts.gate_up_proj.weight"].shape == (
-            2,
-            256,
-            128,
-        )
+        assert f"{gate_up_proj_prefix}.weight_scale_inv" not in sanitized
+        assert f"{gate_up_proj_prefix}.activation_scale" not in sanitized
+        assert sanitized[f"{gate_up_proj_prefix}.weight"].shape == (2, 256, 128)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for runtime compatibility patches."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from types import ModuleType
+
+import numpy as np
+
+import vllm_metal.compat as compat
+
+
+def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):
+    mlx_pkg = ModuleType("mlx")
+    mlx_core = ModuleType("mlx.core")
+    mlx_core.bfloat16 = np.float32
+    mlx_core.from_fp8 = lambda weight, dtype=None: np.asarray(weight, dtype=np.float32)
+    mlx_core.pad = lambda weight, pad_width: np.pad(weight, pad_width)
+    mlx_pkg.core = mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", mlx_pkg)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+
+    mlx_lm_pkg = ModuleType("mlx_lm")
+    mlx_lm_models = ModuleType("mlx_lm.models")
+    mlx_lm_pkg.models = mlx_lm_models
+    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm_pkg)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", mlx_lm_models)
+
+    dense_module = ModuleType("mlx_lm.models.qwen3_5")
+
+    class DenseModel:
+        def sanitize(self, weights):
+            return dict(weights)
+
+    dense_module.Model = DenseModel
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3_5", dense_module)
+    mlx_lm_models.qwen3_5 = dense_module
+
+    moe_module = None
+    if include_moe:
+        moe_module = ModuleType("mlx_lm.models.qwen3_5_moe")
+
+        class MoeModel:
+            def sanitize(self, weights):
+                return dict(weights)
+
+        moe_module.Model = MoeModel
+        monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3_5_moe", moe_module)
+        mlx_lm_models.qwen3_5_moe = moe_module
+
+    def _fake_find_spec(name: str):
+        if name == "mlx_lm.models.qwen3_5":
+            return object()
+        if name == "mlx_lm.models.qwen3_5_moe":
+            return object() if include_moe else None
+        return None
+
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+    return dense_module, moe_module
+
+
+class TestQwen35Fp8CompatPatch:
+    def test_patches_dense_qwen35_even_when_moe_module_is_missing(
+        self, monkeypatch
+    ) -> None:
+        dense_module, _ = _install_fake_qwen35_modules(monkeypatch, include_moe=False)
+
+        compat._patch_mlx_lm_qwen35_fp8_sanitize()
+
+        sanitized = dense_module.Model().sanitize(
+            {
+                "language_model.layers.0.linear.weight": np.ones((128, 128)),
+                "language_model.layers.0.linear.weight_scale_inv": np.ones((1, 1)),
+            }
+        )
+
+        assert "language_model.layers.0.linear.weight_scale_inv" not in sanitized
+        assert sanitized["language_model.layers.0.linear.weight"].shape == (128, 128)
+
+    def test_patches_higher_rank_weights_for_moe(
+        self, monkeypatch
+    ) -> None:
+        _, moe_module = _install_fake_qwen35_modules(monkeypatch, include_moe=True)
+
+        compat._patch_mlx_lm_qwen35_fp8_sanitize()
+
+        sanitized = moe_module.Model().sanitize(
+            {
+                "language_model.layers.0.mlp.experts.gate_up_proj.weight": np.ones(
+                    (2, 256, 128)
+                ),
+                "language_model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv": np.ones(
+                    (2, 2, 1)
+                ),
+                "language_model.layers.0.mlp.experts.gate_up_proj.activation_scale": np.ones(
+                    (2, 2, 1)
+                ),
+            }
+        )
+
+        assert (
+            "language_model.layers.0.mlp.experts.gate_up_proj.weight_scale_inv"
+            not in sanitized
+        )
+        assert (
+            "language_model.layers.0.mlp.experts.gate_up_proj.activation_scale"
+            not in sanitized
+        )
+        assert sanitized["language_model.layers.0.mlp.experts.gate_up_proj.weight"].shape == (
+            2,
+            256,
+            128,
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,7 @@ class TestMetalConfig:
         assert config.block_size == 16
         assert config.debug is False
         assert config.use_paged_attention is True
+        assert config.multimodal_mode == "auto"
 
     def test_custom_config_from_env(self, monkeypatch) -> None:
         """Test configuration from environment variables."""
@@ -44,6 +45,7 @@ class TestMetalConfig:
         monkeypatch.setenv("VLLM_METAL_BLOCK_SIZE", "32")
         monkeypatch.setenv("VLLM_METAL_DEBUG", "1")
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
 
         config = MetalConfig.from_env()
 
@@ -52,6 +54,7 @@ class TestMetalConfig:
         assert config.mlx_device == "cpu"
         assert config.block_size == 32
         assert config.debug is True
+        assert config.multimodal_mode == "multimodal-native"
 
     def test_get_config_singleton(self) -> None:
         """Test that get_config returns a singleton."""
@@ -147,6 +150,30 @@ class TestMetalConfig:
         assert config.turboquant is False
         assert config.k_quant == "q8_0"
         assert config.v_quant == "q3_0"
+
+    def test_text_only_compat_mode_is_accepted(self) -> None:
+        config = MetalConfig(
+            memory_fraction=AUTO_MEMORY_FRACTION,
+            use_mlx=True,
+            mlx_device="gpu",
+            block_size=16,
+            debug=False,
+            use_paged_attention=True,
+            multimodal_mode="text-only-compat",
+        )
+        assert config.multimodal_mode == "text-only-compat"
+
+    def test_invalid_multimodal_mode_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid VLLM_METAL_MULTIMODAL_MODE"):
+            MetalConfig(
+                memory_fraction=AUTO_MEMORY_FRACTION,
+                use_mlx=True,
+                mlx_device="gpu",
+                block_size=16,
+                debug=False,
+                use_paged_attention=True,
+                multimodal_mode="vlm",  # type: ignore[arg-type]
+            )
 
     def test_turboquant_requires_paged_attention(self) -> None:
         """Test that turboquant=True without paged attention is rejected."""

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -82,6 +82,11 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
 
+    def test_none_hf_config_is_not_forced_in_auto_mode(self) -> None:
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(None)
+        assert result is False
+
 
 class TestNormalizeModelConfig:
     """Tests for normalize_model_config()."""
@@ -160,6 +165,19 @@ class TestNormalizeModelConfig:
         model_config = SimpleNamespace(
             multimodal_config=None,
             hf_config=SimpleNamespace(model_type="gemma4"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is None
+
+    def test_text_only_compat_mode_handles_missing_hf_config(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+
+        model_config = SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=False),
+            hf_config=None,
         )
 
         DefaultModelAdapter().normalize_model_config(model_config)

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -38,6 +38,16 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is True
 
+    def test_qwen36_fp8_conditional_generation_uses_auto_override(self) -> None:
+        hf_config = SimpleNamespace(
+            model_type="qwen3_6",
+            architectures=["Qwen3_6ForConditionalGeneration"],
+            quantization_config={"quant_method": "fp8"},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is True
+
     def test_qwen35_non_fp8_conditional_generation_skips_auto_override(self) -> None:
         hf_config = SimpleNamespace(
             model_type="qwen3_5",
@@ -54,14 +64,31 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
 
-    def test_text_only_compat_mode_forces_text_backbone(self, monkeypatch) -> None:
+    def test_text_only_compat_mode_forces_allowlisted_text_backbone(
+        self, monkeypatch
+    ) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
         reset_config()
 
-        hf_config = SimpleNamespace(model_type="qwen3_vl")
+        hf_config = SimpleNamespace(
+            model_type="qwen3_6",
+            architectures=["Qwen3_6MoeForConditionalGeneration"],
+            quantization_config={"quant_method": "fp8"},
+        )
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is True
+
+    def test_text_only_compat_mode_does_not_force_generic_vlm(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+
+        hf_config = SimpleNamespace(model_type="phi3_v")
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
 
     def test_multimodal_native_mode_disables_auto_override(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
@@ -115,7 +142,7 @@ class TestNormalizeModelConfig:
 
         assert model_config.multimodal_config is None
 
-    def test_text_only_compat_mode_clears_multimodal_for_generic_vlm(
+    def test_text_only_compat_mode_clears_multimodal_for_allowlisted_vlm(
         self, monkeypatch
     ) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
@@ -123,12 +150,30 @@ class TestNormalizeModelConfig:
 
         model_config = SimpleNamespace(
             multimodal_config=SimpleNamespace(language_model_only=False),
-            hf_config=SimpleNamespace(model_type="qwen3_vl"),
+            hf_config=SimpleNamespace(
+                model_type="qwen3_6",
+                architectures=["Qwen3_6ForConditionalGeneration"],
+                quantization_config={"quant_method": "fp8"},
+            ),
         )
 
         DefaultModelAdapter().normalize_model_config(model_config)
 
         assert model_config.multimodal_config is None
+
+    def test_text_only_compat_mode_preserves_generic_vlm(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+
+        sentinel = SimpleNamespace(language_model_only=False)
+        model_config = SimpleNamespace(
+            multimodal_config=sentinel,
+            hf_config=SimpleNamespace(model_type="phi3_v"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is sentinel
 
     def test_preserves_multimodal_config_for_other_models(self) -> None:
         sentinel = SimpleNamespace(language_model_only=False)
@@ -171,18 +216,21 @@ class TestNormalizeModelConfig:
 
         assert model_config.multimodal_config is None
 
-    def test_text_only_compat_mode_handles_missing_hf_config(self, monkeypatch) -> None:
+    def test_text_only_compat_mode_preserves_missing_hf_config(
+        self, monkeypatch
+    ) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
         reset_config()
 
+        sentinel = SimpleNamespace(language_model_only=False)
         model_config = SimpleNamespace(
-            multimodal_config=SimpleNamespace(language_model_only=False),
+            multimodal_config=sentinel,
             hf_config=None,
         )
 
         DefaultModelAdapter().normalize_model_config(model_config)
 
-        assert model_config.multimodal_config is None
+        assert model_config.multimodal_config is sentinel
 
 
 class TestTextModel:

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -5,7 +5,18 @@ from types import SimpleNamespace
 
 import pytest
 
+import vllm_metal.envs as envs
+from vllm_metal.config import reset_config
 from vllm_metal.v1.model_adapter import DefaultModelAdapter
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch):
+    for var in envs.environment_variables:
+        monkeypatch.delenv(var, raising=False)
+    reset_config()
+    yield
+    reset_config()
 
 
 class TestShouldForceTextBackbone:
@@ -17,8 +28,50 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is True
 
-    def test_non_overridden_model_type_is_not_forced(self) -> None:
+    def test_qwen35_fp8_conditional_generation_uses_auto_override(self) -> None:
+        hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            architectures=["Qwen3_5ForConditionalGeneration"],
+            quantization_config={"quant_method": "fp8"},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is True
+
+    def test_qwen35_non_fp8_conditional_generation_skips_auto_override(self) -> None:
+        hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            architectures=["Qwen3_5ForConditionalGeneration"],
+            quantization_config={"quant_method": "mxfp4"},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
+    def test_non_overridden_model_type_is_not_forced_in_auto_mode(self) -> None:
         hf_config = SimpleNamespace(model_type="qwen3_5")
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
+    def test_text_only_compat_mode_forces_text_backbone(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+
+        hf_config = SimpleNamespace(model_type="qwen3_vl")
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is True
+
+    def test_multimodal_native_mode_disables_auto_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+
+        hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            architectures=["Qwen3_5ForConditionalGeneration"],
+            quantization_config={"quant_method": "fp8"},
+        )
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
@@ -43,11 +96,60 @@ class TestNormalizeModelConfig:
 
         assert model_config.multimodal_config is None
 
+    def test_clears_multimodal_config_for_qwen35_fp8_in_auto_mode(self) -> None:
+        model_config = SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=False),
+            hf_config=SimpleNamespace(
+                model_type="qwen3_5",
+                architectures=["Qwen3_5ForConditionalGeneration"],
+                quantization_config={"quant_method": "fp8"},
+            ),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is None
+
+    def test_text_only_compat_mode_clears_multimodal_for_generic_vlm(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+
+        model_config = SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=False),
+            hf_config=SimpleNamespace(model_type="qwen3_vl"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is None
+
     def test_preserves_multimodal_config_for_other_models(self) -> None:
         sentinel = SimpleNamespace(language_model_only=False)
         model_config = SimpleNamespace(
             multimodal_config=sentinel,
             hf_config=SimpleNamespace(model_type="qwen3_vl"),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is sentinel
+
+    def test_multimodal_native_mode_preserves_qwen35_fp8_multimodal_config(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+
+        sentinel = SimpleNamespace(language_model_only=False)
+        model_config = SimpleNamespace(
+            multimodal_config=sentinel,
+            hf_config=SimpleNamespace(
+                model_type="qwen3_5",
+                architectures=["Qwen3_5ForConditionalGeneration"],
+                quantization_config={"quant_method": "fp8"},
+            ),
         )
 
         DefaultModelAdapter().normalize_model_config(model_config)

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -11,11 +11,11 @@ import pytest
 import torch
 
 import vllm_metal.envs as envs
+from tests.stub_runner import make_stub_runner
 from vllm_metal.config import reset_config
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
-from tests.stub_runner import make_stub_runner
 
 _TEXT_MODEL_ARGS = {
     "vocab_size": 32000,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -120,7 +121,7 @@ def _make_lifecycle(
 
 
 class TestModelLifecycle:
-    def test_mlx_lm_compatible_model_path_adapts_indexed_custom_shards(
+    def test_private_mlx_lm_compatible_model_path_adapts_indexed_custom_shards(
         self, tmp_path: Path
     ) -> None:
         model_dir = tmp_path / "model"
@@ -144,7 +145,7 @@ class TestModelLifecycle:
             encoding="utf-8",
         )
 
-        with model_lifecycle.mlx_lm_compatible_model_path(str(model_dir)) as compat:
+        with model_lifecycle._mlx_lm_compatible_model_path(str(model_dir)) as compat:
             compat_path = Path(compat)
 
             assert compat_path != model_dir
@@ -159,14 +160,14 @@ class TestModelLifecycle:
                 "model-00003-of-00003.safetensors",
             ]
 
-    def test_mlx_lm_compatible_model_path_keeps_standard_model_shards(
+    def test_private_mlx_lm_compatible_model_path_keeps_standard_model_shards(
         self, tmp_path: Path
     ) -> None:
         model_dir = tmp_path / "model"
         model_dir.mkdir()
         (model_dir / "model.safetensors").write_text("", encoding="utf-8")
 
-        with model_lifecycle.mlx_lm_compatible_model_path(str(model_dir)) as compat:
+        with model_lifecycle._mlx_lm_compatible_model_path(str(model_dir)) as compat:
             assert compat == str(model_dir)
 
     def test_load_uses_adapter_override_for_text_only_multimodal_model(
@@ -195,6 +196,26 @@ class TestModelLifecycle:
                 hf_config=SimpleNamespace(
                     model_type="qwen3_5",
                     architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is False
+
+    def test_load_uses_adapter_override_for_qwen36_fp8_conditional_generation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _cache_generation_model(monkeypatch, config=_text_config())
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_6",
+                    architectures=["Qwen3_6ForConditionalGeneration"],
                     quantization_config={"quant_method": "fp8"},
                 ),
                 is_multimodal_model=True,
@@ -284,23 +305,64 @@ class TestModelLifecycle:
         assert runner.tokenizer is vlm_tokenizer
         assert runner._is_vlm is True
 
-    def test_load_text_only_compat_mode_forces_generic_vlm_to_text_path(
+    def test_load_text_only_compat_mode_keeps_generic_vlm_native(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
         reset_config()
-        _cache_generation_model(monkeypatch, config=_text_config())
+        _cache_generation_model(
+            monkeypatch,
+            config=SimpleNamespace(text_config=_text_config()),
+            is_vlm=True,
+        )
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
-                hf_config=SimpleNamespace(model_type="qwen3_vl"),
+                hf_config=SimpleNamespace(model_type="phi3_v"),
                 is_multimodal_model=True,
             )
         )
 
         lifecycle.load()
 
-        assert runner._is_vlm is False
+        assert runner._is_vlm is True
+
+    @pytest.mark.slow
+    def test_load_text_only_compat_real_qwen_fp8_checkpoint(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        model_path = os.environ.get("VLLM_METAL_QWEN_FP8_COMPAT_MODEL_PATH")
+        if not model_path:
+            pytest.skip("VLLM_METAL_QWEN_FP8_COMPAT_MODEL_PATH not set")
+        if not Path(model_path).exists():
+            pytest.skip(f"Model path does not exist: {model_path}")
+
+        from transformers import AutoConfig
+
+        from vllm_metal.compat import _patch_mlx_lm_qwen35_fp8_sanitize
+
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+        model_lifecycle.reset_model_cache()
+        _patch_mlx_lm_qwen35_fp8_sanitize()
+
+        hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=False)
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                model=model_path,
+                hf_config=hf_config,
+                is_multimodal_model=True,
+            )
+        )
+        try:
+            lifecycle.load()
+
+            assert runner._is_vlm is False
+            assert runner.model is not None
+            assert int(runner.model_args["vocab_size"]) > 0
+        finally:
+            model_lifecycle.reset_model_cache()
 
     def test_load_extracts_text_model_config_from_cached_model(
         self,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -362,7 +362,12 @@ class TestModelLifecycle:
         monkeypatch.setattr(
             model_lifecycle,
             "_MODEL_CACHE",
-            {"stub-model": (fake_model, object())},
+            {
+                model_lifecycle._generation_cache_key("stub-model", is_vlm=False): (
+                    fake_model,
+                    object(),
+                )
+            },
         )
         lifecycle, runner = _make_lifecycle()
 
@@ -415,7 +420,7 @@ class TestModelLifecycle:
         monkeypatch.setattr(
             model_lifecycle,
             "_MODEL_CACHE",
-            {"stub-model": (fake_model, None)},
+            {model_lifecycle._stt_cache_key("stub-model"): (fake_model, None)},
         )
         monkeypatch.setattr(model_lifecycle, "is_stt_model", lambda _model_name: True)
         lifecycle, runner = _make_lifecycle()

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -394,6 +394,7 @@ class TestModelLifecycle:
                     **_TEXT_MODEL_ARGS,
                 )
             ),
+            is_vlm=True,
         )
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -10,12 +10,12 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from tests.stub_runner import make_stub_runner
 import vllm_metal.envs as envs
 from vllm_metal.config import reset_config
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
+from tests.stub_runner import make_stub_runner
 
 _TEXT_MODEL_ARGS = {
     "vocab_size": 32000,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -3,12 +3,16 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 from tests.stub_runner import make_stub_runner
+import vllm_metal.envs as envs
+from vllm_metal.config import reset_config
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
@@ -20,6 +24,15 @@ _TEXT_MODEL_ARGS = {
     "num_key_value_heads": 8,
     "hidden_size": 4096,
 }
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch):
+    for var in envs.environment_variables:
+        monkeypatch.delenv(var, raising=False)
+    reset_config()
+    yield
+    reset_config()
 
 
 class _BaseSlotTextConfig:
@@ -79,13 +92,15 @@ def _cache_generation_model(
     *,
     config: object,
     tokenizer: object | None = None,
+    is_vlm: bool = False,
 ) -> tuple[object, object]:
     fake_model = SimpleNamespace(config=config)
     fake_tokenizer = object() if tokenizer is None else tokenizer
+    cache_key = model_lifecycle._generation_cache_key("stub-model", is_vlm=is_vlm)
     monkeypatch.setattr(
         model_lifecycle,
         "_MODEL_CACHE",
-        {"stub-model": (fake_model, fake_tokenizer)},
+        {cache_key: (fake_model, fake_tokenizer)},
     )
     return fake_model, fake_tokenizer
 
@@ -105,6 +120,53 @@ def _make_lifecycle(
 
 
 class TestModelLifecycle:
+    def test_mlx_lm_compatible_model_path_adapts_indexed_custom_shards(
+        self, tmp_path: Path
+    ) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        for name in ("config.json", "tokenizer.json", "tokenizer_config.json"):
+            (model_dir / name).write_text("{}", encoding="utf-8")
+
+        for name in ("layers-0.safetensors", "outside.safetensors", "mtp.safetensors"):
+            (model_dir / name).write_text("", encoding="utf-8")
+
+        (model_dir / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "weight_map": {
+                        "a": "outside.safetensors",
+                        "b": "layers-0.safetensors",
+                        "c": "mtp.safetensors",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with model_lifecycle.mlx_lm_compatible_model_path(str(model_dir)) as compat:
+            compat_path = Path(compat)
+
+            assert compat_path != model_dir
+            assert (compat_path / "config.json").is_symlink()
+            assert (compat_path / "tokenizer.json").is_symlink()
+            compat_shards = sorted(p.name for p in compat_path.glob("model*.safetensors"))
+            assert compat_shards == [
+                "model-00001-of-00003.safetensors",
+                "model-00002-of-00003.safetensors",
+                "model-00003-of-00003.safetensors",
+            ]
+
+    def test_mlx_lm_compatible_model_path_keeps_standard_model_shards(
+        self, tmp_path: Path
+    ) -> None:
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "model.safetensors").write_text("", encoding="utf-8")
+
+        with model_lifecycle.mlx_lm_compatible_model_path(str(model_dir)) as compat:
+            assert compat == str(model_dir)
+
     def test_load_uses_adapter_override_for_text_only_multimodal_model(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -113,6 +175,123 @@ class TestModelLifecycle:
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
                 hf_config=SimpleNamespace(model_type="gemma4"),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is False
+
+    def test_load_uses_adapter_override_for_qwen35_fp8_conditional_generation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _cache_generation_model(monkeypatch, config=_text_config())
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is False
+
+    def test_load_multimodal_native_mode_keeps_qwen35_fp8_as_vlm(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+        _cache_generation_model(
+            monkeypatch,
+            config=SimpleNamespace(text_config=_text_config()),
+            is_vlm=True,
+        )
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is True
+
+    def test_generation_cache_separates_text_and_vlm_variants(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        text_model = SimpleNamespace(config=_text_config())
+        text_tokenizer = object()
+        vlm_model = SimpleNamespace(config=SimpleNamespace(text_config=_text_config()))
+        vlm_tokenizer = object()
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_MODEL_CACHE",
+            {
+                model_lifecycle._generation_cache_key("stub-model", is_vlm=False): (
+                    text_model,
+                    text_tokenizer,
+                ),
+                model_lifecycle._generation_cache_key("stub-model", is_vlm=True): (
+                    vlm_model,
+                    vlm_tokenizer,
+                ),
+            },
+        )
+
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(model_type="gemma4"),
+                is_multimodal_model=True,
+            )
+        )
+        lifecycle.load()
+
+        assert runner.model is text_model
+        assert runner.tokenizer is text_tokenizer
+        assert runner._is_vlm is False
+
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+                is_multimodal_model=True,
+            )
+        )
+        lifecycle.load()
+
+        assert runner.model is vlm_model
+        assert runner.tokenizer is vlm_tokenizer
+        assert runner._is_vlm is True
+
+    def test_load_text_only_compat_mode_forces_generic_vlm_to_text_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+        _cache_generation_model(monkeypatch, config=_text_config())
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(model_type="qwen3_vl"),
                 is_multimodal_model=True,
             )
         )

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -150,7 +150,9 @@ class TestModelLifecycle:
             assert compat_path != model_dir
             assert (compat_path / "config.json").is_symlink()
             assert (compat_path / "tokenizer.json").is_symlink()
-            compat_shards = sorted(p.name for p in compat_path.glob("model*.safetensors"))
+            compat_shards = sorted(
+                p.name for p in compat_path.glob("model*.safetensors")
+            )
             assert compat_shards == [
                 "model-00001-of-00003.safetensors",
                 "model-00002-of-00003.safetensors",

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -638,7 +638,7 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
-    def test_check_and_update_config_text_only_compat_forces_generic_vlm(
+    def test_check_and_update_config_text_only_compat_preserves_generic_vlm(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         self._patch_stt_resolution(monkeypatch, is_stt=False)
@@ -646,13 +646,14 @@ class TestMetalPlatform:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
         reset_config()
         try:
+            sentinel = SimpleNamespace(language_model_only=False)
             model_config = SimpleNamespace(
                 model="test-model",
                 disable_cascade_attn=False,
                 tokenizer=None,
                 max_model_len=128,
-                multimodal_config=SimpleNamespace(language_model_only=False),
-                hf_config=SimpleNamespace(model_type="qwen3_vl"),
+                multimodal_config=sentinel,
+                hf_config=SimpleNamespace(model_type="phi3_v"),
             )
             vllm_config = SimpleNamespace(
                 parallel_config=SimpleNamespace(
@@ -674,7 +675,7 @@ class TestMetalPlatform:
 
             MetalPlatform.check_and_update_config(vllm_config)
 
-            assert model_config.multimodal_config is None
+            assert model_config.multimodal_config is sentinel
 
         finally:
             reset_config()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -506,6 +506,50 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
+    def test_check_and_update_config_auto_mode_clears_qwen35_fp8_wrapper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            model_config = SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=128,
+                multimodal_config=SimpleNamespace(language_model_only=False),
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+            )
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=model_config,
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert model_config.multimodal_config is None
+
+        finally:
+            reset_config()
+
     def test_check_and_update_config_preserves_multimodal_for_non_gemma4_model(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -544,6 +588,93 @@ class TestMetalPlatform:
             MetalPlatform.check_and_update_config(vllm_config)
 
             assert model_config.multimodal_config is sentinel
+
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_multimodal_native_preserves_qwen35_fp8(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+        try:
+            sentinel = SimpleNamespace(language_model_only=False)
+            model_config = SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=128,
+                multimodal_config=sentinel,
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+            )
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=model_config,
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert model_config.multimodal_config is sentinel
+
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_text_only_compat_forces_generic_vlm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
+        reset_config()
+        try:
+            model_config = SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=128,
+                multimodal_config=SimpleNamespace(language_model_only=False),
+                hf_config=SimpleNamespace(model_type="qwen3_vl"),
+            )
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    block_size=None, enable_prefix_caching=False
+                ),
+                model_config=model_config,
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert model_config.multimodal_config is None
 
         finally:
             reset_config()

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -1,17 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 """Compatibility patches for vLLM + transformers version mismatches.
 
-Applied once at platform registration time.  Each patch is guarded by
-try/except so it degrades silently if the target module changes.
+Applied once at platform registration time. Optional missing dependencies are
+logged; unexpected runtime errors are allowed to surface so regressions remain
+diagnosable.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
+_QWEN35_FP8_BLOCK_SIZE = 128
 
 
 def apply_compat_patches() -> None:
@@ -102,6 +106,109 @@ def _patch_qwen35_rope_validation() -> None:
         pass
 
 
+def _ceildiv(value: int, divisor: int) -> int:
+    return -(-value // divisor)
+
+
+def _shape_tuple(value: Any) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in getattr(value, "shape", ()))
+
+
+def _validate_qwen35_fp8_block_scale_shape(
+    weight: Any,
+    scale_inv: Any,
+    *,
+    block_size: int = _QWEN35_FP8_BLOCK_SIZE,
+) -> None:
+    """Validate the FP8 scale shape before applying the fixed block layout."""
+    weight_shape = _shape_tuple(weight)
+    if len(weight_shape) < 2:
+        return
+
+    scale_shape = _shape_tuple(scale_inv)
+    leading_shape = weight_shape[:-2]
+    rows, cols = weight_shape[-2:]
+    expected_scale_shape = (
+        *leading_shape,
+        _ceildiv(rows, block_size),
+        _ceildiv(cols, block_size),
+    )
+    if scale_shape == expected_scale_shape:
+        return
+
+    raise ValueError(
+        "Unsupported Qwen3.5/Qwen3.6 FP8 block scale shape: "
+        f"weight shape={weight_shape}, weight_scale_inv shape={scale_shape}, "
+        f"expected {expected_scale_shape} for {block_size}x{block_size} FP8 "
+        "blocks."
+    )
+
+
+def _dequantize_qwen35_fp8_weight(
+    weight: Any,
+    scale_inv: Any,
+    mx: Any,
+    *,
+    block_size: int = _QWEN35_FP8_BLOCK_SIZE,
+) -> Any:
+    _validate_qwen35_fp8_block_scale_shape(
+        weight,
+        scale_inv,
+        block_size=block_size,
+    )
+
+    weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+    if weight.ndim < 2:
+        return weight.astype(mx.bfloat16)
+
+    leading_shape = weight.shape[:-2]
+    rows, cols = weight.shape[-2:]
+    pad_rows = (-rows) % block_size
+    pad_cols = (-cols) % block_size
+    pad_width = [(0, 0)] * len(leading_shape)
+    pad_width.extend(((0, pad_rows), (0, pad_cols)))
+    weight = mx.pad(weight, pad_width)
+    block_rows = (rows + pad_rows) // block_size
+    block_cols = (cols + pad_cols) // block_size
+    weight = weight.reshape(
+        (*leading_shape, block_rows, block_size, block_cols, block_size)
+    )
+    weight = (weight * scale_inv[..., :, None, :, None]).reshape(
+        *leading_shape,
+        rows + pad_rows,
+        cols + pad_cols,
+    )
+    return weight[..., :rows, :cols].astype(mx.bfloat16)
+
+
+def _dequantize_qwen35_fp8_weights(
+    weights: Mapping[str, Any], mx: Any
+) -> Mapping[str, Any]:
+    if not any("weight_scale_inv" in key for key in weights):
+        return weights
+
+    new_weights: dict[str, Any] = {}
+    for key, value in weights.items():
+        if "weight_scale_inv" in key:
+            weight_key = key.replace("_scale_inv", "")
+            if weight_key not in weights:
+                raise ValueError(
+                    "Qwen3.5/Qwen3.6 FP8 checkpoint has "
+                    f"{key!r} but is missing matching weight {weight_key!r}."
+                )
+            weight = weights[weight_key]
+            new_weights[weight_key] = _dequantize_qwen35_fp8_weight(
+                weight,
+                value,
+                mx,
+            )
+        elif "activation_scale" in key:
+            continue
+        elif key not in new_weights:
+            new_weights[key] = value
+    return new_weights
+
+
 def _patch_mlx_lm_qwen35_fp8_sanitize() -> None:
     """Teach mlx_lm's Qwen3.5 loaders to consume local FP8 ``weight_scale_inv``.
 
@@ -120,7 +227,12 @@ def _patch_mlx_lm_qwen35_fp8_sanitize() -> None:
 
     try:
         import mlx.core as mx
-    except Exception:
+    except ImportError as exc:
+        logger.warning(
+            "Could not install mlx_lm Qwen3.5/Qwen3.6 FP8 sanitize "
+            "compatibility patch because mlx.core is unavailable: %s",
+            exc,
+        )
         return
 
     model_modules = []
@@ -129,51 +241,19 @@ def _patch_mlx_lm_qwen35_fp8_sanitize() -> None:
             continue
         try:
             model_modules.append(import_module(module_name))
-        except Exception:
-            continue
+        except ImportError as exc:
+            logger.warning(
+                "Could not import %s while installing mlx_lm Qwen3.5/Qwen3.6 "
+                "FP8 sanitize compatibility patch: %s",
+                module_name,
+                exc,
+            )
     if not model_modules:
+        logger.warning(
+            "Could not install mlx_lm Qwen3.5/Qwen3.6 FP8 sanitize "
+            "compatibility patch: no qwen3_5 model modules found."
+        )
         return
-
-    def _dequantize_qwen35_fp8_weights(weights):
-        if not any("weight_scale_inv" in key for key in weights):
-            return weights
-
-        def _dequant(weight, scale_inv):
-            block_size = 128
-            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
-            if weight.ndim < 2:
-                return weight.astype(mx.bfloat16)
-
-            leading_shape = weight.shape[:-2]
-            rows, cols = weight.shape[-2:]
-            pad_rows = (-rows) % block_size
-            pad_cols = (-cols) % block_size
-            pad_width = [(0, 0)] * len(leading_shape)
-            pad_width.extend(((0, pad_rows), (0, pad_cols)))
-            weight = mx.pad(weight, pad_width)
-            block_rows = (rows + pad_rows) // block_size
-            block_cols = (cols + pad_cols) // block_size
-            weight = weight.reshape(
-                (*leading_shape, block_rows, block_size, block_cols, block_size)
-            )
-            weight = (weight * scale_inv[..., :, None, :, None]).reshape(
-                *leading_shape,
-                rows + pad_rows,
-                cols + pad_cols,
-            )
-            return weight[..., :rows, :cols].astype(mx.bfloat16)
-
-        new_weights = {}
-        for key, value in weights.items():
-            if "weight_scale_inv" in key:
-                weight_key = key.replace("_scale_inv", "")
-                weight = weights[weight_key]
-                new_weights[weight_key] = _dequant(weight, value)
-            elif "activation_scale" in key:
-                continue
-            elif key not in new_weights:
-                new_weights[key] = value
-        return new_weights
 
     def _patch_model_sanitize(model_cls) -> bool:
         sanitize = getattr(model_cls, "sanitize", None)
@@ -183,19 +263,29 @@ def _patch_mlx_lm_qwen35_fp8_sanitize() -> None:
         original_sanitize = sanitize
 
         def _patched_sanitize(self, weights):
-            return original_sanitize(self, _dequantize_qwen35_fp8_weights(weights))
+            return original_sanitize(self, _dequantize_qwen35_fp8_weights(weights, mx))
 
         _patched_sanitize._vllm_metal_qwen35_fp8_patch = True
         model_cls.sanitize = _patched_sanitize
         return True
 
     patched_modules = []
+    unpatchable_modules = []
     for module in model_modules:
         model_cls = getattr(module, "Model", None)
-        if model_cls is not None and _patch_model_sanitize(model_cls):
+        if model_cls is None:
+            unpatchable_modules.append(module.__name__.rsplit(".", maxsplit=1)[-1])
+            continue
+        if _patch_model_sanitize(model_cls):
             patched_modules.append(module.__name__.rsplit(".", maxsplit=1)[-1])
     if patched_modules:
         logger.debug(
             "Patched mlx_lm %s FP8 sanitize compatibility",
             ", ".join(sorted(patched_modules)),
+        )
+    elif unpatchable_modules:
+        logger.warning(
+            "Could not install mlx_lm Qwen3.5/Qwen3.6 FP8 sanitize "
+            "compatibility patch for modules without Model classes: %s",
+            ", ".join(sorted(unpatchable_modules)),
         )

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -21,6 +21,7 @@ def apply_compat_patches() -> None:
         return
     _APPLIED = True
     _patch_qwen35_rope_validation()
+    _patch_mlx_lm_qwen35_fp8_sanitize()
 
 
 def _patch_qwen35_rope_validation() -> None:
@@ -99,3 +100,102 @@ def _patch_qwen35_rope_validation() -> None:
             )
     except (ImportError, AttributeError):
         pass
+
+
+def _patch_mlx_lm_qwen35_fp8_sanitize() -> None:
+    """Teach mlx_lm's Qwen3.5 loaders to consume local FP8 ``weight_scale_inv``.
+
+    Some Qwen3.5/Qwen3.6 local checkpoints store FP8 weights plus
+    ``*_weight_scale_inv`` tensors in HuggingFace-style shards. The installed
+    mlx_lm ``qwen3_5`` loaders do not currently dequantize those tensors during
+    ``sanitize()``, so ``model.load_weights()`` aborts with hundreds of
+    unexpected ``weight_scale_inv`` parameters.
+
+    Patch the top-level model ``sanitize()`` methods to dequantize those FP8
+    tensors before the upstream remapping logic runs. This keeps the workaround
+    narrow to the affected architectures and leaves upstream control flow intact.
+    """
+    from importlib import import_module
+    from importlib.util import find_spec
+
+    try:
+        import mlx.core as mx
+    except Exception:
+        return
+
+    model_modules = []
+    for module_name in ("mlx_lm.models.qwen3_5", "mlx_lm.models.qwen3_5_moe"):
+        if find_spec(module_name) is None:
+            continue
+        try:
+            model_modules.append(import_module(module_name))
+        except Exception:
+            continue
+    if not model_modules:
+        return
+
+    def _dequantize_qwen35_fp8_weights(weights):
+        if not any("weight_scale_inv" in key for key in weights):
+            return weights
+
+        def _dequant(weight, scale_inv):
+            block_size = 128
+            weight = mx.from_fp8(weight, dtype=mx.bfloat16)
+            if weight.ndim < 2:
+                return weight.astype(mx.bfloat16)
+
+            leading_shape = weight.shape[:-2]
+            rows, cols = weight.shape[-2:]
+            pad_rows = (-rows) % block_size
+            pad_cols = (-cols) % block_size
+            pad_width = [(0, 0)] * len(leading_shape)
+            pad_width.extend(((0, pad_rows), (0, pad_cols)))
+            weight = mx.pad(weight, pad_width)
+            block_rows = (rows + pad_rows) // block_size
+            block_cols = (cols + pad_cols) // block_size
+            weight = weight.reshape(
+                (*leading_shape, block_rows, block_size, block_cols, block_size)
+            )
+            weight = (weight * scale_inv[..., :, None, :, None]).reshape(
+                *leading_shape,
+                rows + pad_rows,
+                cols + pad_cols,
+            )
+            return weight[..., :rows, :cols].astype(mx.bfloat16)
+
+        new_weights = {}
+        for key, value in weights.items():
+            if "weight_scale_inv" in key:
+                weight_key = key.replace("_scale_inv", "")
+                weight = weights[weight_key]
+                new_weights[weight_key] = _dequant(weight, value)
+            elif "activation_scale" in key:
+                continue
+            elif key not in new_weights:
+                new_weights[key] = value
+        return new_weights
+
+    def _patch_model_sanitize(model_cls) -> bool:
+        sanitize = getattr(model_cls, "sanitize", None)
+        if sanitize is None or getattr(sanitize, "_vllm_metal_qwen35_fp8_patch", False):
+            return False
+
+        original_sanitize = sanitize
+
+        def _patched_sanitize(self, weights):
+            return original_sanitize(self, _dequantize_qwen35_fp8_weights(weights))
+
+        _patched_sanitize._vllm_metal_qwen35_fp8_patch = True
+        model_cls.sanitize = _patched_sanitize
+        return True
+
+    patched_modules = []
+    for module in model_modules:
+        model_cls = getattr(module, "Model", None)
+        if model_cls is not None and _patch_model_sanitize(model_cls):
+            patched_modules.append(module.__name__.rsplit(".", maxsplit=1)[-1])
+    if patched_modules:
+        logger.debug(
+            "Patched mlx_lm %s FP8 sanitize compatibility",
+            ", ".join(sorted(patched_modules)),
+        )

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -28,6 +28,11 @@ TURBOQUANT_VALID_V_QUANTS: frozenset[str] = frozenset(
     {"q2_0", "q3_0", "q4_0", "q5_0", "q8_0"}
 )
 
+MultimodalMode = Literal["auto", "text-only-compat", "multimodal-native"]
+VALID_MULTIMODAL_MODES: frozenset[MultimodalMode] = frozenset(
+    {"auto", "text-only-compat", "multimodal-native"}
+)
+
 
 @dataclass
 class MetalConfig:
@@ -39,6 +44,7 @@ class MetalConfig:
     block_size: int
     debug: bool
     use_paged_attention: bool = True
+    multimodal_mode: MultimodalMode = "auto"
     turboquant: bool = False  # Enable TurboQuant KV cache compression
     k_quant: str = "q8_0"  # Key quantization type: q8_0, q4_0, int8, uint8, etc.
     v_quant: str = "q3_0"  # Value quantization type: q2_0, q3_0, q4_0, q5_0 (Lloyd-Max)
@@ -66,6 +72,13 @@ class MetalConfig:
                     f"Invalid VLLM_METAL_MEMORY_FRACTION={self.memory_fraction}. "
                     "Must be a finite value in (0, 1] when paged attention is enabled."
                 )
+
+        if self.multimodal_mode not in VALID_MULTIMODAL_MODES:
+            available = ", ".join(sorted(VALID_MULTIMODAL_MODES))
+            raise ValueError(
+                f"Invalid VLLM_METAL_MULTIMODAL_MODE={self.multimodal_mode!r}. "
+                f"Available modes: {available}."
+            )
 
         self._validate_turboquant()
 
@@ -128,6 +141,7 @@ class MetalConfig:
             block_size=block_size,
             debug=envs.VLLM_METAL_DEBUG,
             use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
+            multimodal_mode=envs.VLLM_METAL_MULTIMODAL_MODE,  # type: ignore[arg-type]
         )
 
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -53,7 +53,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the
     #   text-only compatibility path.
-    # - "text-only-compat": force multimodal models onto the text-only path.
+    # - "text-only-compat": force known-safe multimodal checkpoints onto the
+    #   text-only compatibility path.
     # - "multimodal-native": keep native multimodal loading enabled.
     "VLLM_METAL_MULTIMODAL_MODE": lambda: os.getenv(
         "VLLM_METAL_MULTIMODAL_MODE", "auto"

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     VLLM_METAL_BLOCK_SIZE: str = "16"
     VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
+    VLLM_METAL_MULTIMODAL_MODE: str = "auto"
     VLLM_METAL_PREFIX_CACHE: bool = False
     VLLM_METAL_PREFIX_CACHE_FRACTION: str = ""
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
@@ -48,6 +49,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use native Metal paged attention (default True).
     "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
         os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
+    ),
+    # Multimodal serving mode:
+    # - "auto": known-incompatible multimodal checkpoints fall back to the
+    #   text-only compatibility path.
+    # - "text-only-compat": force multimodal models onto the text-only path.
+    # - "multimodal-native": keep native multimodal loading enabled.
+    "VLLM_METAL_MULTIMODAL_MODE": lambda: os.getenv(
+        "VLLM_METAL_MULTIMODAL_MODE", "auto"
     ),
     # Enable content-hash prefix caching (presence-based: set to any
     # value to enable, unset to disable).

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -94,6 +94,9 @@ class DefaultModelAdapter(ModelAdapter):
         mlx_lm's qwen3_5 text loader so FP8 `*_weight_scale_inv` tensors are
         consumed correctly instead of failing inside mlx_vlm.load().
         """
+        if hf_config is None:
+            return False
+
         model_type = getattr(hf_config, "model_type", "")
         if model_type in _TEXT_BACKBONE_OVERRIDE_TYPES:
             return True
@@ -141,7 +144,8 @@ class DefaultModelAdapter(ModelAdapter):
         """
         if model_config.multimodal_config is None:
             return
-        if not self.should_force_text_backbone(model_config.hf_config):
+        hf_config = getattr(model_config, "hf_config", None)
+        if not self.should_force_text_backbone(hf_config):
             return
 
         multimodal_mode = self._multimodal_mode()
@@ -149,7 +153,7 @@ class DefaultModelAdapter(ModelAdapter):
         logger.info(
             "Metal: forcing text-only backbone for model_type=%s "
             "(multimodal_mode=%s, cleared multimodal_config)",
-            model_config.hf_config.model_type,
+            getattr(hf_config, "model_type", "unknown"),
             multimodal_mode,
         )
 

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -71,6 +71,8 @@ _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES: frozenset[str] = frozenset(
     {
         "Qwen3_5ForConditionalGeneration",
         "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_6ForConditionalGeneration",
+        "Qwen3_6MoeForConditionalGeneration",
     }
 )
 
@@ -120,7 +122,8 @@ class DefaultModelAdapter(ModelAdapter):
         Modes:
         - ``multimodal-native``: never force compatibility; keep native VLM
           loading active so multimodal support can be developed/tested.
-        - ``text-only-compat``: force the text-only path for multimodal models.
+        - ``text-only-compat``: force the text-only path only for the
+          known-safe compatibility allowlist.
         - ``auto``: apply the compatibility path only for known-incompatible
           checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 wrappers.
         """
@@ -128,7 +131,7 @@ class DefaultModelAdapter(ModelAdapter):
         if multimodal_mode == "multimodal-native":
             return False
         if multimodal_mode == "text-only-compat":
-            return True
+            return self._matches_auto_text_backbone_override(hf_config)
         return self._matches_auto_text_backbone_override(hf_config)
 
     def normalize_model_config(self, model_config: ModelConfig) -> None:

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -60,50 +60,97 @@ class ModelAdapter(Protocol):
         """Return per-layer sliding window sizes, or None for no enforcement."""
 
 
-# Models that vLLM flags as multimodal but must be loaded via mlx_lm.
+# Models/configs that vLLM flags as multimodal but must be loaded via mlx_lm.
 # gemma4: mlx_vlm forward path produces garbled output vs mlx_lm.
-# Remove once mlx_vlm gemma4 parity is fixed upstream.
 _TEXT_BACKBONE_OVERRIDE_TYPES: frozenset[str] = frozenset({"gemma4"})
+# Qwen3.5/Qwen3.6 conditional-generation wrappers expose a multimodal config,
+# but vllm-metal only serves them in text-only mode. Their FP8 checkpoints ship
+# `*_weight_scale_inv` tensors that the mlx_vlm qwen3_5 loader does not
+# currently sanitize, while mlx_lm's qwen3_5 text loader handles them.
+_TEXT_BACKBONE_OVERRIDE_ARCHITECTURES: frozenset[str] = frozenset(
+    {
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+)
 
 
 class DefaultModelAdapter(ModelAdapter):
     """Default adapter implementation for known model quirks."""
 
-    def should_force_text_backbone(self, hf_config: Any) -> bool:
-        """Return True for models that must load via mlx_lm (Gemma4).
+    def _multimodal_mode(self) -> str:
+        from vllm_metal.config import get_config
 
-        mlx_vlm Gemma4 forward currently produces garbled output; remove this
+        return get_config().multimodal_mode
+
+    def _matches_auto_text_backbone_override(self, hf_config: Any) -> bool:
+        """Return True for known multimodal checkpoints that need mlx_lm.
+
+        Gemma4: mlx_vlm forward currently produces garbled output; remove this
         override once mlx_vlm Gemma4 parity is fixed upstream.
+
+        Qwen3.5/Qwen3.6 conditional-generation wrappers: these configs are
+        marked multimodal even when served text-only. Route them through
+        mlx_lm's qwen3_5 text loader so FP8 `*_weight_scale_inv` tensors are
+        consumed correctly instead of failing inside mlx_vlm.load().
         """
         model_type = getattr(hf_config, "model_type", "")
-        return model_type in _TEXT_BACKBONE_OVERRIDE_TYPES
+        if model_type in _TEXT_BACKBONE_OVERRIDE_TYPES:
+            return True
+
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        if not any(
+            arch in _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES for arch in architectures
+        ):
+            return False
+
+        quantization_config = getattr(hf_config, "quantization_config", None)
+        if isinstance(quantization_config, dict):
+            quant_method = quantization_config.get("quant_method")
+        else:
+            quant_method = getattr(quantization_config, "quant_method", None)
+        return quant_method == "fp8"
+
+    def should_force_text_backbone(self, hf_config: Any) -> bool:
+        """Whether the current serve mode should use the text-only path.
+
+        Modes:
+        - ``multimodal-native``: never force compatibility; keep native VLM
+          loading active so multimodal support can be developed/tested.
+        - ``text-only-compat``: force the text-only path for multimodal models.
+        - ``auto``: apply the compatibility path only for known-incompatible
+          checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 wrappers.
+        """
+        multimodal_mode = self._multimodal_mode()
+        if multimodal_mode == "multimodal-native":
+            return False
+        if multimodal_mode == "text-only-compat":
+            return True
+        return self._matches_auto_text_backbone_override(hf_config)
 
     def normalize_model_config(self, model_config: ModelConfig) -> None:
         """Clear ``multimodal_config`` for models served on the text backbone.
 
-        For model types in :data:`_TEXT_BACKBONE_OVERRIDE_TYPES` the runner
-        executes the language-model forward via mlx_lm, even though the HF
-        config marks the architecture as multimodal. Leaving the engine's
-        ``multimodal_config`` populated triggers eager loading of the
-        multimodal feature extractor at engine startup, which crashes on MLX
-        checkpoints that ship neither ``preprocessor_config.json`` nor a
-        ``feature_extractor`` section in ``processor_config.json`` (e.g.
-        ``mlx-community/gemma-4-31b-8bit``).
-
-        Clearing it here makes ``is_multimodal_model`` ``False`` so the
-        input processor skips that path. The ``should_force_text_backbone``
-        predicate is the single source of truth for which model types apply.
+        When the active serve mode routes a multimodal checkpoint through the
+        text-only compatibility path, leaving ``multimodal_config`` populated
+        causes vLLM to eagerly initialize multimodal processors that the
+        compatibility path intentionally bypasses. Clearing it here makes
+        ``is_multimodal_model`` ``False`` so the input processor skips that
+        setup. The ``should_force_text_backbone`` predicate is the single
+        source of truth for whether the compatibility path applies.
         """
         if model_config.multimodal_config is None:
             return
         if not self.should_force_text_backbone(model_config.hf_config):
             return
 
+        multimodal_mode = self._multimodal_mode()
         model_config.multimodal_config = None
         logger.info(
             "Metal: forcing text-only backbone for model_type=%s "
-            "(cleared multimodal_config)",
+            "(multimodal_mode=%s, cleared multimodal_config)",
             model_config.hf_config.model_type,
+            multimodal_mode,
         )
 
     def resolve_max_head_dim(

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -56,7 +56,7 @@ def _stt_cache_key(model_name: str) -> tuple[str, str]:
 
 
 @contextmanager
-def mlx_lm_compatible_model_path(model_name: str):
+def _mlx_lm_compatible_model_path(model_name: str):
     """Yield a model path compatible with ``mlx_lm.load`` shard discovery.
 
     Some local checkpoints ship valid ``.safetensors`` shards and a
@@ -187,7 +187,7 @@ class ModelLifecycle:
             )
             model, tokenizer = mlx_vlm_load(model_name)
         else:
-            with mlx_lm_compatible_model_path(model_name) as compatible_model_name:
+            with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
                 model, tokenizer = mlx_lm_load(
                     compatible_model_name,
                     tokenizer_config={

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
+import json
+import time
 from collections.abc import Mapping
 from contextlib import contextmanager
-import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from threading import Lock
-import time
 from typing import TYPE_CHECKING, Any
 
 import torch

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-import json
-from contextlib import contextmanager
-import time
 from collections.abc import Mapping
+from contextlib import contextmanager
+import json
 from pathlib import Path
-from threading import Lock
 from tempfile import TemporaryDirectory
+from threading import Lock
+import time
 from typing import TYPE_CHECKING, Any
 
 import torch

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -3,9 +3,13 @@
 
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
 import time
 from collections.abc import Mapping
+from pathlib import Path
 from threading import Lock
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -24,7 +28,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-_MODEL_CACHE: dict[str, tuple[Any, Any]] = {}
+_MODEL_CACHE: dict[tuple[str, str], tuple[Any, Any]] = {}
 _MODEL_CACHE_LOCK = Lock()
 
 
@@ -40,6 +44,83 @@ def reset_model_cache() -> None:
     """
     with _MODEL_CACHE_LOCK:
         _MODEL_CACHE.clear()
+
+
+def _generation_cache_key(model_name: str, *, is_vlm: bool) -> tuple[str, str]:
+    loader = "mlx_vlm" if is_vlm else "mlx_lm"
+    return (model_name, loader)
+
+
+def _stt_cache_key(model_name: str) -> tuple[str, str]:
+    return (model_name, "stt")
+
+
+@contextmanager
+def mlx_lm_compatible_model_path(model_name: str):
+    """Yield a model path compatible with ``mlx_lm.load`` shard discovery.
+
+    Some local checkpoints ship valid ``.safetensors`` shards and a
+    ``model.safetensors.index.json`` file, but use custom shard names such as
+    ``layers-*.safetensors`` or ``outside.safetensors``. ``mlx_lm.load`` only
+    discovers shards whose basename matches ``model*.safetensors``.
+
+    For those checkpoints, create a temporary directory that mirrors the
+    original config/tokenizer files and exposes the indexed shard files via
+    ``model-xxxxx-of-yyyyy.safetensors`` symlinks. The actual weight bytes stay
+    in place; only the filenames are adapted for ``mlx_lm``.
+    """
+    model_path = Path(model_name)
+    if not model_path.is_dir():
+        yield model_name
+        return
+
+    if any(model_path.glob("model*.safetensors")):
+        yield model_name
+        return
+
+    index_path = model_path / "model.safetensors.index.json"
+    if not index_path.is_file():
+        yield model_name
+        return
+
+    with index_path.open("r") as fid:
+        weight_map = json.load(fid).get("weight_map", {})
+
+    shard_names = sorted(
+        {
+            shard_name
+            for shard_name in weight_map.values()
+            if isinstance(shard_name, str) and shard_name.endswith(".safetensors")
+        }
+    )
+    if not shard_names:
+        yield model_name
+        return
+
+    with TemporaryDirectory(prefix="vllm-metal-mlx-lm-") as tmpdir:
+        compat_path = Path(tmpdir)
+
+        for src in model_path.iterdir():
+            if not src.is_file() or src.name.endswith(".safetensors"):
+                continue
+            (compat_path / src.name).symlink_to(src)
+
+        total_shards = len(shard_names)
+        for shard_index, shard_name in enumerate(shard_names, start=1):
+            shard_path = model_path / shard_name
+            compat_name = (
+                "model.safetensors"
+                if total_shards == 1
+                else f"model-{shard_index:05d}-of-{total_shards:05d}.safetensors"
+            )
+            (compat_path / compat_name).symlink_to(shard_path)
+
+        logger.info(
+            "Using mlx_lm shard compatibility view for %s (%d shard files)",
+            model_name,
+            total_shards,
+        )
+        yield str(compat_path)
 
 
 class ModelLifecycle:
@@ -62,9 +143,7 @@ class ModelLifecycle:
         # vLLM model_config shape varies across backends.
         hf_config = getattr(model_config, "hf_config", None)
         is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
-        if hf_config is not None and self._model_adapter.should_force_text_backbone(
-            hf_config
-        ):
+        if self._model_adapter.should_force_text_backbone(hf_config):
             is_vlm = False
 
         model, tokenizer = self._load_generation_model(model_name, is_vlm)
@@ -88,9 +167,10 @@ class ModelLifecycle:
     def _load_generation_model(self, model_name: str, is_vlm: bool) -> tuple[Any, Any]:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
+        cache_key = _generation_cache_key(model_name, is_vlm=is_vlm)
 
         with _MODEL_CACHE_LOCK:
-            cached = _MODEL_CACHE.get(model_name)
+            cached = _MODEL_CACHE.get(cache_key)
         if cached is not None:
             logger.info(
                 "Model loaded from cache in %.3fs: %s",
@@ -107,23 +187,25 @@ class ModelLifecycle:
             )
             model, tokenizer = mlx_vlm_load(model_name)
         else:
-            model, tokenizer = mlx_lm_load(
-                model_name,
-                tokenizer_config={
-                    "trust_remote_code": self._runner.model_config.trust_remote_code
-                },
-            )
+            with mlx_lm_compatible_model_path(model_name) as compatible_model_name:
+                model, tokenizer = mlx_lm_load(
+                    compatible_model_name,
+                    tokenizer_config={
+                        "trust_remote_code": self._runner.model_config.trust_remote_code
+                    },
+                )
 
         with _MODEL_CACHE_LOCK:
-            _MODEL_CACHE[model_name] = (model, tokenizer)
+            _MODEL_CACHE[cache_key] = (model, tokenizer)
         logger.info("Model loaded in %.2fs: %s", time.time() - start_time, model_name)
         return model, tokenizer
 
     def _load_stt(self, model_name: str) -> None:
         start_time = time.time()
+        cache_key = _stt_cache_key(model_name)
 
         with _MODEL_CACHE_LOCK:
-            cached = _MODEL_CACHE.get(model_name)
+            cached = _MODEL_CACHE.get(cache_key)
         if cached is not None:
             model, _ = cached
             load_time = time.time() - start_time
@@ -138,7 +220,7 @@ class ModelLifecycle:
             logger.info("Loading STT model: %s", model_name)
             model = stt_load_model(model_name)
             with _MODEL_CACHE_LOCK:
-                _MODEL_CACHE[model_name] = (model, None)
+                _MODEL_CACHE[cache_key] = (model, None)
             load_time = time.time() - start_time
             logger.info("STT model loaded in %.2fs: %s", load_time, model_name)
 


### PR DESCRIPTION
Summary
- add `VLLM_METAL_MULTIMODAL_MODE` with `auto`, `text-only-compat`, and `multimodal-native`
- route known-incompatible multimodal FP8 checkpoints to the text-only `mlx_lm` path
- add local shard and FP8 sanitize compatibility fixes for Qwen3.5/Qwen3.6 loading
- add tests for config, routing, cache separation, and compat behavior

## Notes
This unblocks text generation for the current Qwen3.6 FP8 checkpoint. Native multimodal input support is still follow-up work.

Related #295 