### PR TITLE
Optimise TurboQuant encode / decode kernels

### DIFF
--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -15,8 +15,9 @@ Sections (all run by default unless noted):
   9. Serve Benchmark           — bf16 vs q8_0 via live vllm serve (opt-in: --serve)
 
 Run:
-    uv run python tests/test_turboquant.py           # sections 0-8
-    uv run python tests/test_turboquant.py --serve   # all sections including 9
+    uv run python tests/test_turboquant.py                # sections 0-8
+    uv run python tests/test_turboquant.py --serve        # all sections including 9
+    uv run python tests/test_turboquant.py --fast-serve   # skip 0-8, one TQ serve run
 """
 
 import gc
@@ -535,6 +536,254 @@ def _scatter_fp16(cache, layer, k, v, slot, head_dim):
     cache.value_caches[layer] = flat_v.reshape(cache.value_caches[layer].shape)
 
 
+def section_metal_encode_parity() -> int:
+    """Fused Metal encode (tq_encode) vs Python encode + scatter.
+
+    Verifies the Metal kernel implements the exact same spec as the Python
+    ``turbo_quant_encode`` → 5-scatter pipeline.  This is the hot-path
+    replacement, so any drift here silently corrupts KV cache state at
+    runtime.  Compares all five caches after a single write pass:
+
+      * ``key_caches``        — int8 quantized K (q8_0)
+      * ``value_caches``      — packed uint8 V (e.g. q3_0 → 3 bytes / 8 vals)
+      * ``key_scale_caches``  — fp16 per-32-elem scale
+      * ``value_scale_caches``— fp16 per-32-elem scale
+      * ``key_zero_caches``   — fp16 per-32-elem zero-point
+
+    Tolerances (calibrated to fp16-hardware rounding noise, since Metal
+    and MLX both do fp16 arithmetic but with slightly different rounding
+    at the LSB when fast-math is in play):
+      * K indices:     ±2 on the int8 grid, ≥95% exact.
+      * K scales:      ``allclose(rtol=1e-3, atol=1e-3)``.
+      * K zero-points: ±1 atol (stored as fp16-rounded integer).
+      * V scales:      ``allclose(rtol=1e-2, atol=1e-3)``.
+      * V packed:      byte-exact not required; dequant cos_sim ≥ 0.999.
+    """
+    sep("Section 3.5: Metal Encode vs Python Encode Parity")
+    ops = get_ops()
+    failures = 0
+
+    np.random.seed(7)
+    num_tokens = 32
+    num_blocks = max(4, (num_tokens + Q_BLOCK_SIZE - 1) // Q_BLOCK_SIZE + 1)
+
+    # Sweep covers (a) every K-quant category: signed 8-bit, unsigned 8-bit,
+    # sub-8-bit {5,4,2}, and (b) the V-bit spectrum {3,4,8}.  Q3_0 V is the
+    # cheap, representative default; the extra V rows on q8_0 K exercise the
+    # V packing path at 4-bit and 8-bit widths.
+    configs = [
+        ("q8_0", "q3_0"),  # signed 8-bit K, 3-bit V
+        ("q8_0", "q4_0"),
+        ("q8_0", "q8_0"),
+        ("uint8", "q3_0"),  # unsigned 8-bit K
+        ("q5_0", "q3_0"),  # sub-8-bit K (5)
+        ("q4_0", "q3_0"),  # sub-8-bit K (4)
+        ("int4", "q3_0"),  # sub-8-bit K (4, alias)
+        ("uint2", "q3_0"),  # sub-8-bit K (2)
+    ]
+
+    for k_quant, v_quant in configs:
+        v_bits = V_QUANT_PARAMS[v_quant]["bits"]
+        k_bits = QUANT_PARAMS[k_quant]["bits"]
+        k_signed = bool(QUANT_PARAMS[k_quant]["signed"])
+        print(
+            f"\n  k_quant={k_quant:5s} (kb={k_bits}, {'signed' if k_signed else 'unsigned'})  "
+            f"v_quant={v_quant} (vb={v_bits})"
+        )
+
+        def _mk_cache(_kq: str = k_quant, _vq: str = v_quant) -> MetalPagedKVCache:
+            return MetalPagedKVCache(
+                num_layers=1,
+                num_kv_heads=Q_NUM_KV_HEADS,
+                head_dim=Q_HEAD_DIM,
+                num_blocks=num_blocks,
+                block_size=Q_BLOCK_SIZE,
+                dtype=mx.float16,
+                turboquant=True,
+                k_quant=_kq,
+                v_quant=_vq,
+            )
+
+        cache_py = _mk_cache()
+        cache_mx = _mk_cache()
+
+        # Deterministic inputs — same K/V fed to both paths.
+        k = mx.array(
+            np.random.randn(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+        )
+        v = mx.array(
+            np.random.randn(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+        )
+        slot_mapping = mx.array(list(range(num_tokens)), dtype=mx.int64)
+        mx.eval(k, v, slot_mapping)
+
+        # ---- Python reference ----
+        (packed_k, k_scale, k_zero), (packed_v, v_scale) = turbo_quant_encode(
+            k, v, k_quant, value_bits=v_bits
+        )
+        mx.eval(packed_k, k_scale, k_zero, packed_v, v_scale)
+        _scatter_tq(
+            cache_py,
+            0,
+            packed_k,
+            k_scale,
+            k_zero,
+            packed_v,
+            v_scale,
+            slot_mapping,
+        )
+        mx.eval(
+            cache_py.key_caches[0],
+            cache_py.value_caches[0],
+            cache_py.key_scale_caches[0],
+            cache_py.value_scale_caches[0],
+            cache_py.key_zero_caches[0],
+        )
+
+        # ---- Fused Metal path ----
+        v_centroids = get_v_centroids(v_bits)
+        (
+            new_k,
+            new_v,
+            new_ks,
+            new_vs,
+            new_kz,
+        ) = ops.tq_encode(
+            k,
+            v,
+            cache_mx.key_caches[0],
+            cache_mx.value_caches[0],
+            cache_mx.key_scale_caches[0],
+            cache_mx.value_scale_caches[0],
+            cache_mx.key_zero_caches[0],
+            slot_mapping,
+            v_centroids,
+            v_bits,
+            k_bits,
+            k_signed,
+        )
+        # Rebind to the primitive's outputs so subsequent reads flow through
+        # the MLX graph (otherwise the reads would hit stale provenance on
+        # the original mx.zeros caches and race the kernel's writes).
+        cache_mx.key_caches[0] = new_k
+        cache_mx.value_caches[0] = new_v
+        cache_mx.key_scale_caches[0] = new_ks
+        cache_mx.value_scale_caches[0] = new_vs
+        cache_mx.key_zero_caches[0] = new_kz
+        mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+        # ---- Compare K indices, allow ±2 on <5% of elements ----
+        # For sub-8-bit K the cache stores packed bytes; unpack to the
+        # underlying index grid before diffing so we measure actual index
+        # drift, not scrambled bit positions.
+        k_cache_py = cache_py.key_caches[0]
+        k_cache_mx = cache_mx.key_caches[0]
+        if k_bits < 8:
+            k_idx_py = unpack_bits(k_cache_py, k_bits, Q_HEAD_DIM)
+            k_idx_mx = unpack_bits(k_cache_mx, k_bits, Q_HEAD_DIM)
+            k_py = np.asarray(k_idx_py.astype(mx.int32))
+            k_mx = np.asarray(k_idx_mx.astype(mx.int32))
+        else:
+            # 8-bit path: one byte == one index (signed cast for q8_0/int8).
+            k_py = np.asarray(k_cache_py.astype(mx.int32))
+            k_mx = np.asarray(k_cache_mx.astype(mx.int32))
+        k_diff = np.abs(k_py - k_mx)
+        k_exact = float((k_diff == 0).mean())
+        k_within_two = float((k_diff <= 2).mean())
+        k_ok = k_exact >= 0.95 and k_within_two == 1.0
+        print(
+            f"    K indices: exact={k_exact * 100:.2f}%  ±2={k_within_two * 100:.2f}%  "
+            f"max|diff|={int(k_diff.max())}  [{'OK' if k_ok else 'FAIL'}]"
+        )
+        if not k_ok:
+            failures += 1
+
+        # ---- Compare K scales / zero_points (fp16) ----
+        k_scale_py = np.asarray(cache_py.key_scale_caches[0].astype(mx.float32))
+        k_scale_mx = np.asarray(cache_mx.key_scale_caches[0].astype(mx.float32))
+        k_scale_ok = np.allclose(k_scale_py, k_scale_mx, rtol=1e-3, atol=1e-3)
+        print(
+            f"    K scales:  max|abs diff|={np.abs(k_scale_py - k_scale_mx).max():.2e}  "
+            f"[{'OK' if k_scale_ok else 'FAIL'}]"
+        )
+        if not k_scale_ok:
+            failures += 1
+
+        k_zp_py = np.asarray(cache_py.key_zero_caches[0].astype(mx.float32))
+        k_zp_mx = np.asarray(cache_mx.key_zero_caches[0].astype(mx.float32))
+        k_zp_diff = np.abs(k_zp_py - k_zp_mx)
+        k_zp_ok = bool((k_zp_diff <= 1.0).all())
+        print(
+            f"    K zero-pt: max|abs diff|={k_zp_diff.max():.2e}  "
+            f"[{'OK' if k_zp_ok else 'FAIL'}]"
+        )
+        if not k_zp_ok:
+            failures += 1
+
+        # ---- Compare V scales ----
+        v_scale_py = np.asarray(cache_py.value_scale_caches[0].astype(mx.float32))
+        v_scale_mx = np.asarray(cache_mx.value_scale_caches[0].astype(mx.float32))
+        v_scale_ok = np.allclose(v_scale_py, v_scale_mx, rtol=1e-2, atol=1e-3)
+        print(
+            f"    V scales:  max|abs diff|={np.abs(v_scale_py - v_scale_mx).max():.2e}  "
+            f"[{'OK' if v_scale_ok else 'FAIL'}]"
+        )
+        if not v_scale_ok:
+            failures += 1
+
+        # ---- Compare dequantized V (FWHT fp32 vs fp16 → boundary flips OK) ----
+        # Unpack V indices from both caches, dequant via centroids, compare.
+        from vllm_metal.metal_kernel_backend.turboquant import lloyd_max_centroids
+
+        centroids, _ = lloyd_max_centroids(v_bits)
+        v_packed_dim = cache_py.value_caches[0].shape[-1]
+        # Only the filled slots are populated; take the first num_tokens.
+        flat_py = cache_py.value_caches[0].reshape(-1, Q_NUM_KV_HEADS, v_packed_dim)[
+            :num_tokens
+        ]
+        flat_mx = cache_mx.value_caches[0].reshape(-1, Q_NUM_KV_HEADS, v_packed_dim)[
+            :num_tokens
+        ]
+        v_idx_py = unpack_bits(flat_py, v_bits, Q_HEAD_DIM)
+        v_idx_mx = unpack_bits(flat_mx, v_bits, Q_HEAD_DIM)
+        # Dequantize: idx → centroid * scale, then inverse FWHT
+        vs_py = cache_py.value_scale_caches[0].reshape(
+            -1, Q_NUM_KV_HEADS, Q_HEAD_DIM // BLOCK_SIZE
+        )[:num_tokens]
+        vs_mx = cache_mx.value_scale_caches[0].reshape(
+            -1, Q_NUM_KV_HEADS, Q_HEAD_DIM // BLOCK_SIZE
+        )[:num_tokens]
+        v_dq_py = (
+            centroids[v_idx_py.astype(mx.int32)].reshape(
+                num_tokens, Q_NUM_KV_HEADS, -1, BLOCK_SIZE
+            )
+            * vs_py[..., None]
+        ).reshape(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM)
+        v_dq_mx = (
+            centroids[v_idx_mx.astype(mx.int32)].reshape(
+                num_tokens, Q_NUM_KV_HEADS, -1, BLOCK_SIZE
+            )
+            * vs_mx[..., None]
+        ).reshape(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM)
+        # Inverse FWHT on both to reconstruct original V
+        v_rec_py = fwht(v_dq_py.astype(mx.float32), encode=False)
+        v_rec_mx = fwht(v_dq_mx.astype(mx.float32), encode=False)
+        mx.eval(v_rec_py, v_rec_mx)
+        cos = cos_sim(v_rec_py, v_rec_mx)
+        v_ok = cos >= 0.999
+        v_byte_exact = float((np.asarray(flat_py) == np.asarray(flat_mx)).mean())
+        print(
+            f"    V packed:  byte-exact={v_byte_exact * 100:.2f}%  "
+            f"dequant cos_sim={cos:.6f}  [{'OK' if v_ok else 'FAIL'}]"
+        )
+        if not v_ok:
+            failures += 1
+
+    if failures == 0:
+        print("\n  All encode-parity checks passed.")
+    return failures
+
+
 def section_metal_e2e() -> int:
     """Cache write → paged attention correctness at multiple sequence lengths."""
     sep("Section 4: Metal E2E Correctness (Qwen3-0.6B shape)")
@@ -907,14 +1156,32 @@ def section_published_comparison() -> int:
 
 
 def section_latency() -> int:
-    """Encode + cache-write overhead per decode token."""
+    """Encode + cache-write overhead per decode token.
+
+    Benchmarks the fused Metal kernel ``ops.tq_encode`` against:
+      * the legacy Python encode + 5-scatter path (for speedup A/B), and
+      * a plain fp16 cache scatter (the uncompressed baseline).
+    The fused kernel is the hot-path substitute wired into
+    ``attention_sdpa.py``; this section is the place to measure its cost.
+    """
     sep("Section 7: Quantization Latency")
+    ops = get_ops()
 
     k = mx.random.normal(shape=(1, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(mx.float16)
     v = mx.random.normal(shape=(1, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(mx.float16)
     mx.eval(k, v)
 
     cache_tq = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=Q_NUM_KV_HEADS,
+        head_dim=Q_HEAD_DIM,
+        num_blocks=10,
+        block_size=Q_BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant="q8_0",
+    )
+    cache_tq_py = MetalPagedKVCache(
         num_layers=1,
         num_kv_heads=Q_NUM_KV_HEADS,
         head_dim=Q_HEAD_DIM,
@@ -934,51 +1201,76 @@ def section_latency() -> int:
         turboquant=False,
     )
     slot = mx.array([0], dtype=mx.int64)
-    mx.eval(slot)
-
-    # Warm up
-    for _ in range(10):
-        kq, vq = turbo_quant_encode(k, v, "q8_0")
-        mx.eval(*kq, *vq)
+    v_centroids = get_v_centroids(cache_tq.v_bits)
+    mx.eval(slot, v_centroids)
 
     n = 200
 
-    # Benchmark encode
-    t0 = time.perf_counter()
-    for _ in range(n):
-        kq, vq = turbo_quant_encode(k, v, "q8_0")
-        mx.eval(*kq, *vq)
-    encode_us = (time.perf_counter() - t0) / n * 1e6
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 1: fused Metal kernel — single dispatch replaces encode + 5
+    # scatters.  This is the production hot path.
+    # ──────────────────────────────────────────────────────────────────────
+    def _run_metal_fused():
+        (
+            new_k,
+            new_v,
+            new_ks,
+            new_vs,
+            new_kz,
+        ) = ops.tq_encode(
+            k,
+            v,
+            cache_tq.key_caches[0],
+            cache_tq.value_caches[0],
+            cache_tq.key_scale_caches[0],
+            cache_tq.value_scale_caches[0],
+            cache_tq.key_zero_caches[0],
+            slot,
+            v_centroids,
+            cache_tq.v_bits,
+            cache_tq.k_bits,
+        )
+        cache_tq.key_caches[0] = new_k
+        cache_tq.value_caches[0] = new_v
+        cache_tq.key_scale_caches[0] = new_ks
+        cache_tq.value_scale_caches[0] = new_vs
+        cache_tq.key_zero_caches[0] = new_kz
+        mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
 
-    # Pre-encode once for write benchmarks
-    (pk, ks, kz), (pv, vs) = turbo_quant_encode(
-        k, v, "q8_0", value_bits=cache_tq.v_bits
-    )
-    mx.eval(pk, ks, kz, pv, vs)
-
-    # Benchmark TQ cache write (scatter 5 arrays)
     for _ in range(10):
-        _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, slot)
-        mx.eval(
-            cache_tq.key_caches[0],
-            cache_tq.value_caches[0],
-            cache_tq.key_scale_caches[0],
-            cache_tq.value_scale_caches[0],
-            cache_tq.key_zero_caches[0],
-        )
+        _run_metal_fused()
     t0 = time.perf_counter()
     for _ in range(n):
-        _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, slot)
-        mx.eval(
-            cache_tq.key_caches[0],
-            cache_tq.value_caches[0],
-            cache_tq.key_scale_caches[0],
-            cache_tq.value_scale_caches[0],
-            cache_tq.key_zero_caches[0],
-        )
-    tq_write_us = (time.perf_counter() - t0) / n * 1e6
+        _run_metal_fused()
+    tq_fused_us = (time.perf_counter() - t0) / n * 1e6
 
-    # Benchmark FP16 cache write (scatter K+V)
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 2: legacy Python encode + 5-scatter path, for reference.
+    # Exactly what the fused kernel replaced.
+    # ──────────────────────────────────────────────────────────────────────
+    def _run_python_path():
+        (pk, ks, kz), (pv, vs) = turbo_quant_encode(
+            k, v, "q8_0", value_bits=cache_tq_py.v_bits
+        )
+        _scatter_tq(cache_tq_py, 0, pk, ks, kz, pv, vs, slot)
+        mx.eval(
+            cache_tq_py.key_caches[0],
+            cache_tq_py.value_caches[0],
+            cache_tq_py.key_scale_caches[0],
+            cache_tq_py.value_scale_caches[0],
+            cache_tq_py.key_zero_caches[0],
+        )
+
+    for _ in range(10):
+        _run_python_path()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _run_python_path()
+    tq_python_us = (time.perf_counter() - t0) / n * 1e6
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 3: FP16 baseline — plain scatter of unquantized K/V.
+    # ──────────────────────────────────────────────────────────────────────
     for _ in range(10):
         _scatter_fp16(cache_fp, 0, k, v, slot, Q_HEAD_DIM)
         mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
@@ -988,16 +1280,126 @@ def section_latency() -> int:
         mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
     fp16_write_us = (time.perf_counter() - t0) / n * 1e6
 
-    overhead_us = encode_us + tq_write_us - fp16_write_us
+    overhead_us = tq_fused_us - fp16_write_us
+    speedup = tq_python_us / tq_fused_us if tq_fused_us > 0 else float("inf")
     tok_budget = 1e6 / 60  # ~16,700 µs at 60 tok/s
     print(f"\n  Single-token ({Q_NUM_KV_HEADS} KV heads, hd={Q_HEAD_DIM}):")
-    print(f"    TQ encode (Python):    {encode_us:>8.1f} µs")
-    print(f"    TQ cache write:        {tq_write_us:>8.1f} µs")
-    print(f"    FP16 cache write:      {fp16_write_us:>8.1f} µs")
+    print(f"    TQ fused Metal kernel:  {tq_fused_us:>8.1f} µs   <-- hot path")
+    print(f"    TQ Python encode+scat:  {tq_python_us:>8.1f} µs   (reference)")
+    print(f"    FP16 cache write:       {fp16_write_us:>8.1f} µs   (baseline)")
+    print(f"    Fused speedup vs Py:    {speedup:>8.2f}x")
     print(
-        f"    TQ overhead:           {overhead_us:>8.1f} µs  "
+        f"    TQ overhead vs fp16:    {overhead_us:>8.1f} µs  "
         f"({overhead_us / tok_budget * 100:.1f}% of 60tok/s budget)"
     )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 4: prefill sweep.
+    #
+    # The single-token number above is almost entirely Metal dispatch
+    # overhead — we only fill `num_kv_heads` threadgroups, nowhere near GPU
+    # saturation.  This sweep pushes the grid size up by ~4 orders of
+    # magnitude so we can see the dispatch-bound → compute-bound transition
+    # and verify that optimizations don't regress large batches.
+    #
+    # For each N we measure:
+    #   * total µs per dispatch (absolute wall time)
+    #   * µs/token (derived throughput — should plateau once compute-bound)
+    #   * the FP16-scatter baseline at the same N for overhead accounting
+    #
+    # Steady-state µs/token ≈ steady-state FP16 µs/token  ⇒  the TQ kernel
+    # is roughly memory-bound at parity with a plain scatter, which is the
+    # best we can hope for given we emit similar byte volume.
+    # ──────────────────────────────────────────────────────────────────────
+    bulk_sizes = [256, 1024, 4096]
+    print(f"\n  Prefill sweep ({Q_NUM_KV_HEADS} KV heads, hd={Q_HEAD_DIM}):")
+    print("    ───────────────────────────────────────────────────────────────────────")
+    print("       N    TQ fused (total / per-tok)    FP16 scatter (total / per-tok)")
+    print("    ───────────────────────────────────────────────────────────────────────")
+    for n_tok in bulk_sizes:
+        blocks_needed = (n_tok + Q_BLOCK_SIZE - 1) // Q_BLOCK_SIZE + 2
+        k_bulk = mx.random.normal(shape=(n_tok, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(
+            mx.float16
+        )
+        v_bulk = mx.random.normal(shape=(n_tok, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(
+            mx.float16
+        )
+        slot_bulk = mx.arange(n_tok, dtype=mx.int64)
+        cache_tq_bulk = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=blocks_needed,
+            block_size=Q_BLOCK_SIZE,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant="q8_0",
+        )
+        cache_fp_bulk = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=blocks_needed,
+            block_size=Q_BLOCK_SIZE,
+            dtype=mx.float16,
+            turboquant=False,
+        )
+        mx.eval(k_bulk, v_bulk, slot_bulk)
+
+        # Fewer iters at large N to keep total bench time reasonable.
+        n_iter = 50 if n_tok <= 1024 else 20
+
+        def _run_tq(kb=k_bulk, vb=v_bulk, sb=slot_bulk, ctb=cache_tq_bulk):
+            (
+                new_k,
+                new_v,
+                new_ks,
+                new_vs,
+                new_kz,
+            ) = ops.tq_encode(
+                kb,
+                vb,
+                ctb.key_caches[0],
+                ctb.value_caches[0],
+                ctb.key_scale_caches[0],
+                ctb.value_scale_caches[0],
+                ctb.key_zero_caches[0],
+                sb,
+                v_centroids,
+                ctb.v_bits,
+                ctb.k_bits,
+            )
+            ctb.key_caches[0] = new_k
+            ctb.value_caches[0] = new_v
+            ctb.key_scale_caches[0] = new_ks
+            ctb.value_scale_caches[0] = new_vs
+            ctb.key_zero_caches[0] = new_kz
+            mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+        def _run_fp(kb=k_bulk, vb=v_bulk, sb=slot_bulk, cfb=cache_fp_bulk):
+            _scatter_fp16(cfb, 0, kb, vb, sb, Q_HEAD_DIM)
+            mx.eval(cfb.key_caches[0], cfb.value_caches[0])
+
+        for _ in range(5):
+            _run_tq()
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            _run_tq()
+        tq_total = (time.perf_counter() - t0) / n_iter * 1e6
+        tq_per_tok = tq_total / n_tok
+
+        for _ in range(5):
+            _run_fp()
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            _run_fp()
+        fp_total = (time.perf_counter() - t0) / n_iter * 1e6
+        fp_per_tok = fp_total / n_tok
+
+        print(
+            f"    {n_tok:>5}    {tq_total:>7.1f} µs / {tq_per_tok:>5.3f} µs    "
+            f"{fp_total:>7.1f} µs / {fp_per_tok:>5.3f} µs"
+        )
     return 0
 
 
@@ -1691,6 +2093,45 @@ def _run_serve_config(label: str, additional_config: dict | None, log_dir: str) 
     return result
 
 
+FAST_SERVE_LABEL = "q8q3"
+FAST_SERVE_CONFIG = {"turboquant": True, "k_quant": "q8_0", "v_quant": "q3_0"}
+
+
+def section_fast_serve() -> int:
+    """Boot a single TurboQuant-enabled vllm serve run — smoke test only.
+
+    Skips parity/memory/latency sections entirely and jumps straight to
+    ``_run_serve_config`` with the production TQ config (q8_0 K, q3_0 V).
+    Intended for quickly verifying that the TQ hot path doesn't crash the
+    engine core on a real request — the exact scenario the eager-tq_encode
+    race used to miss.  Returns non-zero if serve fails to come up or the
+    chat completion errors out.
+    """
+    sep(
+        f"Fast Serve ({FAST_SERVE_LABEL}: k={FAST_SERVE_CONFIG['k_quant']}, "
+        f"v={FAST_SERVE_CONFIG['v_quant']})"
+    )
+    print(f"  Model: {SERVE_MODEL}")
+    log_dir = "/tmp/tq-fast-serve"
+    os.makedirs(log_dir, exist_ok=True)
+
+    result = _run_serve_config(FAST_SERVE_LABEL, FAST_SERVE_CONFIG, log_dir)
+
+    print()
+    sep("Fast Serve Result")
+    if not result["ready"]:
+        print("  FAIL: server never became ready")
+        return 1
+    chat = result.get("chat", {})
+    if not chat.get("ok"):
+        print(f"  FAIL: chat completion errored — {chat.get('error', '?')}")
+        return 1
+    print(
+        f"  OK    tok/s={chat['tok_per_s']:.1f}  peak RSS={result['peak_rss']:.0f} MB"
+    )
+    return 0
+
+
 def section_serve_benchmark() -> int:
     """Compare bf16 against the TQ (k_quant, v_quant) sweep via live vllm serve."""
     tq_labels = ", ".join(label for label, cfg in SERVE_CONFIGS if cfg is not None)
@@ -1735,16 +2176,31 @@ def section_serve_benchmark() -> int:
 
 def main() -> int:
     run_serve = "--serve" in sys.argv
+    run_fast_serve = "--fast-serve" in sys.argv
 
     print("╔══════════════════════════════════════════════════════════════════════╗")
     print("║         TurboQuant KV Cache — Comprehensive Test Suite              ║")
     print("╚══════════════════════════════════════════════════════════════════════╝")
+
+    # --fast-serve bypasses the entire parity/memory/latency battery and
+    # jumps straight to a single TQ-enabled live serve run.  Useful for
+    # verifying the TQ hot path survives a real request without waiting
+    # through the full ~1-minute test suite.
+    if run_fast_serve:
+        rc = section_fast_serve()
+        sep("DONE")
+        if rc:
+            print("  fast-serve FAILED.\n")
+        else:
+            print("  fast-serve OK.\n")
+        return rc
 
     failures = 0
     failures += section_quant_type_validation()
     failures += section_pack_unpack_roundtrip()
     failures += section_python_roundtrip_mse()
     failures += section_metal_kernel_dequant()
+    failures += section_metal_encode_parity()
     failures += section_metal_e2e()
     failures += section_memory_capacity()
     failures += section_published_comparison()
@@ -2007,6 +2463,111 @@ def test_turboquant_512_head_dim_matches_python_reference() -> None:
     assert relative_error_percent < 5.0
 
 
+def test_tq_encode_kernel_supports_head_dim_512() -> None:
+    """The fused ``ops.tq_encode`` Metal kernel must accept head_dim=512.
+
+    Regression for the kernel-side 512 gap: ``MetalPagedKVCache`` and the
+    decode kernel already supported 512-dim, but the fused encode primitive
+    only had instantiations for {64, 128, 256} and rejected 512 with a
+    runtime guard — breaking Gemma-style models with full-attn head_dim=512
+    on the first forward pass after the Python encode fallback was removed.
+
+    This test goes through ``ops.tq_encode`` directly (not the Python
+    ``_fill_cache`` path used by ``test_turboquant_512_head_dim_matches_
+    python_reference``) and verifies its outputs match the Python encode.
+    """
+    head_dim = 512
+    num_tokens = 16
+    num_kv_heads = 2
+    num_blocks = 4
+    block_size = 16
+    k_quant, v_quant = "q8_0", "q3_0"
+    k_bits = QUANT_PARAMS[k_quant]["bits"]
+    v_bits = V_QUANT_PARAMS[v_quant]["bits"]
+    k_signed = bool(QUANT_PARAMS[k_quant]["signed"])
+
+    cache = MetalPagedKVCache(
+        num_layers=1,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+
+    np.random.seed(512)
+    k = mx.array(np.random.randn(num_tokens, num_kv_heads, head_dim).astype(np.float16))
+    v = mx.array(np.random.randn(num_tokens, num_kv_heads, head_dim).astype(np.float16))
+    slot_mapping = mx.array(list(range(num_tokens)), dtype=mx.int64)
+    mx.eval(k, v, slot_mapping)
+
+    ops = get_ops()
+    v_centroids = get_v_centroids(v_bits)
+    new_k, new_v, new_ks, new_vs, new_kz = ops.tq_encode(
+        k,
+        v,
+        cache.key_caches[0],
+        cache.value_caches[0],
+        cache.key_scale_caches[0],
+        cache.value_scale_caches[0],
+        cache.key_zero_caches[0],
+        slot_mapping,
+        v_centroids,
+        v_bits,
+        k_bits,
+        k_signed,
+    )
+    mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+    (
+        (packed_k_ref, k_scale_ref, k_zero_ref),
+        (
+            packed_v_ref,
+            v_scale_ref,
+        ),
+    ) = turbo_quant_encode(k, v, k_quant, value_bits=v_bits)
+    mx.eval(packed_k_ref, k_scale_ref, k_zero_ref, packed_v_ref, v_scale_ref)
+
+    # K indices: ±2 on the int8 grid, ≥95% exact (same tolerance the
+    # encode-parity sweep uses for the 128-dim case).
+    flat_k_kernel = new_k.reshape(-1, num_kv_heads, head_dim)[:num_tokens]
+    k_kernel = np.asarray(flat_k_kernel.astype(mx.int32))
+    k_ref = np.asarray(packed_k_ref.astype(mx.int32))
+    k_diff = np.abs(k_kernel - k_ref)
+    assert (k_diff <= 2).all(), f"K indices drift > 2: max={int(k_diff.max())}"
+    assert (k_diff == 0).mean() >= 0.99, (
+        f"K exact-match rate {(k_diff == 0).mean():.4f} below 0.99"
+    )
+
+    # K scales / zero-points (fp16).
+    scale_groups = head_dim // BLOCK_SIZE
+    flat_ks = new_ks.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    flat_kz = new_kz.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    assert np.allclose(
+        np.asarray(flat_ks.astype(mx.float32)),
+        np.asarray(k_scale_ref.astype(mx.float32)),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+    kz_diff = np.abs(
+        np.asarray(flat_kz.astype(mx.float32))
+        - np.asarray(k_zero_ref.astype(mx.float32))
+    )
+    assert (kz_diff <= 1.0).all(), f"K zero-point drift > 1: max={kz_diff.max():.2e}"
+
+    # V scales (fp16).
+    flat_vs = new_vs.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    assert np.allclose(
+        np.asarray(flat_vs.astype(mx.float32)),
+        np.asarray(v_scale_ref.astype(mx.float32)),
+        rtol=1e-2,
+        atol=1e-3,
+    )
+
+
 def test_turboquant_per_layer_shapes_raise_early() -> None:
     """TurboQuant must keep rejecting per-layer KV shapes until PR2 lands."""
     reset_config()
@@ -2192,6 +2753,157 @@ def test_tq_spec_merge_rejects_mixed_quant():
     )
     with pytest.raises(AssertionError, match="same .k_quant, v_quant."):
         TurboQuantAttentionSpec.merge([a, b])
+
+
+@pytest.mark.parametrize(
+    "head_dim,k_quant,v_bits",
+    [
+        (64, "q8_0", 3),
+        (128, "q8_0", 3),
+        (128, "q4_0", 3),
+        (128, "q8_0", 4),
+        (256, "q8_0", 3),
+        (512, "q8_0", 3),
+    ],
+    ids=[
+        "hs64-q80-v3",
+        "hs128-q80-v3",
+        "hs128-q40-v3",
+        "hs128-q80-v4",
+        "hs256-q80-v3",
+        "hs512-q80-v3",
+    ],
+)
+def test_metal_encode_python_decode_roundtrip(
+    head_dim: int, k_quant: str, v_bits: int
+) -> None:
+    """End-to-end: Metal `ops.tq_encode` → Python `turbo_quant_decode` → fp16 K/V.
+
+    The encode-parity test (`test_tq_encode_kernel_supports_head_dim_512` and
+    `section_metal_encode_parity`) only checks that the Metal kernel produces
+    the same packed bytes as Python `turbo_quant_encode`.  That's necessary
+    but not sufficient: a bug in the bit-packing layout, scale-group stride,
+    or signed-vs-unsigned interpretation could produce parity-matching but
+    semantically wrong cache contents that decode to garbage.
+
+    This test goes the other direction: feed random fp16 K/V through the
+    Metal encode kernel, then read the packed cache bytes and dequantise
+    via the Python decode helpers (which the production decode kernel
+    must agree with by parity guarantees).  If the round-trip K/V have
+    abnormally high error vs the original, the bug is in the Metal encode
+    layout regardless of which path consumes it.
+
+    Tolerances are calibrated from the published quantisation MSE numbers:
+    q8_0 K → MSE ≲ 4e-4, 3-bit V → cos_sim ≥ 0.97.  4-bit V is tighter
+    (≥ 0.99); we use the same threshold across V widths since the centroid
+    table compensates.
+    """
+    num_tokens = 16
+    num_kv_heads = 2
+    num_blocks = 4
+    block_size = 16
+    k_bits = QUANT_PARAMS[k_quant]["bits"]
+    k_signed = bool(QUANT_PARAMS[k_quant]["signed"])
+
+    # The cache infra requires v_quant to be a registered name; pick the one
+    # that matches v_bits.  We only run the kernel through `ops.tq_encode`
+    # which takes v_bits directly, so the cache's v_quant is just for shape.
+    v_quant = {3: "q3_0", 4: "q4_0", 8: "uint8"}.get(v_bits, "q3_0")
+
+    cache = MetalPagedKVCache(
+        num_layers=1,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+
+    np.random.seed(hash((head_dim, k_quant, v_bits)) & 0xFFFF)
+    k = mx.array(np.random.randn(num_tokens, num_kv_heads, head_dim).astype(np.float16))
+    v = mx.array(np.random.randn(num_tokens, num_kv_heads, head_dim).astype(np.float16))
+    slot_mapping = mx.array(list(range(num_tokens)), dtype=mx.int64)
+    mx.eval(k, v, slot_mapping)
+
+    # ---- Metal encode ----
+    ops = get_ops()
+    v_centroids = get_v_centroids(v_bits)
+    new_k, new_v, new_ks, new_vs, new_kz = ops.tq_encode(
+        k,
+        v,
+        cache.key_caches[0],
+        cache.value_caches[0],
+        cache.key_scale_caches[0],
+        cache.value_scale_caches[0],
+        cache.key_zero_caches[0],
+        slot_mapping,
+        v_centroids,
+        v_bits,
+        k_bits,
+        k_signed,
+    )
+    mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+    # ---- Slice the populated rows out of the paged cache ----
+    scale_groups = head_dim // BLOCK_SIZE
+    k_packed_dim = cache.k_packed_dim
+    v_packed_dim = cache.v_packed_dim
+
+    k_pkt = new_k.reshape(-1, num_kv_heads, k_packed_dim)[:num_tokens]
+    v_pkt = new_v.reshape(-1, num_kv_heads, v_packed_dim)[:num_tokens]
+    ks_pkt = new_ks.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    vs_pkt = new_vs.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    kz_pkt = new_kz.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    mx.eval(k_pkt, v_pkt, ks_pkt, vs_pkt, kz_pkt)
+
+    # ---- Python decode on Metal-encoded bytes ----
+    k_hat, v_hat = turbo_quant_decode(
+        (k_pkt, ks_pkt, kz_pkt),
+        (v_pkt, vs_pkt),
+        output_dtype=mx.float16,
+        key_quant_type=k_quant,
+        value_bits=v_bits,
+    )
+    mx.eval(k_hat, v_hat)
+
+    # ---- Compare to original ----
+    k_mse = mx.mean((k.astype(mx.float32) - k_hat.astype(mx.float32)) ** 2).item()
+    v_mse = mx.mean((v.astype(mx.float32) - v_hat.astype(mx.float32)) ** 2).item()
+    k_cos = cos_sim(k, k_hat)
+    v_cos = cos_sim(v, v_hat)
+
+    # K tolerance: q8_0 random-input MSE ≈ 1e-4, q4_0 ≈ 5e-3 to 1e-2.  We
+    # set thresholds at ~5x the typical observed value so a bit-layout bug
+    # (which would give MSE ≥ 0.1, often ≥ 0.5) trips the assertion while
+    # benign quant noise doesn't.
+    k_mse_threshold = 1e-3 if k_bits >= 8 else (3e-2 if k_bits >= 4 else 1e-1)
+    assert k_mse < k_mse_threshold, (
+        f"K roundtrip MSE {k_mse:.6f} ≥ {k_mse_threshold} "
+        f"(k_quant={k_quant}, head_dim={head_dim}) — Metal encode bytes do "
+        f"not decode back to the input via Python; suspect bit-packing or "
+        f"scale-group layout mismatch."
+    )
+    assert k_cos >= 0.99, (
+        f"K roundtrip cos_sim {k_cos:.4f} < 0.99 "
+        f"(k_quant={k_quant}, head_dim={head_dim})"
+    )
+
+    # V tolerance: 3-bit FWHT+Lloyd-Max gives cos_sim ≥ 0.97 typically.
+    v_cos_threshold = 0.95 if v_bits <= 3 else 0.98
+    assert v_cos >= v_cos_threshold, (
+        f"V roundtrip cos_sim {v_cos:.4f} < {v_cos_threshold} "
+        f"(v_bits={v_bits}, head_dim={head_dim}) — Metal V encode bytes do "
+        f"not decode back to the input via Python; suspect FWHT sign-table "
+        f"mismatch, centroid lookup, or sub-8-bit packing layout."
+    )
+    # V MSE is bounded loosely by 1.0 (3-bit is intrinsically lossy);
+    # finite + reasonable is the real check.
+    assert math.isfinite(v_mse) and v_mse < 2.0, (
+        f"V roundtrip MSE {v_mse} not finite/reasonable"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -15,8 +15,9 @@ Sections (all run by default unless noted):
   9. Serve Benchmark           — bf16 vs q8_0 via live vllm serve (opt-in: --serve)
 
 Run:
-    uv run python tests/test_turboquant.py           # sections 0-8
-    uv run python tests/test_turboquant.py --serve   # all sections including 9
+    uv run python tests/test_turboquant.py                # sections 0-8
+    uv run python tests/test_turboquant.py --serve        # all sections including 9
+    uv run python tests/test_turboquant.py --fast-serve   # skip 0-8, one TQ serve run
 """
 
 import gc
