### PR TITLE
[Multimodal] Pin merge_multimodal_embeddings non-mutation contract

### DIFF
--- a/vllm_metal/multimodal/embeddings.py
+++ b/vllm_metal/multimodal/embeddings.py
@@ -17,9 +17,8 @@ def merge_multimodal_embeddings(
     """Splice multimodal embeddings into placeholder positions.
 
     Mirrors ``vllm/model_executor/models/utils.py``
-    ``_merge_multimodal_embeddings`` for MLX arrays.  This helper builds and
-    returns the merged tensor; callers should not rely on ``inputs_embeds``
-    being mutated.
+    ``_merge_multimodal_embeddings`` for MLX arrays.  Returns a new array;
+    ``inputs_embeds`` is not mutated.
     """
     if len(multimodal_embeddings) == 0:
         return inputs_embeds
@@ -43,7 +42,11 @@ def merge_multimodal_embeddings(
 
     input_dtype = inputs_embeds.dtype
     hidden_size = inputs_embeds.shape[-1]
-    flat = inputs_embeds.reshape(-1, hidden_size)
+    # Materialize a fresh buffer before the in-place assignment so the
+    # non-mutation contract holds independent of MLX reshape/__setitem__
+    # aliasing semantics. Note ``mx.array(x)`` and ``x.reshape(...)`` both
+    # share storage with ``x`` in MLX 0.31; addition forces a new buffer.
+    flat = (inputs_embeds + mx.zeros((), dtype=input_dtype)).reshape(-1, hidden_size)
     mask_np = np.asarray(mask_flat)
     positions = mx.array(np.where(mask_np)[0], dtype=mx.uint32)
     flat[positions] = mm_embeds_flat.astype(input_dtype)


### PR DESCRIPTION
## Summary

Follow-up to #330. ``merge_multimodal_embeddings`` documents (and a test asserts) that ``inputs_embeds`` is not mutated, but the implementation relied on MLX's current ``__setitem__`` doing implicit copy-on-write through a reshape view — undocumented behavior. A future MLX change that propagates ``__setitem__`` writes through views would silently let callers reusing ``inputs_embeds`` observe modified text rows. The upcoming per-step paged path will rely on this guarantee.

This PR pins the contract by materializing ``inputs_embeds`` into a fresh buffer before the in-place assignment.

## Change

```python
# before
flat = inputs_embeds.reshape(-1, hidden_size)
flat[positions] = mm_embeds_flat.astype(input_dtype)

# after
flat = (inputs_embeds + mx.zeros((), dtype=input_dtype)).reshape(-1, hidden_size)
flat[positions] = mm_embeds_flat.astype(input_dtype)
```

The fresh full-shape output buffer of the addition IS the materialization we want — that is the cost of pinning the contract. The scalar zero broadcasts in the op, so we do not additionally allocate a separate full-shape zeros tensor.

Docstring tightened to state the non-mutation contract positively.

### Notes on alternatives that do not work

- ``mx.array(x)`` does **not** copy: its constructor delegates to ``astype(x, x.dtype())``, which short-circuits and returns ``x`` when the dtype is unchanged. Verified via ``np.asarray(...).ctypes.data`` — the resulting array shares the underlying buffer pointer.
- ``np.array`` round-trip is not viable: ``np.array(bfloat16_arr)`` raises ``RuntimeError: ... PEP 3118 buffer format string`` on bfloat16, which the function must support (``test_merge_dtype_preserved``).

## Test plan

- [x] ``pytest tests/multimodal/test_embeddings.py -v`` — all 8 tests pass, including ``test_merge_does_not_mutate_input`` and ``test_merge_dtype_preserved``
- [x] ``ruff check`` + ``ruff format --check`` clean
- [x] CI green (lint × 3 platforms, test macOS, DCO)