### PR TITLE
docs: verify SmolLM3-3B-4bit on M2 MacBook Air (16GB)

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -41,3 +41,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
 | Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ | [#324](https://github.com/vllm-project/vllm-metal/pull/324) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |
 | Qwen2.5-3B-Instruct | ✅ | GQA (paged) | ✅ | [#323](https://github.com/vllm-project/vllm-metal/pull/323) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-3B-Instruct-4bit` |
+| SmolLM3 | ✅ | GQA (paged) | ✅ |  | Validated on MacBook Air (Apple M2, 16 GB) with `mlx-community/SmolLM3-3B-4bit` |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -41,4 +41,4 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
 | Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ | [#324](https://github.com/vllm-project/vllm-metal/pull/324) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |
 | Qwen2.5-3B-Instruct | ✅ | GQA (paged) | ✅ | [#323](https://github.com/vllm-project/vllm-metal/pull/323) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-3B-Instruct-4bit` |
-| SmolLM3 | ✅ | GQA (paged) | ✅ |  | Validated on MacBook Air (Apple M2, 16 GB) with `mlx-community/SmolLM3-3B-4bit` |
+| SmolLM3-3B | ✅ | GQA (paged) | ✅ | [#334](https://github.com/vllm-project/vllm-metal/pull/334) | Validated on MacBook Air (Apple M2, 16 GB) with `mlx-community/SmolLM3-3B-4bit` |


### PR DESCRIPTION
## Summary

Verified `mlx-community/SmolLM3-3B-4bit` on vllm-metal.

This adds a `SmolLM3` row to `docs/supported_models.md`.

Refs #289.

## Environment

- Hardware: Apple M2 MacBook Air, 16 GB unified memory
- macOS: 15.6 (24G84)
- vllm-metal commit: `1b0496e` (`upstream/main`)
- vLLM: `0.20.0+cpu`
- mlx-lm: `0.31.3`
- mlx: `0.31.2`
- mlx-metal: `0.31.2`
- transformers: `5.7.0`

## Verification

Server command:

```bash
PYTHONPATH=/path/to/vllm-metal \
GLOO_SOCKET_IFNAME=lo0 \
VLLM_HOST_IP=127.0.0.1 \
VLLM_ENABLE_V1_MULTIPROCESSING=0 \
VLLM_METAL_USE_PAGED_ATTENTION=1 \
VLLM_METAL_USE_MLX=1 \
VLLM_METAL_MEMORY_FRACTION=0.55 \
vllm serve mlx-community/SmolLM3-3B-4bit \
  --host 127.0.0.1 \
  --port 8033 \
  --max-model-len 4096 \
  --max-num-seqs 1
```

Relevant startup logs:

```text
Resolved architecture: SmolLM3ForCausalLM
Using max model len 4096
Paged attention memory breakdown: metal_limit=11.45GB, fraction=0.55, usable_metal=6.30GB, model_memory=1.73GB, overhead=0.61GB, kv_budget=3.96GB, per_block_bytes=1179648, num_blocks=3355, max_tokens_cached=53680
KV cache: 3957.7 MB (36 layers, 3355 blocks, 16 tokens/block)
Paged attention enabled: 36 layers patched, 3355 blocks allocated (block_size=16, mla=False, turboquant=False, k_quant=N/A)
Native paged-attention Metal kernels loaded
Application startup complete
```

API checks:

- `/health`: HTTP 200
- `/v1/models`: HTTP 200
- `/v1/completions`: HTTP 200
- `/v1/chat/completions`: HTTP 200

Completion request:

```bash
curl -sS http://127.0.0.1:8033/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/SmolLM3-3B-4bit",
    "prompt": "The capital of France is",
    "max_tokens": 40,
    "temperature": 0
  }'
```

Output included:

```text
Paris, which is located in the north of the country.
```

Chat request:

```bash
curl -sS http://127.0.0.1:8033/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "mlx-community/SmolLM3-3B-4bit",
    "messages": [
      {"role": "system", "content": "/no_think"},
      {"role": "user", "content": "Explain why the sky appears blue in two sentences."}
    ],
    "max_tokens": 80,
    "temperature": 0
  }'
```

Output:

```text
The sky appears blue because the Earth's atmosphere scatters shorter-wavelength blue light more than longer-wavelength colors, like red and orange, due to Rayleigh scattering, which is why the sky is predominantly blue.
```

Note: SmolLM3's bundled chat template defaults to thinking mode. The chat smoke test uses `/no_think` to request a concise final answer. The plain completions endpoint also returned coherent decoded text.