@@ -535,6 +536,254 @@ def _scatter_fp16(cache, layer, k, v, slot, head_dim):
     cache.value_caches[layer] = flat_v.reshape(cache.value_caches[layer].shape)
 
 
+def section_metal_encode_parity() -> int:
+    """Fused Metal encode (tq_encode) vs Python encode + scatter.
+
+    Verifies the Metal kernel implements the exact same spec as the Python
+    ``turbo_quant_encode`` → 5-scatter pipeline.  This is the hot-path
+    replacement, so any drift here silently corrupts KV cache state at
+    runtime.  Compares all five caches after a single write pass:
+
+      * ``key_caches``        — int8 quantized K (q8_0)
+      * ``value_caches``      — packed uint8 V (e.g. q3_0 → 3 bytes / 8 vals)
+      * ``key_scale_caches``  — fp16 per-32-elem scale
+      * ``value_scale_caches``— fp16 per-32-elem scale
+      * ``key_zero_caches``   — fp16 per-32-elem zero-point
+
+    Tolerances (calibrated to fp16-hardware rounding noise, since Metal
+    and MLX both do fp16 arithmetic but with slightly different rounding
+    at the LSB when fast-math is in play):
+      * K indices:     ±2 on the int8 grid, ≥95% exact.
+      * K scales:      ``allclose(rtol=1e-3, atol=1e-3)``.
+      * K zero-points: ±1 atol (stored as fp16-rounded integer).
+      * V scales:      ``allclose(rtol=1e-2, atol=1e-3)``.
+      * V packed:      byte-exact not required; dequant cos_sim ≥ 0.999.
+    """
+    sep("Section 3.5: Metal Encode vs Python Encode Parity")
+    ops = get_ops()
+    failures = 0
+
+    np.random.seed(7)
+    num_tokens = 32
+    num_blocks = max(4, (num_tokens + Q_BLOCK_SIZE - 1) // Q_BLOCK_SIZE + 1)
+
+    # Sweep covers (a) every K-quant category: signed 8-bit, unsigned 8-bit,
+    # sub-8-bit {5,4,2}, and (b) the V-bit spectrum {3,4,8}.  Q3_0 V is the
+    # cheap, representative default; the extra V rows on q8_0 K exercise the
+    # V packing path at 4-bit and 8-bit widths.
+    configs = [
+        ("q8_0", "q3_0"),  # signed 8-bit K, 3-bit V
+        ("q8_0", "q4_0"),
+        ("q8_0", "q8_0"),
+        ("uint8", "q3_0"),  # unsigned 8-bit K
+        ("q5_0", "q3_0"),  # sub-8-bit K (5)
+        ("q4_0", "q3_0"),  # sub-8-bit K (4)
+        ("int4", "q3_0"),  # sub-8-bit K (4, alias)
+        ("uint2", "q3_0"),  # sub-8-bit K (2)
+    ]
+
+    for k_quant, v_quant in configs:
+        v_bits = V_QUANT_PARAMS[v_quant]["bits"]
+        k_bits = QUANT_PARAMS[k_quant]["bits"]
+        k_signed = bool(QUANT_PARAMS[k_quant]["signed"])
+        print(
+            f"\n  k_quant={k_quant:5s} (kb={k_bits}, {'signed' if k_signed else 'unsigned'})  "
+            f"v_quant={v_quant} (vb={v_bits})"
+        )
+
+        def _mk_cache(_kq: str = k_quant, _vq: str = v_quant) -> MetalPagedKVCache:
+            return MetalPagedKVCache(
+                num_layers=1,
+                num_kv_heads=Q_NUM_KV_HEADS,
+                head_dim=Q_HEAD_DIM,
+                num_blocks=num_blocks,
+                block_size=Q_BLOCK_SIZE,
+                dtype=mx.float16,
+                turboquant=True,
+                k_quant=_kq,
+                v_quant=_vq,
+            )
+
+        cache_py = _mk_cache()
+        cache_mx = _mk_cache()
+
+        # Deterministic inputs — same K/V fed to both paths.
+        k = mx.array(
+            np.random.randn(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+        )
+        v = mx.array(
+            np.random.randn(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM).astype(np.float16)
+        )
+        slot_mapping = mx.array(list(range(num_tokens)), dtype=mx.int64)
+        mx.eval(k, v, slot_mapping)
+
+        # ---- Python reference ----
+        (packed_k, k_scale, k_zero), (packed_v, v_scale) = turbo_quant_encode(
+            k, v, k_quant, value_bits=v_bits
+        )
+        mx.eval(packed_k, k_scale, k_zero, packed_v, v_scale)
+        _scatter_tq(
+            cache_py,
+            0,
+            packed_k,
+            k_scale,
+            k_zero,
+            packed_v,
+            v_scale,
+            slot_mapping,
+        )
+        mx.eval(
+            cache_py.key_caches[0],
+            cache_py.value_caches[0],
+            cache_py.key_scale_caches[0],
+            cache_py.value_scale_caches[0],
+            cache_py.key_zero_caches[0],
+        )
+
+        # ---- Fused Metal path ----
+        v_centroids = get_v_centroids(v_bits)
+        (
+            new_k,
+            new_v,
+            new_ks,
+            new_vs,
+            new_kz,
+        ) = ops.tq_encode(
+            k,
+            v,
+            cache_mx.key_caches[0],
+            cache_mx.value_caches[0],
+            cache_mx.key_scale_caches[0],
+            cache_mx.value_scale_caches[0],
+            cache_mx.key_zero_caches[0],
+            slot_mapping,
+            v_centroids,
+            v_bits,
+            k_bits,
+            k_signed,
+        )
+        # Rebind to the primitive's outputs so subsequent reads flow through
+        # the MLX graph (otherwise the reads would hit stale provenance on
+        # the original mx.zeros caches and race the kernel's writes).
+        cache_mx.key_caches[0] = new_k
+        cache_mx.value_caches[0] = new_v
+        cache_mx.key_scale_caches[0] = new_ks
+        cache_mx.value_scale_caches[0] = new_vs
+        cache_mx.key_zero_caches[0] = new_kz
+        mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+        # ---- Compare K indices, allow ±2 on <5% of elements ----
+        # For sub-8-bit K the cache stores packed bytes; unpack to the
+        # underlying index grid before diffing so we measure actual index
+        # drift, not scrambled bit positions.
+        k_cache_py = cache_py.key_caches[0]
+        k_cache_mx = cache_mx.key_caches[0]
+        if k_bits < 8:
+            k_idx_py = unpack_bits(k_cache_py, k_bits, Q_HEAD_DIM)
+            k_idx_mx = unpack_bits(k_cache_mx, k_bits, Q_HEAD_DIM)
+            k_py = np.asarray(k_idx_py.astype(mx.int32))
+            k_mx = np.asarray(k_idx_mx.astype(mx.int32))
+        else:
+            # 8-bit path: one byte == one index (signed cast for q8_0/int8).
+            k_py = np.asarray(k_cache_py.astype(mx.int32))
+            k_mx = np.asarray(k_cache_mx.astype(mx.int32))
+        k_diff = np.abs(k_py - k_mx)
+        k_exact = float((k_diff == 0).mean())
+        k_within_two = float((k_diff <= 2).mean())
+        k_ok = k_exact >= 0.95 and k_within_two == 1.0
+        print(
+            f"    K indices: exact={k_exact * 100:.2f}%  ±2={k_within_two * 100:.2f}%  "
+            f"max|diff|={int(k_diff.max())}  [{'OK' if k_ok else 'FAIL'}]"
+        )
+        if not k_ok:
+            failures += 1
+
+        # ---- Compare K scales / zero_points (fp16) ----
+        k_scale_py = np.asarray(cache_py.key_scale_caches[0].astype(mx.float32))
+        k_scale_mx = np.asarray(cache_mx.key_scale_caches[0].astype(mx.float32))
+        k_scale_ok = np.allclose(k_scale_py, k_scale_mx, rtol=1e-3, atol=1e-3)
+        print(
+            f"    K scales:  max|abs diff|={np.abs(k_scale_py - k_scale_mx).max():.2e}  "
+            f"[{'OK' if k_scale_ok else 'FAIL'}]"
+        )
+        if not k_scale_ok:
+            failures += 1
+
+        k_zp_py = np.asarray(cache_py.key_zero_caches[0].astype(mx.float32))
+        k_zp_mx = np.asarray(cache_mx.key_zero_caches[0].astype(mx.float32))
+        k_zp_diff = np.abs(k_zp_py - k_zp_mx)
+        k_zp_ok = bool((k_zp_diff <= 1.0).all())
+        print(
+            f"    K zero-pt: max|abs diff|={k_zp_diff.max():.2e}  "
+            f"[{'OK' if k_zp_ok else 'FAIL'}]"
+        )
+        if not k_zp_ok:
+            failures += 1
+
+        # ---- Compare V scales ----
+        v_scale_py = np.asarray(cache_py.value_scale_caches[0].astype(mx.float32))
+        v_scale_mx = np.asarray(cache_mx.value_scale_caches[0].astype(mx.float32))
+        v_scale_ok = np.allclose(v_scale_py, v_scale_mx, rtol=1e-2, atol=1e-3)
+        print(
+            f"    V scales:  max|abs diff|={np.abs(v_scale_py - v_scale_mx).max():.2e}  "
+            f"[{'OK' if v_scale_ok else 'FAIL'}]"
+        )
+        if not v_scale_ok:
+            failures += 1
+
+        # ---- Compare dequantized V (FWHT fp32 vs fp16 → boundary flips OK) ----
+        # Unpack V indices from both caches, dequant via centroids, compare.
+        from vllm_metal.metal_kernel_backend.turboquant import lloyd_max_centroids
+
+        centroids, _ = lloyd_max_centroids(v_bits)
+        v_packed_dim = cache_py.value_caches[0].shape[-1]
+        # Only the filled slots are populated; take the first num_tokens.
+        flat_py = cache_py.value_caches[0].reshape(-1, Q_NUM_KV_HEADS, v_packed_dim)[
+            :num_tokens
+        ]
+        flat_mx = cache_mx.value_caches[0].reshape(-1, Q_NUM_KV_HEADS, v_packed_dim)[
+            :num_tokens
+        ]
+        v_idx_py = unpack_bits(flat_py, v_bits, Q_HEAD_DIM)
+        v_idx_mx = unpack_bits(flat_mx, v_bits, Q_HEAD_DIM)
+        # Dequantize: idx → centroid * scale, then inverse FWHT
+        vs_py = cache_py.value_scale_caches[0].reshape(
+            -1, Q_NUM_KV_HEADS, Q_HEAD_DIM // BLOCK_SIZE
+        )[:num_tokens]
+        vs_mx = cache_mx.value_scale_caches[0].reshape(
+            -1, Q_NUM_KV_HEADS, Q_HEAD_DIM // BLOCK_SIZE
+        )[:num_tokens]
+        v_dq_py = (
+            centroids[v_idx_py.astype(mx.int32)].reshape(
+                num_tokens, Q_NUM_KV_HEADS, -1, BLOCK_SIZE
+            )
+            * vs_py[..., None]
+        ).reshape(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM)
+        v_dq_mx = (
+            centroids[v_idx_mx.astype(mx.int32)].reshape(
+                num_tokens, Q_NUM_KV_HEADS, -1, BLOCK_SIZE
+            )
+            * vs_mx[..., None]
+        ).reshape(num_tokens, Q_NUM_KV_HEADS, Q_HEAD_DIM)
+        # Inverse FWHT on both to reconstruct original V
+        v_rec_py = fwht(v_dq_py.astype(mx.float32), encode=False)
+        v_rec_mx = fwht(v_dq_mx.astype(mx.float32), encode=False)
+        mx.eval(v_rec_py, v_rec_mx)
+        cos = cos_sim(v_rec_py, v_rec_mx)
+        v_ok = cos >= 0.999
+        v_byte_exact = float((np.asarray(flat_py) == np.asarray(flat_mx)).mean())
+        print(
+            f"    V packed:  byte-exact={v_byte_exact * 100:.2f}%  "
+            f"dequant cos_sim={cos:.6f}  [{'OK' if v_ok else 'FAIL'}]"
+        )
+        if not v_ok:
+            failures += 1
+
+    if failures == 0:
+        print("\n  All encode-parity checks passed.")
+    return failures
+
+
 def section_metal_e2e() -> int:
     """Cache write → paged attention correctness at multiple sequence lengths."""
     sep("Section 4: Metal E2E Correctness (Qwen3-0.6B shape)")
@@ -907,14 +1156,32 @@ def section_published_comparison() -> int:
 
 
 def section_latency() -> int:
-    """Encode + cache-write overhead per decode token."""
+    """Encode + cache-write overhead per decode token.
+
+    Benchmarks the fused Metal kernel ``ops.tq_encode`` against:
+      * the legacy Python encode + 5-scatter path (for speedup A/B), and
+      * a plain fp16 cache scatter (the uncompressed baseline).
+    The fused kernel is the hot-path substitute wired into
+    ``attention_sdpa.py``; this section is the place to measure its cost.
+    """
     sep("Section 7: Quantization Latency")
+    ops = get_ops()
 
     k = mx.random.normal(shape=(1, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(mx.float16)
     v = mx.random.normal(shape=(1, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(mx.float16)
     mx.eval(k, v)
 
     cache_tq = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=Q_NUM_KV_HEADS,
+        head_dim=Q_HEAD_DIM,
+        num_blocks=10,
+        block_size=Q_BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant="q8_0",
+    )
+    cache_tq_py = MetalPagedKVCache(
         num_layers=1,
         num_kv_heads=Q_NUM_KV_HEADS,
         head_dim=Q_HEAD_DIM,
@@ -934,51 +1201,76 @@ def section_latency() -> int:
         turboquant=False,
     )
     slot = mx.array([0], dtype=mx.int64)
-    mx.eval(slot)
-
-    # Warm up
-    for _ in range(10):
-        kq, vq = turbo_quant_encode(k, v, "q8_0")
-        mx.eval(*kq, *vq)
+    v_centroids = get_v_centroids(cache_tq.v_bits)
+    mx.eval(slot, v_centroids)
 
     n = 200
 
-    # Benchmark encode
-    t0 = time.perf_counter()
-    for _ in range(n):
-        kq, vq = turbo_quant_encode(k, v, "q8_0")
-        mx.eval(*kq, *vq)
-    encode_us = (time.perf_counter() - t0) / n * 1e6
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 1: fused Metal kernel — single dispatch replaces encode + 5
+    # scatters.  This is the production hot path.
+    # ──────────────────────────────────────────────────────────────────────
+    def _run_metal_fused():
+        (
+            new_k,
+            new_v,
+            new_ks,
+            new_vs,
+            new_kz,
+        ) = ops.tq_encode(
+            k,
+            v,
+            cache_tq.key_caches[0],
+            cache_tq.value_caches[0],
+            cache_tq.key_scale_caches[0],
+            cache_tq.value_scale_caches[0],
+            cache_tq.key_zero_caches[0],
+            slot,
+            v_centroids,
+            cache_tq.v_bits,
+            cache_tq.k_bits,
+        )
+        cache_tq.key_caches[0] = new_k
+        cache_tq.value_caches[0] = new_v
+        cache_tq.key_scale_caches[0] = new_ks
+        cache_tq.value_scale_caches[0] = new_vs
+        cache_tq.key_zero_caches[0] = new_kz
+        mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
 
-    # Pre-encode once for write benchmarks
-    (pk, ks, kz), (pv, vs) = turbo_quant_encode(
-        k, v, "q8_0", value_bits=cache_tq.v_bits
-    )
-    mx.eval(pk, ks, kz, pv, vs)
-
-    # Benchmark TQ cache write (scatter 5 arrays)
     for _ in range(10):
-        _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, slot)
-        mx.eval(
-            cache_tq.key_caches[0],
-            cache_tq.value_caches[0],
-            cache_tq.key_scale_caches[0],
-            cache_tq.value_scale_caches[0],
-            cache_tq.key_zero_caches[0],
-        )
+        _run_metal_fused()
     t0 = time.perf_counter()
     for _ in range(n):
-        _scatter_tq(cache_tq, 0, pk, ks, kz, pv, vs, slot)
-        mx.eval(
-            cache_tq.key_caches[0],
-            cache_tq.value_caches[0],
-            cache_tq.key_scale_caches[0],
-            cache_tq.value_scale_caches[0],
-            cache_tq.key_zero_caches[0],
-        )
-    tq_write_us = (time.perf_counter() - t0) / n * 1e6
+        _run_metal_fused()
+    tq_fused_us = (time.perf_counter() - t0) / n * 1e6
 
-    # Benchmark FP16 cache write (scatter K+V)
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 2: legacy Python encode + 5-scatter path, for reference.
+    # Exactly what the fused kernel replaced.
+    # ──────────────────────────────────────────────────────────────────────
+    def _run_python_path():
+        (pk, ks, kz), (pv, vs) = turbo_quant_encode(
+            k, v, "q8_0", value_bits=cache_tq_py.v_bits
+        )
+        _scatter_tq(cache_tq_py, 0, pk, ks, kz, pv, vs, slot)
+        mx.eval(
+            cache_tq_py.key_caches[0],
+            cache_tq_py.value_caches[0],
+            cache_tq_py.key_scale_caches[0],
+            cache_tq_py.value_scale_caches[0],
+            cache_tq_py.key_zero_caches[0],
+        )
+
+    for _ in range(10):
+        _run_python_path()
+    t0 = time.perf_counter()
+    for _ in range(n):
+        _run_python_path()
+    tq_python_us = (time.perf_counter() - t0) / n * 1e6
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 3: FP16 baseline — plain scatter of unquantized K/V.
+    # ──────────────────────────────────────────────────────────────────────
     for _ in range(10):
         _scatter_fp16(cache_fp, 0, k, v, slot, Q_HEAD_DIM)
         mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
@@ -988,16 +1280,126 @@ def section_latency() -> int:
         mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
     fp16_write_us = (time.perf_counter() - t0) / n * 1e6
 
-    overhead_us = encode_us + tq_write_us - fp16_write_us
+    overhead_us = tq_fused_us - fp16_write_us
+    speedup = tq_python_us / tq_fused_us if tq_fused_us > 0 else float("inf")
     tok_budget = 1e6 / 60  # ~16,700 µs at 60 tok/s
     print(f"\n  Single-token ({Q_NUM_KV_HEADS} KV heads, hd={Q_HEAD_DIM}):")
-    print(f"    TQ encode (Python):    {encode_us:>8.1f} µs")
-    print(f"    TQ cache write:        {tq_write_us:>8.1f} µs")
-    print(f"    FP16 cache write:      {fp16_write_us:>8.1f} µs")
+    print(f"    TQ fused Metal kernel:  {tq_fused_us:>8.1f} µs   <-- hot path")
+    print(f"    TQ Python encode+scat:  {tq_python_us:>8.1f} µs   (reference)")
+    print(f"    FP16 cache write:       {fp16_write_us:>8.1f} µs   (baseline)")
+    print(f"    Fused speedup vs Py:    {speedup:>8.2f}x")
     print(
-        f"    TQ overhead:           {overhead_us:>8.1f} µs  "
+        f"    TQ overhead vs fp16:    {overhead_us:>8.1f} µs  "
         f"({overhead_us / tok_budget * 100:.1f}% of 60tok/s budget)"
     )
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Benchmark 4: prefill sweep.
+    #
+    # The single-token number above is almost entirely Metal dispatch
+    # overhead — we only fill `num_kv_heads` threadgroups, nowhere near GPU
+    # saturation.  This sweep pushes the grid size up by ~4 orders of
+    # magnitude so we can see the dispatch-bound → compute-bound transition
+    # and verify that optimizations don't regress large batches.
+    #
+    # For each N we measure:
+    #   * total µs per dispatch (absolute wall time)
+    #   * µs/token (derived throughput — should plateau once compute-bound)
+    #   * the FP16-scatter baseline at the same N for overhead accounting
+    #
+    # Steady-state µs/token ≈ steady-state FP16 µs/token  ⇒  the TQ kernel
+    # is roughly memory-bound at parity with a plain scatter, which is the
+    # best we can hope for given we emit similar byte volume.
+    # ──────────────────────────────────────────────────────────────────────
+    bulk_sizes = [256, 1024, 4096]
+    print(f"\n  Prefill sweep ({Q_NUM_KV_HEADS} KV heads, hd={Q_HEAD_DIM}):")
+    print("    ───────────────────────────────────────────────────────────────────────")
+    print("       N    TQ fused (total / per-tok)    FP16 scatter (total / per-tok)")
+    print("    ───────────────────────────────────────────────────────────────────────")
+    for n_tok in bulk_sizes:
+        blocks_needed = (n_tok + Q_BLOCK_SIZE - 1) // Q_BLOCK_SIZE + 2
+        k_bulk = mx.random.normal(shape=(n_tok, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(
+            mx.float16
+        )
+        v_bulk = mx.random.normal(shape=(n_tok, Q_NUM_KV_HEADS, Q_HEAD_DIM)).astype(
+            mx.float16
+        )
+        slot_bulk = mx.arange(n_tok, dtype=mx.int64)
+        cache_tq_bulk = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=blocks_needed,
+            block_size=Q_BLOCK_SIZE,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant="q8_0",
+        )
+        cache_fp_bulk = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=Q_NUM_KV_HEADS,
+            head_dim=Q_HEAD_DIM,
+            num_blocks=blocks_needed,
+            block_size=Q_BLOCK_SIZE,
+            dtype=mx.float16,
+            turboquant=False,
+        )
+        mx.eval(k_bulk, v_bulk, slot_bulk)
+
+        # Fewer iters at large N to keep total bench time reasonable.
+        n_iter = 50 if n_tok <= 1024 else 20
+
+        def _run_tq(kb=k_bulk, vb=v_bulk, sb=slot_bulk, ctb=cache_tq_bulk):
+            (
+                new_k,
+                new_v,
+                new_ks,
+                new_vs,
+                new_kz,
+            ) = ops.tq_encode(
+                kb,
+                vb,
+                ctb.key_caches[0],
+                ctb.value_caches[0],
+                ctb.key_scale_caches[0],
+                ctb.value_scale_caches[0],
+                ctb.key_zero_caches[0],
+                sb,
+                v_centroids,
+                ctb.v_bits,
+                ctb.k_bits,
+            )
+            ctb.key_caches[0] = new_k
+            ctb.value_caches[0] = new_v
+            ctb.key_scale_caches[0] = new_ks
+            ctb.value_scale_caches[0] = new_vs
+            ctb.key_zero_caches[0] = new_kz
+            mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+        def _run_fp(kb=k_bulk, vb=v_bulk, sb=slot_bulk, cfb=cache_fp_bulk):
+            _scatter_fp16(cfb, 0, kb, vb, sb, Q_HEAD_DIM)
+            mx.eval(cfb.key_caches[0], cfb.value_caches[0])
+
+        for _ in range(5):
+            _run_tq()
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            _run_tq()
+        tq_total = (time.perf_counter() - t0) / n_iter * 1e6
+        tq_per_tok = tq_total / n_tok
+
+        for _ in range(5):
+            _run_fp()
+        t0 = time.perf_counter()
+        for _ in range(n_iter):
+            _run_fp()
+        fp_total = (time.perf_counter() - t0) / n_iter * 1e6
+        fp_per_tok = fp_total / n_tok
+
+        print(
+            f"    {n_tok:>5}    {tq_total:>7.1f} µs / {tq_per_tok:>5.3f} µs    "
+            f"{fp_total:>7.1f} µs / {fp_per_tok:>5.3f} µs"
+        )
     return 0
 
 
@@ -1691,6 +2093,45 @@ def _run_serve_config(label: str, additional_config: dict | None, log_dir: str) 
     return result
 
 
+FAST_SERVE_LABEL = "q8q3"
+FAST_SERVE_CONFIG = {"turboquant": True, "k_quant": "q8_0", "v_quant": "q3_0"}
+
+
+def section_fast_serve() -> int:
+    """Boot a single TurboQuant-enabled vllm serve run — smoke test only.
+
+    Skips parity/memory/latency sections entirely and jumps straight to
+    ``_run_serve_config`` with the production TQ config (q8_0 K, q3_0 V).
+    Intended for quickly verifying that the TQ hot path doesn't crash the
+    engine core on a real request — the exact scenario the eager-tq_encode
+    race used to miss.  Returns non-zero if serve fails to come up or the
+    chat completion errors out.
+    """
+    sep(
+        f"Fast Serve ({FAST_SERVE_LABEL}: k={FAST_SERVE_CONFIG['k_quant']}, "
+        f"v={FAST_SERVE_CONFIG['v_quant']})"
+    )
+    print(f"  Model: {SERVE_MODEL}")
+    log_dir = "/tmp/tq-fast-serve"
+    os.makedirs(log_dir, exist_ok=True)
+
+    result = _run_serve_config(FAST_SERVE_LABEL, FAST_SERVE_CONFIG, log_dir)
+
+    print()
+    sep("Fast Serve Result")
+    if not result["ready"]:
+        print("  FAIL: server never became ready")
+        return 1
+    chat = result.get("chat", {})
+    if not chat.get("ok"):
+        print(f"  FAIL: chat completion errored — {chat.get('error', '?')}")
+        return 1
+    print(
+        f"  OK    tok/s={chat['tok_per_s']:.1f}  peak RSS={result['peak_rss']:.0f} MB"
+    )
+    return 0
+
+
 def section_serve_benchmark() -> int:
     """Compare bf16 against the TQ (k_quant, v_quant) sweep via live vllm serve."""
     tq_labels = ", ".join(label for label, cfg in SERVE_CONFIGS if cfg is not None)
@@ -1735,16 +2176,31 @@ def section_serve_benchmark() -> int:
 
 def main() -> int:
     run_serve = "--serve" in sys.argv
+    run_fast_serve = "--fast-serve" in sys.argv
 
     print("╔══════════════════════════════════════════════════════════════════════╗")
     print("║         TurboQuant KV Cache — Comprehensive Test Suite              ║")
     print("╚══════════════════════════════════════════════════════════════════════╝")
+
+    # --fast-serve bypasses the entire parity/memory/latency battery and
+    # jumps straight to a single TQ-enabled live serve run.  Useful for
+    # verifying the TQ hot path survives a real request without waiting
+    # through the full ~1-minute test suite.
+    if run_fast_serve:
+        rc = section_fast_serve()
+        sep("DONE")
+        if rc:
+            print("  fast-serve FAILED.\n")
+        else:
+            print("  fast-serve OK.\n")
+        return rc
 
     failures = 0
     failures += section_quant_type_validation()
     failures += section_pack_unpack_roundtrip()
     failures += section_python_roundtrip_mse()
     failures += section_metal_kernel_dequant()
+    failures += section_metal_encode_parity()
     failures += section_metal_e2e()
     failures += section_memory_capacity()
     failures += section_published_comparison()
@@ -2005,6 +2461,111 @@ def test_turboquant_512_head_dim_matches_python_reference() -> None:
     relative_error_percent = mean_abs_diff / ref_mean_abs * 100.0
 
     assert relative_error_percent < 5.0
+
+
+def test_tq_encode_kernel_supports_head_dim_512() -> None:
+    """The fused ``ops.tq_encode`` Metal kernel must accept head_dim=512.
+
+    Regression for the kernel-side 512 gap: ``MetalPagedKVCache`` and the
+    decode kernel already supported 512-dim, but the fused encode primitive
+    only had instantiations for {64, 128, 256} and rejected 512 with a
+    runtime guard — breaking Gemma-style models with full-attn head_dim=512
+    on the first forward pass after the Python encode fallback was removed.
+
+    This test goes through ``ops.tq_encode`` directly (not the Python
+    ``_fill_cache`` path used by ``test_turboquant_512_head_dim_matches_
+    python_reference``) and verifies its outputs match the Python encode.
+    """
+    head_dim = 512
+    num_tokens = 16
+    num_kv_heads = 2
+    num_blocks = 4
+    block_size = 16
+    k_quant, v_quant = "q8_0", "q3_0"
+    k_bits = QUANT_PARAMS[k_quant]["bits"]
+    v_bits = V_QUANT_PARAMS[v_quant]["bits"]
+    k_signed = bool(QUANT_PARAMS[k_quant]["signed"])
+
+    cache = MetalPagedKVCache(
+        num_layers=1,
+        num_blocks=num_blocks,
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant=k_quant,
+        v_quant=v_quant,
+    )
+
+    np.random.seed(512)
+    k = mx.array(np.random.randn(num_tokens, num_kv_heads, head_dim).astype(np.float16))
+    v = mx.array(np.random.randn(num_tokens, num_kv_heads, head_dim).astype(np.float16))
+    slot_mapping = mx.array(list(range(num_tokens)), dtype=mx.int64)
+    mx.eval(k, v, slot_mapping)
+
+    ops = get_ops()
+    v_centroids = get_v_centroids(v_bits)
+    new_k, new_v, new_ks, new_vs, new_kz = ops.tq_encode(
+        k,
+        v,
+        cache.key_caches[0],
+        cache.value_caches[0],
+        cache.key_scale_caches[0],
+        cache.value_scale_caches[0],
+        cache.key_zero_caches[0],
+        slot_mapping,
+        v_centroids,
+        v_bits,
+        k_bits,
+        k_signed,
+    )
+    mx.eval(new_k, new_v, new_ks, new_vs, new_kz)
+
+    (
+        (packed_k_ref, k_scale_ref, k_zero_ref),
+        (
+            packed_v_ref,
+            v_scale_ref,
+        ),
+    ) = turbo_quant_encode(k, v, k_quant, value_bits=v_bits)
+    mx.eval(packed_k_ref, k_scale_ref, k_zero_ref, packed_v_ref, v_scale_ref)
+
+    # K indices: ±2 on the int8 grid, ≥95% exact (same tolerance the
+    # encode-parity sweep uses for the 128-dim case).
+    flat_k_kernel = new_k.reshape(-1, num_kv_heads, head_dim)[:num_tokens]
+    k_kernel = np.asarray(flat_k_kernel.astype(mx.int32))
+    k_ref = np.asarray(packed_k_ref.astype(mx.int32))
+    k_diff = np.abs(k_kernel - k_ref)
+    assert (k_diff <= 2).all(), f"K indices drift > 2: max={int(k_diff.max())}"
+    assert (k_diff == 0).mean() >= 0.99, (
+        f"K exact-match rate {(k_diff == 0).mean():.4f} below 0.99"
+    )
+
+    # K scales / zero-points (fp16).
+    scale_groups = head_dim // BLOCK_SIZE
+    flat_ks = new_ks.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    flat_kz = new_kz.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    assert np.allclose(
+        np.asarray(flat_ks.astype(mx.float32)),
+        np.asarray(k_scale_ref.astype(mx.float32)),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+    kz_diff = np.abs(
+        np.asarray(flat_kz.astype(mx.float32))
+        - np.asarray(k_zero_ref.astype(mx.float32))
+    )
+    assert (kz_diff <= 1.0).all(), f"K zero-point drift > 1: max={kz_diff.max():.2e}"
+
+    # V scales (fp16).
+    flat_vs = new_vs.reshape(-1, num_kv_heads, scale_groups)[:num_tokens]
+    assert np.allclose(
+        np.asarray(flat_vs.astype(mx.float32)),
+        np.asarray(v_scale_ref.astype(mx.float32)),
+        rtol=1e-2,
+        atol=1e-3,
+    )
 
 
 def test_turboquant_per_layer_shapes_raise_early() -> None:

--- a/tools/tq_bench.py
+++ b/tools/tq_bench.py
@@ -1,0 +1,751 @@
+"""Manual TurboQuant profiler — since Instruments refuses to show shader names,
+we profile the kernel with surgical `mx.synchronize()` fences and reason about
+bottlenecks from first principles.
+
+Measures four axes that matter for the 16 → 18 tok/s gap:
+
+  A. tq_encode GPU time sweep: N = 1, 4, 16, 64, 256, 1024, 4096, 16384
+     — isolates the kernel at realistic shapes, separating dispatch overhead
+       from compute cost.  Also measures effective bandwidth to diagnose
+       memory-bound vs dispatch-bound.
+
+  B. Decode-step simulation: 28 × (tq_encode + paged_attention_v2_online)
+     back-to-back, comparing TurboQuant vs FP16.  Matches what the model
+     actually does per decode step on Qwen3-0.6B.
+
+  C. Python dispatch overhead: how much of each call is nanobind/MLX graph
+     construction vs actual GPU work.  If this is >30% at N=1, optimizing
+     the kernel is pointless — we need to amortize dispatch.
+
+  D. Grid saturation analysis: theoretical threadgroup count vs M1 GPU
+     capacity (8 cores × 2 concurrent TGs ≈ 16 active TGs for saturation).
+
+Run with:
+    uv run python tools/tq_bench.py
+"""
+
+from __future__ import annotations
+
+import gc
+import math
+import sys
+import time
+from dataclasses import dataclass
+
+import mlx.core as mx
+
+from vllm_metal.metal import get_ops
+from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
+from vllm_metal.metal_kernel_backend.turboquant import get_v_centroids
+
+# -----------------------------------------------------------------------------
+# Config — Qwen3-0.6B shape (28 layers, 4 KV heads, head_dim=128).
+# -----------------------------------------------------------------------------
+NUM_LAYERS = 28
+NUM_KV_HEADS = 4
+NUM_Q_HEADS = 16
+HEAD_DIM = 128
+BLOCK_SIZE = 16
+K_QUANT = "q8_0"  # signed int8, full quality
+V_BITS = 3  # Lloyd-Max 3-bit
+K_BITS = 8
+
+# GPU capacity heuristics (M1 / M1 Pro / M1 Max all similar):
+#   - M1:   8 cores × ~2 concurrent TGs per core   ≈ 16 TGs
+#   - M1P: 14 cores × ~2 concurrent TGs per core   ≈ 28 TGs
+#   - M1M: 32 cores × ~2 concurrent TGs per core   ≈ 64 TGs
+M1_SATURATION_TGS = 16
+
+
+def _sync() -> None:
+    """Block until GPU is idle.  Required for honest wall-clock timing."""
+    mx.synchronize()
+
+
+def _time_gpu(fn, warmup: int = 3, iters: int = 50) -> float:
+    """Return GPU-inclusive wall time per call (µs).  Uses `mx.synchronize`
+    fences on both sides so the measurement includes *all* GPU work."""
+    for _ in range(warmup):
+        fn()
+    _sync()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    _sync()
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+def _time_dispatch_only(fn, warmup: int = 3, iters: int = 200) -> float:
+    """Return time spent in Python → nanobind → MLX graph construction per
+    call (µs), *without* waiting for GPU.  Compare to `_time_gpu` to infer
+    dispatch-bound vs compute-bound."""
+    for _ in range(warmup):
+        fn()
+    _sync()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    # Note: no sync here — we measure only Python + graph construction.
+    return (time.perf_counter() - t0) / iters * 1e6
+
+
+# -----------------------------------------------------------------------------
+# Data helpers
+# -----------------------------------------------------------------------------
+
+
+def _make_tq_cache(num_blocks: int) -> MetalPagedKVCache:
+    return MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        num_blocks=num_blocks,
+        block_size=BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant=K_QUANT,
+    )
+
+
+def _make_fp_cache(num_blocks: int) -> MetalPagedKVCache:
+    return MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        num_blocks=num_blocks,
+        block_size=BLOCK_SIZE,
+        dtype=mx.float16,
+        turboquant=False,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Section A — tq_encode GPU time sweep
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class EncodeSample:
+    n: int
+    tq_us: float
+    tq_dispatch_us: float
+    fp_us: float
+    fp_dispatch_us: float
+
+    @property
+    def tq_per_tok(self) -> float:
+        return self.tq_us / self.n
+
+    @property
+    def fp_per_tok(self) -> float:
+        return self.fp_us / self.n
+
+    @property
+    def tq_gpu_us(self) -> float:
+        """Estimated GPU-only time (subtracting Python dispatch)."""
+        return max(0.0, self.tq_us - self.tq_dispatch_us)
+
+    @property
+    def tq_dispatch_frac(self) -> float:
+        return self.tq_dispatch_us / self.tq_us if self.tq_us > 0 else 0.0
+
+    @property
+    def effective_bw_gbps(self) -> float:
+        """Rough bandwidth: total bytes R+W per call / GPU time."""
+        # Reads: K/V fp16 (2 bytes × 2 tensors × N × H × D)
+        # Writes: K packed (K_BITS/8 B × N × H × D)
+        #         V packed (V_BITS/8 B × N × H × D)
+        #         K scale (2B), V scale (2B), K zp (2B) × N × H × scale_groups
+        scale_groups = HEAD_DIM // 32
+        read_b = 2 * 2 * self.n * NUM_KV_HEADS * HEAD_DIM
+        write_k = (K_BITS / 8) * self.n * NUM_KV_HEADS * HEAD_DIM
+        write_v = (V_BITS / 8) * self.n * NUM_KV_HEADS * HEAD_DIM
+        write_scales = 2 * 3 * self.n * NUM_KV_HEADS * scale_groups
+        total_b = read_b + write_k + write_v + write_scales
+        if self.tq_gpu_us <= 0:
+            return float("nan")
+        return total_b / (self.tq_gpu_us * 1e-6) / 1e9
+
+
+def bench_encode_sweep(ns: list[int]) -> list[EncodeSample]:
+    ops = get_ops()
+    v_centroids = get_v_centroids(V_BITS)
+    mx.eval(v_centroids)
+
+    samples: list[EncodeSample] = []
+
+    for n in ns:
+        num_blocks = (n + BLOCK_SIZE - 1) // BLOCK_SIZE + 2
+        cache_tq = _make_tq_cache(num_blocks)
+        cache_fp = _make_fp_cache(num_blocks)
+
+        k = mx.random.normal(shape=(n, NUM_KV_HEADS, HEAD_DIM)).astype(mx.float16)
+        v = mx.random.normal(shape=(n, NUM_KV_HEADS, HEAD_DIM)).astype(mx.float16)
+        slot = mx.arange(n, dtype=mx.int64)
+        mx.eval(k, v, slot)
+
+        # --- TurboQuant fused encode ---
+        # Loop-scoped vars (cache_tq, k, v, slot) are bound as defaults so the
+        # closures don't late-bind after the end-of-iteration `del` frees them.
+        def run_tq(cache_tq=cache_tq, k=k, v=v, slot=slot):
+            (nk, nv, nks, nvs, nkz) = ops.tq_encode(
+                k,
+                v,
+                cache_tq.key_caches[0],
+                cache_tq.value_caches[0],
+                cache_tq.key_scale_caches[0],
+                cache_tq.value_scale_caches[0],
+                cache_tq.key_zero_caches[0],
+                slot,
+                v_centroids,
+                V_BITS,
+                K_BITS,
+                True,
+            )
+            cache_tq.key_caches[0] = nk
+            cache_tq.value_caches[0] = nv
+            cache_tq.key_scale_caches[0] = nks
+            cache_tq.value_scale_caches[0] = nvs
+            cache_tq.key_zero_caches[0] = nkz
+            return nk, nv, nks, nvs, nkz
+
+        def run_tq_eval(run_tq=run_tq):
+            arrs = run_tq()
+            mx.eval(*arrs)
+
+        # --- FP16 scatter (MLX-native) ---
+        def run_fp(cache_fp=cache_fp, k=k, v=v, slot=slot):
+            flat_k = cache_fp.key_caches[0].reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+            flat_k[slot] = k
+            cache_fp.key_caches[0] = flat_k.reshape(cache_fp.key_caches[0].shape)
+            flat_v = cache_fp.value_caches[0].reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+            flat_v[slot] = v
+            cache_fp.value_caches[0] = flat_v.reshape(cache_fp.value_caches[0].shape)
+
+        def run_fp_eval(run_fp=run_fp, cache_fp=cache_fp):
+            run_fp()
+            mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
+
+        tq_us = _time_gpu(run_tq_eval)
+        fp_us = _time_gpu(run_fp_eval)
+        tq_disp_us = _time_dispatch_only(run_tq)
+        fp_disp_us = _time_dispatch_only(run_fp)
+
+        samples.append(
+            EncodeSample(
+                n=n,
+                tq_us=tq_us,
+                tq_dispatch_us=tq_disp_us,
+                fp_us=fp_us,
+                fp_dispatch_us=fp_disp_us,
+            )
+        )
+        del k, v, slot, cache_tq, cache_fp
+        gc.collect()
+
+    return samples
+
+
+def print_encode_table(samples: list[EncodeSample]) -> None:
+    print()
+    print("  Section A — tq_encode vs FP16-scatter sweep")
+    print("  " + "─" * 78)
+    print(
+        f"  {'N':>6}  {'TGs':>4}  "
+        f"{'TQ total':>10}  {'TQ/tok':>8}  {'TQ GPU':>8}  {'disp%':>6}  "
+        f"{'BW GB/s':>8}  {'FP total':>10}  {'FP/tok':>8}"
+    )
+    print("  " + "─" * 78)
+    for s in samples:
+        tgs = s.n * NUM_KV_HEADS
+        print(
+            f"  {s.n:>6}  {tgs:>4}  "
+            f"{s.tq_us:>8.1f}µs  {s.tq_per_tok:>6.2f}µs  "
+            f"{s.tq_gpu_us:>6.1f}µs  {s.tq_dispatch_frac * 100:>4.1f}%  "
+            f"{s.effective_bw_gbps:>6.1f}   "
+            f"{s.fp_us:>8.1f}µs  {s.fp_per_tok:>6.2f}µs"
+        )
+    print("  " + "─" * 78)
+    print(f"  (Dispatch occupancy: TGs / {M1_SATURATION_TGS} ≈ M1 saturation point)")
+
+
+# -----------------------------------------------------------------------------
+# Section B — Decode-step simulation
+#
+# Mimics the per-step cost of a real decode:
+#   - 28 layers × tq_encode (1 token)      (TurboQuant path)
+#   - 28 layers × FP16 scatter (1 token)   (baseline path)
+#
+# We *don't* include paged_attention here because the decode slowdown we see
+# (16 vs 18 tok/s) is ~5-7 ms which is roughly in the same order as 28 × encode
+# cost.  If this section shows <1 ms for 28 encodes, the bottleneck is elsewhere
+# (e.g. paged_attention reading quantized cache is slower than reading fp16).
+# -----------------------------------------------------------------------------
+
+
+def bench_decode_step() -> None:
+    ops = get_ops()
+    v_centroids = get_v_centroids(V_BITS)
+    mx.eval(v_centroids)
+
+    # One cache per layer for realistic graph structure.
+    caches_tq = [_make_tq_cache(num_blocks=8) for _ in range(NUM_LAYERS)]
+    caches_fp = [_make_fp_cache(num_blocks=8) for _ in range(NUM_LAYERS)]
+
+    k = mx.random.normal(shape=(1, NUM_KV_HEADS, HEAD_DIM)).astype(mx.float16)
+    v = mx.random.normal(shape=(1, NUM_KV_HEADS, HEAD_DIM)).astype(mx.float16)
+    slot = mx.array([0], dtype=mx.int64)
+    mx.eval(k, v, slot)
+
+    def run_tq_step():
+        outs = []
+        for layer in range(NUM_LAYERS):
+            c = caches_tq[layer]
+            (nk, nv, nks, nvs, nkz) = ops.tq_encode(
+                k,
+                v,
+                c.key_caches[0],
+                c.value_caches[0],
+                c.key_scale_caches[0],
+                c.value_scale_caches[0],
+                c.key_zero_caches[0],
+                slot,
+                v_centroids,
+                V_BITS,
+                K_BITS,
+                True,
+            )
+            c.key_caches[0] = nk
+            c.value_caches[0] = nv
+            c.key_scale_caches[0] = nks
+            c.value_scale_caches[0] = nvs
+            c.key_zero_caches[0] = nkz
+            outs.extend([nk, nv, nks, nvs, nkz])
+        mx.eval(*outs)
+
+    def run_fp_step():
+        outs = []
+        for layer in range(NUM_LAYERS):
+            c = caches_fp[layer]
+            flat_k = c.key_caches[0].reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+            flat_k[slot] = k
+            c.key_caches[0] = flat_k.reshape(c.key_caches[0].shape)
+            flat_v = c.value_caches[0].reshape(-1, NUM_KV_HEADS, HEAD_DIM)
+            flat_v[slot] = v
+            c.value_caches[0] = flat_v.reshape(c.value_caches[0].shape)
+            outs.extend([c.key_caches[0], c.value_caches[0]])
+        mx.eval(*outs)
+
+    tq_step = _time_gpu(run_tq_step, warmup=5, iters=30)
+    fp_step = _time_gpu(run_fp_step, warmup=5, iters=30)
+
+    print()
+    print("  Section B — Full decode-step simulation (28 layers × 1 tok)")
+    print("  " + "─" * 78)
+    print(f"    TQ path (28 × tq_encode):      {tq_step:>8.1f} µs")
+    print(f"    FP path (28 × fp16 scatter):   {fp_step:>8.1f} µs")
+    print(f"    Overhead per step:             {tq_step - fp_step:>+8.1f} µs")
+    print(
+        f"    Overhead as tok/s hit:         "
+        f"{_overhead_tok_hit(tq_step - fp_step):>8.2f} tok/s at 60 tok/s base"
+    )
+
+
+def _overhead_tok_hit(overhead_us: float, base_tok_s: float = 60.0) -> float:
+    """Convert a per-step µs overhead into a tok/s delta at a given base rate."""
+    base_ms_per_tok = 1000.0 / base_tok_s
+    new_ms_per_tok = base_ms_per_tok + overhead_us / 1000.0
+    return base_tok_s - (1000.0 / new_ms_per_tok)
+
+
+# -----------------------------------------------------------------------------
+# Section E — Paged-attention READ-side: TQ vs FP16.
+#
+# This is the hypothesis test for the 16 → 18 tok/s gap.  The encode path is
+# already known to be cheap (Section B); if paged_attention on a quantized
+# cache costs ~200 µs more per layer than on a FP16 cache, 28 layers ×
+# 200 µs ≈ 5.6 ms per token which exactly matches the observed gap.
+#
+# We populate a cache at a realistic decode context length (ctx=512) and
+# time a single-query-token attention dispatch against it, repeated many
+# times with proper GPU fencing.
+# -----------------------------------------------------------------------------
+
+
+def bench_paged_attention(
+    ctx_lens: list[int],
+    num_kv_heads: int = NUM_KV_HEADS,
+    num_q_heads: int = NUM_Q_HEADS,
+    num_layers: int = NUM_LAYERS,
+    label: str = "Qwen3-0.6B (28L × 4KVH)",
+    extrapolate_to: int | None = None,
+    skip_fp_above: int | None = None,
+    iters: int = 40,
+) -> list[tuple[int, float, float]]:
+    """Returns list of (ctx, tq_us, fp_us) for optional post-processing."""
+    ops = get_ops()
+    v_centroids = get_v_centroids(V_BITS)
+    mx.eval(v_centroids)
+
+    print()
+    print(f"  Section E — paged_attention read side  [{label}]")
+    print("  " + "─" * 78)
+    print(
+        f"  {'ctx':>7}  {'TQ µs':>10}  {'FP µs':>10}  "
+        f"{'TQ/FP':>6}  {'overhead':>10}  {f'×{num_layers}L step':>12}"
+    )
+    print("  " + "─" * 78)
+
+    results: list[tuple[int, float, float]] = []
+
+    for ctx in ctx_lens:
+        # Allocate enough blocks for ctx tokens (+1 query slot).
+        num_blocks = (ctx + BLOCK_SIZE - 1) // BLOCK_SIZE + 4
+
+        cache_tq = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=num_kv_heads,
+            head_dim=HEAD_DIM,
+            num_blocks=num_blocks,
+            block_size=BLOCK_SIZE,
+            dtype=mx.float16,
+            turboquant=True,
+            k_quant=K_QUANT,
+        )
+        cache_fp: MetalPagedKVCache | None = None
+        measure_fp = skip_fp_above is None or ctx <= skip_fp_above
+        if measure_fp:
+            cache_fp = MetalPagedKVCache(
+                num_layers=1,
+                num_kv_heads=num_kv_heads,
+                head_dim=HEAD_DIM,
+                num_blocks=num_blocks,
+                block_size=BLOCK_SIZE,
+                dtype=mx.float16,
+                turboquant=False,
+            )
+
+        k_fill = mx.random.normal(shape=(ctx, num_kv_heads, HEAD_DIM)).astype(
+            mx.float16
+        )
+        v_fill = mx.random.normal(shape=(ctx, num_kv_heads, HEAD_DIM)).astype(
+            mx.float16
+        )
+        slot_fill = mx.arange(ctx, dtype=mx.int64)
+        mx.eval(k_fill, v_fill, slot_fill)
+
+        (nk, nv, nks, nvs, nkz) = ops.tq_encode(
+            k_fill,
+            v_fill,
+            cache_tq.key_caches[0],
+            cache_tq.value_caches[0],
+            cache_tq.key_scale_caches[0],
+            cache_tq.value_scale_caches[0],
+            cache_tq.key_zero_caches[0],
+            slot_fill,
+            v_centroids,
+            V_BITS,
+            K_BITS,
+            True,
+        )
+        cache_tq.key_caches[0] = nk
+        cache_tq.value_caches[0] = nv
+        cache_tq.key_scale_caches[0] = nks
+        cache_tq.value_scale_caches[0] = nvs
+        cache_tq.key_zero_caches[0] = nkz
+        mx.eval(nk, nv, nks, nvs, nkz)
+
+        if cache_fp is not None:
+            flat_k = cache_fp.key_caches[0].reshape(-1, num_kv_heads, HEAD_DIM)
+            flat_k[slot_fill] = k_fill
+            cache_fp.key_caches[0] = flat_k.reshape(cache_fp.key_caches[0].shape)
+            flat_v = cache_fp.value_caches[0].reshape(-1, num_kv_heads, HEAD_DIM)
+            flat_v[slot_fill] = v_fill
+            cache_fp.value_caches[0] = flat_v.reshape(cache_fp.value_caches[0].shape)
+            mx.eval(cache_fp.key_caches[0], cache_fp.value_caches[0])
+
+        q = mx.random.normal(shape=(1, num_q_heads, HEAD_DIM)).astype(mx.float16)
+        block_table = mx.arange(num_blocks, dtype=mx.int32).reshape(1, -1)
+        seq_lens = mx.array([ctx], dtype=mx.int32)
+        cu_seqlens = mx.array([0, 1], dtype=mx.int32)
+        mx.eval(q, block_table, seq_lens, cu_seqlens)
+
+        scale = 1.0 / (HEAD_DIM**0.5)
+
+        # Bind all loop-scoped vars as defaults (see Section A note above).
+        def run_tq_attn(
+            q=q,
+            cache_tq=cache_tq,
+            block_table=block_table,
+            seq_lens=seq_lens,
+            cu_seqlens=cu_seqlens,
+            ctx=ctx,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+        ):
+            out = mx.array(0)
+            ops.paged_attention_primitive(
+                q,
+                cache_tq.key_caches[0],
+                cache_tq.value_caches[0],
+                num_kv_heads,
+                scale,
+                0.0,
+                block_table,
+                seq_lens,
+                cu_seqlens,
+                BLOCK_SIZE,
+                ctx,
+                -1,
+                out,
+                key_scale_cache=cache_tq.key_scale_caches[0],
+                value_scale_cache=cache_tq.value_scale_caches[0],
+                key_zero_cache=cache_tq.key_zero_caches[0],
+                v_centroids=v_centroids,
+                use_turboquant=True,
+                quant_type=K_QUANT,
+                v_bits=V_BITS,
+            )
+            mx.eval(out)
+
+        def run_fp_attn(
+            q=q,
+            cache_fp=cache_fp,
+            block_table=block_table,
+            seq_lens=seq_lens,
+            cu_seqlens=cu_seqlens,
+            ctx=ctx,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+        ):
+            out = mx.array(0)
+            ops.paged_attention_primitive(
+                q,
+                cache_fp.key_caches[0],
+                cache_fp.value_caches[0],
+                num_kv_heads,
+                scale,
+                0.0,
+                block_table,
+                seq_lens,
+                cu_seqlens,
+                BLOCK_SIZE,
+                ctx,
+                -1,
+                out,
+                use_turboquant=False,
+            )
+            mx.eval(out)
+
+        tq_us = _time_gpu(run_tq_attn, warmup=3, iters=iters)
+        if cache_fp is not None:
+            fp_us = _time_gpu(run_fp_attn, warmup=3, iters=iters)
+        else:
+            fp_us = float("nan")
+        overhead = tq_us - fp_us if not math.isnan(fp_us) else float("nan")
+        per_step = overhead * num_layers if not math.isnan(overhead) else float("nan")
+
+        ratio_str = f"{tq_us / fp_us:>5.2f}x" if not math.isnan(fp_us) else "  n/a"
+        ov_str = f"{overhead:>+8.1f}µs" if not math.isnan(overhead) else "     n/a"
+        step_str = f"{per_step:>+10.1f}µs" if not math.isnan(per_step) else "      n/a"
+
+        print(
+            f"  {ctx:>7}  {tq_us:>8.1f}µs  "
+            f"{(f'{fp_us:>8.1f}µs' if not math.isnan(fp_us) else '    n/a  ')}  "
+            f"{ratio_str}  {ov_str}  {step_str}"
+        )
+        results.append((ctx, tq_us, fp_us))
+
+        del cache_tq, cache_fp, k_fill, v_fill, q, block_table
+        del slot_fill, seq_lens, cu_seqlens, nk, nv, nks, nvs, nkz
+        gc.collect()
+        # Force MLX to return cached device buffers so the next (larger) ctx
+        # iteration actually has headroom on 8 GB machines.
+        try:
+            mx.metal.clear_cache()
+        except (AttributeError, RuntimeError):
+            pass
+
+    print("  " + "─" * 78)
+
+    # ---- Optional linear extrapolation ---------------------------------------
+    if extrapolate_to is not None and len(results) >= 2:
+        # Fit TQ and FP separately as linear: y ≈ a + b*ctx, using the last few
+        # points (where per-token cost has plateaued).
+        xs = [r[0] for r in results[-3:]]
+        tq_ys = [r[1] for r in results[-3:]]
+        fp_ys = [r[2] for r in results[-3:] if not math.isnan(r[2])]
+
+        def _fit(xs: list[int], ys: list[float]) -> tuple[float, float]:
+            n = len(xs)
+            mx_ = sum(xs) / n
+            my_ = sum(ys) / n
+            num = sum((x - mx_) * (y - my_) for x, y in zip(xs, ys, strict=True))
+            den = sum((x - mx_) ** 2 for x in xs)
+            b = num / den if den > 0 else 0.0
+            a = my_ - b * mx_
+            return a, b
+
+        a_tq, b_tq = _fit(xs, tq_ys)
+        if len(fp_ys) >= 2:
+            a_fp, b_fp = _fit(xs[-len(fp_ys) :], fp_ys)
+        else:
+            a_fp = b_fp = float("nan")
+
+        print(f"  Linear extrapolation (fit on last {len(xs)} ctx points):")
+        print(f"    TQ µs ≈ {a_tq:.1f} + {b_tq:.5f} × ctx")
+        if not math.isnan(a_fp):
+            print(f"    FP µs ≈ {a_fp:.1f} + {b_fp:.5f} × ctx")
+        tq_pred = a_tq + b_tq * extrapolate_to
+        print()
+        print(f"    Predicted at ctx={extrapolate_to:,}:")
+        print(f"      TQ attention:    {tq_pred / 1000:>8.2f} ms per layer per step")
+        if not math.isnan(a_fp):
+            fp_pred = a_fp + b_fp * extrapolate_to
+            ov_pred = tq_pred - fp_pred
+            print(
+                f"      FP attention:    {fp_pred / 1000:>8.2f} ms per layer per step"
+            )
+            print(
+                f"      TQ overhead:     {ov_pred / 1000:>+8.2f} ms per layer "
+                f"({tq_pred / fp_pred:.2f}x FP)"
+            )
+            print(
+                f"      × {num_layers} layers:    {tq_pred * num_layers / 1000:>8.2f} ms TQ "
+                f"/ {fp_pred * num_layers / 1000:.2f} ms FP per decode step"
+            )
+        else:
+            print(
+                f"      × {num_layers} layers:    {tq_pred * num_layers / 1000:>8.2f} ms TQ "
+                f"per decode step"
+            )
+
+    return results
+
+
+# -----------------------------------------------------------------------------
+# Section D — Grid-saturation analysis (purely analytical, no GPU).
+# -----------------------------------------------------------------------------
+
+
+def print_saturation_analysis(ns: list[int]) -> None:
+    print()
+    print("  Section D — Grid saturation analysis")
+    print("  " + "─" * 78)
+    print("    Each tq_encode dispatch uses (N × num_kv_heads) threadgroups.")
+    print(
+        f"    Num KV heads: {NUM_KV_HEADS}  |  M1 saturation ≈ {M1_SATURATION_TGS} concurrent TGs"
+    )
+    print(f"    TG size: {HEAD_DIM} threads ({HEAD_DIM // 32} simdgroups per TG)")
+    print("  " + "─" * 78)
+    print(f"    {'N':>6}  {'TGs':>6}  {'occupancy':>12}  {'note':s}")
+    print("  " + "─" * 78)
+    for n in ns:
+        tgs = n * NUM_KV_HEADS
+        occ = min(100, 100.0 * tgs / M1_SATURATION_TGS)
+        note = ""
+        if tgs < M1_SATURATION_TGS // 2:
+            note = "DISPATCH-BOUND — GPU barely utilised"
+        elif tgs < M1_SATURATION_TGS:
+            note = "partial occupancy"
+        elif tgs < 4 * M1_SATURATION_TGS:
+            note = "saturated"
+        else:
+            note = "saturated, high grid oversubscription"
+        print(f"    {n:>6}  {tgs:>6}  {occ:>10.1f}%   {note}")
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+
+def main() -> int:
+    print("═" * 80)
+    print("  TurboQuant kernel profiler — manual mode")
+    print("═" * 80)
+    print(f"  Shape: {NUM_LAYERS}L × {NUM_KV_HEADS}KVH × hd{HEAD_DIM}  (Qwen3-0.6B)")
+    print(
+        f"  Quant: K={K_QUANT} (bits={K_BITS})  V=q{V_BITS}_0 (bits={V_BITS})  "
+        f"block_size={BLOCK_SIZE}"
+    )
+
+    # Warm up the ops module + JIT.
+    ops = get_ops()
+    v_centroids = get_v_centroids(V_BITS)
+    cache_warm = _make_tq_cache(num_blocks=4)
+    k = mx.random.normal(shape=(1, NUM_KV_HEADS, HEAD_DIM)).astype(mx.float16)
+    v = mx.random.normal(shape=(1, NUM_KV_HEADS, HEAD_DIM)).astype(mx.float16)
+    slot = mx.array([0], dtype=mx.int64)
+    mx.eval(k, v, slot, v_centroids)
+    for _ in range(3):
+        (nk, nv, nks, nvs, nkz) = ops.tq_encode(
+            k,
+            v,
+            cache_warm.key_caches[0],
+            cache_warm.value_caches[0],
+            cache_warm.key_scale_caches[0],
+            cache_warm.value_scale_caches[0],
+            cache_warm.key_zero_caches[0],
+            slot,
+            v_centroids,
+            V_BITS,
+            K_BITS,
+            True,
+        )
+        mx.eval(nk, nv, nks, nvs, nkz)
+    _sync()
+
+    ns = [1, 4, 16, 64, 256, 1024, 4096]
+
+    print_saturation_analysis(ns)
+
+    samples = bench_encode_sweep(ns)
+    print_encode_table(samples)
+
+    bench_decode_step()
+
+    bench_paged_attention([128, 512, 2048, 8192])
+
+    # =======================================================================
+    # Kimi K2.5 scale-out stress test.
+    #
+    # Spec from https://huggingface.co/moonshotai/Kimi-K2.5/raw/main/config.json:
+    #   num_hidden_layers:    61
+    #   num_attention_heads:  64
+    #   num_key_value_heads:  64   (MHA config; actual model uses MLA w/ lora_rank=512)
+    #   qk_nope_head_dim:    128
+    #   max_position:         262144 native, extendable to 1M via YaRN
+    #
+    # CAVEAT: K2.5 uses Multi-head Latent Attention — the KV cache stores a
+    # 512-dim shared latent, not per-head K/V.  Our TQ kernel is MHA-shaped
+    # so this is a *pessimistic upper bound*: we treat each of the 64 heads
+    # as if it had its own quantized K/V cache.  For real MLA integration
+    # you'd quantize the 512-dim latent directly.
+    #
+    # Memory: at 64 KV heads × 128 HD, FP16 cache is ~16 KB/token; TQ cache
+    # is ~7.5 KB/token.  On an M1 8 GB, we cap ctx at 16K with both caches
+    # resident, then extrapolate linearly to 1M — our earlier data shows
+    # the per-token overhead is dead-linear in ctx once ctx > ~1K, so linear
+    # fit is defensible.  If you have more RAM, bump the top ctx up.
+    # =======================================================================
+    bench_paged_attention(
+        [1024, 4096, 16384],
+        num_kv_heads=64,
+        num_q_heads=64,
+        num_layers=61,
+        label="Kimi K2.5 MHA-equiv (61L × 64KVH × hd128)",
+        extrapolate_to=1_048_576,
+        skip_fp_above=16384,
+        iters=12,
+    )
+
+    print()
+    print("═" * 80)
+    print("  Done.  Paste output back to Cascade for analysis.")
+    print("═" * 80)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -981,11 +981,11 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
   threadgroup float *warp_scores =
       reinterpret_cast<threadgroup float *>(shared_mem) +
       warp_idx * BLOCK_SIZE;
-  // TurboQuant: per-warp FWHT workspace for V dequantization.
-  // Allocated after warp_scores. Host must provide the extra shmem when use_turboquant.
-  threadgroup float *fwht_buf =
-      reinterpret_cast<threadgroup float *>(shared_mem) +
-      NUM_WARPS * BLOCK_SIZE + warp_idx * HEAD_SIZE;
+  // NOTE: the previous fwht_buf per-warp workspace (NUM_WARPS * HEAD_SIZE
+  // floats) has been removed — the TurboQuant V dequant path now runs
+  // register-only via `tq_load_and_accumulate_v` + `inverse_fwht_in_place`,
+  // so no threadgroup memory is needed for V reconstruction.  The host-side
+  // shmem-size calculation in paged_ops.cpp no longer adds the TQ bonus.
 
   const device uint32_t *block_table =
       block_tables + seq_idx * max_num_blocks_per_seq;
@@ -1136,7 +1136,7 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
             tok * (num_kv_heads * SCALE_GROUPS) +
             kv_head_idx * SCALE_GROUPS;
         tq_load_and_accumulate_v<HEAD_SIZE, NUM_SIMD_LANES>(
-            v_accs, fwht_buf, v_ptr, value_scale_cache, v_scale_base_offset, w, lane,
+            v_accs, v_ptr, value_scale_cache, v_scale_base_offset, w, lane,
             v_centroids, v_bits);
       } else {
         const device V_CACHE_T *v_ptr =
@@ -1258,6 +1258,45 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
       *exp_sums_ptr = warp_l;
     }
 
+    // TurboQuant V: we've been accumulating in the rotated (FWHT) domain
+    // the whole block loop.
+    //
+    // Non-partitioned path (USE_PARTITIONING == false): apply inverse FWHT
+    // ONCE here to the merged per-head output, before the final normalise +
+    // write to `out`.  Replaces O(ctx) per-token FWHTs with exactly one FWHT
+    // per head per kernel dispatch.
+    //
+    // Partitioned path (USE_PARTITIONING == true): SKIP the FWHT here and
+    // write the rotated, un-FWHT'd partial sum to `tmp_out`.  The reduce
+    // kernel then combines partitions in fp32 and applies a single inverse
+    // FWHT on the merged result (see `paged_attention_v2_reduce`).  This is
+    // exact by linearity of FWHT —
+    //   InverseFWHT(Σ_j w_j · V_rot_j) = Σ_j w_j · InverseFWHT(V_rot_j)
+    // — but numerically superior: the weighted sum across partitions is
+    // accumulated in fp32 *before* any FWHT rounding, and the single FWHT
+    // at the end absorbs all fp16 casting once.  The old code applied the
+    // FWHT per partition and stored the fp16-cast post-FWHT result in
+    // tmp_out, compounding rounding error across partitions.  At long
+    // contexts with many partitions the drift was measurable.
+    //
+    // Both branches are constexpr on USE_PARTITIONING so exactly one survives
+    // per instantiation; the non-TQ specialisation dead-strips the entire
+    // block via the `use_turboquant` function constant.
+    //
+    // Compile-time guard: paged_attention is templated for non-power-of-2
+    // head sizes too (80, 112, 192, ...) for non-TQ workloads.  For those,
+    // V_ELEMS_PER_THREAD = ceil(HEAD_SIZE/32) > HEAD_SIZE/32, which would
+    // trip inverse_fwht_in_place's `static_assert(ELEMS_PER_LANE == HEAD_SIZE/32)`
+    // at template instantiation time even though the runtime branch is dead
+    // (use_turboquant=false for those sizes).  `if constexpr` blocks the
+    // template instantiation entirely.  TQ requires HEAD_SIZE ∈ {64,128,256,512},
+    // all multiples of 32, so this never blocks a real TQ dispatch.
+    if constexpr (HEAD_SIZE % 32 == 0) {
+      if (use_turboquant && !USE_PARTITIONING) {
+        inverse_fwht_in_place<HEAD_SIZE, V_ELEMS_PER_THREAD>(v_accs, lane);
+      }
+    }
+
     // Final normalization: O = O / l
     const float inv_l = 1.f / (warp_l + 1e-6f);
 
@@ -1304,27 +1343,69 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   const uint32_t context_len = context_lens[seq_idx];
   const int effective_context_len = (int)context_len - q_len + q_pos_in_seq + 1;
   const int num_partitions = DIVIDE_ROUND_UP(effective_context_len, PARTITION_SIZE);
+
+  // ========================================================================
+  // Workspace declarations (function scope — Metal requires threadgroup
+  // allocations at function scope, not inside conditional branches).  These
+  // are hoisted above the early-out so the TQ deferred-FWHT path can share
+  // the same buffers whether we early-out or run the full reduce.
+  // ========================================================================
+  constexpr int NUM_WARPS = NUM_THREADS / NUM_SIMD_LANES;
+  const int warp_idx = simd_tid;
+  const int lane = simd_lid;
+
+  // Reduction workspace (main path only).
+  threadgroup float red_smem[2 * NUM_WARPS];
+
+  // TQ deferred-FWHT staging: warp 0 applies a single inverse FWHT to the
+  // cross-partition weighted sum, which lives here in fp32 before the final
+  // fp16 cast to `out`.  Declared unconditionally; dead in non-TQ kernels.
+  // Size: HEAD_SIZE * 4 bytes = at most 2 KB at HEAD_SIZE=512.
+  threadgroup float combined[HEAD_SIZE];
+
+  // ========================================================================
+  // Early-out: only one partition actually contributed.  We still need to
+  // apply the deferred inverse FWHT on the TQ path because paged_attention
+  // writes tmp_out in the rotated (un-FWHT'd) domain for PARTITION_SIZE>0.
+  // ========================================================================
   if (num_partitions == 1 && !use_sinks) {
-    // No need to reduce. Only copy tmp_out to out.
     device T *out_ptr =
         out + q_token_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
     const device T *tmp_out_ptr =
         tmp_out + q_token_idx * num_heads * max_num_partitions * HEAD_SIZE +
         head_idx * max_num_partitions * HEAD_SIZE;
-    for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE;
-         i += threads_per_threadgroup.x) {
-      out_ptr[i] = tmp_out_ptr[i];
+
+    if (use_turboquant) {
+      // Warp 0 owns the entire HEAD_SIZE vector as a lane-strided register
+      // slice: lane `l` holds indices { l, l+32, l+64, ... }.  Load,
+      // InverseFWHT once, write — no cross-warp sync needed since only
+      // warp 0 participates.
+      if (warp_idx == 0) {
+        constexpr int ELEMS_PER_LANE = HEAD_SIZE / 32;
+        float v_accs[ELEMS_PER_LANE];
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+          const int d = lane + e * 32;
+          v_accs[e] = (d < HEAD_SIZE) ? float(tmp_out_ptr[d]) : 0.0f;
+        }
+        inverse_fwht_in_place<HEAD_SIZE, ELEMS_PER_LANE>(v_accs, lane);
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+          const int d = lane + e * 32;
+          if (d < HEAD_SIZE) {
+            out_ptr[d] = T(v_accs[e]);
+          }
+        }
+      }
+    } else {
+      // Non-TQ: plain copy from partition 0.
+      for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE;
+           i += threads_per_threadgroup.x) {
+        out_ptr[i] = tmp_out_ptr[i];
+      }
     }
