### PR TITLE
Add experimental Gemma4 YOCO fast prefill

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@
 | `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute (1=yes, 0=no) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
+| `VLLM_METAL_KV_SHARING_FAST_PREFILL` | `0` | Enable experimental Gemma4 YOCO fast prefill on the paged KV path |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
 | `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto`, `text-only-compat`, or `multimodal-native` |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
@@ -20,6 +21,12 @@
 - `auto`: use native multimodal loading by default, but fall back to the text-only compatibility path for known-incompatible checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
 - `text-only-compat`: force the text-only compatibility path only for known-safe checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers. Other multimodal checkpoints stay on the native multimodal loader.
 - `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
+
+## Gemma4 YOCO Fast Prefill
+
+`VLLM_METAL_KV_SHARING_FAST_PREFILL=1` enables an experimental default-off optimization for eligible Gemma4 text models on the paged KV path. It runs the YOCO KV-shared decoder layers only on the selected logits positions during prefill, then scatters those hidden states back before the final norm and LM head.
+
+This path requires `VLLM_METAL_USE_PAGED_ATTENTION=1` and is currently limited to Gemma4/Gemma4 text models with KV-shared layers. If the loaded model is not eligible, vllm-metal logs a warning and continues without fast prefill.
 
 ## Paged KV vs MLX KV Memory Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@
 | `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute (1=yes, 0=no) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
-| `VLLM_METAL_KV_SHARING_FAST_PREFILL` | `0` | Enable experimental Gemma4 YOCO fast prefill on the paged KV path |
+| `VLLM_METAL_KV_SHARING_FAST_PREFILL` | `1` | Enable Gemma4 YOCO fast prefill for eligible Gemma4 models on the paged KV path |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
 | `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto`, `text-only-compat`, or `multimodal-native` |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
@@ -24,9 +24,9 @@
 
 ## Gemma4 YOCO Fast Prefill
 
-`VLLM_METAL_KV_SHARING_FAST_PREFILL=1` enables an experimental default-off optimization for eligible Gemma4 text models on the paged KV path. It runs the YOCO KV-shared decoder layers only on the selected logits positions during prefill, then scatters those hidden states back before the final norm and LM head.
+Gemma4 YOCO fast prefill is enabled by default for eligible Gemma4 text models on the paged KV path. It runs the YOCO KV-shared decoder layers only on the selected logits positions during prefill, then scatters those hidden states back before the final norm and LM head. Set `VLLM_METAL_KV_SHARING_FAST_PREFILL=0` to disable it.
 
-This path requires `VLLM_METAL_USE_PAGED_ATTENTION=1` and is currently limited to Gemma4/Gemma4 text models with KV-shared layers. If the loaded model is not eligible, vllm-metal logs a warning and continues without fast prefill.
+This path requires `VLLM_METAL_USE_PAGED_ATTENTION=1` and is currently limited to Gemma4/Gemma4 text models with KV-shared layers. Ineligible models continue without fast prefill; if `VLLM_METAL_KV_SHARING_FAST_PREFILL=1` was explicitly set, vllm-metal logs a warning for the skipped enablement.
 
 ## Paged KV vs MLX KV Memory Settings
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ class TestMetalConfig:
         assert config.mlx_device == "gpu"
         assert config.debug is False
         assert config.use_paged_attention is True
-        assert config.kv_sharing_fast_prefill is False
+        assert config.kv_sharing_fast_prefill is True
         assert config.multimodal_mode == "auto"
 
     def test_custom_config_from_env(self, monkeypatch) -> None:
@@ -55,6 +55,35 @@ class TestMetalConfig:
         assert config.debug is True
         assert config.kv_sharing_fast_prefill is True
         assert config.multimodal_mode == "multimodal-native"
+
+    def test_kv_sharing_fast_prefill_can_be_disabled(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "0")
+
+        config = MetalConfig.from_env()
+
+        assert config.kv_sharing_fast_prefill is False
+
+    def test_kv_sharing_fast_prefill_default_off_without_paged_attention(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+
+        config = MetalConfig.from_env()
+
+        assert config.use_paged_attention is False
+        assert config.kv_sharing_fast_prefill is False
+
+    def test_explicit_kv_sharing_fast_prefill_requires_paged_attention_env(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        monkeypatch.setenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "1")
+
+        with pytest.raises(
+            ValueError,
+            match="VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention",
+        ):
+            MetalConfig.from_env()
 
     def test_get_config_singleton(self) -> None:
         """Test that get_config returns a singleton."""
@@ -150,7 +179,6 @@ class TestMetalConfig:
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 use_mlx=True,
                 mlx_device="gpu",
-                block_size=16,
                 debug=False,
                 use_paged_attention=False,
                 kv_sharing_fast_prefill=True,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ class TestMetalConfig:
         assert config.mlx_device == "gpu"
         assert config.debug is False
         assert config.use_paged_attention is True
+        assert config.kv_sharing_fast_prefill is False
         assert config.multimodal_mode == "auto"
 
     def test_custom_config_from_env(self, monkeypatch) -> None:
@@ -43,6 +44,7 @@ class TestMetalConfig:
         monkeypatch.setenv("VLLM_MLX_DEVICE", "cpu")
         monkeypatch.setenv("VLLM_METAL_DEBUG", "1")
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        monkeypatch.setenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "1")
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
 
         config = MetalConfig.from_env()
@@ -51,6 +53,7 @@ class TestMetalConfig:
         assert config.use_mlx is False
         assert config.mlx_device == "cpu"
         assert config.debug is True
+        assert config.kv_sharing_fast_prefill is True
         assert config.multimodal_mode == "multimodal-native"
 
     def test_get_config_singleton(self) -> None:
@@ -137,6 +140,21 @@ class TestMetalConfig:
         assert config.turboquant is False
         assert config.k_quant == "q8_0"
         assert config.v_quant == "q3_0"
+
+    def test_kv_sharing_fast_prefill_requires_paged_attention(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match="VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention",
+        ):
+            MetalConfig(
+                memory_fraction=AUTO_MEMORY_FRACTION,
+                use_mlx=True,
+                mlx_device="gpu",
+                block_size=16,
+                debug=False,
+                use_paged_attention=False,
+                kv_sharing_fast_prefill=True,
+            )
 
     def test_text_only_compat_mode_is_accepted(self) -> None:
         config = MetalConfig(

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -3,68 +3,229 @@
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from vllm_metal.yoco_fast_prefill import (
     build_yoco_reduced_context_from_full_metadata,
-    get_yoco_fast_prefill_ineligibility_reason,
-    is_yoco_fast_prefill_eligible,
-    patch_gemma4_yoco_fast_prefill,
+    try_enable_gemma4_yoco_fast_prefill,
 )
 
+_REAL_GEMMA4_MODEL_ENV = "GEMMA4_FAST_PREFILL_MODEL_PATH"
+_REAL_GEMMA4_FALLBACK_MODEL_ENV = "GEMMA4_MODEL_PATH"
+_REAL_GEMMA4_PROMPTS = [
+    "The capital of France is",
+    "One plus one equals",
+]
+_REAL_GEMMA4_MAX_MODEL_LEN = 1024
+_REAL_GEMMA4_MAX_TOKENS = 8
+_FAST_PREFILL_ENABLED_ATTR = "_vllm_metal_yoco_fast_prefill_enabled"
+_REAL_RESULT_MARKER = "VLLM_METAL_YOCO_FAST_PREFILL_RESULT="
 
-@pytest.mark.parametrize("model_type", ["gemma4", "gemma4_text"])
-def test_eligible_for_gemma4_yoco_paged_attention(model_type: str) -> None:
-    assert is_yoco_fast_prefill_eligible(
+
+def _run_real_gemma4_paged_path(
+    model_path: str,
+    *,
+    fast_prefill: bool,
+) -> tuple[dict[str, list[int]], bool]:
+    memory_fraction = os.environ.get(
+        "GEMMA4_FAST_PREFILL_MEMORY_FRACTION",
+        os.environ.get("VLLM_METAL_MEMORY_FRACTION", "0.5"),
+    )
+    env = os.environ.copy()
+    env.update(
         {
-            "model_type": model_type,
-            "num_hidden_layers": 42,
-            "num_kv_shared_layers": 18,
-        },
-        use_paged_attention=True,
+            "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
+            "VLLM_METAL_USE_PAGED_ATTENTION": "1",
+            "VLLM_METAL_KV_SHARING_FAST_PREFILL": "1" if fast_prefill else "0",
+            "VLLM_METAL_MEMORY_FRACTION": memory_fraction,
+        }
+    )
+
+    script = f"""
+import json
+from contextlib import suppress
+
+from vllm import LLM, SamplingParams
+
+model_path = {model_path!r}
+prompts = {json.dumps(_REAL_GEMMA4_PROMPTS)}
+enabled_attr = {_FAST_PREFILL_ENABLED_ATTR!r}
+llm = LLM(
+    model=model_path,
+    max_model_len={_REAL_GEMMA4_MAX_MODEL_LEN},
+    max_num_seqs={len(_REAL_GEMMA4_PROMPTS)},
+    enable_prefix_caching=False,
+)
+runner = llm.llm_engine.model_executor.driver_worker.model_runner
+model = runner.model
+language_model = getattr(model, "language_model", None)
+candidates = [
+    model,
+    getattr(model, "model", None),
+    language_model,
+    getattr(language_model, "model", None),
+]
+fast_prefill_enabled = any(
+    bool(getattr(candidate, enabled_attr, False))
+    for candidate in candidates
+    if candidate is not None
+)
+sp = SamplingParams(
+    temperature=0,
+    max_tokens={_REAL_GEMMA4_MAX_TOKENS},
+    ignore_eos=True,
+)
+outputs = llm.generate(prompts, sp)
+tokens = {{o.prompt: list(o.outputs[0].token_ids) for o in outputs}}
+print(
+    {_REAL_RESULT_MARKER!r}
+    + json.dumps({{"tokens": tokens, "enabled": fast_prefill_enabled}}),
+    flush=True,
+)
+engine = getattr(llm, "llm_engine", None)
+engine_core = getattr(engine, "engine_core", None)
+shutdown = getattr(engine_core, "shutdown", None)
+if callable(shutdown):
+    with suppress(Exception):
+        shutdown()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=300,
+        check=False,
+    )
+    output = f"{result.stdout}\n{result.stderr}"
+    if result.returncode != 0:
+        raise AssertionError(
+            "real Gemma4 paged-path subprocess failed "
+            f"(fast_prefill={fast_prefill}, code={result.returncode})\n"
+            f"{output[-8000:]}"
+        )
+    for line in output.splitlines():
+        if line.startswith(_REAL_RESULT_MARKER):
+            payload = json.loads(line[len(_REAL_RESULT_MARKER) :])
+            return payload["tokens"], bool(payload["enabled"])
+    raise AssertionError(
+        f"real Gemma4 paged-path subprocess did not report result\n{output[-8000:]}"
     )
 
 
 @pytest.mark.parametrize(
-    "model_args",
+    ("model_args", "expected_reason"),
     [
-        {"model_type": "qwen3", "num_hidden_layers": 32, "num_kv_shared_layers": 8},
-        {"model_type": "gemma4", "num_hidden_layers": 42, "num_kv_shared_layers": 0},
-        {"model_type": "gemma4", "num_hidden_layers": 42},
-        {"model_type": "gemma4", "num_hidden_layers": 18, "num_kv_shared_layers": 18},
-        {"model_type": "gemma4", "num_hidden_layers": "bad", "num_kv_shared_layers": 1},
-        {"num_hidden_layers": 42, "num_kv_shared_layers": 18},
+        (
+            {"model_type": "qwen3", "num_hidden_layers": 32, "num_kv_shared_layers": 8},
+            "model_type='qwen3' is not Gemma4",
+        ),
+        (
+            {
+                "model_type": "gemma4",
+                "num_hidden_layers": 42,
+                "num_kv_shared_layers": 0,
+            },
+            "num_kv_shared_layers must be positive",
+        ),
+        (
+            {"model_type": "gemma4", "num_hidden_layers": 42},
+            "num_kv_shared_layers is missing or not an int",
+        ),
+        (
+            {
+                "model_type": "gemma4",
+                "num_hidden_layers": 18,
+                "num_kv_shared_layers": 18,
+            },
+            "num_kv_shared_layers must be smaller than num_hidden_layers (18 >= 18)",
+        ),
+        (
+            {
+                "model_type": "gemma4",
+                "num_hidden_layers": "bad",
+                "num_kv_shared_layers": 1,
+            },
+            "num_hidden_layers is missing or not an int",
+        ),
+        (
+            {"num_hidden_layers": 42, "num_kv_shared_layers": 18},
+            "model_type=None is not Gemma4",
+        ),
     ],
 )
-def test_ineligible_without_supported_gemma4_yoco_shape(model_args) -> None:
-    assert not is_yoco_fast_prefill_eligible(
-        model_args,
-        use_paged_attention=True,
-    )
+def test_try_enable_logs_ineligible_gemma4_yoco_shape(
+    model_args,
+    expected_reason: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
+        assert not try_enable_gemma4_yoco_fast_prefill(
+            object(),
+            model_args,
+            use_paged_attention=True,
+        )
+
+    assert expected_reason in caplog.text
 
 
-def test_ineligible_without_paged_attention() -> None:
-    assert not is_yoco_fast_prefill_eligible(
-        {
-            "model_type": "gemma4",
-            "num_hidden_layers": 42,
-            "num_kv_shared_layers": 18,
-        },
-        use_paged_attention=False,
-    )
+def test_try_enable_logs_without_paged_attention(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
+        assert not try_enable_gemma4_yoco_fast_prefill(
+            object(),
+            {
+                "model_type": "gemma4",
+                "num_hidden_layers": 42,
+                "num_kv_shared_layers": 18,
+            },
+            use_paged_attention=False,
+        )
+
+    assert "paged attention is disabled" in caplog.text
 
 
-def test_ineligibility_reason_reports_missing_num_hidden_layers() -> None:
-    assert (
-        get_yoco_fast_prefill_ineligibility_reason(
+def test_try_enable_logs_when_not_all_layers_are_paged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
+        assert not try_enable_gemma4_yoco_fast_prefill(
+            object(),
+            {
+                "model_type": "gemma4",
+                "num_hidden_layers": 4,
+                "num_kv_shared_layers": 2,
+            },
+            use_paged_attention=True,
+            num_paged_layers=3,
+        )
+
+    assert "only 3/4 layers use paged attention" in caplog.text
+
+
+def test_try_enable_logs_missing_num_hidden_layers(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
+        assert not try_enable_gemma4_yoco_fast_prefill(
+            object(),
             {
                 "model_type": "gemma4",
                 "num_kv_shared_layers": 18,
             },
             use_paged_attention=True,
         )
-        == "num_hidden_layers is missing or not an int"
-    )
+
+    assert "num_hidden_layers is missing or not an int" in caplog.text
 
 
 def test_reduced_context_from_full_paged_metadata() -> None:
@@ -132,7 +293,7 @@ def test_reduced_context_from_empty_full_paged_metadata() -> None:
     assert meta.cu_seqlens == [0]
 
 
-def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
+def test_try_enable_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
     import mlx.core as mx
 
     from vllm_metal.paged_attention_common import (
@@ -204,7 +365,7 @@ def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
     text_model = _TextModel()
     top_model = type("_TopModel", (), {"model": text_model})()
 
-    assert patch_gemma4_yoco_fast_prefill(
+    assert try_enable_gemma4_yoco_fast_prefill(
         top_model,
         {
             "model_type": "gemma4_text",
@@ -212,6 +373,7 @@ def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
             "num_kv_shared_layers": 2,
         },
         use_paged_attention=True,
+        num_paged_layers=4,
     )
 
     inputs = mx.zeros((1, 5, 2), dtype=mx.float32)
@@ -243,6 +405,34 @@ def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
     assert text_model.layers[3].calls[0]["gdn_slot_mapping"] is None
     assert out[0, 0, 0].item() == 3
     assert out[0, 4, 0].item() == 10
+
+
+@pytest.mark.slow
+def test_real_gemma4_paged_path_matches_with_fast_prefill_off_on() -> None:
+    model_path = os.environ.get(_REAL_GEMMA4_MODEL_ENV) or os.environ.get(
+        _REAL_GEMMA4_FALLBACK_MODEL_ENV
+    )
+    if not model_path:
+        pytest.skip(
+            f"Set {_REAL_GEMMA4_MODEL_ENV} or {_REAL_GEMMA4_FALLBACK_MODEL_ENV} "
+            "to run the real Gemma4 fast-prefill parity test"
+        )
+    if not os.path.isdir(model_path):
+        pytest.skip(f"{model_path} is not a directory")
+
+    off_tokens, off_enabled = _run_real_gemma4_paged_path(
+        model_path,
+        fast_prefill=False,
+    )
+    assert not off_enabled
+
+    on_tokens, on_enabled = _run_real_gemma4_paged_path(
+        model_path,
+        fast_prefill=True,
+    )
+
+    assert on_enabled
+    assert on_tokens == off_tokens
 
 
 @pytest.mark.parametrize(

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -7,6 +7,7 @@ import pytest
 
 from vllm_metal.yoco_fast_prefill import (
     build_yoco_reduced_context_from_full_metadata,
+    get_yoco_fast_prefill_ineligibility_reason,
     is_yoco_fast_prefill_eligible,
     patch_gemma4_yoco_fast_prefill,
 )
@@ -53,6 +54,19 @@ def test_ineligible_without_paged_attention() -> None:
     )
 
 
+def test_ineligibility_reason_reports_missing_num_hidden_layers() -> None:
+    assert (
+        get_yoco_fast_prefill_ineligibility_reason(
+            {
+                "model_type": "gemma4",
+                "num_kv_shared_layers": 18,
+            },
+            use_paged_attention=True,
+        )
+        == "num_hidden_layers is missing or not an int"
+    )
+
+
 def test_reduced_context_from_full_paged_metadata() -> None:
     meta = build_yoco_reduced_context_from_full_metadata(
         slot_mapping=[
@@ -84,6 +98,21 @@ def test_reduced_context_from_full_paged_metadata() -> None:
     assert meta.context_lens == [7, 2, 5, 8]
     assert meta.offsets == [6, 1, 4, 7]
     assert meta.cu_seqlens == [0, 1, 2, 3, 4]
+
+
+def test_mlx_slice_assignment_writes_in_place() -> None:
+    import mlx.core as mx
+
+    h = mx.zeros((1, 5, 2), dtype=mx.float32)
+    selected = mx.array([1, 3], dtype=mx.int32)
+    cross_h = mx.array([[[7.0, 8.0], [9.0, 10.0]]], dtype=mx.float32)
+
+    h[:, selected, :] = cross_h
+    mx.eval(h)
+
+    assert h[0, 0, 0].item() == 0.0
+    assert h[0, 1, 0].item() == 7.0
+    assert h[0, 3, 0].item() == 9.0
 
 
 def test_reduced_context_from_empty_full_paged_metadata() -> None:
@@ -138,6 +167,7 @@ def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
                     "tokens": h.shape[1],
                     "cu_seqlens": tuple(ctx.cu_seqlens),
                     "offsets": tuple(ctx.offsets),
+                    "gdn_slot_mapping": ctx.gdn_slot_mapping,
                 }
             )
             return h + (self.layer_idx + 1), (f"k{self.layer_idx}", "v"), offset
@@ -195,6 +225,7 @@ def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
         context_lens=[5],
         offsets=[0],
         cu_seqlens=[0, 5],
+        gdn_slot_mapping=[17],
     )
     set_context(ctx)
     try:
@@ -207,6 +238,9 @@ def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
     assert [layer.calls[0]["tokens"] for layer in text_model.layers] == [5, 5, 1, 1]
     assert text_model.layers[2].calls[0]["cu_seqlens"] == (0, 1)
     assert text_model.layers[2].calls[0]["offsets"] == (4,)
+    assert text_model.layers[0].calls[0]["gdn_slot_mapping"] == [17]
+    assert text_model.layers[2].calls[0]["gdn_slot_mapping"] is None
+    assert text_model.layers[3].calls[0]["gdn_slot_mapping"] is None
     assert out[0, 0, 0].item() == 3
     assert out[0, 4, 0].item() == 10
 

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -188,6 +188,28 @@ def test_try_enable_logs_ineligible_gemma4_yoco_shape(
     assert expected_reason in _logged_warning_text(warning)
 
 
+def test_try_enable_can_skip_ineligible_model_without_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warning = Mock()
+    debug = Mock()
+    monkeypatch.setattr("vllm_metal.yoco_fast_prefill.logger.warning", warning)
+    monkeypatch.setattr("vllm_metal.yoco_fast_prefill.logger.debug", debug)
+
+    assert not try_enable_gemma4_yoco_fast_prefill(
+        object(),
+        {
+            "model_type": "qwen3",
+            "num_hidden_layers": 32,
+            "num_kv_shared_layers": 8,
+        },
+        use_paged_attention=True,
+        warn_on_skip=False,
+    )
+    warning.assert_not_called()
+    debug.assert_called_once()
+
+
 def test_try_enable_logs_without_paged_attention(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for YOCO fast-prefill indexing helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_metal.yoco_fast_prefill import (
+    build_yoco_reduced_context_from_full_metadata,
+    is_yoco_fast_prefill_eligible,
+    patch_gemma4_yoco_fast_prefill,
+)
+
+
+@pytest.mark.parametrize("model_type", ["gemma4", "gemma4_text"])
+def test_eligible_for_gemma4_yoco_paged_attention(model_type: str) -> None:
+    assert is_yoco_fast_prefill_eligible(
+        {
+            "model_type": model_type,
+            "num_hidden_layers": 42,
+            "num_kv_shared_layers": 18,
+        },
+        use_paged_attention=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_args",
+    [
+        {"model_type": "qwen3", "num_hidden_layers": 32, "num_kv_shared_layers": 8},
+        {"model_type": "gemma4", "num_hidden_layers": 42, "num_kv_shared_layers": 0},
+        {"model_type": "gemma4", "num_hidden_layers": 42},
+        {"model_type": "gemma4", "num_hidden_layers": 18, "num_kv_shared_layers": 18},
+        {"model_type": "gemma4", "num_hidden_layers": "bad", "num_kv_shared_layers": 1},
+        {"num_hidden_layers": 42, "num_kv_shared_layers": 18},
+    ],
+)
+def test_ineligible_without_supported_gemma4_yoco_shape(model_args) -> None:
+    assert not is_yoco_fast_prefill_eligible(
+        model_args,
+        use_paged_attention=True,
+    )
+
+
+def test_ineligible_without_paged_attention() -> None:
+    assert not is_yoco_fast_prefill_eligible(
+        {
+            "model_type": "gemma4",
+            "num_hidden_layers": 42,
+            "num_kv_shared_layers": 18,
+        },
+        use_paged_attention=False,
+    )
+
+
+def test_reduced_context_from_full_paged_metadata() -> None:
+    meta = build_yoco_reduced_context_from_full_metadata(
+        slot_mapping=[
+            2 * 4 + 2,
+            3 * 4 + 1,
+            4 * 4 + 0,
+            4 * 4 + 1,
+            4 * 4 + 2,
+            4 * 4 + 3,
+            5 * 4 + 0,
+            7 * 4 + 1,
+            7 * 4 + 2,
+            7 * 4 + 3,
+        ],
+        block_tables=[
+            [1, 2],
+            [3],
+            [4, 5],
+            [6, 7, 8],
+        ],
+        context_lens=[7, 2, 5, 8],
+        offsets=[6, 1, 0, 5],
+        cu_seqlens=[0, 1, 2, 7, 10],
+    )
+
+    assert meta.selected_query_indices == [0, 1, 6, 9]
+    assert meta.slot_mapping == [2 * 4 + 2, 3 * 4 + 1, 5 * 4 + 0, 7 * 4 + 3]
+    assert meta.block_tables == [[1, 2], [3], [4, 5], [6, 7, 8]]
+    assert meta.context_lens == [7, 2, 5, 8]
+    assert meta.offsets == [6, 1, 4, 7]
+    assert meta.cu_seqlens == [0, 1, 2, 3, 4]
+
+
+def test_reduced_context_from_empty_full_paged_metadata() -> None:
+    meta = build_yoco_reduced_context_from_full_metadata(
+        slot_mapping=[],
+        block_tables=[],
+        context_lens=[],
+        offsets=[],
+        cu_seqlens=[0],
+    )
+
+    assert meta.selected_query_indices == []
+    assert meta.slot_mapping == []
+    assert meta.block_tables == []
+    assert meta.context_lens == []
+    assert meta.offsets == []
+    assert meta.cu_seqlens == [0]
+
+
+def test_patch_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> None:
+    import mlx.core as mx
+
+    from vllm_metal.paged_attention_common import (
+        PagedAttentionContext,
+        clear_context,
+        get_context,
+        set_context,
+    )
+
+    class _Config:
+        num_hidden_layers = 4
+        num_kv_shared_layers = 2
+
+    class _Layer:
+        def __init__(self, layer_idx: int) -> None:
+            self.layer_idx = layer_idx
+            self.calls = []
+
+        def __call__(
+            self,
+            h,
+            mask,
+            cache,
+            *,
+            per_layer_input=None,
+            shared_kv=None,
+            offset=None,
+        ):
+            ctx = get_context()
+            self.calls.append(
+                {
+                    "tokens": h.shape[1],
+                    "cu_seqlens": tuple(ctx.cu_seqlens),
+                    "offsets": tuple(ctx.offsets),
+                }
+            )
+            return h + (self.layer_idx + 1), (f"k{self.layer_idx}", "v"), offset
+
+    class _TextModel:
+        config = _Config()
+        embed_scale = 1
+        hidden_size_per_layer_input = 0
+
+        def __init__(self) -> None:
+            self.layers = [_Layer(i) for i in range(4)]
+            self.previous_kvs = [0, 1, 0, 1]
+            self.embed_tokens = lambda inputs: inputs
+            self.norm = lambda h: h
+
+        def _get_per_layer_inputs(self, input_ids, input_embeddings=None):
+            raise AssertionError("per-layer input lookup should not run")
+
+        def _project_per_layer_inputs(self, input_embeddings, per_layer_inputs=None):
+            raise AssertionError("per-layer input projection should not run")
+
+        def _make_masks(self, h, cache):
+            return [None] * len(self.layers)
+
+        def __call__(
+            self,
+            inputs=None,
+            cache=None,
+            input_embeddings=None,
+            per_layer_inputs=None,
+        ):
+            return input_embeddings + 100
+
+    text_model = _TextModel()
+    top_model = type("_TopModel", (), {"model": text_model})()
+
+    assert patch_gemma4_yoco_fast_prefill(
+        top_model,
+        {
+            "model_type": "gemma4_text",
+            "num_hidden_layers": 4,
+            "num_kv_shared_layers": 2,
+        },
+        use_paged_attention=True,
+    )
+
+    inputs = mx.zeros((1, 5, 2), dtype=mx.float32)
+    fallback = text_model(input_embeddings=inputs)
+    mx.eval(fallback)
+    assert fallback[0, 0, 0].item() == 100
+
+    ctx = PagedAttentionContext(
+        slot_mapping=[0, 1, 2, 3, 4],
+        block_tables=[[0, 1]],
+        context_lens=[5],
+        offsets=[0],
+        cu_seqlens=[0, 5],
+    )
+    set_context(ctx)
+    try:
+        out = text_model(input_embeddings=inputs, cache=[object()] * 4)
+        assert get_context() is ctx
+    finally:
+        clear_context()
+
+    mx.eval(out)
+    assert [layer.calls[0]["tokens"] for layer in text_model.layers] == [5, 5, 1, 1]
+    assert text_model.layers[2].calls[0]["cu_seqlens"] == (0, 1)
+    assert text_model.layers[2].calls[0]["offsets"] == (4,)
+    assert out[0, 0, 0].item() == 3
+    assert out[0, 4, 0].item() == 10
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        (
+            {
+                "slot_mapping": [],
+                "block_tables": [],
+                "context_lens": [],
+                "offsets": [],
+                "cu_seqlens": [],
+            },
+            "cu_seqlens must start with 0",
+        ),
+        (
+            {
+                "slot_mapping": [],
+                "block_tables": [],
+                "context_lens": [],
+                "offsets": [],
+                "cu_seqlens": [1],
+            },
+            "cu_seqlens must start with 0",
+        ),
+        (
+            {
+                "slot_mapping": [1],
+                "block_tables": [[1]],
+                "context_lens": [1],
+                "offsets": [],
+                "cu_seqlens": [0, 1],
+            },
+            "block_tables, context_lens, and offsets must match",
+        ),
+        (
+            {
+                "slot_mapping": [1, 2],
+                "block_tables": [[1]],
+                "context_lens": [1],
+                "offsets": [0],
+                "cu_seqlens": [0, 1],
+            },
+            "slot_mapping length must match final cu_seqlens",
+        ),
+        (
+            {
+                "slot_mapping": [],
+                "block_tables": [[1]],
+                "context_lens": [1],
+                "offsets": [0],
+                "cu_seqlens": [0, 1],
+            },
+            "slot_mapping shorter than cu_seqlens",
+        ),
+        (
+            {
+                "slot_mapping": [1],
+                "block_tables": [[1]],
+                "context_lens": [1],
+                "offsets": [0],
+                "cu_seqlens": [0, 0],
+            },
+            "cu_seqlens segments must be positive and increasing",
+        ),
+    ],
+)
+def test_reduced_context_from_full_metadata_validates_inputs(
+    kwargs,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        build_yoco_reduced_context_from_full_metadata(**kwargs)

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -27,6 +27,16 @@ _REAL_GEMMA4_MAX_MODEL_LEN = 1024
 _REAL_GEMMA4_MAX_TOKENS = 8
 _FAST_PREFILL_ENABLED_ATTR = "_vllm_metal_yoco_fast_prefill_enabled"
 _REAL_RESULT_MARKER = "VLLM_METAL_YOCO_FAST_PREFILL_RESULT="
+
+
+def _logged_warning_text(warning: Mock) -> str:
+    rendered = []
+    for call in warning.call_args_list:
+        if not call.args:
+            continue
+        fmt = str(call.args[0])
+        rendered.append(fmt % call.args[1:] if len(call.args) > 1 else fmt)
+    return "\n".join(rendered)
 
 
 def _run_real_gemma4_paged_path(
@@ -165,67 +175,71 @@ if callable(shutdown):
 def test_try_enable_logs_ineligible_gemma4_yoco_shape(
     model_args,
     expected_reason: str,
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
-        assert not try_enable_gemma4_yoco_fast_prefill(
-            object(),
-            model_args,
-            use_paged_attention=True,
-        )
+    warning = Mock()
+    monkeypatch.setattr("vllm_metal.yoco_fast_prefill.logger.warning", warning)
 
-    assert expected_reason in caplog.text
+    assert not try_enable_gemma4_yoco_fast_prefill(
+        object(),
+        model_args,
+        use_paged_attention=True,
+    )
+    assert expected_reason in _logged_warning_text(warning)
 
 
 def test_try_enable_logs_without_paged_attention(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
-        assert not try_enable_gemma4_yoco_fast_prefill(
-            object(),
-            {
-                "model_type": "gemma4",
-                "num_hidden_layers": 42,
-                "num_kv_shared_layers": 18,
-            },
-            use_paged_attention=False,
-        )
+    warning = Mock()
+    monkeypatch.setattr("vllm_metal.yoco_fast_prefill.logger.warning", warning)
 
-    assert "paged attention is disabled" in caplog.text
+    assert not try_enable_gemma4_yoco_fast_prefill(
+        object(),
+        {
+            "model_type": "gemma4",
+            "num_hidden_layers": 42,
+            "num_kv_shared_layers": 18,
+        },
+        use_paged_attention=False,
+    )
+    assert "paged attention is disabled" in _logged_warning_text(warning)
 
 
 def test_try_enable_logs_when_not_all_layers_are_paged(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
-        assert not try_enable_gemma4_yoco_fast_prefill(
-            object(),
-            {
-                "model_type": "gemma4",
-                "num_hidden_layers": 4,
-                "num_kv_shared_layers": 2,
-            },
-            use_paged_attention=True,
-            num_paged_layers=3,
-        )
+    warning = Mock()
+    monkeypatch.setattr("vllm_metal.yoco_fast_prefill.logger.warning", warning)
 
-    assert "only 3/4 layers use paged attention" in caplog.text
+    assert not try_enable_gemma4_yoco_fast_prefill(
+        object(),
+        {
+            "model_type": "gemma4",
+            "num_hidden_layers": 4,
+            "num_kv_shared_layers": 2,
+        },
+        use_paged_attention=True,
+        num_paged_layers=3,
+    )
+    assert "only 3/4 layers use paged attention" in _logged_warning_text(warning)
 
 
 def test_try_enable_logs_missing_num_hidden_layers(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with caplog.at_level(logging.WARNING, logger="vllm_metal.yoco_fast_prefill"):
-        assert not try_enable_gemma4_yoco_fast_prefill(
-            object(),
-            {
-                "model_type": "gemma4",
-                "num_kv_shared_layers": 18,
-            },
-            use_paged_attention=True,
-        )
+    warning = Mock()
+    monkeypatch.setattr("vllm_metal.yoco_fast_prefill.logger.warning", warning)
 
-    assert "num_hidden_layers is missing or not an int" in caplog.text
+    assert not try_enable_gemma4_yoco_fast_prefill(
+        object(),
+        {
+            "model_type": "gemma4",
+            "num_kv_shared_layers": 18,
+        },
+        use_paged_attention=True,
+    )
+    assert "num_hidden_layers is missing or not an int" in _logged_warning_text(warning)
 
 
 def test_reduced_context_from_full_paged_metadata() -> None:

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -43,6 +43,7 @@ class MetalConfig:
     mlx_device: Literal["gpu", "cpu"]
     debug: bool
     use_paged_attention: bool = True
+    kv_sharing_fast_prefill: bool = False
     multimodal_mode: MultimodalMode = "auto"
     turboquant: bool = False  # Enable TurboQuant KV cache compression
     k_quant: str = "q8_0"  # Key quantization type: q8_0, q4_0, int8, uint8, etc.
@@ -55,6 +56,12 @@ class MetalConfig:
                 "supported with paged attention (the default). "
                 "The MLX KV cache path (VLLM_METAL_USE_PAGED_ATTENTION=0) "
                 "requires VLLM_METAL_MEMORY_FRACTION=auto."
+            )
+
+        if self.kv_sharing_fast_prefill and not self.use_paged_attention:
+            raise ValueError(
+                "VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention. "
+                "Enable VLLM_METAL_USE_PAGED_ATTENTION=1 or leave fast prefill off."
             )
 
         if self.use_paged_attention and not self.is_auto_memory:
@@ -122,6 +129,7 @@ class MetalConfig:
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
             debug=envs.VLLM_METAL_DEBUG,
             use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
+            kv_sharing_fast_prefill=envs.VLLM_METAL_KV_SHARING_FAST_PREFILL,
             multimodal_mode=envs.VLLM_METAL_MULTIMODAL_MODE,  # type: ignore[arg-type]
         )
 

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Configuration for vLLM Metal plugin via environment variables."""
 
+import os
 from dataclasses import dataclass
 from typing import Literal
 
@@ -61,7 +62,8 @@ class MetalConfig:
         if self.kv_sharing_fast_prefill and not self.use_paged_attention:
             raise ValueError(
                 "VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention. "
-                "Enable VLLM_METAL_USE_PAGED_ATTENTION=1 or leave fast prefill off."
+                "Enable VLLM_METAL_USE_PAGED_ATTENTION=1 or set "
+                "VLLM_METAL_KV_SHARING_FAST_PREFILL=0."
             )
 
         if self.use_paged_attention and not self.is_auto_memory:
@@ -121,6 +123,14 @@ class MetalConfig:
                     "Must be 'auto' or a numeric value in (0, 1]."
                 ) from e
 
+        use_paged_attention = envs.VLLM_METAL_USE_PAGED_ATTENTION
+        kv_sharing_fast_prefill = envs.VLLM_METAL_KV_SHARING_FAST_PREFILL
+        if (
+            not use_paged_attention
+            and "VLLM_METAL_KV_SHARING_FAST_PREFILL" not in os.environ
+        ):
+            kv_sharing_fast_prefill = False
+
         # TurboQuant config is set via --additional-config, not env vars.
         # See MetalPlatform.check_and_update_config() for how it's applied.
         return cls(
@@ -128,8 +138,8 @@ class MetalConfig:
             use_mlx=envs.VLLM_METAL_USE_MLX,
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
             debug=envs.VLLM_METAL_DEBUG,
-            use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
-            kv_sharing_fast_prefill=envs.VLLM_METAL_KV_SHARING_FAST_PREFILL,
+            use_paged_attention=use_paged_attention,
+            kv_sharing_fast_prefill=kv_sharing_fast_prefill,
             multimodal_mode=envs.VLLM_METAL_MULTIMODAL_MODE,  # type: ignore[arg-type]
         )
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     VLLM_MLX_DEVICE: str = "gpu"
     VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
+    VLLM_METAL_KV_SHARING_FAST_PREFILL: bool = False
     VLLM_METAL_MULTIMODAL_MODE: str = "auto"
     VLLM_METAL_PREFIX_CACHE: bool = False
     VLLM_METAL_PREFIX_CACHE_FRACTION: str = ""
@@ -45,6 +46,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use native Metal paged attention (default True).
     "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
         os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
+    ),
+    # Experimental YOCO/KV-sharing fast prefill. Default off.
+    "VLLM_METAL_KV_SHARING_FAST_PREFILL": lambda: (
+        os.getenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "0") == "1"
     ),
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     VLLM_MLX_DEVICE: str = "gpu"
     VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
-    VLLM_METAL_KV_SHARING_FAST_PREFILL: bool = False
+    VLLM_METAL_KV_SHARING_FAST_PREFILL: bool = True
     VLLM_METAL_MULTIMODAL_MODE: str = "auto"
     VLLM_METAL_PREFIX_CACHE: bool = False
     VLLM_METAL_PREFIX_CACHE_FRACTION: str = ""
@@ -47,9 +47,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
         os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
     ),
-    # Experimental YOCO/KV-sharing fast prefill. Default off.
+    # Experimental YOCO/KV-sharing fast prefill. Default on for eligible
+    # paged-attention models.
     "VLLM_METAL_KV_SHARING_FAST_PREFILL": lambda: (
-        os.getenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "0") == "1"
+        os.getenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "1") == "1"
     ),
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -595,6 +596,7 @@ class WorkerCachePlanner:
                 self._worker.model_runner.model_args,
                 use_paged_attention=config.use_paged_attention,
                 num_paged_layers=n_patched,
+                warn_on_skip="VLLM_METAL_KV_SHARING_FAST_PREFILL" in os.environ,
             )
         logger.info(
             "Paged attention enabled: %d layers patched, "

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -587,6 +587,41 @@ class WorkerCachePlanner:
         backend.initialize(plan.num_blocks)
         n_patched = backend.patch_model(self._worker.model_runner.model)
         config = get_config()
+        if config.kv_sharing_fast_prefill:
+            from vllm_metal.yoco_fast_prefill import patch_gemma4_yoco_fast_prefill
+
+            try:
+                expected_layers = int(
+                    self._worker.model_runner.model_args.get("num_hidden_layers", 0)
+                )
+            except (TypeError, ValueError):
+                expected_layers = 0
+
+            fast_prefill_patched = False
+            if expected_layers and n_patched < expected_layers:
+                logger.warning(
+                    "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
+                    "but only %d/%d layers use paged attention; "
+                    "continuing without fast prefill",
+                    n_patched,
+                    expected_layers,
+                )
+            else:
+                fast_prefill_patched = patch_gemma4_yoco_fast_prefill(
+                    self._worker.model_runner.model,
+                    self._worker.model_runner.model_args,
+                    use_paged_attention=config.use_paged_attention,
+                )
+            if fast_prefill_patched:
+                logger.info(
+                    "Gemma4 YOCO fast prefill enabled "
+                    "(VLLM_METAL_KV_SHARING_FAST_PREFILL=1)"
+                )
+            elif not (expected_layers and n_patched < expected_layers):
+                logger.warning(
+                    "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
+                    "but this model is not eligible; continuing without fast prefill"
+                )
         logger.info(
             "Paged attention enabled: %d layers patched, "
             "%d blocks allocated (block_size=%d, mla=%s, turboquant=%s, k_quant=%s)",

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -588,40 +588,14 @@ class WorkerCachePlanner:
         n_patched = backend.patch_model(self._worker.model_runner.model)
         config = get_config()
         if config.kv_sharing_fast_prefill:
-            from vllm_metal.yoco_fast_prefill import (
-                get_yoco_fast_prefill_ineligibility_reason,
-                patch_gemma4_yoco_fast_prefill,
-            )
+            from vllm_metal.yoco_fast_prefill import try_enable_gemma4_yoco_fast_prefill
 
-            reason = get_yoco_fast_prefill_ineligibility_reason(
+            try_enable_gemma4_yoco_fast_prefill(
+                self._worker.model_runner.model,
                 self._worker.model_runner.model_args,
                 use_paged_attention=config.use_paged_attention,
+                num_paged_layers=n_patched,
             )
-
-            fast_prefill_patched = False
-            if reason is not None:
-                logger.warning(
-                    "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
-                    "but fast prefill is ineligible for this model (%s); "
-                    "continuing without fast prefill",
-                    reason,
-                )
-            else:
-                fast_prefill_patched = patch_gemma4_yoco_fast_prefill(
-                    self._worker.model_runner.model,
-                    self._worker.model_runner.model_args,
-                    use_paged_attention=config.use_paged_attention,
-                )
-            if fast_prefill_patched:
-                logger.info(
-                    "Gemma4 YOCO fast prefill enabled "
-                    "(VLLM_METAL_KV_SHARING_FAST_PREFILL=1)"
-                )
-            elif reason is None:
-                logger.warning(
-                    "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
-                    "but this model is not eligible; continuing without fast prefill"
-                )
         logger.info(
             "Paged attention enabled: %d layers patched, "
             "%d blocks allocated (block_size=%d, mla=%s, turboquant=%s, k_quant=%s)",

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -588,23 +588,23 @@ class WorkerCachePlanner:
         n_patched = backend.patch_model(self._worker.model_runner.model)
         config = get_config()
         if config.kv_sharing_fast_prefill:
-            from vllm_metal.yoco_fast_prefill import patch_gemma4_yoco_fast_prefill
+            from vllm_metal.yoco_fast_prefill import (
+                get_yoco_fast_prefill_ineligibility_reason,
+                patch_gemma4_yoco_fast_prefill,
+            )
 
-            try:
-                expected_layers = int(
-                    self._worker.model_runner.model_args.get("num_hidden_layers", 0)
-                )
-            except (TypeError, ValueError):
-                expected_layers = 0
+            reason = get_yoco_fast_prefill_ineligibility_reason(
+                self._worker.model_runner.model_args,
+                use_paged_attention=config.use_paged_attention,
+            )
 
             fast_prefill_patched = False
-            if expected_layers and n_patched < expected_layers:
+            if reason is not None:
                 logger.warning(
                     "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
-                    "but only %d/%d layers use paged attention; "
+                    "but fast prefill is ineligible for this model (%s); "
                     "continuing without fast prefill",
-                    n_patched,
-                    expected_layers,
+                    reason,
                 )
             else:
                 fast_prefill_patched = patch_gemma4_yoco_fast_prefill(
@@ -617,7 +617,7 @@ class WorkerCachePlanner:
                     "Gemma4 YOCO fast prefill enabled "
                     "(VLLM_METAL_KV_SHARING_FAST_PREFILL=1)"
                 )
-            elif not (expected_layers and n_patched < expected_layers):
+            elif reason is None:
                 logger.warning(
                     "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
                     "but this model is not eligible; continuing without fast prefill"

--- a/vllm_metal/yoco_fast_prefill.py
+++ b/vllm_metal/yoco_fast_prefill.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Gemma4 YOCO fast-prefill helpers.
 
-This module owns the reduced-query metadata contract and the default-off
+This module owns the reduced-query metadata contract and the default-on
 Gemma4 runtime patch. The metadata helpers intentionally avoid importing MLX or
 mlx-lm internals so the indexing contract can be tested in fast CI.
 """
@@ -35,6 +35,7 @@ def try_enable_gemma4_yoco_fast_prefill(
     *,
     use_paged_attention: bool,
     num_paged_layers: int | None = None,
+    warn_on_skip: bool = True,
 ) -> bool:
     """Enable Gemma4 YOCO fast prefill when the loaded model is eligible."""
     reason = _get_yoco_fast_prefill_ineligibility_reason(
@@ -42,12 +43,15 @@ def try_enable_gemma4_yoco_fast_prefill(
         use_paged_attention=use_paged_attention,
     )
     if reason is not None:
-        logger.warning(
-            "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
-            "but fast prefill is ineligible for this model (%s); "
-            "continuing without fast prefill",
-            reason,
-        )
+        if warn_on_skip:
+            logger.warning(
+                "Gemma4 YOCO fast prefill is enabled, "
+                "but this model is ineligible (%s); "
+                "continuing without fast prefill",
+                reason,
+            )
+        else:
+            logger.debug("Gemma4 YOCO fast prefill skipped: %s", reason)
         return False
 
     expected_layers = _get_int_model_arg(model_args, "num_hidden_layers")
@@ -56,13 +60,21 @@ def try_enable_gemma4_yoco_fast_prefill(
         and expected_layers is not None
         and num_paged_layers < expected_layers
     ):
-        logger.warning(
-            "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
-            "but only %d/%d layers use paged attention; "
-            "continuing without fast prefill",
-            num_paged_layers,
-            expected_layers,
-        )
+        if warn_on_skip:
+            logger.warning(
+                "Gemma4 YOCO fast prefill is enabled, "
+                "but only %d/%d layers use paged attention; "
+                "continuing without fast prefill",
+                num_paged_layers,
+                expected_layers,
+            )
+        else:
+            logger.debug(
+                "Gemma4 YOCO fast prefill skipped: only %d/%d layers use paged "
+                "attention",
+                num_paged_layers,
+                expected_layers,
+            )
         return False
 
     if _patch_gemma4_yoco_fast_prefill(
@@ -70,16 +82,19 @@ def try_enable_gemma4_yoco_fast_prefill(
         model_args,
         use_paged_attention=use_paged_attention,
     ):
-        logger.info(
-            "Gemma4 YOCO fast prefill enabled (VLLM_METAL_KV_SHARING_FAST_PREFILL=1)"
-        )
+        logger.info("Gemma4 YOCO fast prefill enabled")
         return True
 
-    logger.warning(
-        "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
-        "but the Gemma4 text-model patch could not be installed; "
-        "continuing without fast prefill"
-    )
+    if warn_on_skip:
+        logger.warning(
+            "Gemma4 YOCO fast prefill is enabled, "
+            "but the Gemma4 text-model patch could not be installed; "
+            "continuing without fast prefill"
+        )
+    else:
+        logger.debug(
+            "Gemma4 YOCO fast prefill skipped: text-model patch could not be installed"
+        )
     return False
 
 

--- a/vllm_metal/yoco_fast_prefill.py
+++ b/vllm_metal/yoco_fast_prefill.py
@@ -23,10 +23,41 @@ logger = logging.getLogger(__name__)
 
 
 def _get_int_model_arg(model_args: Mapping[str, object], key: str) -> int | None:
-    value = model_args.get(key, 0)
+    value = model_args.get(key)
     if not isinstance(value, int):
         return None
     return value
+
+
+def get_yoco_fast_prefill_ineligibility_reason(
+    model_args: Mapping[str, object],
+    *,
+    use_paged_attention: bool,
+) -> str | None:
+    """Return a human-readable reason why Gemma4 YOCO fast prefill is disabled."""
+    if not use_paged_attention:
+        return "paged attention is disabled"
+
+    model_type = model_args.get("model_type")
+    if model_type not in _GEMMA4_MODEL_TYPES:
+        return f"model_type={model_type!r} is not Gemma4"
+
+    num_layers = _get_int_model_arg(model_args, "num_hidden_layers")
+    if num_layers is None:
+        return "num_hidden_layers is missing or not an int"
+
+    num_shared = _get_int_model_arg(model_args, "num_kv_shared_layers")
+    if num_shared is None:
+        return "num_kv_shared_layers is missing or not an int"
+
+    if num_shared <= 0:
+        return "num_kv_shared_layers must be positive"
+    if num_shared >= num_layers:
+        return (
+            "num_kv_shared_layers must be smaller than num_hidden_layers "
+            f"({num_shared} >= {num_layers})"
+        )
+    return None
 
 
 @dataclass(frozen=True)
@@ -59,19 +90,13 @@ def is_yoco_fast_prefill_eligible(
     attention.  Keep this predicate intentionally narrow until runtime
     correctness is proven and benchmarked.
     """
-    if not use_paged_attention:
-        return False
-
-    model_type = model_args.get("model_type")
-    if model_type not in _GEMMA4_MODEL_TYPES:
-        return False
-
-    num_layers = _get_int_model_arg(model_args, "num_hidden_layers")
-    num_shared = _get_int_model_arg(model_args, "num_kv_shared_layers")
-    if num_layers is None or num_shared is None:
-        return False
-
-    return 0 < num_shared < num_layers
+    return (
+        get_yoco_fast_prefill_ineligibility_reason(
+            model_args,
+            use_paged_attention=use_paged_attention,
+        )
+        is None
+    )
 
 
 def build_yoco_reduced_context_from_full_metadata(
@@ -394,7 +419,6 @@ def _gemma4_text_fast_prefill_call(
         context_lens=meta.context_lens,
         offsets=meta.offsets,
         cu_seqlens=meta.cu_seqlens,
-        gdn_slot_mapping=ctx.gdn_slot_mapping,
     )
 
     set_context(reduced_ctx)

--- a/vllm_metal/yoco_fast_prefill.py
+++ b/vllm_metal/yoco_fast_prefill.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Gemma4 YOCO fast-prefill helpers.
+
+This module owns the reduced-query metadata contract and the default-off
+Gemma4 runtime patch. The metadata helpers intentionally avoid importing MLX or
+mlx-lm internals so the indexing contract can be tested in fast CI.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+_GEMMA4_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
+_PATCHED_CALL_ATTR = "_vllm_metal_yoco_fast_prefill_patched"
+_ORIGINAL_CALL_ATTR = "_vllm_metal_yoco_fast_prefill_original_call"
+_ENABLED_ATTR = "_vllm_metal_yoco_fast_prefill_enabled"
+_WARNED_FALLBACK_ATTR = "_vllm_metal_yoco_fast_prefill_warned_fallback"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class YocoReducedContextMetadata:
+    """Reduced-query metadata for YOCO cross-decoder fast prefill.
+
+    ``selected_query_indices`` indexes into the original packed token sequence
+    built by ``MetalModelRunner._start_paged_forward``: decode tokens first,
+    followed by each prefill chunk. The other fields mirror
+    ``PagedAttentionContext`` but describe the reduced cross-decoder query set,
+    where every selected query is represented as a length-1 segment.
+    """
+
+    selected_query_indices: list[int]
+    slot_mapping: list[int]
+    block_tables: list[list[int]]
+    context_lens: list[int]
+    offsets: list[int]
+    cu_seqlens: list[int]
+
+
+def is_yoco_fast_prefill_eligible(
+    model_args: Mapping[str, object],
+    *,
+    use_paged_attention: bool,
+) -> bool:
+    """Return whether model metadata is eligible for YOCO fast prefill.
+
+    The first implementation target is the Gemma4 text path under paged
+    attention.  Keep this predicate intentionally narrow until runtime
+    correctness is proven and benchmarked.
+    """
+    if not use_paged_attention:
+        return False
+
+    model_type = model_args.get("model_type")
+    if model_type not in _GEMMA4_MODEL_TYPES:
+        return False
+
+    try:
+        num_layers = int(model_args.get("num_hidden_layers", 0))
+        num_shared = int(model_args.get("num_kv_shared_layers", 0))
+    except (TypeError, ValueError):
+        return False
+
+    return 0 < num_shared < num_layers
+
+
+def build_yoco_reduced_context_from_full_metadata(
+    *,
+    slot_mapping: Sequence[int],
+    block_tables: Sequence[Sequence[int]],
+    context_lens: Sequence[int],
+    offsets: Sequence[int],
+    cu_seqlens: Sequence[int],
+) -> YocoReducedContextMetadata:
+    """Build reduced YOCO metadata from an existing paged-attention context.
+
+    ``prepare_unified`` already computes the full packed metadata used by the
+    self-decoder. The YOCO cross-decoder needs the last query from each packed
+    segment while preserving that segment's full K/V context. This helper keeps
+    the contract close to the actual ``PagedAttentionContext`` fields without
+    importing MLX or the runtime context class.
+    """
+    if not cu_seqlens or int(cu_seqlens[0]) != 0:
+        raise ValueError("cu_seqlens must start with 0")
+
+    num_segments = len(cu_seqlens) - 1
+    if (
+        len(block_tables) != num_segments
+        or len(context_lens) != num_segments
+        or len(offsets) != num_segments
+    ):
+        raise ValueError(
+            "block_tables, context_lens, and offsets must match cu_seqlens segments"
+        )
+    selected_query_indices: list[int] = []
+    reduced_slot_mapping: list[int] = []
+    reduced_block_tables: list[list[int]] = []
+    reduced_context_lens: list[int] = []
+    reduced_offsets: list[int] = []
+    reduced_cu_seqlens: list[int] = [0]
+
+    for segment_idx in range(num_segments):
+        q_start = int(cu_seqlens[segment_idx])
+        q_end = int(cu_seqlens[segment_idx + 1])
+        if q_end <= q_start:
+            raise ValueError("cu_seqlens segments must be positive and increasing")
+        if q_end > len(slot_mapping):
+            raise ValueError("slot_mapping shorter than cu_seqlens")
+
+        segment_len = q_end - q_start
+        selected_query_index = q_end - 1
+        selected_query_indices.append(selected_query_index)
+        reduced_slot_mapping.append(int(slot_mapping[selected_query_index]))
+        reduced_block_tables.append(
+            [int(block_id) for block_id in block_tables[segment_idx]]
+        )
+        reduced_context_lens.append(int(context_lens[segment_idx]))
+        reduced_offsets.append(int(offsets[segment_idx]) + segment_len - 1)
+        reduced_cu_seqlens.append(reduced_cu_seqlens[-1] + 1)
+
+    if int(cu_seqlens[-1]) != len(slot_mapping):
+        raise ValueError("slot_mapping length must match final cu_seqlens")
+
+    return YocoReducedContextMetadata(
+        selected_query_indices=selected_query_indices,
+        slot_mapping=reduced_slot_mapping,
+        block_tables=reduced_block_tables,
+        context_lens=reduced_context_lens,
+        offsets=reduced_offsets,
+        cu_seqlens=reduced_cu_seqlens,
+    )
+
+
+def find_gemma4_text_model(model: Any) -> Any | None:
+    """Return the mlx-lm Gemma4 text-model object if it matches our contract."""
+    candidates = [
+        model,
+        getattr(model, "model", None),
+        getattr(model, "language_model", None),
+        getattr(getattr(model, "language_model", None), "model", None),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if _has_gemma4_text_model_contract(candidate):
+            return candidate
+    return None
+
+
+def patch_gemma4_yoco_fast_prefill(
+    model: Any,
+    model_args: Mapping[str, object],
+    *,
+    use_paged_attention: bool,
+) -> bool:
+    """Patch an eligible mlx-lm Gemma4 text model for YOCO fast prefill.
+
+    The patch is installed on the model class but guarded by a per-instance
+    enable flag. This avoids changing behavior for other Gemma4 instances in
+    the same process unless this function is called for them.
+    """
+    if not is_yoco_fast_prefill_eligible(
+        model_args,
+        use_paged_attention=use_paged_attention,
+    ):
+        return False
+
+    text_model = find_gemma4_text_model(model)
+    if text_model is None:
+        return False
+
+    text_model_cls = type(text_model)
+    if not getattr(text_model_cls, _PATCHED_CALL_ATTR, False):
+        try:
+            original_call = text_model_cls.__call__
+        except AttributeError:
+            return False
+        if not callable(original_call):
+            return False
+
+        def _patched_call(
+            self,
+            inputs=None,
+            cache=None,
+            input_embeddings=None,
+            per_layer_inputs=None,
+        ):
+            original = getattr(type(self), _ORIGINAL_CALL_ATTR)
+            if not getattr(self, _ENABLED_ATTR, False):
+                return original(
+                    self,
+                    inputs,
+                    cache=cache,
+                    input_embeddings=input_embeddings,
+                    per_layer_inputs=per_layer_inputs,
+                )
+            return _gemma4_text_fast_prefill_call(
+                self,
+                original,
+                inputs=inputs,
+                cache=cache,
+                input_embeddings=input_embeddings,
+                per_layer_inputs=per_layer_inputs,
+            )
+
+        setattr(_patched_call, _PATCHED_CALL_ATTR, True)
+        setattr(text_model_cls, _ORIGINAL_CALL_ATTR, original_call)
+        text_model_cls.__call__ = _patched_call
+        setattr(text_model_cls, _PATCHED_CALL_ATTR, True)
+
+    setattr(text_model, _ENABLED_ATTR, True)
+    return True
+
+
+def _has_gemma4_text_model_contract(model: Any) -> bool:
+    required_attrs = (
+        "config",
+        "layers",
+        "previous_kvs",
+        "embed_tokens",
+        "embed_scale",
+        "hidden_size_per_layer_input",
+        "_get_per_layer_inputs",
+        "_project_per_layer_inputs",
+        "_make_masks",
+        "norm",
+    )
+    return all(hasattr(model, attr) for attr in required_attrs)
+
+
+def _first_kv_shared_layer_idx(model: Any) -> int:
+    config = model.config
+    num_layers = int(getattr(config, "num_hidden_layers", len(model.layers)))
+    num_shared = int(getattr(config, "num_kv_shared_layers", 0))
+    return num_layers - num_shared
+
+
+def _call_original(
+    original_call: Callable[..., Any],
+    model: Any,
+    *,
+    inputs: Any,
+    cache: Any,
+    input_embeddings: Any,
+    per_layer_inputs: Any,
+) -> Any:
+    return original_call(
+        model,
+        inputs,
+        cache=cache,
+        input_embeddings=input_embeddings,
+        per_layer_inputs=per_layer_inputs,
+    )
+
+
+def _warn_fast_prefill_fallback_once(model: Any, reason: str) -> None:
+    if getattr(model, _WARNED_FALLBACK_ATTR, False):
+        return
+    setattr(model, _WARNED_FALLBACK_ATTR, True)
+    logger.warning("Gemma4 YOCO fast prefill disabled for this model: %s", reason)
+
+
+def _gemma4_text_fast_prefill_call(
+    model: Any,
+    original_call: Callable[..., Any],
+    *,
+    inputs: Any,
+    cache: Any,
+    input_embeddings: Any,
+    per_layer_inputs: Any,
+) -> Any:
+    try:
+        import mlx.core as mx
+
+        from vllm_metal.paged_attention_common import (
+            PagedAttentionContext,
+            get_context,
+            set_context,
+        )
+    except ImportError:
+        return _call_original(
+            original_call,
+            model,
+            inputs=inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
+
+    ctx = get_context()
+    if ctx is None or ctx.cu_seqlens is None:
+        return _call_original(
+            original_call,
+            model,
+            inputs=inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
+
+    try:
+        meta = build_yoco_reduced_context_from_full_metadata(
+            slot_mapping=ctx.slot_mapping,
+            block_tables=ctx.block_tables,
+            context_lens=ctx.context_lens,
+            offsets=ctx.offsets,
+            cu_seqlens=ctx.cu_seqlens,
+        )
+    except ValueError as exc:
+        _warn_fast_prefill_fallback_once(model, str(exc))
+        return _call_original(
+            original_call,
+            model,
+            inputs=inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
+
+    if not meta.selected_query_indices:
+        return _call_original(
+            original_call,
+            model,
+            inputs=inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
+
+    first_shared = _first_kv_shared_layer_idx(model)
+    num_layers = len(model.layers)
+    if first_shared <= 0 or first_shared >= num_layers:
+        return _call_original(
+            original_call,
+            model,
+            inputs=inputs,
+            cache=cache,
+            input_embeddings=input_embeddings,
+            per_layer_inputs=per_layer_inputs,
+        )
+
+    if input_embeddings is None:
+        input_embeddings = model.embed_tokens(inputs)
+    h = input_embeddings * model.embed_scale
+
+    if model.hidden_size_per_layer_input:
+        if per_layer_inputs is None:
+            per_layer_inputs = model._get_per_layer_inputs(inputs, input_embeddings)
+        per_layer_inputs = model._project_per_layer_inputs(h, per_layer_inputs)
+
+    if per_layer_inputs is not None:
+        layer_inputs = [
+            per_layer_inputs[:, :, i, :] for i, _ in enumerate(model.layers)
+        ]
+    else:
+        layer_inputs = [None] * num_layers
+
+    if cache is None:
+        cache = [None] * num_layers
+    else:
+        cache = list(cache) + [None] * (num_layers - len(cache))
+
+    masks = model._make_masks(h, cache)
+    intermediates = [(None, None)] * num_layers
+
+    for idx in range(first_shared):
+        layer = model.layers[idx]
+        kvs, offset = intermediates[model.previous_kvs[idx]]
+        h, kvs, offset = layer(
+            h,
+            masks[idx],
+            cache[idx],
+            per_layer_input=layer_inputs[idx],
+            shared_kv=kvs,
+            offset=offset,
+        )
+        intermediates[idx] = (kvs, offset)
+
+    selected = mx.array(meta.selected_query_indices, dtype=mx.int32)
+    cross_h = h[:, selected, :]
+    reduced_ctx = PagedAttentionContext(
+        slot_mapping=meta.slot_mapping,
+        block_tables=meta.block_tables,
+        context_lens=meta.context_lens,
+        offsets=meta.offsets,
+        cu_seqlens=meta.cu_seqlens,
+        gdn_slot_mapping=ctx.gdn_slot_mapping,
+    )
+
+    set_context(reduced_ctx)
+    try:
+        for idx in range(first_shared, num_layers):
+            layer = model.layers[idx]
+            kvs, offset = intermediates[model.previous_kvs[idx]]
+            layer_input = layer_inputs[idx]
+            if layer_input is not None:
+                layer_input = layer_input[:, selected, :]
+            cross_h, kvs, offset = layer(
+                cross_h,
+                masks[idx],
+                cache[idx],
+                per_layer_input=layer_input,
+                shared_kv=kvs,
+                offset=offset,
+            )
+            intermediates[idx] = (kvs, offset)
+    finally:
+        set_context(ctx)
+
+    h[:, selected, :] = cross_h
+    return model.norm(h)

--- a/vllm_metal/yoco_fast_prefill.py
+++ b/vllm_metal/yoco_fast_prefill.py
@@ -22,6 +22,13 @@ _WARNED_FALLBACK_ATTR = "_vllm_metal_yoco_fast_prefill_warned_fallback"
 logger = logging.getLogger(__name__)
 
 
+def _get_int_model_arg(model_args: Mapping[str, object], key: str) -> int | None:
+    value = model_args.get(key, 0)
+    if not isinstance(value, int):
+        return None
+    return value
+
+
 @dataclass(frozen=True)
 class YocoReducedContextMetadata:
     """Reduced-query metadata for YOCO cross-decoder fast prefill.
@@ -59,10 +66,9 @@ def is_yoco_fast_prefill_eligible(
     if model_type not in _GEMMA4_MODEL_TYPES:
         return False
 
-    try:
-        num_layers = int(model_args.get("num_hidden_layers", 0))
-        num_shared = int(model_args.get("num_kv_shared_layers", 0))
-    except (TypeError, ValueError):
+    num_layers = _get_int_model_arg(model_args, "num_hidden_layers")
+    num_shared = _get_int_model_arg(model_args, "num_kv_shared_layers")
+    if num_layers is None or num_shared is None:
         return False
 
     return 0 < num_shared < num_layers

--- a/vllm_metal/yoco_fast_prefill.py
+++ b/vllm_metal/yoco_fast_prefill.py
@@ -29,7 +29,61 @@ def _get_int_model_arg(model_args: Mapping[str, object], key: str) -> int | None
     return value
 
 
-def get_yoco_fast_prefill_ineligibility_reason(
+def try_enable_gemma4_yoco_fast_prefill(
+    model: Any,
+    model_args: Mapping[str, object],
+    *,
+    use_paged_attention: bool,
+    num_paged_layers: int | None = None,
+) -> bool:
+    """Enable Gemma4 YOCO fast prefill when the loaded model is eligible."""
+    reason = _get_yoco_fast_prefill_ineligibility_reason(
+        model_args,
+        use_paged_attention=use_paged_attention,
+    )
+    if reason is not None:
+        logger.warning(
+            "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
+            "but fast prefill is ineligible for this model (%s); "
+            "continuing without fast prefill",
+            reason,
+        )
+        return False
+
+    expected_layers = _get_int_model_arg(model_args, "num_hidden_layers")
+    if (
+        num_paged_layers is not None
+        and expected_layers is not None
+        and num_paged_layers < expected_layers
+    ):
+        logger.warning(
+            "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
+            "but only %d/%d layers use paged attention; "
+            "continuing without fast prefill",
+            num_paged_layers,
+            expected_layers,
+        )
+        return False
+
+    if _patch_gemma4_yoco_fast_prefill(
+        model,
+        model_args,
+        use_paged_attention=use_paged_attention,
+    ):
+        logger.info(
+            "Gemma4 YOCO fast prefill enabled (VLLM_METAL_KV_SHARING_FAST_PREFILL=1)"
+        )
+        return True
+
+    logger.warning(
+        "VLLM_METAL_KV_SHARING_FAST_PREFILL=1 was requested, "
+        "but the Gemma4 text-model patch could not be installed; "
+        "continuing without fast prefill"
+    )
+    return False
+
+
+def _get_yoco_fast_prefill_ineligibility_reason(
     model_args: Mapping[str, object],
     *,
     use_paged_attention: bool,
@@ -79,7 +133,7 @@ class YocoReducedContextMetadata:
     cu_seqlens: list[int]
 
 
-def is_yoco_fast_prefill_eligible(
+def _is_yoco_fast_prefill_eligible(
     model_args: Mapping[str, object],
     *,
     use_paged_attention: bool,
@@ -91,7 +145,7 @@ def is_yoco_fast_prefill_eligible(
     correctness is proven and benchmarked.
     """
     return (
-        get_yoco_fast_prefill_ineligibility_reason(
+        _get_yoco_fast_prefill_ineligibility_reason(
             model_args,
             use_paged_attention=use_paged_attention,
         )
@@ -166,7 +220,7 @@ def build_yoco_reduced_context_from_full_metadata(
     )
 
 
-def find_gemma4_text_model(model: Any) -> Any | None:
+def _find_gemma4_text_model(model: Any) -> Any | None:
     """Return the mlx-lm Gemma4 text-model object if it matches our contract."""
     candidates = [
         model,
@@ -182,7 +236,7 @@ def find_gemma4_text_model(model: Any) -> Any | None:
     return None
 
 
-def patch_gemma4_yoco_fast_prefill(
+def _patch_gemma4_yoco_fast_prefill(
     model: Any,
     model_args: Mapping[str, object],
     *,
@@ -194,13 +248,13 @@ def patch_gemma4_yoco_fast_prefill(
     enable flag. This avoids changing behavior for other Gemma4 instances in
     the same process unless this function is called for them.
     """
-    if not is_yoco_fast_prefill_eligible(
+    if not _is_yoco_fast_prefill_eligible(
         model_args,
         use_paged_attention=use_paged_attention,
     ):
         return False
 
-    text_model = find_gemma4_text_model(model)
+    text_model = _find_gemma4_text_model(model)
     if text_model is None:
         return False
 


### PR DESCRIPTION
This PR Adds a default-off experimental Gemma4 YOCO fast-prefill path for Metal paged attention.

Enable with:

```bash
VLLM_METAL_KV_SHARING_FAST_PREFILL=1
```

For eligible Gemma4 / Gemma4 text models, this runs YOCO KV-shared layers only on selected logits positions during prefill, then scatters the selected hidden states back before final norm / LM head.

## Validation

- Unit tests: 36 passed
- E4B smoke test: server starts, fast prefill enabled, `/v1/completions` returns 200
- Greedy off/on smoke: matched output on 64 / 512 / 960 token prompts

## Benchmark
<img width="1920" height="1047" alt="gemma4-yoco-fast-prefill-benchmark-1" src="https://github.com/user-attachments/assets/3ba7b959-ba4d-4a16-8b09-23dd9873eed8" />
