### PR TITLE
Fix Phi-4-mini-instruct on Metal by supporting Phi3/Phi4-style packed qkv attention

### DIFF
--- a/tests/test_attention_dispatch.py
+++ b/tests/test_attention_dispatch.py
@@ -158,6 +158,73 @@ def test_is_sdpa_rejects_modules_without_v_proj_or_use_k_eq_v():
     assert is_sdpa(_QkoWithUseKEqVTrue())
 
 
+def test_is_sdpa_rejects_packed_qkv_modules_missing_runtime_contract():
+    """Packed-qkv modules must expose the runtime contract SDPA needs."""
+
+    class _PackedQKVOnly:
+        qkv_proj = object()
+        o_proj = object()
+
+    assert not is_sdpa(_PackedQKVOnly())
+
+    class _PackedQKVWithoutRope:
+        qkv_proj = object()
+        o_proj = object()
+        n_heads = 4
+        n_kv_heads = 2
+        head_dim = 16
+        scale = 0.25
+
+    assert not is_sdpa(_PackedQKVWithoutRope())
+
+    class _PackedQKVWithRotaryEmb:
+        qkv_proj = object()
+        o_proj = object()
+        n_heads = 4
+        n_kv_heads = 2
+        head_dim = 16
+        scale = 0.25
+        rotary_emb = object()
+
+    assert is_sdpa(_PackedQKVWithRotaryEmb())
+
+
+def test_is_sdpa_falls_back_to_split_contract_when_packed_fields_incomplete():
+    """Mixed modules should still classify as SDPA via the split contract."""
+
+    class _MixedAttention:
+        qkv_proj = object()
+        q_proj = object()
+        k_proj = object()
+        v_proj = object()
+        o_proj = object()
+
+    assert is_sdpa(_MixedAttention())
+
+
+def test_phi3_attention_detected_as_sdpa():
+    """Real Phi3/Phi4-style packed-projection attention should be SDPA."""
+    from mlx_lm.models.phi3 import Attention, ModelArgs
+
+    args = ModelArgs(
+        model_type="phi3",
+        hidden_size=64,
+        num_hidden_layers=2,
+        intermediate_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        rms_norm_eps=1e-6,
+        vocab_size=100,
+        max_position_embeddings=512,
+        original_max_position_embeddings=512,
+        tie_word_embeddings=False,
+    )
+    attn = Attention(args)
+
+    assert is_sdpa(attn)
+    assert not is_linear_attention(attn)
+
+
 def test_find_layers_on_qwen3_model():
     """find_layers should return the layer list from a real Qwen3 Model."""
     from mlx_lm.models.qwen3 import Model, ModelArgs

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -65,6 +65,16 @@ class _RaisingLinear:
         raise AssertionError(self._message)
 
 