-    // Terminate the thread block.
     return;
   }
-
-  constexpr int NUM_WARPS = NUM_THREADS / NUM_SIMD_LANES;
-  const int warp_idx = simd_tid;
-  const int lane = simd_lid;
-
-  // Workspace for reduction.
-  threadgroup float red_smem[2 * NUM_WARPS];
 
   // Load max logits to shared memory.
   threadgroup float *shared_max_logits =
@@ -1390,21 +1471,73 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
 
   const float inv_global_exp_sum = 1.0f / (global_exp_sum + 1e-6f);
 
+  // ========================================================================
   // Aggregate tmp_out to out.
+  //
+  // Non-TQ path: weighted sum of per-partition outputs, cast to T, done.
+  //
+  // TQ path: per-partition tmp_out entries are in the ROTATED (un-FWHT'd)
+  // domain (paged_attention skips the FWHT when PARTITION_SIZE>0).  We
+  // accumulate the fp32 weighted sum into shared `combined[HEAD_SIZE]`, then
+  // warp 0 applies the deferred inverse FWHT once on the merged vector and
+  // writes the final fp16 output.  This is exact by linearity of FWHT —
+  //   InverseFWHT(Σ_j w_j · V_rot_j) = Σ_j w_j · InverseFWHT(V_rot_j)
+  // — and numerically strictly better than applying the FWHT per partition
+  // because (a) cross-partition sums happen in fp32 with no intermediate
+  // fp16 round-trip, (b) the 1/sqrt(N) normalisation that squeezes values
+  // near fp16's ULP boundary is applied exactly once on the final merged
+  // vector, and (c) the number of FWHTs per kernel drops from
+  // O(num_partitions) to 1.
+  // ========================================================================
   const device T *tmp_out_ptr =
       tmp_out + q_token_idx * num_heads * max_num_partitions * HEAD_SIZE +
       head_idx * max_num_partitions * HEAD_SIZE;
   device T *out_ptr =
       out + q_token_idx * num_heads * HEAD_SIZE + head_idx * HEAD_SIZE;
