### PR TITLE
Fix sample logprobs output on Metal runner

### DIFF
--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -21,6 +21,7 @@ from vllm.sampling_params import SamplingParams
 import vllm_metal.paged_attention_common as pac
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
+from vllm_metal.v1.sampling_batch import SamplingResult
 
 
 def _make_paged_runner(num_layers: int = 2) -> mr.MetalModelRunner:
@@ -229,7 +230,7 @@ class TestSamplingMetadataWithPenalties:
 
         def spy_sample(logits_2d, batch, sampler, device):
             captured_batches.append(batch)
-            return [99]
+            return SamplingResult([99])
 
         with (
             patch.object(

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -21,7 +21,7 @@ from vllm.sampling_params import SamplingParams
 import vllm_metal.paged_attention_common as pac
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
-from vllm_metal.v1.sampling_batch import SamplingResult
+from vllm_metal.v1.sampling_batch import _SamplingResult
 
 
 def _make_paged_runner(num_layers: int = 2) -> mr.MetalModelRunner:
@@ -230,7 +230,7 @@ class TestSamplingMetadataWithPenalties:
 
         def spy_sample(logits_2d, batch, sampler, device):
             captured_batches.append(batch)
-            return SamplingResult([99])
+            return _SamplingResult([99])
 
         with (
             patch.object(

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest
+from vllm.sampling_params import SamplingParams
 
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
@@ -51,14 +52,7 @@ class TestPrefixCacheHybridGuard:
         runner.model.return_value = MagicMock(logits=fake_logits)
 
         token_ids = [1, 2, 3, 4, 5]
-        sampling_params = MagicMock(
-            temperature=0.0,
-            top_p=1.0,
-            top_k=0,
-            frequency_penalty=0,
-            presence_penalty=0,
-            repetition_penalty=1.0,
-        )
+        sampling_params = SamplingParams(temperature=0.0)
 
         runner._prefill_single("req-1", token_ids, sampling_params)
 
@@ -86,14 +80,7 @@ class TestPrefixCacheHybridGuard:
         runner.model.return_value = MagicMock(logits=fake_logits)
 
         token_ids = [1, 2, 3, 4, 5]
-        sampling_params = MagicMock(
-            temperature=0.0,
-            top_p=1.0,
-            top_k=0,
-            frequency_penalty=0,
-            presence_penalty=0,
-            repetition_penalty=1.0,
-        )
+        sampling_params = SamplingParams(temperature=0.0)
 
         runner._prefill_single("req-1", token_ids, sampling_params)
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -5,8 +5,11 @@ import mlx.core as mx
 import numpy as np
 import pytest
 import torch
+from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
+from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
+from vllm.v1.engine.output_processor import OutputProcessor
 from vllm.v1.outputs import LogprobsLists
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -388,6 +391,52 @@ class TestV1SamplingBatch:
         assert output.logprobs is not None
         assert output.logprobs.logprob_token_ids.shape == (2, 3)
         assert output.logprobs.slice_request(1, 1).logprob_token_ids[0, 0] == 7
+
+    def test_logprobs_flow_through_request_output_processing(self) -> None:
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            logprobs=2,
+            max_tokens=1,
+            detokenize=False,
+        )
+        request = EngineCoreRequest(
+            request_id="req-1",
+            prompt_token_ids=[1, 2, 3],
+            mm_features=None,
+            sampling_params=sampling_params,
+            pooling_params=None,
+            arrival_time=0.0,
+            lora_request=None,
+            cache_salt=None,
+            data_parallel_rank=None,
+            external_req_id="req-1",
+        )
+        output_processor = OutputProcessor(tokenizer=None, log_stats=False)
+        output_processor.add_request(request, prompt=None)
+
+        result = output_processor.process_outputs(
+            [
+                EngineCoreOutput(
+                    request_id="req-1",
+                    new_token_ids=[7],
+                    new_logprobs=LogprobsLists(
+                        logprob_token_ids=np.array([[7, 5, 3]], dtype=np.int32),
+                        logprobs=np.array([[-0.1, -1.0, -2.0]], dtype=np.float32),
+                        sampled_token_ranks=np.array([1], dtype=np.int32),
+                    ),
+                    finish_reason=FinishReason.LENGTH,
+                )
+            ]
+        )
+
+        assert not result.reqs_to_abort
+        [request_output] = result.request_outputs
+        assert isinstance(request_output, RequestOutput)
+        [completion_output] = request_output.outputs
+        assert completion_output.token_ids == [7]
+        assert completion_output.logprobs is not None
+        assert completion_output.logprobs[0] is not None
+        assert completion_output.logprobs[0][7].logprob == pytest.approx(-0.1)
 
 
 class TestV1SamplingMetadataLogitsProcessors:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
+from vllm.v1.outputs import LogprobsLists
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
@@ -17,8 +18,9 @@ from vllm_metal.v1.model_runner import (
     MetalModelRunner,
     RequestState,
     _create_request_generator,
+    _ExecutionBatch,
 )
-from vllm_metal.v1.sampling_batch import SamplingBatch
+from vllm_metal.v1.sampling_batch import SamplingBatch, sample_from_logits
 
 VOCAB_SIZE = 1024
 MAX_NUM_PROMPT_TOKENS = 64
@@ -322,6 +324,9 @@ class TestV1SamplingBatch:
         assert not SamplingBatch.can_use_native_greedy(
             [SamplingParams(temperature=0.0, repetition_penalty=1.1)]
         )
+        assert not SamplingBatch.can_use_native_greedy(
+            [SamplingParams(temperature=0.0, logprobs=1)]
+        )
 
     def test_can_use_native_greedy_requires_every_request_to_match(self) -> None:
         assert SamplingBatch.can_use_native_greedy(
@@ -333,6 +338,56 @@ class TestV1SamplingBatch:
         assert not SamplingBatch.can_use_native_greedy(
             [SamplingParams(temperature=0.0), SamplingParams(temperature=0.8, top_k=4)]
         )
+
+    def test_sampling_metadata_uses_requested_logprobs(self) -> None:
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.0, logprobs=5)],
+            [[1, 2, 3]],
+            [[]],
+            vocab_size=VOCAB_SIZE,
+            device=torch.device("cpu"),
+        )
+
+        metadata = batch.make_sampling_metadata()
+
+        assert metadata.max_num_logprobs == 5
+
+    def test_sample_from_logits_returns_logprobs_for_greedy_request(self) -> None:
+        logits = mx.array([[0.0, 1.0, 4.0, 2.0]], dtype=mx.float32)
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.0, logprobs=2)],
+            [[1, 2, 3]],
+            [[]],
+            vocab_size=4,
+            device=torch.device("cpu"),
+        )
+
+        result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+
+        assert result.token_ids == [2]
+        assert result.logprobs is not None
+        assert result.logprobs.logprob_token_ids.shape == (1, 3)
+        assert result.logprobs.logprob_token_ids[0, 0] == 2
+        assert result.logprobs.sampled_token_ranks.tolist() == [1]
+
+    def test_model_runner_output_keeps_logprobs_slot_alignment(self) -> None:
+        batch = _ExecutionBatch()
+        batch.add_output("intermediate", [])
+        batch.add_output(
+            "decode",
+            [7],
+            LogprobsLists(
+                logprob_token_ids=np.array([[7, 7, 3]], dtype=np.int32),
+                logprobs=np.array([[-0.1, -0.1, -2.0]], dtype=np.float32),
+                sampled_token_ranks=np.array([1], dtype=np.int32),
+            ),
+        )
+
+        output = MetalModelRunner._build_output(batch)
+
+        assert output.logprobs is not None
+        assert output.logprobs.logprob_token_ids.shape == (2, 3)
+        assert output.logprobs.slice_request(1, 1).logprob_token_ids[0, 0] == 7
 
 
 class TestV1SamplingMetadataLogitsProcessors:
