### PR TITLE
[Bugfix] cache ByteLevel TokenizersBackend for serving

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -115,6 +115,7 @@ class TestByteLevelTokenizerCompatPatch:
         assert tokenizer.eos_token == "</s>"
         assert tokenizer.pad_token == "</s>"
         assert tokenizer.model_max_length == 128
+        assert tokenizer.max_chars_per_token >= len("\u0120Hello")
         assert compat._loaded_tokenizer_decoder_uses_bytelevel(tokenizer)
 
     def test_keeps_loaded_tokenizer_when_decoder_is_already_bytelevel(

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -189,12 +189,14 @@ def _load_bytelevel_tokenizers_backend(
     kwargs: Mapping[str, Any],
 ) -> Any:
     from transformers.tokenization_utils_tokenizers import TokenizersBackend
+    from vllm.tokenizers.hf import get_cached_tokenizer
 
-    return TokenizersBackend.from_pretrained(
+    tokenizer = TokenizersBackend.from_pretrained(
         path_or_repo_id,
         *args,
         **_tokenizers_backend_kwargs(kwargs),
     )
+    return get_cached_tokenizer(tokenizer)
 
 
 def _maybe_load_bytelevel_tokenizers_backend(


### PR DESCRIPTION
Follow-up to #337.

The ByteLevel compatibility path now wraps the replacement `TokenizersBackend` with vLLM's `get_cached_tokenizer()` before returning it to the serving tokenizer path. This preserves clean ByteLevel decoding while restoring serving metadata such as `max_chars_per_token`, which vLLM uses during request preprocessing.