-#pragma unroll
-  for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE;
-       i += NUM_THREADS) {
-    float acc = 0.0f;
-    for (int j = 0; j < num_partitions; ++j) {
-      acc += float(tmp_out_ptr[j * HEAD_SIZE + i]) * shared_exp_sums[j] *
-             inv_global_exp_sum;
+
+  if (use_turboquant) {
+    // Stage weighted partial sums into `combined[]` in fp32.
+    for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE;
+         i += NUM_THREADS) {
+      float acc = 0.0f;
+      for (int j = 0; j < num_partitions; ++j) {
+        acc += float(tmp_out_ptr[j * HEAD_SIZE + i]) * shared_exp_sums[j] *
+               inv_global_exp_sum;
+      }
+      combined[i] = acc;
     }
-    out_ptr[i] = T(acc);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Warp 0 applies the single inverse FWHT and writes out.
+    if (warp_idx == 0) {
+      constexpr int ELEMS_PER_LANE = HEAD_SIZE / 32;
+      float v_accs[ELEMS_PER_LANE];
+      #pragma unroll
+      for (int e = 0; e < ELEMS_PER_LANE; e++) {
+        const int d = lane + e * 32;
+        v_accs[e] = (d < HEAD_SIZE) ? combined[d] : 0.0f;
+      }
+      inverse_fwht_in_place<HEAD_SIZE, ELEMS_PER_LANE>(v_accs, lane);
+      #pragma unroll
+      for (int e = 0; e < ELEMS_PER_LANE; e++) {
+        const int d = lane + e * 32;
+        if (d < HEAD_SIZE) {
+          out_ptr[d] = T(v_accs[e]);
+        }
+      }
+    }
+  } else {
+    // Non-TQ: direct weighted sum + write.
+#pragma unroll
+    for (int i = thread_position_in_threadgroup.x; i < HEAD_SIZE;
+         i += NUM_THREADS) {
+      float acc = 0.0f;
+      for (int j = 0; j < num_partitions; ++j) {
+        acc += float(tmp_out_ptr[j * HEAD_SIZE + i]) * shared_exp_sums[j] *
+               inv_global_exp_sum;
+      }
+      out_ptr[i] = T(acc);
+    }
   }
 }
 

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -981,11 +981,11 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
   threadgroup float *warp_scores =
       reinterpret_cast<threadgroup float *>(shared_mem) +
       warp_idx * BLOCK_SIZE;