+class _ExplodingPackedLinear:
+    """Packed projection stub that must not be used on split fallback paths."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def __call__(self, x: mx.array) -> mx.array:
+        raise AssertionError(self._message)
+
+
 def _make_ctx(seq_len: int) -> PagedAttentionContext:
     """Return a minimal paged context sufficient for apply_packed_rope."""
     return PagedAttentionContext(
@@ -113,6 +123,29 @@ def _make_inner(
 
         inner.v_norm = v_norm
     return inner
+
+
+def _make_qkv_inner(
+    *,
+    n_heads: int = _N_HEADS,
+    n_kv_heads: int = _N_KV_HEADS,
+    head_dim: int = _HEAD_DIM,
+) -> SimpleNamespace:
+    """Build a Phi3/Phi4-like Attention module with packed qkv_proj."""
+    q_weight = mx.ones((n_heads * head_dim, _HIDDEN))
+    k_weight = mx.full((n_kv_heads * head_dim, _HIDDEN), 2.0)
+    v_weight = mx.full((n_kv_heads * head_dim, _HIDDEN), 3.0)
+    qkv_weight = mx.concatenate([q_weight, k_weight, v_weight], axis=0)
+
+    return SimpleNamespace(
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        head_dim=head_dim,
+        scale=head_dim**-0.5,
+        qkv_proj=_FakeLinear(qkv_weight),
+        o_proj=lambda out: out,
+        rope=_identity_rope,
+    )
 
 
 # === pad_qkv_to_cache_head_dim ===
@@ -256,6 +289,77 @@ class TestPrepareSDPAQKV:
         # After transpose they must be element-equal (same weights, same x).
         mx.eval(keys, values)
         assert bool(mx.all(keys == values).item())
+
+    def test_qkv_proj_path_splits_phi_style_packed_projection(self) -> None:
+        # Arrange — Phi3/Phi4-style attention uses a single qkv_proj linear.
+        inner = _make_qkv_inner()
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
+            inner, x, ctx, _N_HEADS, _N_KV_HEADS, shared_kv=None
+        )
+
+        # Assert — packed projection splits into canonical (B, H, L, D).
+        mx.eval(queries, keys, values)
+        assert queries.shape == (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert keys.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert bool(mx.all(queries == 8.0).item())
+        assert bool(mx.all(keys == 16.0).item())
+        assert bool(mx.all(values == 24.0).item())
+        assert gate is None
+        assert kv_for_sharing == (keys, values)
+
+    def test_qkv_proj_path_supports_phi_style_gqa_head_ratio(self) -> None:
+        # Arrange — real Phi checkpoints use more query heads than KV heads.
+        n_heads = 4
+        n_kv_heads = 2
+        head_dim = _HEAD_DIM
+        inner = _make_qkv_inner(
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        queries, keys, values, gate, _ = prepare_sdpa_qkv(
+            inner, x, ctx, n_heads, n_kv_heads, shared_kv=None
+        )
+
+        # Assert — packed qkv must preserve the GQA head ratio after split.
+        mx.eval(queries, keys, values)
+        assert queries.shape == (_BATCH, n_heads, _SEQ_LEN, head_dim)
+        assert keys.shape == (_BATCH, n_kv_heads, _SEQ_LEN, head_dim)
+        assert values.shape == (_BATCH, n_kv_heads, _SEQ_LEN, head_dim)
+        assert bool(mx.all(queries == 8.0).item())
+        assert bool(mx.all(keys == 16.0).item())
+        assert bool(mx.all(values == 24.0).item())
+        assert gate is None
+
+    def test_mixed_module_falls_back_to_split_projection_path(self) -> None:
+        # Arrange — dispatch may accept mixed modules via the split contract.
+        inner = _make_inner(with_v_proj=True)
+        inner.qkv_proj = _ExplodingPackedLinear(
+            "qkv_proj must not be used when packed metadata is incomplete"
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        queries, keys, values, gate, _ = prepare_sdpa_qkv(
+            inner, x, ctx, _N_HEADS, _N_KV_HEADS, shared_kv=None
+        )
+
+        # Assert — split q_proj/k_proj/v_proj path still works.
+        mx.eval(queries, keys, values)
+        assert queries.shape == (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert keys.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert gate is None
 
     def test_v_norm_is_applied_when_present(self) -> None:
         # Arrange

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -45,20 +45,42 @@ from vllm_metal.paged_attention_common import PagedAttentionContext
 _KERNEL_BLOCK_SIZES = (32, 16, 8)
 
 
+def _has_packed_qkv_sdpa_contract(module: nn.Module) -> bool:
+    """Return True when *module* exposes the packed Phi-style SDPA contract."""
+    has_rotary = hasattr(module, "rope") or hasattr(module, "rotary_emb")
+    return (
+        hasattr(module, "qkv_proj")
+        and hasattr(module, "o_proj")
+        and hasattr(module, "n_heads")
+        and hasattr(module, "n_kv_heads")
+        and hasattr(module, "head_dim")
+        and hasattr(module, "scale")
+        and has_rotary
+    )
+
+
 def is_sdpa(module: nn.Module) -> bool:
     """Return True if *module* is an SDPA attention layer (MHA, GQA, or MQA).
 
-    Requires ``q_proj`` / ``k_proj`` / ``o_proj``, plus EITHER ``v_proj``
-    OR the explicit ``use_k_eq_v = True`` opt-in.  The latter admits
-    Gemma4 26B / 31B full-attention layers which share the K projection
-    for values and never define ``v_proj`` (``prepare_sdpa_qkv`` handles
-    that branch symmetrically).
+    Accepts two contracts:
+
+    - Split-projection SDPA: ``q_proj`` / ``k_proj`` / ``o_proj``, plus
+      EITHER ``v_proj`` OR the explicit ``use_k_eq_v = True`` opt-in.
+      The latter admits Gemma4 26B / 31B full-attention layers which
+      share the K projection for values and never define ``v_proj``
+      (``prepare_sdpa_qkv`` handles that branch symmetrically).
+    - Packed Phi-style SDPA: ``qkv_proj`` / ``o_proj`` plus the runtime
+      metadata ``n_heads`` / ``n_kv_heads`` / ``head_dim`` / ``scale``
+      and RoPE exposure via ``rope`` or ``rotary_emb``.
 
     Keeping this classifier tight matters because
     :meth:`HybridPagedAttentionBackend.patch_model` uses ``is_sdpa`` as
     the dispatch predicate — loose matching would send arbitrary Q/K/O
     modules through the SDPA path.
     """
+    if _has_packed_qkv_sdpa_contract(module):
+        return True
+
     return (
         hasattr(module, "q_proj")
         and hasattr(module, "k_proj")
@@ -169,11 +191,10 @@ def prepare_sdpa_qkv(
     """
     B, L, _ = x.shape  # noqa: N806
 
-    # Projections + reshape.  Qwen3.5 uses gated q_proj (2x head_dim).
-    q_proj_out = inner.q_proj(x)
     gate: mx.array | None = None
+    packed_qkv = _has_packed_qkv_sdpa_contract(inner)
     # head_dim has two architectural sources in our supported models:
-    #   - self.head_dim instance attr (gemma*, llama, mistral, qwen3_5+)
+    #   - self.head_dim instance attr (gemma*, llama, mistral, qwen3_5+, phi3)
     #   - k_proj.weight.shape (qwen3, qwen3_moe never set self.head_dim)
     # KV-shared Gemma 4 layers have head_dim but no k_proj. If neither
     # is present, raise — silently propagating a wrong head_dim would
