### PR TITLE
docs: verify DeepSeek-R1-Distill-Qwen-7B-3bit on M5 MacBook Pro 16GB

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -38,7 +38,7 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | MiniCPM3-4B | ✅ | MLA (paged latent cache, MiniCPM3 kv_b_proj path) | 🟡 | [#322](https://github.com/vllm-project/vllm-metal/pull/322) | Validated with mlx-community/MiniCPM3-4B-4bit completions and chat-completions smoke tests; automatic prefix caching is not yet verified on the MLX MLA path |
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
-| DeepSeek-R1-Distill-Qwen-7B | ✅ | GQA (paged) | ✅ |  | Validated on M5 MacBook Pro (16GB) with `mlx-community/DeepSeek-R1-Distill-Qwen-7B-3bit`|
+| DeepSeek-R1-Distill-Qwen-7B | ✅ | GQA (paged) | ✅ | [#347](https://github.com/vllm-project/vllm-metal/pull/347) | Validated on M5 MacBook Pro (16GB) with `mlx-community/DeepSeek-R1-Distill-Qwen-7B-3bit`|
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
 | Phi-3.5-mini-instruct | ✅ | MHA packed qkv (paged) | ✅ | [#345](https://github.com/vllm-project/vllm-metal/pull/345) | Validated on MacBook Pro (Apple M4 Max, 64 GB) on macOS 26.3.1 with `mlx-community/Phi-3.5-mini-instruct-4bit`; greedy output matches `mlx_lm` reference |
 | Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ | [#324](https://github.com/vllm-project/vllm-metal/pull/324) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -38,6 +38,7 @@ Metal. Qwen3 is explicitly covered by the paged prefix-cache e2e test.
 | MiniCPM3-4B | ✅ | MLA (paged latent cache, MiniCPM3 kv_b_proj path) | 🟡 | [#322](https://github.com/vllm-project/vllm-metal/pull/322) | Validated with mlx-community/MiniCPM3-4B-4bit completions and chat-completions smoke tests; automatic prefix caching is not yet verified on the MLX MLA path |
 | GLM-4.7-Flash | 🔵 | GQA (paged) | ✅ | [#190](https://github.com/vllm-project/vllm-metal/pull/190), [#283](https://github.com/vllm-project/vllm-metal/pull/283) | Default-on for non-hybrid paged models |
 | DeepSeek-R1-Distill-Qwen-1.5B | ✅ | GQA (paged) | ✅ | [#316](https://github.com/vllm-project/vllm-metal/pull/316) | Validated on M4 Mac (16GB) and M1 Mac (16GB) |
+| DeepSeek-R1-Distill-Qwen-7B | ✅ | GQA (paged) | ✅ |  | Validated on M5 MacBook Pro (16GB) with `mlx-community/DeepSeek-R1-Distill-Qwen-7B-3bit`|
 | Phi-4-mini-instruct | ✅ | GQA packed qkv (paged) | ✅ | [#314](https://github.com/vllm-project/vllm-metal/pull/314) | Validated on MacBook Pro (Apple M4 Pro, 24 GB) |
 | Phi-3.5-mini-instruct | ✅ | MHA packed qkv (paged) | ✅ | [#345](https://github.com/vllm-project/vllm-metal/pull/345) | Validated on MacBook Pro (Apple M4 Max, 64 GB) on macOS 26.3.1 with `mlx-community/Phi-3.5-mini-instruct-4bit`; greedy output matches `mlx_lm` reference |
 | Qwen2.5-7B-Instruct | ✅ | GQA (paged) | ✅ | [#324](https://github.com/vllm-project/vllm-metal/pull/324) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-7B-Instruct-4bit` |


### PR DESCRIPTION
## Summary

Verified `mlx-community/DeepSeek-R1-Distill-Qwen-7B-3bit` on vllm-metal.

This adds a DeepSeek-R1-Distill-Qwen-7B-3bit row to docs/supported_models.md.

Refs #289.

## Environment

- Hardware: MacBook Pro (Apple M5, 16 GB unified memory)
- macOS: 26.3.1
- vllm-metal commit: f5c66fdd (upstream/main)
- vLLM: 0.20.0+cpu
- mlx-lm: 0.31.3
- mlx: 0.31.2
- mlx-vlm: 0.4.4
- transformers: 5.7.0

## Verification

Server command:

```bash
MODEL=mlx-community/DeepSeek-R1-Distill-Qwen-7B-3bit

VLLM_METAL_USE_PAGED_ATTENTION=1 \
vllm serve $MODEL \
  --port 8016 \
  --max-model-len 32768
```

Relevant startup logs:

```text
INFO:     Started server process
INFO:     Waiting for application startup.
INFO:     Application startup complete.
```

API checks:

- `/health: HTTP 200`
- `/v1/models: HTTP 200`
- `/v1/completions: HTTP 200`
- `/v1/chat/completions: HTTP 200`

Chat request:

```bash
MODEL=mlx-community/DeepSeek-R1-Distill-Qwen-7B-3bit

curl -sS http://127.0.0.1:8016/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d "{
    \"model\": \"$MODEL\",
    \"messages\": [
      {
        \"role\": \"user\",
        \"content\": \"Hello, how are you?\"
      }
    ],
    \"max_tokens\": 64,
    \"temperature\": 0
  }"
```

Example output:

```text
Okay, so I need to figure out how to respond to the user's message. They said, "Hello, how are you?" and I need to respond in a friendly and helpful manner.
```

Runtime logs after request:

```text
INFO:     127.0.0.1 - "POST /v1/chat/completions HTTP/1.1" 200 OK
Engine 000: Avg prompt throughput: 0.6 tokens/s, Avg generation throughput: 3.5 tokens/s
```

Note: DeepSeek-R1-Distill-Qwen-7B-3bit was successfully initialized and served on Apple Silicon with 16 GB unified memory using `--max-model-len 32768`. 
Basic chat completion requests completed successfully during testing.