### PR TITLE
docs: add Qwen2.5-7B-Instruct to supported models

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -37,5 +37,5 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
-| Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ |  | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |
-| Qwen2.5-3B-Instruct | ✅ | GQA (paged) | ✅ |  | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-3B-Instruct-4bit` |
+| Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ | [#324](https://github.com/vllm-project/vllm-metal/pull/324) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |
+| Qwen2.5-3B-Instruct | ✅ | GQA (paged) | ✅ | [#323](https://github.com/vllm-project/vllm-metal/pull/323) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-3B-Instruct-4bit` |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -37,3 +37,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
+| Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ |  | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |


### PR DESCRIPTION
## Summary

Mark `Qwen2.5-7B-Instruct` as supported in `docs/supported_models.md`.

I tested `mlx-community/Qwen2.5-7B-Instruct-4bit` on Apple M1 Pro (16 GB unified memory). Result: ✅ Working — fits with room to spare on 16 GB.

Sibling PR: #323 covers `Qwen2.5-3B-Instruct` (same row style, same architecture path). Whichever lands first, I'll rebase the other.

Refs #289.

## Verification

Environment:
- Apple M1 Pro, 16 GB unified memory
- macOS 26.2 (Tahoe), arm64
- vllm-metal commit: `282e4ab` (latest main)
- vLLM version: `0.20.0+cpu`

I ran the commands below from an activated `.venv-vllm-metal` environment.

Server (terminal 1):

```bash
vllm serve mlx-community/Qwen2.5-7B-Instruct-4bit --max-model-len 8192
```

Relevant engine startup output:

```
INFO [model.py:555] Resolved architecture: Qwen2ForCausalLM
INFO [worker.py:115] MLX device set to: Device(gpu, 0)
INFO [cache_policy.py:568] Paged attention memory breakdown: metal_limit=12.71GB, fraction=0.90, usable_metal=11.44GB, model_memory=4.29GB, overhead=1.42GB, kv_budget=5.73GB, per_block_bytes=917504, num_blocks=6250, max_tokens_cached=100000
INFO [cache_policy.py:601] Paged attention enabled: 28 layers patched, 6250 blocks allocated (block_size=16, mla=False, turboquant=False, k_quant=N/A)
INFO [__init__.py:230] Native paged-attention Metal kernels loaded
INFO [mha.py:51] Paged attention Metal kernel warm-up complete
INFO [platform.py:259] Metal: chunked prefill enabled (paged attention), max_num_batched_tokens=2048
INFO:     Started server process
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```

Request (terminal 2):

```bash
curl -sS http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/Qwen2.5-7B-Instruct-4bit",
    "messages": [{"role":"user","content":"In two sentences, explain why the sky appears blue."}],
    "max_tokens": 120,
    "temperature": 0.2
  }'
```

Response:

```json
{
  "id": "chatcmpl-...",
  "object": "chat.completion",
  "model": "mlx-community/Qwen2.5-7B-Instruct-4bit",
  "choices": [{
    "index": 0,
    "message": {
      "role": "assistant",
      "content": "The sky appears blue because the Earth's atmosphere scatters sunlight in all directions, and blue light is scattered more than other colors because it travels as shorter, smaller waves. This scattered blue light is what we see when we look up at the sky on a clear day."
    },
    "finish_reason": "stop"
  }],
  "usage": {"prompt_tokens": 40, "completion_tokens": 55, "total_tokens": 95}
}
```

Result:
- Resolved architecture: `Qwen2ForCausalLM` (28 query heads / 4 KV heads → GQA, 28 layers — confirmed via `config.json`)
- Backend: paged-attention Metal kernel (`mla=False`)
- Paged attention enabled for 28 layers
- Memory: `model_memory=4.29 GB`, `kv_budget=5.73 GB` at `--max-model-len 8192`
- Automatic prefix caching: enabled by default (`enable_prefix_caching=True` in engine config)
- Chat completion request returned HTTP 200 with coherent text output

Before opening this PR, I checked #289 and open PRs related to `Qwen2.5` / supported models. Only sibling PR #323 (3B) is open.