### PR TITLE
docs: add Qwen2.5-3B-Instruct to supported models

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -37,3 +37,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
+| Qwen2.5-3B-Instruct | ✅ | GQA (paged) | ✅ |  | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-3B-Instruct-4bit` |


### PR DESCRIPTION
## Summary

Mark `Qwen2.5-3B-Instruct` as supported in `docs/supported_models.md`.

Tested `mlx-community/Qwen2.5-3B-Instruct-4bit` on Apple M1 Pro (16 GB). Result: Working.

Refs #289.

## Verification

Environment:
- Apple M1 Pro, 16 GB unified memory
- macOS 26.2 (Tahoe), arm64
- vllm-metal commit: `282e4ab` (latest main)
- vLLM version: `0.20.0+cpu`

I ran the commands below from an activated `.venv-vllm-metal` environment.

Server (terminal 1):

```bash
vllm serve mlx-community/Qwen2.5-3B-Instruct-4bit --max-model-len 8192
```

Relevant engine startup output:

```
INFO [model.py:555] Resolved architecture: Qwen2ForCausalLM
INFO [worker.py:115] MLX device set to: Device(gpu, 0)
INFO [cache_policy.py:601] Paged attention enabled: 36 layers patched, 14918 blocks allocated (block_size=16, mla=False, turboquant=False, k_quant=N/A)
INFO [__init__.py:230] Native paged-attention Metal kernels loaded
INFO [mha.py:51] Paged attention Metal kernel warm-up complete
INFO [platform.py:259] Metal: chunked prefill enabled (paged attention), max_num_batched_tokens=2048
INFO:     Started server process
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```

Request (terminal 2):

```bash
curl -sS http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/Qwen2.5-3B-Instruct-4bit",
    "messages": [{"role":"user","content":"In two sentences, explain why the sky appears blue."}],
    "max_tokens": 120,
    "temperature": 0.2
  }'
```

Response:

```json
{
  "id": "chatcmpl-b41fd84e243d5087",
  "object": "chat.completion",
  "model": "mlx-community/Qwen2.5-3B-Instruct-4bit",
  "choices": [{
    "index": 0,
    "message": {
      "role": "assistant",
      "content": "The sky appears blue because of the scattering of sunlight by Earth's atmosphere; the shorter blue wavelength of light is more easily scattered by air molecules, making blue the predominant color we see during the day."
    },
    "finish_reason": "stop"
  }],
  "usage": {"prompt_tokens": 40, "completion_tokens": 41, "total_tokens": 81}
}
```

Result:
- Resolved architecture: `Qwen2ForCausalLM` (16 query heads / 2 KV heads → GQA, 36 layers — confirmed via `config.json`)
- Backend: paged-attention Metal kernel (`mla=False`)
- Paged attention enabled for 36 layers
- Automatic prefix caching: enabled by default (`enable_prefix_caching=True` in engine config)
- Chat completion request returned HTTP 200 with coherent text output

Before opening this PR, I checked #289 and open PRs related to `Qwen2.5` / supported models. I did not find a duplicate open PR.