@@ -407,7 +462,7 @@ class TestV1PenaltyTokenAccounting:
             generated_tokens=0,
         )
 
-        next_tokens = runner._sequential_decode([("r1", state)])
+        next_tokens = runner._sequential_decode([("r1", state)]).token_ids
 
         assert next_tokens == [prompt_token]
 
@@ -437,7 +492,7 @@ class TestV1PenaltyTokenAccounting:
             generated_tokens=0,
         )
 
-        next_tokens = runner._sequential_decode([("r1", state)])
+        next_tokens = runner._sequential_decode([("r1", state)]).token_ids
 
         assert next_tokens == [prompt_token]
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -355,6 +355,39 @@ class TestV1SamplingBatch:
 
         assert metadata.max_num_logprobs == 5
 
+    def test_sampling_metadata_rejects_full_vocab_logprobs(self) -> None:
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.0, logprobs=-1)],
+            [[1, 2, 3]],
+            [[]],
+            vocab_size=VOCAB_SIZE,
+            device=torch.device("cpu"),
+        )
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Metal runner does not support logprobs=-1 yet",
+        ):
+            batch.make_sampling_metadata()
+
+    def test_sampling_metadata_rejects_mixed_full_vocab_logprobs(self) -> None:
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0, logprobs=-1),
+                SamplingParams(temperature=0.0, logprobs=2),
+            ],
+            [[1, 2, 3], [4, 5]],
+            [[], []],
+            vocab_size=VOCAB_SIZE,
+            device=torch.device("cpu"),
+        )
+
+        with pytest.raises(
+            NotImplementedError,
+            match="Metal runner does not support logprobs=-1 yet",
+        ):
+            batch.make_sampling_metadata()
+
     def test_sample_from_logits_returns_logprobs_for_greedy_request(self) -> None:
         logits = mx.array([[0.0, 1.0, 4.0, 2.0]], dtype=mx.float32)
         batch = SamplingBatch(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -30,7 +30,7 @@ from vllm.v1.core.sched.output import (
     SchedulerOutput,
 )
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
-from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.outputs import LogprobsLists, ModelRunnerOutput
 from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
@@ -62,6 +62,8 @@ from vllm_metal.v1.model_lifecycle import ModelLifecycle
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
     SamplingBatch,
+    SamplingResult,
+    merge_logprobs_rows,
     sample_decode_tokens,
     sample_from_logits,
     sample_prefill_tokens,
@@ -143,19 +145,36 @@ class _ExecutionBatch:
     req_ids: list[str] = field(default_factory=list)
     req_id_to_index: dict[str, int] = field(default_factory=dict)
     sampled_tokens: list[list[int]] = field(default_factory=list)
+    sample_logprobs: list[LogprobsLists | None] = field(default_factory=list)
     new_reqs_by_id: dict[str, NewRequestData] = field(default_factory=dict)
     paged_prefill_entries: list[_PendingPrefillEntry] = field(default_factory=list)
     paged_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
     scheduled_cached_req_ids: list[str] = field(default_factory=list)
     valid_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
 
-    def add_output(self, req_id: str, token_ids: list[int]) -> int:
+    def add_output(
+        self,
+        req_id: str,
+        token_ids: list[int],
+        logprobs: LogprobsLists | None = None,
+    ) -> int:
         """Append one output slot and return its index."""
         self.req_ids.append(req_id)
         output_idx = len(self.req_ids) - 1
         self.req_id_to_index[req_id] = output_idx
         self.sampled_tokens.append(token_ids)
+        self.sample_logprobs.append(logprobs)
         return output_idx
+
+    def set_output(
+        self,
+        output_idx: int,
+        token_ids: list[int],
+        logprobs: LogprobsLists | None = None,
+    ) -> None:
+        """Set tokens and logprobs for an existing output slot."""
+        self.sampled_tokens[output_idx] = token_ids
+        self.sample_logprobs[output_idx] = logprobs
 
     def has_paged_work(self) -> bool:
         """Return whether this step has any paged execution work."""
@@ -547,7 +566,7 @@ class MetalModelRunner:
         token_ids: list[int],
         sampling_params: SamplingParams,
         generator: torch.Generator | None = None,
-    ) -> tuple[int, list[KVCache]]:
+    ) -> tuple[int, list[KVCache], LogprobsLists | None]:
         """Process a single prefill request.
 
         Args:
@@ -606,14 +625,15 @@ class MetalModelRunner:
             logitsprocs=self._logitsprocs,
             generators=generators,
         )
-        [next_token] = sample_from_logits(
-            last_logits, batch, self._sampler, self.device
-        )
+        result = sample_from_logits(last_logits, batch, self._sampler, self.device)
+        [next_token] = result.token_ids
         mx.eval(*[c.state for c in cache])
 
-        return next_token, cache
+        return next_token, cache, result.logprobs
 
-    def _batched_decode(self, decode_reqs: list[tuple[str, RequestState]]) -> list[int]:
+    def _batched_decode(
+        self, decode_reqs: list[tuple[str, RequestState]]
+    ) -> SamplingResult:
         """Process multiple decode requests in a single batched forward pass.
 
         Uses BatchKVCache to merge individual caches, run ONE forward pass,
