### PR TITLE
[kernel] Fold softmax into log2 space, replace exp with exp2

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -93,11 +93,13 @@ run_smoke_test() {
 
 smoke_tests() {
   # Qwen3-0.6B: standard GQA paged attention path
+  # Golden refreshed after the v2 softmax exp→exp2 fold; the paged path
+  # now matches the MLX inline-cache ground truth on this prompt.
   run_smoke_test \
     "Qwen/Qwen3-0.6B" \
     "c1899de289a04d12100db370d81485cdf75e47ca" \
     "The capital of France is" \
-    " Paris. The capital of Italy is Rome. The"
+    " Paris. The capital of France is also the capital"
 
   # Qwen3.5-0.8B: hybrid SDPA + GDN linear attention paged path
   # max-num-seqs=1: limits GDN linear state allocation (~10MB/slot × N slots)

--- a/tests/test_paged_deterministic.py
+++ b/tests/test_paged_deterministic.py
@@ -1,27 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """Deterministic smoke test: vLLM offline inference with golden token comparison.
 
-Golden token IDs were generated on the main branch using vLLM offline inference
-with temperature=0 (greedy decoding) on Qwen/Qwen3-0.6B, running one sequence
+Golden token IDs were generated using vLLM offline inference with
+temperature=0 (greedy decoding) on Qwen/Qwen3-0.6B, running one sequence
 at a time (max_num_seqs=1) to avoid batch-invariance issues on Metal.
 
-Findings from golden generation (main branch, HF paged-attention kernel):
-- The HF kernel paged KV path produces correct, coherent output.
-- 4/5 prompts are identical to the MLX inline cache path.
-- 1/5 ("The capital of France is") diverges at token 5 — both continuations
-  are valid English ("France is also the capital" vs "Italy is Rome. The").
-  Likely caused by floating-point non-determinism in the attention kernel
-  where top-2 logits are very close.
+Ground truth: the MLX inline-cache path (full-precision MLX softmax).
+The paged-attention path is expected to converge on it numerically. After
+the v2 softmax exp→exp2/log2 fold landed, 5/6 prompts produce the same
+argmax tokens as MLX through 10 decode steps.
 
-The assert accepts EITHER golden set (mlx-cache or paged-cache) and prints
-which path matched.
+The remaining prompt ("One plus one equals") has top-2 logits at the
+divergence step within ULP (',' vs '.'). Either greedy answer is valid
+English; the split is inherent to model rounding behavior at that token,
+not a kernel bug. We keep a paged-specific fallback for that one prompt.
 
 Run (paged KV path, the default):
-    python -m pytest tests/test_paged_deterministic.py -v -s
+    python -m pytest tests/test_paged_deterministic.py -v -s -m slow
 
 To test the MLX inline cache path instead, pass env vars explicitly:
     VLLM_METAL_USE_PAGED_ATTENTION=0 VLLM_METAL_MEMORY_FRACTION=auto \
-        python -m pytest tests/test_paged_deterministic.py -v -s
+        python -m pytest tests/test_paged_deterministic.py -v -s -m slow
 
 Note: MLX requires VLLM_METAL_MEMORY_FRACTION=auto (numeric fractions are
 only valid for the paged attention path).
@@ -50,8 +49,9 @@ PROMPTS = [
 ]
 
 # fmt: off
-# Golden token IDs from MLX inline cache (default path), greedy decoding.
-# Generated via: VLLM_ENABLE_V1_MULTIPROCESSING=0 python tools/gen_golden_token_ids_for_deterministics.py
+# Ground truth: MLX inline cache (greedy, full precision). Regenerate via:
+#   VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+#     python tools/gen_golden_token_ids_for_deterministics.py
 # Environment: mlx 0.31.1, mlx-lm 0.31.1
 GOLDEN_MLX = {
     "The capital of France is":                   [12095, 13, 576, 6722, 315, 9625, 374, 1083, 279, 6722],
@@ -62,17 +62,12 @@ GOLDEN_MLX = {
     "Machine learning is":                        [264, 7988, 5392, 429, 702, 13791, 1506, 279, 2070, 315],
 }
 
-# Golden token IDs from paged KV cache (Metal kernel), greedy decoding.
-# Generated via: VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION=0.2 \
-#                VLLM_ENABLE_V1_MULTIPROCESSING=0 python tools/gen_golden_token_ids_for_deterministics.py
-# Environment: mlx 0.31.1, mlx-lm 0.31.1
-GOLDEN_PAGED = {
-    "The capital of France is":                   [12095, 13, 576, 6722, 315, 15344, 374, 21718, 13, 576],
-    "The weather today is not":                   [1661, 13, 576, 9315, 374, 220, 17, 15, 12348, 13],
+# Per-prompt fallback for prompts whose top-2 logits at the divergence
+# step are within ULP. Paged-path rounding can legitimately pick a
+# different argmax than MLX for those prompts. Listed here as documented
+# exceptions; the test accepts either the MLX golden or this fallback.
+GOLDEN_PAGED_FALLBACK = {
     "One plus one equals":                        [825, 13, 3776, 5519, 825, 16819, 1378, 13, 3776, 5519],
-    "The largest planet in our solar system is":  [1112, 30, 362, 13, 43562, 425, 13, 48976, 356, 13],
-    "Water boils at a temperature of":            [220, 16, 15, 15, 30937, 518, 5297, 44375, 7262, 13],
-    "Machine learning is":                        [264, 7988, 5392, 429, 702, 13791, 1506, 279, 2070, 315],
 }
 # fmt: on
 
@@ -158,28 +153,33 @@ class TestPagedDeterministic:
         text = output.outputs[0].text
 
         mlx_expected = GOLDEN_MLX[prompt]
-        paged_expected = GOLDEN_PAGED[prompt]
+        fallback = GOLDEN_PAGED_FALLBACK.get(prompt)
 
-        mlx_match = token_ids == mlx_expected
-        paged_match = token_ids == paged_expected
         print(
             f"VLLM_METAL_USE_PAGED_ATTENTION: {os.environ.get('VLLM_METAL_USE_PAGED_ATTENTION')}"
         )
         print(f"\n  prompt: {prompt!r}")
         print(f"  output: {text!r}")
         print(f"  ids:    {token_ids}")
-        if mlx_match:
-            print("  result: MATCHED mlx-cache golden")
-        elif paged_match:
-            print("  result: MATCHED paged-cache golden")
-        else:
-            print("  result: NO MATCH")
-            print(f"  expected (mlx):   {mlx_expected}")
-            print(f"  expected (paged): {paged_expected}")
 
-        assert mlx_match or paged_match, (
-            f"Output for {prompt!r} matched neither golden set.\n"
-            f"Got:            {token_ids}\n"
-            f"Expected (mlx): {mlx_expected}\n"
-            f"Expected (pgd): {paged_expected}"
+        if token_ids == mlx_expected:
+            print("  result: MATCHED MLX ground truth")
+            return
+        if fallback is not None and token_ids == fallback:
+            print("  result: MATCHED paged fallback (documented divergence)")
+            return
+
+        print("  result: NO MATCH")
+        print(f"  expected (MLX):   {mlx_expected}")
+        if fallback is not None:
+            print(f"  fallback (paged): {fallback}")
+
+        msg = (
+            f"Output for {prompt!r} did not match the MLX ground truth"
+            f"{' or its paged fallback' if fallback is not None else ''}.\n"
+            f"Got:              {token_ids}\n"
+            f"Expected (MLX):   {mlx_expected}\n"
         )
+        if fallback is not None:
+            msg += f"Fallback (paged): {fallback}\n"
+        raise AssertionError(msg)

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -1065,7 +1065,11 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
         if (sliding_window >= 0) {
           mask = mask || (token_idx < effective_context_len - sliding_window);
         }
-        warp_scores[physical_block_offset] = mask ? -FLT_MAX : qk;
+        // Fold the softmax base change into the score: storing qk * log2(e) lets
+        // every downstream `exp(s - m)` become `exp2(s - m)` (1-instruction on
+        // Apple GPUs). m, l, max_logits, exp_sums all live in log2 space from
+        // here on. Math identity: exp(x - y) == exp2((x - y) * log2e).
+        warp_scores[physical_block_offset] = mask ? -FLT_MAX : qk * M_LOG2E_F;
       }
     }
 
@@ -1100,7 +1104,7 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
     // NaN-safe: if new_m is still -inf (all masked), clamp to 0.
     if (new_m == -FLT_MAX) new_m = 0.f;
 
-    float old_correction = exp(warp_m - new_m);
+    float old_correction = exp2(warp_m - new_m);
     // If warp_m was -FLT_MAX (first iteration), correction = 0, which
     // correctly zeroes out the (already zero) previous O and l.
     if (warp_m == -FLT_MAX) old_correction = 0.f;
@@ -1118,7 +1122,7 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
     // (unnormalized) and accumulate into O.
     for (int tok = 0; tok < block_valid_tokens; tok++) {
       const float score = warp_scores[tok];
-      const float w = exp(score - warp_m);
+      const float w = exp2(score - warp_m);
       warp_l += w;
 
       // Load V and accumulate: O += w * V
@@ -1176,15 +1180,17 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
   // reached by all threads in the threadgroup).
 
   // For non-partitioned mode, include the sink in each warp's state.
+  // Sinks are raw linear-space bias values; lift to log2 space (matches the
+  // log2-space convention adopted at the warp_scores write above).
   if (!USE_PARTITIONING && use_sinks) {
-    float sink_val = sinks[head_idx];
+    float sink_val = sinks[head_idx] * M_LOG2E_F;
     float new_m = max(warp_m, sink_val);
-    float old_corr = (warp_m == -FLT_MAX) ? 0.f : exp(warp_m - new_m);
+    float old_corr = (warp_m == -FLT_MAX) ? 0.f : exp2(warp_m - new_m);
 #pragma unroll
     for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
       v_accs[i] *= old_corr;
     }
-    warp_l = warp_l * old_corr + exp(sink_val - new_m);
+    warp_l = warp_l * old_corr + exp2(sink_val - new_m);
     warp_m = new_m;
   }
 
@@ -1230,8 +1236,8 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
       float new_m = max(warp_m, other_m);
       if (new_m == -FLT_MAX) new_m = 0.f;
 
-      float my_corr = (warp_m == -FLT_MAX) ? 0.f : exp(warp_m - new_m);
-      float other_corr = (other_m == -FLT_MAX) ? 0.f : exp(other_m - new_m);
+      float my_corr = (warp_m == -FLT_MAX) ? 0.f : exp2(warp_m - new_m);
+      float other_corr = (other_m == -FLT_MAX) ? 0.f : exp2(other_m - new_m);
 
       const threadgroup float *other_O = &merge_O[w * HEAD_SIZE];
 #pragma unroll
@@ -1441,9 +1447,10 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   // Broadcast the max value to all threads.
   max_logit = simd_shuffle(max_logit, 0);
 
-  // Include the sink in the global max before rescaling.
+  // Include the sink in the global max before rescaling. max_logits are
+  // stored in log2 space by paged_attention; lift the raw sink to match.
   if (use_sinks) {
-    max_logit = max(max_logit, sinks[head_idx]);
+    max_logit = max(max_logit, sinks[head_idx] * M_LOG2E_F);
   }
 
   // Load rescaled exp sums to shared memory.
@@ -1456,7 +1463,7 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   for (int i = thread_position_in_threadgroup.x; i < num_partitions;
        i += threads_per_threadgroup.x) {
     float l = shared_max_logits[i];
-    float rescaled_exp_sum = exp_sums_ptr[i] * exp(l - max_logit);
+    float rescaled_exp_sum = exp_sums_ptr[i] * exp2(l - max_logit);
     global_exp_sum += rescaled_exp_sum;
     shared_exp_sums[i] = rescaled_exp_sum;
   }
@@ -1464,9 +1471,9 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   global_exp_sum = block_sum<NUM_WARPS, NUM_SIMD_LANES>(
       &red_smem[NUM_WARPS], global_exp_sum, simd_tid, simd_lid);
 
-  // Include the sink in the global exp sum.
+  // Include the sink in the global exp sum (sinks lifted to log2 space).
   if (use_sinks) {
-    global_exp_sum += exp(sinks[head_idx] - max_logit);
+    global_exp_sum += exp2(sinks[head_idx] * M_LOG2E_F - max_logit);
   }
 
   const float inv_global_exp_sum = 1.0f / (global_exp_sum + 1e-6f);


### PR DESCRIPTION

<img width="2675" height="1626" alt="bench_exp2_comparison" src="https://github.com/user-attachments/assets/62a333d7-5f5e-4f05-b720-ac4b9c115047" />

## Summary: 

Just switch exp to exp2, learnt from the mlx sdpa's source code. 

## Deterministic test

Better numeric alignment with mlx sdpa attention

```
France:   MATCHED mlx-cache golden    ← main matched paged-only (drift from MLX)
Weather:  MATCHED mlx-cache golden
One+one:  MATCHED paged-cache golden  ← MLX disagrees even on main (test docstring notes this)
Planet:   MATCHED mlx-cache golden
Water:    MATCHED mlx-cache golden    ← main matched paged-only (drift from MLX)
Machine:  MATCHED mlx-cache golden
```



## Benchmark (50 prompts, sonnet 2048+128, M1 Pro)

| Metric              | main        | this PR     | Δ          |
| ------------------- | ----------: | ----------: | ---------: |
| Total throughput    | 394.1 tok/s | 478.1 tok/s | **+21.3%** |
| Mean TTFT (prefill) | 61.8 s      | 50.2 s      | **−18.6%** |
| Median TTFT         | 38.7 s      | 30.2 s      | **−22.0%** |
| Mean TPOT (decode)  | 838.6 ms    | 691.6 ms    | **−17.5%** |
| Duration            | 274 s       | 226 s       | **−17.6%** |

