### PR TITLE
remove stale TODO comment about -Wno-parentheses

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,9 +131,6 @@ main() {
   cd vllm-$vllm_v
 
   uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
-  # TODO: remove -Wno-parentheses once vllm-project/vllm#38801 is in a release.
-  # Clang 21+ (Apple Clang 21 / Xcode 26) promotes -Wparentheses to an error
-  # for chained comparisons like `0 < M <= 8` in vllm's CPU attention headers.
   CXXFLAGS="-Wno-parentheses" uv pip install .
   cd -
   rm -rf vllm-$vllm_v*


### PR DESCRIPTION
No need to have a TODO here, supressing this does no harm. Removing the comment while keeping the CXXFLAGS in place.