### PR TITLE
[Multimodal] Wire Qwen3.5 lifecycle state

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -32,6 +32,8 @@ def make_stub_runner(
         "model": object(),
         "_is_stt": False,
         "_is_vlm": False,
+        "_multimodal_adapter": None,
+        "encoder_cache": None,
         "_paged_attention_backend": None,
         "_gdn_req_to_slot": {},
         "_gdn_free_slots": [],

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -7,6 +7,7 @@ import pytest
 
 import vllm_metal.envs as envs
 from vllm_metal.config import reset_config
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1.model_adapter import DefaultModelAdapter
 
 
@@ -244,6 +245,51 @@ class TestTextModel:
         model = object()
         adapter = DefaultModelAdapter()
         assert adapter.text_model(model) is model
+
+
+class TestBuildMultimodalAdapter:
+    def test_builds_qwen35_adapter_from_loaded_vlm(self) -> None:
+        vision_tower = object()
+        language_model = object()
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vision_config=SimpleNamespace(spatial_merge_size=2),
+            ),
+            vision_tower=vision_tower,
+            language_model=language_model,
+        )
+        hf_config = SimpleNamespace(model_type="qwen3_5")
+
+        adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
+
+        assert isinstance(adapter, Qwen3VLMultimodalAdapter)
+        assert adapter._vision_tower is vision_tower
+        assert adapter._language_model is language_model
+
+    def test_builds_qwen3_vl_adapter_from_architecture(self) -> None:
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vision_config=SimpleNamespace(spatial_merge_size=2),
+            ),
+            vision_tower=object(),
+            language_model=object(),
+        )
+        hf_config = SimpleNamespace(
+            model_type="custom",
+            architectures=["Qwen3VLForConditionalGeneration"],
+        )
+
+        adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
+
+        assert isinstance(adapter, Qwen3VLMultimodalAdapter)
+
+    def test_generic_vlm_has_no_model_owned_adapter(self) -> None:
+        model = SimpleNamespace()
+        hf_config = SimpleNamespace(model_type="phi3_v")
+
+        adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
+
+        assert adapter is None
 
 
 class TestResolveMaxHeadDim:

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -263,8 +263,9 @@ class TestBuildMultimodalAdapter:
         adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
 
         assert isinstance(adapter, Qwen3VLMultimodalAdapter)