@@ -623,7 +643,7 @@ class MetalModelRunner:
             decode_reqs: List of (req_id, state) tuples
 
         Returns:
-            List of next tokens for each request
+            Sampled token IDs and optional logprobs for each request.
         """
         last_tokens = [
             state.token_ids[-1] if state.token_ids else 0 for _, state in decode_reqs
@@ -667,9 +687,10 @@ class MetalModelRunner:
             logitsprocs=self._logitsprocs,
             generators=generators,
         )
-        next_tokens = sample_from_logits(
+        result = sample_from_logits(
             next_token_logits, batch, self._sampler, self.device
         )
+        next_tokens = result.token_ids
 
         # Extract updated caches back to individual requests
         for i, (_req_id, state) in enumerate(decode_reqs):
@@ -677,11 +698,11 @@ class MetalModelRunner:
             state.token_ids.append(next_tokens[i])
             state.generated_tokens += 1
 
-        return next_tokens
+        return result
 
     def _sequential_decode(
         self, decode_reqs: list[tuple[str, RequestState]]
-    ) -> list[int]:
+    ) -> SamplingResult:
         """Fallback: process decode requests sequentially.
 
         Used when batch size is 1 (no benefit from batching).
@@ -690,9 +711,10 @@ class MetalModelRunner:
             decode_reqs: List of (req_id, state) tuples
 
         Returns:
-            List of next tokens for each request
+            Sampled token IDs and optional logprobs for each request.
         """
         next_tokens = []
+        logprobs_rows: list[LogprobsLists | None] = []
 
         for _req_id, state in decode_reqs:
             last_token = state.token_ids[-1] if state.token_ids else 0
@@ -713,17 +735,20 @@ class MetalModelRunner:
                 logitsprocs=self._logitsprocs,
                 generators=generators,
             )
-            [next_token] = sample_from_logits(
-                last_logits, batch, self._sampler, self.device
-            )
+            result = sample_from_logits(last_logits, batch, self._sampler, self.device)
+            [next_token] = result.token_ids
 
             next_tokens.append(next_token)
+            logprobs_rows.append(result.logprobs)
 
             # Update state
             state.token_ids.append(next_token)
             state.generated_tokens += 1
 
-        return next_tokens
+        return SamplingResult(
+            next_tokens,
+            merge_logprobs_rows(logprobs_rows),
+        )
 
     # ------------------------------------------------------------------
     # Unified prefill + decode (single forward pass)
@@ -854,7 +879,7 @@ class MetalModelRunner:
         # ---- sample tokens ----
         vocab_size = self._vocab_size
         logitsprocs = self._logitsprocs
-        decode_next_tokens = sample_decode_tokens(
+        decode_result = sample_decode_tokens(
             logits,
             decode_reqs,
             num_decode,
@@ -863,7 +888,7 @@ class MetalModelRunner:
             vocab_size=vocab_size,
             logitsprocs=logitsprocs,
         )
-        prefill_next_tokens = sample_prefill_tokens(
+        prefill_result = sample_prefill_tokens(
             logits,
             prefill_reqs,
             cu_seqlens,
@@ -876,7 +901,7 @@ class MetalModelRunner:
 
         # ---- update decode state ----
         for i, (req_id, state) in enumerate(decode_reqs):
-            state.token_ids.append(decode_next_tokens[i])
+            state.token_ids.append(decode_result.token_ids[i])
             state.generated_tokens += 1
             self._paged_request_seq_lens[req_id] = (
                 self._paged_request_seq_lens.get(req_id, len(state.token_ids) - 2) + 1
@@ -888,14 +913,19 @@ class MetalModelRunner:
 
         # ---- postprocess: write results back into batch ----
         for i, entry in enumerate(batch.paged_prefill_entries):
-            next_token = prefill_next_tokens[i]
+            next_token = prefill_result.token_ids[i]
+            logprobs = (
+                prefill_result.logprobs.slice_request(i, 1)
+                if prefill_result.logprobs is not None
+                else None
+            )
             prefill = prefill_reqs[i]
 
             if entry.result_mode == "intermediate":
-                batch.sampled_tokens[entry.output_idx] = []
+                batch.set_output(entry.output_idx, [], logprobs)
                 continue
 
-            batch.sampled_tokens[entry.output_idx] = [next_token]
+            batch.set_output(entry.output_idx, [next_token], logprobs)
             if entry.result_mode == "new_final":
                 prompt_len = prefill.prompt_len
                 assert prompt_len is not None
@@ -920,7 +950,12 @@ class MetalModelRunner:
             req_state.generated_tokens = len(req_state.token_ids) - req_state.prompt_len
 
         for i, (req_id, _) in enumerate(batch.paged_decode_reqs):
-            batch.add_output(req_id, [decode_next_tokens[i]])
+            logprobs = (
+                decode_result.logprobs.slice_request(i, 1)
+                if decode_result.logprobs is not None
+                else None
+            )
+            batch.add_output(req_id, [decode_result.token_ids[i]], logprobs)
 
         return batch, scheduler_output
 
@@ -984,13 +1019,13 @@ class MetalModelRunner:
                     )
                 continue
 
-            next_token, cache = self._prefill_single(
+            next_token, cache, logprobs = self._prefill_single(
                 req_id,
                 token_ids,
                 sampling_params,
                 generator=generator,
             )
-            batch.add_output(req_id, [next_token])
+            batch.add_output(req_id, [next_token], logprobs)
             self._request_states[req_id] = RequestState(
                 token_ids=list(token_ids) + [next_token],
                 prompt_len=len(token_ids),
@@ -1140,7 +1175,7 @@ class MetalModelRunner:
             req_ids=batch.req_ids,
             req_id_to_index=batch.req_id_to_index,
             sampled_token_ids=batch.sampled_tokens,
-            logprobs=None,
+            logprobs=merge_logprobs_rows(batch.sample_logprobs),
             prompt_logprobs_dict={},
             pooler_output=[None] * len(batch.req_ids),
         )
@@ -1152,12 +1187,17 @@ class MetalModelRunner:
         """Run non-paged decode work and append placeholder outputs as needed."""
         if batch.valid_decode_reqs:
             if len(batch.valid_decode_reqs) >= _MIN_BATCH_SIZE_FOR_BATCHING:
-                decode_tokens = self._batched_decode(batch.valid_decode_reqs)
+                decode_result = self._batched_decode(batch.valid_decode_reqs)
             else:
-                decode_tokens = self._sequential_decode(batch.valid_decode_reqs)
+                decode_result = self._sequential_decode(batch.valid_decode_reqs)
 
             for i, (req_id, _) in enumerate(batch.valid_decode_reqs):
-                batch.add_output(req_id, [decode_tokens[i]])
+                logprobs = (
+                    decode_result.logprobs.slice_request(i, 1)
+                    if decode_result.logprobs is not None
+                    else None
+                )
+                batch.add_output(req_id, [decode_result.token_ids[i]], logprobs)
 
         for req_id in batch.scheduled_cached_req_ids:
             if req_id not in batch.req_id_to_index:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
+import numpy as np
 import torch
 from mlx_lm import stream_generate
 from vllm.config import VllmConfig
@@ -62,8 +63,7 @@ from vllm_metal.v1.model_lifecycle import ModelLifecycle
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
     SamplingBatch,
-    SamplingResult,
-    merge_logprobs_rows,
+    _SamplingResult,
     sample_decode_tokens,
     sample_from_logits,
     sample_prefill_tokens,
@@ -175,6 +175,54 @@ class _ExecutionBatch:
         """Set tokens and logprobs for an existing output slot."""
         self.sampled_tokens[output_idx] = token_ids
         self.sample_logprobs[output_idx] = logprobs
+
+    def merged_logprobs(self) -> LogprobsLists | None:
+        """Merge per-output-slot logprobs for ``ModelRunnerOutput``."""
+        present_rows = [row for row in self.sample_logprobs if row is not None]
+        if not present_rows:
+            return None
+
+        max_width = max(row.logprob_token_ids.shape[1] for row in present_rows)
+        token_rows: list[np.ndarray] = []
+        logprob_rows: list[np.ndarray] = []
+        rank_rows: list[np.ndarray] = []
+
+        for row in self.sample_logprobs:
+            if row is None:
+                token_rows.append(np.zeros((1, max_width), dtype=np.int32))
+                logprob_rows.append(
+                    np.full((1, max_width), float("-inf"), dtype=np.float32)
+                )
+                rank_rows.append(np.zeros((1,), dtype=np.int32))
+                continue
+
+            token_ids = row.logprob_token_ids
+            logprobs = row.logprobs
+            if token_ids.shape[1] < max_width:
+                pad_width = max_width - token_ids.shape[1]
+                token_ids = np.pad(
+                    token_ids,
+                    ((0, 0), (0, pad_width)),
+                    mode="constant",
+                    constant_values=0,
+                )
+                logprobs = np.pad(
+                    logprobs,
+                    ((0, 0), (0, pad_width)),
+                    mode="constant",
+                    constant_values=float("-inf"),
+                )
+
+            token_rows.append(token_ids.astype(np.int32, copy=False))
+            logprob_rows.append(logprobs.astype(np.float32, copy=False))
+            rank_rows.append(row.sampled_token_ranks.astype(np.int32, copy=False))
+
+        return LogprobsLists(
+            logprob_token_ids=np.concatenate(token_rows, axis=0),
+            logprobs=np.concatenate(logprob_rows, axis=0),
+            sampled_token_ranks=np.concatenate(rank_rows, axis=0),
+            cu_num_generated_tokens=None,
+        )
 
     def has_paged_work(self) -> bool:
         """Return whether this step has any paged execution work."""
@@ -633,7 +681,7 @@ class MetalModelRunner:
 
     def _batched_decode(
         self, decode_reqs: list[tuple[str, RequestState]]
-    ) -> SamplingResult:
+    ) -> _SamplingResult:
         """Process multiple decode requests in a single batched forward pass.
 
         Uses BatchKVCache to merge individual caches, run ONE forward pass,
