### PR TITLE
Add lazy GDN decode fast path for hybrid models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |
 | `VLLM_METAL_PREFIX_CACHE` | (unset) | Set to enable prefix caching for shared prompt reuse |
 | `VLLM_METAL_PREFIX_CACHE_FRACTION` | `0.05` | Fraction of MLX working set for prefix cache (0, 1] |
+| `VLLM_METAL_GDN_LAZY_DECODE` | `1` | Enable lazy GDN decode kernels for eligible decode-only hybrid batches. Set to `0` to force the eager conv / C++ recurrent fallback path. |
 
 ## Multimodal Serve Modes
 

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -250,6 +250,59 @@ class TestLazyConvDecode:
 
 
 class TestLazyRecurrentDecode:
+    def test_updates_only_active_recurrent_slots(self) -> None:
+        # Arrange
+        class FakeRecurrentKernel:
+            def __init__(self) -> None:
+                self.grid: tuple[int, int, int] | None = None
+                self.output_shapes: list[tuple[int, ...]] | None = None
+
+            def __call__(self, **kwargs: Any) -> tuple[mx.array, mx.array]:
+                self.grid = kwargs["grid"]
+                self.output_shapes = kwargs["output_shapes"]
+                return (
+                    mx.ones((2, 2, 3), dtype=mx.float32),
+                    mx.full((2, 2, 3, 32), 9, dtype=mx.float32),
+                )
+
+        fake_kernel = FakeRecurrentKernel()
+        cache = _make_state_cache(
+            max_seqs=4,
+            num_v_heads=2,
+            value_head_dim=3,
+            key_head_dim=32,
+        )
+        initial_state = mx.arange(4 * 2 * 3 * 32, dtype=mx.float32).reshape(4, 2, 3, 32)
+        cache.recurrent_states[0] = mx.array(initial_state)
+        slot_ids = [3, 1]
+        request = _recurrent_request(
+            q=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+            k=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+            v=mx.zeros((1, 2, 2, 3), dtype=mx.float32),
+            g=mx.zeros((1, 2, 2), dtype=mx.float32),
+            beta=mx.zeros((1, 2, 2), dtype=mx.float32),
+            cache=cache,
+            slot_ids=slot_ids,
+        )
+
+        # Act
+        result = GDNLazyDecodeKernels(
+            enabled=True,
+            conv_kernel=_RaisingKernel(),
+            recurrent_kernel=fake_kernel,
+        ).try_recurrent_decode(request)
+
+        # Assert
+        assert result is not None
+        assert fake_kernel.grid == (32, 3, 4)
+        assert fake_kernel.output_shapes == [(2, 2, 3), (2, 2, 3, 32)]
+        mx.eval(cache.recurrent_states[0])
+        expected_state = np.array(initial_state)
+        expected_state[slot_ids] = 9
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), expected_state
+        )
+
     def test_matches_cpp_recurrent_path(self) -> None:
         # Arrange
         _require_metal()

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -460,6 +460,34 @@ class TestGDNPagedAttentionWrapperLazyDecode:
         finally:
             clear_context()
 
