### PR TITLE
docs: add Phi-4-mini-instruct to supported models table

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -36,3 +36,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | [#213](https://github.com/vllm-project/vllm-metal/pull/213), [#233](https://github.com/vllm-project/vllm-metal/pull/233) | Automatic prefix caching is not yet verified on the MLX MLA path |
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
+| Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |


### PR DESCRIPTION
Refs #314

Add `microsoft/Phi-4-mini-instruct` to the supported-models table,
following the suggestion in #314.