### PR TITLE
[Rust] add vllm-rs frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ https://docs.vllm.ai/en/latest/cli/
 curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh | bash
 ```
 
+### Optional: Rust frontend (experimental)
+
+Pass `--with-vllm-rs` to also install [`vllm-frontend-rs`](https://github.com/Inferact/vllm-frontend-rs), an experimental Rust drop-in for vLLM's serving layer. Requires the Rust toolchain (https://rustup.rs):
+
+```bash
+./install.sh --with-vllm-rs
+```
+
+See [docs/rust_frontend.md](docs/rust_frontend.md) for usage and architecture.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,6 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 - **vLLM compatibility**: Full integration with vLLM's engine, scheduler, and OpenAI-compatible API
 - **Paged attention** *(experimental)*: Efficient KV cache management for long sequences
 - **GQA support**: Grouped-Query Attention for efficient inference
+- **Rust frontend** *(experimental)*: Optional drop-in [`vllm-frontend-rs`](rust_frontend.md) replaces the Python serving layer while keeping vllm-metal's MLX/Metal engine
 
 Check the sidebar for guides on installation, configuration, and supported features.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,6 +19,16 @@ For how to use the `vllm` CLI, please refer to the [official vLLM guide](https:/
 curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh | bash
 ```
 
+### Optional: Rust frontend
+
+Pass `--with-vllm-rs` to also install [`vllm-frontend-rs`](rust_frontend.md), an experimental Rust drop-in for vLLM's serving layer. Requires the Rust toolchain on `PATH` (install from <https://rustup.rs>):
+
+```bash
+./install.sh --with-vllm-rs
+```
+
+The `vllm-rs` binary is installed to `~/.cargo/bin/`. See [Rust Frontend](rust_frontend.md) for usage.
+
 ## Reinstallation and Update
 
 If any issues occur, please use the following command to switch to the latest release version and check if the problem is resolved.

--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -1,85 +1,26 @@
 # Rust Frontend (experimental)
 