+    def test_rejects_out_of_range_gdn_slots(self) -> None:
+        # Arrange
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        set_context(
+            PagedAttentionContext(
+                slot_mapping=[0, 1],
+                cu_seqlens=[0, 1, 2],
+                gdn_slot_mapping=[0, cache.max_seqs],
+            )
+        )
+
+        # Act / Assert
+        try:
+            with pytest.raises(RuntimeError, match="out-of-range slot"):
+                wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
+        finally:
+            clear_context()
+
     def test_kill_switch_uses_recurrent_fallback(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -1,0 +1,441 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused regression tests for lazy GDN decode dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+import pytest
+
+import vllm_metal.metal_kernel_backend.attention_linear as attention_linear
+from vllm_metal.metal import get_ops
+from vllm_metal.metal_kernel_backend.attention_linear import GDNPagedAttentionWrapper
+from vllm_metal.metal_kernel_backend.gdn_lazy_decode import GDNLazyDecodeKernels
+from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
+from vllm_metal.paged_attention_common import (
+    PagedAttentionContext,
+    clear_context,
+    set_context,
+)
+
+
+class _DepthwiseConv1D:
+    def __init__(self, weight: mx.array) -> None:
+        self.weight = weight
+
+    def __call__(self, x: mx.array) -> mx.array:
+        kernel_size = self.weight.shape[1]
+        outputs = []
+        for pos in range(x.shape[1] - kernel_size + 1):
+            window = x[:, pos : pos + kernel_size, :]
+            outputs.append(mx.sum(window * self.weight.T[None, :, :], axis=1))
+        return mx.stack(outputs, axis=1)
+
+
+class _LastTokenConv1D:
+    def __init__(self, conv_dim: int) -> None:
+        self.weight = mx.ones((conv_dim, 1), dtype=mx.float32)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x[:, -1:, :]
+
+
+class _TinyGDNInner:
+    num_k_heads = 1
+    num_v_heads = 1
+    head_k_dim = 32
+    head_v_dim = 4
+    key_dim = 32
+    conv_dim = 68
+    conv_kernel_size = 2
+
+    def __init__(self) -> None:
+        self.conv1d = _LastTokenConv1D(self.conv_dim)
+        self.A_log = mx.zeros((self.num_v_heads,), dtype=mx.float32)
+        self.dt_bias = mx.zeros((self.num_v_heads,), dtype=mx.float32)
+
+    def in_proj_qkv(self, x: mx.array) -> mx.array:
+        return x
+
+    def in_proj_z(self, x: mx.array) -> mx.array:
+        return mx.zeros(
+            (1, x.shape[1], self.num_v_heads * self.head_v_dim), dtype=x.dtype
+        )
+
+    def in_proj_b(self, x: mx.array) -> mx.array:
+        return mx.zeros((1, x.shape[1], self.num_v_heads), dtype=x.dtype)
+
+    def in_proj_a(self, x: mx.array) -> mx.array:
+        return mx.zeros((1, x.shape[1], self.num_k_heads), dtype=x.dtype)
+
+    def norm(self, out: mx.array, z: mx.array) -> mx.array:
+        return out
+
+    def out_proj(self, out: mx.array) -> mx.array:
+        return out
+
+
+class _RaisingKernel:
+    def __call__(self, **_: Any) -> tuple[mx.array, mx.array]:
+        raise AssertionError("fallback path should not invoke lazy kernel")
+
+
+def _require_metal() -> None:
+    try:
+        available = mx.metal.is_available()
+    except AttributeError:
+        available = False
+    if not available:
+        pytest.skip("MLX Metal is not available")
+
+
+def _get_native_ops_or_skip() -> Any:
+    try:
+        return get_ops()
+    except ImportError as exc:
+        if "Symbol not found" in str(exc):
+            pytest.skip(
+                "cached native _paged_ops extension is incompatible with "
+                "the active MLX; remove ~/.cache/vllm-metal/_paged_ops*.so "
+                "to rebuild it"
+            )
+        raise
+
+
+def _make_state_cache(
+    *,
+    max_seqs: int = 3,
+    conv_kernel_dim: int = 3,
+    conv_dim: int = 4,
+    num_v_heads: int = 1,
+    value_head_dim: int = 4,
+    key_head_dim: int = 32,
+) -> GDNPagedStateCache:
+    return GDNPagedStateCache(
+        num_layers=1,
+        max_seqs=max_seqs,
+        conv_kernel_dim=conv_kernel_dim,
+        conv_dim=conv_dim,
+        num_v_heads=num_v_heads,
+        value_head_dim=value_head_dim,
+        key_head_dim=key_head_dim,
+        dtype=mx.float32,
+    )
+
+
+def test_lazy_conv_decode_matches_eager_per_request_conv() -> None:
+    _require_metal()
+    mx.random.seed(0)
+    conv_dim = 4
+    kernel_size = 3
+    cache = _make_state_cache(conv_kernel_dim=kernel_size, conv_dim=conv_dim)
+    initial_state = mx.random.normal(cache.conv_states[0].shape).astype(mx.float32)
+    cache.conv_states[0] = mx.array(initial_state)
+    weight = mx.random.normal((conv_dim, kernel_size)).astype(mx.float32)
+    inner = SimpleNamespace(
+        conv_kernel_size=kernel_size, conv1d=_DepthwiseConv1D(weight)
+    )
+    mixed_qkv = mx.random.normal((1, 2, conv_dim)).astype(mx.float32)
+    slot_ids = [1, 0]
+
+    expected_state = mx.array(initial_state)
+    expected_outputs = []
+    for req_idx, slot in enumerate(slot_ids):
+        conv_input = mx.concatenate(
+            [expected_state[slot : slot + 1], mixed_qkv[:, req_idx : req_idx + 1]],
+            axis=1,
+        )
+        expected_state[slot : slot + 1] = conv_input[:, -(kernel_size - 1) :]
+        expected_outputs.append(nn.silu(inner.conv1d(conv_input))[:, -1:])
+    expected = mx.concatenate(expected_outputs, axis=1)
+
+    actual = GDNLazyDecodeKernels(enabled=True).try_conv_decode(
+        mixed_qkv, inner, cache, 0, slot_ids
+    )
+    assert actual is not None
+    mx.eval(actual, expected, cache.conv_states[0], expected_state)
+
+    np.testing.assert_allclose(np.array(actual), np.array(expected), atol=1e-5)
+    np.testing.assert_allclose(
+        np.array(cache.conv_states[0]), np.array(expected_state), atol=1e-5
+    )
+
+
+def test_lazy_recurrent_decode_matches_cpp_recurrent_path() -> None:
+    _require_metal()
+    mx.random.seed(0)
+    total_tokens = 2
+    n_hk = 1
+    n_hv = 1
+    d_k = 32
+    d_v = 4
+    slot_ids = [1, 0]
+    cache_lazy = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
+    cache_cpp = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
+    initial_state = mx.random.normal(cache_lazy.recurrent_states[0].shape).astype(
+        mx.float32
+    )
+    cache_lazy.recurrent_states[0] = mx.array(initial_state)
+    cache_cpp.recurrent_states[0] = mx.array(initial_state)
+
+    q = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
+    k = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
+    v = mx.random.normal((1, total_tokens, n_hv, d_v)).astype(mx.float32)
+    g = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
+    beta = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
+
+    lazy_out = GDNLazyDecodeKernels(enabled=True).try_recurrent_decode(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cache_lazy,
+        0,
+        slot_ids,
+        total_tokens,
+        n_hk,
+        n_hv,
+        d_k,
+        d_v,
+        mx.float32,
+    )
+    assert lazy_out is not None
+    mx.eval(lazy_out, cache_lazy.recurrent_states[0])
+
+    q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k))
+    k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k))
+    v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v))
+    g_flat = mx.contiguous(g.reshape(total_tokens, n_hv))
+    beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv))
+    cpp_out = mx.zeros((total_tokens, n_hv, d_v), dtype=mx.float32)
+    mx.eval(
+        q_flat,
+        k_flat,
+        v_flat,
+        g_flat,
+        beta_flat,
+        cache_cpp.recurrent_states[0],
+        cpp_out,
+    )
+    _get_native_ops_or_skip().gdn_linear_attention(
+        q_flat,
+        k_flat,
+        v_flat,
+        g_flat,
+        beta_flat,
+        cache_cpp.recurrent_states[0],
+        mx.array([0, 1, 2], dtype=mx.int32),
+        mx.array(slot_ids, dtype=mx.int32),
+        cpp_out,
+        n_hk,
+        n_hv,
+        d_k,
+        d_v,
+    )
+    mx.synchronize()
+    mx.eval(
+        lazy_out, cpp_out, cache_lazy.recurrent_states[0], cache_cpp.recurrent_states[0]
+    )
+
+    np.testing.assert_allclose(np.array(lazy_out), np.array(cpp_out), atol=1e-4)
+    np.testing.assert_allclose(
+        np.array(cache_lazy.recurrent_states[0]),
+        np.array(cache_cpp.recurrent_states[0]),
+        atol=1e-4,
+    )
+
+
+def test_lazy_decode_falls_back_for_multi_token_requests() -> None:
+    cache = _make_state_cache()
+    conv_state = mx.ones_like(cache.conv_states[0])
+    recurrent_state = mx.ones_like(cache.recurrent_states[0])
+    cache.conv_states[0] = conv_state
+    cache.recurrent_states[0] = recurrent_state
+    kernels = GDNLazyDecodeKernels(
+        enabled=True,
+        conv_kernel=_RaisingKernel(),
+        recurrent_kernel=_RaisingKernel(),
+    )
+
+    conv_result = kernels.try_conv_decode(
+        mx.zeros((1, 3, cache.conv_dim), dtype=mx.float32),
+        SimpleNamespace(
+            conv_kernel_size=cache.conv_kernel_dim, conv1d=_RaisingKernel()
+        ),
+        cache,
+        0,
+        [0, 1],
+    )
+    recurrent_result = kernels.try_recurrent_decode(
+        mx.zeros((1, 3, 1, 32), dtype=mx.float32),
+        mx.zeros((1, 3, 1, 32), dtype=mx.float32),
+        mx.zeros((1, 3, 1, 4), dtype=mx.float32),
+        mx.zeros((1, 3, 1), dtype=mx.float32),
+        mx.zeros((1, 3, 1), dtype=mx.float32),
+        cache,
+        0,
+        [0, 1],
+        3,
+        1,
+        1,
+        32,
+        4,
+        mx.float32,
+    )
+
+    assert conv_result is None
+    assert recurrent_result is None
+    np.testing.assert_array_equal(np.array(cache.conv_states[0]), np.array(conv_state))
+    np.testing.assert_array_equal(
+        np.array(cache.recurrent_states[0]), np.array(recurrent_state)
+    )
+
+
+def test_lazy_recurrent_decode_falls_back_for_unsupported_shape() -> None:
+    d_k = 33
+    cache = _make_state_cache(key_head_dim=d_k)
+    initial_state = mx.ones_like(cache.recurrent_states[0])
+    cache.recurrent_states[0] = initial_state
+    result = GDNLazyDecodeKernels(
+        enabled=True,
+        conv_kernel=_RaisingKernel(),
+        recurrent_kernel=_RaisingKernel(),
+    ).try_recurrent_decode(
+        mx.zeros((1, 2, 1, d_k), dtype=mx.float32),
+        mx.zeros((1, 2, 1, d_k), dtype=mx.float32),
+        mx.zeros((1, 2, 1, 4), dtype=mx.float32),
+        mx.zeros((1, 2, 1), dtype=mx.float32),
+        mx.zeros((1, 2, 1), dtype=mx.float32),
+        cache,
+        0,
+        [0, 1],
+        2,
+        1,
+        1,
+        d_k,
+        4,
+        mx.float32,
+    )
+
+    assert result is None
+    np.testing.assert_array_equal(
+        np.array(cache.recurrent_states[0]), np.array(initial_state)
+    )
+
+
+def test_lazy_decode_kill_switch_disables_kernel_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_make_kernel(*_: Any) -> None:
+        raise AssertionError("disabled lazy decode should not construct kernels")
+
+    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
+    monkeypatch.setattr(
+        GDNLazyDecodeKernels,
+        "_make_kernel",
+        staticmethod(fail_make_kernel),
+    )
+
+    kernels = GDNLazyDecodeKernels.from_env()
+    cache = _make_state_cache()
+    assert (
+        kernels.try_conv_decode(
+            mx.zeros((1, 1, cache.conv_dim), dtype=mx.float32), object(), cache, 0, [0]
+        )
+        is None
+    )
+    assert (
+        kernels.try_recurrent_decode(
+            mx.zeros((1, 1, 1, 32), dtype=mx.float32),
+            mx.zeros((1, 1, 1, 32), dtype=mx.float32),
+            mx.zeros((1, 1, 1, 4), dtype=mx.float32),
+            mx.zeros((1, 1, 1), dtype=mx.float32),
+            mx.zeros((1, 1, 1), dtype=mx.float32),
+            cache,
+            0,
+            [0],
+            1,
+            1,
+            1,
+            32,
+            4,
+            mx.float32,
+        )
+        is None
+    )
+
+
+def test_wrapper_kill_switch_uses_recurrent_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeOps:
+        def __init__(self) -> None:
+            self.called = False
+            self.args: tuple[Any, ...] | None = None
+
+        def gdn_linear_attention(self, *args: Any) -> None:
+            self.called = True
+            self.args = args
+            state_pool = args[5]
+            y_flat = args[8]
+            state_pool[:] = 7
+            y_flat[:] = 0
+
+    def fail_make_kernel(*_: Any) -> None:
+        raise AssertionError("disabled wrapper path should not construct kernels")
+
+    fake_ops = FakeOps()
+    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
+    monkeypatch.setattr(attention_linear, "get_ops", lambda: fake_ops)
+    monkeypatch.setattr(
+        GDNLazyDecodeKernels,
+        "_make_kernel",
+        staticmethod(fail_make_kernel),
+    )
+
+    inner = _TinyGDNInner()
+    cache = _make_state_cache(
+        conv_kernel_dim=inner.conv_kernel_size,
+        conv_dim=inner.conv_dim,
+        num_v_heads=inner.num_v_heads,
+        value_head_dim=inner.head_v_dim,
+        key_head_dim=inner.head_k_dim,
+    )
+    wrapper = GDNPagedAttentionWrapper(
+        inner, layer_idx=0, cache_idx=0, state_cache=cache
+    )
+
+    set_context(
+        PagedAttentionContext(
+            slot_mapping=[0, 1],
+            cu_seqlens=[0, 1, 2],
+            gdn_slot_mapping=[0, 1],
+        )
+    )
+    try:
+        out = wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
+    finally:
+        clear_context()
+
+    assert fake_ops.called
+    assert fake_ops.args is not None
+    np.testing.assert_array_equal(np.array(fake_ops.args[6]), np.array([0, 1, 2]))
+    np.testing.assert_array_equal(np.array(fake_ops.args[7]), np.array([0, 1]))
+    np.testing.assert_array_equal(
+        np.array(cache.conv_states[0][:2]),
+        np.ones((2, inner.conv_kernel_size - 1, inner.conv_dim), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        np.array(cache.conv_states[0][2:]),
+        np.zeros((1, inner.conv_kernel_size - 1, inner.conv_dim), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        np.array(cache.recurrent_states[0]),
+        np.full(cache.recurrent_states[0].shape, 7, dtype=np.float32),
+    )
+    assert out.shape == (1, 2, inner.num_v_heads * inner.head_v_dim)

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -432,6 +432,34 @@ class TestGDNLazyDecodeSharedOwner:
 
 
 class TestGDNPagedAttentionWrapperLazyDecode:
+    def test_rejects_duplicate_gdn_slots(self) -> None:
+        # Arrange
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        set_context(
+            PagedAttentionContext(
+                slot_mapping=[0, 1],
+                cu_seqlens=[0, 1, 2],
+                gdn_slot_mapping=[1, 1],
+            )
+        )
+
+        # Act / Assert
+        try:
+            with pytest.raises(RuntimeError, match="unique slots"):
+                wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
+        finally:
+            clear_context()
+
     def test_kill_switch_uses_recurrent_fallback(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -205,6 +205,49 @@ class TestLazyConvDecode:
             np.array(cache.conv_states[0]), np.array(expected_state), atol=1e-5
         )
 
+    def test_updates_only_active_conv_slots(self) -> None:
+        # Arrange
+        class FakeConvKernel:
+            def __init__(self) -> None:
+                self.grid: tuple[int, int, int] | None = None
+                self.output_shapes: list[tuple[int, ...]] | None = None
+
+            def __call__(self, **kwargs: Any) -> tuple[mx.array, mx.array]:
+                self.grid = kwargs["grid"]
+                self.output_shapes = kwargs["output_shapes"]
+                return (
+                    mx.ones((2, 4), dtype=mx.float32),
+                    mx.full((2, 2, 4), 9, dtype=mx.float32),
+                )
+
+        fake_kernel = FakeConvKernel()
+        cache = _make_state_cache(max_seqs=4, conv_kernel_dim=3, conv_dim=4)
+        initial_state = mx.arange(4 * 2 * 4, dtype=mx.float32).reshape(4, 2, 4)
+        cache.conv_states[0] = mx.array(initial_state)
+        inner = SimpleNamespace(
+            conv_kernel_size=3,
+            conv1d=SimpleNamespace(weight=mx.ones((4, 3), dtype=mx.float32)),
+        )
+        slot_ids = [3, 1]
+
+        # Act
+        result = GDNLazyDecodeKernels(
+            enabled=True,
+            conv_kernel=fake_kernel,
+            recurrent_kernel=_RaisingKernel(),
+        ).try_conv_decode(
+            mx.zeros((1, 2, 4), dtype=mx.float32), inner, cache, 0, slot_ids
+        )
+
+        # Assert
+        assert result is not None
+        assert fake_kernel.grid == (8, 1, 1)
+        assert fake_kernel.output_shapes == [(2, 4), (2, 2, 4)]
+        mx.eval(cache.conv_states[0])
+        expected_state = np.array(initial_state)
+        expected_state[slot_ids] = 9
+        np.testing.assert_array_equal(np.array(cache.conv_states[0]), expected_state)
+
 
 class TestLazyRecurrentDecode:
     def test_matches_cpp_recurrent_path(self) -> None:

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -16,8 +16,7 @@ from vllm_metal.metal import get_ops
 from vllm_metal.metal_kernel_backend.attention_linear import GDNPagedAttentionWrapper
 from vllm_metal.metal_kernel_backend.gdn_lazy_decode import (
     GDNLazyDecodeKernels,
-    get_gdn_lazy_decode_kernels,
-    reset_gdn_lazy_decode_kernels,
+    GDNRecurrentDecodeRequest,
 )
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import (
@@ -29,9 +28,9 @@ from vllm_metal.paged_attention_common import (
 
 @pytest.fixture(autouse=True)
 def _reset_lazy_decode_kernels() -> None:
-    reset_gdn_lazy_decode_kernels()
+    GDNLazyDecodeKernels.reset_shared_for_tests()
     yield
-    reset_gdn_lazy_decode_kernels()
+    GDNLazyDecodeKernels.reset_shared_for_tests()
 
 
 class _DepthwiseConv1D:
@@ -138,344 +137,369 @@ def _make_state_cache(
     )
 
 
-def test_lazy_conv_decode_matches_eager_per_request_conv() -> None:
-    _require_metal()
-    mx.random.seed(0)
-    conv_dim = 4
-    kernel_size = 3
-    cache = _make_state_cache(conv_kernel_dim=kernel_size, conv_dim=conv_dim)
-    initial_state = mx.random.normal(cache.conv_states[0].shape).astype(mx.float32)
-    cache.conv_states[0] = mx.array(initial_state)
-    weight = mx.random.normal((conv_dim, kernel_size)).astype(mx.float32)
-    inner = SimpleNamespace(
-        conv_kernel_size=kernel_size, conv1d=_DepthwiseConv1D(weight)
+def _recurrent_request(
+    *,
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    cache: GDNPagedStateCache,
+    slot_ids: list[int],
+    output_dtype: mx.Dtype = mx.float32,
+) -> GDNRecurrentDecodeRequest:
+    return GDNRecurrentDecodeRequest(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        state_cache=cache,
+        cache_idx=0,
+        slot_ids=slot_ids,
+        output_dtype=output_dtype,
     )
-    mixed_qkv = mx.random.normal((1, 2, conv_dim)).astype(mx.float32)
-    slot_ids = [1, 0]
 
-    expected_state = mx.array(initial_state)
-    expected_outputs = []
-    for req_idx, slot in enumerate(slot_ids):
-        conv_input = mx.concatenate(
-            [expected_state[slot : slot + 1], mixed_qkv[:, req_idx : req_idx + 1]],
-            axis=1,
+
+class TestLazyConvDecode:
+    def test_matches_eager_per_request_conv(self) -> None:
+        # Arrange
+        _require_metal()
+        mx.random.seed(0)
+        conv_dim = 4
+        kernel_size = 3
+        cache = _make_state_cache(conv_kernel_dim=kernel_size, conv_dim=conv_dim)
+        initial_state = mx.random.normal(cache.conv_states[0].shape).astype(mx.float32)
+        cache.conv_states[0] = mx.array(initial_state)
+        weight = mx.random.normal((conv_dim, kernel_size)).astype(mx.float32)
+        inner = SimpleNamespace(
+            conv_kernel_size=kernel_size, conv1d=_DepthwiseConv1D(weight)
         )
-        expected_state[slot : slot + 1] = conv_input[:, -(kernel_size - 1) :]
-        expected_outputs.append(nn.silu(inner.conv1d(conv_input))[:, -1:])
-    expected = mx.concatenate(expected_outputs, axis=1)
+        mixed_qkv = mx.random.normal((1, 2, conv_dim)).astype(mx.float32)
+        slot_ids = [1, 0]
 
-    actual = GDNLazyDecodeKernels(enabled=True).try_conv_decode(
-        mixed_qkv, inner, cache, 0, slot_ids
-    )
-    assert actual is not None
-    mx.eval(actual, expected, cache.conv_states[0], expected_state)
+        expected_state = mx.array(initial_state)
+        expected_outputs = []
+        for req_idx, slot in enumerate(slot_ids):
+            conv_input = mx.concatenate(
+                [
+                    expected_state[slot : slot + 1],
+                    mixed_qkv[:, req_idx : req_idx + 1],
+                ],
+                axis=1,
+            )
+            expected_state[slot : slot + 1] = conv_input[:, -(kernel_size - 1) :]
+            expected_outputs.append(nn.silu(inner.conv1d(conv_input))[:, -1:])
+        expected = mx.concatenate(expected_outputs, axis=1)
 
-    np.testing.assert_allclose(np.array(actual), np.array(expected), atol=1e-5)
-    np.testing.assert_allclose(
-        np.array(cache.conv_states[0]), np.array(expected_state), atol=1e-5
-    )
-
-
-def test_lazy_recurrent_decode_matches_cpp_recurrent_path() -> None:
-    _require_metal()
-    mx.random.seed(0)
-    total_tokens = 2
-    n_hk = 1
-    n_hv = 1
-    d_k = 32
-    d_v = 4
-    slot_ids = [1, 0]
-    cache_lazy = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
-    cache_cpp = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
-    initial_state = mx.random.normal(cache_lazy.recurrent_states[0].shape).astype(
-        mx.float32
-    )
-    cache_lazy.recurrent_states[0] = mx.array(initial_state)
-    cache_cpp.recurrent_states[0] = mx.array(initial_state)
-
-    q = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
-    k = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
-    v = mx.random.normal((1, total_tokens, n_hv, d_v)).astype(mx.float32)
-    g = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
-    beta = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
-
-    lazy_out = GDNLazyDecodeKernels(enabled=True).try_recurrent_decode(
-        q,
-        k,
-        v,
-        g,
-        beta,
-        cache_lazy,
-        0,
-        slot_ids,
-        total_tokens,
-        n_hk,
-        n_hv,
-        d_k,
-        d_v,
-        mx.float32,
-    )
-    assert lazy_out is not None
-    mx.eval(lazy_out, cache_lazy.recurrent_states[0])
-
-    q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k))
-    k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k))
-    v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v))
-    g_flat = mx.contiguous(g.reshape(total_tokens, n_hv))
-    beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv))
-    cpp_out = mx.zeros((total_tokens, n_hv, d_v), dtype=mx.float32)
-    mx.eval(
-        q_flat,
-        k_flat,
-        v_flat,
-        g_flat,
-        beta_flat,
-        cache_cpp.recurrent_states[0],
-        cpp_out,
-    )
-    _get_native_ops_or_skip().gdn_linear_attention(
-        q_flat,
-        k_flat,
-        v_flat,
-        g_flat,
-        beta_flat,
-        cache_cpp.recurrent_states[0],
-        mx.array([0, 1, 2], dtype=mx.int32),
-        mx.array(slot_ids, dtype=mx.int32),
-        cpp_out,
-        n_hk,
-        n_hv,
-        d_k,
-        d_v,
-    )
-    mx.synchronize()
-    mx.eval(
-        lazy_out, cpp_out, cache_lazy.recurrent_states[0], cache_cpp.recurrent_states[0]
-    )
-
-    np.testing.assert_allclose(np.array(lazy_out), np.array(cpp_out), atol=1e-4)
-    np.testing.assert_allclose(
-        np.array(cache_lazy.recurrent_states[0]),
-        np.array(cache_cpp.recurrent_states[0]),
-        atol=1e-4,
-    )
-
-
-def test_lazy_decode_falls_back_for_multi_token_requests() -> None:
-    cache = _make_state_cache()
-    conv_state = mx.ones_like(cache.conv_states[0])
-    recurrent_state = mx.ones_like(cache.recurrent_states[0])
-    cache.conv_states[0] = conv_state
-    cache.recurrent_states[0] = recurrent_state
-    kernels = GDNLazyDecodeKernels(
-        enabled=True,
-        conv_kernel=_RaisingKernel(),
-        recurrent_kernel=_RaisingKernel(),
-    )
-
-    conv_result = kernels.try_conv_decode(
-        mx.zeros((1, 3, cache.conv_dim), dtype=mx.float32),
-        SimpleNamespace(
-            conv_kernel_size=cache.conv_kernel_dim, conv1d=_RaisingKernel()
-        ),
-        cache,
-        0,
-        [0, 1],
-    )
-    recurrent_result = kernels.try_recurrent_decode(
-        mx.zeros((1, 3, 1, 32), dtype=mx.float32),
-        mx.zeros((1, 3, 1, 32), dtype=mx.float32),
-        mx.zeros((1, 3, 1, 4), dtype=mx.float32),
-        mx.zeros((1, 3, 1), dtype=mx.float32),
-        mx.zeros((1, 3, 1), dtype=mx.float32),
-        cache,
-        0,
-        [0, 1],
-        3,
-        1,
-        1,
-        32,
-        4,
-        mx.float32,
-    )
-
-    assert conv_result is None
-    assert recurrent_result is None
-    np.testing.assert_array_equal(np.array(cache.conv_states[0]), np.array(conv_state))
-    np.testing.assert_array_equal(
-        np.array(cache.recurrent_states[0]), np.array(recurrent_state)
-    )
-
-
-def test_lazy_recurrent_decode_falls_back_for_unsupported_shape() -> None:
-    d_k = 33
-    cache = _make_state_cache(key_head_dim=d_k)
-    initial_state = mx.ones_like(cache.recurrent_states[0])
-    cache.recurrent_states[0] = initial_state
-    result = GDNLazyDecodeKernels(
-        enabled=True,
-        conv_kernel=_RaisingKernel(),
-        recurrent_kernel=_RaisingKernel(),
-    ).try_recurrent_decode(
-        mx.zeros((1, 2, 1, d_k), dtype=mx.float32),
-        mx.zeros((1, 2, 1, d_k), dtype=mx.float32),
-        mx.zeros((1, 2, 1, 4), dtype=mx.float32),
-        mx.zeros((1, 2, 1), dtype=mx.float32),
-        mx.zeros((1, 2, 1), dtype=mx.float32),
-        cache,
-        0,
-        [0, 1],
-        2,
-        1,
-        1,
-        d_k,
-        4,
-        mx.float32,
-    )
-
-    assert result is None
-    np.testing.assert_array_equal(
-        np.array(cache.recurrent_states[0]), np.array(initial_state)
-    )
-
-
-def test_lazy_decode_kill_switch_disables_kernel_construction(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def fail_make_kernel(*_: Any) -> None:
-        raise AssertionError("disabled lazy decode should not construct kernels")
-
-    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
-    monkeypatch.setattr(
-        GDNLazyDecodeKernels,
-        "_make_kernel",
-        staticmethod(fail_make_kernel),
-    )
-
-    kernels = GDNLazyDecodeKernels.from_env()
-    cache = _make_state_cache()
-    assert (
-        kernels.try_conv_decode(
-            mx.zeros((1, 1, cache.conv_dim), dtype=mx.float32), object(), cache, 0, [0]
+        # Act
+        actual = GDNLazyDecodeKernels(enabled=True).try_conv_decode(
+            mixed_qkv, inner, cache, 0, slot_ids
         )
-        is None
-    )
-    assert (
-        kernels.try_recurrent_decode(
-            mx.zeros((1, 1, 1, 32), dtype=mx.float32),
-            mx.zeros((1, 1, 1, 32), dtype=mx.float32),
-            mx.zeros((1, 1, 1, 4), dtype=mx.float32),
-            mx.zeros((1, 1, 1), dtype=mx.float32),
-            mx.zeros((1, 1, 1), dtype=mx.float32),
+
+        # Assert
+        assert actual is not None
+        mx.eval(actual, expected, cache.conv_states[0], expected_state)
+        np.testing.assert_allclose(np.array(actual), np.array(expected), atol=1e-5)
+        np.testing.assert_allclose(
+            np.array(cache.conv_states[0]), np.array(expected_state), atol=1e-5
+        )
+
+
+class TestLazyRecurrentDecode:
+    def test_matches_cpp_recurrent_path(self) -> None:
+        # Arrange
+        _require_metal()
+        mx.random.seed(0)
+        total_tokens = 2
+        n_hk = 1
+        n_hv = 1
+        d_k = 32
+        d_v = 4
+        slot_ids = [1, 0]
+        cache_lazy = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
+        cache_cpp = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
+        initial_state = mx.random.normal(cache_lazy.recurrent_states[0].shape).astype(
+            mx.float32
+        )
+        cache_lazy.recurrent_states[0] = mx.array(initial_state)
+        cache_cpp.recurrent_states[0] = mx.array(initial_state)
+
+        q = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
+        k = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
+        v = mx.random.normal((1, total_tokens, n_hv, d_v)).astype(mx.float32)
+        g = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
+        beta = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
+        request = _recurrent_request(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            cache=cache_lazy,
+            slot_ids=slot_ids,
+        )
+
+        # Act
+        lazy_out = GDNLazyDecodeKernels(enabled=True).try_recurrent_decode(request)
+
+        # Assert
+        assert lazy_out is not None
+        mx.eval(lazy_out, cache_lazy.recurrent_states[0])
+
+        q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k))
+        k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k))
+        v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v))
+        g_flat = mx.contiguous(g.reshape(total_tokens, n_hv))
+        beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv))
+        cpp_out = mx.zeros((total_tokens, n_hv, d_v), dtype=mx.float32)
+        mx.eval(
+            q_flat,
+            k_flat,
+            v_flat,
+            g_flat,
+            beta_flat,
+            cache_cpp.recurrent_states[0],
+            cpp_out,
+        )
+        _get_native_ops_or_skip().gdn_linear_attention(
+            q_flat,
+            k_flat,
+            v_flat,
+            g_flat,
+            beta_flat,
+            cache_cpp.recurrent_states[0],
+            mx.array([0, 1, 2], dtype=mx.int32),
+            mx.array(slot_ids, dtype=mx.int32),
+            cpp_out,
+            n_hk,
+            n_hv,
+            d_k,
+            d_v,
+        )
+        mx.synchronize()
+        mx.eval(
+            lazy_out,
+            cpp_out,
+            cache_lazy.recurrent_states[0],
+            cache_cpp.recurrent_states[0],
+        )
+        np.testing.assert_allclose(np.array(lazy_out), np.array(cpp_out), atol=1e-4)
+        np.testing.assert_allclose(
+            np.array(cache_lazy.recurrent_states[0]),
+            np.array(cache_cpp.recurrent_states[0]),
+            atol=1e-4,
+        )
+
+
+class TestLazyDecodeFallbacks:
+    def test_falls_back_for_multi_token_requests(self) -> None:
+        # Arrange
+        cache = _make_state_cache()
+        conv_state = mx.ones_like(cache.conv_states[0])
+        recurrent_state = mx.ones_like(cache.recurrent_states[0])
+        cache.conv_states[0] = conv_state
+        cache.recurrent_states[0] = recurrent_state
+        kernels = GDNLazyDecodeKernels(
+            enabled=True,
+            conv_kernel=_RaisingKernel(),
+            recurrent_kernel=_RaisingKernel(),
+        )
+        recurrent_request = _recurrent_request(
+            q=mx.zeros((1, 3, 1, 32), dtype=mx.float32),
+            k=mx.zeros((1, 3, 1, 32), dtype=mx.float32),
+            v=mx.zeros((1, 3, 1, 4), dtype=mx.float32),
+            g=mx.zeros((1, 3, 1), dtype=mx.float32),
+            beta=mx.zeros((1, 3, 1), dtype=mx.float32),
+            cache=cache,
+            slot_ids=[0, 1],
+        )
+
+        # Act
+        conv_result = kernels.try_conv_decode(
+            mx.zeros((1, 3, cache.conv_dim), dtype=mx.float32),
+            SimpleNamespace(
+                conv_kernel_size=cache.conv_kernel_dim, conv1d=_RaisingKernel()
+            ),
             cache,
             0,
-            [0],
-            1,
-            1,
-            1,
-            32,
-            4,
-            mx.float32,
+            [0, 1],
         )
-        is None
-    )
+        recurrent_result = kernels.try_recurrent_decode(recurrent_request)
 
-
-def test_shared_lazy_decode_owner_reuses_kernel_construction(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls = []
-
-    def fake_make_kernel(name: str, *_: Any) -> object:
-        calls.append(name)
-        return object()
-
-    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "1")
-    monkeypatch.setattr(
-        GDNLazyDecodeKernels,
-        "_make_kernel",
-        staticmethod(fake_make_kernel),
-    )
-
-    first = get_gdn_lazy_decode_kernels()
-    second = get_gdn_lazy_decode_kernels()
-
-    assert first is second
-    assert calls == ["gdn_conv1d_silu_decode_v2", "gdn_recurrent_v2"]
-
-    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
-    disabled = get_gdn_lazy_decode_kernels()
-
-    assert disabled is not first
-    assert calls == ["gdn_conv1d_silu_decode_v2", "gdn_recurrent_v2"]
-
-
-def test_wrapper_kill_switch_uses_recurrent_fallback(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class FakeOps:
-        def __init__(self) -> None:
-            self.called = False
-            self.args: tuple[Any, ...] | None = None
-
-        def gdn_linear_attention(self, *args: Any) -> None:
-            self.called = True
-            self.args = args
-            state_pool = args[5]
-            y_flat = args[8]
-            state_pool[:] = 7
-            y_flat[:] = 0
-
-    def fail_make_kernel(*_: Any) -> None:
-        raise AssertionError("disabled wrapper path should not construct kernels")
-
-    fake_ops = FakeOps()
-    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
-    monkeypatch.setattr(attention_linear, "get_ops", lambda: fake_ops)
-    monkeypatch.setattr(
-        GDNLazyDecodeKernels,
-        "_make_kernel",
-        staticmethod(fail_make_kernel),
-    )
-
-    inner = _TinyGDNInner()
-    cache = _make_state_cache(
-        conv_kernel_dim=inner.conv_kernel_size,
-        conv_dim=inner.conv_dim,
-        num_v_heads=inner.num_v_heads,
-        value_head_dim=inner.head_v_dim,
-        key_head_dim=inner.head_k_dim,
-    )
-    wrapper = GDNPagedAttentionWrapper(
-        inner, layer_idx=0, cache_idx=0, state_cache=cache
-    )
-
-    set_context(
-        PagedAttentionContext(
-            slot_mapping=[0, 1],
-            cu_seqlens=[0, 1, 2],
-            gdn_slot_mapping=[0, 1],
+        # Assert
+        assert conv_result is None
+        assert recurrent_result is None
+        np.testing.assert_array_equal(
+            np.array(cache.conv_states[0]), np.array(conv_state)
         )
-    )
-    try:
-        out = wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
-    finally:
-        clear_context()
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), np.array(recurrent_state)
+        )
 