-  // TurboQuant: per-warp FWHT workspace for V dequantization.
-  // Allocated after warp_scores. Host must provide the extra shmem when use_turboquant.
-  threadgroup float *fwht_buf =
-      reinterpret_cast<threadgroup float *>(shared_mem) +
-      NUM_WARPS * BLOCK_SIZE + warp_idx * HEAD_SIZE;
+  // NOTE: the previous fwht_buf per-warp workspace (NUM_WARPS * HEAD_SIZE
+  // floats) has been removed — the TurboQuant V dequant path now runs
+  // register-only via `tq_load_and_accumulate_v` + `inverse_fwht_in_place`,
+  // so no threadgroup memory is needed for V reconstruction.  The host-side
+  // shmem-size calculation in paged_ops.cpp no longer adds the TQ bonus.
 
   const device uint32_t *block_table =
       block_tables + seq_idx * max_num_blocks_per_seq;
@@ -1136,7 +1136,7 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
             tok * (num_kv_heads * SCALE_GROUPS) +
             kv_head_idx * SCALE_GROUPS;
         tq_load_and_accumulate_v<HEAD_SIZE, NUM_SIMD_LANES>(
-            v_accs, fwht_buf, v_ptr, value_scale_cache, v_scale_base_offset, w, lane,
+            v_accs, v_ptr, value_scale_cache, v_scale_base_offset, w, lane,
             v_centroids, v_bits);
       } else {
         const device V_CACHE_T *v_ptr =
@@ -1256,6 +1256,22 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
                                    q_token_idx * num_heads * max_num_partitions +
                                    head_idx * max_num_partitions + partition_idx;
       *exp_sums_ptr = warp_l;
+    }
+
+    // TurboQuant V: we've been accumulating in the rotated (FWHT) domain
+    // the whole block loop.  Apply inverse FWHT ONCE here, to the merged
+    // per-head output, before the final normalise + write.  This replaces
+    // O(ctx) per-token FWHTs with exactly one FWHT per head per kernel
+    // dispatch — the difference between a tight short-ctx kernel and a
+    // long-ctx kernel that scales linearly with token count.
+    //
+    // Guarded by the `use_turboquant` function constant so the non-TQ
+    // specialisation compiles this away completely.  Safe across all 32
+    // lanes of warp 0 (simd_shuffle_xor requires full-warp participation).
+    // For partitioned mode, applying the FWHT to each partition's output
+    // is still correct by linearity of the reduce kernel's weighted sum.
+    if (use_turboquant) {
+      inverse_fwht_in_place<HEAD_SIZE>(v_accs, lane);
     }
 
     // Final normalization: O = O / l

