### PR TITLE
Bump mlx-lm minimum to 0.31.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # Upper-bound: paged_ops.cpp uses mlx/backend/metal/device.h (private API).
     # Bump after verifying the JIT build against the new MLX minor release.
     "mlx>=0.31.0,<0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "mlx-lm>=0.31.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-vlm>=0.4.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
     # Model loading and weights
     # Lower bound aligned with vllm 0.19.1's exclude list in requirements/common.txt

--- a/tests/test_qwen35_smoke.py
+++ b/tests/test_qwen35_smoke.py
@@ -2,7 +2,7 @@
 """Smoke test for Qwen3.5-0.8B: proves transformers 5.x model works end-to-end.
 
 Qwen3.5 uses the `qwen3_5` architecture which requires transformers>=5.0.0.
-This test verifies that the upgraded dependency stack (mlx-lm>=0.31.0,
+This test verifies that the upgraded dependency stack (mlx-lm>=0.31.3,
 mlx-vlm>=0.4.0, transformers>=5.0.0) works correctly with vLLM on Metal.
 
 Golden token IDs were generated with greedy decoding (temperature=0) on


### PR DESCRIPTION
`mlx-lm>=0.31.3` is the verified stack for the Gemma4 KV-shared sanitize compatibility patch added in #303, and avoids the Gemma4 load issue tracked in #299.