@@ -702,7 +750,7 @@ class MetalModelRunner:
 
     def _sequential_decode(
         self, decode_reqs: list[tuple[str, RequestState]]
-    ) -> SamplingResult:
+    ) -> _SamplingResult:
         """Fallback: process decode requests sequentially.
 
         Used when batch size is 1 (no benefit from batching).
@@ -745,9 +793,9 @@ class MetalModelRunner:
             state.token_ids.append(next_token)
             state.generated_tokens += 1
 
-        return SamplingResult(
+        return _SamplingResult(
             next_tokens,
-            merge_logprobs_rows(logprobs_rows),
+            SamplingBatch.merge_logprobs_rows(logprobs_rows),
         )
 
     # ------------------------------------------------------------------
@@ -1175,7 +1223,7 @@ class MetalModelRunner:
             req_ids=batch.req_ids,
             req_id_to_index=batch.req_id_to_index,
             sampled_token_ids=batch.sampled_tokens,
-            logprobs=merge_logprobs_rows(batch.sample_logprobs),
+            logprobs=batch.merged_logprobs(),
             prompt_logprobs_dict={},
             pooler_output=[None] * len(batch.req_ids),
         )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
-import numpy as np
 import torch
 from mlx_lm import stream_generate
 from vllm.config import VllmConfig
@@ -178,51 +177,7 @@ class _ExecutionBatch:
 
     def merged_logprobs(self) -> LogprobsLists | None:
         """Merge per-output-slot logprobs for ``ModelRunnerOutput``."""
-        present_rows = [row for row in self.sample_logprobs if row is not None]
-        if not present_rows:
-            return None
-
-        max_width = max(row.logprob_token_ids.shape[1] for row in present_rows)
-        token_rows: list[np.ndarray] = []
-        logprob_rows: list[np.ndarray] = []
-        rank_rows: list[np.ndarray] = []
-
-        for row in self.sample_logprobs:
-            if row is None:
-                token_rows.append(np.zeros((1, max_width), dtype=np.int32))
-                logprob_rows.append(
-                    np.full((1, max_width), float("-inf"), dtype=np.float32)
-                )
-                rank_rows.append(np.zeros((1,), dtype=np.int32))
-                continue
-
-            token_ids = row.logprob_token_ids
-            logprobs = row.logprobs
-            if token_ids.shape[1] < max_width:
-                pad_width = max_width - token_ids.shape[1]
-                token_ids = np.pad(
-                    token_ids,
-                    ((0, 0), (0, pad_width)),
-                    mode="constant",
-                    constant_values=0,
-                )
-                logprobs = np.pad(
-                    logprobs,
-                    ((0, 0), (0, pad_width)),
-                    mode="constant",
-                    constant_values=float("-inf"),
-                )
-
-            token_rows.append(token_ids.astype(np.int32, copy=False))
-            logprob_rows.append(logprobs.astype(np.float32, copy=False))
-            rank_rows.append(row.sampled_token_ranks.astype(np.int32, copy=False))
-
-        return LogprobsLists(
-            logprob_token_ids=np.concatenate(token_rows, axis=0),
-            logprobs=np.concatenate(logprob_rows, axis=0),
-            sampled_token_ranks=np.concatenate(rank_rows, axis=0),
-            cu_num_generated_tokens=None,
-        )
+        return SamplingBatch.merge_logprobs_rows(self.sample_logprobs)
 
     def has_paged_work(self) -> bool:
         """Return whether this step has any paged execution work."""

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -5,11 +5,14 @@ Pure functions: logits in, token IDs out.  No model runner state accessed.
 """
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import mlx.core as mx
+import numpy as np
 import torch
 from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
+from vllm.v1.outputs import LogprobsLists
 from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
@@ -17,6 +20,28 @@ from vllm.v1.sample.sampler import Sampler
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 
 GREEDY_TEMPERATURE_EPS = 1e-5
+
+
+def _num_sample_logprobs(sampling_params: SamplingParams) -> int | None:
+    """Return requested sample logprobs across supported vLLM versions."""
+    num_logprobs = getattr(sampling_params, "num_logprobs", None)
+    if num_logprobs is not None:
+        return num_logprobs
+
+    logprobs = getattr(sampling_params, "logprobs", None)
+    if logprobs is not None:
+        return logprobs
+
+    logprob_token_ids = getattr(sampling_params, "logprob_token_ids", None)
+    return len(logprob_token_ids) if logprob_token_ids else None
+
+
+@dataclass(frozen=True)
+class SamplingResult:
+    """Sampled token ids plus optional vLLM logprobs rows."""
+
+    token_ids: list[int]
+    logprobs: LogprobsLists | None = None
 
 
 class SamplingBatch:
@@ -86,6 +111,35 @@ class SamplingBatch:
             for sampling_params in self.sampling_params_list
         )
 
+    @property
+    def max_num_logprobs(self) -> int | None:
+        """Return the batch-wide sample-logprobs request, if any."""
+        requested = [
+            num_logprobs
+            for sampling_params in self.sampling_params_list
+            if (num_logprobs := _num_sample_logprobs(sampling_params)) is not None
+        ]
+        if not requested:
+            return None
+        if any(num_logprobs == -1 for num_logprobs in requested):
+            # vLLM's generic Sampler returns full-vocab logprobs for -1
+            # without token ids/ranks. Ask for top-vocab instead so the engine
+            # receives the same token-id/rank shape as ordinary sample logprobs.
+            return self.vocab_size
+        return max(requested)
+
+    @property
+    def needs_logprobs(self) -> bool:
+        return self.max_num_logprobs is not None
+
+    def _make_logprob_token_ids(self) -> dict[int, list[int]] | None:
+        logprob_token_ids: dict[int, list[int]] = {}
+        for i, sampling_params in enumerate(self.sampling_params_list):
+            token_ids = getattr(sampling_params, "logprob_token_ids", None)
+            if token_ids:
+                logprob_token_ids[i] = list(token_ids)
+        return logprob_token_ids or None
+
     @staticmethod
     def can_use_native_greedy(
         sampling_params_list: Sequence[SamplingParams],
@@ -98,6 +152,7 @@ class SamplingBatch:
             and sampling_params.frequency_penalty == 0.0
             and sampling_params.presence_penalty == 0.0
             and sampling_params.repetition_penalty == 1.0
+            and _num_sample_logprobs(sampling_params) is None
             for sampling_params in sampling_params_list
         )
 