-    assert fake_ops.called
-    assert fake_ops.args is not None
-    np.testing.assert_array_equal(np.array(fake_ops.args[6]), np.array([0, 1, 2]))
-    np.testing.assert_array_equal(np.array(fake_ops.args[7]), np.array([0, 1]))
-    np.testing.assert_array_equal(
-        np.array(cache.conv_states[0][:2]),
-        np.ones((2, inner.conv_kernel_size - 1, inner.conv_dim), dtype=np.float32),
-    )
-    np.testing.assert_array_equal(
-        np.array(cache.conv_states[0][2:]),
-        np.zeros((1, inner.conv_kernel_size - 1, inner.conv_dim), dtype=np.float32),
-    )
-    np.testing.assert_array_equal(
-        np.array(cache.recurrent_states[0]),
-        np.full(cache.recurrent_states[0].shape, 7, dtype=np.float32),
-    )
-    assert out.shape == (1, 2, inner.num_v_heads * inner.head_v_dim)
+    def test_falls_back_for_unsupported_recurrent_shape(self) -> None:
+        # Arrange
+        d_k = 33
+        cache = _make_state_cache(key_head_dim=d_k)
+        initial_state = mx.ones_like(cache.recurrent_states[0])
+        cache.recurrent_states[0] = initial_state
+        request = _recurrent_request(
+            q=mx.zeros((1, 2, 1, d_k), dtype=mx.float32),
+            k=mx.zeros((1, 2, 1, d_k), dtype=mx.float32),
+            v=mx.zeros((1, 2, 1, 4), dtype=mx.float32),
+            g=mx.zeros((1, 2, 1), dtype=mx.float32),
+            beta=mx.zeros((1, 2, 1), dtype=mx.float32),
+            cache=cache,
+            slot_ids=[0, 1],
+        )
+
+        # Act
+        result = GDNLazyDecodeKernels(
+            enabled=True,
+            conv_kernel=_RaisingKernel(),
+            recurrent_kernel=_RaisingKernel(),
+        ).try_recurrent_decode(request)
+
+        # Assert
+        assert result is None
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), np.array(initial_state)
+        )
+
+    def test_kill_switch_disables_kernel_construction(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Arrange
+        def fail_make_kernel(*_: Any) -> None:
+            raise AssertionError("disabled lazy decode should not construct kernels")
+
+        monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
+        monkeypatch.setattr(
+            GDNLazyDecodeKernels,
+            "_make_kernel",
+            staticmethod(fail_make_kernel),
+        )
+        kernels = GDNLazyDecodeKernels.from_env()
+        cache = _make_state_cache()
+        request = _recurrent_request(
+            q=mx.zeros((1, 1, 1, 32), dtype=mx.float32),
+            k=mx.zeros((1, 1, 1, 32), dtype=mx.float32),
+            v=mx.zeros((1, 1, 1, 4), dtype=mx.float32),
+            g=mx.zeros((1, 1, 1), dtype=mx.float32),
+            beta=mx.zeros((1, 1, 1), dtype=mx.float32),
+            cache=cache,
+            slot_ids=[0],
+        )
+
+        # Act
+        conv_result = kernels.try_conv_decode(
+            mx.zeros((1, 1, cache.conv_dim), dtype=mx.float32), object(), cache, 0, [0]
+        )
+        recurrent_result = kernels.try_recurrent_decode(request)
+
+        # Assert
+        assert conv_result is None
+        assert recurrent_result is None
+
+
+class TestGDNLazyDecodeSharedOwner:
+    def test_reuses_kernel_construction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Arrange
+        calls = []
+
+        def fake_make_kernel(name: str, *_: Any) -> object:
+            calls.append(name)
+            return object()
+
+        monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "1")
+        monkeypatch.setattr(
+            GDNLazyDecodeKernels,
+            "_make_kernel",
+            staticmethod(fake_make_kernel),
+        )
+
+        # Act
+        first = GDNLazyDecodeKernels.shared()
+        second = GDNLazyDecodeKernels.shared()
+
+        # Assert
+        assert first is second
+        assert calls == ["gdn_conv1d_silu_decode_v2", "gdn_recurrent_v2"]
+        monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
+        disabled = GDNLazyDecodeKernels.shared()
+        assert disabled is not first
+        assert calls == ["gdn_conv1d_silu_decode_v2", "gdn_recurrent_v2"]
+
+
+class TestGDNPagedAttentionWrapperLazyDecode:
+    def test_kill_switch_uses_recurrent_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Arrange
+        class FakeOps:
+            def __init__(self) -> None:
+                self.called = False
+                self.args: tuple[Any, ...] | None = None
+
+            def gdn_linear_attention(self, *args: Any) -> None:
+                self.called = True
+                self.args = args
+                state_pool = args[5]
+                y_flat = args[8]
+                state_pool[:] = 7
+                y_flat[:] = 0
+
+        def fail_make_kernel(*_: Any) -> None:
+            raise AssertionError("disabled wrapper path should not construct kernels")
+
+        fake_ops = FakeOps()
+        monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
+        monkeypatch.setattr(attention_linear, "get_ops", lambda: fake_ops)
+        monkeypatch.setattr(
+            GDNLazyDecodeKernels,
+            "_make_kernel",
+            staticmethod(fail_make_kernel),
+        )
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        set_context(
+            PagedAttentionContext(
+                slot_mapping=[0, 1],
+                cu_seqlens=[0, 1, 2],
+                gdn_slot_mapping=[0, 1],
+            )
+        )
+
+        # Act
+        try:
+            out = wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
+        finally:
+            clear_context()
+
+        # Assert
+        assert fake_ops.called
+        assert fake_ops.args is not None
+        np.testing.assert_array_equal(np.array(fake_ops.args[6]), np.array([0, 1, 2]))
+        np.testing.assert_array_equal(np.array(fake_ops.args[7]), np.array([0, 1]))
+        np.testing.assert_array_equal(
+            np.array(cache.conv_states[0][:2]),
+            np.ones((2, inner.conv_kernel_size - 1, inner.conv_dim), dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            np.array(cache.conv_states[0][2:]),
+            np.zeros((1, inner.conv_kernel_size - 1, inner.conv_dim), dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]),
+            np.full(cache.recurrent_states[0].shape, 7, dtype=np.float32),
+        )
+        assert out.shape == (1, 2, inner.num_v_heads * inner.head_v_dim)

--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -14,13 +14,24 @@ import pytest
 import vllm_metal.metal_kernel_backend.attention_linear as attention_linear
 from vllm_metal.metal import get_ops
 from vllm_metal.metal_kernel_backend.attention_linear import GDNPagedAttentionWrapper
-from vllm_metal.metal_kernel_backend.gdn_lazy_decode import GDNLazyDecodeKernels
+from vllm_metal.metal_kernel_backend.gdn_lazy_decode import (
+    GDNLazyDecodeKernels,
+    get_gdn_lazy_decode_kernels,
+    reset_gdn_lazy_decode_kernels,
+)
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import (
     PagedAttentionContext,
     clear_context,
     set_context,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_lazy_decode_kernels() -> None:
+    reset_gdn_lazy_decode_kernels()
+    yield
+    reset_gdn_lazy_decode_kernels()
 
 
 class _DepthwiseConv1D:
@@ -368,6 +379,35 @@ def test_lazy_decode_kill_switch_disables_kernel_construction(
         )
         is None
     )
+
+
+def test_shared_lazy_decode_owner_reuses_kernel_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_make_kernel(name: str, *_: Any) -> object:
+        calls.append(name)
+        return object()
+
+    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "1")
+    monkeypatch.setattr(
+        GDNLazyDecodeKernels,
+        "_make_kernel",
+        staticmethod(fake_make_kernel),
+    )
+
+    first = get_gdn_lazy_decode_kernels()
+    second = get_gdn_lazy_decode_kernels()
+
+    assert first is second
+    assert calls == ["gdn_conv1d_silu_decode_v2", "gdn_recurrent_v2"]
+
+    monkeypatch.setenv("VLLM_METAL_GDN_LAZY_DECODE", "0")
+    disabled = get_gdn_lazy_decode_kernels()
+
+    assert disabled is not first
+    assert calls == ["gdn_conv1d_silu_decode_v2", "gdn_recurrent_v2"]
 
 
 def test_wrapper_kill_switch_uses_recurrent_fallback(

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -29,10 +29,7 @@ if TYPE_CHECKING:
     VLLM_METAL_PREFIX_CACHE: bool = False
     VLLM_METAL_PREFIX_CACHE_FRACTION: str = ""
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
-    VLLM_METAL_GDN_CONV_KERNEL: str = "2"
-    VLLM_METAL_GDN_RECURRENT_KERNEL: str = "2"
-    VLLM_GDN_CONV_KERNEL: str = "2"
-    VLLM_GDN_RECURRENT_KERNEL: str = "2"
+    VLLM_METAL_GDN_LAZY_DECODE: bool = True
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
@@ -75,17 +72,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Custom cache directory for ModelScope downloads (None if unset).
     "VLLM_METAL_MODELSCOPE_CACHE": lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
-    # GDN decode kernel selectors. Prefer the VLLM_METAL_GDN_* names;
-    # VLLM_GDN_* aliases remain for compatibility with existing local scripts.
-    "VLLM_METAL_GDN_CONV_KERNEL": lambda: os.getenv(
-        "VLLM_METAL_GDN_CONV_KERNEL", os.getenv("VLLM_GDN_CONV_KERNEL", "2")
+    # Enable lazy GDN decode kernels by default. Set to "0" to force the
+    # eager conv / C++ recurrent fallback path.
+    "VLLM_METAL_GDN_LAZY_DECODE": lambda: (
+        os.getenv("VLLM_METAL_GDN_LAZY_DECODE", "1") == "1"
     ),
-    "VLLM_METAL_GDN_RECURRENT_KERNEL": lambda: os.getenv(
-        "VLLM_METAL_GDN_RECURRENT_KERNEL",
-        os.getenv("VLLM_GDN_RECURRENT_KERNEL", "2"),
-    ),
-    "VLLM_GDN_CONV_KERNEL": lambda: os.getenv("VLLM_GDN_CONV_KERNEL", "2"),
-    "VLLM_GDN_RECURRENT_KERNEL": lambda: os.getenv("VLLM_GDN_RECURRENT_KERNEL", "2"),
 }
 
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -29,6 +29,10 @@ if TYPE_CHECKING:
     VLLM_METAL_PREFIX_CACHE: bool = False
     VLLM_METAL_PREFIX_CACHE_FRACTION: str = ""
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
+    VLLM_METAL_GDN_CONV_KERNEL: str = "2"
+    VLLM_METAL_GDN_RECURRENT_KERNEL: str = "2"
+    VLLM_GDN_CONV_KERNEL: str = "2"
+    VLLM_GDN_RECURRENT_KERNEL: str = "2"
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
@@ -71,6 +75,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Custom cache directory for ModelScope downloads (None if unset).
     "VLLM_METAL_MODELSCOPE_CACHE": lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
+    # GDN decode kernel selectors. Prefer the VLLM_METAL_GDN_* names;
+    # VLLM_GDN_* aliases remain for compatibility with existing local scripts.
+    "VLLM_METAL_GDN_CONV_KERNEL": lambda: os.getenv(
+        "VLLM_METAL_GDN_CONV_KERNEL", os.getenv("VLLM_GDN_CONV_KERNEL", "2")
+    ),
+    "VLLM_METAL_GDN_RECURRENT_KERNEL": lambda: os.getenv(
+        "VLLM_METAL_GDN_RECURRENT_KERNEL",
+        os.getenv("VLLM_GDN_RECURRENT_KERNEL", "2"),
+    ),
+    "VLLM_GDN_CONV_KERNEL": lambda: os.getenv("VLLM_GDN_CONV_KERNEL", "2"),
+    "VLLM_GDN_RECURRENT_KERNEL": lambda: os.getenv("VLLM_GDN_RECURRENT_KERNEL", "2"),
 }
 
 

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -42,6 +42,11 @@ def _read_metal_source(path: Path) -> str:
     return text
 
 