--- a/vllm_metal/metal/kernels_v2/turboquant.metal
+++ b/vllm_metal/metal/kernels_v2/turboquant.metal
@@ -194,57 +194,75 @@ template<> inline constexpr float fwht_inv_sqrt_n<512>() { return 0.044194173824
 
 // ========================================== Inverse FWHT
 
-// In-place inverse FWHT for HEAD_SIZE elements using threadgroup memory.
-// Supports HEAD_SIZE = 64 (6 stages), 128 (7 stages), 256 (8 stages),
-// or 512 (9 stages).
-// Each SIMD lane owns HEAD_SIZE/32 elements (lane i → indices i, i+32, i+64, ...).
-template<int HEAD_SIZE>
-inline void threadgroup_inverse_fwht(threadgroup float* fwht_buf, uint lane) {
+// In-place inverse FWHT on a thread-local register array `vals` of size
+// ELEMS_PER_LANE.  Each SIMD lane owns the slice
+// { lane, lane+32, lane+64, ... } of the logical HEAD_SIZE-vector.
+// The caller must supply `ELEMS_PER_LANE` explicitly; a `static_assert`
+// enforces the only valid coupling (one element per 32 lanes) so any future
+// mis-sized register array is a compile error, not silent OOB register access.
+//
+// Entirely register-resident:
+//   * Stages where mask < 32 exchange values across lanes of the same simd-
+//     group via `simd_shuffle_xor` — no threadgroup memory, no barriers.
+//   * Stages where mask >= 32 are intra-thread: the partner lives in the
+//     same lane at a different `e` offset.  RAW hazard across `e` iterations
+//     is handled by the snapshot-then-commit pattern (memory 86c1ae49).
+//
+// Called from tq_load_and_accumulate_v which dequantises V straight into
+// registers, runs this FWHT, and accumulates into v_accs — there is no
+// threadgroup-memory round-trip on the V read path.  Supports HEAD_SIZE
+// = 64 (6 stages), 128 (7 stages), 256 (8 stages), or 512 (9 stages).
+template<int HEAD_SIZE, int ELEMS_PER_LANE>
+inline void inverse_fwht_in_place(thread float* vals, uint lane) {
+    static_assert(ELEMS_PER_LANE == HEAD_SIZE / 32,
+        "inverse_fwht_in_place: ELEMS_PER_LANE must equal HEAD_SIZE/32; "
+        "callers allocate `vals[V_ELEMS_PER_THREAD]` at NUM_SIMD_LANES=32 and "
+        "passing a mismatched size would walk off the register array silently.");
     constexpr int NUM_STAGES = fwht_num_stages<HEAD_SIZE>();
-    constexpr int ELEMS_PER_LANE = HEAD_SIZE / 32;
-    float vals[ELEMS_PER_LANE];
 
+    // Stages 0-4: intra-simdgroup butterflies via register shuffle.  Zero TG
+    // memory, zero barriers.  On Apple GPUs simd_shuffle_xor is a single-
+    // cycle warp-level primitive; compare to the old path which paid 5
+    // sequential TG-memory-plus-barrier round-trips.
     #pragma unroll
-    for (int stage = 0; stage < NUM_STAGES; stage++) {
-        uint mask = 1u << stage;
+    for (int stage = 0; stage < 5; stage++) {
+        const uint mask = 1u << stage;
         #pragma unroll
         for (int e = 0; e < ELEMS_PER_LANE; e++) {
-            vals[e] = fwht_buf[lane + e * 32];
+            const float partner = simd_shuffle_xor(vals[e], mask);
+            const uint  idx     = lane + uint(e) * 32u;
+            vals[e] = (idx & mask) ? (partner - vals[e]) : (vals[e] + partner);
         }
-        if (mask < 32) {
-            // Partners in different lanes — safe to read from threadgroup memory
-            #pragma unroll
-            for (int e = 0; e < ELEMS_PER_LANE; e++) {
-                uint idx = lane + e * 32;
-                float partner_val = fwht_buf[idx ^ mask];
-                fwht_buf[idx] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
-            }
-        } else {
-            // Partner owned by this thread at a different e offset
-            float results[ELEMS_PER_LANE];
-            #pragma unroll
-            for (int e = 0; e < ELEMS_PER_LANE; e++) {
-                uint idx = lane + e * 32;
-                uint partner_idx = idx ^ mask;
-                int partner_e = static_cast<int>((partner_idx - lane) / 32);
-                float partner_val = vals[partner_e];
-                results[e] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
-            }
-            #pragma unroll
-            for (int e = 0; e < ELEMS_PER_LANE; e++) {
-                fwht_buf[lane + e * 32] = results[e];
-            }
-        }
-        simdgroup_barrier(mem_flags::mem_threadgroup);
     }
-    // Normalisation: 1/sqrt(HEAD_SIZE) + random sign flip
+    // Stages 5..NUM_STAGES-1: partner is on the same thread at a different
+    // `e` offset.  Snapshot-then-commit to avoid reading a slot after an
+    // earlier `e` iteration in the same stage wrote it (RAW across e).
+    #pragma unroll
+    for (int stage = 5; stage < NUM_STAGES; stage++) {
+        const uint mask = 1u << stage;
+        float results[ELEMS_PER_LANE];
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+            const uint idx         = lane + uint(e) * 32u;
+            const uint partner_idx = idx ^ mask;
+            const int  partner_e   = int((partner_idx - lane) / 32u);
+            const float partner_val = vals[partner_e];
+            results[e] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
+        }
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+            vals[e] = results[e];
+        }
+    }
+
+    // Fused normalisation + random-sign flip in registers.  The sign table
+    // is `constant` memory (broadcast-cached), so these reads are free.
     constexpr float INV_SQRT_N = fwht_inv_sqrt_n<HEAD_SIZE>();
     #pragma unroll
     for (int e = 0; e < ELEMS_PER_LANE; e++) {
-        uint idx = lane + e * 32;
-        fwht_buf[idx] *= INV_SQRT_N * get_fwht_sign<HEAD_SIZE>(idx);
+        const uint idx = lane + uint(e) * 32u;
+        vals[e] *= INV_SQRT_N * get_fwht_sign<HEAD_SIZE>(idx);
     }
-    simdgroup_barrier(mem_flags::mem_threadgroup);
 }
 
 // ========================================== High-level K/V load helpers
@@ -266,28 +284,34 @@ inline void tq_load_k_vec(
     K_vec k_vec_result;
     thread T* result_ptr = reinterpret_cast<thread T*>(&k_vec_result);
 
+    // All VEC_SIZE elements share the same scale group.
+    //
+    // Proof: vec covers elements [vec_idx*VEC_SIZE, vec_idx*VEC_SIZE + VEC_SIZE).
+    // VEC_SIZE is derived as MAX(16/(THREAD_GROUP_SIZE*sizeof(T)), 1) in the
+    // paged-attention kernel, so VEC_SIZE ∈ {1, 2, 4, 8, 16} — all divisors of
+    // SCALE_GROUP_SIZE=32.  Therefore (vec_idx*VEC_SIZE) % 32 + VEC_SIZE ≤ 32
+    // whenever vec_idx*VEC_SIZE is aligned to VEC_SIZE (it is, by construction),
+    // so no vec ever straddles a scale-group boundary.  One scale/zero load
+    // per call instead of VEC_SIZE loads.
+    const int group_idx = (vec_idx * VEC_SIZE) / SCALE_GROUP_SIZE;
+    const float s = key_scale_cache[k_scale_base_offset + group_idx];
+    const float z = key_zero_cache [k_scale_base_offset + group_idx];
+
     if constexpr (is_char<K_CACHE_T>()) {
         // int8 K path (signed)
         const device K_CACHE_T* k_elem_ptr = k_ptr + vec_idx * VEC_SIZE;
         #pragma unroll
         for (int e = 0; e < VEC_SIZE; e++) {
-            int elem_idx = vec_idx * VEC_SIZE + e;
-            int group_idx = elem_idx / SCALE_GROUP_SIZE;
-            float s = key_scale_cache[k_scale_base_offset + group_idx];
-            float z = key_zero_cache[k_scale_base_offset + group_idx];
             result_ptr[e] = T(tq_dequant_k(k_elem_ptr[e], s, z));
         }
     } else {
         // uchar K path (uint8 or sub-8-bit packed)
         if (k_bits >= 8) {
             // 8-bit unsigned: one byte per element
-            const device uchar* k_elem_ptr = reinterpret_cast<const device uchar*>(k_ptr) + vec_idx * VEC_SIZE;
+            const device uchar* k_elem_ptr =
+                reinterpret_cast<const device uchar*>(k_ptr) + vec_idx * VEC_SIZE;
             #pragma unroll
             for (int e = 0; e < VEC_SIZE; e++) {
-                int elem_idx = vec_idx * VEC_SIZE + e;
-                int group_idx = elem_idx / SCALE_GROUP_SIZE;
-                float s = key_scale_cache[k_scale_base_offset + group_idx];
-                float z = key_zero_cache[k_scale_base_offset + group_idx];
                 result_ptr[e] = T(tq_dequant_k(k_elem_ptr[e], s, z));
             }
         } else {
@@ -295,11 +319,8 @@ inline void tq_load_k_vec(
             const device uchar* k_bytes = reinterpret_cast<const device uchar*>(k_ptr);
             #pragma unroll
             for (int e = 0; e < VEC_SIZE; e++) {
-                int elem_idx = vec_idx * VEC_SIZE + e;
-                int group_idx = elem_idx / SCALE_GROUP_SIZE;
-                float s = key_scale_cache[k_scale_base_offset + group_idx];
-                float z = key_zero_cache[k_scale_base_offset + group_idx];
-                uint raw = unpack_k_bits(k_bytes, elem_idx, k_bits);
+                const int  elem_idx = vec_idx * VEC_SIZE + e;
+                const uint raw      = unpack_k_bits(k_bytes, elem_idx, k_bits);
                 result_ptr[e] = T(tq_dequant_k_raw(raw, s, z));
             }
         }
@@ -326,7 +347,6 @@ inline uint unpack_v_bits(const device uchar* bytes, int elem_idx, int bits) {
 template <int HEAD_SIZE, int NUM_SIMD_LANES>
 inline void tq_load_and_accumulate_v(
     thread float* v_accs,
-    threadgroup float* fwht_buf,
     const device uchar* v_ptr,
     const device half* value_scale_cache,
     int64_t v_scale_base_offset,
@@ -338,28 +358,370 @@ inline void tq_load_and_accumulate_v(
     constexpr int SCALE_GROUP_SIZE = 32;
     constexpr int V_ELEMS_PER_THREAD = (HEAD_SIZE + NUM_SIMD_LANES - 1) / NUM_SIMD_LANES;
 
-    // Load packed v_bits V, dequantize via centroid lookup, write to fwht_buf
+    // Dequantise V directly into registers.  Centroid lookup + scale, no
+    // threadgroup memory traffic on the V hot path.
+    //
+    // Deferred V FWHT
+    //
+    // Inverse FWHT is a *linear* transform.  By linearity:
+    //
+    //     Σᵢ wᵢ · InverseFWHT(dequant(Vᵢ))
+    //   = InverseFWHT(Σᵢ wᵢ · dequant(Vᵢ))
+    //
+    // So we accumulate in the rotated-and-dequantised domain and apply
+    // InverseFWHT *once* at the end of the attention kernel — not per V
+    // token.  That replaces O(ctx × num_kv_heads) FWHTs per decode step
+    // with O(num_kv_heads) FWHTs, a ~4 orders-of-magnitude reduction at
+    // long context.  The paged_attention kernel calls
+    // `inverse_fwht_in_place` once in warp 0 after cross-warp merge, just
+    // before writing the final output.  `v_accs` therefore holds *rotated*
+    // values throughout the block loop — correct by linearity, same final
+    // numerics once the end-of-kernel FWHT fires.
+    float vals[V_ELEMS_PER_THREAD];
     #pragma unroll
     for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
         const int d = lane + i * NUM_SIMD_LANES;
         if (d < HEAD_SIZE) {
-            int group_idx = d / SCALE_GROUP_SIZE;
-            float vs = value_scale_cache[v_scale_base_offset + group_idx];
-            uchar v_idx = (v_bits == 3) ? unpack_3bit(v_ptr, d) : uchar(unpack_v_bits(v_ptr, d, v_bits));
-            fwht_buf[d] = tq_dequant_v_centroid(v_idx, vs, v_centroids, v_bits);
+            const int group_idx = d / SCALE_GROUP_SIZE;
+            const float vs = value_scale_cache[v_scale_base_offset + group_idx];
+            const uchar v_idx = (v_bits == 3)
+                ? unpack_3bit(v_ptr, d)
+                : uchar(unpack_v_bits(v_ptr, d, v_bits));
+            vals[i] = tq_dequant_v_centroid(v_idx, vs, v_centroids, v_bits);
+        } else {
+            vals[i] = 0.f;
         }
     }
-    simdgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Apply inverse FWHT to reconstruct the original V vector
-    threadgroup_inverse_fwht<HEAD_SIZE>(fwht_buf, lane);
-
-    // Accumulate: O += weight * V_reconstructed
+    // Accumulate in rotated domain: O_rot += weight * dequant(V_rot).
     #pragma unroll
     for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
         const int d = lane + i * NUM_SIMD_LANES;
         if (d < HEAD_SIZE) {
-            v_accs[i] += weight * fwht_buf[d];
+            v_accs[i] += weight * vals[i];
         }
     }
 }
+
+// ===========================================================================
+// Encode path: forward FWHT (one element per thread, TG size == HEAD_SIZE).
+// Mirrors Python fwht(..., encode=True):
+//   x_signed = x * random_signs;  x_rot = hadamard(x_signed);  x_rot /= sqrt(N)
+// The random_signs table is the same deterministic constant consumed by the
+// decode path (see FWHT_SIGNS_*).
+//
+// Stages 0..4 (butterfly mask < 32) are entirely within a simdgroup, so we
+// use simd_shuffle_xor (register <-> register) instead of threadgroup memory
+// + barriers — 5 stages with zero shared-memory traffic and zero barriers.
+// Stages 5..NUM_STAGES-1 cross simdgroup boundaries and fall back to
+// threadgroup memory with barriers.  Takes the input value `x` in a register
+// (no pre-call TG write or barrier needed) and returns the transformed value
+// in a register (no post-call barrier needed since every caller reads buf[t]
+// only from its own thread, i.e. register-equivalent).
+// ===========================================================================
+
+template <int HEAD_SIZE>
+inline float tg_forward_fwht_scalar(float x, threadgroup float* buf, uint t) {
+    constexpr int   NUM_STAGES = fwht_num_stages<HEAD_SIZE>();
+    constexpr float INV_SQRT_N = fwht_inv_sqrt_n<HEAD_SIZE>();
+
+    x *= get_fwht_sign<HEAD_SIZE>(t);
+
+    // Intra-simdgroup butterflies: purely register, no TG memory, no barriers.
+    #pragma unroll
+    for (int stage = 0; stage < 5; stage++) {
+        const uint  mask    = 1u << stage;
+        const float partner = simd_shuffle_xor(x, mask);
+        x = (t & mask) ? (partner - x) : (x + partner);
+    }
+
+    // Cross-simdgroup butterflies: threadgroup memory + barriers.
+    // NUM_STAGES is 6..8, so 1..3 iterations below.
+    if (NUM_STAGES > 5) {
+        buf[t] = x;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        #pragma unroll
+        for (int stage = 5; stage < NUM_STAGES; stage++) {
+            const uint  mask    = 1u << stage;
+            const float me      = buf[t];
+            const float partner = buf[t ^ mask];
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            buf[t] = (t & mask) ? (partner - me) : (me + partner);
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        x = buf[t];
+    }
+
+    return x * INV_SQRT_N;
+}
+
+// ===========================================================================
+// Fused encode-and-cache kernel
+//
+// Replaces Python `turbo_quant_encode()` + 5 paged scatters with a single
+// dispatch.  Writes K (any bit width in QUANT_PARAMS), V (packed v_bits),
+// and the three scale/zero caches directly at slot_mapping[token] offsets.
+//
+// Grid:        (num_tokens, num_kv_heads, 1)
+// Threadgroup: (HEAD_SIZE, 1, 1)
+// One threadgroup encodes one (token, kv_head) pair.  Each simdgroup
+// (32 lanes) corresponds to exactly one 32-element scale group, so
+// min/max/RMS reductions are free via simd_min / simd_max / simd_sum.
+//
+// K spec (must match `quantize()` in turboquant.py):
+//   signed (q8_0/int8, bits=8):
+//     max_val = (1 << (bits-1)) - 1 = 127
+//     scale   = fp16((x_max - x_min) / (2 * max_val))
+//     zp      = round(fp16((x_max + x_min) / (2 * scale)))
+//     idx     = clip(round(fp16(x / scale) - zp), -max_val, max_val)
+//   unsigned (uint8 + sub-8-bit: q5_0/q4_0/int4/uint4/int2/uint2):
+//     max_val = (1 << bits) - 1
+//     scale   = fp16((x_max - x_min) / max_val)
+//     zp      = round(fp16(x_min / scale))
+//     idx     = clip(round(fp16(x / scale) - zp), 0, max_val)
+//
+// The `+ 1e-8` epsilon used in Python's scale guard underflows to 0 in fp16
+// (min subnormal ~6e-8), so it is a no-op and we drop it — matching Python's
+// actual behaviour bit-for-bit.
+//
+// Bit packing: 8-bit K writes one byte per element directly; sub-8-bit K
+// stages unsigned indices in `k_idx_buf` then the first `k_packed` threads
+// assemble bytes in parallel (identical to V packing).  The key_cache
+// buffer is bound as uchar* universally — int8 values use two's-complement
+// bit patterns which read back correctly as `int8_t` in decode kernels.
+// ===========================================================================
+
+constant int  tq_enc_k_bits   [[function_constant(80)]];
+constant bool tq_enc_k_signed [[function_constant(81)]];
+constant int  tq_enc_v_bits   [[function_constant(90)]];
+
+// Generic byte-packer: assembles one output byte from the staged uchar index
+// buffer `idx_buf`.  Each byte covers 8 contiguous bit positions which may
+// straddle up to two logical elements when `bits` does not divide 8 (e.g.
+// 3-bit: 8 values -> 3 bytes).  `bits` must be in [1, 8].
+inline uint tq_pack_byte(threadgroup const uchar* idx_buf,
+                         int bit_start, int bits) {
+    const int first_e = bit_start / bits;
+    const int last_e  = (bit_start + 7) / bits;
+    const uint mask   = (1u << bits) - 1u;
+    uint byte = 0;
+    for (int e = first_e; e <= last_e; e++) {
+        const int  e_bit  = e * bits;
+        const int  shift  = e_bit - bit_start;
+        const uint idx_v  = uint(idx_buf[e]) & mask;
+        if (shift >= 0) {
+            byte |= idx_v << shift;
+        } else {
+            byte |= idx_v >> (-shift);
+        }
+    }
+    return byte & 0xFFu;
+}
+
+template <typename T, int HEAD_SIZE>
+[[kernel]] void tq_encode(
+    const device T*       __restrict__ key                [[buffer(0)]],
+    const device T*       __restrict__ value              [[buffer(1)]],
+    device uchar*         __restrict__ key_cache          [[buffer(2)]],
+    device uchar*         __restrict__ value_cache        [[buffer(3)]],
+    device half*          __restrict__ key_scale_cache    [[buffer(4)]],
+    device half*          __restrict__ value_scale_cache  [[buffer(5)]],
+    device half*          __restrict__ key_zero_cache     [[buffer(6)]],
+    const device int64_t* __restrict__ slot_mapping       [[buffer(7)]],
+    const device float*   __restrict__ v_centroids        [[buffer(8)]],
+    const constant int&   num_kv_heads                    [[buffer(9)]],
+    const constant int&   block_size                      [[buffer(10)]],
+    uint3 tgid  [[threadgroup_position_in_grid]],
+    uint3 tid3  [[thread_position_in_threadgroup]],
+    uint  sid   [[simdgroup_index_in_threadgroup]],
+    uint  lane  [[thread_index_in_simdgroup]]
+) {
+    constexpr int SG_SIZE = 32;
+
+    const uint t     = tid3.x;
+    const int  token = int(tgid.x);
+    const int  kvh   = int(tgid.y);
+
+    const int64_t slot = slot_mapping[token];
+    if (slot < 0) {
+        return;
+    }
+    const int block_idx = int(slot / block_size);
+    const int block_off = int(slot % block_size);
+
+    constexpr int head_dim     = HEAD_SIZE;
+    constexpr int scale_groups = HEAD_SIZE / SG_SIZE;
+    const int     k_packed     = (head_dim * tq_enc_k_bits + 7) / 8;
+    const int     v_packed     = (head_dim * tq_enc_v_bits + 7) / 8;
+
+    // -------- Source element (one per thread) --------
+    const int64_t src_base =
+        (int64_t(token) * num_kv_heads + kvh) * head_dim;
+    const float k_val = float(key[src_base + t]);
+    const float v_val = float(value[src_base + t]);
+
+    // -------- Threadgroup staging buffers --------
+    threadgroup float fwht_buf[HEAD_SIZE];    // V FWHT rotation scratch
+    threadgroup uchar k_idx_buf[HEAD_SIZE];   // K indices (sub-8-bit path)
+    threadgroup uchar v_idx_buf[HEAD_SIZE];   // V indices (always staged)
+
+    // Precomputed V-centroid midpoints (searchsorted boundaries).  Sized for
+    // the worst case (v_bits = 8 → 255 boundaries; ~1 KB of TG memory).  For
+    // smaller v_bits only a prefix is used.  Strided fill covers arbitrary
+    // num_centroids up to the max without requiring HEAD_SIZE >= num_centroids.
+    //
+    // Why: without this, every one of the HEAD_SIZE threads per TG would
+    // independently read v_centroids[i] and v_centroids[i+1] from device
+    // memory inside the searchsorted loop — at large batch sizes that adds
+    // up to hundreds of megabytes of redundant device reads across the full
+    // grid.  Preloading once per TG reduces that to num_centroids reads per
+    // TG and folds the per-thread midpoint compute into a single pass.
+    threadgroup float v_boundaries[255];
+
+    // Strided preload.  Fully async with the K-encode work that follows —
+    // the explicit barrier just before the searchsorted consumer (below) is
+    // the sole synchronisation point.  We deliberately do NOT lean on the
+    // forward FWHT's internal barriers or the sub-8-bit K-pack barrier to
+    // publish these writes: doing so silently couples this searchsorted path
+    // to implementation details of unrelated helpers, which would break the
+    // preload the next time those helpers are rearranged.
+    const int num_centroids = 1 << tq_enc_v_bits;
+    #pragma unroll 1
+    for (int i = int(t); i < num_centroids - 1; i += HEAD_SIZE) {
+        v_boundaries[i] = 0.5f * (v_centroids[i] + v_centroids[i + 1]);
+    }
+
+    // -------- Cache destination bases --------
+    const int64_t token_base =
+        (int64_t(block_idx) * block_size + block_off) * num_kv_heads;
+    const int64_t kc_base     = (token_base + kvh) * k_packed;
+    const int64_t vc_base     = (token_base + kvh) * v_packed;
+    const int64_t scale_base  = (token_base + kvh) * scale_groups;
+
+    // ======================================================================
+    // K encode: asymmetric uniform, signed or unsigned.  All arithmetic
+    // routed through fp16 (matching Python's fp16 scale/zp storage).
+    // ======================================================================
+    const float k_min_f = simd_min(k_val);
+    const float k_max_f = simd_max(k_val);
+
+    half  k_scale_h;
+    float k_zp_f;
+    int   k_idx_i;
+
+    if (tq_enc_k_signed) {
+        // q8_0 / int8  (bits == 8)
+        const int max_val = (1 << (tq_enc_k_bits - 1)) - 1;
+        k_scale_h = half(half(k_max_f - k_min_f) / half(2.0f * float(max_val)));
+        const half k_sum_h = half(k_max_f + k_min_f);
+        k_zp_f    = rint(float(k_sum_h / (half(2.0f) * k_scale_h)));
+        k_idx_i   = int(rint(float(half(k_val) / k_scale_h) - k_zp_f));
+        k_idx_i   = clamp(k_idx_i, -max_val, max_val);
+    } else {
+        // uint8 / q5_0 / q4_0 / int4 / uint4 / int2 / uint2
+        const int max_val = (1 << tq_enc_k_bits) - 1;
+        k_scale_h = half(half(k_max_f - k_min_f) / half(float(max_val)));
+        k_zp_f    = rint(float(half(k_min_f) / k_scale_h));
+        k_idx_i   = int(rint(float(half(k_val) / k_scale_h) - k_zp_f));
+        k_idx_i   = clamp(k_idx_i, 0, max_val);
+    }
+
+    // Lane 0 of each simdgroup publishes the per-group scale + zero_point.
+    if (lane == 0) {
+        key_scale_cache[scale_base + int(sid)] = k_scale_h;
+        key_zero_cache [scale_base + int(sid)] = half(k_zp_f);
+    }
+
+    // -------- Write K indices --------
+    if (tq_enc_k_bits == 8) {
+        // 8-bit (signed or unsigned): one byte per element, direct write.
+        // Signed values are stored as two's-complement bit patterns via the
+        // uchar cast, so decode kernels reading `int8_t*` see the right sign.
+        key_cache[kc_base + t] = uchar(uint(k_idx_i) & 0xFFu);
+    } else {
+        // Sub-8-bit unsigned: stage indices then pack bytes in parallel.
+        k_idx_buf[t] = uchar(uint(k_idx_i) & ((1u << tq_enc_k_bits) - 1u));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (int(t) < k_packed) {
+            const uint byte = tq_pack_byte(k_idx_buf, int(t) * 8, tq_enc_k_bits);
+            key_cache[kc_base + t] = uchar(byte);
+        }
+    }
+
+    // ======================================================================
+    // V encode: FWHT rotation + Lloyd-Max quantization.
+    // Python flow (mirrored exactly):
+    //   x_rot   = fwht(v, encode=True)           # fp16
+    //   scale   = sqrt(mean(x_rot^2))            # fp16, per 32-elem block
+    //   x_norm  = x_rot / scale                  # fp16 (1e-8 guard dropped)
+    //   idx     = searchsorted(boundaries, x_norm)
+    // Boundaries are midpoints of ascending fp32 centroids.
+    // ======================================================================
+    // FWHT takes the input value in-register and returns the rotated value
+    // in-register; threadgroup memory is used only for cross-simdgroup
+    // butterfly stages.  No pre- or post-call barrier needed.
+    const float v_rot_f   = tg_forward_fwht_scalar<HEAD_SIZE>(v_val, fwht_buf, t);
+    const half  v_rot_h   = half(v_rot_f);
+    const float v_sqsum   = simd_sum(float(v_rot_h) * float(v_rot_h));
+    const half  v_scale_h = half(sqrt(v_sqsum * (1.0f / float(SG_SIZE))));
+    const float v_norm    = float(v_rot_h / v_scale_h);
+
+    // Searchsorted against the preloaded midpoint boundaries.  The explicit
+    // barrier below is the sync point that publishes the strided preload of
+    // `v_boundaries` to all threads in the TG.  We don't rely on any barrier
+    // baked into tg_forward_fwht_scalar or the K-pack path — those are
+    // implementation details of *other* code paths and MUST NOT be load-
+    // bearing for this one.  The barrier sits on the V-encode hot path but
+    // adds at most one cycle above the preload cost since the writes have
+    // been inflight since kernel entry.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    int v_idx = 0;
+    for (int i = 0; i < num_centroids - 1; i++) {
+        if (v_norm > v_boundaries[i]) v_idx++;
+    }
+    v_idx_buf[t] = uchar(v_idx & ((1 << tq_enc_v_bits) - 1));
+
+    if (lane == 0) {
+        value_scale_cache[scale_base + int(sid)] = v_scale_h;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // -------- Pack V indices into bytes --------
+    if (int(t) < v_packed) {
+        const uint byte = tq_pack_byte(v_idx_buf, int(t) * 8, tq_enc_v_bits);
+        value_cache[vc_base + t] = uchar(byte);
+    }
+}
+
+#define instantiate_tq_encode(T, HS)                                           \
+  template [[host_name("tq_encode_" #T "_hs" #HS)]] [[kernel]] void          \
+  tq_encode<T, HS>(                                                            \
+      const device T*       __restrict__ key                [[buffer(0)]],     \
+      const device T*       __restrict__ value              [[buffer(1)]],     \
+      device uchar*         __restrict__ key_cache          [[buffer(2)]],     \
+      device uchar*         __restrict__ value_cache        [[buffer(3)]],     \
+      device half*          __restrict__ key_scale_cache    [[buffer(4)]],     \
+      device half*          __restrict__ value_scale_cache  [[buffer(5)]],     \
+      device half*          __restrict__ key_zero_cache     [[buffer(6)]],     \
+      const device int64_t* __restrict__ slot_mapping       [[buffer(7)]],     \
+      const device float*   __restrict__ v_centroids        [[buffer(8)]],     \
+      const constant int&   num_kv_heads                    [[buffer(9)]],     \
+      const constant int&   block_size                      [[buffer(10)]],    \
+      uint3 tgid  [[threadgroup_position_in_grid]],                            \
+      uint3 tid3  [[thread_position_in_threadgroup]],                          \
+      uint  sid   [[simdgroup_index_in_threadgroup]],                          \
+      uint  lane  [[thread_index_in_simdgroup]]);
+
+instantiate_tq_encode(half, 64)
+instantiate_tq_encode(half, 128)
+instantiate_tq_encode(half, 256)
+instantiate_tq_encode(half, 512)
+instantiate_tq_encode(bfloat16_t, 64)
+instantiate_tq_encode(bfloat16_t, 128)
+instantiate_tq_encode(bfloat16_t, 256)
+instantiate_tq_encode(bfloat16_t, 512)
+instantiate_tq_encode(float, 64)
+instantiate_tq_encode(float, 128)
+instantiate_tq_encode(float, 256)
+instantiate_tq_encode(float, 512)

--- a/vllm_metal/metal/kernels_v2/turboquant.metal
+++ b/vllm_metal/metal/kernels_v2/turboquant.metal
@@ -194,57 +194,69 @@ template<> inline constexpr float fwht_inv_sqrt_n<512>() { return 0.044194173824
 
 // ========================================== Inverse FWHT
 
-// In-place inverse FWHT for HEAD_SIZE elements using threadgroup memory.
-// Supports HEAD_SIZE = 64 (6 stages), 128 (7 stages), 256 (8 stages),
-// or 512 (9 stages).
-// Each SIMD lane owns HEAD_SIZE/32 elements (lane i → indices i, i+32, i+64, ...).
+// In-place inverse FWHT on a thread-local register array `vals` of size
+// ELEMS_PER_LANE = HEAD_SIZE/32.  Each SIMD lane owns the slice
+// { lane, lane+32, lane+64, ... } of the logical HEAD_SIZE-vector.
+//
+// Entirely register-resident:
+//   * Stages where mask < 32 exchange values across lanes of the same simd-
+//     group via `simd_shuffle_xor` — no threadgroup memory, no barriers.
+//   * Stages where mask >= 32 are intra-thread: the partner lives in the
+//     same lane at a different `e` offset.  RAW hazard across `e` iterations
+//     is handled by the snapshot-then-commit pattern (memory 86c1ae49).
+//
+// Called from tq_load_and_accumulate_v which dequantises V straight into
+// registers, runs this FWHT, and accumulates into v_accs — there is no
+// threadgroup-memory round-trip on the V read path.  Supports HEAD_SIZE
+// = 64 (6 stages), 128 (7 stages), 256 (8 stages), or 512 (9 stages).
 template<int HEAD_SIZE>
-inline void threadgroup_inverse_fwht(threadgroup float* fwht_buf, uint lane) {
+inline void inverse_fwht_in_place(thread float* vals, uint lane) {
     constexpr int NUM_STAGES = fwht_num_stages<HEAD_SIZE>();
     constexpr int ELEMS_PER_LANE = HEAD_SIZE / 32;
-    float vals[ELEMS_PER_LANE];
 
+    // Stages 0-4: intra-simdgroup butterflies via register shuffle.  Zero TG
+    // memory, zero barriers.  On Apple GPUs simd_shuffle_xor is a single-
+    // cycle warp-level primitive; compare to the old path which paid 5
+    // sequential TG-memory-plus-barrier round-trips.
     #pragma unroll
-    for (int stage = 0; stage < NUM_STAGES; stage++) {
-        uint mask = 1u << stage;
+    for (int stage = 0; stage < 5; stage++) {
+        const uint mask = 1u << stage;
         #pragma unroll
         for (int e = 0; e < ELEMS_PER_LANE; e++) {
-            vals[e] = fwht_buf[lane + e * 32];
+            const float partner = simd_shuffle_xor(vals[e], mask);
+            const uint  idx     = lane + uint(e) * 32u;
+            vals[e] = (idx & mask) ? (partner - vals[e]) : (vals[e] + partner);
         }
-        if (mask < 32) {
-            // Partners in different lanes — safe to read from threadgroup memory
-            #pragma unroll
-            for (int e = 0; e < ELEMS_PER_LANE; e++) {
-                uint idx = lane + e * 32;
-                float partner_val = fwht_buf[idx ^ mask];
-                fwht_buf[idx] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
-            }
-        } else {
-            // Partner owned by this thread at a different e offset
-            float results[ELEMS_PER_LANE];
-            #pragma unroll
-            for (int e = 0; e < ELEMS_PER_LANE; e++) {
-                uint idx = lane + e * 32;
-                uint partner_idx = idx ^ mask;
-                int partner_e = static_cast<int>((partner_idx - lane) / 32);
-                float partner_val = vals[partner_e];
-                results[e] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
-            }
-            #pragma unroll
-            for (int e = 0; e < ELEMS_PER_LANE; e++) {
-                fwht_buf[lane + e * 32] = results[e];
-            }
-        }
-        simdgroup_barrier(mem_flags::mem_threadgroup);
     }
-    // Normalisation: 1/sqrt(HEAD_SIZE) + random sign flip
+    // Stages 5..NUM_STAGES-1: partner is on the same thread at a different
+    // `e` offset.  Snapshot-then-commit to avoid reading a slot after an
+    // earlier `e` iteration in the same stage wrote it (RAW across e).
+    #pragma unroll
+    for (int stage = 5; stage < NUM_STAGES; stage++) {
+        const uint mask = 1u << stage;
+        float results[ELEMS_PER_LANE];
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+            const uint idx         = lane + uint(e) * 32u;
+            const uint partner_idx = idx ^ mask;
+            const int  partner_e   = int((partner_idx - lane) / 32u);
+            const float partner_val = vals[partner_e];
+            results[e] = (idx & mask) ? (partner_val - vals[e]) : (vals[e] + partner_val);
+        }
+        #pragma unroll
+        for (int e = 0; e < ELEMS_PER_LANE; e++) {
+            vals[e] = results[e];
+        }
+    }
+
+    // Fused normalisation + random-sign flip in registers.  The sign table
+    // is `constant` memory (broadcast-cached), so these reads are free.
     constexpr float INV_SQRT_N = fwht_inv_sqrt_n<HEAD_SIZE>();
     #pragma unroll
     for (int e = 0; e < ELEMS_PER_LANE; e++) {
-        uint idx = lane + e * 32;
-        fwht_buf[idx] *= INV_SQRT_N * get_fwht_sign<HEAD_SIZE>(idx);
+        const uint idx = lane + uint(e) * 32u;
+        vals[e] *= INV_SQRT_N * get_fwht_sign<HEAD_SIZE>(idx);
     }
-    simdgroup_barrier(mem_flags::mem_threadgroup);
 }
 
 // ========================================== High-level K/V load helpers
@@ -266,28 +278,34 @@ inline void tq_load_k_vec(
     K_vec k_vec_result;
     thread T* result_ptr = reinterpret_cast<thread T*>(&k_vec_result);
 
+    // All VEC_SIZE elements share the same scale group.
+    //
+    // Proof: vec covers elements [vec_idx*VEC_SIZE, vec_idx*VEC_SIZE + VEC_SIZE).
+    // VEC_SIZE is derived as MAX(16/(THREAD_GROUP_SIZE*sizeof(T)), 1) in the
+    // paged-attention kernel, so VEC_SIZE ∈ {1, 2, 4, 8, 16} — all divisors of
+    // SCALE_GROUP_SIZE=32.  Therefore (vec_idx*VEC_SIZE) % 32 + VEC_SIZE ≤ 32
+    // whenever vec_idx*VEC_SIZE is aligned to VEC_SIZE (it is, by construction),
+    // so no vec ever straddles a scale-group boundary.  One scale/zero load
+    // per call instead of VEC_SIZE loads.
+    const int group_idx = (vec_idx * VEC_SIZE) / SCALE_GROUP_SIZE;
+    const float s = key_scale_cache[k_scale_base_offset + group_idx];
+    const float z = key_zero_cache [k_scale_base_offset + group_idx];
+
     if constexpr (is_char<K_CACHE_T>()) {
         // int8 K path (signed)
         const device K_CACHE_T* k_elem_ptr = k_ptr + vec_idx * VEC_SIZE;
         #pragma unroll
         for (int e = 0; e < VEC_SIZE; e++) {
-            int elem_idx = vec_idx * VEC_SIZE + e;
-            int group_idx = elem_idx / SCALE_GROUP_SIZE;
-            float s = key_scale_cache[k_scale_base_offset + group_idx];
-            float z = key_zero_cache[k_scale_base_offset + group_idx];
             result_ptr[e] = T(tq_dequant_k(k_elem_ptr[e], s, z));
         }
     } else {
         // uchar K path (uint8 or sub-8-bit packed)
         if (k_bits >= 8) {
             // 8-bit unsigned: one byte per element
-            const device uchar* k_elem_ptr = reinterpret_cast<const device uchar*>(k_ptr) + vec_idx * VEC_SIZE;
+            const device uchar* k_elem_ptr =
+                reinterpret_cast<const device uchar*>(k_ptr) + vec_idx * VEC_SIZE;
             #pragma unroll
             for (int e = 0; e < VEC_SIZE; e++) {
-                int elem_idx = vec_idx * VEC_SIZE + e;
-                int group_idx = elem_idx / SCALE_GROUP_SIZE;
-                float s = key_scale_cache[k_scale_base_offset + group_idx];
-                float z = key_zero_cache[k_scale_base_offset + group_idx];
                 result_ptr[e] = T(tq_dequant_k(k_elem_ptr[e], s, z));
             }
         } else {
@@ -295,11 +313,8 @@ inline void tq_load_k_vec(
             const device uchar* k_bytes = reinterpret_cast<const device uchar*>(k_ptr);
             #pragma unroll
             for (int e = 0; e < VEC_SIZE; e++) {
-                int elem_idx = vec_idx * VEC_SIZE + e;
-                int group_idx = elem_idx / SCALE_GROUP_SIZE;
-                float s = key_scale_cache[k_scale_base_offset + group_idx];
-                float z = key_zero_cache[k_scale_base_offset + group_idx];
-                uint raw = unpack_k_bits(k_bytes, elem_idx, k_bits);
+                const int  elem_idx = vec_idx * VEC_SIZE + e;
+                const uint raw      = unpack_k_bits(k_bytes, elem_idx, k_bits);
                 result_ptr[e] = T(tq_dequant_k_raw(raw, s, z));
             }
         }
@@ -326,7 +341,6 @@ inline uint unpack_v_bits(const device uchar* bytes, int elem_idx, int bits) {
 template <int HEAD_SIZE, int NUM_SIMD_LANES>
 inline void tq_load_and_accumulate_v(
     thread float* v_accs,
-    threadgroup float* fwht_buf,
     const device uchar* v_ptr,
     const device half* value_scale_cache,
     int64_t v_scale_base_offset,
@@ -338,28 +352,363 @@ inline void tq_load_and_accumulate_v(
     constexpr int SCALE_GROUP_SIZE = 32;
     constexpr int V_ELEMS_PER_THREAD = (HEAD_SIZE + NUM_SIMD_LANES - 1) / NUM_SIMD_LANES;
 
-    // Load packed v_bits V, dequantize via centroid lookup, write to fwht_buf
+    // Dequantise V directly into registers.  Centroid lookup + scale, no
+    // threadgroup memory traffic on the V hot path.
+    //
+    // Deferred V FWHT
+    //
+    // Inverse FWHT is a *linear* transform.  By linearity:
+    //
+    //     Σᵢ wᵢ · InverseFWHT(dequant(Vᵢ))
+    //   = InverseFWHT(Σᵢ wᵢ · dequant(Vᵢ))
+    //
+    // So we accumulate in the rotated-and-dequantised domain and apply
+    // InverseFWHT *once* at the end of the attention kernel — not per V
+    // token.  That replaces O(ctx × num_kv_heads) FWHTs per decode step
+    // with O(num_kv_heads) FWHTs, a ~4 orders-of-magnitude reduction at
+    // long context.  The paged_attention kernel calls
+    // `inverse_fwht_in_place` once in warp 0 after cross-warp merge, just
+    // before writing the final output.  `v_accs` therefore holds *rotated*
+    // values throughout the block loop — correct by linearity, same final
+    // numerics once the end-of-kernel FWHT fires.
+    float vals[V_ELEMS_PER_THREAD];
     #pragma unroll
     for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
         const int d = lane + i * NUM_SIMD_LANES;
         if (d < HEAD_SIZE) {
-            int group_idx = d / SCALE_GROUP_SIZE;
-            float vs = value_scale_cache[v_scale_base_offset + group_idx];
-            uchar v_idx = (v_bits == 3) ? unpack_3bit(v_ptr, d) : uchar(unpack_v_bits(v_ptr, d, v_bits));
-            fwht_buf[d] = tq_dequant_v_centroid(v_idx, vs, v_centroids, v_bits);
+            const int group_idx = d / SCALE_GROUP_SIZE;
+            const float vs = value_scale_cache[v_scale_base_offset + group_idx];
+            const uchar v_idx = (v_bits == 3)
+                ? unpack_3bit(v_ptr, d)
+                : uchar(unpack_v_bits(v_ptr, d, v_bits));
+            vals[i] = tq_dequant_v_centroid(v_idx, vs, v_centroids, v_bits);
+        } else {
+            vals[i] = 0.f;
         }
     }
-    simdgroup_barrier(mem_flags::mem_threadgroup);
 
-    // Apply inverse FWHT to reconstruct the original V vector
-    threadgroup_inverse_fwht<HEAD_SIZE>(fwht_buf, lane);
-
-    // Accumulate: O += weight * V_reconstructed
+    // Accumulate in rotated domain: O_rot += weight * dequant(V_rot).
     #pragma unroll
     for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
         const int d = lane + i * NUM_SIMD_LANES;
         if (d < HEAD_SIZE) {
-            v_accs[i] += weight * fwht_buf[d];
+            v_accs[i] += weight * vals[i];
         }
+    }
+    // v_centroids / v_bits no longer referenced after this point; silence
+    // unused-parameter warnings when the compiler decides so.
+    (void)v_centroids; (void)v_bits;
+}
+
+// ===========================================================================
+// Encode path: forward FWHT (one element per thread, TG size == HEAD_SIZE).
+// Mirrors Python fwht(..., encode=True):
+//   x_signed = x * random_signs;  x_rot = hadamard(x_signed);  x_rot /= sqrt(N)
+// The random_signs table is the same deterministic constant consumed by the
+// decode path (see FWHT_SIGNS_*).
+//
+// Stages 0..4 (butterfly mask < 32) are entirely within a simdgroup, so we
+// use simd_shuffle_xor (register <-> register) instead of threadgroup memory
+// + barriers — 5 stages with zero shared-memory traffic and zero barriers.
+// Stages 5..NUM_STAGES-1 cross simdgroup boundaries and fall back to
+// threadgroup memory with barriers.  Takes the input value `x` in a register
+// (no pre-call TG write or barrier needed) and returns the transformed value
+// in a register (no post-call barrier needed since every caller reads buf[t]
+// only from its own thread, i.e. register-equivalent).
+// ===========================================================================
+
+template <int HEAD_SIZE>
+inline float tg_forward_fwht_scalar(float x, threadgroup float* buf, uint t) {
+    constexpr int   NUM_STAGES = fwht_num_stages<HEAD_SIZE>();
+    constexpr float INV_SQRT_N = fwht_inv_sqrt_n<HEAD_SIZE>();
+
+    x *= get_fwht_sign<HEAD_SIZE>(t);
+
+    // Intra-simdgroup butterflies: purely register, no TG memory, no barriers.
+    #pragma unroll
+    for (int stage = 0; stage < 5; stage++) {
+        const uint  mask    = 1u << stage;
+        const float partner = simd_shuffle_xor(x, mask);
+        x = (t & mask) ? (partner - x) : (x + partner);
+    }
+
+    // Cross-simdgroup butterflies: threadgroup memory + barriers.
+    // NUM_STAGES is 6..8, so 1..3 iterations below.
+    if (NUM_STAGES > 5) {
+        buf[t] = x;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        #pragma unroll
+        for (int stage = 5; stage < NUM_STAGES; stage++) {
+            const uint  mask    = 1u << stage;
+            const float me      = buf[t];
+            const float partner = buf[t ^ mask];
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            buf[t] = (t & mask) ? (partner - me) : (me + partner);
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        x = buf[t];
+    }
+
+    return x * INV_SQRT_N;
+}
+
+// ===========================================================================
+// Fused encode-and-cache kernel
+//
+// Replaces Python `turbo_quant_encode()` + 5 paged scatters with a single
+// dispatch.  Writes K (any bit width in QUANT_PARAMS), V (packed v_bits),
+// and the three scale/zero caches directly at slot_mapping[token] offsets.
+//
+// Grid:        (num_tokens, num_kv_heads, 1)
+// Threadgroup: (HEAD_SIZE, 1, 1)
+// One threadgroup encodes one (token, kv_head) pair.  Each simdgroup
+// (32 lanes) corresponds to exactly one 32-element scale group, so
+// min/max/RMS reductions are free via simd_min / simd_max / simd_sum.
+//
+// K spec (must match `quantize()` in turboquant.py):
+//   signed (q8_0/int8, bits=8):
+//     max_val = (1 << (bits-1)) - 1 = 127
+//     scale   = fp16((x_max - x_min) / (2 * max_val))
+//     zp      = round(fp16((x_max + x_min) / (2 * scale)))
+//     idx     = clip(round(fp16(x / scale) - zp), -max_val, max_val)
+//   unsigned (uint8 + sub-8-bit: q5_0/q4_0/int4/uint4/int2/uint2):
+//     max_val = (1 << bits) - 1
+//     scale   = fp16((x_max - x_min) / max_val)
+//     zp      = round(fp16(x_min / scale))
+//     idx     = clip(round(fp16(x / scale) - zp), 0, max_val)
+//
+// The `+ 1e-8` epsilon used in Python's scale guard underflows to 0 in fp16
+// (min subnormal ~6e-8), so it is a no-op and we drop it — matching Python's
+// actual behaviour bit-for-bit.
+//
+// Bit packing: 8-bit K writes one byte per element directly; sub-8-bit K
+// stages unsigned indices in `k_idx_buf` then the first `k_packed` threads
+// assemble bytes in parallel (identical to V packing).  The key_cache
+// buffer is bound as uchar* universally — int8 values use two's-complement
+// bit patterns which read back correctly as `int8_t` in decode kernels.
+// ===========================================================================
+
+constant int  tq_enc_k_bits   [[function_constant(80)]];
+constant bool tq_enc_k_signed [[function_constant(81)]];
+constant int  tq_enc_v_bits   [[function_constant(90)]];
+
+// Generic byte-packer: assembles one output byte from the staged uchar index
+// buffer `idx_buf`.  Each byte covers 8 contiguous bit positions which may
+// straddle up to two logical elements when `bits` does not divide 8 (e.g.
+// 3-bit: 8 values -> 3 bytes).  `bits` must be in [1, 8].
+inline uint tq_pack_byte(threadgroup const uchar* idx_buf,
+                         int bit_start, int bits) {
+    const int first_e = bit_start / bits;
+    const int last_e  = (bit_start + 7) / bits;
+    const uint mask   = (1u << bits) - 1u;
+    uint byte = 0;
+    for (int e = first_e; e <= last_e; e++) {
+        const int  e_bit  = e * bits;
+        const int  shift  = e_bit - bit_start;
+        const uint idx_v  = uint(idx_buf[e]) & mask;
+        if (shift >= 0) {
+            byte |= idx_v << shift;
+        } else {
+            byte |= idx_v >> (-shift);
+        }
+    }
+    return byte & 0xFFu;
+}
+
+template <typename T, int HEAD_SIZE>
+[[kernel]] void tq_encode(
+    const device T*       __restrict__ key                [[buffer(0)]],
+    const device T*       __restrict__ value              [[buffer(1)]],
+    device uchar*         __restrict__ key_cache          [[buffer(2)]],
+    device uchar*         __restrict__ value_cache        [[buffer(3)]],
+    device half*          __restrict__ key_scale_cache    [[buffer(4)]],
+    device half*          __restrict__ value_scale_cache  [[buffer(5)]],
+    device half*          __restrict__ key_zero_cache     [[buffer(6)]],
+    const device int64_t* __restrict__ slot_mapping       [[buffer(7)]],
+    const device float*   __restrict__ v_centroids        [[buffer(8)]],
+    const constant int&   num_kv_heads                    [[buffer(9)]],
+    const constant int&   block_size                      [[buffer(10)]],
+    uint3 tgid  [[threadgroup_position_in_grid]],
+    uint3 tid3  [[thread_position_in_threadgroup]],
+    uint  sid   [[simdgroup_index_in_threadgroup]],
+    uint  lane  [[thread_index_in_simdgroup]]
+) {
+    constexpr int SG_SIZE = 32;
+
+    const uint t     = tid3.x;
+    const int  token = int(tgid.x);
+    const int  kvh   = int(tgid.y);
+
+    const int64_t slot = slot_mapping[token];
+    if (slot < 0) {
+        return;
+    }
+    const int block_idx = int(slot / block_size);
+    const int block_off = int(slot % block_size);
+
+    constexpr int head_dim     = HEAD_SIZE;
+    constexpr int scale_groups = HEAD_SIZE / SG_SIZE;
+    const int     k_packed     = (head_dim * tq_enc_k_bits + 7) / 8;
+    const int     v_packed     = (head_dim * tq_enc_v_bits + 7) / 8;
+
+    // -------- Source element (one per thread) --------
+    const int64_t src_base =
+        (int64_t(token) * num_kv_heads + kvh) * head_dim;
+    const float k_val = float(key[src_base + t]);
+    const float v_val = float(value[src_base + t]);
+
+    // -------- Threadgroup staging buffers --------
+    threadgroup float fwht_buf[HEAD_SIZE];    // V FWHT rotation scratch
+    threadgroup uchar k_idx_buf[HEAD_SIZE];   // K indices (sub-8-bit path)
+    threadgroup uchar v_idx_buf[HEAD_SIZE];   // V indices (always staged)
+
+    // Precomputed V-centroid midpoints (searchsorted boundaries).  Sized for
+    // the worst case (v_bits = 8 → 255 boundaries; ~1 KB of TG memory).  For
+    // smaller v_bits only a prefix is used.  Strided fill covers arbitrary
+    // num_centroids up to the max without requiring HEAD_SIZE >= num_centroids.
+    //
+    // Why: without this, every one of the HEAD_SIZE threads per TG would
+    // independently read v_centroids[i] and v_centroids[i+1] from device
+    // memory inside the searchsorted loop — at large batch sizes that adds
+    // up to hundreds of megabytes of redundant device reads across the full
+    // grid.  Preloading once per TG reduces that to num_centroids reads per
+    // TG and folds the per-thread midpoint compute into a single pass.
+    threadgroup float v_boundaries[255];
+
+    // Strided preload.  Fully async with the K-encode work that follows —
+    // the FWHT's first cross-simdgroup barrier (or the sub-8-bit K barrier)
+    // serves as the sync point before the searchsorted reads.
+    const int num_centroids = 1 << tq_enc_v_bits;
+    #pragma unroll 1
+    for (int i = int(t); i < num_centroids - 1; i += HEAD_SIZE) {
+        v_boundaries[i] = 0.5f * (v_centroids[i] + v_centroids[i + 1]);
+    }
+
+    // -------- Cache destination bases --------
+    const int64_t token_base =
+        (int64_t(block_idx) * block_size + block_off) * num_kv_heads;
+    const int64_t kc_base     = (token_base + kvh) * k_packed;
+    const int64_t vc_base     = (token_base + kvh) * v_packed;
+    const int64_t scale_base  = (token_base + kvh) * scale_groups;
+
+    // ======================================================================
+    // K encode: asymmetric uniform, signed or unsigned.  All arithmetic
+    // routed through fp16 (matching Python's fp16 scale/zp storage).
+    // ======================================================================
+    const float k_min_f = simd_min(k_val);
+    const float k_max_f = simd_max(k_val);
+
+    half  k_scale_h;
+    float k_zp_f;
+    int   k_idx_i;
+
+    if (tq_enc_k_signed) {
+        // q8_0 / int8  (bits == 8)
+        const int max_val = (1 << (tq_enc_k_bits - 1)) - 1;
+        k_scale_h = half(half(k_max_f - k_min_f) / half(2.0f * float(max_val)));
+        const half k_sum_h = half(k_max_f + k_min_f);
+        k_zp_f    = rint(float(k_sum_h / (half(2.0f) * k_scale_h)));
+        k_idx_i   = int(rint(float(half(k_val) / k_scale_h) - k_zp_f));
+        k_idx_i   = clamp(k_idx_i, -max_val, max_val);
+    } else {
+        // uint8 / q5_0 / q4_0 / int4 / uint4 / int2 / uint2
+        const int max_val = (1 << tq_enc_k_bits) - 1;
+        k_scale_h = half(half(k_max_f - k_min_f) / half(float(max_val)));
+        k_zp_f    = rint(float(half(k_min_f) / k_scale_h));
+        k_idx_i   = int(rint(float(half(k_val) / k_scale_h) - k_zp_f));
+        k_idx_i   = clamp(k_idx_i, 0, max_val);
+    }
+
+    // Lane 0 of each simdgroup publishes the per-group scale + zero_point.
+    if (lane == 0) {
+        key_scale_cache[scale_base + int(sid)] = k_scale_h;
+        key_zero_cache [scale_base + int(sid)] = half(k_zp_f);
+    }
+
+    // -------- Write K indices --------
+    if (tq_enc_k_bits == 8) {
+        // 8-bit (signed or unsigned): one byte per element, direct write.
+        // Signed values are stored as two's-complement bit patterns via the
+        // uchar cast, so decode kernels reading `int8_t*` see the right sign.
+        key_cache[kc_base + t] = uchar(uint(k_idx_i) & 0xFFu);
+    } else {
+        // Sub-8-bit unsigned: stage indices then pack bytes in parallel.
+        k_idx_buf[t] = uchar(uint(k_idx_i) & ((1u << tq_enc_k_bits) - 1u));
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (int(t) < k_packed) {
+            const uint byte = tq_pack_byte(k_idx_buf, int(t) * 8, tq_enc_k_bits);
+            key_cache[kc_base + t] = uchar(byte);
+        }
+    }
+
+    // ======================================================================
+    // V encode: FWHT rotation + Lloyd-Max quantization.
+    // Python flow (mirrored exactly):
+    //   x_rot   = fwht(v, encode=True)           # fp16
+    //   scale   = sqrt(mean(x_rot^2))            # fp16, per 32-elem block
+    //   x_norm  = x_rot / scale                  # fp16 (1e-8 guard dropped)
+    //   idx     = searchsorted(boundaries, x_norm)
+    // Boundaries are midpoints of ascending fp32 centroids.
+    // ======================================================================
+    // FWHT takes the input value in-register and returns the rotated value
+    // in-register; threadgroup memory is used only for cross-simdgroup
+    // butterfly stages.  No pre- or post-call barrier needed.
+    const float v_rot_f   = tg_forward_fwht_scalar<HEAD_SIZE>(v_val, fwht_buf, t);
+    const half  v_rot_h   = half(v_rot_f);
+    const float v_sqsum   = simd_sum(float(v_rot_h) * float(v_rot_h));
+    const half  v_scale_h = half(sqrt(v_sqsum * (1.0f / float(SG_SIZE))));
+    const float v_norm    = float(v_rot_h / v_scale_h);
+
+    // Searchsorted against the preloaded midpoint boundaries.  All reads
+    // hit threadgroup memory; the FWHT barriers above already flushed the
+    // preload writes.
+    int v_idx = 0;
+    for (int i = 0; i < num_centroids - 1; i++) {
+        if (v_norm > v_boundaries[i]) v_idx++;
+    }
+    v_idx_buf[t] = uchar(v_idx & ((1 << tq_enc_v_bits) - 1));
+
+    if (lane == 0) {
+        value_scale_cache[scale_base + int(sid)] = v_scale_h;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // -------- Pack V indices into bytes --------
+    if (int(t) < v_packed) {
+        const uint byte = tq_pack_byte(v_idx_buf, int(t) * 8, tq_enc_v_bits);
+        value_cache[vc_base + t] = uchar(byte);
     }
 }
+
+#define instantiate_tq_encode(T, HS)                                           \
+  template [[host_name("tq_encode_" #T "_hs" #HS)]] [[kernel]] void          \
+  tq_encode<T, HS>(                                                            \
+      const device T*       __restrict__ key                [[buffer(0)]],     \
+      const device T*       __restrict__ value              [[buffer(1)]],     \
+      device uchar*         __restrict__ key_cache          [[buffer(2)]],     \
+      device uchar*         __restrict__ value_cache        [[buffer(3)]],     \
+      device half*          __restrict__ key_scale_cache    [[buffer(4)]],     \
+      device half*          __restrict__ value_scale_cache  [[buffer(5)]],     \
+      device half*          __restrict__ key_zero_cache     [[buffer(6)]],     \
+      const device int64_t* __restrict__ slot_mapping       [[buffer(7)]],     \
+      const device float*   __restrict__ v_centroids        [[buffer(8)]],     \
+      const constant int&   num_kv_heads                    [[buffer(9)]],     \
+      const constant int&   block_size                      [[buffer(10)]],    \
+      uint3 tgid  [[threadgroup_position_in_grid]],                            \
+      uint3 tid3  [[thread_position_in_threadgroup]],                          \
+      uint  sid   [[simdgroup_index_in_threadgroup]],                          \
+      uint  lane  [[thread_index_in_simdgroup]]);
+
+instantiate_tq_encode(half, 64)
+instantiate_tq_encode(half, 128)
+instantiate_tq_encode(half, 256)
+instantiate_tq_encode(half, 512)
+instantiate_tq_encode(bfloat16_t, 64)
+instantiate_tq_encode(bfloat16_t, 128)
+instantiate_tq_encode(bfloat16_t, 256)
+instantiate_tq_encode(bfloat16_t, 512)
+instantiate_tq_encode(float, 64)
+instantiate_tq_encode(float, 128)
+instantiate_tq_encode(float, 256)
+instantiate_tq_encode(float, 512)

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -386,10 +386,11 @@ static void dispatch_paged_attention_v2_online(
                           * static_cast<int>(sizeof(float));
   int merge_bytes = (2 * NUM_WARPS + NUM_WARPS * head_size)
                     * static_cast<int>(sizeof(float));
-  // TurboQuant: add per-warp FWHT buffer (NUM_WARPS * head_size floats)
-  if (use_turboquant) {
-    warp_scores_bytes += NUM_WARPS * head_size * static_cast<int>(sizeof(float));
-  }
+  // TurboQuant V path is now register-only (inverse FWHT runs entirely on
+  // the simdgroup register file via simd_shuffle_xor).  The previous
+  // per-warp NUM_WARPS * head_size FWHT workspace in shared_mem has been
+  // removed from the kernel, so no TQ bonus is needed here.
+  (void)use_turboquant;
   size_t shmem = static_cast<size_t>(std::max(warp_scores_bytes, merge_bytes));
 
   auto& enc = get_command_encoder_compat(d, s);
@@ -611,11 +612,18 @@ void paged_attention_v2_online_impl_common(
         "paged_attention_v2_reduce_" + dt +
         "_hs" + std::to_string(head_size) +
         "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
+    // The reduce kernel now references function_constant(50) (use_turboquant)
+    // to gate the deferred-FWHT path.  Reaching this dispatch from the
+    // non-TQ wrapper means use_turboquant is always false here; encode it
+    // in the hash name anyway so a future TQ-partitioned dispatch picks up
+    // its own specialisation instead of reusing the non-TQ one.
+    bool reduce_use_tq = false;
     auto* reduce_kernel = d.get_kernel(
         reduce_kname,
         lib,
-        reduce_kname + "_v2_reduce",
-        {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)}});
+        reduce_kname + "_v2_reduce_tq" + (reduce_use_tq ? "1" : "0"),
+        {{&use_sinks,       MTL::DataType::DataTypeBool, NS::UInteger(40)},
+         {&reduce_use_tq,   MTL::DataType::DataTypeBool, NS::UInteger(50)}});
     size_t reduce_shmem =
         static_cast<size_t>(2 * max_num_partitions * sizeof(float));
     enc.set_compute_pipeline_state(reduce_kernel);
@@ -834,6 +842,189 @@ void paged_attention_v2_online_partitioned_impl(
 }
 
 // ---------------------------------------------------------------------------
+// tq_encode — fused TurboQuant encode + paged scatter
+//
+// Replaces the Python turbo_quant_encode() + 5 MLX scatters on the hot path.
+// Lives in the v2 library because turboquant.metal is concatenated there.
+// Supports all K quants in QUANT_PARAMS: signed 8-bit (q8_0/int8) and
+// unsigned {8,5,4,2}-bit (uint8/q5_0/q4_0/int4/uint4/int2/uint2).  V supports
+// any v_bits in [1, 8] via the v_centroids buffer.
+//
+// Wrapped in a proper MLX Primitive so that the five cache writes become
+// new MLX-graph nodes with provenance pointing at this primitive.  This is
+// critical: paged_attention_primitive runs on a separate command buffer and
+// reads the same cache arrays, and the downstream decode step re-reads
+// them too.  Without a real graph edge, MLX's scheduler has no idea this
+// op must complete before those readers — the primitives submit to their
+// encoders out of order and the reader sees uninitialised / in-flight
+// bytes (silent GPU fault → EngineCore crash on first real request).
+//
+// Each of the five outputs aliases the corresponding input cache buffer
+// via copy_shared_buffer, so the kernel writes in place (no extra
+// allocation) while MLX still gets clean graph provenance.  The caller
+// rebinds kv_cache.key_caches[layer_idx] = new_k_cache so the next decode
+// step's tq_encode input reads through this primitive's output.
+// ---------------------------------------------------------------------------
+
+class TQEncodePrimitive : public Primitive {
+ public:
+  TQEncodePrimitive(Stream stream, int v_bits, int k_bits, bool k_signed)
+      : Primitive(stream),
+        v_bits_(v_bits),
+        k_bits_(k_bits),
+        k_signed_(k_signed) {}
+
+  void eval_cpu(
+      const std::vector<array>&,
+      std::vector<array>&) override {
+    throw std::runtime_error("TQEncodePrimitive only supports GPU");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    // inputs:  0=key, 1=value,
+    //          2=key_cache_in, 3=value_cache_in,
+    //          4=key_scale_in, 5=value_scale_in, 6=key_zero_in,
+    //          7=slot_mapping, 8=v_centroids
+    // outputs: 0=new_key_cache, 1=new_value_cache,
+    //          2=new_key_scale, 3=new_value_scale, 4=new_key_zero
+
+    // Alias each output onto the corresponding input cache buffer.  The
+    // kernel writes in place — the aliasing simply gives the output a
+    // distinct graph identity (new ArrayDesc with primitive = this) while
+    // sharing the underlying Metal buffer.  After eval, Python rebinds
+    // kv_cache.<cache>[layer_idx] = outputs[i], so subsequent ops naturally
+    // depend on this primitive via the MLX graph.
+    outputs[0].copy_shared_buffer(inputs[2]);
+    outputs[1].copy_shared_buffer(inputs[3]);
+    outputs[2].copy_shared_buffer(inputs[4]);
+    outputs[3].copy_shared_buffer(inputs[5]);
+    outputs[4].copy_shared_buffer(inputs[6]);
+
+    const array& key          = inputs[0];
+    const array& value        = inputs[1];
+    const array& slot_mapping = inputs[7];
+    const array& v_centroids  = inputs[8];
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+
+    // key shape: [num_tokens, num_kv_heads, head_size]
+    int num_tokens   = static_cast<int>(key.shape(0));
+    int num_kv_heads = static_cast<int>(key.shape(1));
+    int head_size    = static_cast<int>(key.shape(2));
+    int block_size   = static_cast<int>(inputs[2].shape(1));
+
+    auto kv_dt = dtype_to_metal(key.dtype());
+    std::string kname = "tq_encode_" + kv_dt +
+                        "_hs" + std::to_string(head_size);
+
+    // Function constants control bit widths + signedness used inside the
+    // kernel.  The hash name MUST encode them so MLX caches the right
+    // specialization per (k_bits, k_signed, v_bits) tuple.
+    int  k_bits_i   = k_bits_;
+    int  v_bits_i   = v_bits_;
+    bool k_signed_b = k_signed_;
+    std::string hash_name = kname +
+        "_kb" + std::to_string(k_bits_i) +
+        "_ks" + (k_signed_b ? "1" : "0") +
+        "_vb" + std::to_string(v_bits_i);
+
+    auto* lib = d.get_library("paged_attention_v2_kern");
+    auto* kernel = d.get_kernel(
+        kname, lib, hash_name,
+        {{&k_bits_i,   MTL::DataType::DataTypeInt,  NS::UInteger(80)},
+         {&k_signed_b, MTL::DataType::DataTypeBool, NS::UInteger(81)},
+         {&v_bits_i,   MTL::DataType::DataTypeInt,  NS::UInteger(90)}});
+
+    int32_t num_kv_heads_i = static_cast<int32_t>(num_kv_heads);
+    int32_t block_size_i   = static_cast<int32_t>(block_size);
+
+    auto& enc = get_command_encoder_compat(d, s);
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_input_array(key,                0);
+    enc.set_input_array(value,              1);
+    enc.set_output_array(outputs[0],        2);
+    enc.set_output_array(outputs[1],        3);
+    enc.set_output_array(outputs[2],        4);
+    enc.set_output_array(outputs[3],        5);
+    enc.set_output_array(outputs[4],        6);
+    enc.set_input_array(slot_mapping,       7);
+    enc.set_input_array(v_centroids,        8);
+    enc.set_bytes(num_kv_heads_i,           9);
+    enc.set_bytes(block_size_i,             10);
+
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(num_tokens, num_kv_heads, 1),
+        MTL::Size::Make(head_size, 1, 1));
+
+    // Intentionally no add_temporary: inside a primitive, MLX's evaluator
+    // manages array lifetimes via the completion handler.  add_temporary
+    // here would strip outputs[0..4] from the encoder's tracking and
+    // silently defeat the fence for downstream primitives.
+  }
+
+  const char* name() const override { return "TQEncode"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* rhs = dynamic_cast<const TQEncodePrimitive*>(&other);
+    return rhs && rhs->v_bits_   == v_bits_
+               && rhs->k_bits_   == k_bits_
+               && rhs->k_signed_ == k_signed_;
+  }
+
+ private:
+  int  v_bits_;
+  int  k_bits_;
+  bool k_signed_;
+};
+
+static std::vector<array> tq_encode_primitive_fn(
+    const array& key, const array& value,
+    const array& key_cache, const array& value_cache,
+    const array& key_scale_cache, const array& value_scale_cache,
+    const array& key_zero_cache,
+    const array& slot_mapping, const array& v_centroids,
+    int v_bits, int k_bits, bool k_signed) {
+  // Accept every bit width present in QUANT_PARAMS (2/3/4/5/8).  Signed is
+  // only legal at bits=8 because Python stores signed sub-8-bit types as
+  // unsigned for packability (e.g. int4 is signed:False in QUANT_PARAMS).
+  if (k_bits != 2 && k_bits != 3 && k_bits != 4 && k_bits != 5 && k_bits != 8) {
+    throw std::runtime_error(
+        "tq_encode: k_bits must be 2, 3, 4, 5, or 8 (got " +
+        std::to_string(k_bits) + ")");
+  }
+  if (k_signed && k_bits != 8) {
+    throw std::runtime_error(
+        "tq_encode: signed K is only supported at k_bits=8 "
+        "(matches QUANT_PARAMS in turboquant.py).");
+  }
+  int head_size = static_cast<int>(key.shape(2));
+  if (head_size != 64 && head_size != 128 && head_size != 256 && head_size != 512) {
+    throw std::runtime_error(
+        "tq_encode: head_size must be 64, 128, 256, or 512 (got " +
+        std::to_string(head_size) + ")");
+  }
+
+  auto prim = std::make_shared<TQEncodePrimitive>(
+      default_stream(Device::gpu), v_bits, k_bits, k_signed);
+
+  return array::make_arrays(
+      {key_cache.shape(), value_cache.shape(),
+       key_scale_cache.shape(), value_scale_cache.shape(),
+       key_zero_cache.shape()},
+      {key_cache.dtype(), value_cache.dtype(),
+       key_scale_cache.dtype(), value_scale_cache.dtype(),
+       key_zero_cache.dtype()},
+      prim,
+      {key, value,
+       key_cache, value_cache,
+       key_scale_cache, value_scale_cache, key_zero_cache,
+       slot_mapping, v_centroids});
+}
+
+// ---------------------------------------------------------------------------
 // GDN linear attention — in-place paged state
 // ---------------------------------------------------------------------------
 
@@ -938,6 +1129,70 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("key_cache"), nb::arg("value_cache"),
         nb::arg("slot_mapping"),
         "Write projected K/V into the paged cache.");
+
+  m.def("tq_encode",
+        [](nb::handle key_h, nb::handle value_h,
+           nb::handle key_cache_h, nb::handle value_cache_h,
+           nb::handle key_scale_cache_h, nb::handle value_scale_cache_h,
+           nb::handle key_zero_cache_h,
+           nb::handle slot_mapping_h,
+           nb::handle v_centroids_h,
+           int v_bits, int k_bits, bool k_signed) {
+          auto results = tq_encode_primitive_fn(
+              *nb::inst_ptr<array>(key_h),
+              *nb::inst_ptr<array>(value_h),
+              *nb::inst_ptr<array>(key_cache_h),
+              *nb::inst_ptr<array>(value_cache_h),
+              *nb::inst_ptr<array>(key_scale_cache_h),
+              *nb::inst_ptr<array>(value_scale_cache_h),
+              *nb::inst_ptr<array>(key_zero_cache_h),
+              *nb::inst_ptr<array>(slot_mapping_h),
+              *nb::inst_ptr<array>(v_centroids_h),
+              v_bits, k_bits, k_signed);
+
+          // Mint five Python mx.core.array placeholders inside the binding
+          // (callers never see the placeholder dance).  We go through the
+          // Python-side mlx.core.array constructor because cross-module
+          // nanobind RTTI for nb::class_<array> from libmlx is broken under
+          // hidden symbol visibility; overwrite_descriptor is the same
+          // escape hatch used by paged_attention_primitive below.
+          nb::object mx_core  = nb::module_::import_("mlx.core");
+          nb::object arr_cls  = mx_core.attr("array");
+          nb::object zero_arg = nb::int_(0);
+          nb::object out_k    = arr_cls(zero_arg);
+          nb::object out_v    = arr_cls(zero_arg);
+          nb::object out_ks   = arr_cls(zero_arg);
+          nb::object out_vs   = arr_cls(zero_arg);
+          nb::object out_kz   = arr_cls(zero_arg);
+          nb::inst_ptr<array>(out_k)->overwrite_descriptor(results[0]);
+          nb::inst_ptr<array>(out_v)->overwrite_descriptor(results[1]);
+          nb::inst_ptr<array>(out_ks)->overwrite_descriptor(results[2]);
+          nb::inst_ptr<array>(out_vs)->overwrite_descriptor(results[3]);
+          nb::inst_ptr<array>(out_kz)->overwrite_descriptor(results[4]);
+          return nb::make_tuple(out_k, out_v, out_ks, out_vs, out_kz);
+        },
+        nb::arg("key"), nb::arg("value"),
+        nb::arg("key_cache"), nb::arg("value_cache"),
+        nb::arg("key_scale_cache"), nb::arg("value_scale_cache"),
+        nb::arg("key_zero_cache"),
+        nb::arg("slot_mapping"),
+        nb::arg("v_centroids"),
+        nb::arg("v_bits"),
+        nb::arg("k_bits"),
+        nb::arg("k_signed"),
+        "Fused TurboQuant encode + paged scatter.  Wraps a real MLX "
+        "Primitive so its five cache writes carry graph provenance — "
+        "downstream paged_attention_primitive and the next decode step's "
+        "tq_encode depend on this op through the lazy graph instead of "
+        "racing it on a separate command buffer.  Returns a 5-tuple "
+        "(new_key_cache, new_value_cache, new_key_scale_cache, "
+        "new_value_scale_cache, new_key_zero_cache); each aliases the "
+        "corresponding input buffer in place and the caller MUST rebind "
+        "kv_cache.<cache>[layer_idx] to the returned value so subsequent "
+        "ops see the post-write provenance.  Supports all K quants in "
+        "QUANT_PARAMS (signed q8_0/int8 at k_bits=8; unsigned uint8/q5_0/"
+        "q4_0/int4/uint4/int2/uint2 at k_bits in {2,3,4,5,8}). V supports "
+        "any v_bits in [1, 8] via the v_centroids buffer.");
 
   m.def("paged_attention_v1", &paged_attention_v1_impl,
         nb::arg("out"), nb::arg("query"),

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -386,10 +386,11 @@ static void dispatch_paged_attention_v2_online(
                           * static_cast<int>(sizeof(float));
   int merge_bytes = (2 * NUM_WARPS + NUM_WARPS * head_size)
                     * static_cast<int>(sizeof(float));
-  // TurboQuant: add per-warp FWHT buffer (NUM_WARPS * head_size floats)
-  if (use_turboquant) {
-    warp_scores_bytes += NUM_WARPS * head_size * static_cast<int>(sizeof(float));
-  }
+  // TurboQuant V path is now register-only (inverse FWHT runs entirely on
+  // the simdgroup register file via simd_shuffle_xor).  The previous
+  // per-warp NUM_WARPS * head_size FWHT workspace in shared_mem has been
+  // removed from the kernel, so no TQ bonus is needed here.
+  (void)use_turboquant;
   size_t shmem = static_cast<size_t>(std::max(warp_scores_bytes, merge_bytes));
 
   auto& enc = get_command_encoder_compat(d, s);
@@ -834,6 +835,189 @@ void paged_attention_v2_online_partitioned_impl(
 }
 
 // ---------------------------------------------------------------------------
+// tq_encode — fused TurboQuant encode + paged scatter
+//
+// Replaces the Python turbo_quant_encode() + 5 MLX scatters on the hot path.
+// Lives in the v2 library because turboquant.metal is concatenated there.
+// Supports all K quants in QUANT_PARAMS: signed 8-bit (q8_0/int8) and
+// unsigned {8,5,4,2}-bit (uint8/q5_0/q4_0/int4/uint4/int2/uint2).  V supports
+// any v_bits in [1, 8] via the v_centroids buffer.
+//
+// Wrapped in a proper MLX Primitive so that the five cache writes become
+// new MLX-graph nodes with provenance pointing at this primitive.  This is
+// critical: paged_attention_primitive runs on a separate command buffer and
+// reads the same cache arrays, and the downstream decode step re-reads
+// them too.  Without a real graph edge, MLX's scheduler has no idea this
+// op must complete before those readers — the primitives submit to their
+// encoders out of order and the reader sees uninitialised / in-flight
+// bytes (silent GPU fault → EngineCore crash on first real request).
+//
+// Each of the five outputs aliases the corresponding input cache buffer
+// via copy_shared_buffer, so the kernel writes in place (no extra
+// allocation) while MLX still gets clean graph provenance.  The caller
+// rebinds kv_cache.key_caches[layer_idx] = new_k_cache so the next decode
+// step's tq_encode input reads through this primitive's output.
+// ---------------------------------------------------------------------------
+
+class TQEncodePrimitive : public Primitive {
+ public:
+  TQEncodePrimitive(Stream stream, int v_bits, int k_bits, bool k_signed)
+      : Primitive(stream),
+        v_bits_(v_bits),
+        k_bits_(k_bits),
+        k_signed_(k_signed) {}
+
+  void eval_cpu(
+      const std::vector<array>&,
+      std::vector<array>&) override {
+    throw std::runtime_error("TQEncodePrimitive only supports GPU");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    // inputs:  0=key, 1=value,
+    //          2=key_cache_in, 3=value_cache_in,
+    //          4=key_scale_in, 5=value_scale_in, 6=key_zero_in,
+    //          7=slot_mapping, 8=v_centroids
+    // outputs: 0=new_key_cache, 1=new_value_cache,
+    //          2=new_key_scale, 3=new_value_scale, 4=new_key_zero
+
+    // Alias each output onto the corresponding input cache buffer.  The
+    // kernel writes in place — the aliasing simply gives the output a
+    // distinct graph identity (new ArrayDesc with primitive = this) while
+    // sharing the underlying Metal buffer.  After eval, Python rebinds
+    // kv_cache.<cache>[layer_idx] = outputs[i], so subsequent ops naturally
+    // depend on this primitive via the MLX graph.
+    outputs[0].copy_shared_buffer(inputs[2]);
+    outputs[1].copy_shared_buffer(inputs[3]);
+    outputs[2].copy_shared_buffer(inputs[4]);
+    outputs[3].copy_shared_buffer(inputs[5]);
+    outputs[4].copy_shared_buffer(inputs[6]);
+
+    const array& key          = inputs[0];
+    const array& value        = inputs[1];
+    const array& slot_mapping = inputs[7];
+    const array& v_centroids  = inputs[8];
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+
+    // key shape: [num_tokens, num_kv_heads, head_size]
+    int num_tokens   = static_cast<int>(key.shape(0));
+    int num_kv_heads = static_cast<int>(key.shape(1));
+    int head_size    = static_cast<int>(key.shape(2));
+    int block_size   = static_cast<int>(inputs[2].shape(1));
+
+    auto kv_dt = dtype_to_metal(key.dtype());
+    std::string kname = "tq_encode_" + kv_dt +
+                        "_hs" + std::to_string(head_size);
+
+    // Function constants control bit widths + signedness used inside the
+    // kernel.  The hash name MUST encode them so MLX caches the right
+    // specialization per (k_bits, k_signed, v_bits) tuple.
+    int  k_bits_i   = k_bits_;
+    int  v_bits_i   = v_bits_;
+    bool k_signed_b = k_signed_;
+    std::string hash_name = kname +
+        "_kb" + std::to_string(k_bits_i) +
+        "_ks" + (k_signed_b ? "1" : "0") +
+        "_vb" + std::to_string(v_bits_i);
+
+    auto* lib = d.get_library("paged_attention_v2_kern");
+    auto* kernel = d.get_kernel(
+        kname, lib, hash_name,
+        {{&k_bits_i,   MTL::DataType::DataTypeInt,  NS::UInteger(80)},
+         {&k_signed_b, MTL::DataType::DataTypeBool, NS::UInteger(81)},
+         {&v_bits_i,   MTL::DataType::DataTypeInt,  NS::UInteger(90)}});
+
+    int32_t num_kv_heads_i = static_cast<int32_t>(num_kv_heads);
+    int32_t block_size_i   = static_cast<int32_t>(block_size);
+
+    auto& enc = get_command_encoder_compat(d, s);
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_input_array(key,                0);
+    enc.set_input_array(value,              1);
+    enc.set_output_array(outputs[0],        2);
+    enc.set_output_array(outputs[1],        3);
+    enc.set_output_array(outputs[2],        4);
+    enc.set_output_array(outputs[3],        5);
+    enc.set_output_array(outputs[4],        6);
+    enc.set_input_array(slot_mapping,       7);
+    enc.set_input_array(v_centroids,        8);
+    enc.set_bytes(num_kv_heads_i,           9);
+    enc.set_bytes(block_size_i,             10);
+
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(num_tokens, num_kv_heads, 1),
+        MTL::Size::Make(head_size, 1, 1));
+
+    // Intentionally no add_temporary: inside a primitive, MLX's evaluator
+    // manages array lifetimes via the completion handler.  add_temporary
+    // here would strip outputs[0..4] from the encoder's tracking and
+    // silently defeat the fence for downstream primitives.
+  }
+
+  const char* name() const override { return "TQEncode"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* rhs = dynamic_cast<const TQEncodePrimitive*>(&other);
+    return rhs && rhs->v_bits_   == v_bits_
+               && rhs->k_bits_   == k_bits_
+               && rhs->k_signed_ == k_signed_;
+  }
+
+ private:
+  int  v_bits_;
+  int  k_bits_;
+  bool k_signed_;
+};
+
+static std::vector<array> tq_encode_primitive_fn(
+    const array& key, const array& value,
+    const array& key_cache, const array& value_cache,
+    const array& key_scale_cache, const array& value_scale_cache,
+    const array& key_zero_cache,
+    const array& slot_mapping, const array& v_centroids,
+    int v_bits, int k_bits, bool k_signed) {
+  // Accept every bit width present in QUANT_PARAMS (2/3/4/5/8).  Signed is
+  // only legal at bits=8 because Python stores signed sub-8-bit types as
+  // unsigned for packability (e.g. int4 is signed:False in QUANT_PARAMS).
+  if (k_bits != 2 && k_bits != 3 && k_bits != 4 && k_bits != 5 && k_bits != 8) {
+    throw std::runtime_error(
+        "tq_encode: k_bits must be 2, 3, 4, 5, or 8 (got " +
+        std::to_string(k_bits) + ")");
+  }
+  if (k_signed && k_bits != 8) {
+    throw std::runtime_error(
+        "tq_encode: signed K is only supported at k_bits=8 "
+        "(matches QUANT_PARAMS in turboquant.py).");
+  }
+  int head_size = static_cast<int>(key.shape(2));
+  if (head_size != 64 && head_size != 128 && head_size != 256 && head_size != 512) {
+    throw std::runtime_error(
+        "tq_encode: head_size must be 64, 128, 256, or 512 (got " +
+        std::to_string(head_size) + ")");
+  }
+
+  auto prim = std::make_shared<TQEncodePrimitive>(
+      default_stream(Device::gpu), v_bits, k_bits, k_signed);
+
+  return array::make_arrays(
+      {key_cache.shape(), value_cache.shape(),
+       key_scale_cache.shape(), value_scale_cache.shape(),
+       key_zero_cache.shape()},
+      {key_cache.dtype(), value_cache.dtype(),
+       key_scale_cache.dtype(), value_scale_cache.dtype(),
+       key_zero_cache.dtype()},
+      prim,
+      {key, value,
+       key_cache, value_cache,
+       key_scale_cache, value_scale_cache, key_zero_cache,
+       slot_mapping, v_centroids});
+}
+
+// ---------------------------------------------------------------------------
 // GDN linear attention — in-place paged state
 // ---------------------------------------------------------------------------
 
@@ -938,6 +1122,70 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("key_cache"), nb::arg("value_cache"),
         nb::arg("slot_mapping"),
         "Write projected K/V into the paged cache.");
+
+  m.def("tq_encode",
+        [](nb::handle key_h, nb::handle value_h,
+           nb::handle key_cache_h, nb::handle value_cache_h,
+           nb::handle key_scale_cache_h, nb::handle value_scale_cache_h,
+           nb::handle key_zero_cache_h,
+           nb::handle slot_mapping_h,
+           nb::handle v_centroids_h,
+           int v_bits, int k_bits, bool k_signed) {
+          auto results = tq_encode_primitive_fn(
+              *nb::inst_ptr<array>(key_h),
+              *nb::inst_ptr<array>(value_h),
+              *nb::inst_ptr<array>(key_cache_h),
+              *nb::inst_ptr<array>(value_cache_h),
+              *nb::inst_ptr<array>(key_scale_cache_h),
+              *nb::inst_ptr<array>(value_scale_cache_h),
+              *nb::inst_ptr<array>(key_zero_cache_h),
+              *nb::inst_ptr<array>(slot_mapping_h),
+              *nb::inst_ptr<array>(v_centroids_h),
+              v_bits, k_bits, k_signed);
+
+          // Mint five Python mx.core.array placeholders inside the binding
+          // (callers never see the placeholder dance).  We go through the
+          // Python-side mlx.core.array constructor because cross-module
+          // nanobind RTTI for nb::class_<array> from libmlx is broken under
+          // hidden symbol visibility; overwrite_descriptor is the same
+          // escape hatch used by paged_attention_primitive below.
+          nb::object mx_core  = nb::module_::import_("mlx.core");
+          nb::object arr_cls  = mx_core.attr("array");
+          nb::object zero_arg = nb::int_(0);
+          nb::object out_k    = arr_cls(zero_arg);
+          nb::object out_v    = arr_cls(zero_arg);
+          nb::object out_ks   = arr_cls(zero_arg);
+          nb::object out_vs   = arr_cls(zero_arg);
+          nb::object out_kz   = arr_cls(zero_arg);
+          nb::inst_ptr<array>(out_k)->overwrite_descriptor(results[0]);
+          nb::inst_ptr<array>(out_v)->overwrite_descriptor(results[1]);
+          nb::inst_ptr<array>(out_ks)->overwrite_descriptor(results[2]);
+          nb::inst_ptr<array>(out_vs)->overwrite_descriptor(results[3]);
+          nb::inst_ptr<array>(out_kz)->overwrite_descriptor(results[4]);
+          return nb::make_tuple(out_k, out_v, out_ks, out_vs, out_kz);
+        },
+        nb::arg("key"), nb::arg("value"),
+        nb::arg("key_cache"), nb::arg("value_cache"),
+        nb::arg("key_scale_cache"), nb::arg("value_scale_cache"),
+        nb::arg("key_zero_cache"),
+        nb::arg("slot_mapping"),
+        nb::arg("v_centroids"),
+        nb::arg("v_bits"),
+        nb::arg("k_bits") = 8,
+        nb::arg("k_signed") = true,
+        "Fused TurboQuant encode + paged scatter.  Wraps a real MLX "
+        "Primitive so its five cache writes carry graph provenance — "
+        "downstream paged_attention_primitive and the next decode step's "
+        "tq_encode depend on this op through the lazy graph instead of "
+        "racing it on a separate command buffer.  Returns a 5-tuple "
+        "(new_key_cache, new_value_cache, new_key_scale_cache, "
+        "new_value_scale_cache, new_key_zero_cache); each aliases the "
+        "corresponding input buffer in place and the caller MUST rebind "
+        "kv_cache.<cache>[layer_idx] to the returned value so subsequent "
+        "ops see the post-write provenance.  Supports all K quants in "
+        "QUANT_PARAMS (signed q8_0/int8 at k_bits=8; unsigned uint8/q5_0/"
+        "q4_0/int4/uint4/int2/uint2 at k_bits in {2,3,4,5,8}). V supports "
+        "any v_bits in [1, 8] via the v_centroids buffer.");
 
   m.def("paged_attention_v1", &paged_attention_v1_impl,
         nb::arg("out"), nb::arg("query"),

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -35,7 +35,6 @@ from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 from vllm_metal.metal_kernel_backend.packed_prefill_compat import (
     apply_packed_rope,
 )
-from vllm_metal.metal_kernel_backend.turboquant import turbo_quant_encode
 from vllm_metal.paged_attention_common import PagedAttentionContext
 
 # === Metal kernel block-size support ===
@@ -405,38 +404,53 @@ def sdpa_forward(
             new_value_scale_cache = kv_cache.value_scale_caches[layer_idx]
             new_key_zero_cache = kv_cache.key_zero_caches[layer_idx]
     elif kv_cache.turboquant:
-        # --- TurboQuant cache write: Python quantize → MLX scatter ---
-        # Quantize K/V, then scatter each of the 5 caches independently.
-        (packed_k, k_scale, k_zero), (packed_v, v_scale) = turbo_quant_encode(
-            k_3d, v_3d, kv_cache.k_quant, value_bits=kv_cache.v_bits
+        # --- TurboQuant cache write: fused Metal encode + scatter ---
+        # Single dispatch replaces Python turbo_quant_encode + 5 MLX scatters.
+        # Supports the full QUANT_PARAMS matrix: signed q8_0/int8 at k_bits=8
+        # and unsigned uint8/q5_0/q4_0/int4/uint4/int2/uint2 at k_bits in
+        # {2, 3, 4, 5, 8}.
+        from vllm_metal.metal_kernel_backend.turboquant import (
+            QUANT_PARAMS,
+            get_v_centroids,
         )
 
-        def _scatter(cache_arr, data):
-            flat = cache_arr.reshape(-1, kv_cache.num_kv_heads, data.shape[-1])
-            flat[slot_mapping] = data
-            return flat.reshape(cache_arr.shape)
-
-        kv_cache.key_caches[layer_idx] = _scatter(
-            kv_cache.key_caches[layer_idx], packed_k
+        v_centroids = get_v_centroids(kv_cache.v_bits)
+        k_signed = bool(QUANT_PARAMS[kv_cache.k_quant]["signed"])
+        # tq_encode is a proper MLX Primitive: it returns five NEW array
+        # objects that alias the input cache buffers in place but carry
+        # fresh graph provenance pointing at the primitive.  The subsequent
+        # paged_attention_primitive (separate command buffer) depends on
+        # these outputs through the lazy graph, which is what lets MLX
+        # insert the fence that serialises reader-after-writer.  Using the
+        # original cache arrays here instead would silently race on the
+        # first real forward pass (EngineCore crash).  We must also rebind
+        # kv_cache.<cache>[layer_idx] to the new arrays so the next decode
+        # step's tq_encode input reads through this primitive's output.
+        (
+            new_k_cache,
+            new_v_cache,
+            new_key_scale_cache,
+            new_value_scale_cache,
+            new_key_zero_cache,
+        ) = get_ops().tq_encode(
+            k_3d,
+            v_3d,
+            kv_cache.key_caches[layer_idx],
+            kv_cache.value_caches[layer_idx],
+            kv_cache.key_scale_caches[layer_idx],
+            kv_cache.value_scale_caches[layer_idx],
+            kv_cache.key_zero_caches[layer_idx],
+            slot_mapping,
+            v_centroids,
+            kv_cache.v_bits,
+            kv_cache.k_bits,
+            k_signed,
         )
-        kv_cache.value_caches[layer_idx] = _scatter(
-            kv_cache.value_caches[layer_idx], packed_v
-        )
-        kv_cache.key_scale_caches[layer_idx] = _scatter(
-            kv_cache.key_scale_caches[layer_idx], k_scale
-        )
-        kv_cache.value_scale_caches[layer_idx] = _scatter(
-            kv_cache.value_scale_caches[layer_idx], v_scale
-        )
-        kv_cache.key_zero_caches[layer_idx] = _scatter(
-            kv_cache.key_zero_caches[layer_idx], k_zero
-        )
-
-        new_k_cache = kv_cache.key_caches[layer_idx]
-        new_v_cache = kv_cache.value_caches[layer_idx]
-        new_key_scale_cache = kv_cache.key_scale_caches[layer_idx]
-        new_value_scale_cache = kv_cache.value_scale_caches[layer_idx]
-        new_key_zero_cache = kv_cache.key_zero_caches[layer_idx]
+        kv_cache.key_caches[layer_idx] = new_k_cache
+        kv_cache.value_caches[layer_idx] = new_v_cache
+        kv_cache.key_scale_caches[layer_idx] = new_key_scale_cache
+        kv_cache.value_scale_caches[layer_idx] = new_value_scale_cache
+        kv_cache.key_zero_caches[layer_idx] = new_key_zero_cache
     else:
         flat_k = kv_cache.key_caches[layer_idx].reshape(-1, cache_kv_heads, head_dim)
         flat_k[slot_mapping] = k_3d


### PR DESCRIPTION
**What**

Improves on the TurboQuant decode Metal kernels and adds a TQ encode kernel to improve encode/decode overhead 
|ctx | old total per step | new total per step | savings | speedup|
|-- | -- | -- | -- | --|
|128 | 10.82 + 28×0.47 = 24.01 ms | 0.53 + 28×0.20 = 6.23 ms | 17.79 ms | 3.86×|
|512 | 10.82 + 28×1.03 = 39.55 ms | 0.53 + 28×0.31 = 9.30 ms | 30.25 ms | 4.25×|
|2048 | 10.82 + 28×1.77 = 60.39 ms | 0.53 + 28×0.70 = 20.26 ms | 40.13 ms | 2.98×|
|8192 | 10.82 + 28×6.53 = 193.63 ms | 0.53 + 28×2.03 = 57.46 ms | 136.17 ms | 3.37×|

**How**

- Inverse FWHT — replaced 5–8 TG-memory + barrier round-trips with simd_shuffle_xor (stages 0–4) + intra-thread snapshot-commit (stages 5+), going to zero TG memory and zero barriers per inverse FWHT.
- Forward FWHT — lifted stages 0–4 onto simd_shuffle_xor, halving the TG-memory round-trips in the encode hot path (stages 5+ still need TG because encode threads don't own lane-contiguous slices).
- Deferred V FWHT — exploited FWHT linearity to accumulate in the rotated domain and apply one inverse FWHT per head at end-of-kernel, collapsing O(ctx × num_kv_heads) FWHTs to O(num_kv_heads) and eliminating the per-warp NUM_WARPS × head_dim TG workspace.
- Fused encode kernel — collapsed 6 per-layer dispatches into a single tq_encode Metal kernel with simd-reduced K scales, in-place forward FWHT, strided-fill V boundaries, and a generic tq_pack_byte packer — 168 dispatches/step → 28.
- MLX graph integration — aliases 5 input caches via copy_shared_buffer for in-place writes with distinct graph identity

Plus, adds 512 head dim hardcoded support for Gemma 4 with the new kernels