@@ -190,7 +245,7 @@ class SamplingBatch:
             top_p=self._make_top_p(),
             top_k=self._make_top_k(),
             generators=self.generators,
-            max_num_logprobs=None,
+            max_num_logprobs=self.max_num_logprobs,
             prompt_token_ids=self._make_prompt_token_ids(),
             output_token_ids=self.output_token_id_lists,
             frequency_penalties=frequency_penalties,
@@ -200,6 +255,7 @@ class SamplingBatch:
             allowed_token_ids_mask=None,
             bad_words_token_ids={},
             logitsprocs=self.logitsprocs,
+            logprob_token_ids=self._make_logprob_token_ids(),
         )
 
 
@@ -218,24 +274,93 @@ def sample_from_logits(
     batch: SamplingBatch,
     sampler: Sampler,
     device: torch.device,
-) -> list[int]:
+) -> SamplingResult:
     """Sample tokens from pre-sliced 2D logits ``(batch_size, vocab)``.
 
     Single entry point for all sampling paths.  Chooses native MLX greedy
-    when possible, otherwise bridges to the vLLM torch sampler.
+    when possible, otherwise bridges to the vLLM torch sampler. Requests that
+    need sample logprobs must use the vLLM sampler so ``ModelRunnerOutput`` can
+    satisfy the OpenAI serving contract.
     """
-    if batch.all_greedy and batch.no_top_k and batch.no_top_p and batch.no_penalties:
+    if (
+        batch.all_greedy
+        and batch.no_top_k
+        and batch.no_top_p
+        and batch.no_penalties
+        and not batch.needs_logprobs
+    ):
         tokens = _mlx_greedy_sample(logits_2d)
         mx.eval(tokens)
         if tokens.ndim == 0:
-            return [int(tokens.item())]
-        return tokens.tolist()  # type: ignore[return-value]
+            return SamplingResult([int(tokens.item())])
+        return SamplingResult(tokens.tolist())  # type: ignore[arg-type]
 
     mx.eval(logits_2d)
     logits_torch = mlx_to_torch(logits_2d.astype(mx.float32), device=device)
     metadata = batch.make_sampling_metadata()
     output = sampler.forward(logits_torch, metadata)
-    return output.sampled_token_ids[:, 0].tolist()
+    logprobs = (
+        output.logprobs_tensors.tolists()
+        if output.logprobs_tensors is not None
+        else None
+    )
+    return SamplingResult(output.sampled_token_ids[:, 0].tolist(), logprobs)
+
+
+def merge_logprobs_rows(
+    rows: Sequence[LogprobsLists | None],
+) -> LogprobsLists | None:
+    """Merge per-output-slot logprob rows into one ``LogprobsLists``.
+
+    ``ModelRunnerOutput.logprobs`` is indexed by request output index. When one
+    request in the step asks for logprobs, all earlier output slots still need a
+    row so later requests slice the correct position.
+    """
+    present_rows = [row for row in rows if row is not None]
+    if not present_rows:
+        return None
+
+    max_width = max(row.logprob_token_ids.shape[1] for row in present_rows)
+    token_rows: list[np.ndarray] = []
+    logprob_rows: list[np.ndarray] = []
+    rank_rows: list[np.ndarray] = []
+
+    for row in rows:
+        if row is None:
+            token_rows.append(np.zeros((1, max_width), dtype=np.int32))
+            logprob_rows.append(
+                np.full((1, max_width), float("-inf"), dtype=np.float32)
+            )
+            rank_rows.append(np.zeros((1,), dtype=np.int32))
+            continue
+
+        token_ids = row.logprob_token_ids
+        logprobs = row.logprobs
+        if token_ids.shape[1] < max_width:
+            pad_width = max_width - token_ids.shape[1]
+            token_ids = np.pad(
+                token_ids,
+                ((0, 0), (0, pad_width)),
+                mode="constant",
+                constant_values=0,
+            )
+            logprobs = np.pad(
+                logprobs,
+                ((0, 0), (0, pad_width)),
+                mode="constant",
+                constant_values=float("-inf"),
+            )
+
+        token_rows.append(token_ids.astype(np.int32, copy=False))
+        logprob_rows.append(logprobs.astype(np.float32, copy=False))
+        rank_rows.append(row.sampled_token_ranks.astype(np.int32, copy=False))
+
+    return LogprobsLists(
+        logprob_token_ids=np.concatenate(token_rows, axis=0),
+        logprobs=np.concatenate(logprob_rows, axis=0),
+        sampled_token_ranks=np.concatenate(rank_rows, axis=0),
+        cu_num_generated_tokens=None,
+    )
 
 
 def sample_decode_tokens(
@@ -247,7 +372,7 @@ def sample_decode_tokens(
     *,
     vocab_size: int,
     logitsprocs: LogitsProcessors | None = None,
-) -> list[int]:
+) -> SamplingResult:
     """Sample one token per decode request from evaluated logits.
 
     Args:
@@ -260,10 +385,10 @@ def sample_decode_tokens(
         logitsprocs: Optional logits processors.
 
     Returns:
-        List of sampled token IDs, one per decode request.
+        Sampled token IDs and optional logprobs, one row per decode request.
     """
     if not decode_reqs:
-        return []
+        return SamplingResult([])
 
     decode_logits = logits[0, :num_decode, :]  # (num_decode, vocab)
 
@@ -302,7 +427,7 @@ def sample_prefill_tokens(
     *,
     vocab_size: int,
     logitsprocs: LogitsProcessors | None = None,
-) -> list[int]:
+) -> SamplingResult:
     """Sample one token per prefill request from the last logit position.
 
     Args:
@@ -316,9 +441,10 @@ def sample_prefill_tokens(
         logitsprocs: Optional logits processors.
 
     Returns:
-        List of sampled token IDs, one per prefill request.
+        Sampled token IDs and optional logprobs, one row per prefill request.
     """
     prefill_next_tokens: list[int] = []