+def _read_v2_metal_source(filename: str) -> str:
+    """Read a kernels_v2 .metal source file."""
+    return _read_metal_source(_KERNELS_V2_DIR / filename)
+
+
 def _build_reshape_cache_source() -> str:
     """Concatenate float8 + utils + reshape_and_cache into a single source."""
     parts = [

--- a/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
@@ -1,49 +1,34 @@
-// Template params: T (dtype), CONV_DIM, KERNEL_SIZE, MAX_SEQS
+// Template params: T (dtype), CONV_DIM, KERNEL_SIZE
 // Inputs: input, conv_state_in, weights, slot_mapping, num_requests
 // Outputs: output, conv_state_out
-// Grid: (MAX_SEQS * CONV_DIM, 1, 1) — one thread per (slot, channel)
+// Grid: (num_requests * CONV_DIM, 1, 1) — one thread per (request, channel)
 
 uint tid = thread_position_in_grid.x;
-uint slot = tid / CONV_DIM;
+uint req_idx = tid / CONV_DIM;
 uint c = tid % CONV_DIM;
 
-if (slot >= MAX_SEQS) return;
+if (req_idx >= (uint)num_requests) return;
 
 constexpr int state_len = KERNEL_SIZE - 1;
+uint slot = (uint)slot_mapping[req_idx];
 int state_base = slot * state_len * CONV_DIM + c;
+int state_out_base = req_idx * state_len * CONV_DIM + c;
 int weight_base = c * KERNEL_SIZE;
 
-// Find if this slot has an active request
-int req_idx = -1;
-for (uint r = 0; r < (uint)num_requests; ++r) {
-    if (slot_mapping[r] == (int)slot) {
-        req_idx = r;
-        break;
-    }
+// Active request: compute conv + SiLU and emit compact state update.
+float inp = static_cast<float>(input[req_idx * CONV_DIM + c]);
+
+float acc = 0.0f;
+for (int t = 0; t < state_len; ++t) {
+    acc += static_cast<float>(conv_state_in[state_base + t * CONV_DIM])
+         * static_cast<float>(weights[weight_base + t]);
 }
+acc += inp * static_cast<float>(weights[weight_base + state_len]);
 
-if (req_idx >= 0) {
-    // Active slot: compute conv + SiLU and shift state
-    float inp = static_cast<float>(input[req_idx * CONV_DIM + c]);
+output[req_idx * CONV_DIM + c] = static_cast<T>(acc / (1.0f + metal::exp(-acc)));
 
-    float acc = 0.0f;
-    for (int t = 0; t < state_len; ++t) {
-        acc += static_cast<float>(conv_state_in[state_base + t * CONV_DIM])
-             * static_cast<float>(weights[weight_base + t]);
-    }
-    acc += inp * static_cast<float>(weights[weight_base + state_len]);
-
-    output[req_idx * CONV_DIM + c] = static_cast<T>(acc / (1.0f + metal::exp(-acc)));
-
-    for (int t = 0; t < state_len - 1; ++t) {
-        conv_state_out[state_base + t * CONV_DIM] =
-            conv_state_in[state_base + (t + 1) * CONV_DIM];
-    }
-    conv_state_out[state_base + (state_len - 1) * CONV_DIM] = static_cast<T>(inp);
-} else {
-    // Inactive slot: identity copy
-    for (int t = 0; t < state_len; ++t) {
-        conv_state_out[state_base + t * CONV_DIM] =
-            conv_state_in[state_base + t * CONV_DIM];
-    }
+for (int t = 0; t < state_len - 1; ++t) {
+    conv_state_out[state_out_base + t * CONV_DIM] =
+        conv_state_in[state_base + (t + 1) * CONV_DIM];
 }
+conv_state_out[state_out_base + (state_len - 1) * CONV_DIM] = static_cast<T>(inp);

--- a/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
@@ -1,0 +1,49 @@
+// Template params: T (dtype), CONV_DIM, KERNEL_SIZE, MAX_SEQS
+// Inputs: input, conv_state_in, weights, slot_mapping, num_requests
+// Outputs: output, conv_state_out
+// Grid: (MAX_SEQS * CONV_DIM, 1, 1) — one thread per (slot, channel)
+
+uint tid = thread_position_in_grid.x;
+uint slot = tid / CONV_DIM;
+uint c = tid % CONV_DIM;
+
+if (slot >= MAX_SEQS) return;
+
+constexpr int state_len = KERNEL_SIZE - 1;
+int state_base = slot * state_len * CONV_DIM + c;
+int weight_base = c * KERNEL_SIZE;
+
+// Find if this slot has an active request
+int req_idx = -1;
+for (uint r = 0; r < (uint)num_requests; ++r) {
+    if (slot_mapping[r] == (int)slot) {
+        req_idx = r;
+        break;
+    }
+}
+
+if (req_idx >= 0) {
+    // Active slot: compute conv + SiLU and shift state
+    float inp = static_cast<float>(input[req_idx * CONV_DIM + c]);
+
+    float acc = 0.0f;
+    for (int t = 0; t < state_len; ++t) {
+        acc += static_cast<float>(conv_state_in[state_base + t * CONV_DIM])
+             * static_cast<float>(weights[weight_base + t]);
+    }
+    acc += inp * static_cast<float>(weights[weight_base + state_len]);
+
+    output[req_idx * CONV_DIM + c] = static_cast<T>(acc / (1.0f + metal::exp(-acc)));
+
+    for (int t = 0; t < state_len - 1; ++t) {
+        conv_state_out[state_base + t * CONV_DIM] =
+            conv_state_in[state_base + (t + 1) * CONV_DIM];
+    }
+    conv_state_out[state_base + (state_len - 1) * CONV_DIM] = static_cast<T>(inp);
+} else {
+    // Inactive slot: identity copy
+    for (int t = 0; t < state_len; ++t) {
+        conv_state_out[state_base + t * CONV_DIM] =
+            conv_state_in[state_base + t * CONV_DIM];
+    }
+}

--- a/vllm_metal/metal/kernels_v2/gdn_recurrent_decode.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_recurrent_decode.metal
@@ -1,26 +1,19 @@
-// Grid: (32, Dv, MAX_SEQS * Hv), Threadgroup: (32, 4, 1)
-// Each SIMD group of 32 threads handles Dk elements for one (slot, hv, dv).
+// Grid: (32, Dv, num_requests * Hv), Threadgroup: (32, 4, 1)
+// Each SIMD group of 32 threads handles Dk elements for one (request, hv, dv).
 auto n = thread_position_in_grid.z;
-auto slot_idx = n / Hv;
+auto req_idx = n / Hv;
 auto hv_idx = n % Hv;
 auto hk_idx = hv_idx / (Hv / Hk);
 auto dv_idx = thread_position_in_grid.y;
 auto dk_idx = thread_position_in_threadgroup.x;
 constexpr int n_per_t = Dk / 32;
 
-if (slot_idx >= MAX_SEQS || dv_idx >= (uint)Dv) return;
-
-// Find if this slot has an active request
-int req_idx = -1;
-for (uint r = 0; r < (uint)num_requests; ++r) {
-    if (slot_mapping[r] == (int)slot_idx) {
-        req_idx = r;
-        break;
-    }
-}
+if (req_idx >= (uint)num_requests || dv_idx >= (uint)Dv) return;
 
 // State: [MAX_SEQS, Hv, Dv, Dk]
+auto slot_idx = (uint)slot_mapping[req_idx];
 int state_base = ((slot_idx * Hv + hv_idx) * Dv + dv_idx) * Dk;
+int state_out_base = ((req_idx * Hv + hv_idx) * Dv + dv_idx) * Dk;
 
 // Load state into registers
 float state[n_per_t];
@@ -29,46 +22,42 @@ for (int i = 0; i < n_per_t; ++i) {
     state[i] = static_cast<float>(state_in[state_base + s_idx]);
 }
 
-if (req_idx >= 0) {
-    // Active request: run recurrence
-    auto q_ = q + req_idx * Hk * Dk + hk_idx * Dk;
-    auto k_ = k + req_idx * Hk * Dk + hk_idx * Dk;
-    auto v_ = v + req_idx * Hv * Dv + hv_idx * Dv;
-    auto g_ = g + req_idx * Hv;
-    auto beta_ = beta + req_idx * Hv;
+auto q_ = q + req_idx * Hk * Dk + hk_idx * Dk;
+auto k_ = k + req_idx * Hk * Dk + hk_idx * Dk;
+auto v_ = v + req_idx * Hv * Dv + hv_idx * Dv;
+auto g_ = g + req_idx * Hv;
+auto beta_ = beta + req_idx * Hv;
 
-    float g_val = static_cast<float>(g_[hv_idx]);
+float g_val = static_cast<float>(g_[hv_idx]);
 
-    // Decay + k . state dot product
-    float kv_mem = 0.0f;
-    for (int i = 0; i < n_per_t; ++i) {
-        int s_idx = n_per_t * dk_idx + i;
-        state[i] *= g_val;
-        kv_mem += state[i] * static_cast<float>(k_[s_idx]);
-    }
-    kv_mem = simd_sum(kv_mem);
-
-    // Delta update
-    float delta = (static_cast<float>(v_[dv_idx]) - kv_mem)
-                  * static_cast<float>(beta_[hv_idx]);
-
-    // State update + q . state output
-    float out = 0.0f;
-    for (int i = 0; i < n_per_t; ++i) {
-        int s_idx = n_per_t * dk_idx + i;
-        state[i] += static_cast<float>(k_[s_idx]) * delta;
-        out += state[i] * static_cast<float>(q_[s_idx]);
-    }
-    out = simd_sum(out);
-
-    if (thread_index_in_simdgroup == 0) {
-        y[req_idx * Hv * Dv + hv_idx * Dv + dv_idx] = static_cast<T>(out);
-    }
-}
-// else: inactive slot, y not written (zero-initialized by MLX)
-
-// Write state out (all slots — identity copy for inactive)
+// Decay + k . state dot product
+float kv_mem = 0.0f;
 for (int i = 0; i < n_per_t; ++i) {
     int s_idx = n_per_t * dk_idx + i;
-    state_out[state_base + s_idx] = static_cast<StT>(state[i]);
+    state[i] *= g_val;
+    kv_mem += state[i] * static_cast<float>(k_[s_idx]);
+}
+kv_mem = simd_sum(kv_mem);
+
+// Delta update
+float delta = (static_cast<float>(v_[dv_idx]) - kv_mem)
+              * static_cast<float>(beta_[hv_idx]);
+
+// State update + q . state output
+float out = 0.0f;
+for (int i = 0; i < n_per_t; ++i) {
+    int s_idx = n_per_t * dk_idx + i;
+    state[i] += static_cast<float>(k_[s_idx]) * delta;
+    out += state[i] * static_cast<float>(q_[s_idx]);
+}
+out = simd_sum(out);
+
+if (thread_index_in_simdgroup == 0) {
+    y[req_idx * Hv * Dv + hv_idx * Dv + dv_idx] = static_cast<T>(out);
+}
+
+// Write compact state updates for active requests only.
+for (int i = 0; i < n_per_t; ++i) {
+    int s_idx = n_per_t * dk_idx + i;
+    state_out[state_out_base + s_idx] = static_cast<StT>(state[i]);
 }

--- a/vllm_metal/metal/kernels_v2/gdn_recurrent_decode.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_recurrent_decode.metal
@@ -1,0 +1,74 @@
+// Grid: (32, Dv, MAX_SEQS * Hv), Threadgroup: (32, 4, 1)
+// Each SIMD group of 32 threads handles Dk elements for one (slot, hv, dv).
+auto n = thread_position_in_grid.z;
+auto slot_idx = n / Hv;
+auto hv_idx = n % Hv;
+auto hk_idx = hv_idx / (Hv / Hk);
+auto dv_idx = thread_position_in_grid.y;
+auto dk_idx = thread_position_in_threadgroup.x;
+constexpr int n_per_t = Dk / 32;
+
+if (slot_idx >= MAX_SEQS || dv_idx >= (uint)Dv) return;
+
+// Find if this slot has an active request
+int req_idx = -1;
+for (uint r = 0; r < (uint)num_requests; ++r) {
+    if (slot_mapping[r] == (int)slot_idx) {
+        req_idx = r;
+        break;
+    }
+}
+
+// State: [MAX_SEQS, Hv, Dv, Dk]
+int state_base = ((slot_idx * Hv + hv_idx) * Dv + dv_idx) * Dk;
+
+// Load state into registers
+float state[n_per_t];
+for (int i = 0; i < n_per_t; ++i) {
+    int s_idx = n_per_t * dk_idx + i;
+    state[i] = static_cast<float>(state_in[state_base + s_idx]);
+}
+
+if (req_idx >= 0) {
+    // Active request: run recurrence
+    auto q_ = q + req_idx * Hk * Dk + hk_idx * Dk;
+    auto k_ = k + req_idx * Hk * Dk + hk_idx * Dk;
+    auto v_ = v + req_idx * Hv * Dv + hv_idx * Dv;
+    auto g_ = g + req_idx * Hv;
+    auto beta_ = beta + req_idx * Hv;
+
+    float g_val = static_cast<float>(g_[hv_idx]);
+
+    // Decay + k . state dot product
+    float kv_mem = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+        int s_idx = n_per_t * dk_idx + i;
+        state[i] *= g_val;
+        kv_mem += state[i] * static_cast<float>(k_[s_idx]);
+    }
+    kv_mem = simd_sum(kv_mem);
+
+    // Delta update
+    float delta = (static_cast<float>(v_[dv_idx]) - kv_mem)
+                  * static_cast<float>(beta_[hv_idx]);
+
+    // State update + q . state output
+    float out = 0.0f;
+    for (int i = 0; i < n_per_t; ++i) {
+        int s_idx = n_per_t * dk_idx + i;
+        state[i] += static_cast<float>(k_[s_idx]) * delta;
+        out += state[i] * static_cast<float>(q_[s_idx]);
+    }
+    out = simd_sum(out);
+
+    if (thread_index_in_simdgroup == 0) {
+        y[req_idx * Hv * Dv + hv_idx * Dv + dv_idx] = static_cast<T>(out);
+    }
+}
+// else: inactive slot, y not written (zero-initialized by MLX)
+
+// Write state out (all slots — identity copy for inactive)
+for (int i = 0; i < n_per_t; ++i) {
+    int s_idx = n_per_t * dk_idx + i;
+    state_out[state_base + s_idx] = static_cast<StT>(state[i]);
+}

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -1,13 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Linear attention (Gated DeltaNet) with mx.fast.metal_kernel for paged state.
+"""Linear attention (Gated DeltaNet) with C++ Metal kernel for paged state.
 
 Decomposes the mlx_lm GDN module's forward pass and replaces the recurrent
-update step with an mx.fast.metal_kernel that operates on gathered state
-slices from a paged pool via slot_mapping.
-
-The decode fast path participates in MLX's lazy evaluation graph — no
-explicit mx.eval barriers are needed there.  Prefill and unsupported decode
-shapes fall back to the original upstream paths.
+update step with a C++ nanobind Metal kernel that reads/writes state in-place
+from a managed pool via slot_mapping.
 
 Conv1d remains per-request (stateful), but the expensive recurrent step is
 dispatched as a single batched Metal kernel call across all requests.
@@ -15,91 +11,19 @@ dispatched as a single batched Metal kernel call across all requests.
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm.models.gated_delta import compute_g
 
-from vllm_metal.metal import _read_v2_metal_source, get_ops
+from vllm_metal.metal import get_ops
+from vllm_metal.metal_kernel_backend.gdn_lazy_decode import (
+    apply_lazy_gdn_conv_decode,
+    apply_lazy_gdn_recurrent_decode,
+)
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import get_context
-
-# ---------------------------------------------------------------------------
-# mx.fast.metal_kernel conv1d + SiLU decode (lazy graph integration)
-# ---------------------------------------------------------------------------
-
-_GDN_CONV1D_V2_SOURCE = _read_v2_metal_source("gdn_conv1d_silu_decode.metal")
-
-
-def _make_conv1d_silu_decode_kernel():
-    """Build mx.fast.metal_kernel for batched depthwise conv1d + SiLU decode."""
-    try:
-        if not mx.metal.is_available():
-            return None
-    except AttributeError:
-        return None
-    return mx.fast.metal_kernel(
-        name="gdn_conv1d_silu_decode_v2",
-        input_names=[
-            "input",
-            "conv_state_in",
-            "weights",
-            "slot_mapping",
-            "num_requests",
-        ],
-        output_names=["output", "conv_state_out"],
-        source=_GDN_CONV1D_V2_SOURCE,
-    )
-
-
-_conv1d_silu_decode_kernel = _make_conv1d_silu_decode_kernel()
-_conv_kernel_mode = os.environ.get(
-    "VLLM_METAL_GDN_CONV_KERNEL",
-    os.environ.get("VLLM_GDN_CONV_KERNEL", "2"),
-)
-
-# ---------------------------------------------------------------------------
-# Recurrent kernel modes: "1" = C++ eager, "2" = lazy (default)
-# ---------------------------------------------------------------------------
-_recurrent_kernel_mode = os.environ.get(
-    "VLLM_METAL_GDN_RECURRENT_KERNEL",
-    os.environ.get("VLLM_GDN_RECURRENT_KERNEL", "2"),
-)
-
-# mx.fast.metal_kernel recurrent update (lazy graph integration)
-# Ported from mlx_lm/models/gated_delta.py with slot_mapping for paged state.
-_GDN_RECURRENT_V2_SOURCE = _read_v2_metal_source("gdn_recurrent_decode.metal")
-
-
-def _make_recurrent_v2_kernel():
-    """Build mx.fast.metal_kernel for GDN recurrent update (lazy graph)."""
-    try:
-        if not mx.metal.is_available():
-            return None
-    except AttributeError:
-        return None
-    return mx.fast.metal_kernel(
-        name="gdn_recurrent_v2",
-        input_names=[
-            "q",
-            "k",
-            "v",
-            "g",
-            "beta",
-            "state_in",
-            "slot_mapping",
-            "num_requests",
-        ],
-        output_names=["y", "state_out"],
-        source=_GDN_RECURRENT_V2_SOURCE,
-    )
-
-
-_recurrent_v2_kernel = (
-    _make_recurrent_v2_kernel() if _recurrent_kernel_mode == "2" else None
-)
 
 
 def is_linear_attention(module: nn.Module) -> bool:
@@ -112,13 +36,13 @@ def is_linear_attention(module: nn.Module) -> bool:
 
 
 class GDNPagedAttentionWrapper(nn.Module):
-    """Wraps a GDN linear attention module with lazy Metal kernel dispatch.
+    """Wraps a GDN linear attention module with C++ Metal kernel dispatch.
 
     The forward pass decomposes the mlx_lm GDN module into:
     1. Projections (in_proj_qkv, z, a, b) — stateless, batched
     2. Conv1d with state management — per-request (stateful)
     3. Q/K/V split + RMS norm + gating — stateless, batched
-    4. Recurrent update — lazy Metal kernel, batched functional state
+    4. Recurrent update — C++ Metal kernel, batched, in-place state pool
     5. Output norm + projection — stateless, batched
 
     When no ``PagedAttentionContext`` is active, delegates to the original
@@ -186,97 +110,41 @@ class GDNPagedAttentionWrapper(nn.Module):
             b = inner.in_proj_b(x)  # [1, total_tokens, Hv]
             a = inner.in_proj_a(x)  # [1, total_tokens, Hk]
 
-        # === Step 2: Conv1d (batched for decode, per-request for prefill) ===
+        # === Step 2: Conv1d (per-request, needs conv_state) ===
         # Use stable slot mapping for state pool access.
         slot_ids = (
             ctx.gdn_slot_mapping
             if ctx.gdn_slot_mapping is not None
             else list(range(num_requests))
         )
-
-        is_decode = total_tokens == num_requests
-        use_v2 = (
-            _conv_kernel_mode == "2"
-            and _conv1d_silu_decode_kernel is not None
-            and is_decode
+        conv_packed = apply_lazy_gdn_conv_decode(
+            mixed_qkv, inner, state_cache, cache_idx, slot_ids
         )
-        if use_v2:
-            # --- mx.fast.metal_kernel decode path (lazy, no sync) ---
-            conv_dim = state_cache.conv_dim
-            kernel_size = inner.conv_kernel_size
-            max_seqs = state_cache.max_seqs
-            conv_state_in = state_cache.conv_states[cache_idx]
-            weight = inner.conv1d.weight
+        conv_outputs = []
+        use_original_conv = conv_packed is None
+        conv_req_indices = range(num_requests) if use_original_conv else ()
+        for req_idx in conv_req_indices:
+            slot = slot_ids[req_idx]
+            start = cu_seqlens[req_idx]
+            end = cu_seqlens[req_idx + 1]
+            req_qkv = mixed_qkv[:, start:end, :]
 
-            mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
-            slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
+            # Load conv state from stable slot
+            conv_state = state_cache.conv_states[cache_idx][slot : slot + 1]
+            conv_input = mx.concatenate([conv_state, req_qkv], axis=1)
 
-            grid_size = max_seqs * conv_dim
-            tg_size = min(256, grid_size)
-            state_shape = (max_seqs, kernel_size - 1, conv_dim)
+            # Save updated conv state back to stable slot
+            new_conv = conv_input[:, -(inner.conv_kernel_size - 1) :]
+            cs = state_cache.conv_states[cache_idx]
+            cs[slot : slot + 1] = new_conv
+            state_cache.conv_states[cache_idx] = cs
 
-            conv_silu_out, conv_state_out = _conv1d_silu_decode_kernel(
-                inputs=[
-                    mixed_qkv_2d,
-                    conv_state_in,
-                    weight,
-                    slot_ids_arr,
-                    num_requests,
-                ],
-                template=[
-                    ("T", mixed_qkv.dtype),
-                    ("CONV_DIM", conv_dim),
-                    ("KERNEL_SIZE", kernel_size),
-                    ("MAX_SEQS", max_seqs),
-                ],
-                grid=(grid_size, 1, 1),
-                threadgroup=(tg_size, 1, 1),
-                output_shapes=[(num_requests, conv_dim), state_shape],
-                output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
-            )
-            state_cache.conv_states[cache_idx] = conv_state_out
-            conv_packed = conv_silu_out.reshape(1, total_tokens, conv_dim)
+            conv_out = nn.silu(inner.conv1d(conv_input))
+            # Take only the output tokens (not the conv state prefix)
+            conv_outputs.append(conv_out[:, -(end - start) :, :])
 
-        else:
-            # --- Fallback: batched for decode, per-request for prefill ---
-            all_decode = all(
-                cu_seqlens[i + 1] - cu_seqlens[i] == 1 for i in range(num_requests)
-            )
-
-            if all_decode and num_requests > 1:
-                # Batched decode: gather states → concat → single conv1d → scatter
-                slot_mapping_conv = mx.array(slot_ids, dtype=mx.int32)
-                gathered_states = state_cache.conv_states[cache_idx][slot_mapping_conv]
-                qkv_batch = mixed_qkv[0, :, :].reshape(num_requests, 1, -1)
-                conv_input = mx.concatenate([gathered_states, qkv_batch], axis=1)
-                new_states = conv_input[:, -(inner.conv_kernel_size - 1) :]
-                pool = state_cache.conv_states[cache_idx]
-                pool[slot_mapping_conv] = new_states
-                state_cache.conv_states[cache_idx] = pool
-                conv_out = nn.silu(inner.conv1d(conv_input))
-                conv_packed = conv_out[:, -1:, :].reshape(1, num_requests, -1)
-            else:
-                # Per-request loop (prefill with variable lengths, or single request)
-                conv_outputs = []
-                for req_idx in range(num_requests):
-                    slot = slot_ids[req_idx]
-                    start = cu_seqlens[req_idx]
-                    end = cu_seqlens[req_idx + 1]
-                    req_qkv = mixed_qkv[:, start:end, :]
-
-                    conv_state = state_cache.conv_states[cache_idx][slot : slot + 1]
-                    conv_input = mx.concatenate([conv_state, req_qkv], axis=1)
-
-                    new_conv = conv_input[:, -(inner.conv_kernel_size - 1) :]
-                    cs = state_cache.conv_states[cache_idx]
-                    cs[slot : slot + 1] = new_conv
-                    state_cache.conv_states[cache_idx] = cs
-
-                    conv_out = nn.silu(inner.conv1d(conv_input))
-                    # Take only the output tokens (not the conv state prefix)
-                    conv_outputs.append(conv_out[:, -(end - start) :, :])
-
-                conv_packed = mx.concatenate(conv_outputs, axis=1)
+        if use_original_conv:
+            conv_packed = mx.concatenate(conv_outputs, axis=1)
 
         # === Step 3: Split Q/K/V + norm ===
         q, k, v = [
@@ -301,122 +169,83 @@ class GDNPagedAttentionWrapper(nn.Module):
         g = compute_g(inner.A_log, a, inner.dt_bias).astype(x.dtype)
         beta = mx.sigmoid(b).astype(x.dtype)
 
-        # === Step 5: Recurrent update — V2 lazy / V1 eager ===
+        # === Step 5: C++ Metal kernel — batched recurrent update ===
         n_hk = inner.num_k_heads
         n_hv = inner.num_v_heads
         d_k = inner.head_k_dim
         d_v = inner.head_v_dim
 
-        is_decode = total_tokens == num_requests
-        # The Metal source uses one 32-lane SIMD group across Dk and a
-        # fixed-size per-thread register array, matching the original C++
-        # kernel's practical Dk <= 256 envelope.  Fall back for unusual head
-        # dimensions rather than silently dropping remainder channels.
-        recurrent_shape_supported = d_k % 32 == 0 and d_k <= 256
-        use_recurrent_v2 = (
-            _recurrent_kernel_mode == "2"
-            and _recurrent_v2_kernel is not None
-            and is_decode
-            and recurrent_shape_supported
+        y_flat = apply_lazy_gdn_recurrent_decode(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            state_cache,
+            cache_idx,
+            slot_ids,
+            total_tokens,
+            n_hk,
+            n_hv,
+            d_k,
+            d_v,
+            x.dtype,
         )
+        if y_flat is not None:
+            out = y_flat.reshape(1, total_tokens, n_hv, d_v)
+            out = inner.norm(out, z)
+            return inner.out_proj(out.reshape(1, total_tokens, -1))
+
+        # Flatten for kernel: remove batch dim.
+        # Use float32 for kernel dispatch to avoid float16 overflow in
+        # recurrent state accumulation.  Output is cast back after.
+        kernel_dtype = mx.float32
+        q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
+        k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
+        v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype))
+        g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
+        beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv).astype(kernel_dtype))
+
+        cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
         # Stable request → slot mapping from model_runner's allocator.
         if ctx.gdn_slot_mapping is not None:
-            slot_ids = ctx.gdn_slot_mapping
+            slot_mapping = mx.array(ctx.gdn_slot_mapping, dtype=mx.int32)
         else:
-            slot_ids = list(range(num_requests))
+            slot_mapping = mx.arange(num_requests, dtype=mx.int32)
 
-        if use_recurrent_v2:
-            # --- mx.fast.metal_kernel lazy recurrent dispatch ---
-            # No mx.eval — stays in lazy graph for downstream fusion.
-            state_in = state_cache.recurrent_states[cache_idx]
-            max_seqs = state_cache.max_seqs
+        y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
+        recurrent_pool = state_cache.recurrent_states[cache_idx]
 
-            slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
+        mx.eval(
+            q_flat,
+            k_flat,
+            v_flat,
+            g_flat,
+            beta_flat,
+            recurrent_pool,
+            cu_seqlens_arr,
+            slot_mapping,
+            y_flat,
+        )
 
-            y_out, state_out = _recurrent_v2_kernel(
-                inputs=[
-                    q.reshape(total_tokens, n_hk, d_k),
-                    k.reshape(total_tokens, n_hk, d_k),
-                    v.reshape(total_tokens, n_hv, d_v),
-                    g.reshape(total_tokens, n_hv),
-                    beta.reshape(total_tokens, n_hv),
-                    state_in,
-                    slot_ids_arr,
-                    num_requests,
-                ],
-                template=[
-                    ("T", x.dtype),
-                    ("StT", mx.float32),
-                    ("Dk", d_k),
-                    ("Dv", d_v),
-                    ("Hk", n_hk),
-                    ("Hv", n_hv),
-                    ("MAX_SEQS", max_seqs),
-                ],
-                grid=(32, d_v, max_seqs * n_hv),
-                threadgroup=(32, 4, 1),
-                output_shapes=[
-                    (total_tokens, n_hv, d_v),
-                    state_in.shape,
-                ],
-                output_dtypes=[x.dtype, mx.float32],
-            )
-            state_cache.recurrent_states[cache_idx] = state_out
-            y_flat = y_out
-
-        else:
-            # --- V1: C++ eager dispatch (original path) ---
-            kernel_dtype = mx.float32
-            q_flat = mx.contiguous(
-                q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype)
-            )
-            k_flat = mx.contiguous(
-                k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype)
-            )
-            v_flat = mx.contiguous(
-                v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype)
-            )
-            g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
-            beta_flat = mx.contiguous(
-                beta.reshape(total_tokens, n_hv).astype(kernel_dtype)
-            )
-
-            cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
-            slot_mapping = mx.array(slot_ids, dtype=mx.int32)
-
-            y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
-            recurrent_pool = state_cache.recurrent_states[cache_idx]
-
-            mx.eval(
-                q_flat,
-                k_flat,
-                v_flat,
-                g_flat,
-                beta_flat,
-                recurrent_pool,
-                cu_seqlens_arr,
-                slot_mapping,
-                y_flat,
-            )
-
-            ops = get_ops()
-            ops.gdn_linear_attention(
-                q_flat,
-                k_flat,
-                v_flat,
-                g_flat,
-                beta_flat,
-                recurrent_pool,
-                cu_seqlens_arr,
-                slot_mapping,
-                y_flat,
-                n_hk,
-                n_hv,
-                d_k,
-                d_v,
-            )
-            mx.eval(y_flat, recurrent_pool)
-            y_flat = y_flat.astype(x.dtype)
+        ops = get_ops()
+        ops.gdn_linear_attention(
+            q_flat,
+            k_flat,
+            v_flat,
+            g_flat,
+            beta_flat,
+            recurrent_pool,
+            cu_seqlens_arr,
+            slot_mapping,
+            y_flat,
+            n_hk,
+            n_hv,
+            d_k,
+            d_v,
+        )
+        mx.eval(y_flat, recurrent_pool)
+        y_flat = y_flat.astype(x.dtype)
 
         # === Step 6: Output norm + projection ===
         out = y_flat.reshape(1, total_tokens, n_hv, d_v)

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -18,10 +18,7 @@ import mlx.nn as nn
 from mlx_lm.models.gated_delta import compute_g
 
 from vllm_metal.metal import get_ops
-from vllm_metal.metal_kernel_backend.gdn_lazy_decode import (
-    apply_lazy_gdn_conv_decode,
-    apply_lazy_gdn_recurrent_decode,
-)
+from vllm_metal.metal_kernel_backend.gdn_lazy_decode import GDNLazyDecodeKernels
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import get_context
 
@@ -61,6 +58,7 @@ class GDNPagedAttentionWrapper(nn.Module):
         object.__setattr__(self, "_gdn_layer_idx", layer_idx)
         object.__setattr__(self, "_gdn_cache_idx", cache_idx)
         object.__setattr__(self, "_gdn_state_cache", state_cache)
+        object.__setattr__(self, "_gdn_lazy_decode", GDNLazyDecodeKernels.from_env())
 
     def __call__(
         self,
@@ -117,7 +115,7 @@ class GDNPagedAttentionWrapper(nn.Module):
             if ctx.gdn_slot_mapping is not None
             else list(range(num_requests))
         )
-        conv_packed = apply_lazy_gdn_conv_decode(
+        conv_packed = self._gdn_lazy_decode.try_conv_decode(
             mixed_qkv, inner, state_cache, cache_idx, slot_ids
         )
         conv_outputs = []
@@ -175,7 +173,7 @@ class GDNPagedAttentionWrapper(nn.Module):
         d_k = inner.head_k_dim
         d_v = inner.head_v_dim
 
-        y_flat = apply_lazy_gdn_recurrent_decode(
+        y_flat = self._gdn_lazy_decode.try_recurrent_decode(
             q,
             k,
             v,

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -160,11 +160,12 @@ class GDNPagedAttentionWrapper(nn.Module):
         cache_idx = self._gdn_cache_idx
         slot_ids = state.slot_ids
 
-        conv_packed = self._gdn_lazy_decode.try_conv_decode(
-            mixed_qkv, inner, state_cache, cache_idx, slot_ids
-        )
-        if conv_packed is not None:
-            return conv_packed
+        if state.total_tokens == state.num_requests:
+            conv_packed = self._gdn_lazy_decode.try_conv_decode(
+                mixed_qkv, inner, state_cache, cache_idx, slot_ids
+            )
+            if conv_packed is not None:
+                return conv_packed
 
         conv_outputs = []
         for req_idx in range(state.num_requests):
@@ -231,20 +232,21 @@ class GDNPagedAttentionWrapper(nn.Module):
         state: _GDNForwardState,
     ) -> mx.array:
         # === Step 5: Batched recurrent update ===
-        request = GDNRecurrentDecodeRequest(
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            state_cache=self._gdn_state_cache,
-            cache_idx=self._gdn_cache_idx,
-            slot_ids=state.slot_ids,
-            output_dtype=state.x.dtype,
-        )
-        y_flat = self._gdn_lazy_decode.try_recurrent_decode(request)
-        if y_flat is not None:
-            return y_flat
+        if state.total_tokens == state.num_requests:
+            request = GDNRecurrentDecodeRequest(
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                state_cache=self._gdn_state_cache,
+                cache_idx=self._gdn_cache_idx,
+                slot_ids=state.slot_ids,
+                output_dtype=state.x.dtype,
+            )
+            y_flat = self._gdn_lazy_decode.try_recurrent_decode(request)
+            if y_flat is not None:
+                return y_flat
         return self._run_recurrent_fallback(q, k, v, g, beta, state)
 
     def _run_recurrent_fallback(

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -105,6 +105,10 @@ class GDNPagedAttentionWrapper(nn.Module):
             if ctx.gdn_slot_mapping is not None
             else list(range(num_requests))
         )
+        if len(slot_ids) != num_requests:
+            raise RuntimeError("GDN wrapper requires one slot per request")
+        if len(set(slot_ids)) != len(slot_ids):
+            raise RuntimeError("GDN wrapper requires unique slots per request")
 
         return _GDNForwardState(
             x=x,

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -18,7 +18,9 @@ import mlx.nn as nn
 from mlx_lm.models.gated_delta import compute_g
 
 from vllm_metal.metal import get_ops
-from vllm_metal.metal_kernel_backend.gdn_lazy_decode import GDNLazyDecodeKernels
+from vllm_metal.metal_kernel_backend.gdn_lazy_decode import (
+    get_gdn_lazy_decode_kernels,
+)
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import get_context
 
@@ -58,7 +60,7 @@ class GDNPagedAttentionWrapper(nn.Module):
         object.__setattr__(self, "_gdn_layer_idx", layer_idx)
         object.__setattr__(self, "_gdn_cache_idx", cache_idx)
         object.__setattr__(self, "_gdn_state_cache", state_cache)
-        object.__setattr__(self, "_gdn_lazy_decode", GDNLazyDecodeKernels.from_env())
+        object.__setattr__(self, "_gdn_lazy_decode", get_gdn_lazy_decode_kernels())
 
     def __call__(
         self,

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -5,9 +5,9 @@ Decomposes the mlx_lm GDN module's forward pass and replaces the recurrent
 update step with an mx.fast.metal_kernel that operates on gathered state
 slices from a paged pool via slot_mapping.
 
-The kernel participates in MLX's lazy evaluation graph — no explicit mx.eval
-barriers are needed in the forward path.  State is gathered from the pool
-before the kernel and scattered back afterward, both as lazy MLX ops.
+The decode fast path participates in MLX's lazy evaluation graph — no
+explicit mx.eval barriers are needed there.  Prefill and unsupported decode
+shapes fall back to the original upstream paths.
 
 Conv1d remains per-request (stateful), but the expensive recurrent step is
 dispatched as a single batched Metal kernel call across all requests.
@@ -27,7 +27,7 @@ from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import get_context
 
 # ---------------------------------------------------------------------------
-# Phase 2: mx.fast.metal_kernel conv1d + SiLU decode (lazy graph integration)
+# mx.fast.metal_kernel conv1d + SiLU decode (lazy graph integration)
 # ---------------------------------------------------------------------------
 
 _GDN_CONV1D_V2_SOURCE = _read_v2_metal_source("gdn_conv1d_silu_decode.metal")
@@ -55,14 +55,20 @@ def _make_conv1d_silu_decode_kernel():
 
 
 _conv1d_silu_decode_kernel = _make_conv1d_silu_decode_kernel()
-_conv_kernel_mode = os.environ.get("VLLM_GDN_CONV_KERNEL", "2")
+_conv_kernel_mode = os.environ.get(
+    "VLLM_METAL_GDN_CONV_KERNEL",
+    os.environ.get("VLLM_GDN_CONV_KERNEL", "2"),
+)
 
 # ---------------------------------------------------------------------------
 # Recurrent kernel modes: "1" = C++ eager, "2" = lazy (default)
 # ---------------------------------------------------------------------------
-_recurrent_kernel_mode = os.environ.get("VLLM_GDN_RECURRENT_KERNEL", "2")
+_recurrent_kernel_mode = os.environ.get(
+    "VLLM_METAL_GDN_RECURRENT_KERNEL",
+    os.environ.get("VLLM_GDN_RECURRENT_KERNEL", "2"),
+)
 
-# Phase 2.5: mx.fast.metal_kernel recurrent update (lazy graph integration)
+# mx.fast.metal_kernel recurrent update (lazy graph integration)
 # Ported from mlx_lm/models/gated_delta.py with slot_mapping for paged state.
 _GDN_RECURRENT_V2_SOURCE = _read_v2_metal_source("gdn_recurrent_decode.metal")
 
@@ -195,7 +201,7 @@ class GDNPagedAttentionWrapper(nn.Module):
             and is_decode
         )
         if use_v2:
-            # --- Phase 2: mx.fast.metal_kernel (lazy, no sync) ---
+            # --- mx.fast.metal_kernel decode path (lazy, no sync) ---
             conv_dim = state_cache.conv_dim
             kernel_size = inner.conv_kernel_size
             max_seqs = state_cache.max_seqs
@@ -295,17 +301,23 @@ class GDNPagedAttentionWrapper(nn.Module):
         g = compute_g(inner.A_log, a, inner.dt_bias).astype(x.dtype)
         beta = mx.sigmoid(b).astype(x.dtype)
 
-        # === Step 5: Recurrent update — V2 lazy / noop / V1 eager ===
+        # === Step 5: Recurrent update — V2 lazy / V1 eager ===
         n_hk = inner.num_k_heads
         n_hv = inner.num_v_heads
         d_k = inner.head_k_dim
         d_v = inner.head_v_dim
 
         is_decode = total_tokens == num_requests
+        # The Metal source uses one 32-lane SIMD group across Dk and a
+        # fixed-size per-thread register array, matching the original C++
+        # kernel's practical Dk <= 256 envelope.  Fall back for unusual head
+        # dimensions rather than silently dropping remainder channels.
+        recurrent_shape_supported = d_k % 32 == 0 and d_k <= 256
         use_recurrent_v2 = (
             _recurrent_kernel_mode == "2"
             and _recurrent_v2_kernel is not None
             and is_decode
+            and recurrent_shape_supported
         )
         # Stable request → slot mapping from model_runner's allocator.
         if ctx.gdn_slot_mapping is not None:
@@ -314,7 +326,7 @@ class GDNPagedAttentionWrapper(nn.Module):
             slot_ids = list(range(num_requests))
 
         if use_recurrent_v2:
-            # --- Phase 2.5: mx.fast.metal_kernel lazy dispatch ---
+            # --- mx.fast.metal_kernel lazy recurrent dispatch ---
             # No mx.eval — stays in lazy graph for downstream fusion.
             state_in = state_cache.recurrent_states[cache_idx]
             max_seqs = state_cache.max_seqs

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Linear attention (Gated DeltaNet) with C++ Metal kernel for paged state.
+"""Linear attention (Gated DeltaNet) with mx.fast.metal_kernel for paged state.
 
 Decomposes the mlx_lm GDN module's forward pass and replaces the recurrent
-update step with a C++ nanobind Metal kernel that reads/writes state in-place
-from a managed pool via slot_mapping.
+update step with an mx.fast.metal_kernel that operates on gathered state
+slices from a paged pool via slot_mapping.
+
+The kernel participates in MLX's lazy evaluation graph — no explicit mx.eval
+barriers are needed in the forward path.  State is gathered from the pool
+before the kernel and scattered back afterward, both as lazy MLX ops.
 
 Conv1d remains per-request (stateful), but the expensive recurrent step is
 dispatched as a single batched Metal kernel call across all requests.
@@ -11,15 +15,85 @@ dispatched as a single batched Metal kernel call across all requests.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm.models.gated_delta import compute_g
 
-from vllm_metal.metal import get_ops
+from vllm_metal.metal import _read_v2_metal_source, get_ops
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 from vllm_metal.paged_attention_common import get_context
+
+# ---------------------------------------------------------------------------
+# Phase 2: mx.fast.metal_kernel conv1d + SiLU decode (lazy graph integration)
+# ---------------------------------------------------------------------------
+
+_GDN_CONV1D_V2_SOURCE = _read_v2_metal_source("gdn_conv1d_silu_decode.metal")
+
+
+def _make_conv1d_silu_decode_kernel():
+    """Build mx.fast.metal_kernel for batched depthwise conv1d + SiLU decode."""
+    try:
+        if not mx.metal.is_available():
+            return None
+    except AttributeError:
+        return None
+    return mx.fast.metal_kernel(
+        name="gdn_conv1d_silu_decode_v2",
+        input_names=[
+            "input",
+            "conv_state_in",
+            "weights",
+            "slot_mapping",
+            "num_requests",
+        ],
+        output_names=["output", "conv_state_out"],
+        source=_GDN_CONV1D_V2_SOURCE,
+    )
+
+
+_conv1d_silu_decode_kernel = _make_conv1d_silu_decode_kernel()
+_conv_kernel_mode = os.environ.get("VLLM_GDN_CONV_KERNEL", "2")
+
+# ---------------------------------------------------------------------------
+# Recurrent kernel modes: "1" = C++ eager, "2" = lazy (default)
+# ---------------------------------------------------------------------------
+_recurrent_kernel_mode = os.environ.get("VLLM_GDN_RECURRENT_KERNEL", "2")
+
+# Phase 2.5: mx.fast.metal_kernel recurrent update (lazy graph integration)
+# Ported from mlx_lm/models/gated_delta.py with slot_mapping for paged state.
+_GDN_RECURRENT_V2_SOURCE = _read_v2_metal_source("gdn_recurrent_decode.metal")
+
+
+def _make_recurrent_v2_kernel():
+    """Build mx.fast.metal_kernel for GDN recurrent update (lazy graph)."""
+    try:
+        if not mx.metal.is_available():
+            return None
+    except AttributeError:
+        return None
+    return mx.fast.metal_kernel(
+        name="gdn_recurrent_v2",
+        input_names=[
+            "q",
+            "k",
+            "v",
+            "g",
+            "beta",
+            "state_in",
+            "slot_mapping",
+            "num_requests",
+        ],
+        output_names=["y", "state_out"],
+        source=_GDN_RECURRENT_V2_SOURCE,
+    )
+
+
+_recurrent_v2_kernel = (
+    _make_recurrent_v2_kernel() if _recurrent_kernel_mode == "2" else None
+)
 
 
 def is_linear_attention(module: nn.Module) -> bool:
@@ -32,13 +106,13 @@ def is_linear_attention(module: nn.Module) -> bool:
 
 
 class GDNPagedAttentionWrapper(nn.Module):
-    """Wraps a GDN linear attention module with C++ Metal kernel dispatch.
+    """Wraps a GDN linear attention module with lazy Metal kernel dispatch.
 
     The forward pass decomposes the mlx_lm GDN module into:
     1. Projections (in_proj_qkv, z, a, b) — stateless, batched
     2. Conv1d with state management — per-request (stateful)
     3. Q/K/V split + RMS norm + gating — stateless, batched
-    4. Recurrent update — C++ Metal kernel, batched, in-place state pool
+    4. Recurrent update — lazy Metal kernel, batched functional state
     5. Output norm + projection — stateless, batched
 
     When no ``PagedAttentionContext`` is active, delegates to the original
@@ -106,35 +180,97 @@ class GDNPagedAttentionWrapper(nn.Module):
             b = inner.in_proj_b(x)  # [1, total_tokens, Hv]
             a = inner.in_proj_a(x)  # [1, total_tokens, Hk]
 
-        # === Step 2: Conv1d (per-request, needs conv_state) ===
+        # === Step 2: Conv1d (batched for decode, per-request for prefill) ===
         # Use stable slot mapping for state pool access.
         slot_ids = (
             ctx.gdn_slot_mapping
             if ctx.gdn_slot_mapping is not None
             else list(range(num_requests))
         )
-        conv_outputs = []
-        for req_idx in range(num_requests):
-            slot = slot_ids[req_idx]
-            start = cu_seqlens[req_idx]
-            end = cu_seqlens[req_idx + 1]
-            req_qkv = mixed_qkv[:, start:end, :]
 
-            # Load conv state from stable slot
-            conv_state = state_cache.conv_states[cache_idx][slot : slot + 1]
-            conv_input = mx.concatenate([conv_state, req_qkv], axis=1)
+        is_decode = total_tokens == num_requests
+        use_v2 = (
+            _conv_kernel_mode == "2"
+            and _conv1d_silu_decode_kernel is not None
+            and is_decode
+        )
+        if use_v2:
+            # --- Phase 2: mx.fast.metal_kernel (lazy, no sync) ---
+            conv_dim = state_cache.conv_dim
+            kernel_size = inner.conv_kernel_size
+            max_seqs = state_cache.max_seqs
+            conv_state_in = state_cache.conv_states[cache_idx]
+            weight = inner.conv1d.weight
 
-            # Save updated conv state back to stable slot
-            new_conv = conv_input[:, -(inner.conv_kernel_size - 1) :]
-            cs = state_cache.conv_states[cache_idx]
-            cs[slot : slot + 1] = new_conv
-            state_cache.conv_states[cache_idx] = cs
+            mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
+            slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
 
-            conv_out = nn.silu(inner.conv1d(conv_input))
-            # Take only the output tokens (not the conv state prefix)
-            conv_outputs.append(conv_out[:, -(end - start) :, :])
+            grid_size = max_seqs * conv_dim
+            tg_size = min(256, grid_size)
+            state_shape = (max_seqs, kernel_size - 1, conv_dim)
 
-        conv_packed = mx.concatenate(conv_outputs, axis=1)
+            conv_silu_out, conv_state_out = _conv1d_silu_decode_kernel(
+                inputs=[
+                    mixed_qkv_2d,
+                    conv_state_in,
+                    weight,
+                    slot_ids_arr,
+                    num_requests,
+                ],
+                template=[
+                    ("T", mixed_qkv.dtype),
+                    ("CONV_DIM", conv_dim),
+                    ("KERNEL_SIZE", kernel_size),
+                    ("MAX_SEQS", max_seqs),
+                ],
+                grid=(grid_size, 1, 1),
+                threadgroup=(tg_size, 1, 1),
+                output_shapes=[(num_requests, conv_dim), state_shape],
+                output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
+            )
+            state_cache.conv_states[cache_idx] = conv_state_out
+            conv_packed = conv_silu_out.reshape(1, total_tokens, conv_dim)
+
+        else:
+            # --- Fallback: batched for decode, per-request for prefill ---
+            all_decode = all(
+                cu_seqlens[i + 1] - cu_seqlens[i] == 1 for i in range(num_requests)
+            )
+
+            if all_decode and num_requests > 1:
+                # Batched decode: gather states → concat → single conv1d → scatter
+                slot_mapping_conv = mx.array(slot_ids, dtype=mx.int32)
+                gathered_states = state_cache.conv_states[cache_idx][slot_mapping_conv]
+                qkv_batch = mixed_qkv[0, :, :].reshape(num_requests, 1, -1)
+                conv_input = mx.concatenate([gathered_states, qkv_batch], axis=1)
+                new_states = conv_input[:, -(inner.conv_kernel_size - 1) :]
+                pool = state_cache.conv_states[cache_idx]
+                pool[slot_mapping_conv] = new_states
+                state_cache.conv_states[cache_idx] = pool
+                conv_out = nn.silu(inner.conv1d(conv_input))
+                conv_packed = conv_out[:, -1:, :].reshape(1, num_requests, -1)
+            else:
+                # Per-request loop (prefill with variable lengths, or single request)
+                conv_outputs = []
+                for req_idx in range(num_requests):
+                    slot = slot_ids[req_idx]
+                    start = cu_seqlens[req_idx]
+                    end = cu_seqlens[req_idx + 1]
+                    req_qkv = mixed_qkv[:, start:end, :]
+
+                    conv_state = state_cache.conv_states[cache_idx][slot : slot + 1]
+                    conv_input = mx.concatenate([conv_state, req_qkv], axis=1)
+
+                    new_conv = conv_input[:, -(inner.conv_kernel_size - 1) :]
+                    cs = state_cache.conv_states[cache_idx]
+                    cs[slot : slot + 1] = new_conv
+                    state_cache.conv_states[cache_idx] = cs
+
+                    conv_out = nn.silu(inner.conv1d(conv_input))
+                    # Take only the output tokens (not the conv state prefix)
+                    conv_outputs.append(conv_out[:, -(end - start) :, :])
+
+                conv_packed = mx.concatenate(conv_outputs, axis=1)
 
         # === Step 3: Split Q/K/V + norm ===
         q, k, v = [
@@ -159,62 +295,116 @@ class GDNPagedAttentionWrapper(nn.Module):
         g = compute_g(inner.A_log, a, inner.dt_bias).astype(x.dtype)
         beta = mx.sigmoid(b).astype(x.dtype)
 
-        # === Step 5: C++ Metal kernel — batched recurrent update ===
+        # === Step 5: Recurrent update — V2 lazy / noop / V1 eager ===
         n_hk = inner.num_k_heads
         n_hv = inner.num_v_heads
         d_k = inner.head_k_dim
         d_v = inner.head_v_dim
 
-        # Flatten for kernel: remove batch dim.
-        # Use float32 for kernel dispatch to avoid float16 overflow in
-        # recurrent state accumulation.  Output is cast back after.
-        kernel_dtype = mx.float32
-        q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
-        k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
-        v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype))
-        g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
-        beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv).astype(kernel_dtype))
-
-        cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
+        is_decode = total_tokens == num_requests
+        use_recurrent_v2 = (
+            _recurrent_kernel_mode == "2"
+            and _recurrent_v2_kernel is not None
+            and is_decode
+        )
         # Stable request → slot mapping from model_runner's allocator.
         if ctx.gdn_slot_mapping is not None:
-            slot_mapping = mx.array(ctx.gdn_slot_mapping, dtype=mx.int32)
+            slot_ids = ctx.gdn_slot_mapping
         else:
-            slot_mapping = mx.arange(num_requests, dtype=mx.int32)
+            slot_ids = list(range(num_requests))
 
-        y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
-        recurrent_pool = state_cache.recurrent_states[cache_idx]
+        if use_recurrent_v2:
+            # --- Phase 2.5: mx.fast.metal_kernel lazy dispatch ---
+            # No mx.eval — stays in lazy graph for downstream fusion.
+            state_in = state_cache.recurrent_states[cache_idx]
+            max_seqs = state_cache.max_seqs
 
-        mx.eval(
-            q_flat,
-            k_flat,
-            v_flat,
-            g_flat,
-            beta_flat,
-            recurrent_pool,
-            cu_seqlens_arr,
-            slot_mapping,
-            y_flat,
-        )
+            slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
 
-        ops = get_ops()
-        ops.gdn_linear_attention(
-            q_flat,
-            k_flat,
-            v_flat,
-            g_flat,
-            beta_flat,
-            recurrent_pool,
-            cu_seqlens_arr,
-            slot_mapping,
-            y_flat,
-            n_hk,
-            n_hv,
-            d_k,
-            d_v,
-        )
-        mx.eval(y_flat, recurrent_pool)
-        y_flat = y_flat.astype(x.dtype)
+            y_out, state_out = _recurrent_v2_kernel(
+                inputs=[
+                    q.reshape(total_tokens, n_hk, d_k),
+                    k.reshape(total_tokens, n_hk, d_k),
+                    v.reshape(total_tokens, n_hv, d_v),
+                    g.reshape(total_tokens, n_hv),
+                    beta.reshape(total_tokens, n_hv),
+                    state_in,
+                    slot_ids_arr,
+                    num_requests,
+                ],
+                template=[
+                    ("T", x.dtype),
+                    ("StT", mx.float32),
+                    ("Dk", d_k),
+                    ("Dv", d_v),
+                    ("Hk", n_hk),
+                    ("Hv", n_hv),
+                    ("MAX_SEQS", max_seqs),
+                ],
+                grid=(32, d_v, max_seqs * n_hv),
+                threadgroup=(32, 4, 1),
+                output_shapes=[
+                    (total_tokens, n_hv, d_v),
+                    state_in.shape,
+                ],
+                output_dtypes=[x.dtype, mx.float32],
+            )
+            state_cache.recurrent_states[cache_idx] = state_out
+            y_flat = y_out
+
+        else:
+            # --- V1: C++ eager dispatch (original path) ---
+            kernel_dtype = mx.float32
+            q_flat = mx.contiguous(
+                q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype)
+            )
+            k_flat = mx.contiguous(
+                k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype)
+            )
+            v_flat = mx.contiguous(
+                v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype)
+            )
+            g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
+            beta_flat = mx.contiguous(
+                beta.reshape(total_tokens, n_hv).astype(kernel_dtype)
+            )
+
+            cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
+            slot_mapping = mx.array(slot_ids, dtype=mx.int32)
+
+            y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
+            recurrent_pool = state_cache.recurrent_states[cache_idx]
+
+            mx.eval(
+                q_flat,
+                k_flat,
+                v_flat,
+                g_flat,
+                beta_flat,
+                recurrent_pool,
+                cu_seqlens_arr,
+                slot_mapping,
+                y_flat,
+            )
+
+            ops = get_ops()
+            ops.gdn_linear_attention(
+                q_flat,
+                k_flat,
+                v_flat,
+                g_flat,
+                beta_flat,
+                recurrent_pool,
+                cu_seqlens_arr,
+                slot_mapping,
+                y_flat,
+                n_hk,
+                n_hv,
+                d_k,
+                d_v,
+            )
+            mx.eval(y_flat, recurrent_pool)
+            y_flat = y_flat.astype(x.dtype)
 
         # === Step 6: Output norm + projection ===
         out = y_flat.reshape(1, total_tokens, n_hv, d_v)

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -1,16 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Linear attention (Gated DeltaNet) with C++ Metal kernel for paged state.
+"""Linear attention (Gated DeltaNet) with paged Metal state dispatch.
 
-Decomposes the mlx_lm GDN module's forward pass and replaces the recurrent
-update step with a C++ nanobind Metal kernel that reads/writes state in-place
-from a managed pool via slot_mapping.
-
-Conv1d remains per-request (stateful), but the expensive recurrent step is
-dispatched as a single batched Metal kernel call across all requests.
+Decomposes the mlx_lm GDN module's forward pass and routes eligible decode-only
+batches through lazy Metal conv/recurrent kernels.  Unsupported shapes, mixed
+prefill+decode batches, or disabled lazy decode use the eager conv / C++ Metal
+recurrent fallback path.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 import mlx.core as mx
@@ -19,10 +18,11 @@ from mlx_lm.models.gated_delta import compute_g
 
 from vllm_metal.metal import get_ops
 from vllm_metal.metal_kernel_backend.gdn_lazy_decode import (
-    get_gdn_lazy_decode_kernels,
+    GDNLazyDecodeKernels,
+    GDNRecurrentDecodeRequest,
 )
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
-from vllm_metal.paged_attention_common import get_context
+from vllm_metal.paged_attention_common import PagedAttentionContext, get_context
 
 
 def is_linear_attention(module: nn.Module) -> bool:
@@ -34,14 +34,23 @@ def is_linear_attention(module: nn.Module) -> bool:
     return hasattr(module, "conv1d") and not hasattr(module, "q_proj")
 
 
+@dataclass(frozen=True)
+class _GDNForwardState:
+    x: mx.array
+    cu_seqlens: list[int]
+    num_requests: int
+    total_tokens: int
+    slot_ids: list[int]
+
+
 class GDNPagedAttentionWrapper(nn.Module):
-    """Wraps a GDN linear attention module with C++ Metal kernel dispatch.
+    """Wraps a GDN linear attention module for paged state dispatch.
 
     The forward pass decomposes the mlx_lm GDN module into:
     1. Projections (in_proj_qkv, z, a, b) — stateless, batched
     2. Conv1d with state management — per-request (stateful)
     3. Q/K/V split + RMS norm + gating — stateless, batched
-    4. Recurrent update — C++ Metal kernel, batched, in-place state pool
+    4. Recurrent update — lazy Metal decode fast path, with C++ Metal fallback
     5. Output norm + projection — stateless, batched
 
     When no ``PagedAttentionContext`` is active, delegates to the original
@@ -60,7 +69,7 @@ class GDNPagedAttentionWrapper(nn.Module):
         object.__setattr__(self, "_gdn_layer_idx", layer_idx)
         object.__setattr__(self, "_gdn_cache_idx", cache_idx)
         object.__setattr__(self, "_gdn_state_cache", state_cache)
-        object.__setattr__(self, "_gdn_lazy_decode", get_gdn_lazy_decode_kernels())
+        object.__setattr__(self, "_gdn_lazy_decode", GDNLazyDecodeKernels.shared())
 
     def __call__(
         self,
@@ -75,18 +84,44 @@ class GDNPagedAttentionWrapper(nn.Module):
             # GDN is recurrent — does not use position_ids; drop it.
             return self._inner(x, mask=mask, cache=cache)
 
-        inner = self._inner
-        cache_idx: int = self._gdn_cache_idx
-        state_cache: GDNPagedStateCache = self._gdn_state_cache
+        state = self._prepare_gdn_forward_state(x, ctx)
+        mixed_qkv, z, a, b = self._project_inputs(state)
+        conv_packed = self._run_conv(mixed_qkv, state)
+        q, k, v = self._split_and_normalize(conv_packed, state)
+        g, beta = self._compute_gates(a, b, state)
+        y_flat = self._run_recurrent(q, k, v, g, beta, state)
+        return self._project_output(y_flat, z, state)
 
+    def _prepare_gdn_forward_state(
+        self, x: mx.array, ctx: PagedAttentionContext
+    ) -> _GDNForwardState:
         cu_seqlens = ctx.cu_seqlens
         if cu_seqlens is None or len(cu_seqlens) < 2:
             raise RuntimeError("GDN wrapper requires cu_seqlens in context")
 
         num_requests = len(cu_seqlens) - 1
-        total_tokens = x.shape[1]
+        slot_ids = (
+            ctx.gdn_slot_mapping
+            if ctx.gdn_slot_mapping is not None
+            else list(range(num_requests))
+        )
 
+        return _GDNForwardState(
+            x=x,
+            cu_seqlens=cu_seqlens,
+            num_requests=num_requests,
+            total_tokens=x.shape[1],
+            slot_ids=slot_ids,
+        )
+
+    def _project_inputs(
+        self, state: _GDNForwardState
+    ) -> tuple[mx.array, mx.array, mx.array, mx.array]:
         # === Step 1: Projections (stateless, on full packed input) ===
+        inner = self._inner
+        total_tokens = state.total_tokens
+        x = state.x
+
         if hasattr(inner, "in_proj_qkvz"):
             # Qwen3-Next style: combined projections
             q_pre, k_pre, v_pre, z, b, a = inner.fix_query_key_value_ordering(
@@ -110,23 +145,26 @@ class GDNPagedAttentionWrapper(nn.Module):
             b = inner.in_proj_b(x)  # [1, total_tokens, Hv]
             a = inner.in_proj_a(x)  # [1, total_tokens, Hk]
 
+        return mixed_qkv, z, a, b
+
+    def _run_conv(self, mixed_qkv: mx.array, state: _GDNForwardState) -> mx.array:
         # === Step 2: Conv1d (per-request, needs conv_state) ===
-        # Use stable slot mapping for state pool access.
-        slot_ids = (
-            ctx.gdn_slot_mapping
-            if ctx.gdn_slot_mapping is not None
-            else list(range(num_requests))
-        )
+        inner = self._inner
+        state_cache = self._gdn_state_cache
+        cache_idx = self._gdn_cache_idx
+        slot_ids = state.slot_ids
+
         conv_packed = self._gdn_lazy_decode.try_conv_decode(
             mixed_qkv, inner, state_cache, cache_idx, slot_ids
         )
+        if conv_packed is not None:
+            return conv_packed
+
         conv_outputs = []
-        use_original_conv = conv_packed is None
-        conv_req_indices = range(num_requests) if use_original_conv else ()
-        for req_idx in conv_req_indices:
+        for req_idx in range(state.num_requests):
             slot = slot_ids[req_idx]
-            start = cu_seqlens[req_idx]
-            end = cu_seqlens[req_idx + 1]
+            start = state.cu_seqlens[req_idx]
+            end = state.cu_seqlens[req_idx + 1]
             req_qkv = mixed_qkv[:, start:end, :]
 
             # Load conv state from stable slot
@@ -143,12 +181,15 @@ class GDNPagedAttentionWrapper(nn.Module):
             # Take only the output tokens (not the conv state prefix)
             conv_outputs.append(conv_out[:, -(end - start) :, :])
 
-        if use_original_conv:
-            conv_packed = mx.concatenate(conv_outputs, axis=1)
+        return mx.concatenate(conv_outputs, axis=1)
 
+    def _split_and_normalize(
+        self, conv_packed: mx.array, state: _GDNForwardState
+    ) -> tuple[mx.array, mx.array, mx.array]:
         # === Step 3: Split Q/K/V + norm ===
+        inner = self._inner
         q, k, v = [
-            t.reshape(1, total_tokens, h, d)
+            t.reshape(1, state.total_tokens, h, d)
             for t, h, d in zip(
                 mx.split(
                     conv_packed,
@@ -163,38 +204,59 @@ class GDNPagedAttentionWrapper(nn.Module):
         inv_scale = k.shape[-1] ** -0.5
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+        return q, k, v
 
+    def _compute_gates(
+        self, a: mx.array, b: mx.array, state: _GDNForwardState
+    ) -> tuple[mx.array, mx.array]:
         # === Step 4: Gating (stateless) ===
         # compute_g returns float32; cast to match kernel dispatch dtype.
-        g = compute_g(inner.A_log, a, inner.dt_bias).astype(x.dtype)
-        beta = mx.sigmoid(b).astype(x.dtype)
+        g = compute_g(self._inner.A_log, a, self._inner.dt_bias).astype(state.x.dtype)
+        beta = mx.sigmoid(b).astype(state.x.dtype)
+        return g, beta
 
-        # === Step 5: C++ Metal kernel — batched recurrent update ===
+    def _run_recurrent(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        g: mx.array,
+        beta: mx.array,
+        state: _GDNForwardState,
+    ) -> mx.array:
+        # === Step 5: Batched recurrent update ===
+        request = GDNRecurrentDecodeRequest(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            state_cache=self._gdn_state_cache,
+            cache_idx=self._gdn_cache_idx,
+            slot_ids=state.slot_ids,
+            output_dtype=state.x.dtype,
+        )
+        y_flat = self._gdn_lazy_decode.try_recurrent_decode(request)
+        if y_flat is not None:
+            return y_flat
+        return self._run_recurrent_fallback(q, k, v, g, beta, state)
+
+    def _run_recurrent_fallback(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        g: mx.array,
+        beta: mx.array,
+        state: _GDNForwardState,
+    ) -> mx.array:
+        # C++ Metal fallback path.
+        inner = self._inner
+        total_tokens = state.total_tokens
         n_hk = inner.num_k_heads
         n_hv = inner.num_v_heads
         d_k = inner.head_k_dim
         d_v = inner.head_v_dim
-
-        y_flat = self._gdn_lazy_decode.try_recurrent_decode(
-            q,
-            k,
-            v,
-            g,
-            beta,
-            state_cache,
-            cache_idx,
-            slot_ids,
-            total_tokens,
-            n_hk,
-            n_hv,
-            d_k,
-            d_v,
-            x.dtype,
-        )
-        if y_flat is not None:
-            out = y_flat.reshape(1, total_tokens, n_hv, d_v)
-            out = inner.norm(out, z)
-            return inner.out_proj(out.reshape(1, total_tokens, -1))
 
         # Flatten for kernel: remove batch dim.
         # Use float32 for kernel dispatch to avoid float16 overflow in
@@ -206,15 +268,12 @@ class GDNPagedAttentionWrapper(nn.Module):
         g_flat = mx.contiguous(g.reshape(total_tokens, n_hv).astype(kernel_dtype))
         beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv).astype(kernel_dtype))
 
-        cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
+        cu_seqlens_arr = mx.array(state.cu_seqlens, dtype=mx.int32)
         # Stable request → slot mapping from model_runner's allocator.
-        if ctx.gdn_slot_mapping is not None:
-            slot_mapping = mx.array(ctx.gdn_slot_mapping, dtype=mx.int32)
-        else:
-            slot_mapping = mx.arange(num_requests, dtype=mx.int32)
+        slot_mapping = mx.array(state.slot_ids, dtype=mx.int32)
 
         y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
-        recurrent_pool = state_cache.recurrent_states[cache_idx]
+        recurrent_pool = self._gdn_state_cache.recurrent_states[self._gdn_cache_idx]
 
         mx.eval(
             q_flat,
@@ -245,9 +304,13 @@ class GDNPagedAttentionWrapper(nn.Module):
             d_v,
         )
         mx.eval(y_flat, recurrent_pool)
-        y_flat = y_flat.astype(x.dtype)
+        return y_flat.astype(state.x.dtype)
 
+    def _project_output(
+        self, y_flat: mx.array, z: mx.array, state: _GDNForwardState
+    ) -> mx.array:
         # === Step 6: Output norm + projection ===
-        out = y_flat.reshape(1, total_tokens, n_hv, d_v)
+        inner = self._inner
+        out = y_flat.reshape(1, state.total_tokens, inner.num_v_heads, inner.head_v_dim)
         out = inner.norm(out, z)
-        return inner.out_proj(out.reshape(1, total_tokens, -1))
+        return inner.out_proj(out.reshape(1, state.total_tokens, -1))

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -109,6 +109,8 @@ class GDNPagedAttentionWrapper(nn.Module):
             raise RuntimeError("GDN wrapper requires one slot per request")
         if len(set(slot_ids)) != len(slot_ids):
             raise RuntimeError("GDN wrapper requires unique slots per request")
+        if any(slot < 0 or slot >= self._gdn_state_cache.max_seqs for slot in slot_ids):
+            raise RuntimeError("GDN wrapper received out-of-range slot mapping")
 
         return _GDNForwardState(
             x=x,

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import mlx.core as mx
 
+import vllm_metal.envs as envs
 from vllm_metal.metal import _read_v2_metal_source
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 
@@ -15,162 +15,200 @@ _GDN_CONV1D_V2_SOURCE = _read_v2_metal_source("gdn_conv1d_silu_decode.metal")
 _GDN_RECURRENT_V2_SOURCE = _read_v2_metal_source("gdn_recurrent_decode.metal")
 
 
-def _make_lazy_kernel(
-    name: str,
-    input_names: list[str],
-    output_names: list[str],
-    source: str,
-):
-    try:
-        if not mx.metal.is_available():
+class GDNLazyDecodeKernels:
+    """Owner for lazy GDN decode fast-path policy and kernels.
+
+    The fast path uses ``mx.fast.metal_kernel`` source snippets from
+    ``kernels_v2``.  Unlike the legacy recurrent C++ path, these kernels
+    materialize replacement state arrays (``conv_state_out`` / ``state_out``)
+    and then swap the active cache entry.  That allocation tradeoff keeps the
+    decode-only path lazy and avoids the eager in-place synchronization cost;
+    callers fall back to the legacy path when a request shape is ineligible.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        conv_kernel: Any | None = None,
+        recurrent_kernel: Any | None = None,
+    ) -> None:
+        self._enabled = enabled
+        if not enabled:
+            self._conv_kernel = None
+            self._recurrent_kernel = None
+            return
+
+        self._conv_kernel = (
+            conv_kernel
+            if conv_kernel is not None
+            else self._make_kernel(
+                "gdn_conv1d_silu_decode_v2",
+                ["input", "conv_state_in", "weights", "slot_mapping", "num_requests"],
+                ["output", "conv_state_out"],
+                _GDN_CONV1D_V2_SOURCE,
+            )
+        )
+        self._recurrent_kernel = (
+            recurrent_kernel
+            if recurrent_kernel is not None
+            else self._make_kernel(
+                "gdn_recurrent_v2",
+                [
+                    "q",
+                    "k",
+                    "v",
+                    "g",
+                    "beta",
+                    "state_in",
+                    "slot_mapping",
+                    "num_requests",
+                ],
+                ["y", "state_out"],
+                _GDN_RECURRENT_V2_SOURCE,
+            )
+        )
+
+    @classmethod
+    def from_env(cls) -> GDNLazyDecodeKernels:
+        return cls(enabled=envs.VLLM_METAL_GDN_LAZY_DECODE)
+
+    @staticmethod
+    def _make_kernel(
+        name: str,
+        input_names: list[str],
+        output_names: list[str],
+        source: str,
+    ) -> Any | None:
+        try:
+            if not mx.metal.is_available():
+                return None
+        except AttributeError:
             return None
