### PR TITLE
[kernel] Add encoder varlen attention (Qwen2.5-VL et al.)

### DIFF
--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -84,6 +84,21 @@ def _build_gdn_source() -> str:
     return "\n".join(parts)
 
 
+def _build_encoder_varlen_source() -> str:
+    """Concatenate utils + encoder_varlen_attention into a single source.
+
+    utils.metal is mandatory ahead of the kernel: it defines bfloat16_t and
+    the shared simd / numeric helpers used by the kernel.  A single-file
+    read of encoder_varlen_attention.metal alone is fragile or fails to
+    compile for the bf16 specializations.
+    """
+    parts = [
+        _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "encoder_varlen_attention.metal"),
+    ]
+    return "\n".join(parts)
+
+
 def metal_unified_attention(
     q,  # [total_q_tokens, num_q_heads, head_size]
     k,  # [num_blocks, block_size, num_kv_heads, head_size]
@@ -226,6 +241,34 @@ def get_ops() -> ModuleType:
     gdn_src = _build_gdn_source()
     mod.init_gdn_library(gdn_src)
 
+    # The encoder-varlen library is compiled lazily on first call to
+    # encoder_varlen_attention() — see _ensure_encoder_varlen_library.
+    # Paged-only and text-only callers share this module and never invoke
+    # the encoder helper, so eager init here would charge them the encoder
+    # shader's compile cost on every cold start for no benefit.
+
     _ops_module = mod
     logger.info("Native paged-attention Metal kernels loaded")
     return mod
+
+
+# Tracks whether init_encoder_varlen_library has been called on the C++
+# extension yet.  The encoder shader is compiled lazily on first invocation
+# of encoder_varlen_attention() so paged-only and text-only consumers don't
+# pay its compile cost on cold start.
+_encoder_varlen_loaded: bool = False
+
+
+def _ensure_encoder_varlen_library() -> ModuleType:
+    """Return the ops module with the encoder-varlen Metal library compiled.
+
+    JIT-compiles the encoder-varlen shader on first call and caches the
+    result for the lifetime of the process.  Subsequent calls hit MLX's
+    library cache and are effectively free.
+    """
+    global _encoder_varlen_loaded
+    ops = get_ops()
+    if not _encoder_varlen_loaded:
+        ops.init_encoder_varlen_library(_build_encoder_varlen_source())
+        _encoder_varlen_loaded = True
+    return ops

--- a/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
+++ b/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Dense non-causal varlen encoder attention kernel.
+//
+// Grid:           (total_tokens, num_q_heads, 1)
+// Threadgroup:    (32, 1, 1) — exactly one SIMD-group on Apple Silicon.
+//
+// One threadgroup computes one (query_token, q_head) output vector via a
+// two-pass safe softmax (max → renormalize; distinct from the running
+// (m, l, O) online softmax in sibling kernels_v2/pagedattention.metal):
+//   pass 1 — segment-wide max via lane-strided keys + simd_max.
+//   pass 2 — denom + per-dim numerator partials, simd_sum reductions, lane-
+//            strided writeback (lane d % 32 owns dim d).
+//
+// Per-lane register state across both passes is q_reg[HEAD_DIM] (loaded
+// once and reused) plus num_partial[HEAD_DIM] (live in pass 2), both fp32.
+// At HEAD_DIM=128 that is ~1 KB/lane plus a handful of scalars, which must
+// fit in the per-lane register file on Apple Silicon.  The perfgate
+// (compile-smoke + perf-ratio) bounds register-spill regressions against
+// this ceiling.
+//
+// Softmax runs in log2 space: scale is folded as `scale * log2(e)` at the
+// top of the kernel so the pre-max score is already log2-scaled, and the
+// pass-2 weight is `exp2(score - seg_max)` (1-instruction on Apple GPUs)
+// rather than base-e `exp`.  Math identity: exp(qk*scale - m) ==
+// exp2(qk*scale*log2e - m) when m has been accumulated in log2-scaled
+// space (which it has — pass 1 takes the max of qk*scale_log2).  Matches
+// the convention in sibling kernels_v2/pagedattention.metal.
+//
+// utils.metal is concatenated ahead of this file by the source builder in
+// vllm_metal.metal.__init__, so bfloat16_t is available.
+
+#include <metal_stdlib>
+#include <metal_simdgroup>
+
+using namespace metal;
+
+// Hand-mirrored on the C++ side at paged_ops.cpp.  Field order is part of
+// the ABI; do not reorder without updating the C++ struct in lockstep.
+struct EncoderVarlenParams {
+    int   num_q_heads;
+    int   num_kv_heads;
+    int   total_tokens;
+    int   num_segments;   // == cu_seqlens.shape[0] - 1; binary-search bound.
+    int   max_seqlen;     // Reserved ABI / launch hint only; kernel must not
+                          // read this unless host-side is_equivalent is updated.
+    float softmax_scale;
+};
+
+// Metal-side ABI tripwire mirroring the C++ static_asserts in paged_ops.cpp.
+// needs_rebuild() in build.py only stats the
+// .cpp, so a .metal-only struct edit would JIT-compile cleanly and
+// silently misdecode the C++ bytes; this size check fires at JIT time
+// when the .metal struct drifts from the C++ side.  sizeof catches add /
+// remove / type-widen drift; same-size reorders still need the C++-side
+// per-field offsetof checks (asymmetric on purpose — Metal does not
+// expose the standard `offsetof` macro through metal_stdlib).
+static_assert(sizeof(EncoderVarlenParams) == 24,
+              "EncoderVarlenParams ABI drift: size diverges from "
+              "paged_ops.cpp; update both files in lockstep.");
+
+// Binary-search cu_seqlens to find the segment containing token_idx.
+// cu_seqlens is sorted ascending: [0, len_0, len_0+len_1, ..., total_tokens].
+// Returns seg such that cu_seqlens[seg] <= token_idx < cu_seqlens[seg + 1].
+inline int find_segment(const device int* cu_seqlens,
+                        int token_idx, int num_segments) {
+    int lo = 0, hi = num_segments;
+    while (lo < hi) {
+        int mid = (lo + hi + 1) / 2;
+        if (cu_seqlens[mid] <= token_idx) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return lo;
+}
+
+template <typename T, uint HEAD_DIM>
+[[kernel]] void encoder_varlen_attention_kernel(
+    device const T*       q           [[buffer(0)]],
+    device const T*       k           [[buffer(1)]],
+    device const T*       v           [[buffer(2)]],
+    device const int*     cu_seqlens  [[buffer(3)]],
+    device       T*       out         [[buffer(4)]],
+    constant     EncoderVarlenParams& params [[buffer(5)]],
+    uint3 tg_id     [[threadgroup_position_in_grid]],
+    uint  simd_lane [[thread_index_in_simdgroup]])
+{
+    const int token_idx = int(tg_id.x);
+    const int head_idx  = int(tg_id.y);
+    const int num_q     = params.num_q_heads;
+    const int num_kv    = params.num_kv_heads;
+    // Fold log2(e) into the scale so the pre-max score is already in
+    // log2 space and pass-2 can use exp2 (see top-of-file comment).
+    const float scale   = params.softmax_scale * M_LOG2E_F;
+
+    const int seg     = find_segment(cu_seqlens, token_idx, params.num_segments);
+    const int seg_lo  = cu_seqlens[seg];
+    const int seg_hi  = cu_seqlens[seg + 1];
+
+    // Q pointer for this (token, head).  v1 requires num_q_heads == num_kv_heads
+    // (validated host-side).  K/V indexing already uses the num_kv stride, but
+    // the GQA follow-up still needs a kernel edit to map head_idx -> kv_head_idx.
+    const device T* q_ptr = q + (token_idx * num_q + head_idx) * HEAD_DIM;
+
+    // v1 cost (deferred to the GQA-mapping follow-up):
+    //   1. Every lane in the SIMD-group loads the full Q vector below — 32×
+    //      redundant device traffic.  Successor should load HEAD_DIM/32 dims
+    //      per lane and broadcast the rest via simd_shuffle.
+    //   2. Pass 2 below recomputes Q·K rather than caching pass-1 dot
+    //      products.  A threadgroup-scratch (or shuffle-based) cache would
+    //      halve the pass-2 K-stream traffic.
+    //   3. The pass-2 numerator reduction loop runs one full-warp simd_sum
+    //      per output dim — at HEAD_DIM=128 that is 128 reductions where
+    //      only one lane consumes each result (the writer selected by
+    //      `simd_lane == d % 32`).  A reduce-scatter or shuffle-rotated
+    //      layout where each lane owns disjoint dim subsets would cut the
+    //      reduction count; the exact ratio depends on the chosen design.
+    // Load Q into per-lane fp32 register array.
+    float q_reg[HEAD_DIM];
+    for (uint d = 0; d < HEAD_DIM; ++d) {
+        q_reg[d] = float(q_ptr[d]);
+    }
+
+    // ---------------------------------------------------------------
+    // Pass 1: segment-wide max.
+    // ---------------------------------------------------------------
+    float lane_max = -INFINITY;
+    for (int j = seg_lo + int(simd_lane); j < seg_hi; j += 32) {
+        const device T* k_ptr = k + (j * num_kv + head_idx) * HEAD_DIM;
+        float qk = 0.0f;
+        for (uint d = 0; d < HEAD_DIM; ++d) {
+            qk += q_reg[d] * float(k_ptr[d]);
+        }
+        qk *= scale;
+        lane_max = max(lane_max, qk);
+    }
+    const float seg_max = simd_max(lane_max);
+
+    // ---------------------------------------------------------------
+    // Pass 2: denom + per-dim numerator partials.
+    //
+    // Each lane re-streams *its assigned keys only* (lane-strided by 32) and
+    // updates a HEAD_DIM-wide per-lane numerator vector.  Every lane updates
+    // every dim because every output dim needs every assigned key's
+    // contribution.
+    // ---------------------------------------------------------------
+    float denom_partial = 0.0f;
+    float num_partial[HEAD_DIM];
+    for (uint d = 0; d < HEAD_DIM; ++d) {
+        num_partial[d] = 0.0f;
+    }
+
+    for (int j = seg_lo + int(simd_lane); j < seg_hi; j += 32) {
+        const device T* k_ptr = k + (j * num_kv + head_idx) * HEAD_DIM;
+        const device T* v_ptr = v + (j * num_kv + head_idx) * HEAD_DIM;
+        float qk = 0.0f;
+        for (uint d = 0; d < HEAD_DIM; ++d) {
+            qk += q_reg[d] * float(k_ptr[d]);
+        }
+        qk = qk * scale - seg_max;
+        const float w = exp2(qk);
+        denom_partial += w;
+        for (uint d = 0; d < HEAD_DIM; ++d) {
+            num_partial[d] += w * float(v_ptr[d]);
+        }
+    }
+
+    const float denom = simd_sum(denom_partial);
+    const float inv_denom = 1.0f / denom;
+
+    device T* out_ptr = out + (token_idx * num_q + head_idx) * HEAD_DIM;
+
+    // Lane-strided writeback: lane (d % 32) owns dim d.  For HEAD_DIM=80 the
+    // count is uneven (lanes 0..15 own 3 dims, lanes 16..31 own 2), but the
+    // (simd_lane == d % 32) form handles that without a per-head-dim branch.
+    for (uint d = 0; d < HEAD_DIM; ++d) {
+        const float full_num_d = simd_sum(num_partial[d]);
+        if (simd_lane == (d % 32)) {
+            out_ptr[d] = T(full_num_d * inv_denom);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Specialization macros — generates 12 [[host_name]] instantiations:
+//   {f16, bf16, f32} × {64, 80, 96, 128}
+//
+// host_name spelling is part of the ABI; the C++ dispatch helper builds the
+// same kname string from (dtype_tag, head_dim).  An off-by-one between this
+// macro and the C++ name builder silently mis-binds an argument with no
+// Metal-side error.
+// ---------------------------------------------------------------------------
+
+#define instantiate_encoder_varlen_attention_inner(type, type_tag, head_dim) \
+    template [[host_name("encoder_varlen_attention_" #type_tag "_" #head_dim)]] \
+    [[kernel]] void encoder_varlen_attention_kernel<type, head_dim>( \
+        device const type*       q           [[buffer(0)]], \
+        device const type*       k           [[buffer(1)]], \
+        device const type*       v           [[buffer(2)]], \
+        device const int*        cu_seqlens  [[buffer(3)]], \
+        device       type*       out         [[buffer(4)]], \
+        constant     EncoderVarlenParams& params [[buffer(5)]], \
+        uint3 tg_id     [[threadgroup_position_in_grid]], \
+        uint  simd_lane [[thread_index_in_simdgroup]]);
+
+#define instantiate_encoder_varlen_attention(type, type_tag) \
+    instantiate_encoder_varlen_attention_inner(type, type_tag, 64)  \
+    instantiate_encoder_varlen_attention_inner(type, type_tag, 80)  \
+    instantiate_encoder_varlen_attention_inner(type, type_tag, 96)  \
+    instantiate_encoder_varlen_attention_inner(type, type_tag, 128)
+
+instantiate_encoder_varlen_attention(half,       f16)
+instantiate_encoder_varlen_attention(bfloat16_t, bf16)
+instantiate_encoder_varlen_attention(float,      f32)

--- a/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
+++ b/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
@@ -1,37 +1,61 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Dense non-causal varlen encoder attention kernel.
+// Dense non-causal varlen encoder attention kernel — flash-attention with
+// register-resident MMA fragments and in-register online softmax, mirroring
+// MLX's `steel_attention` kernel structure (BQ=32, BK=32, WM=4, WN=1).
 //
-// Grid:           (total_tokens, num_q_heads, 1)
-// Threadgroup:    (32, 1, 1) — exactly one SIMD-group on Apple Silicon.
+// M3 redesign vs. M2
+//   • All MMA tiles (Q, K, S, V, O) live as per-lane `vec<float,2>` fragments
+//     using Apple's simdgroup_matrix<float,8,8> lane layout (the same one
+//     MLX targets via BaseMMAFrag::get_coord).  Each lane holds 1 row × 2
+//     contiguous cols of every 8x8 frag it participates in.
+//   • Softmax row reductions run in registers via simd_shuffle_xor(1) +
+//     simd_shuffle_xor(8) — the two-shuffle butterfly that traverses the
+//     four lanes that share a row in the simdgroup_matrix layout.  No
+//     more s_buf round-trip via simdgroup_store / simdgroup_load.
+//   • α-rescale of the running O accumulator is now a per-lane scalar
+//     `o_frags[d] *= factor` instead of a `diag(α) @ O` 8x8 MMA.  At
+//     HEAD_DIM=128 that's TD=16 register-vec multiplies replacing 16 MMAs.
+//   • Threadgroup memory uses pad = 16/sizeof(T) on the inner stride
+//     (matches MLX's padQ / padK / padV) to avoid bank conflicts on
+//     simdgroup-cooperative loads.
+//   • V_smem is now row-major [K_TILE, HEAD_DIM]  (M2 had it transposed
+//     as a hold-over from the iter1 manual kernel).
 //
-// One threadgroup computes one (query_token, q_head) output vector via a
-// two-pass safe softmax (max → renormalize; distinct from the running
-// (m, l, O) online softmax in sibling kernels_v2/pagedattention.metal):
-//   pass 1 — segment-wide max via lane-strided keys + simd_max.
-//   pass 2 — denom + per-dim numerator partials, simd_sum reductions, lane-
-//            strided writeback (lane d % 32 owns dim d).
+// Per-lane state
+//   q_frag:       vec<float,2>      reloaded each `dd` (Q is dim-tiled)
+//   s_frags[TK]:  vec<float,2>[TK]  S = Q @ K^T accumulated across dd
+//   v_frag:       vec<float,2>      reloaded each (id, ik) MMA
+//   o_frags[TD]:  vec<float,2>[TD]  running unnormalised output (fp32)
+//   max_score:    float             online softmax row max
+//   sum_score:    float             online softmax row sum (= l)
 //
-// Per-lane register state across both passes is q_reg[HEAD_DIM] (loaded
-// once and reused) plus num_partial[HEAD_DIM] (live in pass 2), both fp32.
-// At HEAD_DIM=128 that is ~1 KB/lane plus a handful of scalars, which must
-// fit in the per-lane register file on Apple Silicon.  The perfgate
-// (compile-smoke + perf-ratio) bounds register-spill regressions against
-// this ceiling.
+// MMA dispatch identity
+//   simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat) requires
+//   simdgroup_matrix operands.  We marshal `vec<float,2>` ↔
+//   `simdgroup_float8x8::thread_elements()` via a reinterpret_cast.
+//   Apple's simdgroup_matrix<float,8,8> stores exactly two fp32 elements
+//   per lane in a `vec<float,2>` thread_elements slot, so the cast is a
+//   bitwise no-op.
 //
-// Softmax runs in log2 space: scale is folded as `scale * log2(e)` at the
-// top of the kernel so the pre-max score is already log2-scaled, and the
-// pass-2 weight is `exp2(score - seg_max)` (1-instruction on Apple GPUs)
-// rather than base-e `exp`.  Math identity: exp(qk*scale - m) ==
-// exp2(qk*scale*log2e - m) when m has been accumulated in log2-scaled
-// space (which it has — pass 1 takes the max of qk*scale_log2).  Matches
-// the convention in sibling kernels_v2/pagedattention.metal.
+// Lane coord (MLX BaseMMAFrag::get_coord)
+//   const ushort qid = simd_lane_id / 4;
+//   const ushort fm  = (qid & 4) + ((simd_lane_id / 2) % 4);   // 0..7 row
+//   const ushort fn  = (qid & 2) * 2 + (simd_lane_id % 2) * 2; // 0/2/4/6 col
+//   Lane owns frag[fm, fn..fn+1].  Four lanes per row are { l, l^1, l^8,
+//   l^9 } — confirming xor-1 + xor-8 as a 4-way row reduction butterfly.
+//
+// f32 path (`encoder_varlen_attention_manual_kernel`) is unchanged from
+// M2 — fp32 elements double tg-memory pressure and the 32×32 MMA tile
+// blows the 32 KB cap at HEAD_DIM=128, so f32 stays on the smaller-tile
+// manual-SIMD fallback (Q=8, K=16).
 //
 // utils.metal is concatenated ahead of this file by the source builder in
 // vllm_metal.metal.__init__, so bfloat16_t is available.
 
 #include <metal_stdlib>
 #include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
 
 using namespace metal;
 
@@ -42,175 +66,536 @@ struct EncoderVarlenParams {
     int   num_kv_heads;
     int   total_tokens;
     int   num_segments;   // == cu_seqlens.shape[0] - 1; binary-search bound.
-    int   max_seqlen;     // Reserved ABI / launch hint only; kernel must not
-                          // read this unless host-side is_equivalent is updated.
+    int   max_seqlen;     // Drives launch-grid pitch (tiles_per_segment).
     float softmax_scale;
 };
 
 // Metal-side ABI tripwire mirroring the C++ static_asserts in paged_ops.cpp.
-// needs_rebuild() in build.py only stats the
-// .cpp, so a .metal-only struct edit would JIT-compile cleanly and
-// silently misdecode the C++ bytes; this size check fires at JIT time
-// when the .metal struct drifts from the C++ side.  sizeof catches add /
-// remove / type-widen drift; same-size reorders still need the C++-side
-// per-field offsetof checks (asymmetric on purpose — Metal does not
-// expose the standard `offsetof` macro through metal_stdlib).
+// needs_rebuild() in build.py only stats the .cpp, so a .metal-only struct
+// edit would JIT-compile cleanly and silently misdecode the C++ bytes;
+// this size check fires at JIT time when the .metal struct drifts from
+// the C++ side.
 static_assert(sizeof(EncoderVarlenParams) == 24,
               "EncoderVarlenParams ABI drift: size diverges from "
               "paged_ops.cpp; update both files in lockstep.");
 
-// Binary-search cu_seqlens to find the segment containing token_idx.
-// cu_seqlens is sorted ascending: [0, len_0, len_0+len_1, ..., total_tokens].
-// Returns seg such that cu_seqlens[seg] <= token_idx < cu_seqlens[seg + 1].
-inline int find_segment(const device int* cu_seqlens,
-                        int token_idx, int num_segments) {
-    int lo = 0, hi = num_segments;
-    while (lo < hi) {
-        int mid = (lo + hi + 1) / 2;
-        if (cu_seqlens[mid] <= token_idx) {
-            lo = mid;
-        } else {
-            hi = mid - 1;
-        }
-    }
-    return lo;
-}
+// ---------------------------------------------------------------------------
+// MMA kernel — bf16 / f16
+// ---------------------------------------------------------------------------
 
 template <typename T, uint HEAD_DIM>
-[[kernel]] void encoder_varlen_attention_kernel(
+[[kernel]] void encoder_varlen_attention_mma_kernel(
     device const T*       q           [[buffer(0)]],
     device const T*       k           [[buffer(1)]],
     device const T*       v           [[buffer(2)]],
     device const int*     cu_seqlens  [[buffer(3)]],
     device       T*       out         [[buffer(4)]],
     constant     EncoderVarlenParams& params [[buffer(5)]],
-    uint3 tg_id     [[threadgroup_position_in_grid]],
-    uint  simd_lane [[thread_index_in_simdgroup]])
+    uint3 tg_id        [[threadgroup_position_in_grid]],
+    uint  lid          [[thread_index_in_threadgroup]],
+    uint  simd_lane_id [[thread_index_in_simdgroup]],
+    uint  simd_id      [[simdgroup_index_in_threadgroup]])
 {
-    const int token_idx = int(tg_id.x);
-    const int head_idx  = int(tg_id.y);
-    const int num_q     = params.num_q_heads;
-    const int num_kv    = params.num_kv_heads;
-    // Fold log2(e) into the scale so the pre-max score is already in
-    // log2 space and pass-2 can use exp2 (see top-of-file comment).
-    const float scale   = params.softmax_scale * M_LOG2E_F;
+    constexpr uint THREADS    = 256;
+    constexpr uint NUM_SIMDS  = 8;
+    constexpr uint Q_TILE     = 64;
+    constexpr uint K_TILE     = 32;
+    constexpr uint kFragSize  = 8;
+    constexpr uint TQ         = 1;                       // Each simdgroup owns 1×8=8 query rows
+    constexpr uint TK         = K_TILE / kFragSize;       // 4
+    constexpr uint TD         = HEAD_DIM / kFragSize;     // 8 / 10 / 12 / 16
+    static_assert(HEAD_DIM % kFragSize == 0,
+                  "HEAD_DIM must be a multiple of 8 for the 8x8 MMA path");
 
-    const int seg     = find_segment(cu_seqlens, token_idx, params.num_segments);
-    const int seg_lo  = cu_seqlens[seg];
-    const int seg_hi  = cu_seqlens[seg + 1];
+    // Padding in tg memory to avoid bank conflicts on Apple GPU.
+    // pad = 16/sizeof(T) matches MLX's steel_attention padQ/padK/padV
+    // and helps hd64/80/128 by 2–5%.  At HEAD_DIM=96 the padded inner
+    // stride (104 elements / 208 bytes for bf16) is empirically *worse*
+    // than the unpadded (96 / 192 bytes), losing ~8% on the bench —
+    // 96 is exactly 1.5 bank cycles wide so the unpadded layout already
+    // distributes lanes across banks evenly, and the +8 extra elements
+    // both inflate tg-memory pressure and shift the bank pattern in a
+    // way that re-introduces conflicts.  Disabling padding for hd96
+    // recovers that loss.  Verified by ablation 2026-05-03.
+    constexpr uint pad_default = 16 / sizeof(T);
+    constexpr uint padQ    = (HEAD_DIM == 96) ? 0 : pad_default;
+    constexpr uint padK    = pad_default;                  // K_TILE=32 always
+    constexpr uint padV    = (HEAD_DIM == 96) ? 0 : pad_default;
+    constexpr uint LDQ_tgp = HEAD_DIM + padQ;             // Q row stride
+    constexpr uint LDK_tgp = K_TILE  + padK;              // K col stride (K is transposed)
+    constexpr uint LDV_tgp = HEAD_DIM + padV;             // V row stride
 
-    // Q pointer for this (token, head).  v1 requires num_q_heads == num_kv_heads
-    // (validated host-side).  K/V indexing already uses the num_kv stride, but
-    // the GQA follow-up still needs a kernel edit to map head_idx -> kv_head_idx.
-    const device T* q_ptr = q + (token_idx * num_q + head_idx) * HEAD_DIM;
+    // ---- Threadgroup memory ------------------------------------------------
+    // Q_smem  row-major  [Q_TILE, LDQ_tgp]   — Q[q, d]
+    // KV_smem aliases    K_smem and V_smem (max of the two; non-overlapping
+    //                    in time — V is loaded after the Q@K^T MMAs done).
+    //   K_smem  transposed [HEAD_DIM, LDK_tgp]  — K[d, k] (logically K^T)
+    //   V_smem  row-major  [K_TILE,   LDV_tgp]  — V[k, d]
+    threadgroup T Q_smem[Q_TILE * LDQ_tgp];
+    constexpr uint tgp_mem_K  = HEAD_DIM * LDK_tgp;
+    constexpr uint tgp_mem_V  = K_TILE   * LDV_tgp;
+    constexpr uint tgp_mem_KV = (tgp_mem_K > tgp_mem_V) ? tgp_mem_K : tgp_mem_V;
+    threadgroup T KV_smem[tgp_mem_KV];
+    threadgroup T* Ks = KV_smem;
+    threadgroup T* Vs = KV_smem;
 
-    // v1 cost (deferred to the GQA-mapping follow-up):
-    //   1. Every lane in the SIMD-group loads the full Q vector below — 32×
-    //      redundant device traffic.  Successor should load HEAD_DIM/32 dims
-    //      per lane and broadcast the rest via simd_shuffle.
-    //   2. Pass 2 below recomputes Q·K rather than caching pass-1 dot
-    //      products.  A threadgroup-scratch (or shuffle-based) cache would
-    //      halve the pass-2 K-stream traffic.
-    //   3. The pass-2 numerator reduction loop runs one full-warp simd_sum
-    //      per output dim — at HEAD_DIM=128 that is 128 reductions where
-    //      only one lane consumes each result (the writer selected by
-    //      `simd_lane == d % 32`).  A reduce-scatter or shuffle-rotated
-    //      layout where each lane owns disjoint dim subsets would cut the
-    //      reduction count; the exact ratio depends on the chosen design.
-    // Load Q into per-lane fp32 register array.
-    float q_reg[HEAD_DIM];
-    for (uint d = 0; d < HEAD_DIM; ++d) {
-        q_reg[d] = float(q_ptr[d]);
-    }
+    const int   head_idx = int(tg_id.y);
+    const int   num_q    = params.num_q_heads;
+    const int   num_kv   = params.num_kv_heads;
+    const float scale    = params.softmax_scale * M_LOG2E_F;
 
-    // ---------------------------------------------------------------
-    // Pass 1: segment-wide max.
-    // ---------------------------------------------------------------
-    float lane_max = -INFINITY;
-    for (int j = seg_lo + int(simd_lane); j < seg_hi; j += 32) {
-        const device T* k_ptr = k + (j * num_kv + head_idx) * HEAD_DIM;
-        float qk = 0.0f;
-        for (uint d = 0; d < HEAD_DIM; ++d) {
-            qk += q_reg[d] * float(k_ptr[d]);
+    // Decode (segment, q_base) from tg_id.x.  tiles_per_segment uses
+    // params.max_seqlen as the launch-grid pitch (matches C++ launcher).
+    const int tiles_per_segment =
+        (params.max_seqlen + int(Q_TILE) - 1) / int(Q_TILE);
+    const int seg         = int(tg_id.x) / tiles_per_segment;
+    const int tile_in_seg = int(tg_id.x) % tiles_per_segment;
+    if (seg >= params.num_segments) return;
+
+    const int seg_lo = cu_seqlens[seg];
+    const int seg_hi = cu_seqlens[seg + 1];
+    const int q_base = seg_lo + tile_in_seg * int(Q_TILE);
+    if (q_base >= seg_hi) return;
+    const int q_end   = min(q_base + int(Q_TILE), seg_hi);
+    const int q_count = q_end - q_base;
+
+    // ---- Lane coords within an 8×8 simdgroup_matrix frag ------------------
+    // (MLX BaseMMAFrag::get_coord, the canonical Apple simdgroup_matrix
+    //  layout on Apple GPU 7+.)  Lane owns 1 row × 2 cols at (fm, fn..fn+1).
+    const ushort qid = simd_lane_id / 4;
+    const ushort fm  = (qid & 4) + ((simd_lane_id / 2) % 4);   // 0..7
+    const ushort fn  = (qid & 2) * 2 + (simd_lane_id % 2) * 2; // 0,2,4,6
+
+    // Per-simdgroup row offset.  Each simdgroup owns rows [tm, tm+8).
+    const ushort tm = simd_id * kFragSize;
+
+    // ---- Cooperative load of Q-tile (vectorized, 16-byte) ----------------
+    // Q_smem[q, d] = q[q_base + q, head_idx, d].  HEAD_DIM is a multiple
+    // of VEC_T (=16/sizeof(T)) for every supported head dim, so the
+    // vec read+write are exact-aligned.  Padded rows zero-filled.
+    constexpr uint VEC_T = 16 / sizeof(T);     // 8 (bf16/f16), 4 (f32)
+    static_assert(HEAD_DIM % VEC_T == 0,
+                  "HEAD_DIM must be a multiple of 16/sizeof(T) for vec loads");
+    constexpr uint Q_VECS = (Q_TILE * HEAD_DIM) / VEC_T;
+    for (uint vi = lid; vi < Q_VECS; vi += THREADS) {
+        const uint base = vi * VEC_T;
+        const uint qrow = base / HEAD_DIM;
+        const uint d    = base % HEAD_DIM;
+        threadgroup vec<T, VEC_T>* qdst =
+            reinterpret_cast<threadgroup vec<T, VEC_T>*>(
+                &Q_smem[qrow * LDQ_tgp + d]);
+        if (qrow < uint(q_count)) {
+            const int qi = q_base + int(qrow);
+            *qdst = *reinterpret_cast<const device vec<T, VEC_T>*>(
+                &q[(qi * num_q + head_idx) * HEAD_DIM + d]);
+        } else {
+            *qdst = vec<T, VEC_T>(T(0));
         }
-        qk *= scale;
-        lane_max = max(lane_max, qk);
-    }
-    const float seg_max = simd_max(lane_max);
-
-    // ---------------------------------------------------------------
-    // Pass 2: denom + per-dim numerator partials.
-    //
-    // Each lane re-streams *its assigned keys only* (lane-strided by 32) and
-    // updates a HEAD_DIM-wide per-lane numerator vector.  Every lane updates
-    // every dim because every output dim needs every assigned key's
-    // contribution.
-    // ---------------------------------------------------------------
-    float denom_partial = 0.0f;
-    float num_partial[HEAD_DIM];
-    for (uint d = 0; d < HEAD_DIM; ++d) {
-        num_partial[d] = 0.0f;
     }
 
-    for (int j = seg_lo + int(simd_lane); j < seg_hi; j += 32) {
-        const device T* k_ptr = k + (j * num_kv + head_idx) * HEAD_DIM;
-        const device T* v_ptr = v + (j * num_kv + head_idx) * HEAD_DIM;
-        float qk = 0.0f;
-        for (uint d = 0; d < HEAD_DIM; ++d) {
-            qk += q_reg[d] * float(k_ptr[d]);
+    // ---- Per-lane register state ------------------------------------------
+    // Each lane "owns" query row (tm + fm) for the duration of the kernel.
+    // The four lanes that share that row (l, l^1, l^8, l^9) all maintain
+    // the same max_score / sum_score (after the 2-shuffle butterfly).
+    using FragF = vec<float, 2>;
+    float max_score = -INFINITY;
+    float sum_score = 0.0f;
+    FragF o_frags[TD];
+    for (uint dt = 0; dt < TD; ++dt) o_frags[dt] = FragF(0.0f);
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ---- Tg-memory offsets for fragment loads -----------------------------
+    // Q_smem[(tm + fm) * LDQ_tgp + fn + dd*kFragSize + {0,1}]
+    const uint Qs_offset    = uint(tm + fm) * LDQ_tgp + uint(fn);
+    constexpr uint Qs_d_stride = kFragSize;          // dd advances along d cols
+    // K_smem[(fm + dd*kFragSize) * LDK_tgp + fn + kt*kFragSize + {0,1}]
+    const uint Ks_base      = uint(fm) * LDK_tgp + uint(fn);
+    constexpr uint Ks_d_stride = kFragSize * LDK_tgp; // dd advances along d rows
+    constexpr uint Ks_k_stride = kFragSize;           // kt advances along k cols
+    // V_smem[(fm + ik*kFragSize) * LDV_tgp + fn + id*kFragSize + {0,1}]
+    const uint Vs_base      = uint(fm) * LDV_tgp + uint(fn);
+    constexpr uint Vs_k_stride = kFragSize * LDV_tgp; // ik advances along k rows
+    constexpr uint Vs_d_stride = kFragSize;           // id advances along d cols
+
+
+    // =====================================================================
+    // K-tile loop
+    // =====================================================================
+    for (int tile_lo = seg_lo; tile_lo < seg_hi; tile_lo += int(K_TILE)) {
+        const int tile_hi = min(tile_lo + int(K_TILE), seg_hi);
+        const int k_count = tile_hi - tile_lo;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- Cooperative load K (transposed; vec read + scatter write) ---
+        // K_smem[d, krow] = K[ki, d].  Reads are vectorized (8 contiguous
+        // d's per device load); writes are scattered into the LDK_tgp-
+        // stride layout and stay scalar.  Net effect: 1/VEC_T fewer
+        // device-mem transactions.
+        constexpr uint K_VECS = (K_TILE * HEAD_DIM) / VEC_T;
+        for (uint vi = lid; vi < K_VECS; vi += THREADS) {
+            const uint base    = vi * VEC_T;
+            const uint krow    = base / HEAD_DIM;
+            const uint d_start = base % HEAD_DIM;
+            vec<T, VEC_T> k_vec;
+            if (krow < uint(k_count)) {
+                const int ki = tile_lo + int(krow);
+                k_vec = *reinterpret_cast<const device vec<T, VEC_T>*>(
+                    &k[(ki * num_kv + head_idx) * HEAD_DIM + d_start]);
+            } else {
+                k_vec = vec<T, VEC_T>(T(0));
+            }
+            for (uint i = 0; i < VEC_T; ++i) {
+                Ks[(d_start + i) * LDK_tgp + krow] = k_vec[i];
+            }
         }
-        qk = qk * scale - seg_max;
-        const float w = exp2(qk);
-        denom_partial += w;
-        for (uint d = 0; d < HEAD_DIM; ++d) {
-            num_partial[d] += w * float(v_ptr[d]);
+
+        // S accumulator (one frag per K-axis 8-block; accumulated across dd)
+        FragF s_frags[TK];
+        for (uint kt = 0; kt < TK; ++kt) s_frags[kt] = FragF(0.0f);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- S = Q @ K^T via TD × TK MMAs --------------------------------
+        // Outer: dd iterates the shared dim.  Q frag is reused across kt.
+        // simdgroup_barrier(mem_none) bracket every dd for instruction-
+        // ordering hint; inside the kt loop the loads are independent of
+        // the previous MMA and don't need extra barriers.
+        for (uint dd = 0; dd < TD; ++dd) {
+            simdgroup_barrier(mem_flags::mem_none);
+
+            // Load this lane's 1×2 slice of the Q frag at d offset dd*8.
+            FragF q_frag;
+            q_frag.x = float(Q_smem[Qs_offset + dd * Qs_d_stride + 0]);
+            q_frag.y = float(Q_smem[Qs_offset + dd * Qs_d_stride + 1]);
+
+            for (uint kt = 0; kt < TK; ++kt) {
+                FragF k_frag;
+                k_frag.x = float(Ks[Ks_base + dd * Ks_d_stride
+                                            + kt * Ks_k_stride + 0]);
+                k_frag.y = float(Ks[Ks_base + dd * Ks_d_stride
+                                            + kt * Ks_k_stride + 1]);
+
+                simdgroup_float8x8 D_mat, A_mat, B_mat, C_mat;
+                reinterpret_cast<thread FragF&>(A_mat.thread_elements()) = q_frag;
+                reinterpret_cast<thread FragF&>(B_mat.thread_elements()) = k_frag;
+                reinterpret_cast<thread FragF&>(C_mat.thread_elements()) = s_frags[kt];
+                simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat);
+                s_frags[kt] = reinterpret_cast<thread FragF&>(D_mat.thread_elements());
+            }
+        }
+
+        // ---- Apply softmax scale (fold-of-log2e already in `scale`) ------
+        for (uint kt = 0; kt < TK; ++kt) {
+            s_frags[kt] *= scale;
+        }
+
+        // ---- Mask out keys past tile_hi ----------------------------------
+        // Lane owns cols (fn, fn+1) of frag kt at global K positions
+        // (kt*8 + fn, kt*8 + fn + 1).  Set to -INF so exp2 → 0.
+        if (k_count < int(K_TILE)) {
+            for (uint kt = 0; kt < TK; ++kt) {
+                const int col0 = int(kt * kFragSize) + int(fn);
+                if (col0     >= k_count) s_frags[kt].x = -INFINITY;
+                if (col0 + 1 >= k_count) s_frags[kt].y = -INFINITY;
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- Cooperative load V (row-major, vectorized 16-byte) ----------
+        // V_smem[krow, d] = V[ki, d]; row-major writes are vectorizable.
+        constexpr uint V_VECS = (K_TILE * HEAD_DIM) / VEC_T;
+        for (uint vi = lid; vi < V_VECS; vi += THREADS) {
+            const uint base = vi * VEC_T;
+            const uint krow = base / HEAD_DIM;
+            const uint d    = base % HEAD_DIM;
+            threadgroup vec<T, VEC_T>* vdst =
+                reinterpret_cast<threadgroup vec<T, VEC_T>*>(
+                    &Vs[krow * LDV_tgp + d]);
+            if (krow < uint(k_count)) {
+                const int ki = tile_lo + int(krow);
+                *vdst = *reinterpret_cast<const device vec<T, VEC_T>*>(
+                    &v[(ki * num_kv + head_idx) * HEAD_DIM + d]);
+            } else {
+                *vdst = vec<T, VEC_T>(T(0));
+            }
+        }
+
+        // ---- Online softmax (in registers) -------------------------------
+        // Row max: per-frag (xor 1, xor 8) butterfly across the 4 lanes
+        // that share this row, accumulated into `new_max` across all TK
+        // frags.  Final per-row max is identical on all 4 lanes.
+        float new_max = max_score;
+        for (uint kt = 0; kt < TK; ++kt) {
+            float v = max(s_frags[kt].x, s_frags[kt].y);
+            v = max(v, simd_shuffle_xor(v, ushort(1)));
+            v = max(v, simd_shuffle_xor(v, ushort(8)));
+            new_max = max(new_max, v);
+        }
+        // NaN-safe: if every key in this and all prior tiles was masked,
+        // pin new_max to 0 so exp2(s - 0) is well-defined (s == -INF → 0).
+        if (new_max == -INFINITY) new_max = 0.0f;
+
+        const float factor =
+            (max_score == -INFINITY) ? 0.0f : exp2(max_score - new_max);
+        max_score = new_max;
+
+        // P = exp2(S - new_max), in place; lane-local row sum.
+        float sum_score_tmp = 0.0f;
+        for (uint kt = 0; kt < TK; ++kt) {
+            s_frags[kt].x = exp2(s_frags[kt].x - new_max);
+            s_frags[kt].y = exp2(s_frags[kt].y - new_max);
+            sum_score_tmp += s_frags[kt].x + s_frags[kt].y;
+        }
+        sum_score_tmp += simd_shuffle_xor(sum_score_tmp, ushort(1));
+        sum_score_tmp += simd_shuffle_xor(sum_score_tmp, ushort(8));
+
+        sum_score = sum_score * factor + sum_score_tmp;
+
+        // ---- Rescale O by factor (per-lane scalar; no diag-α MMA) -------
+        for (uint dt = 0; dt < TD; ++dt) {
+            o_frags[dt] *= factor;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- O += P @ V via TD × TK MMAs ---------------------------------
+        // O[iq][id] += S[iq][ik] @ V[ik][id], iq fixed at 0 (TQ=1).
+        // ik OUTER / id INNER: within an ik iteration, all TD MMAs hit
+        // distinct o_frags[id] outputs and are independent — gives the
+        // compiler TD parallel MMAs to schedule before the next ik.
+        for (uint ik = 0; ik < TK; ++ik) {
+            for (uint id = 0; id < TD; ++id) {
+                FragF v_frag;
+                v_frag.x = float(Vs[Vs_base + ik * Vs_k_stride
+                                            + id * Vs_d_stride + 0]);
+                v_frag.y = float(Vs[Vs_base + ik * Vs_k_stride
+                                            + id * Vs_d_stride + 1]);
+
+                simdgroup_float8x8 D_mat, A_mat, B_mat, C_mat;
+                reinterpret_cast<thread FragF&>(A_mat.thread_elements()) = s_frags[ik];
+                reinterpret_cast<thread FragF&>(B_mat.thread_elements()) = v_frag;
+                reinterpret_cast<thread FragF&>(C_mat.thread_elements()) = o_frags[id];
+                simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat);
+                o_frags[id] = reinterpret_cast<thread FragF&>(D_mat.thread_elements());
+            }
         }
     }
 
-    const float denom = simd_sum(denom_partial);
-    const float inv_denom = 1.0f / denom;
-
-    device T* out_ptr = out + (token_idx * num_q + head_idx) * HEAD_DIM;
-
-    // Lane-strided writeback: lane (d % 32) owns dim d.  For HEAD_DIM=80 the
-    // count is uneven (lanes 0..15 own 3 dims, lanes 16..31 own 2), but the
-    // (simd_lane == d % 32) form handles that without a per-head-dim branch.
-    for (uint d = 0; d < HEAD_DIM; ++d) {
-        const float full_num_d = simd_sum(num_partial[d]);
-        if (simd_lane == (d % 32)) {
-            out_ptr[d] = T(full_num_d * inv_denom);
+    // =====================================================================
+    // Final write: O / l → out (only valid query rows).
+    // Lane (fm, fn) owns query row (tm + fm) and d cols
+    // (id*8 + fn, id*8 + fn + 1) for each id frag.
+    // =====================================================================
+    const float inv_l = (sum_score > 0.0f) ? (1.0f / sum_score) : 0.0f;
+    const int q_row_local = int(tm) + int(fm);
+    if (q_row_local < q_count) {
+        const int qi = q_base + q_row_local;
+        device T* out_row = out + (qi * num_q + head_idx) * HEAD_DIM;
+        for (uint id = 0; id < TD; ++id) {
+            out_row[id * kFragSize + fn + 0] = T(o_frags[id].x * inv_l);
+            out_row[id * kFragSize + fn + 1] = T(o_frags[id].y * inv_l);
         }
     }
 }
 
 // ---------------------------------------------------------------------------
-// Specialization macros — generates 12 [[host_name]] instantiations:
-//   {f16, bf16, f32} × {64, 80, 96, 128}
-//
-// host_name spelling is part of the ABI; the C++ dispatch helper builds the
-// same kname string from (dtype_tag, head_dim).  An off-by-one between this
-// macro and the C++ name builder silently mis-binds an argument with no
-// Metal-side error.
+// Manual SIMD kernel — f32 fallback (Q_TILE=8, K_TILE=16 to fit tg-mem)
 // ---------------------------------------------------------------------------
 
-#define instantiate_encoder_varlen_attention_inner(type, type_tag, head_dim) \
+template <typename T, uint HEAD_DIM, uint Q_TILE, uint K_TILE>
+[[kernel]] void encoder_varlen_attention_manual_kernel(
+    device const T*       q           [[buffer(0)]],
+    device const T*       k           [[buffer(1)]],
+    device const T*       v           [[buffer(2)]],
+    device const int*     cu_seqlens  [[buffer(3)]],
+    device       T*       out         [[buffer(4)]],
+    constant     EncoderVarlenParams& params [[buffer(5)]],
+    uint3 tg_id        [[threadgroup_position_in_grid]],
+    uint  lid          [[thread_index_in_threadgroup]],
+    uint  simd_lane_id [[thread_index_in_simdgroup]],
+    uint  simd_id      [[simdgroup_index_in_threadgroup]])
+{
+    constexpr uint THREADS    = 128;
+    constexpr uint NUM_SIMDS  = 4;
+    constexpr uint Q_PER_SIMD = Q_TILE / NUM_SIMDS;
+    static_assert(Q_TILE % NUM_SIMDS == 0,
+                  "Q_TILE must be a multiple of NUM_SIMDS (4)");
+    static_assert(K_TILE <= 32,
+                  "K_TILE > 32 unsupported in v1 (lane = 1 key)");
+
+    threadgroup T     Q_buf[Q_TILE * HEAD_DIM];
+    threadgroup T     K_buf[HEAD_DIM * K_TILE];
+    threadgroup T     V_buf[HEAD_DIM * K_TILE];
+    threadgroup float O_buf[Q_TILE * HEAD_DIM];
+    threadgroup float m_buf[Q_TILE];
+    threadgroup float l_buf[Q_TILE];
+
+    const int head_idx = int(tg_id.y);
+    const int num_q    = params.num_q_heads;
+    const int num_kv   = params.num_kv_heads;
+    const float scale  = params.softmax_scale * M_LOG2E_F;
+
+    const int tiles_per_segment =
+        (params.max_seqlen + int(Q_TILE) - 1) / int(Q_TILE);
+    const int seg         = int(tg_id.x) / tiles_per_segment;
+    const int tile_in_seg = int(tg_id.x) % tiles_per_segment;
+    if (seg >= params.num_segments) return;
+
+    const int seg_lo = cu_seqlens[seg];
+    const int seg_hi = cu_seqlens[seg + 1];
+    const int q_base = seg_lo + tile_in_seg * int(Q_TILE);
+    if (q_base >= seg_hi) return;
+    const int q_end   = min(q_base + int(Q_TILE), seg_hi);
+    const int q_count = q_end - q_base;
+
+    for (uint e = lid; e < Q_TILE * HEAD_DIM; e += THREADS) {
+        const uint qrow = e / HEAD_DIM;
+        const uint d    = e % HEAD_DIM;
+        if (qrow < uint(q_count)) {
+            const int qi = q_base + int(qrow);
+            Q_buf[e] = q[(qi * num_q + head_idx) * HEAD_DIM + d];
+        } else {
+            Q_buf[e] = T(0);
+        }
+    }
+
+    if (lid < Q_TILE) {
+        m_buf[lid] = -INFINITY;
+        l_buf[lid] = 0.0f;
+    }
+    for (uint e = lid; e < Q_TILE * HEAD_DIM; e += THREADS) {
+        O_buf[e] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (int tile_lo = seg_lo; tile_lo < seg_hi; tile_lo += int(K_TILE)) {
+        const int tile_hi = min(tile_lo + int(K_TILE), seg_hi);
+        const int k_count = tile_hi - tile_lo;
+
+        for (uint e = lid; e < K_TILE * HEAD_DIM; e += THREADS) {
+            const uint krow = e / HEAD_DIM;
+            const uint d    = e % HEAD_DIM;
+            const uint dst  = d * K_TILE + krow;
+            if (krow < uint(k_count)) {
+                const int ki = tile_lo + int(krow);
+                K_buf[dst] = k[(ki * num_kv + head_idx) * HEAD_DIM + d];
+                V_buf[dst] = v[(ki * num_kv + head_idx) * HEAD_DIM + d];
+            } else {
+                K_buf[dst] = T(0);
+                V_buf[dst] = T(0);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint local_q = 0; local_q < Q_PER_SIMD; ++local_q) {
+            const uint q_idx = simd_id * Q_PER_SIMD + local_q;
+
+            float s_l;
+            if (simd_lane_id < uint(K_TILE) && simd_lane_id < uint(k_count)) {
+                float dot = 0.0f;
+                for (uint d = 0; d < HEAD_DIM; ++d) {
+                    dot += float(Q_buf[q_idx * HEAD_DIM + d]) *
+                           float(K_buf[d * K_TILE + simd_lane_id]);
+                }
+                s_l = dot * scale;
+            } else {
+                s_l = -INFINITY;
+            }
+
+            const float tile_row_max = simd_max(s_l);
+            const float m_old        = m_buf[q_idx];
+            const float m_new        = max(m_old, tile_row_max);
+            const float alpha        = exp2(m_old - m_new);
+
+            const float p_l    = exp2(s_l - m_new);
+            const float l_sum  = simd_sum(p_l);
+
+            if (simd_lane_id == 0) {
+                m_buf[q_idx] = m_new;
+                l_buf[q_idx] = alpha * l_buf[q_idx] + l_sum;
+            }
+
+            const bool lane_has_key = simd_lane_id < uint(K_TILE);
+            for (uint d = 0; d < HEAD_DIM; ++d) {
+                const float v_ld =
+                    lane_has_key
+                        ? float(V_buf[d * K_TILE + simd_lane_id])
+                        : 0.0f;
+                const float pv_local = p_l * v_ld;
+                const float pv_sum   = simd_sum(pv_local);
+                if (simd_lane_id == 0) {
+                    O_buf[q_idx * HEAD_DIM + d] =
+                        alpha * O_buf[q_idx * HEAD_DIM + d] + pv_sum;
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (uint e = lid; e < Q_TILE * HEAD_DIM; e += THREADS) {
+        const uint qrow = e / HEAD_DIM;
+        const uint d    = e % HEAD_DIM;
+        if (qrow < uint(q_count)) {
+            const int qi  = q_base + int(qrow);
+            const float o = O_buf[e] / l_buf[qrow];
+            out[(qi * num_q + head_idx) * HEAD_DIM + d] = T(o);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Specialization macros — bf16/f16 dispatch to the MMA kernel; f32 dispatches
+// to the manual kernel.  All twelve [[host_name]] strings stay in the
+// `encoder_varlen_attention_<dtype>_<head_dim>` format that the C++
+// dispatcher in paged_ops.cpp builds.  The C++ launcher chooses the
+// appropriate (Q_TILE, threadgroup) per dtype:
+//   bf16/f16 → Q_TILE=32, threadgroup=128
+//   f32      → Q_TILE=8,  threadgroup=128
+// ---------------------------------------------------------------------------
+
+#define instantiate_encoder_varlen_mma(type, type_tag, head_dim) \
     template [[host_name("encoder_varlen_attention_" #type_tag "_" #head_dim)]] \
-    [[kernel]] void encoder_varlen_attention_kernel<type, head_dim>( \
+    [[kernel]] void encoder_varlen_attention_mma_kernel<type, head_dim>( \
         device const type*       q           [[buffer(0)]], \
         device const type*       k           [[buffer(1)]], \
         device const type*       v           [[buffer(2)]], \
         device const int*        cu_seqlens  [[buffer(3)]], \
         device       type*       out         [[buffer(4)]], \
         constant     EncoderVarlenParams& params [[buffer(5)]], \
-        uint3 tg_id     [[threadgroup_position_in_grid]], \
-        uint  simd_lane [[thread_index_in_simdgroup]]);
+        uint3 tg_id        [[threadgroup_position_in_grid]], \
+        uint  lid          [[thread_index_in_threadgroup]], \
+        uint  simd_lane_id [[thread_index_in_simdgroup]], \
+        uint  simd_id      [[simdgroup_index_in_threadgroup]]);
 
-#define instantiate_encoder_varlen_attention(type, type_tag) \
-    instantiate_encoder_varlen_attention_inner(type, type_tag, 64)  \
-    instantiate_encoder_varlen_attention_inner(type, type_tag, 80)  \
-    instantiate_encoder_varlen_attention_inner(type, type_tag, 96)  \
-    instantiate_encoder_varlen_attention_inner(type, type_tag, 128)
+#define instantiate_encoder_varlen_manual(type, type_tag, head_dim, q_tile, k_tile) \
+    template [[host_name("encoder_varlen_attention_" #type_tag "_" #head_dim)]] \
+    [[kernel]] void encoder_varlen_attention_manual_kernel<type, head_dim, q_tile, k_tile>( \
+        device const type*       q           [[buffer(0)]], \
+        device const type*       k           [[buffer(1)]], \
+        device const type*       v           [[buffer(2)]], \
+        device const int*        cu_seqlens  [[buffer(3)]], \
+        device       type*       out         [[buffer(4)]], \
+        constant     EncoderVarlenParams& params [[buffer(5)]], \
+        uint3 tg_id        [[threadgroup_position_in_grid]], \
+        uint  lid          [[thread_index_in_threadgroup]], \
+        uint  simd_lane_id [[thread_index_in_simdgroup]], \
+        uint  simd_id      [[simdgroup_index_in_threadgroup]]);
 
-instantiate_encoder_varlen_attention(half,       f16)
-instantiate_encoder_varlen_attention(bfloat16_t, bf16)
-instantiate_encoder_varlen_attention(float,      f32)
+#define instantiate_encoder_varlen_mma_set(type, type_tag) \
+    instantiate_encoder_varlen_mma(type, type_tag,  64) \
+    instantiate_encoder_varlen_mma(type, type_tag,  80) \
+    instantiate_encoder_varlen_mma(type, type_tag,  96) \
+    instantiate_encoder_varlen_mma(type, type_tag, 128)
+
+#define instantiate_encoder_varlen_manual_set(type, type_tag) \
+    instantiate_encoder_varlen_manual(type, type_tag,  64, 8, 16) \
+    instantiate_encoder_varlen_manual(type, type_tag,  80, 8, 16) \
+    instantiate_encoder_varlen_manual(type, type_tag,  96, 8, 16) \
+    instantiate_encoder_varlen_manual(type, type_tag, 128, 8, 16)
+
+instantiate_encoder_varlen_mma_set(half,       f16)
+instantiate_encoder_varlen_mma_set(bfloat16_t, bf16)
+instantiate_encoder_varlen_manual_set(float,   f32)

--- a/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
+++ b/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
@@ -1,57 +1,61 @@
 // SPDX-License-Identifier: Apache-2.0
+
+// Portions of this file are adapted from Apple's MLX framework
+// (https://github.com/ml-explore/mlx)
+// Licensed under the Apache License 2.0
+// Copyright © 2023 Apple Inc.
+
+// ========================================== Encoder varlen attention kernel
 //
-// Dense non-causal varlen encoder attention kernel — flash-attention with
-// register-resident MMA fragments and in-register online softmax, mirroring
-// MLX's `steel_attention` kernel structure (BQ=32, BK=32, WM=4, WN=1).
+// Dense non-causal attention over a packed batch of variable-length
+// segments — the attention shape used by vision-tower models (Qwen2.5-VL
+// et al.), where each segment is one image's patch grid.
 //
-// M3 redesign vs. M2
-//   • All MMA tiles (Q, K, S, V, O) live as per-lane `vec<float,2>` fragments
-//     using Apple's simdgroup_matrix<float,8,8> lane layout (the same one
-//     MLX targets via BaseMMAFrag::get_coord).  Each lane holds 1 row × 2
-//     contiguous cols of every 8x8 frag it participates in.
-//   • Softmax row reductions run in registers via simd_shuffle_xor(1) +
-//     simd_shuffle_xor(8) — the two-shuffle butterfly that traverses the
-//     four lanes that share a row in the simdgroup_matrix layout.  No
-//     more s_buf round-trip via simdgroup_store / simdgroup_load.
-//   • α-rescale of the running O accumulator is now a per-lane scalar
-//     `o_frags[d] *= factor` instead of a `diag(α) @ O` 8x8 MMA.  At
-//     HEAD_DIM=128 that's TD=16 register-vec multiplies replacing 16 MMAs.
-//   • Threadgroup memory uses pad = 16/sizeof(T) on the inner stride
-//     (matches MLX's padQ / padK / padV) to avoid bank conflicts on
-//     simdgroup-cooperative loads.
-//   • V_smem is now row-major [K_TILE, HEAD_DIM]  (M2 had it transposed
-//     as a hold-over from the iter1 manual kernel).
+// Inputs are shaped [total_tokens, num_heads, head_dim], with cu_seqlens
+// recording segment boundaries.  Each threadgroup is bound to one
+// (segment, q_tile, head) triple via the launch grid; cross-segment
+// attention is skipped by construction.
 //
-// Per-lane state
-//   q_frag:       vec<float,2>      reloaded each `dd` (Q is dim-tiled)
-//   s_frags[TK]:  vec<float,2>[TK]  S = Q @ K^T accumulated across dd
-//   v_frag:       vec<float,2>      reloaded each (id, ik) MMA
-//   o_frags[TD]:  vec<float,2>[TD]  running unnormalised output (fp32)
-//   max_score:    float             online softmax row max
-//   sum_score:    float             online softmax row sum (= l)
+// Implementation mirrors Apple's MLX `steel_attention` kernel structure
+// (BQ=32, BK=32, WM=4, WN=1).  All MMA tiles (Q, K, S, V, O) live as
+// per-lane `vec<float, 2>` fragments using simdgroup_matrix<float, 8, 8>'s
+// BaseMMAFrag lane layout — each lane owns 1 row × 2 cols of every 8×8
+// frag it participates in.  Softmax row reductions run in registers via
+// the simd_shuffle_xor(1) + simd_shuffle_xor(8) butterfly that traverses
+// the four lanes that share a row in the simdgroup_matrix layout.
+// α-rescale of the running O accumulator is a per-lane scalar
+// `o_frags[d] *= factor`, not a `diag(α) @ O` 8×8 MMA.
 //
-// MMA dispatch identity
+// Per-lane register state.
+//   q_frag        vec<float, 2>      reloaded each `dd` (Q is dim-tiled)
+//   s_frags[TK]   vec<float, 2>[TK]  S = Q @ K^T accumulated across dd
+//   v_frag        vec<float, 2>      reloaded each (id, ik) MMA
+//   o_frags[TD]   vec<float, 2>[TD]  running unnormalised output (fp32)
+//   max_score     float              online softmax row max
+//   sum_score     float              online softmax row sum (= l)
+//
+// MMA dispatch identity.
 //   simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat) requires
-//   simdgroup_matrix operands.  We marshal `vec<float,2>` ↔
-//   `simdgroup_float8x8::thread_elements()` via a reinterpret_cast.
-//   Apple's simdgroup_matrix<float,8,8> stores exactly two fp32 elements
-//   per lane in a `vec<float,2>` thread_elements slot, so the cast is a
+//   simdgroup_matrix operands.  We marshal `vec<float, 2>` ↔
+//   `simdgroup_float8x8::thread_elements()` via reinterpret_cast.  Apple's
+//   simdgroup_matrix<float, 8, 8> stores exactly two fp32 elements per
+//   lane in a `vec<float, 2>` thread_elements slot, so the cast is a
 //   bitwise no-op.
 //
-// Lane coord (MLX BaseMMAFrag::get_coord)
+// Lane coord (MLX BaseMMAFrag::get_coord).
 //   const ushort qid = simd_lane_id / 4;
 //   const ushort fm  = (qid & 4) + ((simd_lane_id / 2) % 4);   // 0..7 row
 //   const ushort fn  = (qid & 2) * 2 + (simd_lane_id % 2) * 2; // 0/2/4/6 col
-//   Lane owns frag[fm, fn..fn+1].  Four lanes per row are { l, l^1, l^8,
-//   l^9 } — confirming xor-1 + xor-8 as a 4-way row reduction butterfly.
+// Lane owns frag[fm, fn..fn+1].  The four lanes per row are { l, l^1,
+// l^8, l^9 } — confirming xor-1 + xor-8 as the 4-way row reduction.
 //
-// f32 path (`encoder_varlen_attention_manual_kernel`) is unchanged from
-// M2 — fp32 elements double tg-memory pressure and the 32×32 MMA tile
-// blows the 32 KB cap at HEAD_DIM=128, so f32 stays on the smaller-tile
-// manual-SIMD fallback (Q=8, K=16).
+// f32 path (`encoder_varlen_attention_manual_kernel`) uses smaller tiles
+// (Q_TILE=8, K_TILE=16) on a manual-SIMD fallback: fp32 doubles
+// tg-memory pressure and a 32×32 MMA tile blows the 32 KB cap at
+// HEAD_DIM=128, so the MMA path stays bf16/f16 only.
 //
-// utils.metal is concatenated ahead of this file by the source builder in
-// vllm_metal.metal.__init__, so bfloat16_t is available.
+// NOTE: utils.metal is concatenated ahead of this file by the source
+// builder in vllm_metal.metal.__init__, so bfloat16_t is available.
 
 #include <metal_stdlib>
 #include <metal_simdgroup>
@@ -79,9 +83,7 @@ static_assert(sizeof(EncoderVarlenParams) == 24,
               "EncoderVarlenParams ABI drift: size diverges from "
               "paged_ops.cpp; update both files in lockstep.");
 
-// ---------------------------------------------------------------------------
-// MMA kernel — bf16 / f16
-// ---------------------------------------------------------------------------
+// ========================================== MMA kernel — bf16 / f16
 
 template <typename T, uint HEAD_DIM>
 [[kernel]] void encoder_varlen_attention_mma_kernel(
@@ -108,15 +110,14 @@ template <typename T, uint HEAD_DIM>
                   "HEAD_DIM must be a multiple of 8 for the 8x8 MMA path");
 
     // Padding in tg memory to avoid bank conflicts on Apple GPU.
-    // pad = 16/sizeof(T) matches MLX's steel_attention padQ/padK/padV
+    // pad = 16/sizeof(T) matches MLX steel_attention's padQ/padK/padV
     // and helps hd64/80/128 by 2–5%.  At HEAD_DIM=96 the padded inner
-    // stride (104 elements / 208 bytes for bf16) is empirically *worse*
-    // than the unpadded (96 / 192 bytes), losing ~8% on the bench —
-    // 96 is exactly 1.5 bank cycles wide so the unpadded layout already
-    // distributes lanes across banks evenly, and the +8 extra elements
-    // both inflate tg-memory pressure and shift the bank pattern in a
-    // way that re-introduces conflicts.  Disabling padding for hd96
-    // recovers that loss.  Verified by ablation 2026-05-03.
+    // stride (104 elements / 208 bytes for bf16) is empirically worse
+    // than the unpadded (96 / 192 bytes), losing ~8%: 96 is exactly 1.5
+    // bank cycles wide so the unpadded layout already distributes lanes
+    // across banks evenly, and the extra 8 elements both inflate tg
+    // pressure and shift the bank pattern in a way that re-introduces
+    // conflicts.  Disabling padding for hd96 recovers that loss.
     constexpr uint pad_default = 16 / sizeof(T);
     constexpr uint padQ    = (HEAD_DIM == 96) ? 0 : pad_default;
     constexpr uint padK    = pad_default;                  // K_TILE=32 always
@@ -218,10 +219,7 @@ template <typename T, uint HEAD_DIM>
     constexpr uint Vs_k_stride = kFragSize * LDV_tgp; // ik advances along k rows
     constexpr uint Vs_d_stride = kFragSize;           // id advances along d cols
 
-
-    // =====================================================================
-    // K-tile loop
-    // =====================================================================
+    // ========================================== K-tile loop
     for (int tile_lo = seg_lo; tile_lo < seg_hi; tile_lo += int(K_TILE)) {
         const int tile_hi = min(tile_lo + int(K_TILE), seg_hi);
         const int k_count = tile_hi - tile_lo;
@@ -384,11 +382,9 @@ template <typename T, uint HEAD_DIM>
         }
     }
 
-    // =====================================================================
-    // Final write: O / l → out (only valid query rows).
-    // Lane (fm, fn) owns query row (tm + fm) and d cols
-    // (id*8 + fn, id*8 + fn + 1) for each id frag.
-    // =====================================================================
+    // ========================================== Final write
+    // O / l → out, valid query rows only.  Lane (fm, fn) owns query row
+    // (tm + fm) and d cols (id*8 + fn, id*8 + fn + 1) for each id frag.
     const float inv_l = (sum_score > 0.0f) ? (1.0f / sum_score) : 0.0f;
     const int q_row_local = int(tm) + int(fm);
     if (q_row_local < q_count) {
@@ -401,9 +397,12 @@ template <typename T, uint HEAD_DIM>
     }
 }
 
-// ---------------------------------------------------------------------------
-// Manual SIMD kernel — f32 fallback (Q_TILE=8, K_TILE=16 to fit tg-mem)
-// ---------------------------------------------------------------------------
+// ========================================== Manual SIMD kernel — f32 fallback
+//
+// f32 elements double tg-memory pressure and a 32×32 MMA tile would blow
+// the 32 KB cap at HEAD_DIM=128, so the f32 path drops to manual SIMD
+// reductions on a smaller (Q_TILE=8, K_TILE=16) tile.  Same online-softmax
+// math as the MMA path, expressed without simdgroup_matrix.
 
 template <typename T, uint HEAD_DIM, uint Q_TILE, uint K_TILE>
 [[kernel]] void encoder_varlen_attention_manual_kernel(
@@ -546,15 +545,15 @@ template <typename T, uint HEAD_DIM, uint Q_TILE, uint K_TILE>
     }
 }
 
-// ---------------------------------------------------------------------------
-// Specialization macros — bf16/f16 dispatch to the MMA kernel; f32 dispatches
-// to the manual kernel.  All twelve [[host_name]] strings stay in the
+// ========================================== Specialization macros
+//
+// bf16/f16 dispatch to the MMA kernel; f32 dispatches to the manual
+// kernel.  All twelve [[host_name]] strings stay in the
 // `encoder_varlen_attention_<dtype>_<head_dim>` format that the C++
 // dispatcher in paged_ops.cpp builds.  The C++ launcher chooses the
 // appropriate (Q_TILE, threadgroup) per dtype:
 //   bf16/f16 → Q_TILE=32, threadgroup=128
 //   f32      → Q_TILE=8,  threadgroup=128
-// ---------------------------------------------------------------------------
 
 #define instantiate_encoder_varlen_mma(type, type_tag, head_dim) \
     template [[host_name("encoder_varlen_attention_" #type_tag "_" #head_dim)]] \

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1354,13 +1354,28 @@ class EncoderVarlenAttentionPrimitive : public UnaryPrimitive {
     enc.set_output_array(out, 4);
     enc.set_bytes(params, 5);
 
-    // Grid: (total_tokens, num_q_heads, 1).  One threadgroup per
-    // (query_token, q_head) output vector.  Threadgroup width 32 == one
-    // SIMD-group on Apple Silicon, so simd_max / simd_sum reduce across the
-    // whole threadgroup in a single instruction with no inter-SIMD barriers.
+    // Grid: segment-pitched Q-tile grid.  Each threadgroup owns one
+    // Q-tile (Q_TILE consecutive queries from a single segment, same
+    // q_head).  Tiles past seg_hi are over-launched and early-exit in
+    // the kernel — the pitch is `tiles_per_segment = ceil(max_seqlen /
+    // Q_TILE)` so every active threadgroup stays on exactly one segment
+    // and the kernel can decode (seg, tile_in_seg) from tg_id.x by
+    // simple division.  Per-dtype Q_TILE:
+    //   bf16/f16 → 32 (MMA path; 4 simdgroups × 8 queries = 8x8 MMA tile)
+    //   f32      →  8 (manual-SIMD fallback; smaller because fp32 elements
+    //                 double tg-memory pressure → 32×32 doesn't fit at hd128).
+    // Threadgroup width:
+    //   bf16/f16 (M3 MMA path) → 256 = 8 simdgroups, each owning 8 query
+    //                             rows; doubled Q_TILE amortises K-tile
+    //                             cooperative loads over twice the queries.
+    //   f32 (manual fallback) → 128 = 4 simdgroups, smaller tile.
+    const int q_tile             = (dtype_tag_ == 2) ? 8 : 64;
+    const int threadgroup_width  = (dtype_tag_ == 2) ? 128 : 256;
+    const int tiles_per_segment  = (max_seqlen_ + q_tile - 1) / q_tile;
+    const int x_dim              = num_segments * tiles_per_segment;
     enc.dispatch_threadgroups(
-        MTL::Size::Make(total_tokens, num_q_heads, 1),
-        MTL::Size::Make(32, 1, 1));
+        MTL::Size::Make(x_dim, num_q_heads, 1),
+        MTL::Size::Make(threadgroup_width, 1, 1));
 
     // No add_temporary calls: inside a primitive, MLX's evaluator manages
     // array lifetimes via the completion handler, and add_temporary would
@@ -1376,9 +1391,14 @@ class EncoderVarlenAttentionPrimitive : public UnaryPrimitive {
         && rhs->num_kv_heads_  == num_kv_heads_
         && rhs->softmax_scale_ == softmax_scale_
         && rhs->dtype_tag_     == dtype_tag_
-        && rhs->head_dim_      == head_dim_;
-    // max_seqlen_ is intentionally excluded: it is a launch hint only,
-    // never used to bound cu_seqlens indexing in-kernel.
+        && rhs->head_dim_      == head_dim_
+        && rhs->max_seqlen_    == max_seqlen_;
+    // max_seqlen_ IS part of the equivalence: the tiled kernel uses it
+    // as the segment-pitched grid pitch (tiles_per_segment =
+    // ceil(max_seqlen / Q_TILE)).  Two primitives with different
+    // max_seqlen_ would over-launch by different amounts and decode
+    // (seg, tile_in_seg) from tg_id.x differently, so they are NOT
+    // interchangeable for caching purposes.
   }
 
  private:

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -9,6 +9,7 @@
 // RTTI matching which fails due to hidden symbol visibility in libmlx.
 
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <unordered_map>
 
@@ -1106,6 +1107,335 @@ void gdn_linear_attention_impl(
 }
 
 // ---------------------------------------------------------------------------
+// Encoder varlen attention — dense non-causal varlen attention.
+//
+// Wrapped as a real MLX UnaryPrimitive so the kernel dispatch carries graph
+// provenance through the lazy graph (mirroring the PagedAttentionPrimitive
+// class above).  The primitive is read-only: Q/K/V/cu_seqlens go in, a fresh
+// output array comes out.  Validation lives in two layers: the Python
+// helper at vllm_metal.metal.encoder_varlen_attention rejects bad shapes /
+// dtypes / cu_seqlens before launch; eval_gpu enforces row-contiguity on
+// every input array (the only layer that can — the Python mx.array surface
+// does not expose flags().row_contiguous).
+// ---------------------------------------------------------------------------
+
+static std::string encoder_varlen_source_;
+static bool encoder_varlen_library_initialized_ = false;
+
+void init_encoder_varlen_library(const std::string& src) {
+  // The MLX library cache (Device::library_map_) is name-keyed: a second
+  // get_library("encoder_varlen_kern", ...) call hits the cache and never
+  // re-reads the source.  The Python layer's _encoder_varlen_loaded flag
+  // gates Python callers, but this binding is part of the public C++ API
+  // and a direct caller bypasses that gate.  Guard explicitly here so the
+  // actual behavior is visible at the call site.
+  if (encoder_varlen_library_initialized_) {
+    if (src != encoder_varlen_source_) {
+      throw std::runtime_error(
+          "init_encoder_varlen_library called twice with different source; "
+          "MLX library cache is name-keyed and will not pick up the new "
+          "source. Restart the interpreter to recompile.");
+    }
+    return;
+  }
+  encoder_varlen_source_ = src;
+  auto& d = metal::device(Device::gpu);
+  d.get_library(
+      "encoder_varlen_kern",
+      [&]() { return encoder_varlen_source_; });
+  // Set the flag only after get_library returns successfully so a Metal
+  // compile failure leaves the slot retryable rather than wedged.
+  encoder_varlen_library_initialized_ = true;
+}
+
+// Hand-mirrored on the .metal side at
+// kernels_v2/encoder_varlen_attention.metal.  Field order is part of the
+// ABI; do not reorder without updating both files in lockstep.  We do not
+// stuff this into a project-local header because needs_rebuild() in
+// build.py only stats paged_ops.cpp / build.py / constants.py — header-only
+// edits would silently fail to trigger an .so rebuild.
+struct EncoderVarlenParams {
+  int   num_q_heads;
+  int   num_kv_heads;
+  int   total_tokens;
+  int   num_segments;   // == cu_seqlens.shape[0] - 1; binary-search bound.
+  // Reserved ABI: launch hint only; not used to bound indexing in the
+  // current kernel.  Intentionally excluded from is_equivalent (see below).
+  // If a future kernel reads this in a way that affects output, dispatch
+  // shape, or scratch sizing, it MUST be added to is_equivalent — otherwise
+  // two calls with different max_seqlen values will alias in the lazy graph.
+  int   max_seqlen;
+  float softmax_scale;
+};
+
+// ABI tripwires for the .metal-side struct mirror.  Per-field offsetof is
+// stronger than size-only: a same-size reorder (e.g. swapping two int fields)
+// would slip past sizeof but break field decoding in-kernel.  needs_rebuild()
+// in build.py only stats the .cpp, so a struct edit here is the only way to
+// force an .so rebuild and surface this check at compile time.
+static_assert(offsetof(EncoderVarlenParams, num_q_heads)   ==  0,
+              "EncoderVarlenParams ABI drift: num_q_heads offset changed");
+static_assert(offsetof(EncoderVarlenParams, num_kv_heads)  ==  4,
+              "EncoderVarlenParams ABI drift: num_kv_heads offset changed");
+static_assert(offsetof(EncoderVarlenParams, total_tokens)  ==  8,
+              "EncoderVarlenParams ABI drift: total_tokens offset changed");
+static_assert(offsetof(EncoderVarlenParams, num_segments)  == 12,
+              "EncoderVarlenParams ABI drift: num_segments offset changed");
+static_assert(offsetof(EncoderVarlenParams, max_seqlen)    == 16,
+              "EncoderVarlenParams ABI drift: max_seqlen offset changed");
+static_assert(offsetof(EncoderVarlenParams, softmax_scale) == 20,
+              "EncoderVarlenParams ABI drift: softmax_scale offset changed");
+static_assert(sizeof(EncoderVarlenParams) == 24,
+              "EncoderVarlenParams ABI drift: struct size changed; "
+              "update kernels_v2/encoder_varlen_attention.metal in lockstep");
+
+class EncoderVarlenAttentionPrimitive : public UnaryPrimitive {
+ public:
+  EncoderVarlenAttentionPrimitive(
+      Stream stream,
+      int num_kv_heads,
+      float softmax_scale,
+      int dtype_tag,
+      int head_dim,
+      int max_seqlen)
+      : UnaryPrimitive(stream),
+        num_kv_heads_(num_kv_heads),
+        softmax_scale_(softmax_scale),
+        dtype_tag_(dtype_tag),
+        head_dim_(head_dim),
+        max_seqlen_(max_seqlen) {}
+
+  void eval_cpu(const std::vector<array>&, array&) override {
+    throw std::runtime_error(
+        "EncoderVarlenAttentionPrimitive only supports GPU");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, array& out) override {
+    const auto& q          = inputs[0];
+    const auto& k          = inputs[1];
+    const auto& v          = inputs[2];
+    const auto& cu_seqlens = inputs[3];
+
+    // Defense-in-depth: the Python helper does not (and cannot) check
+    // contiguity, so this is the only layer that catches non-row-contiguous
+    // inputs.  Run before set_data so a rejected call does not leak a
+    // freshly-allocated output buffer.
+    if (!q.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q must be row-contiguous "
+          "(wrap upstream in mx.contiguous(...) before calling).");
+    }
+    if (!k.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: k must be row-contiguous.");
+    }
+    if (!v.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: v must be row-contiguous.");
+    }
+    if (!cu_seqlens.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must be row-contiguous.");
+    }
+
+    // Defense-in-depth: the Python helper validates shape / dtype /
+    // num_kv_heads, but a caller that drives the underscore-prefixed
+    // _encoder_varlen_attention_primitive binding directly bypasses that.
+    // Re-check the structural invariants the kernel relies on so a
+    // bypass surfaces as a clean throw rather than silent K/V misindexing
+    // in-kernel.  Value-level checks (cu_seqlens monotonicity /
+    // final-token-count) are intentionally not re-checked here — those
+    // belong in the helper, and the binding's docstring marks it internal.
+    // cu_seqlens dtype / ndim / shape and q/k/v dtype-match ARE re-checked
+    // below: all of them are load-fatal failure modes through the kernel's
+    // typed bindings (int* for cu_seqlens; a single template parameter T
+    // for q/k/v, selected from q.dtype() only — a mismatched k/v would
+    // mis-stride the load against the resource binding).
+    if (q.ndim() != 3 || k.ndim() != 3 || v.ndim() != 3) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q, k, v must each be 3-D "
+          "[total_tokens, num_heads, head_dim].");
+    }
+    if (k.shape(0) != q.shape(0) || v.shape(0) != q.shape(0) ||
+        k.shape(2) != q.shape(2) || v.shape(2) != q.shape(2) ||
+        k.shape(1) != q.shape(1) || v.shape(1) != q.shape(1)) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q, k, v must share the same shape "
+          "(v1 requires num_q_heads == num_kv_heads).");
+    }
+    if (k.dtype() != q.dtype() || v.dtype() != q.dtype()) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q, k, v must share dtype "
+          "(kernel template binds all three to the same T, selected from "
+          "q.dtype() only; a mismatched k/v dtype mis-strides the load "
+          "against the resource binding and may read past the K/V buffer).");
+    }
+    if (static_cast<int>(k.shape(1)) != num_kv_heads_) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: num_kv_heads parameter does not "
+          "match k.shape(1); kernel would silently misindex K/V.");
+    }
+    if (static_cast<int>(q.shape(2)) != head_dim_) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: head_dim parameter does not "
+          "match q.shape(2).");
+    }
+    // cu_seqlens dtype / shape / rank: the kernel binding is
+    // `device const int*`, and find_segment dereferences cu_seqlens[seg + 1]
+    // up through cu_seqlens[num_segments].  A non-int32 dtype mis-strides
+    // the load (4-byte stride read as 8 / 2 bytes); ndim != 1 silently
+    // mis-strides the load; shape(0) < 2 → num_segments <= 0 and the very
+    // first dereference is out-of-bounds.  The Python helper enforces all
+    // three on the raw and ValidatedSeqlens paths; these guards catch
+    // direct callers of the underscore binding that bypass those layers.
+    if (cu_seqlens.dtype() != int32) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must have dtype int32 "
+          "(kernel binding is device const int*; any other element width "
+          "would mis-stride the load).");
+    }
+    if (cu_seqlens.ndim() != 1) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must be 1-D "
+          "(kernel binding is device const int*; any other rank "
+          "would mis-stride the load).");
+    }
+    if (cu_seqlens.shape(0) < 2) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must have at least 2 "
+          "entries (num_segments + 1); the kernel reads cu_seqlens[seg + 1] "
+          "in find_segment and would dereference out of bounds.");
+    }
+
+    // Allocate output via the MLX allocator (mirroring
+    // PagedAttentionPrimitive::eval_gpu's set_data + allocator::malloc
+    // pattern).  This is the array whose descriptor the
+    // _encoder_varlen_attention_primitive binding's overwrite_descriptor
+    // call publishes back to Python — the cross-module RTTI bypass path
+    // documented at the top of this file.
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const int total_tokens = static_cast<int>(q.shape(0));
+    const int num_q_heads  = static_cast<int>(q.shape(1));
+    const int num_segments = static_cast<int>(cu_seqlens.shape(0)) - 1;
+
+    EncoderVarlenParams params{};
+    params.num_q_heads   = num_q_heads;
+    params.num_kv_heads  = num_kv_heads_;
+    params.total_tokens  = total_tokens;
+    params.num_segments  = num_segments;
+    params.max_seqlen    = max_seqlen_;
+    params.softmax_scale = softmax_scale_;
+
+    const char* dtype_tag = nullptr;
+    switch (dtype_tag_) {
+      case 0: dtype_tag = "f16";  break;
+      case 1: dtype_tag = "bf16"; break;
+      case 2: dtype_tag = "f32";  break;
+      default:
+        throw std::runtime_error(
+            "Unknown dtype_tag in EncoderVarlenAttentionPrimitive");
+    }
+    const std::string kname =
+        "encoder_varlen_attention_" + std::string(dtype_tag) + "_" +
+        std::to_string(head_dim_);
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+    auto* lib = d.get_library("encoder_varlen_kern");
+    auto* kernel = d.get_kernel(kname, lib, kname, {});
+
+    auto& enc = get_command_encoder_compat(d, s);
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_input_array(q, 0);
+    enc.set_input_array(k, 1);
+    enc.set_input_array(v, 2);
+    enc.set_input_array(cu_seqlens, 3);
+    enc.set_output_array(out, 4);
+    enc.set_bytes(params, 5);
+
+    // Grid: (total_tokens, num_q_heads, 1).  One threadgroup per
+    // (query_token, q_head) output vector.  Threadgroup width 32 == one
+    // SIMD-group on Apple Silicon, so simd_max / simd_sum reduce across the
+    // whole threadgroup in a single instruction with no inter-SIMD barriers.
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(total_tokens, num_q_heads, 1),
+        MTL::Size::Make(32, 1, 1));
+
+    // No add_temporary calls: inside a primitive, MLX's evaluator manages
+    // array lifetimes via the completion handler, and add_temporary would
+    // strip buffer pointers from the encoder's input/output tracking and
+    // silently defeat the fence for downstream primitives.
+  }
+
+  const char* name() const override { return "EncoderVarlenAttention"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* rhs = dynamic_cast<const EncoderVarlenAttentionPrimitive*>(&other);
+    return rhs
+        && rhs->num_kv_heads_  == num_kv_heads_
+        && rhs->softmax_scale_ == softmax_scale_
+        && rhs->dtype_tag_     == dtype_tag_
+        && rhs->head_dim_      == head_dim_;
+    // max_seqlen_ is intentionally excluded: it is a launch hint only,
+    // never used to bound cu_seqlens indexing in-kernel.
+  }
+
+ private:
+  int   num_kv_heads_;
+  float softmax_scale_;
+  int   dtype_tag_;
+  int   head_dim_;
+  int   max_seqlen_;
+};
+
+static int encoder_varlen_dtype_to_tag(Dtype dt) {
+  switch (dt) {
+    case float16:  return 0;
+    case bfloat16: return 1;
+    case float32:  return 2;
+    default:
+      throw std::runtime_error(
+          "Unsupported dtype for encoder_varlen_attention "
+          "(supported: float16, bfloat16, float32)");
+  }
+}
+
+static array encoder_varlen_attention_primitive_fn(
+    const array& q,
+    const array& k,
+    const array& v,
+    const array& cu_seqlens,
+    int num_kv_heads,
+    float softmax_scale,
+    int max_seqlen) {
+  // Rank guard before q.shape(2): a direct underscore-binding caller with
+  // ndim < 3 would otherwise hit MLX's low-level out-of-range from shape()
+  // here, before eval_gpu's "must each be 3-D" check could fire.  Same
+  // message as eval_gpu so callers see one consistent error regardless of
+  // path.  k/v rank stays in eval_gpu since they aren't accessed here.
+  if (q.ndim() != 3) {
+    throw std::invalid_argument(
+        "encoder_varlen_attention: q, k, v must each be 3-D "
+        "[total_tokens, num_heads, head_dim].");
+  }
+  const int dtype_tag = encoder_varlen_dtype_to_tag(q.dtype());
+  const int head_dim  = static_cast<int>(q.shape(2));
+  auto prim = std::make_shared<EncoderVarlenAttentionPrimitive>(
+      default_stream(Device::gpu),
+      num_kv_heads,
+      softmax_scale,
+      dtype_tag,
+      head_dim,
+      max_seqlen);
+  return array(
+      q.shape(),
+      q.dtype(),
+      std::move(prim),
+      {q, k, v, cu_seqlens});
+}
+
+// ---------------------------------------------------------------------------
 // nanobind module
 // ---------------------------------------------------------------------------
 
@@ -1123,6 +1453,10 @@ NB_MODULE(_paged_ops, m) {
   m.def("init_gdn_library", &init_gdn_library,
         nb::arg("gdn_src"),
         "JIT-compile the GDN linear attention Metal shader.");
+
+  m.def("init_encoder_varlen_library", &init_encoder_varlen_library,
+        nb::arg("src"),
+        "JIT-compile the dense non-causal varlen encoder attention shader.");
 
   m.def("reshape_and_cache", &reshape_and_cache_impl,
         nb::arg("key"), nb::arg("value"),
@@ -1290,4 +1624,44 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("slot_mapping"), nb::arg("y"),
         nb::arg("Hk"), nb::arg("Hv"), nb::arg("Dk"), nb::arg("Dv"),
         "GDN linear attention with in-place paged state management.");
+
+  // Dense non-causal varlen encoder attention.  Caller supplies a
+  // placeholder mx.array(0); the binding publishes the result via
+  // overwrite_descriptor (mirroring the paged_attention_primitive binding
+  // above) so the returned array carries the kernel dependency through
+  // MLX's lazy graph.  Validation of shapes / dtypes / cu_seqlens lives
+  // in the Python helper (vllm_metal.metal.encoder_varlen_attention);
+  // contiguity is enforced inside eval_gpu.
+  m.def("_encoder_varlen_attention_primitive",
+        [](nb::handle q_h,
+           nb::handle k_h,
+           nb::handle v_h,
+           nb::handle cu_seqlens_h,
+           int num_kv_heads,
+           float softmax_scale,
+           int max_seqlen,
+           nb::handle out_h) {
+          auto result = encoder_varlen_attention_primitive_fn(
+              *nb::inst_ptr<array>(q_h),
+              *nb::inst_ptr<array>(k_h),
+              *nb::inst_ptr<array>(v_h),
+              *nb::inst_ptr<array>(cu_seqlens_h),
+              num_kv_heads,
+              softmax_scale,
+              max_seqlen);
+          nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
+        },
+        nb::arg("q"),
+        nb::arg("k"),
+        nb::arg("v"),
+        nb::arg("cu_seqlens"),
+        nb::arg("num_kv_heads"),
+        nb::arg("softmax_scale"),
+        nb::arg("max_seqlen"),
+        nb::arg("out"),
+        "Internal: call via vllm_metal.metal.encoder_varlen_attention. "
+        "Direct calls bypass cu_seqlens monotonicity / final-token-count "
+        "validation; contiguity, basic Q/K/V shape / num_kv_heads / "
+        "head_dim invariants, q/k/v dtype-match, and cu_seqlens dtype / "
+        "ndim / shape are enforced inside eval_gpu.");
 }


### PR DESCRIPTION
## Summary
Dense non-causal varlen encoder attention primitive used by vision-tower models (Qwen2.5-VL and similar). Tiled FlashAttention-2 Metal kernel with simdgroup-MMA and register-resident online softmax, plus the C++ `EncoderVarlenAttentionPrimitive` and nanobind binding.

## Kernel notes
- Q_TILE=64 / K_TILE=32 register-resident MMA via `simdgroup_matrix<float, 8, 8>` lane fragments (mirrors MLX `steel_attention`'s BaseMMAFrag layout).
- All of (Q, K, S, V, O) live in registers as `vec<float, 2>` per-lane fragments.
- Softmax row reductions run via the `simd_shuffle_xor(1) + simd_shuffle_xor(8)` butterfly.
- log2-space online softmax (`exp2` per K-tile).
- Three template specializations: bf16 / f16 MMA + f32 manual fallback (Q_TILE=8, K_TILE=16).
- Twelve `[[host_name]]` entries: `{f16, bf16, f32}` × head_dim `{64, 80, 96, 128}`.

## Performance
Full-layer vs `mlx_vlm.models.qwen2_5_vl.vision.Qwen2_5_VLVisionAttention` (shared weights from the stock `Attention` instance; only the per-segment SDPA loop swapped for `encoder_varlen_attention`).  M1 Pro / 16 GB, MLX 0.31, bf16, warmup 3 / iters 20.

| config                   | tokens | mlx-vlm Attention ms | Metal-swapped ms | speedup |
|--------------------------|-------:|---------------------:|-----------------:|--------:|
| 4×256                    |  1,024 |                6.322 |            6.118 |   1.03× |
| 8×1024                   |  8,192 |               55.349 |           58.012 |   0.95× |
| 4×4096                   | 16,384 |              198.972 |          211.903 |   0.94× |
| varied (Qwen2.5-VL-ish)  |  3,840 |               25.713 |           27.144 |   0.95× |
| 4×1024 hd128             |  4,096 |               59.895 |           62.062 |   0.97× |
| 8×512  hd64              |  4,096 |               17.058 |           17.355 |   0.98× |
| 8×768  hd96              |  6,144 |               54.212 |           53.332 |   1.02× |

At the full-layer level the tiled kernel is at **0.94×–1.03×** of stock (parity, no daylight on this hardware).  Parity vs mlx-vlm output passes within bf16 numeric noise.

Refs #333.

CC @WindChimeRan