+    logprobs_rows: list[LogprobsLists | None] = []
     for j, pr in enumerate(prefill_reqs):
         last_idx = cu_seqlens[num_decode + j + 1] - 1
         last_logits = logits[0, last_idx : last_idx + 1, :]  # (1, vocab)
@@ -346,7 +472,12 @@ def sample_prefill_tokens(
             logitsprocs=logitsprocs,
             generators=generators,
         )
-        [next_token] = sample_from_logits(last_logits, batch, sampler, device)
+        result = sample_from_logits(last_logits, batch, sampler, device)
+        [next_token] = result.token_ids
         prefill_next_tokens.append(next_token)
+        logprobs_rows.append(result.logprobs)
 
-    return prefill_next_tokens
+    return SamplingResult(
+        prefill_next_tokens,
+        merge_logprobs_rows(logprobs_rows),
+    )

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -22,22 +22,8 @@ from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 GREEDY_TEMPERATURE_EPS = 1e-5
 
 
-def _num_sample_logprobs(sampling_params: SamplingParams) -> int | None:
-    """Return requested sample logprobs across supported vLLM versions."""
-    num_logprobs = getattr(sampling_params, "num_logprobs", None)
-    if num_logprobs is not None:
-        return num_logprobs
-
-    logprobs = getattr(sampling_params, "logprobs", None)
-    if logprobs is not None:
-        return logprobs
-
-    logprob_token_ids = getattr(sampling_params, "logprob_token_ids", None)
-    return len(logprob_token_ids) if logprob_token_ids else None
-
-
 @dataclass(frozen=True)
-class SamplingResult:
+class _SamplingResult:
     """Sampled token ids plus optional vLLM logprobs rows."""
 
     token_ids: list[int]
@@ -115,30 +101,66 @@ class SamplingBatch:
     def max_num_logprobs(self) -> int | None:
         """Return the batch-wide sample-logprobs request, if any."""
         requested = [
-            num_logprobs
+            sampling_params.logprobs
             for sampling_params in self.sampling_params_list
-            if (num_logprobs := _num_sample_logprobs(sampling_params)) is not None
+            if sampling_params.logprobs is not None
         ]
-        if not requested:
-            return None
-        if any(num_logprobs == -1 for num_logprobs in requested):
-            # vLLM's generic Sampler returns full-vocab logprobs for -1
-            # without token ids/ranks. Ask for top-vocab instead so the engine
-            # receives the same token-id/rank shape as ordinary sample logprobs.
-            return self.vocab_size
-        return max(requested)
+        return max(requested) if requested else None
 
     @property
     def needs_logprobs(self) -> bool:
         return self.max_num_logprobs is not None
 
-    def _make_logprob_token_ids(self) -> dict[int, list[int]] | None:
-        logprob_token_ids: dict[int, list[int]] = {}
-        for i, sampling_params in enumerate(self.sampling_params_list):
-            token_ids = getattr(sampling_params, "logprob_token_ids", None)
-            if token_ids:
-                logprob_token_ids[i] = list(token_ids)
-        return logprob_token_ids or None
+    @staticmethod
+    def merge_logprobs_rows(
+        rows: Sequence[LogprobsLists | None],
+    ) -> LogprobsLists | None:
+        """Merge per-request sample logprobs from sampling calls."""
+        present_rows = [row for row in rows if row is not None]
+        if not present_rows:
+            return None
+
+        max_width = max(row.logprob_token_ids.shape[1] for row in present_rows)
+        token_rows: list[np.ndarray] = []
+        logprob_rows: list[np.ndarray] = []
+        rank_rows: list[np.ndarray] = []
+
+        for row in rows:
+            if row is None:
+                token_rows.append(np.zeros((1, max_width), dtype=np.int32))
+                logprob_rows.append(
+                    np.full((1, max_width), float("-inf"), dtype=np.float32)
+                )
+                rank_rows.append(np.zeros((1,), dtype=np.int32))
+                continue
+
+            token_ids = row.logprob_token_ids
+            logprobs = row.logprobs
+            if token_ids.shape[1] < max_width:
+                pad_width = max_width - token_ids.shape[1]
+                token_ids = np.pad(
+                    token_ids,
+                    ((0, 0), (0, pad_width)),
+                    mode="constant",
+                    constant_values=0,
+                )
+                logprobs = np.pad(
+                    logprobs,
+                    ((0, 0), (0, pad_width)),
+                    mode="constant",
+                    constant_values=float("-inf"),
+                )
+
+            token_rows.append(token_ids.astype(np.int32, copy=False))
+            logprob_rows.append(logprobs.astype(np.float32, copy=False))
+            rank_rows.append(row.sampled_token_ranks.astype(np.int32, copy=False))
+
+        return LogprobsLists(
+            logprob_token_ids=np.concatenate(token_rows, axis=0),
+            logprobs=np.concatenate(logprob_rows, axis=0),
+            sampled_token_ranks=np.concatenate(rank_rows, axis=0),
+            cu_num_generated_tokens=None,
+        )
 
     @staticmethod
     def can_use_native_greedy(
@@ -152,7 +174,7 @@ class SamplingBatch:
             and sampling_params.frequency_penalty == 0.0
             and sampling_params.presence_penalty == 0.0
             and sampling_params.repetition_penalty == 1.0
-            and _num_sample_logprobs(sampling_params) is None
+            and sampling_params.logprobs is None
             for sampling_params in sampling_params_list
         )
 
@@ -255,7 +277,7 @@ class SamplingBatch:
             allowed_token_ids_mask=None,
             bad_words_token_ids={},
             logitsprocs=self.logitsprocs,