-vllm-metal can be paired with [`vllm-frontend-rs`](https://github.com/Inferact/vllm-frontend-rs), an early-stage Rust drop-in for vLLM's frontend (HTTP server, tokenizer, chat templating, OpenAI protocol).
+vllm-metal supports the optional [`vllm-frontend-rs`](https://github.com/Inferact/vllm-frontend-rs) Rust frontend as a drop-in replacement for vLLM's Python serving layer. The Rust frontend is hardware-agnostic; vllm-metal continues to run the engine on Metal/MLX inside the spawned Python subprocess.
 
-The Rust frontend talks to the Python engine over **ZMQ + MessagePack** — the same boundary upstream vLLM uses internally — so it is hardware-agnostic and works alongside vllm-metal unchanged. vllm-metal still runs the model and KV cache on Metal/MLX inside the Python engine subprocess; only the northbound serving layer is replaced.
+For architecture, flag reference, and usage, see the [upstream README](https://github.com/Inferact/vllm-frontend-rs#readme).
 
-First, install vllm-metal with the Rust frontend opt-in (see [Installation](installation.md)):
+## Install
 
 ```bash
 ./install.sh --with-vllm-rs
 ```
 
-Requires the Rust toolchain (cargo + rustup) on `PATH`. The upstream pins a nightly toolchain via its `rust-toolchain.toml`, which `rustup` auto-fetches on first build. The `vllm-rs` binary lands in `~/.cargo/bin/`.
+See [Installation](installation.md) for prerequisites (Rust toolchain).
 
-## Architecture
+## Run
 
-```
-  HTTP request (OpenAI API)
-        │
-        ▼
-  vllm-rs (Rust)            ← frontend: tokenizer, chat templating, protocol
-        │
-        │ ZMQ + MessagePack
-        ▼
-  Python EngineCore         ← scheduler, sampling
-        │
-        ▼
-  vllm-metal plugin         ← MLX paged attention, native Metal kernels
-```
-
-## Quick Start
-
-Activate the venv so `vllm-rs serve` finds the Python interpreter that has vllm and vllm-metal installed, then launch the server:
+Activate the venv first so the spawned headless Python engine inherits vllm-metal:
 
 ```bash
 source ~/.venv-vllm-metal/bin/activate
 vllm-rs serve Qwen/Qwen3-0.6B
-# OpenAI-compatible API now on http://127.0.0.1:8000
 ```
 
-`vllm-rs serve` spawns a managed headless Python engine, performs the data-parallel handshake over ZMQ, and starts the Rust OpenAI server once the engine is ready. Inside the engine, vllm-metal activates as the platform plugin exactly as it would under `vllm serve`.
+## Caveat: integration direction
 
-Verify with a chat completion:
-
-```bash
-curl -sS http://127.0.0.1:8000/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "Qwen/Qwen3-0.6B",
-    "messages": [{"role": "user", "content": "What is the capital of France?"}],
-    "max_tokens": 32,
-    "chat_template_kwargs": {"enable_thinking": false}
-  }'
-```
-
-## Useful Flags
-
-`vllm-rs serve --help` lists the full set. Common options:
-
-| Flag | Default | Description |
-|---|---|---|
-| `--host` | `127.0.0.1` | HTTP bind host |
-| `--port` | `8000` | HTTP bind port |
-| `--python` | `python3` | Python interpreter used for the managed engine (env: `VLLM_RS_PYTHON`) |
-| `--max-model-len` | from config | Override the model's max context length |
-| `--reasoning-parser` | `auto` | Tool/reasoning parser selection (`auto`, `none`, or a specific parser) |
-| `--tool-call-parser` | `auto` | Tool-call parser selection |
-| `--headless` | off | Only launch the managed engine, do not start the Rust frontend |
-
-## Two Integration Directions
-
-There are two ways the Rust frontend and Python engine can be wired together:
-
-| Direction | Command | Status |
-|---|---|---|
-| **Rust-driven** — Rust binary spawns headless Python engine | `vllm-rs serve <MODEL>` | **Works today** with bundled vllm 0.20.0 |
-| **Python-driven** — Python `vllm` spawns Rust binary as subprocess | `VLLM_USE_RUST_FRONTEND=1 vllm serve <MODEL>` | Requires an upstream vLLM hook that has not landed yet |
-
-Use the Rust-driven direction (`vllm-rs serve`) on the bundled vllm 0.20.0. The Python-driven direction will become available once the upstream hook merges.
-
-## Limitations
-
-- This is an early-stage project. APIs and CLI flags may change without notice.
-- The first `cargo install` compiles ~70 crates and typically takes several minutes on Apple Silicon.
-- The toolchain is pinned to a specific nightly; if the upstream bumps the pin, `rustup` will fetch a different nightly on the next reinstall.
+Use `vllm-rs serve` (Rust binary spawns Python engine) on bundled vllm 0.20.0. The reverse direction `VLLM_USE_RUST_FRONTEND=1 vllm serve` requires an upstream vLLM hook that has not landed yet.

--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -1,0 +1,85 @@
+# Rust Frontend (experimental)
+
+vllm-metal can be paired with [`vllm-frontend-rs`](https://github.com/Inferact/vllm-frontend-rs), an early-stage Rust drop-in for vLLM's frontend (HTTP server, tokenizer, chat templating, OpenAI protocol).
+
+The Rust frontend talks to the Python engine over **ZMQ + MessagePack** — the same boundary upstream vLLM uses internally — so it is hardware-agnostic and works alongside vllm-metal unchanged. vllm-metal still runs the model and KV cache on Metal/MLX inside the Python engine subprocess; only the northbound serving layer is replaced.
+
+First, install vllm-metal with the Rust frontend opt-in (see [Installation](installation.md)):
+
+```bash
+./install.sh --with-vllm-rs
+```
+
+Requires the Rust toolchain (cargo + rustup) on `PATH`. The upstream pins a nightly toolchain via its `rust-toolchain.toml`, which `rustup` auto-fetches on first build. The `vllm-rs` binary lands in `~/.cargo/bin/`.
+
+## Architecture
+
+```
+  HTTP request (OpenAI API)
+        │
+        ▼
+  vllm-rs (Rust)            ← frontend: tokenizer, chat templating, protocol
+        │
+        │ ZMQ + MessagePack
+        ▼
+  Python EngineCore         ← scheduler, sampling
+        │
+        ▼
+  vllm-metal plugin         ← MLX paged attention, native Metal kernels
+```
+
+## Quick Start
+
+Activate the venv so `vllm-rs serve` finds the Python interpreter that has vllm and vllm-metal installed, then launch the server:
+
+```bash
+source ~/.venv-vllm-metal/bin/activate
+vllm-rs serve Qwen/Qwen3-0.6B
+# OpenAI-compatible API now on http://127.0.0.1:8000
+```
+
+`vllm-rs serve` spawns a managed headless Python engine, performs the data-parallel handshake over ZMQ, and starts the Rust OpenAI server once the engine is ready. Inside the engine, vllm-metal activates as the platform plugin exactly as it would under `vllm serve`.
+
+Verify with a chat completion:
+
+```bash
+curl -sS http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}],
+    "max_tokens": 32,
+    "chat_template_kwargs": {"enable_thinking": false}
+  }'
+```
+
+## Useful Flags
+
+`vllm-rs serve --help` lists the full set. Common options:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--host` | `127.0.0.1` | HTTP bind host |
+| `--port` | `8000` | HTTP bind port |
+| `--python` | `python3` | Python interpreter used for the managed engine (env: `VLLM_RS_PYTHON`) |
+| `--max-model-len` | from config | Override the model's max context length |
+| `--reasoning-parser` | `auto` | Tool/reasoning parser selection (`auto`, `none`, or a specific parser) |
+| `--tool-call-parser` | `auto` | Tool-call parser selection |
+| `--headless` | off | Only launch the managed engine, do not start the Rust frontend |
+
+## Two Integration Directions
+
+There are two ways the Rust frontend and Python engine can be wired together:
+
+| Direction | Command | Status |
+|---|---|---|
+| **Rust-driven** — Rust binary spawns headless Python engine | `vllm-rs serve <MODEL>` | **Works today** with bundled vllm 0.20.0 |
+| **Python-driven** — Python `vllm` spawns Rust binary as subprocess | `VLLM_USE_RUST_FRONTEND=1 vllm serve <MODEL>` | Requires an upstream vLLM hook that has not landed yet |
+
+Use the Rust-driven direction (`vllm-rs serve`) on the bundled vllm 0.20.0. The Python-driven direction will become available once the upstream hook merges.
+
+## Limitations
+
+- This is an early-stage project. APIs and CLI flags may change without notice.
+- The first `cargo install` compiles ~70 crates and typically takes several minutes on Apple Silicon.
+- The toolchain is pinned to a specific nightly; if the upstream bumps the pin, `rustup` will fetch a different nightly on the next reinstall.

--- a/install.sh
+++ b/install.sh
@@ -77,12 +77,68 @@ download_and_install_wheel() {
   success "Installed ${package_name}"
 }
 
+install_vllm_rs() {
+  section "Installing vllm-rs (experimental Rust frontend)"
+
+  if ! command -v cargo &> /dev/null || ! command -v rustup &> /dev/null; then
+    error "cargo/rustup not found on PATH; install Rust from https://rustup.rs first."
+    exit 1
+  fi
+
+  local repo_url="https://github.com/inferact/vllm-frontend-rs"
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp_dir'" RETURN
+
+  echo "Cloning $repo_url ..."
+  if ! git clone --depth 1 "$repo_url" "$tmp_dir/vllm-frontend-rs"; then
+    error "Failed to clone vllm-frontend-rs."
+    exit 1
+  fi
+
+  # Run cargo from inside the tree so rustup honors rust-toolchain.toml;
+  # `cargo install --git` would ignore it and use the system default toolchain.
+  if ! ( cd "$tmp_dir/vllm-frontend-rs" && cargo install --path src/cmd --bin vllm-rs ); then
+    error "Failed to install vllm-rs."
+    exit 1
+  fi
+
+  success "Installed vllm-rs to ~/.cargo/bin"
+}
+
 main() {
   set -eu -o pipefail
 
   local repo_owner="vllm-project"
   local repo_name="vllm-metal"
   local package_name="vllm-metal"
+  local with_vllm_rs=0
+
+  for arg in "$@"; do
+    case "$arg" in
+      --with-vllm-rs)
+        with_vllm_rs=1
+        ;;
+      -h|--help)
+        cat <<'EOF'
+Usage: install.sh [--with-vllm-rs]
+
+Options:
+  --with-vllm-rs    Also install vllm-rs (experimental Rust frontend) via
+                    cargo from https://github.com/inferact/vllm-frontend-rs.
+                    Requires the Rust toolchain on PATH (https://rustup.rs).
+  -h, --help        Show this help.
+EOF
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $arg" >&2
+        echo "Run with --help for usage." >&2
+        exit 1
+        ;;
+    esac
+  done
 
   # Source shared library functions
   # Try local lib.sh first (when running ./install.sh), fall back to remote (when piped from curl)
@@ -152,6 +208,10 @@ main() {
     download_and_install_wheel "$wheel_url" "$package_name"
   fi
 
+  if [[ "$with_vllm_rs" == "1" ]]; then
+    install_vllm_rs
+  fi
+
   echo ""
   success "Installation complete!"
   echo ""
@@ -160,6 +220,12 @@ main() {
   echo ""
   echo "Or add the venv to your PATH:"
   echo "  export PATH=\"$venv/bin:\$PATH\""
+
+  if [[ "$with_vllm_rs" == "1" ]]; then
+    echo ""
+    echo "vllm-rs is installed to ~/.cargo/bin. Make sure that directory is on your PATH."
+    echo "Activate the venv, then run: vllm-rs serve <MODEL>"
+  fi
 }
 
 main "$@"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -71,4 +71,5 @@ nav:
     - Speech-to-Text: stt.md
     - Turboquant: turboquant.md
     - GPU Profiling: profiling.md
+    - Rust Frontend: rust_frontend.md
   - Contributing: CONTRIBUTING.md


### PR DESCRIPTION
## Summary

#304 

Add rust front end as an **optional** serving frontend. Deps installation is also optional (see docs)

```bash
source ~/.venv-vllm-metal/bin/activate
vllm-rs serve Qwen/Qwen3-0.6B
# OpenAI-compatible API now on http://127.0.0.1:8000
```

In the future when the gate is unblocked, it can be served by vllm directly:
```
VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B
```

## Performance benchmarks

Mimicking [vllm#40846](https://github.com/vllm-project/vllm/issues/40846), three configurations on **single-engine M1 Pro 32 GB** (vllm-metal 0.2.0). Each pair runs the same vllm-metal engine; only the frontend binary differs (`vllm serve` Python vs `vllm-rs serve` Rust). Numbers are from a single run each.

**Bench 0 — Default load** (`--backend vllm`, sonnet 1024+128, prefix caching on, 100 prompts, request_rate=10, concurrency=32)

| Frontend | Throughput (req/s) | Total tok/s | P50 TTFT (ms) | P99 TTFT (ms) | P50 TPOT (ms) | P99 TPOT (ms) |
|---|---:|---:|---:|---:|---:|---:|
| Python | 0.54 |  610.86 | 6914.29 | 37744.77 | 399.74 | 442.12 |
| Rust   | 0.54 |  611.92 | 6991.53 | 37929.97 | 399.59 | 441.61 |

**Bench 1 — Decode-streaming** (`--backend vllm`, random 32+512, prefix caching **off**, 50 prompts, request_rate=inf, concurrency=256)

| Frontend | Throughput (req/s) | Total tok/s | P50 TTFT (ms) | P99 TTFT (ms) | P50 TPOT (ms) | P99 TPOT (ms) |
|---|---:|---:|---:|---:|---:|---:|
| Python | 0.78 |  422.58 |  2769.78 |  2772.18 | 120.53 | 121.48 |
| Rust   | 0.73 |  399.26 |  6508.73 |  6511.02 | 120.57 | 121.49 |

**Bench 2 — Preprocess-hot** (`--backend vllm`, sonnet 1500-prefix + 2048+16, prefix cache pre-warmed, 50 prompts, request_rate=inf, concurrency=96)

| Frontend | Throughput (req/s) | Total tok/s | P50 TTFT (ms) | P99 TTFT (ms) | P50 TPOT (ms) | P99 TPOT (ms) |
|---|---:|---:|---:|---:|---:|---:|
| Python | 0.55 | 1126.93 | 36836.37 | 88478.02 | 3587.02 | 5725.66 |
| Rust   | 0.52 | 1080.88 | 40421.48 | 92363.26 | 3608.89 | 5933.08 |

### Takeaway

- **python frontend is still faster than rust frontend**
- **Don't** advertise a perf win that does not exist on Apple Silicon at this scale.

> Hardware: Apple M1 Pro, 32 GB unified memory · `VLLM_METAL_MEMORY_FRACTION=0.6` · vllm 0.20.0 · vllm-rs built from [`inferact/vllm-frontend-rs@7bffcc7`](https://github.com/Inferact/vllm-frontend-rs/commit/7bffcc7) with the upstream-pinned Rust toolchain (`rust-toolchain.toml` → `nightly-2026-03-10`)