-        assert adapter._vision_tower is vision_tower
-        assert adapter._language_model is language_model
+        assert adapter.forward_ready is False
+        assert adapter.vision_tower is vision_tower
+        assert adapter.language_model is language_model
 
     def test_builds_qwen3_vl_adapter_from_architecture(self) -> None:
         model = SimpleNamespace(

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -263,9 +263,7 @@ class TestBuildMultimodalAdapter:
         adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
 
         assert isinstance(adapter, Qwen3VLMultimodalAdapter)
-        assert adapter.forward_ready is False
-        assert adapter.vision_tower is vision_tower
-        assert adapter.language_model is language_model
+        assert adapter.text_model() is language_model
 
     def test_builds_qwen3_vl_adapter_from_architecture(self) -> None:
         model = SimpleNamespace(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -14,6 +14,7 @@ import torch
 import vllm_metal.envs as envs
 from tests.stub_runner import make_stub_runner
 from vllm_metal.config import reset_config
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
@@ -88,14 +89,31 @@ def _text_config(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**(_TEXT_MODEL_ARGS | overrides))
 
 
+def _qwen35_vlm_model(
+    *,
+    vision_tower: object | None = None,
+    language_model: object | None = None,
+    spatial_merge_size: int = 2,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            text_config=_text_config(),
+            vision_config=SimpleNamespace(spatial_merge_size=spatial_merge_size),
+        ),
+        vision_tower=object() if vision_tower is None else vision_tower,
+        language_model=object() if language_model is None else language_model,
+    )
+
+
 def _cache_generation_model(
     monkeypatch: pytest.MonkeyPatch,
     *,
     config: object,
     tokenizer: object | None = None,
     is_vlm: bool = False,
+    model: object | None = None,
 ) -> tuple[object, object]:
-    fake_model = SimpleNamespace(config=config)
+    fake_model = model or SimpleNamespace(config=config)
     fake_tokenizer = object() if tokenizer is None else tokenizer
     cache_key = model_lifecycle._generation_cache_key("stub-model", is_vlm=is_vlm)
     monkeypatch.setattr(
@@ -205,6 +223,7 @@ class TestModelLifecycle:
         lifecycle.load()
 
         assert runner._is_vlm is False
+        assert runner._multimodal_adapter is None
 
     def test_load_uses_adapter_override_for_qwen36_fp8_conditional_generation(
         self,
@@ -232,10 +251,12 @@ class TestModelLifecycle:
     ) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
         reset_config()
+        fake_model = _qwen35_vlm_model()
         _cache_generation_model(
             monkeypatch,
-            config=SimpleNamespace(text_config=_text_config()),
+            config=fake_model.config,
             is_vlm=True,
+            model=fake_model,
         )
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
@@ -252,13 +273,70 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is True
 
+    def test_load_multimodal_native_qwen35_builds_model_adapter(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+        vision_tower = object()
+        language_model = object()
+        fake_model = _qwen35_vlm_model(
+            vision_tower=vision_tower,
+            language_model=language_model,
+        )
+        _cache_generation_model(
+            monkeypatch,
+            config=fake_model.config,
+            is_vlm=True,
+            model=fake_model,
+        )
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization_config={"quant_method": "fp8"},
+                ),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is True
+        assert isinstance(runner._multimodal_adapter, Qwen3VLMultimodalAdapter)
+        assert runner._multimodal_adapter._vision_tower is vision_tower
+        assert runner._multimodal_adapter._language_model is language_model
+
+    def test_load_generic_vlm_leaves_model_adapter_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _cache_generation_model(
+            monkeypatch,
+            config=SimpleNamespace(text_config=_text_config()),
+            is_vlm=True,
+        )
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(model_type="phi3_v"),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is True
+        assert runner._multimodal_adapter is None
+
     def test_generation_cache_separates_text_and_vlm_variants(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         text_model = SimpleNamespace(config=_text_config())
         text_tokenizer = object()
-        vlm_model = SimpleNamespace(config=SimpleNamespace(text_config=_text_config()))
+        vlm_model = _qwen35_vlm_model()
         vlm_tokenizer = object()
         monkeypatch.setattr(
             model_lifecycle,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -307,8 +307,7 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is True
         assert isinstance(runner._multimodal_adapter, Qwen3VLMultimodalAdapter)
-        assert runner._multimodal_adapter.vision_tower is vision_tower
-        assert runner._multimodal_adapter.language_model is language_model
+        assert runner._multimodal_adapter.text_model() is language_model
         assert isinstance(runner.encoder_cache, EncoderCache)
 
     def test_load_generic_vlm_leaves_model_adapter_unset(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -17,6 +17,7 @@ from vllm_metal.config import reset_config
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.v1 import model_lifecycle
+from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 
 _TEXT_MODEL_ARGS = {
@@ -306,8 +307,9 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is True
         assert isinstance(runner._multimodal_adapter, Qwen3VLMultimodalAdapter)
-        assert runner._multimodal_adapter._vision_tower is vision_tower
-        assert runner._multimodal_adapter._language_model is language_model
+        assert runner._multimodal_adapter.vision_tower is vision_tower
+        assert runner._multimodal_adapter.language_model is language_model
+        assert isinstance(runner.encoder_cache, EncoderCache)
 
     def test_load_generic_vlm_leaves_model_adapter_unset(
         self,
@@ -329,6 +331,7 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is True
         assert runner._multimodal_adapter is None
+        assert runner.encoder_cache is None
 
     def test_generation_cache_separates_text_and_vlm_variants(
         self,

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -12,11 +12,15 @@ Run with:
 from __future__ import annotations
 
 from collections.abc import Callable
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
 
 import vllm_metal.paged_attention_common as pac
 import vllm_metal.v1.model_runner as mr
@@ -42,10 +46,10 @@ def _greedy_sp() -> SamplingParams:
 
 
 def _make_scheduler_output(
-    new_reqs: list[SimpleNamespace],
+    new_reqs: list[NewRequestData],
     num_scheduled: dict[str, int] | None = None,
-) -> SimpleNamespace:
-    """Minimal SchedulerOutput stub."""
+) -> SchedulerOutput:
+    """Build a SchedulerOutput with new requests."""
     if num_scheduled is None:
         num_scheduled = {}
         for r in new_reqs:
@@ -53,19 +57,26 @@ def _make_scheduler_output(
             total = len(r.prompt_token_ids)
             num_scheduled[r.req_id] = total - computed
 
-    return SimpleNamespace(
+    return SchedulerOutput(
         scheduled_new_reqs=new_reqs,
-        scheduled_cached_reqs=SimpleNamespace(
+        scheduled_cached_reqs=CachedRequestData(
             req_ids=[],
             new_block_ids=[],
             resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
             num_computed_tokens=[],
+            num_output_tokens=[],
         ),
         num_scheduled_tokens=num_scheduled,
         total_num_scheduled_tokens=sum(num_scheduled.values()),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
         finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
         preempted_req_ids=set(),
-        grammar_bitmask=None,
+        has_structured_output_requests=False,
     )
 
 
@@ -74,16 +85,19 @@ def _make_new_req(
     prompt_token_ids: list[int],
     num_computed_tokens: int = 0,
     block_ids: list[int] | None = None,
-) -> SimpleNamespace:
+) -> NewRequestData:
     if block_ids is None:
         num_blocks = (len(prompt_token_ids) + 3) // 4 + 1
         block_ids = list(range(num_blocks))
-    return SimpleNamespace(
+    return NewRequestData(
         req_id=req_id,
         prompt_token_ids=prompt_token_ids,
+        mm_features=[],
         sampling_params=_greedy_sp(),
+        pooling_params=None,
         block_ids=(block_ids,),
         num_computed_tokens=num_computed_tokens,
+        lora_request=None,
     )
 
 
@@ -269,23 +283,30 @@ def _make_cached_scheduler_output(
     num_computed_tokens: list[int],
     num_scheduled: dict[str, int],
     new_block_ids: list | None = None,
-) -> SimpleNamespace:
-    """Minimal SchedulerOutput with cached requests only."""
+) -> SchedulerOutput:
+    """Build a SchedulerOutput with cached requests only."""
     if new_block_ids is None:
         new_block_ids = [None] * len(req_ids)
-    return SimpleNamespace(
+    return SchedulerOutput(
         scheduled_new_reqs=[],
-        scheduled_cached_reqs=SimpleNamespace(
+        scheduled_cached_reqs=CachedRequestData(
             req_ids=req_ids,
             new_block_ids=new_block_ids,
             resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
             num_computed_tokens=num_computed_tokens,
+            num_output_tokens=[0] * len(req_ids),
         ),
         num_scheduled_tokens=num_scheduled,
         total_num_scheduled_tokens=sum(num_scheduled.values()),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
         finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
         preempted_req_ids=set(),
-        grammar_bitmask=None,
+        has_structured_output_requests=False,
     )
 
 
@@ -303,11 +324,14 @@ class TestCachedRequestBlockUpdates:
         )
         runner._paged_request_seq_lens["req-1"] = 5
 
-        cached_reqs = SimpleNamespace(
+        cached_reqs = CachedRequestData(
             req_ids=["req-1"],
             new_block_ids=[([7, 8],)],
             resumed_req_ids={"req-1"},
+            new_token_ids=[],
+            all_token_ids={},
             num_computed_tokens=[4],
+            num_output_tokens=[0],
         )
 
         runner._update_cached_request_blocks(cached_reqs)
@@ -347,19 +371,26 @@ class TestMixedDecodeAndPrefixHitPrefill:
         greedy_tokens = [mx.array([decode_token]), mx.array([prefill_token])]
 
         new_req_b = _make_new_req("req-B", prompt_b, num_computed_tokens=num_computed_b)
-        sched_out = SimpleNamespace(
+        sched_out = SchedulerOutput(
             scheduled_new_reqs=[new_req_b],
-            scheduled_cached_reqs=SimpleNamespace(
+            scheduled_cached_reqs=CachedRequestData(
                 req_ids=["req-A"],
                 new_block_ids=[None],
                 resumed_req_ids=set(),
+                new_token_ids=[],
+                all_token_ids={},
                 num_computed_tokens=[len(prompt_a)],
+                num_output_tokens=[0],
             ),
             num_scheduled_tokens={"req-A": 1, "req-B": suffix_len_b},
             total_num_scheduled_tokens=1 + suffix_len_b,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
             finished_req_ids=set(),
+            free_encoder_mm_hashes=[],
             preempted_req_ids=set(),
-            grammar_bitmask=None,
+            has_structured_output_requests=False,
         )
 
         with (

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -20,10 +20,10 @@ Run golden token test (requires model download):
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
@@ -281,19 +281,26 @@ class TestGDNSlotLifecycle:
         runner.model = object()
         runner.model_args = {"full_attention_interval": 2}
         runner._gdn_req_to_slot = {"req-A": 0}
-        scheduler_output = SimpleNamespace(
+        scheduler_output = SchedulerOutput(
             scheduled_new_reqs=[],
-            scheduled_cached_reqs=SimpleNamespace(
+            scheduled_cached_reqs=CachedRequestData(
                 req_ids=[],
                 new_block_ids=[],
                 resumed_req_ids=set(),
+                new_token_ids=[],
+                all_token_ids={},
                 num_computed_tokens=[],
+                num_output_tokens=[],
             ),
             num_scheduled_tokens={},
             total_num_scheduled_tokens=0,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
             finished_req_ids={"req-A"},
+            free_encoder_mm_hashes=[],
             preempted_req_ids=set(),
-            grammar_bitmask=None,
+            has_structured_output_requests=False,
         )
 
         with (

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -320,6 +320,53 @@ class TestGDNSlotLifecycle:
         assert runner._gdn_needs_materialize is True
         mock_materialize.assert_not_called()
 
+    def test_sample_tokens_drains_paged_pending_materialization(self):
+        from vllm_metal.v1.model_runner import _ExecutionBatch
+
+        runner, _ = self._make_runner_stub()
+        runner._execute_model_state = object()
+        runner._gdn_needs_materialize = True
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=CachedRequestData(
+                req_ids=[],
+                new_block_ids=[],
+                resumed_req_ids=set(),
+                new_token_ids=[],
+                all_token_ids={},
+                num_computed_tokens=[],
+                num_output_tokens=[],
+            ),
+            num_scheduled_tokens={},
+            total_num_scheduled_tokens=0,
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
+            finished_req_ids=set(),
+            free_encoder_mm_hashes=[],
+            preempted_req_ids=set(),
+            has_structured_output_requests=False,
+        )
+
+        with (
+            patch.object(
+                runner,
+                "_sample_paged_batch",
+                return_value=(_ExecutionBatch(), scheduler_output),
+            ),
+            patch.object(
+                runner,
+                "_gdn_materialize_state_cache",
+                wraps=runner._gdn_materialize_state_cache,
+            ) as mock_materialize,
+        ):
+            output = runner.sample_tokens(None)
+
+        assert output is not None
+        assert output.req_ids == []
+        mock_materialize.assert_called_once()
+        assert runner._gdn_needs_materialize is False
+
     def test_cleanup_finished_requests_drains_pending_materialization(self):
         runner, _ = self._make_runner_stub()
         runner._gdn_needs_materialize = True

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -8,6 +8,7 @@ from vllm.v1.outputs import ModelRunnerOutput
 
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 
 
 class TestV1MetalModelRunnerGenerate:
@@ -72,7 +73,11 @@ class TestV1MetalModelRunnerGenerate:
 
         language_model = object()
         runner = self._make_runner()
-        runner.model = SimpleNamespace(language_model=language_model)
+        runner.model = SimpleNamespace(language_model=object())
+        runner._multimodal_adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=2,
+            language_model=language_model,
+        )
         runner._is_vlm = True
 
         out = runner.generate("p", max_tokens=1)

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -18,6 +18,7 @@ class TestV1MetalModelRunnerGenerate:
         captured: dict[str, object] = {}
 
         def fake_stream_generate(model, tokenizer, prompt, max_tokens=256, **kwargs):
+            captured["model"] = model
             captured["prompt"] = prompt
             captured["max_tokens"] = max_tokens
             captured["kwargs"] = kwargs
@@ -31,6 +32,7 @@ class TestV1MetalModelRunnerGenerate:
         out = runner.generate("p", max_tokens=3, temperature=0.0)
 
         assert out == "hello world"
+        assert captured["model"] is runner.model
         assert captured["prompt"] == "p"
         assert captured["max_tokens"] == 3
         kwargs = captured.get("kwargs")
@@ -58,6 +60,25 @@ class TestV1MetalModelRunnerGenerate:
         kwargs = captured.get("kwargs")
         assert isinstance(kwargs, dict)
         assert "sampler" in kwargs
+
+    def test_uses_forward_model_for_vlm_composite(self, monkeypatch) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_stream_generate(model, tokenizer, prompt, max_tokens=256, **kwargs):
+            captured["model"] = model
+            yield SimpleNamespace(text="ok")
+
+        monkeypatch.setattr(mr, "stream_generate", fake_stream_generate)
+
+        language_model = object()
+        runner = self._make_runner()
+        runner.model = SimpleNamespace(language_model=language_model)
+        runner._is_vlm = True
+
+        out = runner.generate("p", max_tokens=1)
+
+        assert out == "ok"
+        assert captured["model"] is language_model
 
 
 class TestV1MetalModelRunnerSampleTokens:

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -42,6 +42,22 @@ class TestWorkerRunnerBoundaryDelegation:
         model_runner.load_model.assert_called_once_with()
         worker._setup_paged_attention.assert_not_called()
 
+    def test_reset_mm_cache_delegates_to_runner(self) -> None:
+        model_runner = MagicMock()
+        worker = _make_worker(model_runner, use_paged_attention=True)
+
+        MetalWorker.reset_mm_cache(worker)
+
+        model_runner.reset_mm_cache.assert_called_once_with()
+
+    def test_reset_encoder_cache_delegates_to_runner(self) -> None:
+        model_runner = MagicMock()
+        worker = _make_worker(model_runner, use_paged_attention=True)
+
+        MetalWorker.reset_encoder_cache(worker)
+
+        model_runner.reset_encoder_cache.assert_called_once_with()
+
     def test_determine_available_memory_stt_nominal_mode(self) -> None:
         model_runner = SimpleNamespace(
             scheduler_memory_reporting_mode=MagicMock(return_value="stt_nominal"),

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest
+from vllm.sampling_params import SamplingParams
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     NewRequestData,
@@ -16,6 +17,7 @@ from vllm.v1.core.sched.output import (
 from tests.stub_runner import make_stub_runner
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
 from vllm_metal.v1.mm import EncoderCache
+from vllm_metal.v1.model_runner import RequestState
 
 
 def _feature(identifier: str) -> MultiModalFeatureSpec:
@@ -118,15 +120,27 @@ def test_cleanup_finished_requests_removes_mm_features() -> None:
     assert "req-0" not in runner.encoder_cache.mm_features
 
 
-def test_cleanup_preempted_requests_removes_mm_features() -> None:
+def test_preempted_requests_keep_resume_state() -> None:
     runner = _runner_with_encoder_cache()
     features = [_feature("image-0")]
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", features)
+    state = RequestState(
+        token_ids=[1, 2],
+        prompt_len=1,
+        cache=[],
+        sampling_params=SamplingParams(),
+    )
+    runner._request_states["req-0"] = state
+    runner._paged_request_seq_lens["req-0"] = 2
+    runner._gdn_req_to_slot["req-0"] = 0
 
     runner.execute_model(_scheduler_output(preempted_req_ids={"req-0"}))
 
-    assert "req-0" not in runner.encoder_cache.mm_features
+    assert runner.encoder_cache.mm_features["req-0"] == features
+    assert runner._request_states["req-0"] is state
+    assert runner._paged_request_seq_lens["req-0"] == 2
+    assert runner._gdn_req_to_slot["req-0"] == 0
 
 
 def test_resubmitted_request_keeps_new_mm_features() -> None:

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Metal runner multimodal cache lifecycle wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+from vllm_metal.v1.mm import EncoderCache
+
+
+def _feature(identifier: str) -> MultiModalFeatureSpec:
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=0, length=1),
+    )
+
+
+def _cached_reqs(req_ids: list[str] | None = None) -> CachedRequestData:
+    ids = req_ids or []
+    return CachedRequestData(
+        req_ids=ids,
+        resumed_req_ids=set(),
+        new_token_ids=[],
+        all_token_ids={},
+        new_block_ids=[None] * len(ids),
+        num_computed_tokens=[0] * len(ids),
+        num_output_tokens=[0] * len(ids),
+    )
+
+
+def _scheduler_output(
+    *,
+    scheduled_new_reqs: list[NewRequestData] | None = None,
+    scheduled_encoder_inputs: dict[str, list[int]] | None = None,
+    finished_req_ids: set[str] | None = None,
+    preempted_req_ids: set[str] | None = None,
+    free_encoder_mm_hashes: list[str] | None = None,
+) -> SchedulerOutput:
+    new_reqs = scheduled_new_reqs or []
+    num_scheduled_tokens = {
+        req.req_id: len(req.prompt_token_ids or []) - req.num_computed_tokens
+        for req in new_reqs
+    }
+    return SchedulerOutput(
+        scheduled_new_reqs=new_reqs,
+        scheduled_cached_reqs=_cached_reqs(),
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs=scheduled_encoder_inputs or {},
+        num_common_prefix_blocks=[],
+        finished_req_ids=finished_req_ids or set(),
+        free_encoder_mm_hashes=free_encoder_mm_hashes or [],
+        preempted_req_ids=preempted_req_ids or set(),
+        has_structured_output_requests=False,
+    )
+
+
+def _new_request(req_id: str, features: list[MultiModalFeatureSpec]) -> NewRequestData:
+    return NewRequestData(
+        req_id=req_id,
+        prompt_token_ids=[1],
+        mm_features=features,
+        sampling_params=None,
+        pooling_params=None,
+        block_ids=([0],),
+        num_computed_tokens=0,
+        lora_request=None,
+    )
+
+
+def _runner_with_encoder_cache():
+    return make_stub_runner(encoder_cache=EncoderCache())
+
+
+def _paged_runner_with_encoder_cache():
+    runner = make_stub_runner(
+        encoder_cache=EncoderCache(),
+        _paged_attention_backend=MagicMock(),
+        _paged_block_size=16,
+    )
+    runner._start_paged_forward = MagicMock()
+    return runner
+
+
+def test_execute_model_registers_new_request_mm_features() -> None:
+    runner = _paged_runner_with_encoder_cache()
+    features = [_feature("image-0")]
+
+    runner.execute_model(
+        _scheduler_output(scheduled_new_reqs=[_new_request("req-0", features)])
+    )
+
+    assert runner.encoder_cache is not None
+    assert runner.encoder_cache.mm_features["req-0"] == features
+
+
+def test_cleanup_finished_requests_removes_mm_features() -> None:
+    runner = _runner_with_encoder_cache()
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+
+    runner.execute_model(_scheduler_output(finished_req_ids={"req-0"}))
+
+    assert "req-0" not in runner.encoder_cache.mm_features
+
+
+def test_cleanup_preempted_requests_removes_mm_features() -> None:
+    runner = _runner_with_encoder_cache()
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+
+    runner.execute_model(_scheduler_output(preempted_req_ids={"req-0"}))
+
+    assert "req-0" not in runner.encoder_cache.mm_features
+
+
+def test_resubmitted_request_keeps_new_mm_features() -> None:
+    runner = _paged_runner_with_encoder_cache()
+    old_features = [_feature("old-image")]
+    new_features = [_feature("new-image")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", old_features)
+
+    runner.execute_model(
+        _scheduler_output(
+            scheduled_new_reqs=[_new_request("req-0", new_features)],
+            finished_req_ids={"req-0"},
+        )
+    )
+
+    assert runner.encoder_cache.mm_features["req-0"] == new_features
+
+
+def test_execute_model_frees_released_encoder_outputs() -> None:
+    runner = _runner_with_encoder_cache()
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.encoder_outputs["keep"] = mx.array([[1.0]])
+    runner.encoder_cache.encoder_outputs["drop"] = mx.array([[2.0]])
+
+    runner.execute_model(_scheduler_output(free_encoder_mm_hashes=["drop"]))
+
+    assert set(runner.encoder_cache.encoder_outputs) == {"keep"}
+
+
+def test_reset_encoder_cache_delegates_to_encoder_cache() -> None:
+    runner = _runner_with_encoder_cache()
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.encoder_outputs["image-0"] = mx.array([[1.0]])
+
+    runner.reset_encoder_cache()
+
+    assert runner.encoder_cache.encoder_outputs == {}
+
+
+def test_reset_mm_cache_delegates_to_encoder_cache() -> None:
+    encoder_cache = MagicMock()
+    runner = make_stub_runner(encoder_cache=encoder_cache)
+
+    runner.reset_mm_cache()
+
+    encoder_cache.reset_mm_cache.assert_called_once_with()
+
+
+def test_execute_model_rejects_scheduled_encoder_inputs_until_encoder_path() -> None:
+    runner = _runner_with_encoder_cache()
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.encoder_outputs["drop"] = mx.array([[1.0]])
+
+    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+        runner.execute_model(
+            _scheduler_output(
+                scheduled_encoder_inputs={"req-0": [0]},
+                free_encoder_mm_hashes=["drop"],
+            )
+        )
+
+    assert "drop" in runner.encoder_cache.encoder_outputs

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -17,6 +16,7 @@ from vllm.v1.core.sched.output import (
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_runner import RequestState
 
@@ -231,8 +231,12 @@ def test_execute_model_cleans_finished_requests_before_encoder_fail_fast() -> No
     assert "done" not in runner._request_states
 
 
-def test_execute_model_honors_forward_ready_multimodal_adapter() -> None:
+def test_execute_model_rejects_encoder_inputs_until_forward_is_wired() -> None:
     runner = _runner_with_encoder_cache()
-    runner._multimodal_adapter = SimpleNamespace(forward_ready=True)
+    runner._multimodal_adapter = Qwen3VLMultimodalAdapter(
+        spatial_merge_size=2,
+        language_model=object(),
+    )
 
-    runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))
+    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+        runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -190,7 +191,7 @@ def test_reset_mm_cache_delegates_to_encoder_cache() -> None:
     encoder_cache.reset_mm_cache.assert_called_once_with()
 
 
-def test_execute_model_rejects_scheduled_encoder_inputs_until_encoder_path() -> None:
+def test_execute_model_frees_encoder_outputs_before_encoder_fail_fast() -> None:
     runner = _runner_with_encoder_cache()
     assert runner.encoder_cache is not None
     runner.encoder_cache.encoder_outputs["drop"] = mx.array([[1.0]])
@@ -203,4 +204,11 @@ def test_execute_model_rejects_scheduled_encoder_inputs_until_encoder_path() -> 
             )
         )
 
-    assert "drop" in runner.encoder_cache.encoder_outputs
+    assert "drop" not in runner.encoder_cache.encoder_outputs
+
+
+def test_execute_model_honors_forward_ready_multimodal_adapter() -> None:
+    runner = _runner_with_encoder_cache()
+    runner._multimodal_adapter = SimpleNamespace(forward_ready=True)
+
+    runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -207,6 +207,30 @@ def test_execute_model_frees_encoder_outputs_before_encoder_fail_fast() -> None:
     assert "drop" not in runner.encoder_cache.encoder_outputs
 
 
+def test_execute_model_cleans_finished_requests_before_encoder_fail_fast() -> None:
+    runner = _runner_with_encoder_cache()
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("done", features)
+    runner._request_states["done"] = RequestState(
+        token_ids=[1, 2],
+        prompt_len=1,
+        cache=[],
+        sampling_params=SamplingParams(),
+    )
+
+    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+        runner.execute_model(
+            _scheduler_output(
+                finished_req_ids={"done"},
+                scheduled_encoder_inputs={"req-0": [0]},
+            )
+        )
+
+    assert "done" not in runner.encoder_cache.mm_features
+    assert "done" not in runner._request_states
+
+
 def test_execute_model_honors_forward_ready_multimodal_adapter() -> None:
     runner = _runner_with_encoder_cache()
     runner._multimodal_adapter = SimpleNamespace(forward_ready=True)

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -16,6 +16,8 @@ from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 class Qwen3VLMultimodalAdapter:
     """Model-owned multimodal helpers for the Qwen3-VL execution path."""
 
+    forward_ready: bool = False
+
     def __init__(
         self,
         *,
@@ -31,8 +33,18 @@ class Qwen3VLMultimodalAdapter:
         self._vision_tower = vision_tower
         self._language_model = language_model
 
+    @property
+    def vision_tower(self) -> Any:
+        """Return the loaded Qwen3-VL vision tower."""
+        return self._vision_tower
+
+    @property
+    def language_model(self) -> Any:
+        """Return the loaded Qwen3-VL language model."""
+        return self._language_model
+
     @classmethod
-    def _from_loaded_model(cls, model: Any) -> Qwen3VLMultimodalAdapter:
+    def from_loaded_model(cls, model: Any) -> Qwen3VLMultimodalAdapter:
         """Create an adapter from an mlx-vlm Qwen3-VL/Qwen3.5 composite."""
         vision_tower = model.vision_tower
         language_model = model.language_model

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -16,8 +16,6 @@ from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 class Qwen3VLMultimodalAdapter:
     """Model-owned multimodal helpers for the Qwen3-VL execution path."""
 
-    forward_ready: bool = False
-
     def __init__(
         self,
         *,
@@ -33,13 +31,7 @@ class Qwen3VLMultimodalAdapter:
         self._vision_tower = vision_tower
         self._language_model = language_model
 
-    @property
-    def vision_tower(self) -> Any:
-        """Return the loaded Qwen3-VL vision tower."""
-        return self._vision_tower
-
-    @property
-    def language_model(self) -> Any:
+    def text_model(self) -> Any:
         """Return the loaded Qwen3-VL language model."""
         return self._language_model
 

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -16,12 +16,32 @@ from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 class Qwen3VLMultimodalAdapter:
     """Model-owned multimodal helpers for the Qwen3-VL execution path."""
 
-    def __init__(self, *, spatial_merge_size: int) -> None:
+    def __init__(
+        self,
+        *,
+        spatial_merge_size: int,
+        vision_tower: Any | None = None,
+        language_model: Any | None = None,
+    ) -> None:
         if spatial_merge_size <= 0:
             raise ValueError(
                 f"spatial_merge_size must be positive, got {spatial_merge_size}"
             )
         self._spatial_merge_size = spatial_merge_size
+        self._vision_tower = vision_tower
+        self._language_model = language_model
+
+    @classmethod
+    def _from_loaded_model(cls, model: Any) -> Qwen3VLMultimodalAdapter:
+        """Create an adapter from an mlx-vlm Qwen3-VL/Qwen3.5 composite."""
+        vision_tower = model.vision_tower
+        language_model = model.language_model
+        spatial_merge_size = int(model.config.vision_config.spatial_merge_size)
+        return cls(
+            spatial_merge_size=spatial_merge_size,
+            vision_tower=vision_tower,
+            language_model=language_model,
+        )
 
     def get_mrope_input_positions(
         self,

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -10,21 +10,23 @@ from vllm.logger import init_logger
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
+    from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
+
 logger = init_logger(__name__)
 
 
 class MultimodalRuntimeAdapter(Protocol):
-    """Model-owned runtime state needed for native multimodal execution."""
+    """Model-owned behavior needed for native multimodal execution."""
 
-    forward_ready: bool
+    def text_model(self) -> Any:
+        """Return the callable language model for text-only VLM execution."""
 
-    @property
-    def vision_tower(self) -> Any:
-        """Return the loaded vision encoder component."""
-
-    @property
-    def language_model(self) -> Any:
-        """Return the loaded language-model component."""
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[Any, int]:
+        """Return model-specific M-RoPE positions for multimodal inputs."""
 
 
 class ModelAdapter(Protocol):

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -13,6 +13,20 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+class MultimodalRuntimeAdapter(Protocol):
+    """Model-owned runtime state needed for native multimodal execution."""
+
+    forward_ready: bool
+
+    @property
+    def vision_tower(self) -> Any:
+        """Return the loaded vision encoder component."""
+
+    @property
+    def language_model(self) -> Any:
+        """Return the loaded language-model component."""
+
+
 class ModelAdapter(Protocol):
     """Model-specific hooks used by runner and cache orchestration."""
 
@@ -39,7 +53,9 @@ class ModelAdapter(Protocol):
     def text_model(self, model: Any) -> Any:
         """Return the callable model used for text-only execution."""
 
-    def build_multimodal_adapter(self, model: Any, hf_config: Any) -> Any | None:
+    def build_multimodal_adapter(
+        self, model: Any, hf_config: Any
+    ) -> MultimodalRuntimeAdapter | None:
         """Return a model-owned multimodal adapter for native VLM execution."""
 
     def build_yoco_cache_mapping(
@@ -214,7 +230,9 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             return model.language_model
         return model
 
-    def build_multimodal_adapter(self, model: Any, hf_config: Any) -> Any | None:
+    def build_multimodal_adapter(
+        self, model: Any, hf_config: Any
+    ) -> MultimodalRuntimeAdapter | None:
         """Build the native multimodal adapter for supported model families."""
         if hf_config is None:
             return None
@@ -228,7 +246,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
 
         from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 
-        return Qwen3VLMultimodalAdapter._from_loaded_model(model)
+        return Qwen3VLMultimodalAdapter.from_loaded_model(model)
 
     def build_yoco_cache_mapping(
         self, args: dict[str, Any]

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -39,6 +39,9 @@ class ModelAdapter(Protocol):
     def text_model(self, model: Any) -> Any:
         """Return the callable model used for text-only execution."""
 
+    def build_multimodal_adapter(self, model: Any, hf_config: Any) -> Any | None:
+        """Return a model-owned multimodal adapter for native VLM execution."""
+
     def build_yoco_cache_mapping(
         self, args: dict[str, Any]
     ) -> tuple[int, dict[int, int]] | None:
@@ -73,6 +76,13 @@ _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES: frozenset[str] = frozenset(
         "Qwen3_5MoeForConditionalGeneration",
         "Qwen3_6ForConditionalGeneration",
         "Qwen3_6MoeForConditionalGeneration",
+    }
+)
+_QWEN3_VL_MODEL_TYPES: frozenset[str] = frozenset({"qwen3_5", "qwen3_vl"})
+_QWEN3_VL_ARCHITECTURES: frozenset[str] = frozenset(
+    {
+        "Qwen3_5ForConditionalGeneration",
+        "Qwen3VLForConditionalGeneration",
     }
 )
 
@@ -203,6 +213,22 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         if hasattr(model, "language_model"):
             return model.language_model
         return model
+
+    def build_multimodal_adapter(self, model: Any, hf_config: Any) -> Any | None:
+        """Build the native multimodal adapter for supported model families."""
+        if hf_config is None:
+            return None
+
+        model_type = getattr(hf_config, "model_type", "")
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        if model_type not in _QWEN3_VL_MODEL_TYPES and not any(
+            arch in _QWEN3_VL_ARCHITECTURES for arch in architectures
+        ):
+            return None
+
+        from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
+
+        return Qwen3VLMultimodalAdapter._from_loaded_model(model)
 
     def build_yoco_cache_mapping(
         self, args: dict[str, Any]

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -22,6 +22,7 @@ from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.stt.detection import is_stt_model
 from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_adapter import ModelAdapter
 
 # Engine-core subprocesses don't always re-invoke `vllm_metal._register()`,
@@ -160,10 +161,14 @@ class ModelLifecycle:
         runner._is_vlm = is_vlm
         runner._is_stt = False
         runner._stt_runtime_adapter = None
-        runner._multimodal_adapter = (
+        multimodal_adapter = (
             self._model_adapter.build_multimodal_adapter(model, hf_config)
             if is_vlm
             else None
+        )
+        runner._multimodal_adapter = multimodal_adapter
+        runner.encoder_cache = (
+            EncoderCache() if multimodal_adapter is not None else None
         )
 
         model_args = self._extract_model_args(model, is_vlm)
@@ -245,6 +250,7 @@ class ModelLifecycle:
         self._runner._is_stt = True
         self._runner._stt_runtime_adapter = model.create_runtime_adapter(model_name)
         self._runner._multimodal_adapter = None
+        self._runner.encoder_cache = None
 
     def resolve_model_dims(self) -> None:
         args = self._runner.model_args

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -160,6 +160,11 @@ class ModelLifecycle:
         runner._is_vlm = is_vlm
         runner._is_stt = False
         runner._stt_runtime_adapter = None
+        runner._multimodal_adapter = (
+            self._model_adapter.build_multimodal_adapter(model, hf_config)
+            if is_vlm
+            else None
+        )
 
         model_args = self._extract_model_args(model, is_vlm)
         runner.model_args = model_args
@@ -189,8 +194,9 @@ class ModelLifecycle:
         if is_vlm:
             logger.info("Using mlx-vlm for vision-language model")
             logger.warning(
-                "VLM loaded in text-only mode: multimodal (image) inputs are "
-                "not yet supported. Vision encoder will be bypassed."
+                "VLM loaded via mlx-vlm; Metal multimodal encoder execution "
+                "is not wired yet. Text-only requests continue through the "
+                "language model."
             )
             model, tokenizer = mlx_vlm_load(model_name)
         else:
@@ -238,6 +244,7 @@ class ModelLifecycle:
         self._runner._is_vlm = False
         self._runner._is_stt = True
         self._runner._stt_runtime_adapter = model.create_runtime_adapter(model_name)
+        self._runner._multimodal_adapter = None
 
     def resolve_model_dims(self) -> None:
         args = self._runner.model_args

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1321,8 +1321,17 @@ class MetalModelRunner:
             return self._execute_stt(scheduler_output)
 
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
-        self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
+        has_scheduled_encoder_inputs = bool(scheduler_output.scheduled_encoder_inputs)
+
+        # Scheduler cleanup is independent of whether this step is supported.
+        # If the next check raises, old request state must still be evicted and
+        # any pending GDN release must be materialized now.
+        self._cleanup_finished_requests(
+            evicted_req_ids,
+            materialize_gdn_state=has_scheduled_encoder_inputs,
+        )
+        self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
 
         # Fail fast before any model work runs.  On the non-paged path,
         # _handle_new_requests immediately calls _prefill_single for new
@@ -1337,11 +1346,6 @@ class MetalModelRunner:
                 "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
                 "to use structured output."
             )
-
-        self._cleanup_finished_requests(
-            evicted_req_ids,
-            materialize_gdn_state=False,
-        )
 
         batch = _ExecutionBatch()
         self._handle_new_requests(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -963,13 +963,11 @@ class MetalModelRunner:
             self.encoder_cache.free_encoder_cache(mm_hash)
 
     @staticmethod
-    def _finished_or_preempted_req_ids(
+    def _finished_req_ids(
         scheduler_output: SchedulerOutput,
     ) -> set[str]:
         """Return request ids whose runner-owned state should be evicted."""
-        return scheduler_output.finished_req_ids.union(
-            scheduler_output.preempted_req_ids or set()
-        )
+        return scheduler_output.finished_req_ids
 
     @staticmethod
     def _reject_scheduled_encoder_inputs(
@@ -1282,7 +1280,7 @@ class MetalModelRunner:
         *,
         materialize_gdn_state: bool = True,
     ) -> None:
-        """Evict runner-owned state for finished or preempted requests."""
+        """Evict runner-owned state for finished requests."""
         if not evicted_req_ids:
             if materialize_gdn_state:
                 self._gdn_materialize_pending_state_cache()
@@ -1321,7 +1319,7 @@ class MetalModelRunner:
 
         self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
-        evicted_req_ids = self._finished_or_preempted_req_ids(scheduler_output)
+        evicted_req_ids = self._finished_req_ids(scheduler_output)
 
         # Fail fast before any model work runs.  On the non-paged path,
         # _handle_new_requests immediately calls _prefill_single for new
@@ -1400,6 +1398,7 @@ class MetalModelRunner:
         # Paged path: wait for MLX forward, apply grammar bitmask, sample tokens.
         if self._execute_model_state is not None:
             batch, scheduler_output = self._sample_paged_batch(grammar_output)
+            self._gdn_materialize_pending_state_cache()
             self._validate_scheduled_outputs(batch, scheduler_output)
             return self._build_output(batch)
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -57,6 +57,7 @@ from vllm_metal.v1.contiguous_cache import (
     _extract_kv_cache,
     _merge_kv_caches,
 )
+from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_adapter import DefaultModelAdapter, ModelAdapter
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 from vllm_metal.v1.sampling_batch import (
@@ -211,6 +212,10 @@ class MetalModelRunner:
         self._stt_runtime_adapter: STTRuntimeAdapter | None = (
             None  # Set during STT loading
         )
+        self._multimodal_adapter: Any | None = None
+        self.encoder_cache: EncoderCache | None = (
+            EncoderCache() if self._supports_multimodal_inputs() else None
+        )
 
         # Request state cache for incremental decoding
         self._request_states: dict[str, RequestState] = {}
@@ -294,14 +299,16 @@ class MetalModelRunner:
         requests.  Routing through ``model.language_model`` bypasses the vision
         encoder and uses the standard ``(input_ids, cache=...)`` signature.
 
-        NOTE: This means multimodal (image) inputs are not supported — the
-        vision head is intentionally skipped.  Full multimodal inference would
-        require a decomposed encode → feature-fusion → forward pass, following
-        the upstream pattern, and is a separate future effort.
+        NOTE: scheduled multimodal encoder inputs fail fast until the runner
+        wires decomposed encode → feature-fusion → forward execution.
         """
         if self._is_vlm:
             return self._model_adapter.text_model(self.model)
         return self.model
+
+    def _supports_multimodal_inputs(self) -> bool:
+        """Return whether vLLM scheduled multimodal features for this model."""
+        return bool(getattr(self.model_config, "is_multimodal_model", False))
 
     @property
     def mla_latent_dim(self) -> int:
@@ -444,6 +451,16 @@ class MetalModelRunner:
         This method exists to satisfy the engine's initialization protocol.
         """
         self._cache_policy.initialize_kv_cache(kv_cache_config)
+
+    def reset_mm_cache(self) -> None:
+        """Reset profiling-time multimodal cache state when present."""
+        if self.encoder_cache is not None:
+            self.encoder_cache.reset_mm_cache()
+
+    def reset_encoder_cache(self) -> None:
+        """Clear cached multimodal encoder outputs when present."""
+        if self.encoder_cache is not None:
+            self.encoder_cache.reset_encoder_cache()
 
     def get_cache_block_size_bytes(self) -> int:
         """Get the size of a single cache block in bytes.
@@ -924,6 +941,49 @@ class MetalModelRunner:
 
         return batch, scheduler_output
 
+    def _register_new_request_mm_features(
+        self, req_id: str, new_req: NewRequestData
+    ) -> None:
+        """Store scheduler-provided multimodal features for future encoder use."""
+        if self.encoder_cache is None:
+            return
+        self.encoder_cache.remove_request(req_id)
+        self.encoder_cache.add_request(req_id, new_req.mm_features)
+
+    def _remove_request_mm_features(self, req_id: str) -> None:
+        """Drop request-scoped multimodal feature metadata."""
+        if self.encoder_cache is not None:
+            self.encoder_cache.remove_request(req_id)
+
+    def _free_encoder_outputs(self, mm_hashes: list[str]) -> None:
+        """Drop encoder outputs released by the scheduler."""
+        if self.encoder_cache is None:
+            return
+        for mm_hash in mm_hashes:
+            self.encoder_cache.free_encoder_cache(mm_hash)
+
+    @staticmethod
+    def _finished_or_preempted_req_ids(
+        scheduler_output: SchedulerOutput,
+    ) -> set[str]:
+        """Return request ids whose runner-owned state should be evicted."""
+        return scheduler_output.finished_req_ids.union(
+            scheduler_output.preempted_req_ids or set()
+        )
+
+    @staticmethod
+    def _reject_scheduled_encoder_inputs(
+        scheduled_encoder_inputs: dict[str, list[int]],
+    ) -> None:
+        """Fail fast until encoder execution and embedding splice are wired."""
+        if not scheduled_encoder_inputs:
+            return
+        raise NotImplementedError(
+            "Multimodal encoder execution is not wired on Metal yet. "
+            "Metal currently registers multimodal runtime state, but image "
+            "encoding and embedding splice are not connected to the runner."
+        )
+
     def _handle_new_requests(
         self,
         batch: _ExecutionBatch,
@@ -935,6 +995,7 @@ class MetalModelRunner:
 
         for new_req in new_reqs:
             req_id = new_req.req_id
+            self._register_new_request_mm_features(req_id, new_req)
             token_ids = new_req.prompt_token_ids or []
             sampling_params = new_req.sampling_params or SamplingParams()
 
@@ -1217,25 +1278,31 @@ class MetalModelRunner:
 
     def _cleanup_finished_requests(
         self,
-        finished_req_ids: set[str],
+        evicted_req_ids: set[str],
+        *,
+        materialize_gdn_state: bool = True,
     ) -> None:
-        """Evict runner-owned state for finished requests."""
-        if not finished_req_ids:
-            self._gdn_materialize_pending_state_cache()
+        """Evict runner-owned state for finished or preempted requests."""
+        if not evicted_req_ids:
+            if materialize_gdn_state:
+                self._gdn_materialize_pending_state_cache()
             return
 
-        for req_id in finished_req_ids:
+        for req_id in evicted_req_ids:
             state = self._request_states.pop(req_id, None)
             if state is not None:
                 if state.cache:
                     del state.cache
                 del state
 
+            self._remove_request_mm_features(req_id)
+
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
 
-        self._gdn_release_slots(finished_req_ids)
-        self._gdn_materialize_pending_state_cache()
+        self._gdn_release_slots(evicted_req_ids)
+        if materialize_gdn_state:
+            self._gdn_materialize_pending_state_cache()
 
     def execute_model(
         self, scheduler_output: SchedulerOutput
@@ -1252,6 +1319,10 @@ class MetalModelRunner:
         if self._is_stt:
             return self._execute_stt(scheduler_output)
 
+        self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
+        self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
+        evicted_req_ids = self._finished_or_preempted_req_ids(scheduler_output)
+
         # Fail fast before any model work runs.  On the non-paged path,
         # _handle_new_requests immediately calls _prefill_single for new
         # requests, so the guard must come before it — not after.
@@ -1266,6 +1337,11 @@ class MetalModelRunner:
                 "to use structured output."
             )
 
+        self._cleanup_finished_requests(
+            evicted_req_ids,
+            materialize_gdn_state=False,
+        )
+
         batch = _ExecutionBatch()
         self._handle_new_requests(
             batch, scheduler_output.scheduled_new_reqs, scheduler_output
@@ -1276,11 +1352,6 @@ class MetalModelRunner:
         self._collect_cached_requests(batch, cached_reqs, scheduler_output)
 
         if self._paged_attention_backend is not None and batch.has_paged_work():
-            # Free GDN slots for finished requests BEFORE allocating new
-            # ones, so slots can be reused within the same scheduling step.
-            if self.is_hybrid and scheduler_output.finished_req_ids:
-                self._gdn_release_slots(scheduler_output.finished_req_ids)
-
             prefill_pack = self._build_prefill_pack(batch)
             self._start_paged_forward(
                 batch,
@@ -1309,8 +1380,8 @@ class MetalModelRunner:
             self._run_non_paged_decode_batch(batch)
 
         # Non-paged path: complete synchronously
+        self._gdn_materialize_pending_state_cache()
         self._validate_scheduled_outputs(batch, scheduler_output)
-        self._cleanup_finished_requests(scheduler_output.finished_req_ids)
         if not batch.req_ids:
             return self._build_output(batch)
         self._pending_output = self._build_output(batch)
@@ -1330,7 +1401,6 @@ class MetalModelRunner:
         if self._execute_model_state is not None:
             batch, scheduler_output = self._sample_paged_batch(grammar_output)
             self._validate_scheduled_outputs(batch, scheduler_output)
-            self._cleanup_finished_requests(scheduler_output.finished_req_ids)
             return self._build_output(batch)
 
         # Non-paged path: return output built by execute_model

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -305,6 +305,8 @@ class MetalModelRunner:
         wires decomposed encode → feature-fusion → forward execution.
         """
         if self._is_vlm:
+            if self._multimodal_adapter is not None:
+                return self._multimodal_adapter.text_model()
             return self._model_adapter.text_model(self.model)
         return self.model
 
@@ -974,11 +976,6 @@ class MetalModelRunner:
         """Fail fast until encoder execution and embedding splice are wired."""
         if not scheduled_encoder_inputs:
             return
-        if (
-            self._multimodal_adapter is not None
-            and self._multimodal_adapter.forward_ready
-        ):
-            return
         raise NotImplementedError(
             "Multimodal encoder execution is not wired on Metal yet. "
             "Metal currently registers multimodal runtime state, but image "
@@ -1324,9 +1321,9 @@ class MetalModelRunner:
         evicted_req_ids = self._finished_req_ids(scheduler_output)
         has_scheduled_encoder_inputs = bool(scheduler_output.scheduled_encoder_inputs)
 
-        # Scheduler cleanup is independent of whether this step is supported.
-        # If the next check raises, old request state must still be evicted and
-        # any pending GDN release must be materialized now.
+        # Scheduler cleanup is independent of whether this step's work is
+        # supported. If the next check raises, old request state must still be
+        # evicted and any pending GDN release must be materialized now.
         self._cleanup_finished_requests(
             evicted_req_ids,
             materialize_gdn_state=has_scheduled_encoder_inputs,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -58,7 +58,11 @@ from vllm_metal.v1.contiguous_cache import (
     _merge_kv_caches,
 )
 from vllm_metal.v1.mm import EncoderCache
-from vllm_metal.v1.model_adapter import DefaultModelAdapter, ModelAdapter
+from vllm_metal.v1.model_adapter import (
+    DefaultModelAdapter,
+    ModelAdapter,
+    MultimodalRuntimeAdapter,
+)
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
@@ -212,10 +216,8 @@ class MetalModelRunner:
         self._stt_runtime_adapter: STTRuntimeAdapter | None = (
             None  # Set during STT loading
         )
-        self._multimodal_adapter: Any | None = None
-        self.encoder_cache: EncoderCache | None = (
-            EncoderCache() if self._supports_multimodal_inputs() else None
-        )
+        self._multimodal_adapter: MultimodalRuntimeAdapter | None = None
+        self.encoder_cache: EncoderCache | None = None
 
         # Request state cache for incremental decoding
         self._request_states: dict[str, RequestState] = {}
@@ -305,10 +307,6 @@ class MetalModelRunner:
         if self._is_vlm:
             return self._model_adapter.text_model(self.model)
         return self.model
-
-    def _supports_multimodal_inputs(self) -> bool:
-        """Return whether vLLM scheduled multimodal features for this model."""
-        return bool(getattr(self.model_config, "is_multimodal_model", False))
 
     @property
     def mla_latent_dim(self) -> int:
@@ -969,12 +967,17 @@ class MetalModelRunner:
         """Return request ids whose runner-owned state should be evicted."""
         return scheduler_output.finished_req_ids
 
-    @staticmethod
     def _reject_scheduled_encoder_inputs(
+        self,
         scheduled_encoder_inputs: dict[str, list[int]],
     ) -> None:
         """Fail fast until encoder execution and embedding splice are wired."""
         if not scheduled_encoder_inputs:
+            return
+        if (
+            self._multimodal_adapter is not None
+            and self._multimodal_adapter.forward_ready
+        ):
             return
         raise NotImplementedError(
             "Multimodal encoder execution is not wired on Metal yet. "
@@ -1317,8 +1320,8 @@ class MetalModelRunner:
         if self._is_stt:
             return self._execute_stt(scheduler_output)
 
-        self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
+        self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
 
         # Fail fast before any model work runs.  On the non-paged path,
@@ -1521,7 +1524,7 @@ class MetalModelRunner:
             return mx.random.categorical(logits / temperature)
 
         for response in stream_generate(
-            self.model,
+            self._forward_model,
             self.tokenizer,
             prompt=prompt,
             max_tokens=max_tokens,

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -249,6 +249,14 @@ class MetalWorker(WorkerBase):
         self.model_runner.warm_up()
         return CompilationTimes(language_model=time.perf_counter() - start, encoder=0.0)
 
+    def reset_mm_cache(self) -> None:
+        """Reset profiling-time multimodal cache state."""
+        self.model_runner.reset_mm_cache()
+
+    def reset_encoder_cache(self) -> None:
+        """Clear cached multimodal encoder outputs."""
+        self.model_runner.reset_encoder_cache()
+
     def execute_model(
         self, scheduler_output: SchedulerOutput
     ) -> ModelRunnerOutput | None:


### PR DESCRIPTION
This PR wires the v1 lifecycle state needed by the Qwen3.5/Qwen3-VL multimodal path.

It does not run the vision encoder or splice image embeddings yet. Those remain follow-up runner changes. This PR keeps the first runtime step focused on loading and preserving model-owned multimodal state, registering scheduler-provided multimodal features, and failing fast when encoder execution is scheduled before the Metal runner path is wired.

##  Adds

- Build a Qwen3-VL multimodal adapter for Qwen3.5/Qwen3-VL native VLM loads.
- Preserve the loaded `vision_tower` and `language_model` behind the model-owned adapter.
- Add Metal runner encoder-cache lifecycle wiring for:
  - new request `mm_features`
  - finished and preempted request cleanup
  - scheduler-released encoder output hashes
  - `reset_mm_cache()` and `reset_encoder_cache()`
- Fail fast on scheduled multimodal encoder inputs until encode/splice/forward is implemented.
- Keep text-only VLM execution unchanged through the language model.
- Use real upstream scheduler DTOs in touched runner tests.