-            logprob_token_ids=self._make_logprob_token_ids(),
+            logprob_token_ids=None,
         )
 
 
@@ -274,7 +296,7 @@ def sample_from_logits(
     batch: SamplingBatch,
     sampler: Sampler,
     device: torch.device,
-) -> SamplingResult:
+) -> _SamplingResult:
     """Sample tokens from pre-sliced 2D logits ``(batch_size, vocab)``.
 
     Single entry point for all sampling paths.  Chooses native MLX greedy
@@ -292,8 +314,8 @@ def sample_from_logits(
         tokens = _mlx_greedy_sample(logits_2d)
         mx.eval(tokens)
         if tokens.ndim == 0:
-            return SamplingResult([int(tokens.item())])
-        return SamplingResult(tokens.tolist())  # type: ignore[arg-type]
+            return _SamplingResult([int(tokens.item())])
+        return _SamplingResult(tokens.tolist())  # type: ignore[arg-type]
 
     mx.eval(logits_2d)
     logits_torch = mlx_to_torch(logits_2d.astype(mx.float32), device=device)
@@ -304,63 +326,7 @@ def sample_from_logits(
         if output.logprobs_tensors is not None
         else None
     )
-    return SamplingResult(output.sampled_token_ids[:, 0].tolist(), logprobs)
-
-
-def merge_logprobs_rows(
-    rows: Sequence[LogprobsLists | None],
-) -> LogprobsLists | None:
-    """Merge per-output-slot logprob rows into one ``LogprobsLists``.
-
-    ``ModelRunnerOutput.logprobs`` is indexed by request output index. When one
-    request in the step asks for logprobs, all earlier output slots still need a
-    row so later requests slice the correct position.
-    """
-    present_rows = [row for row in rows if row is not None]
-    if not present_rows:
-        return None
-
-    max_width = max(row.logprob_token_ids.shape[1] for row in present_rows)
-    token_rows: list[np.ndarray] = []
-    logprob_rows: list[np.ndarray] = []
-    rank_rows: list[np.ndarray] = []
-
-    for row in rows:
-        if row is None:
-            token_rows.append(np.zeros((1, max_width), dtype=np.int32))
-            logprob_rows.append(
-                np.full((1, max_width), float("-inf"), dtype=np.float32)
-            )
-            rank_rows.append(np.zeros((1,), dtype=np.int32))
-            continue
-
-        token_ids = row.logprob_token_ids
-        logprobs = row.logprobs
-        if token_ids.shape[1] < max_width:
-            pad_width = max_width - token_ids.shape[1]
-            token_ids = np.pad(
-                token_ids,
-                ((0, 0), (0, pad_width)),
-                mode="constant",
-                constant_values=0,
-            )
-            logprobs = np.pad(
-                logprobs,
-                ((0, 0), (0, pad_width)),
-                mode="constant",
-                constant_values=float("-inf"),
-            )
-
-        token_rows.append(token_ids.astype(np.int32, copy=False))
-        logprob_rows.append(logprobs.astype(np.float32, copy=False))
-        rank_rows.append(row.sampled_token_ranks.astype(np.int32, copy=False))
-
-    return LogprobsLists(
-        logprob_token_ids=np.concatenate(token_rows, axis=0),
-        logprobs=np.concatenate(logprob_rows, axis=0),
-        sampled_token_ranks=np.concatenate(rank_rows, axis=0),
-        cu_num_generated_tokens=None,
-    )
+    return _SamplingResult(output.sampled_token_ids[:, 0].tolist(), logprobs)
 
 
 def sample_decode_tokens(
@@ -372,7 +338,7 @@ def sample_decode_tokens(
     *,
     vocab_size: int,
     logitsprocs: LogitsProcessors | None = None,
-) -> SamplingResult:
+) -> _SamplingResult:
     """Sample one token per decode request from evaluated logits.
 
     Args:
@@ -388,7 +354,7 @@ def sample_decode_tokens(
         Sampled token IDs and optional logprobs, one row per decode request.
     """
     if not decode_reqs:
-        return SamplingResult([])
+        return _SamplingResult([])
 
     decode_logits = logits[0, :num_decode, :]  # (num_decode, vocab)
 
@@ -427,7 +393,7 @@ def sample_prefill_tokens(
     *,
     vocab_size: int,
     logitsprocs: LogitsProcessors | None = None,
-) -> SamplingResult:
+) -> _SamplingResult:
     """Sample one token per prefill request from the last logit position.
 
     Args:
@@ -477,7 +443,7 @@ def sample_prefill_tokens(
         prefill_next_tokens.append(next_token)
         logprobs_rows.append(result.logprobs)
 
-    return SamplingResult(
+    return _SamplingResult(
         prefill_next_tokens,
-        merge_logprobs_rows(logprobs_rows),
+        SamplingBatch.merge_logprobs_rows(logprobs_rows),
     )

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -105,6 +105,8 @@ class SamplingBatch:
             for sampling_params in self.sampling_params_list
             if sampling_params.logprobs is not None
         ]
+        if any(num_logprobs == -1 for num_logprobs in requested):
+            raise NotImplementedError("Metal runner does not support logprobs=-1 yet")
         return max(requested) if requested else None
 
     @property


### PR DESCRIPTION
The Metal runner previously sampled tokens but always returned `logprobs=None` in `ModelRunnerOutput`, even when
requests asked for `logprobs` / `top_logprobs`. The OpenAI serving layer then attempted to index missing per-token
logprobs and returned `500 Internal Server Error`.

This PR:
- Passes requested sample logprobs into `SamplingMetadata.max_num_logprobs`.
- Routes greedy requests that need logprobs through the vLLM sampler instead of the MLX argmax fast path.
- Propagates sampler `LogprobsLists` into `ModelRunnerOutput.logprobs`.
- Preserves output-slot alignment for paged prefill/decode batches.
- Keeps `prompt_logprobs` out of scope.

Fixes #331 