-    except AttributeError:
-        return None
-    return mx.fast.metal_kernel(
-        name=name,
-        input_names=input_names,
-        output_names=output_names,
-        source=source,
-    )
+        return mx.fast.metal_kernel(
+            name=name,
+            input_names=input_names,
+            output_names=output_names,
+            source=source,
+        )
 
+    def try_conv_decode(
+        self,
+        mixed_qkv: mx.array,
+        inner: Any,
+        state_cache: GDNPagedStateCache,
+        cache_idx: int,
+        slot_ids: list[int],
+    ) -> mx.array | None:
+        """Run the lazy GDN conv decode fast path, or return None."""
+        num_requests = len(slot_ids)
+        total_tokens = mixed_qkv.shape[1]
+        if not (
+            self._enabled
+            and self._conv_kernel is not None
+            and total_tokens == num_requests
+        ):
+            return None
 
-_conv_kernel_mode = os.environ.get(
-    "VLLM_METAL_GDN_CONV_KERNEL",
-    os.environ.get("VLLM_GDN_CONV_KERNEL", "2"),
-)
-_recurrent_kernel_mode = os.environ.get(
-    "VLLM_METAL_GDN_RECURRENT_KERNEL",
-    os.environ.get("VLLM_GDN_RECURRENT_KERNEL", "2"),
-)
+        conv_dim = state_cache.conv_dim
+        kernel_size = inner.conv_kernel_size
+        max_seqs = state_cache.max_seqs
+        conv_state_in = state_cache.conv_states[cache_idx]
+        weight = inner.conv1d.weight
 