@@ -188,13 +209,25 @@ def prepare_sdpa_qkv(
             f"{type(inner).__module__}.{type(inner).__name__}: "
             "neither 'head_dim' nor 'k_proj' attribute present"
         )
-    q_full_head = q_proj_out.shape[-1] // n_heads
-    if q_full_head == 2 * head_dim:
-        q_reshaped = q_proj_out.reshape(B, L, n_heads, q_full_head)
-        queries, gate = mx.split(q_reshaped, 2, axis=-1)
-        gate = gate.reshape(B, L, -1)
+
+    if packed_qkv:
+        qkv = inner.qkv_proj(x)
+        q_width = n_heads * head_dim
+        kv_width = n_kv_heads * head_dim
+        queries, keys, values = mx.split(qkv, [q_width, q_width + kv_width], axis=-1)
+        queries = queries.reshape(B, L, n_heads, head_dim)
+        keys = keys.reshape(B, L, n_kv_heads, head_dim)
+        values = values.reshape(B, L, n_kv_heads, head_dim)
     else:
-        queries = q_proj_out.reshape(B, L, n_heads, -1)
+        # Projections + reshape.  Qwen3.5 uses gated q_proj (2x head_dim).
+        q_proj_out = inner.q_proj(x)
+        q_full_head = q_proj_out.shape[-1] // n_heads
+        if q_full_head == 2 * head_dim:
+            q_reshaped = q_proj_out.reshape(B, L, n_heads, q_full_head)
+            queries, gate = mx.split(q_reshaped, 2, axis=-1)
+            gate = gate.reshape(B, L, -1)
+        else:
+            queries = q_proj_out.reshape(B, L, n_heads, -1)
 
     if shared_kv is not None:
         # YOCO: reuse K/V from a reference layer.  Q still needs norm + RoPE.
@@ -216,14 +249,15 @@ def prepare_sdpa_qkv(
             apply_keys=False,
         )
     else:
-        keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
-        # K-eq-V variant (Gemma4 26B/31B): no v_proj, values = keys.
-        if hasattr(inner, "v_proj"):
-            values = inner.v_proj(x).reshape(B, L, n_kv_heads, -1)
-        else:
-            values = keys
+        if not packed_qkv:
+            keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
+            # K-eq-V variant (Gemma4 26B/31B): no v_proj, values = keys.
+            if hasattr(inner, "v_proj"):
+                values = inner.v_proj(x).reshape(B, L, n_kv_heads, -1)
+            else:
+                values = keys
 
-        # Per-head RMSNorm (Qwen3, Qwen3.5, Gemma4).
+        # Per-head RMSNorm (Qwen3, Qwen3.5, Gemma4, Phi3/Phi4 when present).
         if hasattr(inner, "q_norm"):
             queries = inner.q_norm(queries)
         if hasattr(inner, "k_norm"):


### PR DESCRIPTION
Refs issue #289

This PR fixes the Metal SDPA path for Phi3/Phi4-style packed attention modules and unblocks local validation of `microsoft/Phi-4-mini-instruct` on Apple Silicon.

## Summary

This PR fixes the Metal SDPA path for Phi3/Phi4-style packed attention modules that expose a single `qkv_proj` projection instead of split `q_proj` / `k_proj` / `v_proj` layers.

Concretely, this change:
- teaches `is_sdpa()` to recognize Phi3/Phi4-style packed attention modules while keeping the existing split-projection SDPA contract intact
- updates `prepare_sdpa_qkv()` to split packed Q/K/V projections into the canonical SDPA layout
- preserves fallback to the split-projection contract for mixed modules so packed detection does not short-circuit valid existing paths
- adds regression tests for packed-qkv dispatch, packed Q/K/V splitting, Phi-style GQA head ratios, and mixed-contract fallback

## Validation

Validated locally on a MacBook Pro (Apple M4 Pro, 24 GB unified memory).

End-to-end model validation:
- served `microsoft/Phi-4-mini-instruct` successfully on Apple Silicon with Metal paged attention
- confirmed successful text generation through the OpenAI-compatible chat completions endpoint

Regression / unit validation:
- ran `env -u SSLKEYLOGFILE pytest -q tests/test_attention_sdpa.py tests/test_attention_dispatch.py -k 'not slow'`
- result: `23 passed, 1 deselected`

The added tests specifically cover:
- dispatch detection for Phi3/Phi4-style packed attention
- packed Q/K/V splitting into the SDPA layout
- Phi-style GQA head ratios (`n_heads != n_kv_heads`)
- fallback behavior when a module exposes packed fields but should still match the split-projection SDPA contract
- adds regression tests for packed-qkv dispatch, packed Q/K/V splitting, Phi-style GQA head ratios, and mixed-contract fallback

## Notes

This PR intentionally scopes support to the Phi3/Phi4-style packed `qkv_proj` attention path rather than claiming support for the entire Phi family, since other Phi variants in `mlx_lm` use different attention module layouts.

If there are other Phi-family checkpoints or additional follow-up validations that would be useful, I’m happy to follow up in this PR or in a separate one.