### PR TITLE
Add paged decode row-span metadata foundation

### DIFF
--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for paged speculative decode metadata helpers."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_metal.v1.spec_decode import (
+    PagedDecodeSegment,
+    build_paged_decode_segments,
+)
+
+
+def _state(token_ids: list[int], block_ids: list[int]) -> SimpleNamespace:
+    return SimpleNamespace(token_ids=token_ids, block_ids=block_ids)
+
+
+class TestPagedDecodeSegment:
+    def test_freezes_single_row_decode_shape(self) -> None:
+        segment = PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(9,),
+            start_row=0,
+            num_query_tokens=1,
+            draft_token_ids=(),
+            cache_start_pos=7,
+            block_ids=(11, 12),
+        )
+
+        assert segment.req_id == "r0"
+        assert segment.input_token_ids == (9,)
+        assert segment.draft_token_ids == ()
+        assert segment.draft_verification_rows == ()
+        assert segment.bonus_row == 0
+
+        with pytest.raises(FrozenInstanceError):
+            segment.start_row = 1  # type: ignore[misc]
+
+
+class TestBuildPagedDecodeSegments:
+    def test_single_row_decode_matches_current_shape(self) -> None:
+        segments = build_paged_decode_segments(
+            [("r0", _state([5, 9], [41, 42]))],
+            scheduled_spec_decode_tokens={},
+            paged_request_seq_lens={"r0": 7},
+        )
+
+        assert len(segments) == 1
+        segment = segments[0]
+        assert segment.req_id == "r0"
+        assert segment.input_token_ids == (9,)
+        assert segment.start_row == 0
+        assert segment.num_query_tokens == 1
+        assert segment.draft_token_ids == ()
+        assert segment.cache_start_pos == 7
+        assert segment.block_ids == (41, 42)
+        assert segment.draft_verification_rows == ()
+        assert segment.bonus_row == 0
+
+    def test_single_row_decode_uses_len_minus_one_fallback(self) -> None:
+        segments = build_paged_decode_segments(
+            [("r0", _state([5, 9, 17], [41, 42]))],
+            scheduled_spec_decode_tokens=None,
+            paged_request_seq_lens={},
+        )
+
+        assert segments[0].cache_start_pos == 2
+
+    def test_draft_tokens_expand_the_row_span(self) -> None:
+        segments = build_paged_decode_segments(
+            [("r0", _state([5, 9], [41, 42]))],
+            scheduled_spec_decode_tokens={"r0": [23, 24]},
+            paged_request_seq_lens={"r0": 7},
+        )
+
+        segment = segments[0]
+        assert segment.input_token_ids == (9, 23, 24)
+        assert segment.num_query_tokens == 3
+        assert segment.draft_token_ids == (23, 24)
+        assert segment.start_row == 0
+        assert segment.draft_verification_rows == (0, 1)
+        assert segment.bonus_row == 2
+
+    def test_mixed_batch_uses_cumulative_start_rows(self) -> None:
+        segments = build_paged_decode_segments(
+            [
+                ("r0", _state([1, 2], [10])),
+                ("r1", _state([3, 4, 5], [11])),
+                ("r2", _state([6], [12])),
+            ],
+            scheduled_spec_decode_tokens={
+                "r1": [21, 22],
+                "r2": [31],
+            },
+            paged_request_seq_lens={"r0": 1, "r1": 2, "r2": 0},
+        )
+
+        assert [segment.start_row for segment in segments] == [0, 1, 4]
+        assert [segment.num_query_tokens for segment in segments] == [1, 3, 2]
+        assert segments[1].draft_verification_rows == (1, 2)
+        assert segments[1].bonus_row == 3
+        assert segments[2].draft_verification_rows == (4,)
+        assert segments[2].bonus_row == 5

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Paged decode metadata helpers for speculative token row spans."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _PagedDecodeStateLike(Protocol):
+    token_ids: Sequence[int]
+    block_ids: Sequence[int]
+
+
+@dataclass(frozen=True, slots=True)
+class PagedDecodeSegment:
+    """Logits-row metadata for one paged decode request."""
+
+    req_id: str
+    input_token_ids: tuple[int, ...]
+    start_row: int
+    num_query_tokens: int
+    draft_token_ids: tuple[int, ...]
+    cache_start_pos: int
+    block_ids: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if self.start_row < 0:
+            raise ValueError("start_row must be non-negative")
+        if self.num_query_tokens != len(self.input_token_ids):
+            raise ValueError("num_query_tokens must match input_token_ids")
+        if self.num_query_tokens != len(self.draft_token_ids) + 1:
+            raise ValueError(
+                "num_query_tokens must include one bonus row after draft tokens"
+            )
+
+    @property
+    def draft_verification_rows(self) -> tuple[int, ...]:
+        return tuple(range(self.start_row, self.start_row + len(self.draft_token_ids)))
+
+    @property
+    def bonus_row(self) -> int:
+        return self.start_row + len(self.draft_token_ids)
+
+
+def build_paged_decode_segments(
+    decode_reqs: Sequence[tuple[str, _PagedDecodeStateLike]],
+    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
+    paged_request_seq_lens: Mapping[str, int],
+) -> tuple[PagedDecodeSegment, ...]:
+    """Build row-span metadata for paged decode requests.
+
+    The returned metadata mirrors the current no-draft decode shape when a
+    request has no scheduled draft tokens.
+    """
+    spec_tokens = scheduled_spec_decode_tokens or {}
+    segments: list[PagedDecodeSegment] = []
+    start_row = 0
+
+    for req_id, state in decode_reqs:
+        token_ids = tuple(state.token_ids)
+        block_ids = tuple(state.block_ids)
+        draft_token_ids = tuple(spec_tokens.get(req_id, ()))
+        last_token = token_ids[-1] if token_ids else 0
+        input_token_ids = (last_token, *draft_token_ids)
+        cache_start_pos = paged_request_seq_lens.get(req_id, len(token_ids) - 1)
+
+        segment = PagedDecodeSegment(
+            req_id=req_id,
+            input_token_ids=input_token_ids,
+            start_row=start_row,
+            num_query_tokens=len(input_token_ids),
+            draft_token_ids=draft_token_ids,
+            cache_start_pos=cache_start_pos,
+            block_ids=block_ids,
+        )
+        segments.append(segment)
+        start_row += segment.num_query_tokens
+
+    return tuple(segments)
+
+
+__all__ = [
+    "PagedDecodeSegment",
+    "build_paged_decode_segments",
+]


### PR DESCRIPTION
## Summary
- Start the staged implementation for #308 by adding a metadata-only foundation for paged speculative decode row spans.
- Add an immutable `PagedDecodeSegment` type and a pure helper for constructing per-request decode segments from the last token plus any scheduled draft tokens.
- Preserve the current paged runtime contract: no forward-path, sampling, `prepare_unified()`, or structured-output behavior changes.

## Scope
This PR intentionally covers only the first accepted step from #308: paged-path speculative row-span / metadata support with no behavior change.

Target verification, draft-token handoff, draft-model proposer wiring, rejection sampling, and structured-output multi-position bitmasking remain follow-up work.

## Tests
- `.venv-vllm-metal/bin/pytest tests/test_spec_decode_metadata.py`
- `.venv-vllm-metal/bin/pytest tests/test_paged_attention.py`
- `.venv-vllm-metal/bin/pytest tests/test_grammar_bitmask.py -k "spec_decode"`
- `.venv-vllm-metal/bin/ruff check vllm_metal/v1/spec_decode.py tests/test_spec_decode_metadata.py`
- `.venv-vllm-metal/bin/ruff format --check vllm_metal/v1/spec_decode.py tests/test_spec_decode_metadata.py`