-_conv1d_silu_decode_kernel = _make_lazy_kernel(
-    "gdn_conv1d_silu_decode_v2",
-    ["input", "conv_state_in", "weights", "slot_mapping", "num_requests"],
-    ["output", "conv_state_out"],
-    _GDN_CONV1D_V2_SOURCE,
-)
-_recurrent_v2_kernel = (
-    _make_lazy_kernel(
-        "gdn_recurrent_v2",
-        ["q", "k", "v", "g", "beta", "state_in", "slot_mapping", "num_requests"],
-        ["y", "state_out"],
-        _GDN_RECURRENT_V2_SOURCE,
-    )
-    if _recurrent_kernel_mode == "2"
-    else None
-)
+        mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
+        slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
 
+        grid_size = max_seqs * conv_dim
+        tg_size = min(256, grid_size)
+        state_shape = (max_seqs, kernel_size - 1, conv_dim)
 
-def apply_lazy_gdn_conv_decode(
-    mixed_qkv: mx.array,
-    inner: Any,
-    state_cache: GDNPagedStateCache,
-    cache_idx: int,
-    slot_ids: list[int],
-) -> mx.array | None:
-    """Run the lazy GDN conv decode fast path, or return None if ineligible."""
-    num_requests = len(slot_ids)
-    total_tokens = mixed_qkv.shape[1]
-    if not (
-        _conv_kernel_mode == "2"
-        and _conv1d_silu_decode_kernel is not None
-        and total_tokens == num_requests
-    ):
-        return None
+        kernel_inputs = [
+            mixed_qkv_2d,
+            conv_state_in,
+            weight,
+            slot_ids_arr,
+            num_requests,
+        ]
+        template = [
+            ("T", mixed_qkv.dtype),
+            ("CONV_DIM", conv_dim),
+            ("KERNEL_SIZE", kernel_size),
+            ("MAX_SEQS", max_seqs),
+        ]
+        conv_silu_out, conv_state_out = self._conv_kernel(
+            inputs=kernel_inputs,
+            template=template,
+            grid=(grid_size, 1, 1),
+            threadgroup=(tg_size, 1, 1),
+            output_shapes=[(num_requests, conv_dim), state_shape],
+            output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
+        )
+        state_cache.conv_states[cache_idx] = conv_state_out
+        return conv_silu_out.reshape(1, total_tokens, conv_dim)
 
-    conv_dim = state_cache.conv_dim
-    kernel_size = inner.conv_kernel_size
-    max_seqs = state_cache.max_seqs
-    conv_state_in = state_cache.conv_states[cache_idx]
-    weight = inner.conv1d.weight
+    def try_recurrent_decode(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        g: mx.array,
+        beta: mx.array,
+        state_cache: GDNPagedStateCache,
+        cache_idx: int,
+        slot_ids: list[int],
+        total_tokens: int,
+        n_hk: int,
+        n_hv: int,
+        d_k: int,
+        d_v: int,
+        output_dtype: mx.Dtype,
+    ) -> mx.array | None:
+        """Run the lazy GDN recurrent decode fast path, or return None."""
+        num_requests = len(slot_ids)
+        # The Metal source uses one 32-lane SIMD group across Dk and a
+        # fixed-size per-thread register array, matching the original C++
+        # kernel's practical Dk <= 256 envelope. Fall back for unusual head
+        # dimensions rather than silently dropping remainder channels.
+        recurrent_shape_supported = d_k % 32 == 0 and d_k <= 256
+        if not (
+            self._enabled
+            and self._recurrent_kernel is not None
+            and total_tokens == num_requests
+            and recurrent_shape_supported
+        ):
+            return None
 
-    mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
-    slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
+        state_in = state_cache.recurrent_states[cache_idx]
+        max_seqs = state_cache.max_seqs
+        slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
 
-    grid_size = max_seqs * conv_dim
-    tg_size = min(256, grid_size)
-    state_shape = (max_seqs, kernel_size - 1, conv_dim)
-
-    kernel_inputs = [mixed_qkv_2d, conv_state_in, weight, slot_ids_arr, num_requests]
-    template = [
-        ("T", mixed_qkv.dtype),
-        ("CONV_DIM", conv_dim),
-        ("KERNEL_SIZE", kernel_size),
-        ("MAX_SEQS", max_seqs),
-    ]
-    conv_silu_out, conv_state_out = _conv1d_silu_decode_kernel(
-        inputs=kernel_inputs,
-        template=template,
-        grid=(grid_size, 1, 1),
-        threadgroup=(tg_size, 1, 1),
-        output_shapes=[(num_requests, conv_dim), state_shape],
-        output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
-    )
-    state_cache.conv_states[cache_idx] = conv_state_out
-    return conv_silu_out.reshape(1, total_tokens, conv_dim)
-
-
-def apply_lazy_gdn_recurrent_decode(
-    q: mx.array,
-    k: mx.array,
-    v: mx.array,
-    g: mx.array,
-    beta: mx.array,
-    state_cache: GDNPagedStateCache,
-    cache_idx: int,
-    slot_ids: list[int],
-    total_tokens: int,
-    n_hk: int,
-    n_hv: int,
-    d_k: int,
-    d_v: int,
-    output_dtype: mx.Dtype,
-) -> mx.array | None:
-    """Run the lazy GDN recurrent decode fast path, or return None if ineligible."""
-    num_requests = len(slot_ids)
-    # The Metal source uses one 32-lane SIMD group across Dk and a fixed-size
-    # per-thread register array, matching the original C++ kernel's practical
-    # Dk <= 256 envelope. Fall back for unusual head dimensions rather than
-    # silently dropping remainder channels.
-    recurrent_shape_supported = d_k % 32 == 0 and d_k <= 256
-    if not (
-        _recurrent_kernel_mode == "2"
-        and _recurrent_v2_kernel is not None
-        and total_tokens == num_requests
-        and recurrent_shape_supported
-    ):
-        return None
-
-    state_in = state_cache.recurrent_states[cache_idx]
-    max_seqs = state_cache.max_seqs
-    slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
-
-    kernel_inputs = [
-        q.reshape(total_tokens, n_hk, d_k),
-        k.reshape(total_tokens, n_hk, d_k),
-        v.reshape(total_tokens, n_hv, d_v),
-        g.reshape(total_tokens, n_hv),
-        beta.reshape(total_tokens, n_hv),
-        state_in,
-        slot_ids_arr,
-        num_requests,
-    ]
-    template = [
-        ("T", output_dtype),
-        ("StT", mx.float32),
-        ("Dk", d_k),
-        ("Dv", d_v),
-        ("Hk", n_hk),
-        ("Hv", n_hv),
-        ("MAX_SEQS", max_seqs),
-    ]
-    y_out, state_out = _recurrent_v2_kernel(
-        inputs=kernel_inputs,
-        template=template,
-        grid=(32, d_v, max_seqs * n_hv),
-        threadgroup=(32, 4, 1),
-        output_shapes=[(total_tokens, n_hv, d_v), state_in.shape],
-        output_dtypes=[output_dtype, mx.float32],
-    )
-    state_cache.recurrent_states[cache_idx] = state_out
-    return y_out
+        kernel_inputs = [
+            q.reshape(total_tokens, n_hk, d_k),
+            k.reshape(total_tokens, n_hk, d_k),
+            v.reshape(total_tokens, n_hv, d_v),
+            g.reshape(total_tokens, n_hv),
+            beta.reshape(total_tokens, n_hv),
+            state_in,
+            slot_ids_arr,
+            num_requests,
+        ]
+        template = [
+            ("T", output_dtype),
+            ("StT", mx.float32),
+            ("Dk", d_k),
+            ("Dv", d_v),
+            ("Hk", n_hk),
+            ("Hv", n_hv),
+            ("MAX_SEQS", max_seqs),
+        ]
+        y_out, state_out = self._recurrent_kernel(
+            inputs=kernel_inputs,
+            template=template,
+            grid=(32, d_v, max_seqs * n_hv),
+            threadgroup=(32, 4, 1),
+            output_shapes=[(total_tokens, n_hv, d_v), state_in.shape],
+            output_dtypes=[output_dtype, mx.float32],
+        )
+        state_cache.recurrent_states[cache_idx] = state_out
+        return y_out

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -57,9 +57,9 @@ class GDNLazyDecodeKernels:
 
     The fast path uses ``mx.fast.metal_kernel`` source snippets from
     ``kernels_v2``.  Unlike the legacy recurrent C++ path, these kernels
-    materialize replacement conv state arrays and compact recurrent state
-    updates.  Recurrent updates are scattered back into the stable cache pool
-    so decode-only recurrent work stays proportional to active request count;
+    materialize compact conv/recurrent state updates.  Updates are scattered
+    back into the stable cache pool so decode-only state work stays
+    proportional to active request count;
     callers fall back to the legacy path when a request shape is ineligible.
     """
 
@@ -174,16 +174,15 @@ class GDNLazyDecodeKernels:
 
         conv_dim = state_cache.conv_dim
         kernel_size = inner.conv_kernel_size
-        max_seqs = state_cache.max_seqs
         conv_state_in = state_cache.conv_states[cache_idx]
         weight = inner.conv1d.weight
 
         mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
         slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
 
-        grid_size = max_seqs * conv_dim
+        grid_size = num_requests * conv_dim
         tg_size = min(256, grid_size)
-        state_shape = (max_seqs, kernel_size - 1, conv_dim)
+        state_updates_shape = (num_requests, kernel_size - 1, conv_dim)
 
         kernel_inputs = [
             mixed_qkv_2d,
@@ -196,17 +195,17 @@ class GDNLazyDecodeKernels:
             ("T", mixed_qkv.dtype),
             ("CONV_DIM", conv_dim),
             ("KERNEL_SIZE", kernel_size),
-            ("MAX_SEQS", max_seqs),
         ]
-        conv_silu_out, conv_state_out = self._conv_kernel(
+        conv_silu_out, conv_state_updates = self._conv_kernel(
             inputs=kernel_inputs,
             template=template,
             grid=(grid_size, 1, 1),
             threadgroup=(tg_size, 1, 1),
-            output_shapes=[(num_requests, conv_dim), state_shape],
+            output_shapes=[(num_requests, conv_dim), state_updates_shape],
             output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
         )
-        state_cache.conv_states[cache_idx] = conv_state_out
+        conv_state_in[slot_ids_arr] = conv_state_updates
+        state_cache.conv_states[cache_idx] = conv_state_in
         return conv_silu_out.reshape(1, total_tokens, conv_dim)
 
     def try_recurrent_decode(

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from threading import Lock
-from typing import Any
+from typing import Any, ClassVar
 
 import mlx.core as mx
 
@@ -14,6 +15,41 @@ from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
 
 _GDN_CONV1D_V2_SOURCE = _read_v2_metal_source("gdn_conv1d_silu_decode.metal")
 _GDN_RECURRENT_V2_SOURCE = _read_v2_metal_source("gdn_recurrent_decode.metal")
+
+
+@dataclass(frozen=True)
+class GDNRecurrentDecodeRequest:
+    """Inputs for one lazy GDN recurrent decode attempt."""
+
+    q: mx.array
+    k: mx.array
+    v: mx.array
+    g: mx.array
+    beta: mx.array
+    state_cache: GDNPagedStateCache
+    cache_idx: int
+    slot_ids: list[int]
+    output_dtype: mx.Dtype
+
+    @property
+    def total_tokens(self) -> int:
+        return self.q.shape[1]
+
+    @property
+    def num_key_heads(self) -> int:
+        return self.q.shape[2]
+
+    @property
+    def num_value_heads(self) -> int:
+        return self.v.shape[2]
+
+    @property
+    def key_head_dim(self) -> int:
+        return self.q.shape[3]
+
+    @property
+    def value_head_dim(self) -> int:
+        return self.v.shape[3]
 
 
 class GDNLazyDecodeKernels:
@@ -26,6 +62,10 @@ class GDNLazyDecodeKernels:
     decode-only path lazy and avoids the eager in-place synchronization cost;
     callers fall back to the legacy path when a request shape is ineligible.
     """
