### PR TITLE
docs: add M1 Mac validation for DeepSeek-R1-Distill-Qwen-1.5B

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -35,4 +35,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | GPT-OSS | 🔵 | Sink attention (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#221](https://github.com/vllm-project/vllm-metal/pull/221), [#212](https://github.com/vllm-project/vllm-metal/issues/212), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | [#213](https://github.com/vllm-project/vllm-metal/pull/213), [#233](https://github.com/vllm-project/vllm-metal/pull/233) | Automatic prefix caching is not yet verified on the MLX MLA path |
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
-| DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
+| DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -35,4 +35,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | GPT-OSS | 🔵 | Sink attention (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#221](https://github.com/vllm-project/vllm-metal/pull/221), [#212](https://github.com/vllm-project/vllm-metal/issues/212), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | [#213](https://github.com/vllm-project/vllm-metal/pull/213), [#233](https://github.com/vllm-project/vllm-metal/pull/233) | Automatic prefix caching is not yet verified on the MLX MLA path |
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
-| DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | | Validated on M4 Mac (16GB) |
+| DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | | Validated on M4 Mac (16GB) and M1 Mac (16GB) |


### PR DESCRIPTION
Summary
-
I tested:

mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit
Result: ✅ Working on Apple M1 MacBook Air with 16 GB unified memory.

Refs #289.

Verification
Environment:

Apple M1 MacBook Air, 16 GB unified memory
macOS 14.2.1
vllm-metal: 0.20.0 (latest main)

I ran the command below from an activated .venv-vllm-metal environment.

Terminal 1:
```bash
vllm serve mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit \
  --max-model-len 32768
```

Startup output included:

Started server process
Waiting for application startup
Application startup complete

Terminal 2:

```bash
curl http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit",
    "prompt": "Hello, how are you?",
    "max_tokens": 50
  }'
```

Result:

```bash
Terminal 1 logged a successful POST /v1/completions request with HTTP 200
Terminal 2 returned a valid JSON completion response with generated text and token usage
The model served correctly on Apple M1 with this configuration
```

Before opening this PR, I checked #289 and open PRs related to `DeepSeek-R1-Distill-Qwen-1.5B` / supported models. 
I did not find a duplicate open PR.

AI assistance was used to organize the PR text. I reviewed the docs change and verification details.
