### PR TITLE
Remove duplicate TurboQuant per-layer KV shapes guard

### DIFF
--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -273,12 +273,12 @@ class TestCachePolicyPerLayerBytes:
 
         with pytest.raises(
             NotImplementedError,
-            match="Per-layer KV shapes with TurboQuant are not yet implemented",
+            match="TurboQuant with per-layer KV shapes is not yet supported",
         ):
             runner.validate_paged_attention_support()
 
         with pytest.raises(
             NotImplementedError,
-            match="Per-layer KV shapes with TurboQuant are not yet implemented",
+            match="TurboQuant with per-layer KV shapes is not yet supported",
         ):
             runner.get_kv_cache_spec()

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -509,10 +509,6 @@ class ModelCachePolicy:
                 "Per-layer KV shapes with hybrid models require "
                 "SDPA-layer index remapping, which is not yet implemented."
             )
-        if get_config().turboquant:
-            raise NotImplementedError(
-                "Per-layer KV shapes with TurboQuant are not yet implemented."
-            )
 
     def _kv_layer_size_sum(self) -> int:
         """Sum of ``kv_heads × head_dim`` across KV cache layers.


### PR DESCRIPTION
#288 and #292 each added the same `if get_config().turboquant` guard to `_require_supported_per_layer_shapes`. The second is unreachable and #292's test matches that dead message, so `pytest` fails on main. Drop the duplicate; point the test at #288's live message.