+
+    _shared: ClassVar[GDNLazyDecodeKernels | None] = None
+    _shared_enabled: ClassVar[bool | None] = None
+    _shared_lock: ClassVar[Lock] = Lock()
 
     def __init__(
         self,
@@ -73,6 +113,27 @@ class GDNLazyDecodeKernels:
     @classmethod
     def from_env(cls) -> GDNLazyDecodeKernels:
         return cls(enabled=envs.VLLM_METAL_GDN_LAZY_DECODE)
+
+    @classmethod
+    def shared(cls) -> GDNLazyDecodeKernels:
+        """Get the process-level lazy GDN decode kernel owner.
+
+        The env kill switch is read when the shared owner is acquired;
+        existing wrappers keep the owner they stored at construction time.
+        """
+        with cls._shared_lock:
+            enabled = envs.VLLM_METAL_GDN_LAZY_DECODE
+            if cls._shared is None or cls._shared_enabled != enabled:
+                cls._shared = cls(enabled=enabled)
+                cls._shared_enabled = enabled
+            return cls._shared
+
+    @classmethod
+    def reset_shared_for_tests(cls) -> None:
+        """Reset the shared lazy GDN decode kernel owner for tests."""
+        with cls._shared_lock:
+            cls._shared = None
+            cls._shared_enabled = None
 
     @staticmethod
     def _make_kernel(
@@ -150,23 +211,15 @@ class GDNLazyDecodeKernels:
 
     def try_recurrent_decode(
         self,
-        q: mx.array,
-        k: mx.array,
-        v: mx.array,
-        g: mx.array,
-        beta: mx.array,
-        state_cache: GDNPagedStateCache,
-        cache_idx: int,
-        slot_ids: list[int],
-        total_tokens: int,
-        n_hk: int,
-        n_hv: int,
-        d_k: int,
-        d_v: int,
-        output_dtype: mx.Dtype,
+        request: GDNRecurrentDecodeRequest,
     ) -> mx.array | None:
         """Run the lazy GDN recurrent decode fast path, or return None."""
-        num_requests = len(slot_ids)
+        total_tokens = request.total_tokens
+        n_hk = request.num_key_heads
+        n_hv = request.num_value_heads
+        d_k = request.key_head_dim
+        d_v = request.value_head_dim
+        num_requests = len(request.slot_ids)
         # The Metal source uses one 32-lane SIMD group across Dk and a
         # fixed-size per-thread register array, matching the original C++
         # kernel's practical Dk <= 256 envelope. Fall back for unusual head
@@ -180,22 +233,22 @@ class GDNLazyDecodeKernels:
         ):
             return None
 
-        state_in = state_cache.recurrent_states[cache_idx]
-        max_seqs = state_cache.max_seqs
-        slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
+        state_in = request.state_cache.recurrent_states[request.cache_idx]
+        max_seqs = request.state_cache.max_seqs
+        slot_ids_arr = mx.array(request.slot_ids, dtype=mx.int32)
 
         kernel_inputs = [
-            q.reshape(total_tokens, n_hk, d_k),
-            k.reshape(total_tokens, n_hk, d_k),
-            v.reshape(total_tokens, n_hv, d_v),
-            g.reshape(total_tokens, n_hv),
-            beta.reshape(total_tokens, n_hv),
+            request.q.reshape(total_tokens, n_hk, d_k),
+            request.k.reshape(total_tokens, n_hk, d_k),
+            request.v.reshape(total_tokens, n_hv, d_v),
+            request.g.reshape(total_tokens, n_hv),
+            request.beta.reshape(total_tokens, n_hv),
             state_in,
             slot_ids_arr,
             num_requests,
         ]
         template = [
-            ("T", output_dtype),
+            ("T", request.output_dtype),
             ("StT", mx.float32),
             ("Dk", d_k),
             ("Dv", d_v),
@@ -209,37 +262,7 @@ class GDNLazyDecodeKernels:
             grid=(32, d_v, max_seqs * n_hv),
             threadgroup=(32, 4, 1),
             output_shapes=[(total_tokens, n_hv, d_v), state_in.shape],
-            output_dtypes=[output_dtype, mx.float32],
+            output_dtypes=[request.output_dtype, mx.float32],
         )
-        state_cache.recurrent_states[cache_idx] = state_out
+        request.state_cache.recurrent_states[request.cache_idx] = state_out
         return y_out
-
-
-_gdn_lazy_decode_kernels: GDNLazyDecodeKernels | None = None
-_gdn_lazy_decode_enabled: bool | None = None
-_gdn_lazy_decode_lock = Lock()
-
-
-def get_gdn_lazy_decode_kernels() -> GDNLazyDecodeKernels:
-    """Get the process-level lazy GDN decode kernel owner.
-
-    The env kill switch is read when the shared owner is acquired; existing
-    wrappers keep the owner they stored at construction time.
-    """
-    global _gdn_lazy_decode_enabled, _gdn_lazy_decode_kernels
-
-    with _gdn_lazy_decode_lock:
-        enabled = envs.VLLM_METAL_GDN_LAZY_DECODE
-        if _gdn_lazy_decode_kernels is None or _gdn_lazy_decode_enabled != enabled:
-            _gdn_lazy_decode_kernels = GDNLazyDecodeKernels(enabled=enabled)
-            _gdn_lazy_decode_enabled = enabled
-        return _gdn_lazy_decode_kernels
-
-
-def reset_gdn_lazy_decode_kernels() -> None:
-    """Reset the shared lazy GDN decode kernel owner for tests."""
-    global _gdn_lazy_decode_enabled, _gdn_lazy_decode_kernels
-
-    with _gdn_lazy_decode_lock:
-        _gdn_lazy_decode_kernels = None
-        _gdn_lazy_decode_enabled = None

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -57,9 +57,9 @@ class GDNLazyDecodeKernels:
 
     The fast path uses ``mx.fast.metal_kernel`` source snippets from
     ``kernels_v2``.  Unlike the legacy recurrent C++ path, these kernels
-    materialize replacement state arrays (``conv_state_out`` / ``state_out``)
-    and then swap the active cache entry.  That allocation tradeoff keeps the
-    decode-only path lazy and avoids the eager in-place synchronization cost;
+    materialize replacement conv state arrays and compact recurrent state
+    updates.  Recurrent updates are scattered back into the stable cache pool
+    so decode-only recurrent work stays proportional to active request count;
     callers fall back to the legacy path when a request shape is ineligible.
     """
 
@@ -234,7 +234,6 @@ class GDNLazyDecodeKernels:
             return None
 
         state_in = request.state_cache.recurrent_states[request.cache_idx]
-        max_seqs = request.state_cache.max_seqs
         slot_ids_arr = mx.array(request.slot_ids, dtype=mx.int32)
 
         kernel_inputs = [
@@ -254,15 +253,15 @@ class GDNLazyDecodeKernels:
             ("Dv", d_v),
             ("Hk", n_hk),
             ("Hv", n_hv),
-            ("MAX_SEQS", max_seqs),
         ]
-        y_out, state_out = self._recurrent_kernel(
+        y_out, state_updates = self._recurrent_kernel(
             inputs=kernel_inputs,
             template=template,
-            grid=(32, d_v, max_seqs * n_hv),
+            grid=(32, d_v, num_requests * n_hv),
             threadgroup=(32, 4, 1),
-            output_shapes=[(total_tokens, n_hv, d_v), state_in.shape],
+            output_shapes=[(total_tokens, n_hv, d_v), (num_requests, n_hv, d_v, d_k)],
             output_dtypes=[request.output_dtype, mx.float32],
         )
-        request.state_cache.recurrent_states[request.cache_idx] = state_out
+        state_in[slot_ids_arr] = state_updates
+        request.state_cache.recurrent_states[request.cache_idx] = state_in
         return y_out

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lazy Gated DeltaNet decode kernels for MLX/Metal execution."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import mlx.core as mx
+
+from vllm_metal.metal import _read_v2_metal_source
+from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
+
+_GDN_CONV1D_V2_SOURCE = _read_v2_metal_source("gdn_conv1d_silu_decode.metal")
+_GDN_RECURRENT_V2_SOURCE = _read_v2_metal_source("gdn_recurrent_decode.metal")
+
+
+def _make_lazy_kernel(
+    name: str,
+    input_names: list[str],
+    output_names: list[str],
+    source: str,
+):
+    try:
+        if not mx.metal.is_available():
+            return None
+    except AttributeError:
+        return None
+    return mx.fast.metal_kernel(
+        name=name,
+        input_names=input_names,
+        output_names=output_names,
+        source=source,
+    )
+
+
+_conv_kernel_mode = os.environ.get(
+    "VLLM_METAL_GDN_CONV_KERNEL",
+    os.environ.get("VLLM_GDN_CONV_KERNEL", "2"),
+)
+_recurrent_kernel_mode = os.environ.get(
+    "VLLM_METAL_GDN_RECURRENT_KERNEL",
+    os.environ.get("VLLM_GDN_RECURRENT_KERNEL", "2"),
+)
+
+_conv1d_silu_decode_kernel = _make_lazy_kernel(
+    "gdn_conv1d_silu_decode_v2",
+    ["input", "conv_state_in", "weights", "slot_mapping", "num_requests"],
+    ["output", "conv_state_out"],
+    _GDN_CONV1D_V2_SOURCE,
+)
+_recurrent_v2_kernel = (
+    _make_lazy_kernel(
+        "gdn_recurrent_v2",
+        ["q", "k", "v", "g", "beta", "state_in", "slot_mapping", "num_requests"],
+        ["y", "state_out"],
+        _GDN_RECURRENT_V2_SOURCE,
+    )
+    if _recurrent_kernel_mode == "2"
+    else None
+)
+
+
+def apply_lazy_gdn_conv_decode(
+    mixed_qkv: mx.array,
+    inner: Any,
+    state_cache: GDNPagedStateCache,
+    cache_idx: int,
+    slot_ids: list[int],
+) -> mx.array | None:
+    """Run the lazy GDN conv decode fast path, or return None if ineligible."""
+    num_requests = len(slot_ids)
+    total_tokens = mixed_qkv.shape[1]
+    if not (
+        _conv_kernel_mode == "2"
+        and _conv1d_silu_decode_kernel is not None
+        and total_tokens == num_requests
+    ):
+        return None
+
+    conv_dim = state_cache.conv_dim
+    kernel_size = inner.conv_kernel_size
+    max_seqs = state_cache.max_seqs
+    conv_state_in = state_cache.conv_states[cache_idx]
+    weight = inner.conv1d.weight
+
+    mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
+    slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
+
+    grid_size = max_seqs * conv_dim
+    tg_size = min(256, grid_size)
+    state_shape = (max_seqs, kernel_size - 1, conv_dim)
+
+    kernel_inputs = [mixed_qkv_2d, conv_state_in, weight, slot_ids_arr, num_requests]
+    template = [
+        ("T", mixed_qkv.dtype),
+        ("CONV_DIM", conv_dim),
+        ("KERNEL_SIZE", kernel_size),
+        ("MAX_SEQS", max_seqs),
+    ]
+    conv_silu_out, conv_state_out = _conv1d_silu_decode_kernel(
+        inputs=kernel_inputs,
+        template=template,
+        grid=(grid_size, 1, 1),
+        threadgroup=(tg_size, 1, 1),
+        output_shapes=[(num_requests, conv_dim), state_shape],
+        output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
+    )
+    state_cache.conv_states[cache_idx] = conv_state_out
+    return conv_silu_out.reshape(1, total_tokens, conv_dim)
+
+
+def apply_lazy_gdn_recurrent_decode(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state_cache: GDNPagedStateCache,
+    cache_idx: int,
+    slot_ids: list[int],
+    total_tokens: int,
+    n_hk: int,
+    n_hv: int,
+    d_k: int,
+    d_v: int,
+    output_dtype: mx.Dtype,
+) -> mx.array | None:
+    """Run the lazy GDN recurrent decode fast path, or return None if ineligible."""
+    num_requests = len(slot_ids)
+    # The Metal source uses one 32-lane SIMD group across Dk and a fixed-size
+    # per-thread register array, matching the original C++ kernel's practical
+    # Dk <= 256 envelope. Fall back for unusual head dimensions rather than
+    # silently dropping remainder channels.
+    recurrent_shape_supported = d_k % 32 == 0 and d_k <= 256
+    if not (
+        _recurrent_kernel_mode == "2"
+        and _recurrent_v2_kernel is not None
+        and total_tokens == num_requests
+        and recurrent_shape_supported
+    ):
+        return None
+
+    state_in = state_cache.recurrent_states[cache_idx]
+    max_seqs = state_cache.max_seqs
+    slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
+
+    kernel_inputs = [
+        q.reshape(total_tokens, n_hk, d_k),
+        k.reshape(total_tokens, n_hk, d_k),
+        v.reshape(total_tokens, n_hv, d_v),
+        g.reshape(total_tokens, n_hv),
+        beta.reshape(total_tokens, n_hv),
+        state_in,
+        slot_ids_arr,
+        num_requests,
+    ]
+    template = [
+        ("T", output_dtype),
+        ("StT", mx.float32),
+        ("Dk", d_k),
+        ("Dv", d_v),
+        ("Hk", n_hk),
+        ("Hv", n_hv),
+        ("MAX_SEQS", max_seqs),
+    ]
+    y_out, state_out = _recurrent_v2_kernel(
+        inputs=kernel_inputs,
+        template=template,
+        grid=(32, d_v, max_seqs * n_hv),
+        threadgroup=(32, 4, 1),
+        output_shapes=[(total_tokens, n_hv, d_v), state_in.shape],
+        output_dtypes=[output_dtype, mx.float32],
+    )
+    state_cache.recurrent_states[cache_idx] = state_out
+    return y_out

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from threading import Lock
 from typing import Any
 
 import mlx.core as mx
@@ -212,3 +213,33 @@ class GDNLazyDecodeKernels:
         )
         state_cache.recurrent_states[cache_idx] = state_out
         return y_out
+
+
+_gdn_lazy_decode_kernels: GDNLazyDecodeKernels | None = None
+_gdn_lazy_decode_enabled: bool | None = None
+_gdn_lazy_decode_lock = Lock()
+
+
+def get_gdn_lazy_decode_kernels() -> GDNLazyDecodeKernels:
+    """Get the process-level lazy GDN decode kernel owner.
+
+    The env kill switch is read when the shared owner is acquired; existing
+    wrappers keep the owner they stored at construction time.
+    """
+    global _gdn_lazy_decode_enabled, _gdn_lazy_decode_kernels
+
+    with _gdn_lazy_decode_lock:
+        enabled = envs.VLLM_METAL_GDN_LAZY_DECODE
+        if _gdn_lazy_decode_kernels is None or _gdn_lazy_decode_enabled != enabled:
+            _gdn_lazy_decode_kernels = GDNLazyDecodeKernels(enabled=enabled)
+            _gdn_lazy_decode_enabled = enabled
+        return _gdn_lazy_decode_kernels
+
+
+def reset_gdn_lazy_decode_kernels() -> None:
+    """Reset the shared lazy GDN decode kernel owner for tests."""
+    global _gdn_lazy_decode_enabled, _gdn_lazy_decode_kernels
+
+    with _gdn_lazy_decode_lock:
+        _gdn_lazy_decode_kernels = None
+        _gdn_lazy_decode_enabled = None


### PR DESCRIPTION
## Summary

Add a lazy Metal decode fast path for GDN-backed hybrid models. The path is enabled by default for decode-only batches and keeps the existing eager conv / C++ recurrent path as the fallback for unsupported shapes, mixed prefill+decode batches, or when the public kill switch is disabled.

## Problem

Hybrid GDN models such as Qwen3-Next/Qwen3.5 spend a large share of decode time in small per-request conv/recurrent work. For multi-request decode, the existing path repeatedly slices host-side metadata and launches smaller operations even when the active batch is already decode-only.

## Changes

- Add a lazy decode-only conv1d+SiLU Metal path for GDN convolution.
- Add a lazy recurrent decode Metal path for supported recurrent state shapes.
- Isolate lazy decode policy and kernel ownership in `GDNLazyDecodeKernels`.
- Reuse a process-level lazy decode kernel owner from the GDN wrapper to avoid per-wrapper `mx.fast.metal_kernel` callable construction.
- Keep `GDNLazyDecodeKernels.from_env()` as a fresh env-derived factory for tests/direct construction, while `GDNLazyDecodeKernels.shared()` owns shared process reuse.
- Collapse the public control surface to a single Metal-specific kill switch:
  - `VLLM_METAL_GDN_LAZY_DECODE=0` forces the eager conv / C++ recurrent fallback path.
- Keep fallback behavior for:
  - non decode-only batches (`total_tokens != num_requests`)
  - unsupported recurrent head shapes
  - unavailable Metal lazy kernels
  - disabled lazy decode kill switch

## Runtime tradeoff

The lazy Metal kernels materialize replacement state arrays (`conv_state_out` / `state_out`) and then swap the active cache entry. This differs from the legacy recurrent C++ path, which updates the recurrent state pool in place. The allocation tradeoff keeps the decode-only fast path lazy and avoids the eager host synchronization cost; ineligible shapes continue to use the existing fallback path.

The env kill switch is read when the shared lazy decode owner is acquired. Existing wrappers keep the owner captured at wrapper construction time, matching the process-level configuration style used elsewhere in the plugin.

## Benchmarks

Compared against upstream/main on a local Apple M2 Ultra with 192 GB unified memory, using the vLLM 0.20.0 benchmark environment and `VLLM_METAL_MEMORY_FRACTION=0.70`. The final reruns used `VLLM_ENABLE_V1_MULTIPROCESSING=0` for both upstream and this PR.

### Qwen3.5-0.8B

Workload: input 128, output 64, 10 requests. 11 runs, with the first run discarded as warmup.

| Metric | Upstream | This PR | Delta |
| --- | ---: | ---: | ---: |
| TTFT | 0.236s | 0.238s | +0.7% |
| Decode TPS | 330.7 | 451.5 | +36.5% |
| Wall time | 2.143s | 1.635s | -23.7% |
| Wall TPS | 298.7 | 391.5 | +31.1% |

### Qwen3-Next 80B A3B

| Workload | Upstream TTFT | This PR TTFT | Upstream decode TPS | This PR decode TPS | Wall delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1K input, batch 1, output 16 | 1.547s | 1.543s | 23.62 | 34.43 | -9.3% |
| 1K input, batch 5, output 16 | 6.478s | 6.464s | 83.74 | 113.60 | -3.8% |
| 4K input, batch 1, output 16 | 6.279s | 6.248s | 18.28 | 23.41 | -3.1% |
| 4K input, batch 5, output 16 | 24.332s | 24.080s | 11.58 | 11.80 | -1.4% |

## Test plan

- `python -m ruff check vllm_metal/envs.py vllm_metal/metal/__init__.py vllm_metal/metal_kernel_backend/attention_linear.py vllm_metal/metal_kernel_backend/gdn_lazy_decode.py tests/test_gdn_lazy_decode.py docs/configuration.md`
- `python -m ruff format --check vllm_metal/envs.py vllm_metal/metal/__init__.py vllm_metal/metal_kernel_backend/attention_linear.py vllm_metal/metal_kernel_backend/gdn_lazy_decode.py tests/test_gdn_lazy_decode.py`
- `python -m py_compile vllm_metal/envs.py vllm_metal/metal/__init__.py vllm_metal/metal_kernel_backend/attention_linear.py vllm_metal/metal_kernel_backend/gdn_lazy_decode.py tests/test_gdn_lazy_decode.py`
- `git diff --check`
- `python -m pytest tests/test_gdn_lazy_decode.py -q`
- `python -m pytest tests/test_qwen3_next_gdn.py -q -k 'not slow'`
- `python -m pytest tests/test_register.py tests/test_config.py -q`
- `rm -f ~/.cache/vllm-metal/_paged_ops*.so && /tmp/vllm-metal-bench-v020/bin/python -m pytest tests/test_attention_dispatch.py::test_qwen35_paged_attention_hybrid -q`
- `/tmp/vllm-metal-bench-v020/bin/python -m pytest tests/test_paged_deterministic.py -q`

Additional full-suite check:

- `/tmp/vllm-metal-bench-v020/bin/python -m pytest tests -q` reached `674 passed, 16 skipped`; the remaining `tests/test_paged_deterministic.py` cases hit an order-dependent Metal memory budget error after the full suite and passed when rerun standalone with the same vLLM 0.20 environment.

## Focused regression coverage

`tests/test_gdn_lazy_decode.py` covers:

- lazy conv decode parity against eager per-request conv
- lazy recurrent decode parity against `ops.gdn_linear_attention(...)`
- fallback when `total_tokens != num_requests`
- fallback when recurrent shape is unsupported
- kill-switch-off behavior without constructing lazy kernels
- wrapper fallback dispatch metadata and state updates when lazy decode is disabled
- shared lazy decode owner reuse






