### PR TITLE
[Multimodal] Wire Qwen3-VL paged forward through adapter.call_lm

### DIFF
--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -404,11 +404,19 @@ class _RecordingLanguageModel:
     """Captures call kwargs for ``call_lm`` assertions.
 
     Mirrors mlx_vlm 0.4.x's ``LanguageModel.__call__`` shape: ``inputs_embeds``
-    is a named parameter so signature sniffing finds it.
+    is a named parameter so signature sniffing finds it.  ``self.model.embed_tokens``
+    mirrors the bottom-level embedding callable the real LM exposes.
     """
 
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.embed_calls: list[mx.array] = []
+
+        def _embed(input_ids: mx.array) -> mx.array:
+            self.embed_calls.append(input_ids)
+            return input_ids
+
+        self.model = SimpleNamespace(embed_tokens=_embed)
 
     def __call__(
         self,
@@ -430,6 +438,9 @@ class _RecordingLanguageModel:
 
 class _LegacyLanguageModel:
     """LM that uses the older ``input_embeddings`` keyword."""
+
+    def __init__(self) -> None:
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids)
 
     def __call__(
         self,
@@ -556,3 +567,79 @@ class TestQwen3VLMultimodalAdapterFromLoadedModel:
 
         assert adapter._embeds_kwarg == "inputs_embeds"
         assert adapter._spatial_merge_size == 2
+
+    def test_resolves_embed_tokens_at_load_time(self) -> None:
+        language_model = _RecordingLanguageModel()
+
+        class _LoadedModel:
+            class _Config:
+                class _VisionConfig:
+                    spatial_merge_size = 2
+
+                vision_config = _VisionConfig()
+
+            config = _Config()
+            vision_tower = _RecordingVisionTower()
+
+        loaded = _LoadedModel()
+        loaded.language_model = language_model
+
+        adapter = Qwen3VLMultimodalAdapter.from_loaded_model(loaded)
+
+        assert adapter._embed_tokens_fn is language_model.model.embed_tokens
+
+
+class TestQwen3VLMultimodalAdapterResolveEmbedTokens:
+    def test_returns_inner_embed_tokens_callable(self) -> None:
+        language_model = _RecordingLanguageModel()
+
+        resolved = Qwen3VLMultimodalAdapter._resolve_embed_tokens(language_model)
+
+        assert resolved is language_model.model.embed_tokens
+
+    def test_raises_when_inner_model_missing(self) -> None:
+        class _NoInner:
+            def __call__(self, *args: object, **kwargs: object) -> None:
+                return None
+
+        with pytest.raises(RuntimeError, match="language_model.model attribute"):
+            Qwen3VLMultimodalAdapter._resolve_embed_tokens(_NoInner())
+
+    def test_raises_when_embed_tokens_missing(self) -> None:
+        bad = SimpleNamespace(model=SimpleNamespace())
+
+        with pytest.raises(RuntimeError, match="embed_tokens missing"):
+            Qwen3VLMultimodalAdapter._resolve_embed_tokens(bad)
+
+    def test_raises_when_embed_tokens_not_callable(self) -> None:
+        bad = SimpleNamespace(model=SimpleNamespace(embed_tokens="not-a-callable"))
+
+        with pytest.raises(RuntimeError, match="not callable"):
+            Qwen3VLMultimodalAdapter._resolve_embed_tokens(bad)
+
+
+class TestQwen3VLMultimodalAdapterEmbedTokens:
+    def test_forwards_to_resolved_callable(self) -> None:
+        recorded: list[mx.array] = []
+
+        def _embed(input_ids: mx.array) -> mx.array:
+            recorded.append(input_ids)
+            return input_ids + 1
+
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            embed_tokens_fn=_embed,
+        )
+        input_ids = mx.array([[1, 2, 3]], dtype=mx.int32)
+
+        out = adapter.embed_tokens(input_ids)
+
+        assert mx.allclose(out, input_ids + 1).item()
+        assert len(recorded) == 1
+        assert recorded[0] is input_ids
+
+    def test_raises_when_not_resolved(self) -> None:
+        adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=_SPATIAL_MERGE_SIZE)
+
+        with pytest.raises(RuntimeError, match="embed_tokens_fn not resolved"):
+            adapter.embed_tokens(mx.array([[1]], dtype=mx.int32))

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -661,7 +661,7 @@ class TestQwen3VLMultimodalAdapterCallLm:
                 mx.zeros((3, 1, 1), dtype=mx.int32),
             )
 
-    def test_omits_deepstack_kwargs_when_unsupported(self) -> None:
+    def test_omits_deepstack_kwargs_when_unsupported_and_none(self) -> None:
         lm = _KwargsOnlyLanguageModel()
         adapter = Qwen3VLMultimodalAdapter(
             spatial_merge_size=_SPATIAL_MERGE_SIZE,
@@ -676,11 +676,31 @@ class TestQwen3VLMultimodalAdapterCallLm:
             [None],
             mx.zeros((3, 1, 3), dtype=mx.int32),
             visual_pos_masks=mx.array([[True, False, True]]),
-            deepstack_visual_embeds=[mx.zeros((1, 2, 8))],
+            deepstack_visual_embeds=None,
         )
 
         assert len(lm.calls) == 1
         assert lm.calls[0]["extra"] == {}
+
+    def test_raises_when_unsupported_lm_receives_deepstack_residuals(self) -> None:
+        lm = _KwargsOnlyLanguageModel()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=lm,
+            embeds_kwarg="inputs_embeds",
+            supports_deepstack=False,
+        )
+
+        with pytest.raises(RuntimeError, match="deepstack_visual_embeds were produced"):
+            adapter.call_lm(
+                mx.array([[1, 2, 3]], dtype=mx.int32),
+                mx.zeros((1, 3, 8), dtype=mx.float32),
+                [None],
+                mx.zeros((3, 1, 3), dtype=mx.int32),
+                visual_pos_masks=mx.array([[True, False, True]]),
+                deepstack_visual_embeds=[mx.zeros((1, 2, 8))],
+            )
+        assert lm.calls == []
 
     def test_forwards_deepstack_kwargs_when_supported(self) -> None:
         lm = _DeepstackLanguageModel()

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -129,16 +129,23 @@ class TestQwen3VLMultimodalAdapterValidation:
 
 
 class TestQwen3VLMultimodalAdapterPositions:
+    def test_empty_positions_carry_batch_axis(self) -> None:
+        positions, delta = _adapter().get_mrope_input_positions([], [])
+
+        assert positions.shape == (3, 1, 0)
+        assert delta == 0
+
     def test_text_only_positions(self) -> None:
         positions, delta = _adapter().get_mrope_input_positions(
             [_TEXT_TOKEN_ID] * 4,
             [],
         )
-        assert positions.tolist() == [[0, 1, 2, 3]] * 3
+        assert positions.shape == (3, 1, 4)
+        assert positions.tolist() == [[[0, 1, 2, 3]]] * 3
         assert delta == 0
 
     @pytest.mark.parametrize(
-        ("text_before", "text_after", "expected_positions", "expected_delta"),
+        ("text_before", "text_after", "expected_rows", "expected_delta"),
         [
             pytest.param(
                 0,
@@ -179,7 +186,7 @@ class TestQwen3VLMultimodalAdapterPositions:
         self,
         text_before: int,
         text_after: int,
-        expected_positions: list[list[int]],
+        expected_rows: list[list[int]],
         expected_delta: int,
     ) -> None:
         tokens = _single_image_tokens(
@@ -193,7 +200,8 @@ class TestQwen3VLMultimodalAdapterPositions:
 
         positions, delta = _adapter().get_mrope_input_positions(tokens, [feature])
 
-        assert positions.tolist() == expected_positions
+        assert positions.shape == (3, 1, len(tokens))
+        assert positions.tolist() == [[row] for row in expected_rows]
         assert delta == expected_delta
 
     def test_multi_image_positions_preserve_feature_offsets(self) -> None:
@@ -211,10 +219,11 @@ class TestQwen3VLMultimodalAdapterPositions:
 
         positions, delta = _adapter().get_mrope_input_positions(tokens, features)
 
+        assert positions.shape == (3, 1, len(tokens))
         assert positions.tolist() == [
-            [0, 1, 1, 1, 1, 3, 4, 4, 4, 4, 6],
-            [0, 1, 1, 2, 2, 3, 4, 4, 5, 5, 6],
-            [0, 1, 2, 1, 2, 3, 4, 5, 4, 5, 6],
+            [[0, 1, 1, 1, 1, 3, 4, 4, 4, 4, 6]],
+            [[0, 1, 1, 2, 2, 3, 4, 4, 5, 5, 6]],
+            [[0, 1, 2, 1, 2, 3, 4, 5, 4, 5, 6]],
         ]
         assert delta == -4
 

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -551,9 +551,7 @@ class TestQwen3VLMultimodalAdapterDetectEmbedsKwarg:
 class TestQwen3VLMultimodalAdapterDetectDeepstackKwargs:
     def test_detects_explicit_deepstack_params(self) -> None:
         assert (
-            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(
-                _DeepstackLanguageModel()
-            )
+            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(_DeepstackLanguageModel())
             is True
         )
 
@@ -567,9 +565,7 @@ class TestQwen3VLMultimodalAdapterDetectDeepstackKwargs:
 
     def test_rejects_lm_missing_both_params(self) -> None:
         assert (
-            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(
-                _RecordingLanguageModel()
-            )
+            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(_RecordingLanguageModel())
             is False
         )
 

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -230,6 +230,7 @@ class _RecordingVisionTower:
     def __init__(
         self,
         hidden_factory: Any | None = None,
+        deepstack_factory: Any | None = None,
         *,
         weight_dtype: mx.Dtype = mx.float32,
     ) -> None:
@@ -237,15 +238,17 @@ class _RecordingVisionTower:
         self._hidden_factory = hidden_factory or (
             lambda call_idx: mx.full((4, 8), float(call_idx), dtype=mx.float32)
         )
+        self._deepstack_factory = deepstack_factory or (lambda call_idx: None)
         # ``mlx_vlm.Model.get_input_embeddings`` reads
         # ``vision_tower.patch_embed.proj.weight.dtype``; mirror that path.
         self.patch_embed = SimpleNamespace(
             proj=SimpleNamespace(weight=mx.zeros((1,), dtype=weight_dtype))
         )
 
-    def __call__(self, pixel_values: Any, grid_thw: Any) -> tuple[mx.array, None]:
+    def __call__(self, pixel_values: Any, grid_thw: Any) -> tuple[mx.array, Any]:
         self.calls.append((pixel_values, grid_thw))
-        return self._hidden_factory(len(self.calls) - 1), None
+        call_idx = len(self.calls) - 1
+        return self._hidden_factory(call_idx), self._deepstack_factory(call_idx)
 
 
 def _vision_feature(
@@ -276,8 +279,9 @@ def _vision_feature(
 
 
 class TestQwen3VLMultimodalAdapterEncodeMultimodal:
-    def test_calls_vision_tower_and_strips_deepstack(self) -> None:
-        tower = _RecordingVisionTower()
+    def test_calls_vision_tower_and_preserves_deepstack(self) -> None:
+        deepstack = [mx.full((4, 8), 9.0, dtype=mx.float32)]
+        tower = _RecordingVisionTower(deepstack_factory=lambda _: deepstack)
         adapter = Qwen3VLMultimodalAdapter(
             spatial_merge_size=_SPATIAL_MERGE_SIZE,
             vision_tower=tower,
@@ -287,8 +291,9 @@ class TestQwen3VLMultimodalAdapterEncodeMultimodal:
         outputs = adapter.encode_multimodal([feature])
 
         assert len(outputs) == 1
-        assert outputs[0].shape == (4, 8)
-        assert outputs[0].tolist() == [[0.0] * 8] * 4
+        assert outputs[0].hidden_states.shape == (4, 8)
+        assert outputs[0].hidden_states.tolist() == [[0.0] * 8] * 4
+        assert outputs[0].deepstack_visual_embeds is deepstack
         assert len(tower.calls) == 1
 
     def test_returns_one_output_per_feature(self) -> None:
@@ -305,8 +310,8 @@ class TestQwen3VLMultimodalAdapterEncodeMultimodal:
         outputs = adapter.encode_multimodal(features)
 
         assert len(outputs) == 2
-        assert outputs[0].tolist()[0][0] == 0.0
-        assert outputs[1].tolist()[0][0] == 1.0
+        assert outputs[0].hidden_states.tolist()[0][0] == 0.0
+        assert outputs[1].hidden_states.tolist()[0][0] == 1.0
         assert len(tower.calls) == 2
 
     def test_passes_mlx_arrays_to_vision_tower(self) -> None:

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for Qwen3.5-4B multimodal M-RoPE helpers."""
+"""Tests for Qwen3.5-4B multimodal helpers and adapter capabilities."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
 import pytest
 import torch
 from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItem
@@ -213,3 +217,337 @@ class TestQwen3VLMultimodalAdapterPositions:
             [0, 1, 2, 1, 2, 3, 4, 5, 4, 5, 6],
         ]
         assert delta == -4
+
+
+class _RecordingVisionTower:
+    """Records its calls and returns deterministic ``(hidden, deepstack)`` pairs.
+
+    Exposes ``patch_embed.proj.weight.dtype`` so the adapter's input-dtype
+    cast — mirroring ``mlx_vlm.Model.get_input_embeddings`` — has a real
+    target to read.
+    """
+
+    def __init__(
+        self,
+        hidden_factory: Any | None = None,
+        *,
+        weight_dtype: mx.Dtype = mx.float32,
+    ) -> None:
+        self.calls: list[tuple[Any, Any]] = []
+        self._hidden_factory = hidden_factory or (
+            lambda call_idx: mx.full((4, 8), float(call_idx), dtype=mx.float32)
+        )
+        # ``mlx_vlm.Model.get_input_embeddings`` reads
+        # ``vision_tower.patch_embed.proj.weight.dtype``; mirror that path.
+        self.patch_embed = SimpleNamespace(
+            proj=SimpleNamespace(weight=mx.zeros((1,), dtype=weight_dtype))
+        )
+
+    def __call__(self, pixel_values: Any, grid_thw: Any) -> tuple[mx.array, None]:
+        self.calls.append((pixel_values, grid_thw))
+        return self._hidden_factory(len(self.calls) - 1), None
+
+
+def _vision_feature(
+    *,
+    offset: int = 0,
+    length: int = _IMAGE_TOKEN_COUNT_2X2,
+    grid_thw: tuple[int, ...] = _IMAGE_GRID_THW_2X2,
+    pixel_rows: int | None = None,
+    modality: str = "image",
+) -> MultiModalFeatureSpec:
+    """Build a feature with both ``pixel_values`` and ``image_grid_thw`` fields."""
+    if pixel_rows is None:
+        pixel_rows = length
+    field_config = MultiModalFieldConfig.batched("image", keep_on_cpu=True)
+    grid_elem = field_config.build_elems("image_grid_thw", torch.tensor([grid_thw]))[0]
+    pixel_elem = field_config.build_elems(
+        "pixel_values", torch.zeros((1, pixel_rows, 8), dtype=torch.float32)
+    )[0]
+    data = MultiModalKwargsItem(
+        {"image_grid_thw": grid_elem, "pixel_values": pixel_elem}
+    )
+    return MultiModalFeatureSpec(
+        data=data,
+        modality=modality,
+        identifier=f"{modality}-{offset}",
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+class TestQwen3VLMultimodalAdapterEncodeMultimodal:
+    def test_calls_vision_tower_and_strips_deepstack(self) -> None:
+        tower = _RecordingVisionTower()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+        feature = _vision_feature()
+
+        outputs = adapter.encode_multimodal([feature])
+
+        assert len(outputs) == 1
+        assert outputs[0].shape == (4, 8)
+        assert outputs[0].tolist() == [[0.0] * 8] * 4
+        assert len(tower.calls) == 1
+
+    def test_returns_one_output_per_feature(self) -> None:
+        tower = _RecordingVisionTower()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+        features = [
+            _vision_feature(offset=0),
+            _vision_feature(offset=10),
+        ]
+
+        outputs = adapter.encode_multimodal(features)
+
+        assert len(outputs) == 2
+        assert outputs[0].tolist()[0][0] == 0.0
+        assert outputs[1].tolist()[0][0] == 1.0
+        assert len(tower.calls) == 2
+
+    def test_passes_mlx_arrays_to_vision_tower(self) -> None:
+        tower = _RecordingVisionTower()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+
+        adapter.encode_multimodal([_vision_feature()])
+
+        pixel_values, grid_thw = tower.calls[0]
+        assert isinstance(pixel_values, mx.array)
+        assert isinstance(grid_thw, mx.array)
+
+    def test_reshapes_grid_thw_to_two_dim_for_vision_tower(self) -> None:
+        """vLLM batched fields deliver ``(3,)``; tower indexes ``grid_thw[:, 1:]``."""
+        tower = _RecordingVisionTower()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+
+        adapter.encode_multimodal([_vision_feature(grid_thw=_IMAGE_GRID_THW_2X2)])
+
+        _, grid_thw = tower.calls[0]
+        assert grid_thw.shape == (1, 3)
+        assert grid_thw.tolist() == [list(_IMAGE_GRID_THW_2X2)]
+
+    @pytest.mark.parametrize(
+        "weight_dtype",
+        [mx.float16, mx.bfloat16, mx.float32],
+    )
+    def test_casts_pixel_values_to_vision_tower_weight_dtype(
+        self,
+        weight_dtype: mx.Dtype,
+    ) -> None:
+        tower = _RecordingVisionTower(weight_dtype=weight_dtype)
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+
+        adapter.encode_multimodal([_vision_feature()])
+
+        pixel_values, _ = tower.calls[0]
+        assert pixel_values.dtype == weight_dtype
+
+    def test_raises_on_video_feature(self) -> None:
+        tower = _RecordingVisionTower()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+        feature = _vision_feature()
+        feature = MultiModalFeatureSpec(
+            data=feature.data,
+            modality="video",
+            identifier=feature.identifier,
+            mm_position=feature.mm_position,
+        )
+
+        with pytest.raises(ValueError, match="image features"):
+            adapter.encode_multimodal([feature])
+
+    def test_raises_when_vision_tower_is_none(self) -> None:
+        adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=_SPATIAL_MERGE_SIZE)
+
+        with pytest.raises(RuntimeError, match="vision_tower not loaded"):
+            adapter.encode_multimodal([_vision_feature()])
+
+    def test_raises_on_missing_feature_data(self) -> None:
+        tower = _RecordingVisionTower()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+        feature = MultiModalFeatureSpec(
+            data=None,
+            modality="image",
+            identifier="image-0",
+            mm_position=PlaceholderRange(offset=0, length=4),
+        )
+
+        with pytest.raises(ValueError, match="feature.data is required"):
+            adapter.encode_multimodal([feature])
+
+
+class _RecordingLanguageModel:
+    """Captures call kwargs for ``call_lm`` assertions.
+
+    Mirrors mlx_vlm 0.4.x's ``LanguageModel.__call__`` shape: ``inputs_embeds``
+    is a named parameter so signature sniffing finds it.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: mx.array | None = None,
+        cache: list[Any] | None = None,
+        position_ids: mx.array | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "inputs": inputs,
+                "inputs_embeds": inputs_embeds,
+                "cache": cache,
+                "position_ids": position_ids,
+            }
+        )
+        return "lm-output"
+
+
+class _LegacyLanguageModel:
+    """LM that uses the older ``input_embeddings`` keyword."""
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        input_embeddings: mx.array | None = None,
+        cache: list[Any] | None = None,
+        position_ids: mx.array | None = None,
+    ) -> str:
+        return "legacy-output"
+
+
+class _UnknownLanguageModel:
+    """LM that exposes neither supported embeds keyword."""
+
+    def __call__(self, inputs: mx.array, cache: list[Any] | None = None) -> str:
+        return "no-embeds"
+
+
+class TestQwen3VLMultimodalAdapterDetectEmbedsKwarg:
+    def test_detects_inputs_embeds(self) -> None:
+        kwarg = Qwen3VLMultimodalAdapter._detect_embeds_kwarg(_RecordingLanguageModel())
+        assert kwarg == "inputs_embeds"
+
+    def test_detects_input_embeddings(self) -> None:
+        kwarg = Qwen3VLMultimodalAdapter._detect_embeds_kwarg(_LegacyLanguageModel())
+        assert kwarg == "input_embeddings"
+
+    def test_raises_on_drift(self) -> None:
+        with pytest.raises(RuntimeError, match="mlx_vlm version drift"):
+            Qwen3VLMultimodalAdapter._detect_embeds_kwarg(_UnknownLanguageModel())
+
+
+class TestQwen3VLMultimodalAdapterCallLm:
+    def test_passes_sniffed_kwarg_to_language_model(self) -> None:
+        lm = _RecordingLanguageModel()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=lm,
+            embeds_kwarg="inputs_embeds",
+        )
+        input_ids = mx.array([[1, 2, 3]], dtype=mx.int32)
+        inputs_embeds = mx.zeros((1, 3, 8), dtype=mx.float32)
+        position_ids = mx.zeros((3, 1, 3), dtype=mx.int32)
+
+        output = adapter.call_lm(input_ids, inputs_embeds, [None], position_ids)
+
+        assert output == "lm-output"
+        assert len(lm.calls) == 1
+        call = lm.calls[0]
+        assert "inputs_embeds" in call
+        assert call["inputs_embeds"] is inputs_embeds
+        assert call["position_ids"] is position_ids
+        assert call["cache"] == [None]
+
+    def test_routes_through_legacy_input_embeddings_kwarg(self) -> None:
+        captured: dict[str, Any] = {}
+
+        class _Capture:
+            def __call__(
+                self,
+                inputs: mx.array,
+                input_embeddings: mx.array | None = None,
+                cache: list[Any] | None = None,
+                position_ids: mx.array | None = None,
+            ) -> None:
+                captured["input_embeddings"] = input_embeddings
+
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=_Capture(),
+            embeds_kwarg="input_embeddings",
+        )
+        inputs_embeds = mx.zeros((1, 1, 8), dtype=mx.float32)
+
+        adapter.call_lm(
+            mx.array([[1]], dtype=mx.int32),
+            inputs_embeds,
+            [None],
+            mx.zeros((3, 1, 1), dtype=mx.int32),
+        )
+
+        assert captured["input_embeddings"] is inputs_embeds
+
+    def test_raises_when_language_model_missing(self) -> None:
+        adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=_SPATIAL_MERGE_SIZE)
+
+        with pytest.raises(RuntimeError, match="language_model not loaded"):
+            adapter.call_lm(
+                mx.array([[1]], dtype=mx.int32),
+                mx.zeros((1, 1, 8), dtype=mx.float32),
+                [None],
+                mx.zeros((3, 1, 1), dtype=mx.int32),
+            )
+
+    def test_raises_when_embeds_kwarg_not_detected(self) -> None:
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=_RecordingLanguageModel(),
+        )
+
+        with pytest.raises(RuntimeError, match="embeds_kwarg not detected"):
+            adapter.call_lm(
+                mx.array([[1]], dtype=mx.int32),
+                mx.zeros((1, 1, 8), dtype=mx.float32),
+                [None],
+                mx.zeros((3, 1, 1), dtype=mx.int32),
+            )
+
+
+class TestQwen3VLMultimodalAdapterFromLoadedModel:
+    def test_sniffs_embeds_kwarg_from_language_model(self) -> None:
+        class _LoadedModel:
+            class _Config:
+                class _VisionConfig:
+                    spatial_merge_size = 2
+
+                vision_config = _VisionConfig()
+
+            config = _Config()
+            vision_tower = _RecordingVisionTower()
+            language_model = _RecordingLanguageModel()
+
+        adapter = Qwen3VLMultimodalAdapter.from_loaded_model(_LoadedModel())
+
+        assert adapter._embeds_kwarg == "inputs_embeds"
+        assert adapter._spatial_merge_size == 2

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -468,6 +468,72 @@ class _UnknownLanguageModel:
         return "no-embeds"
 
 
+class _DeepstackLanguageModel:
+    """Mirrors mlx_vlm 0.5.x Qwen3-VL ``LanguageModel.__call__``.
+
+    Declares ``visual_pos_masks`` and ``deepstack_visual_embeds`` as named
+    parameters so the deepstack detector flips to True.  Records the kwargs
+    each call receives.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: mx.array | None = None,
+        cache: list[Any] | None = None,
+        position_ids: mx.array | None = None,
+        visual_pos_masks: Any | None = None,
+        deepstack_visual_embeds: Any | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "inputs": inputs,
+                "inputs_embeds": inputs_embeds,
+                "cache": cache,
+                "position_ids": position_ids,
+                "visual_pos_masks": visual_pos_masks,
+                "deepstack_visual_embeds": deepstack_visual_embeds,
+            }
+        )
+        return "deepstack-output"
+
+
+class _KwargsOnlyLanguageModel:
+    """LM with ``inputs_embeds`` plus ``**kwargs`` — qwen3_5 0.4.x shape.
+
+    Catches deepstack-named kwargs into the catch-all rather than via
+    explicit parameters, so ``_detect_deepstack_kwargs`` should return
+    False and the adapter must omit deepstack kwargs entirely.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: mx.array | None = None,
+        cache: list[Any] | None = None,
+        position_ids: mx.array | None = None,
+        **kwargs: Any,
+    ) -> str:
+        self.calls.append(
+            {
+                "inputs": inputs,
+                "inputs_embeds": inputs_embeds,
+                "cache": cache,
+                "position_ids": position_ids,
+                "extra": dict(kwargs),
+            }
+        )
+        return "kwargs-only-output"
+
+
 class TestQwen3VLMultimodalAdapterDetectEmbedsKwarg:
     def test_detects_inputs_embeds(self) -> None:
         kwarg = Qwen3VLMultimodalAdapter._detect_embeds_kwarg(_RecordingLanguageModel())
@@ -480,6 +546,47 @@ class TestQwen3VLMultimodalAdapterDetectEmbedsKwarg:
     def test_raises_on_drift(self) -> None:
         with pytest.raises(RuntimeError, match="mlx_vlm version drift"):
             Qwen3VLMultimodalAdapter._detect_embeds_kwarg(_UnknownLanguageModel())
+
+
+class TestQwen3VLMultimodalAdapterDetectDeepstackKwargs:
+    def test_detects_explicit_deepstack_params(self) -> None:
+        assert (
+            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(
+                _DeepstackLanguageModel()
+            )
+            is True
+        )
+
+    def test_rejects_kwargs_catch_all(self) -> None:
+        assert (
+            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(
+                _KwargsOnlyLanguageModel()
+            )
+            is False
+        )
+
+    def test_rejects_lm_missing_both_params(self) -> None:
+        assert (
+            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(
+                _RecordingLanguageModel()
+            )
+            is False
+        )
+
+    def test_rejects_when_only_one_param_present(self) -> None:
+        class _PartialDeepstackLM:
+            def __call__(
+                self,
+                inputs: mx.array,
+                inputs_embeds: mx.array | None = None,
+                visual_pos_masks: Any | None = None,
+            ) -> None:
+                return None
+
+        assert (
+            Qwen3VLMultimodalAdapter._detect_deepstack_kwargs(_PartialDeepstackLM())
+            is False
+        )
 
 
 class TestQwen3VLMultimodalAdapterCallLm:
@@ -558,6 +665,72 @@ class TestQwen3VLMultimodalAdapterCallLm:
                 mx.zeros((3, 1, 1), dtype=mx.int32),
             )
 
+    def test_omits_deepstack_kwargs_when_unsupported(self) -> None:
+        lm = _KwargsOnlyLanguageModel()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=lm,
+            embeds_kwarg="inputs_embeds",
+            supports_deepstack=False,
+        )
+
+        adapter.call_lm(
+            mx.array([[1, 2, 3]], dtype=mx.int32),
+            mx.zeros((1, 3, 8), dtype=mx.float32),
+            [None],
+            mx.zeros((3, 1, 3), dtype=mx.int32),
+            visual_pos_masks=mx.array([[True, False, True]]),
+            deepstack_visual_embeds=[mx.zeros((1, 2, 8))],
+        )
+
+        assert len(lm.calls) == 1
+        assert lm.calls[0]["extra"] == {}
+
+    def test_forwards_deepstack_kwargs_when_supported(self) -> None:
+        lm = _DeepstackLanguageModel()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=lm,
+            embeds_kwarg="inputs_embeds",
+            supports_deepstack=True,
+        )
+        visual_pos_masks = mx.array([[True, False, True]])
+        deepstack_visual_embeds = [mx.zeros((1, 2, 8))]
+
+        adapter.call_lm(
+            mx.array([[1, 2, 3]], dtype=mx.int32),
+            mx.zeros((1, 3, 8), dtype=mx.float32),
+            [None],
+            mx.zeros((3, 1, 3), dtype=mx.int32),
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+        )
+
+        assert len(lm.calls) == 1
+        call = lm.calls[0]
+        assert call["visual_pos_masks"] is visual_pos_masks
+        assert call["deepstack_visual_embeds"] is deepstack_visual_embeds
+
+    def test_passes_none_deepstack_kwargs_when_supported_and_unset(self) -> None:
+        lm = _DeepstackLanguageModel()
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            language_model=lm,
+            embeds_kwarg="inputs_embeds",
+            supports_deepstack=True,
+        )
+
+        adapter.call_lm(
+            mx.array([[1]], dtype=mx.int32),
+            mx.zeros((1, 1, 8), dtype=mx.float32),
+            [None],
+            mx.zeros((3, 1, 1), dtype=mx.int32),
+        )
+
+        assert len(lm.calls) == 1
+        assert lm.calls[0]["visual_pos_masks"] is None
+        assert lm.calls[0]["deepstack_visual_embeds"] is None
+
 
 class TestQwen3VLMultimodalAdapterFromLoadedModel:
     def test_sniffs_embeds_kwarg_from_language_model(self) -> None:
@@ -596,6 +769,38 @@ class TestQwen3VLMultimodalAdapterFromLoadedModel:
         adapter = Qwen3VLMultimodalAdapter.from_loaded_model(loaded)
 
         assert adapter._embed_tokens_fn is language_model.model.embed_tokens
+
+    def test_detects_no_deepstack_on_qwen3_5_style_lm(self) -> None:
+        class _LoadedModel:
+            class _Config:
+                class _VisionConfig:
+                    spatial_merge_size = 2
+
+                vision_config = _VisionConfig()
+
+            config = _Config()
+            vision_tower = _RecordingVisionTower()
+            language_model = _RecordingLanguageModel()
+
+        adapter = Qwen3VLMultimodalAdapter.from_loaded_model(_LoadedModel())
+
+        assert adapter._supports_deepstack is False
+
+    def test_detects_deepstack_on_qwen3_vl_style_lm(self) -> None:
+        class _LoadedModel:
+            class _Config:
+                class _VisionConfig:
+                    spatial_merge_size = 2
+
+                vision_config = _VisionConfig()
+
+            config = _Config()
+            vision_tower = _RecordingVisionTower()
+            language_model = _DeepstackLanguageModel()
+
+        adapter = Qwen3VLMultimodalAdapter.from_loaded_model(_LoadedModel())
+
+        assert adapter._supports_deepstack is True
 
 
 class TestQwen3VLMultimodalAdapterResolveEmbedTokens:

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -802,6 +802,7 @@ class TestSampleTokensGrammarPagedPath:
                 ),
             ),
             num_decode_tokens=1,
+            mm_prefill_deltas={},
         )
 
         output = runner.sample_tokens(grammar_output=grammar_output)

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -369,10 +369,24 @@ class TestTextModel:
         assert adapter.text_model(model) is model
 
 
+class _Qwen35LanguageModelStub:
+    """Mirrors mlx_vlm 0.4.x ``LanguageModel.__call__`` so signature sniffing works."""
+
+    def __call__(
+        self,
+        inputs: object,
+        inputs_embeds: object | None = None,
+        cache: object | None = None,
+        position_ids: object | None = None,
+        mask: object | None = None,
+    ) -> None:
+        return None
+
+
 class TestBuildMultimodalAdapter:
     def test_builds_qwen35_adapter_from_loaded_vlm(self) -> None:
         vision_tower = object()
-        language_model = object()
+        language_model = _Qwen35LanguageModelStub()
         model = SimpleNamespace(
             config=SimpleNamespace(
                 vision_config=SimpleNamespace(spatial_merge_size=2),
@@ -393,7 +407,7 @@ class TestBuildMultimodalAdapter:
                 vision_config=SimpleNamespace(spatial_merge_size=2),
             ),
             vision_tower=object(),
-            language_model=object(),
+            language_model=_Qwen35LanguageModelStub(),
         )
         hf_config = SimpleNamespace(
             model_type="custom",

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -370,7 +370,15 @@ class TestTextModel:
 
 
 class _Qwen35LanguageModelStub:
-    """Mirrors mlx_vlm 0.4.x ``LanguageModel.__call__`` so signature sniffing works."""
+    """Mirrors mlx_vlm 0.4.x ``LanguageModel.__call__`` so signature sniffing works.
+
+    Also exposes ``self.model.embed_tokens`` to mirror the bottom-level
+    embedding callable the real LM holds — ``from_loaded_model`` resolves
+    it at load time.
+    """
+
+    def __init__(self) -> None:
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids)
 
     def __call__(
         self,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -91,7 +91,14 @@ def _text_config(**overrides: object) -> SimpleNamespace:
 
 
 class _Qwen35LanguageModelStub:
-    """Mirrors mlx_vlm 0.4.x ``LanguageModel.__call__`` so signature sniffing works."""
+    """Mirrors mlx_vlm 0.4.x ``LanguageModel.__call__`` so signature sniffing works.
+
+    Also exposes ``self.model.embed_tokens`` so ``from_loaded_model`` can
+    resolve the bottom-level embedding callable at load time.
+    """
+
+    def __init__(self) -> None:
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids)
 
     def __call__(
         self,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -90,6 +90,20 @@ def _text_config(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**(_TEXT_MODEL_ARGS | overrides))
 
 
+class _Qwen35LanguageModelStub:
+    """Mirrors mlx_vlm 0.4.x ``LanguageModel.__call__`` so signature sniffing works."""
+
+    def __call__(
+        self,
+        inputs: object,
+        inputs_embeds: object | None = None,
+        cache: object | None = None,
+        position_ids: object | None = None,
+        mask: object | None = None,
+    ) -> None:
+        return None
+
+
 def _qwen35_vlm_model(
     *,
     vision_tower: object | None = None,
@@ -102,7 +116,9 @@ def _qwen35_vlm_model(
             vision_config=SimpleNamespace(spatial_merge_size=spatial_merge_size),
         ),
         vision_tower=object() if vision_tower is None else vision_tower,
-        language_model=object() if language_model is None else language_model,
+        language_model=(
+            _Qwen35LanguageModelStub() if language_model is None else language_model
+        ),
     )
 
 
@@ -281,7 +297,7 @@ class TestModelLifecycle:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
         reset_config()
         vision_tower = object()
-        language_model = object()
+        language_model = _Qwen35LanguageModelStub()
         fake_model = _qwen35_vlm_model(
             vision_tower=vision_tower,
             language_model=language_model,

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -218,17 +218,12 @@ class TestPackedRoPE:
         # restores the original sys.modules entry at teardown so this fake
         # cannot leak into later tests in the same process.
         fake_mod = types.ModuleType("mlx_vlm.models.qwen3_5.language")
-        fake_mod.apply_multimodal_rotary_pos_emb = (
-            lambda q, k, cos, sin: (q, k)
-        )
-        monkeypatch.setitem(
-            sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod
-        )
+        fake_mod.apply_multimodal_rotary_pos_emb = lambda q, k, cos, sin: (q, k)
+        monkeypatch.setitem(sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod)
 
         q = mx.zeros((1, 1, 3, 2))
         k = mx.zeros((1, 1, 3, 2))
-        provided = mx.array([[[0, 1, 2]], [[0, 1, 2]], [[0, 1, 2]]],
-                             dtype=mx.int32)
+        provided = mx.array([[[0, 1, 2]], [[0, 1, 2]], [[0, 1, 2]]], dtype=mx.int32)
         apply_packed_rope(
             FakeMRoPE(),
             q,
@@ -263,20 +258,14 @@ class TestPackedRoPE:
                 return cos, sin
 
         fake_mod = types.ModuleType("mlx_vlm.models.qwen3_5.language")
-        fake_mod.apply_multimodal_rotary_pos_emb = (
-            lambda q, k, cos, sin: (q, k)
-        )
-        monkeypatch.setitem(
-            sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod
-        )
+        fake_mod.apply_multimodal_rotary_pos_emb = lambda q, k, cos, sin: (q, k)
+        monkeypatch.setitem(sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod)
 
         q = mx.zeros((1, 1, 5, 2))
         k = mx.zeros((1, 1, 5, 2))
         # Two segments: first uses int offset (no positions[0]),
         # second uses array positions[1].
-        caller_pos = mx.array(
-            [[[10, 11]], [[10, 11]], [[10, 11]]], dtype=mx.int32
-        )
+        caller_pos = mx.array([[[10, 11]], [[10, 11]], [[10, 11]]], dtype=mx.int32)
         apply_packed_rope(
             FakeMRoPE(),
             q,

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -7,6 +7,8 @@ Run with:
 
 from __future__ import annotations
 
+import pytest
+
 from vllm_metal.paged_attention_common import (
     OffsetCache,
     clear_context,
@@ -163,3 +165,130 @@ class TestPackedRoPE:
         assert q_out.shape == (1, 1, 5, 2)
         assert mx.allclose(q_out, mx.zeros_like(q_out)).item()
         assert mx.allclose(k_out, mx.zeros_like(k_out)).item()
+
+    def test_rejects_positions_on_mlx_lm_rope_path(self):
+        """Caller-provided positions are only valid on the M-RoPE path."""
+        import mlx.core as mx
+
+        from vllm_metal.metal_kernel_backend.packed_prefill_compat import (
+            apply_packed_rope,
+        )
+
+        class FakeRoPE:
+            def rope(self, x, offset=0):
+                return x
+
+        q = mx.zeros((1, 1, 3, 2))
+        k = mx.zeros((1, 1, 3, 2))
+        with pytest.raises(NotImplementedError, match="position-array slot"):
+            apply_packed_rope(
+                FakeRoPE(),
+                q,
+                k,
+                [0, 3],
+                positions=[mx.zeros((3, 1, 3), dtype=mx.int32)],
+            )
+
+    def test_mrope_uses_caller_positions_when_provided(self, monkeypatch):
+        """When ``positions[i]`` is an array, M-RoPE consumes it directly."""
+        import sys
+        import types
+
+        import mlx.core as mx
+
+        from vllm_metal.metal_kernel_backend.packed_prefill_compat import (
+            apply_packed_rope,
+        )
+
+        captured: list[mx.array] = []
+
+        class FakeMRoPE:
+            def rotary_emb(self, x, position_ids):
+                captured.append(position_ids)
+                # Return cos/sin shaped to match rotary_emb's contract; we
+                # do not care about correctness here, only routing.
+                seg_len = x.shape[2]
+                head_dim = x.shape[3]
+                cos = mx.zeros((1, 1, seg_len, head_dim))
+                sin = mx.zeros((1, 1, seg_len, head_dim))
+                return cos, sin
+
+        # Patch apply_multimodal_rotary_pos_emb so we do not need real mlx_vlm
+        # math; just route q,k through unchanged.  ``monkeypatch.setitem``
+        # restores the original sys.modules entry at teardown so this fake
+        # cannot leak into later tests in the same process.
+        fake_mod = types.ModuleType("mlx_vlm.models.qwen3_5.language")
+        fake_mod.apply_multimodal_rotary_pos_emb = (
+            lambda q, k, cos, sin: (q, k)
+        )
+        monkeypatch.setitem(
+            sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod
+        )
+
+        q = mx.zeros((1, 1, 3, 2))
+        k = mx.zeros((1, 1, 3, 2))
+        provided = mx.array([[[0, 1, 2]], [[0, 1, 2]], [[0, 1, 2]]],
+                             dtype=mx.int32)
+        apply_packed_rope(
+            FakeMRoPE(),
+            q,
+            k,
+            [0, 3],
+            positions=[provided],
+        )
+
+        assert len(captured) == 1
+        assert captured[0] is provided
+
+    def test_mrope_mixed_int_offset_and_array_positions(self, monkeypatch):
+        """Each segment independently picks int-offset or array-position."""
+        import sys
+        import types
+
+        import mlx.core as mx
+
+        from vllm_metal.metal_kernel_backend.packed_prefill_compat import (
+            apply_packed_rope,
+        )
+
+        recorded: list[mx.array] = []
+
+        class FakeMRoPE:
+            def rotary_emb(self, x, position_ids):
+                recorded.append(position_ids)
+                seg_len = x.shape[2]
+                head_dim = x.shape[3]
+                cos = mx.zeros((1, 1, seg_len, head_dim))
+                sin = mx.zeros((1, 1, seg_len, head_dim))
+                return cos, sin
+
+        fake_mod = types.ModuleType("mlx_vlm.models.qwen3_5.language")
+        fake_mod.apply_multimodal_rotary_pos_emb = (
+            lambda q, k, cos, sin: (q, k)
+        )
+        monkeypatch.setitem(
+            sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod
+        )
+
+        q = mx.zeros((1, 1, 5, 2))
+        k = mx.zeros((1, 1, 5, 2))
+        # Two segments: first uses int offset (no positions[0]),
+        # second uses array positions[1].
+        caller_pos = mx.array(
+            [[[10, 11]], [[10, 11]], [[10, 11]]], dtype=mx.int32
+        )
+        apply_packed_rope(
+            FakeMRoPE(),
+            q,
+            k,
+            [0, 3, 5],
+            offsets=[7, 0],
+            positions=[None, caller_pos],
+        )
+
+        assert len(recorded) == 2
+        # First seg: arange(7, 10) broadcast over (3, 1, 3)
+        assert recorded[0].shape == (3, 1, 3)
+        assert recorded[0].tolist() == [[[7, 8, 9]]] * 3
+        # Second seg: caller-supplied positions used verbatim
+        assert recorded[1] is caller_pos

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -233,6 +233,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             ],
             decode_segments=decode_segments,
             num_decode_tokens=sum(s.num_query_tokens for s in decode_segments),
+            mm_prefill_deltas={},
         )
 
     def test_start_paged_forward_includes_scheduled_drafts(self, monkeypatch) -> None:

--- a/tests/v1/mm/conftest.py
+++ b/tests/v1/mm/conftest.py
@@ -13,13 +13,7 @@ from vllm_metal.multimodal.qwen3_vl import Qwen3VLVisionEncodeResult
 
 @pytest.fixture
 def fake_encode_result():
-    """Return a builder for ``Qwen3VLVisionEncodeResult`` cache entries.
-
-    Tests previously stuffed raw ``mx.array`` into ``encoder_outputs``; the
-    cache now stores the adapter's full encode result, so populating it
-    from a test needs the dataclass wrapper.  This fixture is a closure so
-    each call site reads naturally.
-    """
+    """Return a builder for ``Qwen3VLVisionEncodeResult`` cache entries."""
 
     def _make(
         hidden_states: mx.array,

--- a/tests/v1/mm/conftest.py
+++ b/tests/v1/mm/conftest.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for multimodal runtime tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLVisionEncodeResult
+
+
+@pytest.fixture
+def fake_encode_result():
+    """Return a builder for ``Qwen3VLVisionEncodeResult`` cache entries.
+
+    Tests previously stuffed raw ``mx.array`` into ``encoder_outputs``; the
+    cache now stores the adapter's full encode result, so populating it
+    from a test needs the dataclass wrapper.  This fixture is a closure so
+    each call site reads naturally.
+    """
+
+    def _make(
+        hidden_states: mx.array,
+        *,
+        deepstack: Any | None = None,
+    ) -> Qwen3VLVisionEncodeResult:
+        return Qwen3VLVisionEncodeResult(
+            hidden_states=hidden_states,
+            deepstack_visual_embeds=deepstack,
+        )
+
+    return _make

--- a/tests/v1/mm/test_build_prefill_pack_mm.py
+++ b/tests/v1/mm/test_build_prefill_pack_mm.py
@@ -131,9 +131,7 @@ class TestBuildPrefillPackMmFullPrompt:
         entry = _make_prefill_entry(
             "req-0", token_ids=[1, 99], prompt_len=4, start_pos=0
         )
-        batch = self._make_batch(
-            [entry], [_new_req("req-0", [1, 99, 99, 2])]
-        )
+        batch = self._make_batch([entry], [_new_req("req-0", [1, 99, 99, 2])])
 
         pack = runner._build_prefill_pack(batch)
 
@@ -142,9 +140,7 @@ class TestBuildPrefillPackMmFullPrompt:
     def test_mm_raises_when_state_and_new_req_both_missing(self) -> None:
         runner = make_stub_runner(encoder_cache=EncoderCache())
         runner.encoder_cache.add_request("req-0", [_feature("img-0")])
-        entry = _make_prefill_entry(
-            "req-0", token_ids=[1], prompt_len=4, start_pos=0
-        )
+        entry = _make_prefill_entry("req-0", token_ids=[1], prompt_len=4, start_pos=0)
         batch = self._make_batch([entry], [])
 
         with pytest.raises(RuntimeError, match="state tracking bug"):
@@ -153,9 +149,7 @@ class TestBuildPrefillPackMmFullPrompt:
     def test_mm_raises_when_new_req_prompt_token_ids_missing(self) -> None:
         runner = make_stub_runner(encoder_cache=EncoderCache())
         runner.encoder_cache.add_request("req-0", [_feature("img-0")])
-        entry = _make_prefill_entry(
-            "req-0", token_ids=[1], prompt_len=4, start_pos=0
-        )
+        entry = _make_prefill_entry("req-0", token_ids=[1], prompt_len=4, start_pos=0)
         batch = self._make_batch([entry], [_new_req("req-0", None)])
 
         with pytest.raises(RuntimeError, match="scheduler contract bug"):

--- a/tests/v1/mm/test_build_prefill_pack_mm.py
+++ b/tests/v1/mm/test_build_prefill_pack_mm.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for multimodal-aware ``_build_prefill_pack`` full-prompt resolution."""
+
+from __future__ import annotations
+
+import pytest
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import NewRequestData
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+from vllm_metal.v1.mm import EncoderCache
+from vllm_metal.v1.model_runner import (
+    PrefillRequest,
+    RequestState,
+    _ExecutionBatch,
+    _PendingPrefillEntry,
+)
+
+
+def _feature(identifier: str) -> MultiModalFeatureSpec:
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=0, length=1),
+    )
+
+
+def _make_prefill_entry(
+    req_id: str,
+    *,
+    token_ids: list[int],
+    prompt_len: int,
+    start_pos: int = 0,
+) -> _PendingPrefillEntry:
+    prefill = PrefillRequest(
+        req_id=req_id,
+        token_ids=token_ids,
+        sampling_params=SamplingParams(temperature=0.0),
+        block_ids=[],
+        generator=None,
+        prompt_len=prompt_len,
+        start_pos=start_pos,
+        full_prompt_token_ids=None,
+    )
+    return _PendingPrefillEntry(
+        output_idx=0,
+        prefill=prefill,
+        result_mode="new_final",
+    )
+
+
+def _new_req(req_id: str, prompt_token_ids: list[int] | None) -> NewRequestData:
+    return NewRequestData(
+        req_id=req_id,
+        prompt_token_ids=prompt_token_ids,
+        mm_features=[],
+        sampling_params=None,
+        pooling_params=None,
+        block_ids=([0],),
+        num_computed_tokens=0,
+        lora_request=None,
+    )
+
+
+class TestIsMmRequest:
+    def test_returns_false_when_no_encoder_cache(self) -> None:
+        runner = make_stub_runner()
+        assert runner._is_mm_request("req-0") is False
+
+    def test_returns_false_when_empty_features_list(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner.encoder_cache.add_request("req-0", [])
+        assert runner._is_mm_request("req-0") is False
+
+    def test_returns_true_with_registered_features(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner.encoder_cache.add_request("req-0", [_feature("img-0")])
+        assert runner._is_mm_request("req-0") is True
+
+    def test_returns_false_for_unknown_request(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        assert runner._is_mm_request("missing") is False
+
+
+class TestBuildPrefillPackMmFullPrompt:
+    def _make_batch(
+        self, entries: list[_PendingPrefillEntry], new_reqs: list[NewRequestData]
+    ) -> _ExecutionBatch:
+        batch = _ExecutionBatch()
+        batch.paged_prefill_entries = entries
+        batch.new_reqs_by_id = {nr.req_id: nr for nr in new_reqs}
+        return batch
+
+    def test_text_only_start_pos_zero_keeps_full_prompt_none(self) -> None:
+        # Behavior preservation: text-only first-chunk prefill still gets
+        # ``full_prompt_token_ids=None`` (callers fall back to token_ids).
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        entry = _make_prefill_entry(
+            "req-0", token_ids=[1, 2, 3], prompt_len=3, start_pos=0
+        )
+        batch = self._make_batch([entry], [_new_req("req-0", [1, 2, 3])])
+
+        pack = runner._build_prefill_pack(batch)
+
+        assert pack[0].full_prompt_token_ids is None
+
+    def test_mm_start_pos_zero_uses_state_token_ids(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner.encoder_cache.add_request("req-0", [_feature("img-0")])
+        runner._request_states["req-0"] = RequestState(
+            token_ids=[1, 99, 99, 2, 3, 4],  # 4 prompt + 2 generated
+            prompt_len=4,
+            cache=[],
+            sampling_params=SamplingParams(),
+        )
+        entry = _make_prefill_entry(
+            "req-0", token_ids=[1, 99], prompt_len=4, start_pos=0
+        )
+        batch = self._make_batch([entry], [])
+
+        pack = runner._build_prefill_pack(batch)
+
+        assert pack[0].full_prompt_token_ids == [1, 99, 99, 2]
+
+    def test_mm_start_pos_zero_falls_back_to_new_req(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner.encoder_cache.add_request("req-0", [_feature("img-0")])
+        # No RequestState yet — first time we see this request.
+        entry = _make_prefill_entry(
+            "req-0", token_ids=[1, 99], prompt_len=4, start_pos=0
+        )
+        batch = self._make_batch(
+            [entry], [_new_req("req-0", [1, 99, 99, 2])]
+        )
+
+        pack = runner._build_prefill_pack(batch)
+
+        assert pack[0].full_prompt_token_ids == [1, 99, 99, 2]
+
+    def test_mm_raises_when_state_and_new_req_both_missing(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner.encoder_cache.add_request("req-0", [_feature("img-0")])
+        entry = _make_prefill_entry(
+            "req-0", token_ids=[1], prompt_len=4, start_pos=0
+        )
+        batch = self._make_batch([entry], [])
+
+        with pytest.raises(RuntimeError, match="state tracking bug"):
+            runner._build_prefill_pack(batch)
+
+    def test_mm_raises_when_new_req_prompt_token_ids_missing(self) -> None:
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner.encoder_cache.add_request("req-0", [_feature("img-0")])
+        entry = _make_prefill_entry(
+            "req-0", token_ids=[1], prompt_len=4, start_pos=0
+        )
+        batch = self._make_batch([entry], [_new_req("req-0", None)])
+
+        with pytest.raises(RuntimeError, match="scheduler contract bug"):
+            runner._build_prefill_pack(batch)
+
+    def test_text_only_continuation_chunk_still_uses_full_prompt(self) -> None:
+        # Regression guard: ``start_pos > 0`` text path unchanged.
+        runner = make_stub_runner(encoder_cache=EncoderCache())
+        runner._request_states["req-0"] = RequestState(
+            token_ids=[1, 2, 3, 4, 5, 6, 7],
+            prompt_len=5,
+            cache=[],
+            sampling_params=SamplingParams(),
+        )
+        entry = _make_prefill_entry(
+            "req-0", token_ids=[3, 4, 5], prompt_len=5, start_pos=2
+        )
+        batch = self._make_batch([entry], [])
+
+        pack = runner._build_prefill_pack(batch)
+
+        assert pack[0].full_prompt_token_ids == [1, 2, 3, 4, 5]

--- a/tests/v1/mm/test_encoder_cache.py
+++ b/tests/v1/mm/test_encoder_cache.py
@@ -42,10 +42,10 @@ def test_remove_request_is_idempotent() -> None:
     assert "req-0" not in cache.mm_features
 
 
-def test_free_encoder_cache_removes_one_hash() -> None:
+def test_free_encoder_cache_removes_one_hash(fake_encode_result) -> None:
     cache = EncoderCache()
-    cache.encoder_outputs["hash-0"] = mx.array([[1.0]])
-    cache.encoder_outputs["hash-1"] = mx.array([[2.0]])
+    cache.encoder_outputs["hash-0"] = fake_encode_result(mx.array([[1.0]]))
+    cache.encoder_outputs["hash-1"] = fake_encode_result(mx.array([[2.0]]))
 
     cache.free_encoder_cache("hash-0")
     cache.free_encoder_cache("missing")
@@ -53,11 +53,11 @@ def test_free_encoder_cache_removes_one_hash() -> None:
     assert set(cache.encoder_outputs) == {"hash-1"}
 
 
-def test_reset_encoder_cache_clears_outputs_only() -> None:
+def test_reset_encoder_cache_clears_outputs_only(fake_encode_result) -> None:
     cache = EncoderCache()
     features = [_feature("image-0")]
     cache.add_request("req-0", features)
-    cache.encoder_outputs["hash-0"] = mx.array([[1.0]])
+    cache.encoder_outputs["hash-0"] = fake_encode_result(mx.array([[1.0]]))
 
     cache.reset_encoder_cache()
 

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -344,9 +344,7 @@ def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
     stored = runner.encoder_cache.encoder_outputs["image-0"]
     assert mx.allclose(stored.hidden_states, expected).item()
     assert stored.deepstack_visual_embeds is not None
-    assert mx.allclose(
-        stored.deepstack_visual_embeds[0], mx.array([[3.0, 4.0]])
-    ).item()
+    assert mx.allclose(stored.deepstack_visual_embeds[0], mx.array([[3.0, 4.0]])).item()
 
 
 def test_run_vision_encoders_skips_cached_features(fake_encode_result) -> None:

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -16,7 +16,10 @@ from vllm.v1.core.sched.output import (
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
-from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
+from vllm_metal.multimodal.qwen3_vl import (
+    Qwen3VLMultimodalAdapter,
+    Qwen3VLVisionEncodeResult,
+)
 from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_runner import RequestState
 
@@ -249,9 +252,9 @@ class _RecordingAdapter:
 
     def __init__(self) -> None:
         self.encode_calls: list[list[MultiModalFeatureSpec]] = []
-        self._next_outputs: list[list[mx.array]] | None = None
+        self._next_outputs: list[list[Qwen3VLVisionEncodeResult]] | None = None
 
-    def queue_outputs(self, outputs: list[list[mx.array]]) -> None:
+    def queue_outputs(self, outputs: list[list[Qwen3VLVisionEncodeResult]]) -> None:
         """Force a sequence of return values for successive encode calls."""
         self._next_outputs = list(outputs)
 
@@ -263,11 +266,17 @@ class _RecordingAdapter:
 
     def encode_multimodal(
         self, features: list[MultiModalFeatureSpec]
-    ) -> list[mx.array]:
+    ) -> list[Qwen3VLVisionEncodeResult]:
         self.encode_calls.append(list(features))
         if self._next_outputs is not None and self._next_outputs:
             return self._next_outputs.pop(0)
-        return [mx.zeros((1, 4)) for _ in features]
+        return [
+            Qwen3VLVisionEncodeResult(
+                hidden_states=mx.zeros((1, 4)),
+                deepstack_visual_embeds=None,
+            )
+            for _ in features
+        ]
 
     def call_lm(self, *args: object, **kwargs: object) -> object:
         raise AssertionError("call_lm not exercised in commit 3")
@@ -314,7 +323,16 @@ def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", features)
     expected = mx.array([[1.0, 2.0]])
-    adapter.queue_outputs([[expected]])
+    adapter.queue_outputs(
+        [
+            [
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=expected,
+                    deepstack_visual_embeds=[mx.array([[3.0, 4.0]])],
+                )
+            ]
+        ]
+    )
 
     runner._run_vision_encoders({"req-0": [0]})
 
@@ -382,7 +400,20 @@ def test_run_vision_encoders_raises_when_adapter_returns_wrong_count() -> None:
     features = [_feature("image-0")]
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", features)
-    adapter.queue_outputs([[mx.zeros((1,)), mx.zeros((1,))]])
+    adapter.queue_outputs(
+        [
+            [
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=mx.zeros((1,)),
+                    deepstack_visual_embeds=None,
+                ),
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=mx.zeros((1,)),
+                    deepstack_visual_embeds=None,
+                ),
+            ]
+        ]
+    )
 
     with pytest.raises(RuntimeError, match="encode_multimodal returned 2"):
         runner._run_vision_encoders({"req-0": [0]})

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -249,6 +249,45 @@ def test_execute_model_rejects_encoder_inputs_until_forward_is_wired() -> None:
         runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))
 
 
+def test_execute_model_pre_registers_new_request_before_encoder_dispatch() -> None:
+    """A brand-new mm request + its first encoder input in one SchedulerOutput.
+
+    Upstream's scheduler can place a new multimodal request and its first
+    ``scheduled_encoder_inputs`` in the same step; encoder dispatch must
+    find the request's ``mm_features`` already registered.  Before the
+    pre-register step was lifted out of ``_handle_new_requests``, encoder
+    dispatch ran first and raised an "unregistered request" RuntimeError.
+    """
+    runner = _paged_runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("image-0")]
+    expected_hidden = mx.array([[5.0, 6.0]])
+    adapter.queue_outputs(
+        [
+            [
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=expected_hidden,
+                    deepstack_visual_embeds=None,
+                )
+            ]
+        ]
+    )
+
+    runner.execute_model(
+        _scheduler_output(
+            scheduled_new_reqs=[_new_request("req-0", features)],
+            scheduled_encoder_inputs={"req-0": [0]},
+        )
+    )
+
+    assert runner.encoder_cache is not None
+    assert runner.encoder_cache.mm_features["req-0"] == features
+    assert adapter.encode_calls == [features]
+    stored = runner.encoder_cache.encoder_outputs["image-0"]
+    assert mx.allclose(stored.hidden_states, expected_hidden).item()
+
+
 class _RecordingAdapter:
     """Adapter stub that records ``encode_multimodal`` invocations."""
 

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -242,21 +242,52 @@ def test_execute_model_rejects_encoder_inputs_until_forward_is_wired() -> None:
         runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))
 
 
-def test_reject_scheduled_encoder_inputs_passes_when_adapter_is_forward_ready() -> None:
+class _RecordingAdapter:
+    """Adapter stub that records ``encode_multimodal`` invocations."""
+
+    forward_ready = True
+
+    def __init__(self) -> None:
+        self.encode_calls: list[list[MultiModalFeatureSpec]] = []
+        self._next_outputs: list[list[mx.array]] | None = None
+
+    def queue_outputs(self, outputs: list[list[mx.array]]) -> None:
+        """Force a sequence of return values for successive encode calls."""
+        self._next_outputs = list(outputs)
+
+    def text_model(self) -> object:
+        return object()
+
+    def get_mrope_input_positions(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def encode_multimodal(
+        self, features: list[MultiModalFeatureSpec]
+    ) -> list[mx.array]:
+        self.encode_calls.append(list(features))
+        if self._next_outputs is not None and self._next_outputs:
+            return self._next_outputs.pop(0)
+        return [mx.zeros((1, 4)) for _ in features]
+
+    def call_lm(self, *args: object, **kwargs: object) -> object:
+        raise AssertionError("call_lm not exercised in commit 3")
+
+
+def test_reject_scheduled_encoder_inputs_dispatches_when_adapter_is_forward_ready() -> (
+    None
+):
     runner = _runner_with_encoder_cache()
-
-    class _ReadyAdapter:
-        forward_ready = True
-
-        def text_model(self) -> object:
-            return object()
-
-        def get_mrope_input_positions(self, *args: object, **kwargs: object) -> None:
-            return None
-
-    runner._multimodal_adapter = _ReadyAdapter()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
 
     runner._reject_scheduled_encoder_inputs({"req-0": [0]})
+
+    assert len(adapter.encode_calls) == 1
+    assert adapter.encode_calls[0] == features
+    assert "image-0" in runner.encoder_cache.encoder_outputs
 
 
 def test_reject_scheduled_encoder_inputs_raises_when_adapter_not_ready() -> None:
@@ -273,3 +304,100 @@ def test_reject_scheduled_encoder_inputs_raises_when_no_adapter() -> None:
 
     with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
         runner._reject_scheduled_encoder_inputs({"req-0": [0]})
+
+
+def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+    expected = mx.array([[1.0, 2.0]])
+    adapter.queue_outputs([[expected]])
+
+    runner._run_vision_encoders({"req-0": [0]})
+
+    assert adapter.encode_calls == [features]
+    stored = runner.encoder_cache.encoder_outputs["image-0"]
+    assert mx.allclose(stored, expected).item()
+
+
+def test_run_vision_encoders_skips_cached_features() -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+    cached = mx.array([[7.0]])
+    runner.encoder_cache.encoder_outputs["image-0"] = cached
+
+    runner._run_vision_encoders({"req-0": [0]})
+
+    assert adapter.encode_calls == []
+    assert runner.encoder_cache.encoder_outputs["image-0"] is cached
+
+
+def test_run_vision_encoders_iterates_multiple_requests_and_indices() -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    req0_features = [_feature("img-a"), _feature("img-b")]
+    req1_features = [_feature("img-c")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", req0_features)
+    runner.encoder_cache.add_request("req-1", req1_features)
+
+    runner._run_vision_encoders({"req-0": [0, 1], "req-1": [0]})
+
+    assert len(adapter.encode_calls) == 3
+    encoded_identifiers = [call[0].identifier for call in adapter.encode_calls]
+    assert encoded_identifiers == ["img-a", "img-b", "img-c"]
+    assert set(runner.encoder_cache.encoder_outputs) == {"img-a", "img-b", "img-c"}
+
+
+def test_run_vision_encoders_raises_for_unregistered_request() -> None:
+    runner = _runner_with_encoder_cache()
+    runner._multimodal_adapter = _RecordingAdapter()
+
+    with pytest.raises(RuntimeError, match="unregistered request"):
+        runner._run_vision_encoders({"missing-req": [0]})
+
+
+def test_run_vision_encoders_raises_for_out_of_range_index() -> None:
+    runner = _runner_with_encoder_cache()
+    runner._multimodal_adapter = _RecordingAdapter()
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", [_feature("image-0")])
+
+    with pytest.raises(IndexError, match="out of range"):
+        runner._run_vision_encoders({"req-0": [3]})
+
+
+def test_run_vision_encoders_raises_when_adapter_returns_wrong_count() -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("image-0")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+    adapter.queue_outputs([[mx.zeros((1,)), mx.zeros((1,))]])
+
+    with pytest.raises(RuntimeError, match="encode_multimodal returned 2"):
+        runner._run_vision_encoders({"req-0": [0]})
+
+
+def test_run_vision_encoders_no_op_when_no_adapter() -> None:
+    runner = _runner_with_encoder_cache()
+    runner._multimodal_adapter = None
+
+    runner._run_vision_encoders({"req-0": [0]})
+
+
+def test_run_vision_encoders_no_op_when_no_encoder_cache() -> None:
+    runner = make_stub_runner()
+    runner._multimodal_adapter = _RecordingAdapter()
+    assert runner.encoder_cache is None
+
+    runner._run_vision_encoders({"req-0": [0]})

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -240,3 +240,36 @@ def test_execute_model_rejects_encoder_inputs_until_forward_is_wired() -> None:
 
     with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
         runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))
+
+
+def test_reject_scheduled_encoder_inputs_passes_when_adapter_is_forward_ready() -> None:
+    runner = _runner_with_encoder_cache()
+
+    class _ReadyAdapter:
+        forward_ready = True
+
+        def text_model(self) -> object:
+            return object()
+
+        def get_mrope_input_positions(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    runner._multimodal_adapter = _ReadyAdapter()
+
+    runner._reject_scheduled_encoder_inputs({"req-0": [0]})
+
+
+def test_reject_scheduled_encoder_inputs_raises_when_adapter_not_ready() -> None:
+    runner = _runner_with_encoder_cache()
+    runner._multimodal_adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=2)
+
+    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+        runner._reject_scheduled_encoder_inputs({"req-0": [0]})
+
+
+def test_reject_scheduled_encoder_inputs_raises_when_no_adapter() -> None:
+    runner = _runner_with_encoder_cache()
+    runner._multimodal_adapter = None
+
+    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+        runner._reject_scheduled_encoder_inputs({"req-0": [0]})

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -164,21 +164,23 @@ def test_resubmitted_request_keeps_new_mm_features() -> None:
     assert runner.encoder_cache.mm_features["req-0"] == new_features
 
 
-def test_execute_model_frees_released_encoder_outputs() -> None:
+def test_execute_model_frees_released_encoder_outputs(fake_encode_result) -> None:
     runner = _runner_with_encoder_cache()
     assert runner.encoder_cache is not None
-    runner.encoder_cache.encoder_outputs["keep"] = mx.array([[1.0]])
-    runner.encoder_cache.encoder_outputs["drop"] = mx.array([[2.0]])
+    runner.encoder_cache.encoder_outputs["keep"] = fake_encode_result(mx.array([[1.0]]))
+    runner.encoder_cache.encoder_outputs["drop"] = fake_encode_result(mx.array([[2.0]]))
 
     runner.execute_model(_scheduler_output(free_encoder_mm_hashes=["drop"]))
 
     assert set(runner.encoder_cache.encoder_outputs) == {"keep"}
 
 
-def test_reset_encoder_cache_delegates_to_encoder_cache() -> None:
+def test_reset_encoder_cache_delegates_to_encoder_cache(fake_encode_result) -> None:
     runner = _runner_with_encoder_cache()
     assert runner.encoder_cache is not None
-    runner.encoder_cache.encoder_outputs["image-0"] = mx.array([[1.0]])
+    runner.encoder_cache.encoder_outputs["image-0"] = fake_encode_result(
+        mx.array([[1.0]])
+    )
 
     runner.reset_encoder_cache()
 
@@ -194,10 +196,12 @@ def test_reset_mm_cache_delegates_to_encoder_cache() -> None:
     encoder_cache.reset_mm_cache.assert_called_once_with()
 
 
-def test_execute_model_frees_encoder_outputs_before_encoder_fail_fast() -> None:
+def test_execute_model_frees_encoder_outputs_before_encoder_fail_fast(
+    fake_encode_result,
+) -> None:
     runner = _runner_with_encoder_cache()
     assert runner.encoder_cache is not None
-    runner.encoder_cache.encoder_outputs["drop"] = mx.array([[1.0]])
+    runner.encoder_cache.encoder_outputs["drop"] = fake_encode_result(mx.array([[1.0]]))
 
     with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
         runner.execute_model(
@@ -338,17 +342,21 @@ def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
 
     assert adapter.encode_calls == [features]
     stored = runner.encoder_cache.encoder_outputs["image-0"]
-    assert mx.allclose(stored, expected).item()
+    assert mx.allclose(stored.hidden_states, expected).item()
+    assert stored.deepstack_visual_embeds is not None
+    assert mx.allclose(
+        stored.deepstack_visual_embeds[0], mx.array([[3.0, 4.0]])
+    ).item()
 
 
-def test_run_vision_encoders_skips_cached_features() -> None:
+def test_run_vision_encoders_skips_cached_features(fake_encode_result) -> None:
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
     features = [_feature("image-0")]
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", features)
-    cached = mx.array([[7.0]])
+    cached = fake_encode_result(mx.array([[7.0]]))
     runner.encoder_cache.encoder_outputs["image-0"] = cached
 
     runner._run_vision_encoders({"req-0": [0]})

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -300,7 +300,14 @@ class TestMmDecodeSegmentPositions:
         # No visual mask positions on a decode token.
         assert call["visual_pos_masks"].tolist() == [[False]]
 
-    def test_spec_decode_multi_query_arange_plus_delta(self) -> None:
+    def test_spec_decode_for_mm_request_is_rejected(self) -> None:
+        # ``prepare_unified`` expands a decode segment with
+        # ``num_query_tokens > 1`` into one cu_seqlens span per query
+        # token, but ``_run_mm_paged_forward`` only stores one entry per
+        # ``PagedDecodeSegment`` in ``ctx.segment_positions``.  Until that
+        # mismatch is resolved (RFC #319 follow-up), spec decode on the
+        # mm paged path must fail fast instead of corrupting downstream
+        # M-RoPE positions for segments packed after the draft.
         adapter = _MmAdapter()
         runner = _runner(adapter)
         state = RequestState(
@@ -311,8 +318,6 @@ class TestMmDecodeSegmentPositions:
             mrope_position_delta=-3,
         )
         runner._request_states["req-mm"] = state
-        # 3 draft rows + 1 bonus row = 4 query tokens, cache_start_pos=5.
-        # Expected positions = arange(5, 5+4) + -3 = [2, 3, 4, 5] tiled.
         segment = PagedDecodeSegment(
             req_id="req-mm",
             input_token_ids=(6, 100, 101, 102),
@@ -326,20 +331,68 @@ class TestMmDecodeSegmentPositions:
             return_value=(segment,)
         )
 
-        runner._start_paged_forward(
-            batch=MagicMock(),
-            prefill_reqs=[],
-            decode_reqs=[("req-mm", state)],
-            scheduler_output=_scheduler_output(),
+        with pytest.raises(NotImplementedError, match="Speculative decode"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[],
+                decode_reqs=[("req-mm", state)],
+                scheduler_output=_scheduler_output(),
+            )
+        assert adapter.call_lm_calls == []
+
+    def test_text_spec_decode_alongside_mm_prefill_is_rejected(self) -> None:
+        # Mixed batch: an mm prefill forces the runner onto
+        # ``_run_mm_paged_forward``, and a text-only request with
+        # ``num_query_tokens > 1`` rides along.  Even though the text
+        # segment carries no ``mrope_position_delta``, prepare_unified
+        # still appends one cu_seqlens span per draft token while
+        # ``ctx.segment_positions`` keeps a single ``None`` for the
+        # whole segment — so the misalignment leaks into the mm prefill
+        # positions packed after it.  The guard must trigger on the
+        # segment regardless of mm-vs-text origin.
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=0, length=2)]
+        runner.encoder_cache.add_request("req-mm", features)
+        _put_encode(runner, "img-0", hidden_states=mx.ones((2, adapter.hidden_size)))
+
+        text_state = RequestState(
+            token_ids=[1, 2, 3, 4, 5],
+            prompt_len=4,
+            cache=[],
+            sampling_params=SamplingParams(),
+            mrope_position_delta=None,
+        )
+        runner._request_states["req-text"] = text_state
+        text_segment = PagedDecodeSegment(
+            req_id="req-text",
+            input_token_ids=(5, 100, 101),
+            start_row=0,
+            num_query_tokens=3,
+            draft_token_ids=(100, 101),
+            cache_start_pos=4,
+            block_ids=(0,),
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=(text_segment,)
         )
 
-        call = adapter.call_lm_calls[0]
-        assert call["position_ids"].shape == (3, 1, 4)
-        assert call["position_ids"].tolist() == [
-            [[2, 3, 4, 5]],
-            [[2, 3, 4, 5]],
-            [[2, 3, 4, 5]],
-        ]
+        mm_prefill = _mm_prefill(
+            "req-mm",
+            token_ids=[99, 99],
+            prompt_len=2,
+            start_pos=0,
+            full_prompt=[99, 99],
+        )
+
+        with pytest.raises(NotImplementedError, match="Speculative decode"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[mm_prefill],
+                decode_reqs=[("req-text", text_state)],
+                scheduler_output=_scheduler_output(),
+            )
+        assert adapter.call_lm_calls == []
 
 
 class TestMixedMmAndText:
@@ -362,6 +415,7 @@ class TestMixedMmAndText:
         def capturing_call_lm(*args, **kwargs):
             ctx = get_context()
             captured_ctx["segment_positions"] = list(ctx.segment_positions)
+            captured_ctx["cu_seqlens"] = list(ctx.cu_seqlens)
             return original_call_lm(*args, **kwargs)
 
         adapter.call_lm = capturing_call_lm  # type: ignore[method-assign]
@@ -392,8 +446,13 @@ class TestMixedMmAndText:
         )
 
         seg_positions = captured_ctx["segment_positions"]
+        cu_seqlens = captured_ctx["cu_seqlens"]
         # Two prefill segments: mm first, then text.
         assert len(seg_positions) == 2
+        # ``apply_packed_rope`` iterates ``range(len(cu_seqlens) - 1)`` and
+        # indexes ``segment_positions[i]``; these two must stay in lockstep
+        # or M-RoPE positions slip onto the wrong segment.
+        assert len(seg_positions) == len(cu_seqlens) - 1
         # mm segment: caller-supplied positions (shape (3, 1, 2)).
         assert seg_positions[0] is not None
         assert seg_positions[0].shape == (3, 1, 2)

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -37,6 +37,33 @@ class _MmAdapter:
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
         self.call_lm_calls: list[dict[str, Any]] = []
+        self.encode_calls: list[list[MultiModalFeatureSpec]] = []
+        self._encode_outputs: dict[str, Qwen3VLVisionEncodeResult] = {}
+
+    def queue_encode_output(
+        self, identifier: str, result: Qwen3VLVisionEncodeResult
+    ) -> None:
+        """Map a feature identifier to a fake vision-tower result."""
+        self._encode_outputs[identifier] = result
+
+    def encode_multimodal(
+        self, features: list[MultiModalFeatureSpec]
+    ) -> list[Qwen3VLVisionEncodeResult]:
+        self.encode_calls.append(list(features))
+        outputs: list[Qwen3VLVisionEncodeResult] = []
+        for feature in features:
+            queued = self._encode_outputs.get(feature.identifier)
+            if queued is not None:
+                outputs.append(queued)
+                continue
+            length = feature.mm_position.length
+            outputs.append(
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=mx.zeros((length, self.hidden_size)),
+                    deepstack_visual_embeds=None,
+                )
+            )
+        return outputs
 
     def text_model(self) -> Any:
         return MagicMock(
@@ -592,3 +619,64 @@ class TestMmPrefillFullPromptRequired:
                 decode_reqs=[],
                 scheduler_output=_scheduler_output(),
             )
+
+
+class TestMmIdentifierFlowsEncoderToCallLm:
+    """Prove the encoder→cache→paged-forward chain uses the same identifier.
+
+    Avoids stubbing ``_start_paged_forward`` or pre-seeding the encoder
+    cache: ``_run_vision_encoders`` populates ``encoder_outputs`` via the
+    adapter's real ``encode_multimodal`` keyed by ``feature.identifier``,
+    and the immediately-following paged forward looks the result back up
+    by the same identifier and splices its ``hidden_states`` into the
+    ``inputs_embeds`` payload passed to ``adapter.call_lm``.
+    """
+
+    def test_paged_forward_consumes_encoder_output_by_identifier(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=1, length=2)]
+        runner.encoder_cache.add_request("req-0", features)
+        sentinel = mx.array(
+            [[float(11)] * adapter.hidden_size, [float(22)] * adapter.hidden_size],
+            dtype=mx.float32,
+        )
+        adapter.queue_encode_output(
+            "img-0",
+            Qwen3VLVisionEncodeResult(
+                hidden_states=sentinel,
+                deepstack_visual_embeds=None,
+            ),
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        # Step 1: encoder dispatch populates encoder_outputs by identifier.
+        runner._run_vision_encoders({"req-0": [0]})
+
+        assert adapter.encode_calls == [features]
+        stored = runner.encoder_cache.encoder_outputs["img-0"]
+        assert mx.allclose(stored.hidden_states, sentinel).item()
+
+        # Step 2: paged forward picks the same identifier out of the cache
+        # and splices its hidden_states into the call_lm inputs_embeds.
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[10, 99, 99, 11],
+            prompt_len=4,
+            start_pos=0,
+            full_prompt=[10, 99, 99, 11],
+        )
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        assert len(adapter.call_lm_calls) == 1
+        embeds = adapter.call_lm_calls[0]["inputs_embeds"]
+        # Placeholder rows at offsets 1, 2 carry the encoder output rows.
+        assert mx.allclose(embeds[0, 1], sentinel[0]).item()
+        assert mx.allclose(embeds[0, 2], sentinel[1]).item()

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -429,6 +429,143 @@ class TestDeepstackPerChunkSlice:
         ).item()
 
 
+class TestMmPrefillDeltaRoundTrip:
+    """``_start_paged_forward`` → ``_sample_paged_batch`` round-trip.
+
+    The mm prefill's ``mrope_position_delta`` must land on the new
+    ``RequestState`` so the next paged round routes through the mm
+    decode path; otherwise the next round would treat the request as
+    text-only and produce wrong M-RoPE positions.
+    """
+
+    def _patch_sampling(self, monkeypatch, prefill_tokens, decode_tokens):
+        import vllm_metal.v1.model_runner as mr
+        from vllm_metal.v1.sampling_batch import _SamplingResult
+
+        monkeypatch.setattr(
+            mr,
+            "sample_prefill_tokens",
+            lambda *a, **kw: _SamplingResult(prefill_tokens, None),
+        )
+        monkeypatch.setattr(
+            mr,
+            "sample_decode_tokens",
+            lambda *a, **kw: _SamplingResult(decode_tokens, None),
+        )
+
+    def test_new_final_mm_prefill_writes_delta_to_request_state(
+        self, monkeypatch
+    ) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=0, length=1)]
+        runner.encoder_cache.add_request("req-0", features)
+        _put_encode(runner, "img-0", hidden_states=mx.ones((1, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[99, 11],
+            prompt_len=2,
+            start_pos=0,
+            full_prompt=[99, 11],
+        )
+
+        # Use the runner's real ExecutionBatch path so the postprocess
+        # iterates ``paged_prefill_entries``.
+        from vllm_metal.v1.model_runner import (
+            _ExecutionBatch,
+            _PendingPrefillEntry,
+        )
+
+        batch = _ExecutionBatch()
+        entry = _PendingPrefillEntry(
+            output_idx=batch.add_output("req-0", []),
+            prefill=prefill,
+            result_mode="new_final",
+        )
+        batch.paged_prefill_entries.append(entry)
+
+        runner._start_paged_forward(
+            batch=batch,
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        # mm_prefill_deltas stashed on _PagedForwardState.
+        state = runner._execute_model_state
+        assert state is not None
+        assert state.mm_prefill_deltas == {"req-0": -2}
+
+        # Run _sample_paged_batch to drive postprocess; patch sampling
+        # to bypass the real sampler stack.
+        self._patch_sampling(monkeypatch, prefill_tokens=[42], decode_tokens=[])
+        runner._sample_paged_batch()
+
+        new_state = runner._request_states["req-0"]
+        assert new_state.mrope_position_delta == -2
+        # Sanity: token_ids = full_prompt + [next_token]
+        assert new_state.token_ids == [99, 11, 42]
+
+    def test_cached_final_mm_prefill_updates_existing_state_delta(
+        self, monkeypatch
+    ) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=0, length=1)]
+        runner.encoder_cache.add_request("req-0", features)
+        _put_encode(runner, "img-0", hidden_states=mx.ones((1, adapter.hidden_size)))
+        # Pre-existing state from a prior intermediate chunk — delta
+        # not yet stashed (mirrors the gap this fix closes).
+        runner._request_states["req-0"] = RequestState(
+            token_ids=[99, 11],  # prompt only (no sampled token yet)
+            prompt_len=2,
+            cache=[],
+            sampling_params=SamplingParams(temperature=0.0),
+            mrope_position_delta=None,
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[11],  # final continuation chunk
+            prompt_len=2,
+            start_pos=1,
+            full_prompt=[99, 11],
+        )
+
+        from vllm_metal.v1.model_runner import (
+            _ExecutionBatch,
+            _PendingPrefillEntry,
+        )
+
+        batch = _ExecutionBatch()
+        entry = _PendingPrefillEntry(
+            output_idx=batch.add_output("req-0", []),
+            prefill=prefill,
+            result_mode="cached_final",
+        )
+        batch.paged_prefill_entries.append(entry)
+
+        runner._start_paged_forward(
+            batch=batch,
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        self._patch_sampling(monkeypatch, prefill_tokens=[42], decode_tokens=[])
+        runner._sample_paged_batch()
+
+        state = runner._request_states["req-0"]
+        assert state.mrope_position_delta == -2
+
+
 class TestMmPrefillFullPromptRequired:
     def test_raises_when_full_prompt_missing(self) -> None:
         adapter = _MmAdapter()

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -519,7 +519,7 @@ class TestMmPrefillDeltaRoundTrip:
         runner.encoder_cache.add_request("req-0", features)
         _put_encode(runner, "img-0", hidden_states=mx.ones((1, adapter.hidden_size)))
         # Pre-existing state from a prior intermediate chunk — delta
-        # not yet stashed (mirrors the gap this fix closes).
+        # not yet stashed.
         runner._request_states["req-0"] = RequestState(
             token_ids=[99, 11],  # prompt only (no sampled token yet)
             prompt_len=2,

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for paged forward multimodal splice + per-segment positions."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLVisionEncodeResult
+from vllm_metal.paged_attention_common import get_context
+from vllm_metal.v1.mm import EncoderCache
+from vllm_metal.v1.model_runner import PrefillRequest, RequestState
+from vllm_metal.v1.spec_decode import PagedDecodeSegment
+
+
+def _feature(identifier: str, *, offset: int, length: int) -> MultiModalFeatureSpec:
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+class _MmAdapter:
+    """Fake adapter that records call_lm + supplies stable positions."""
+
+    forward_ready = True
+
+    def __init__(self, *, hidden_size: int = 4, vocab_size: int = 8) -> None:
+        self.hidden_size = hidden_size
+        self.vocab_size = vocab_size
+        self.call_lm_calls: list[dict[str, Any]] = []
+
+    def text_model(self) -> Any:
+        return MagicMock(
+            return_value=MagicMock(
+                logits=mx.zeros((1, 1, self.vocab_size), dtype=mx.float32)
+            )
+        )
+
+    def embed_tokens(self, input_ids: mx.array) -> mx.array:
+        batch, seq_len = input_ids.shape
+        return mx.zeros((batch, seq_len, self.hidden_size), dtype=mx.float32)
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[mx.array, int]:
+        # Deterministic positions: sequential arange tiled across 3 sections.
+        # The delta is -2 to mirror the typical Qwen3-VL image squeeze.
+        seq_len = len(input_tokens)
+        positions = mx.arange(seq_len, dtype=mx.int32)
+        positions = mx.broadcast_to(positions[None, None, :], (3, 1, seq_len))
+        return positions, -2
+
+    def call_lm(
+        self,
+        input_ids: mx.array,
+        inputs_embeds: mx.array,
+        cache: list[Any],
+        position_ids: mx.array,
+        *,
+        visual_pos_masks: Any | None = None,
+        deepstack_visual_embeds: Any | None = None,
+    ) -> Any:
+        self.call_lm_calls.append(
+            {
+                "input_ids": input_ids,
+                "inputs_embeds": inputs_embeds,
+                "cache": cache,
+                "position_ids": position_ids,
+                "visual_pos_masks": visual_pos_masks,
+                "deepstack_visual_embeds": deepstack_visual_embeds,
+            }
+        )
+        batch, seq_len = input_ids.shape
+        return MagicMock(
+            logits=mx.zeros((batch, seq_len, self.vocab_size), dtype=mx.float32)
+        )
+
+
+def _runner(adapter: _MmAdapter, *, num_layers: int = 1):
+    runner = make_stub_runner(
+        encoder_cache=EncoderCache(),
+        _is_vlm=True,
+        _paged_attention_backend=MagicMock(),
+        _paged_block_size=16,
+        num_layers=num_layers,
+        model_args={"vocab_size": adapter.vocab_size},
+    )
+    runner._multimodal_adapter = adapter
+    runner._spec_decode_controller = MagicMock()
+    # Each test sets build_decode_segments return per-need.
+    return runner
+
+
+def _scheduler_output() -> MagicMock:
+    out = MagicMock()
+    out.scheduled_spec_decode_tokens = {}
+    return out
+
+
+def _put_encode(
+    runner,
+    identifier: str,
+    *,
+    hidden_states: mx.array,
+    deepstack: Any | None = None,
+) -> None:
+    runner.encoder_cache.encoder_outputs[identifier] = Qwen3VLVisionEncodeResult(
+        hidden_states=hidden_states,
+        deepstack_visual_embeds=deepstack,
+    )
+
+
+def _mm_prefill(
+    req_id: str,
+    *,
+    token_ids: list[int],
+    prompt_len: int,
+    start_pos: int = 0,
+    full_prompt: list[int] | None = None,
+) -> PrefillRequest:
+    return PrefillRequest(
+        req_id=req_id,
+        token_ids=token_ids,
+        sampling_params=SamplingParams(temperature=0.0),
+        block_ids=[0],
+        generator=None,
+        prompt_len=prompt_len,
+        start_pos=start_pos,
+        full_prompt_token_ids=full_prompt,
+    )
+
+
+class TestSingleMmPrefillNoChunking:
+    def test_routes_through_call_lm_with_splice_and_positions(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=1, length=2)]
+        runner.encoder_cache.add_request("req-0", features)
+        _put_encode(runner, "img-0", hidden_states=mx.ones((2, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[10, 99, 99, 11],
+            prompt_len=4,
+            start_pos=0,
+            full_prompt=[10, 99, 99, 11],
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        assert len(adapter.call_lm_calls) == 1
+        call = adapter.call_lm_calls[0]
+        # input_ids shape (1, total=4); position_ids (3, 1, 4).
+        assert call["input_ids"].shape == (1, 4)
+        assert call["position_ids"].shape == (3, 1, 4)
+        # Visual mask covers placeholder tokens at offsets 1 and 2.
+        assert call["visual_pos_masks"].tolist() == [[False, True, True, False]]
+        # No deepstack supplied → adapter sees None.
+        assert call["deepstack_visual_embeds"] is None
+        # Spliced rows at placeholder positions equal the encoder hidden_states (1.0).
+        embeds = call["inputs_embeds"]
+        assert mx.allclose(
+            embeds[0, 1], mx.ones(adapter.hidden_size, dtype=mx.float32)
+        ).item()
+        assert mx.allclose(
+            embeds[0, 2], mx.ones(adapter.hidden_size, dtype=mx.float32)
+        ).item()
+
+
+class TestMmPrefillChunkedFeatureSlicing:
+    def test_cross_chunk_feature_slices_hidden_states_and_mask(self) -> None:
+        # Feature spans global positions 2..7 (length=6).  Chunk 2 covers
+        # global positions 4..7 (start_pos=4, len=4), so the chunk-local
+        # mask should be positions 0..3 and the encoder hidden_states
+        # rows 2..5 should be the ones that land in this chunk.
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=2, length=6)]
+        runner.encoder_cache.add_request("req-0", features)
+        # 6 placeholder rows in the encoder output; rows i carry value
+        # ``float(i + 10)`` so we can spot which subset is spliced.
+        hidden = mx.array([[float(i + 10)] * adapter.hidden_size for i in range(6)])
+        _put_encode(runner, "img-0", hidden_states=hidden)
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[99] * 4,
+            prompt_len=8,
+            start_pos=4,
+            full_prompt=[1, 1, 99, 99, 99, 99, 99, 99],
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        call = adapter.call_lm_calls[0]
+        # All 4 chunk tokens are placeholders.
+        assert call["visual_pos_masks"].tolist() == [[True, True, True, True]]
+        # The spliced rows should carry feature-local indices 2..5 (values 12..15).
+        embeds = call["inputs_embeds"]
+        for chunk_local, feature_local in enumerate(range(2, 6)):
+            value = float(feature_local + 10)
+            assert mx.allclose(
+                embeds[0, chunk_local],
+                mx.full((adapter.hidden_size,), value, dtype=mx.float32),
+            ).item()
+
+
+class TestMmDecodeSegmentPositions:
+    def test_decode_positions_use_cache_start_pos_plus_delta(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        # State carries delta = -3; cache_start_pos = 5, n=1 →
+        # M-RoPE position = [5 + -3] = [2], tiled across 3 sections.
+        state = RequestState(
+            token_ids=[1, 2, 3, 4, 5, 6],
+            prompt_len=5,
+            cache=[],
+            sampling_params=SamplingParams(),
+            mrope_position_delta=-3,
+        )
+        runner._request_states["req-mm"] = state
+
+        segment = PagedDecodeSegment(
+            req_id="req-mm",
+            input_token_ids=(6,),
+            start_row=0,
+            num_query_tokens=1,
+            draft_token_ids=(),
+            cache_start_pos=5,
+            block_ids=(0,),
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=(segment,)
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[],
+            decode_reqs=[("req-mm", state)],
+            scheduler_output=_scheduler_output(),
+        )
+
+        call = adapter.call_lm_calls[0]
+        assert call["position_ids"].shape == (3, 1, 1)
+        assert call["position_ids"].tolist() == [[[2]], [[2]], [[2]]]
+        # No visual mask positions on a decode token.
+        assert call["visual_pos_masks"].tolist() == [[False]]
+
+    def test_spec_decode_multi_query_arange_plus_delta(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        state = RequestState(
+            token_ids=[1, 2, 3, 4, 5, 6],
+            prompt_len=5,
+            cache=[],
+            sampling_params=SamplingParams(),
+            mrope_position_delta=-3,
+        )
+        runner._request_states["req-mm"] = state
+        # 3 draft rows + 1 bonus row = 4 query tokens, cache_start_pos=5.
+        # Expected positions = arange(5, 5+4) + -3 = [2, 3, 4, 5] tiled.
+        segment = PagedDecodeSegment(
+            req_id="req-mm",
+            input_token_ids=(6, 100, 101, 102),
+            start_row=0,
+            num_query_tokens=4,
+            draft_token_ids=(100, 101, 102),
+            cache_start_pos=5,
+            block_ids=(0,),
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=(segment,)
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[],
+            decode_reqs=[("req-mm", state)],
+            scheduler_output=_scheduler_output(),
+        )
+
+        call = adapter.call_lm_calls[0]
+        assert call["position_ids"].shape == (3, 1, 4)
+        assert call["position_ids"].tolist() == [
+            [[2, 3, 4, 5]],
+            [[2, 3, 4, 5]],
+            [[2, 3, 4, 5]],
+        ]
+
+
+class TestMixedMmAndText:
+    def test_text_prefill_alongside_mm_prefill_gets_none_segment_positions(
+        self,
+    ) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=0, length=2)]
+        runner.encoder_cache.add_request("req-mm", features)
+        _put_encode(runner, "img-0", hidden_states=mx.ones((2, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        captured_ctx: dict[str, Any] = {}
+
+        original_call_lm = adapter.call_lm
+
+        def capturing_call_lm(*args, **kwargs):
+            ctx = get_context()
+            captured_ctx["segment_positions"] = list(ctx.segment_positions)
+            return original_call_lm(*args, **kwargs)
+
+        adapter.call_lm = capturing_call_lm  # type: ignore[method-assign]
+
+        mm_prefill = _mm_prefill(
+            "req-mm",
+            token_ids=[99, 99],
+            prompt_len=2,
+            start_pos=0,
+            full_prompt=[99, 99],
+        )
+        text_prefill = PrefillRequest(
+            req_id="req-text",
+            token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(temperature=0.0),
+            block_ids=[1],
+            generator=None,
+            prompt_len=3,
+            start_pos=0,
+            full_prompt_token_ids=None,
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[mm_prefill, text_prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        seg_positions = captured_ctx["segment_positions"]
+        # Two prefill segments: mm first, then text.
+        assert len(seg_positions) == 2
+        # mm segment: caller-supplied positions (shape (3, 1, 2)).
+        assert seg_positions[0] is not None
+        assert seg_positions[0].shape == (3, 1, 2)
+        # text segment: None so attention falls back to int-offset arange.
+        assert seg_positions[1] is None
+
+
+class TestDeepstackPerChunkSlice:
+    def test_deepstack_concat_across_features_uses_chunk_slice(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        # Two features, both spanning length 2 within a single chunk.
+        # Feature A at offset 1, feature B at offset 5.  Each carries one
+        # deepstack layer with distinct values so we can verify the
+        # per-feature concat order and slicing.
+        features = [
+            _feature("img-A", offset=1, length=2),
+            _feature("img-B", offset=5, length=2),
+        ]
+        runner.encoder_cache.add_request("req-0", features)
+        _put_encode(
+            runner,
+            "img-A",
+            hidden_states=mx.zeros((2, adapter.hidden_size)),
+            deepstack=[mx.array([[1.0, 1.0], [2.0, 2.0]])],
+        )
+        _put_encode(
+            runner,
+            "img-B",
+            hidden_states=mx.zeros((2, adapter.hidden_size)),
+            deepstack=[mx.array([[3.0, 3.0], [4.0, 4.0]])],
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[0, 99, 99, 0, 0, 99, 99, 0],
+            prompt_len=8,
+            start_pos=0,
+            full_prompt=[0, 99, 99, 0, 0, 99, 99, 0],
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        call = adapter.call_lm_calls[0]
+        ds = call["deepstack_visual_embeds"]
+        assert ds is not None
+        assert len(ds) == 1
+        # Layer 0: A's two rows then B's two rows in offset order.
+        assert mx.allclose(
+            ds[0],
+            mx.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]]),
+        ).item()
+
+
+class TestMmPrefillFullPromptRequired:
+    def test_raises_when_full_prompt_missing(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        features = [_feature("img-0", offset=0, length=1)]
+        runner.encoder_cache.add_request("req-0", features)
+        _put_encode(runner, "img-0", hidden_states=mx.ones((1, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[99],
+            prompt_len=1,
+            start_pos=0,
+            full_prompt=None,  # missing!
+        )
+
+        with pytest.raises(RuntimeError, match="full_prompt_token_ids"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[prefill],
+                decode_reqs=[],
+                scheduler_output=_scheduler_output(),
+            )

--- a/tests/v1/mm/test_paged_forward_mm_gate.py
+++ b/tests/v1/mm/test_paged_forward_mm_gate.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for paged forward multimodal gating + ctx.segment_positions field."""
+"""Tests for paged forward multimodal fail-fast + ctx.segment_positions field.
+
+The successful mm paged forward is exercised in
+``test_paged_forward_mm.py``; this file holds the fail-fast invariants:
+a misconfigured adapter (``forward_ready=False`` or no adapter) must
+not allow an mm request to slip into the text path silently.
+"""
 
 from __future__ import annotations
 
@@ -36,10 +42,8 @@ class TestPagedAttentionContextSegmentPositions:
         assert ctx.segment_positions is positions
 
 
-class TestStartPagedForwardMmGate:
-    def _runner(self, *, forward_ready: bool):
-        adapter = MagicMock()
-        adapter.forward_ready = forward_ready
+class TestStartPagedForwardMmFailFast:
+    def _runner(self, *, adapter):
         runner = make_stub_runner(
             encoder_cache=EncoderCache(),
             _is_vlm=True,
@@ -48,7 +52,6 @@ class TestStartPagedForwardMmGate:
         )
         runner._multimodal_adapter = adapter
         runner._spec_decode_controller = MagicMock()
-        # No spec decode segments
         runner._spec_decode_controller.build_decode_segments = MagicMock(
             return_value=[]
         )
@@ -59,55 +62,10 @@ class TestStartPagedForwardMmGate:
         out.scheduled_spec_decode_tokens = {}
         return out
 
-    def test_raises_when_mm_prefill_with_forward_ready(self) -> None:
-        runner = self._runner(forward_ready=True)
-        runner.encoder_cache.add_request("req-mm", [_feature("img-0")])
-
-        from vllm_metal.v1.model_runner import PrefillRequest
-
-        prefill = PrefillRequest(
-            req_id="req-mm",
-            token_ids=[1, 99, 11],
-            sampling_params=SamplingParams(temperature=0.0),
-            block_ids=[0],
-            generator=None,
-            prompt_len=3,
-            start_pos=0,
-            full_prompt_token_ids=[1, 99, 11],
-        )
-
-        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
-            runner._start_paged_forward(
-                batch=MagicMock(),
-                prefill_reqs=[prefill],
-                decode_reqs=[],
-                scheduler_output=self._scheduler_output(),
-            )
-
-    def test_raises_when_mm_decode_with_forward_ready(self) -> None:
-        runner = self._runner(forward_ready=True)
-        state = RequestState(
-            token_ids=[1, 2, 3],
-            prompt_len=2,
-            cache=[],
-            sampling_params=SamplingParams(),
-            mrope_position_delta=-1,
-        )
-
-        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
-            runner._start_paged_forward(
-                batch=MagicMock(),
-                prefill_reqs=[],
-                decode_reqs=[("req-mm", state)],
-                scheduler_output=self._scheduler_output(),
-            )
-
     def test_raises_when_mm_with_forward_ready_false(self) -> None:
-        # The gate is unconditional w.r.t. adapter.forward_ready — a
-        # misconfigured adapter (gate off but mm request still reaches
-        # paged forward) must not silently fall through to the text
-        # path.  Mirrors C's _prefill_single fail-fast.
-        runner = self._runner(forward_ready=False)
+        adapter = MagicMock()
+        adapter.forward_ready = False
+        runner = self._runner(adapter=adapter)
         runner.encoder_cache.add_request("req-mm", [_feature("img-0")])
 
         from vllm_metal.v1.model_runner import PrefillRequest
@@ -123,7 +81,7 @@ class TestStartPagedForwardMmGate:
             full_prompt_token_ids=[1, 99, 11],
         )
 
-        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
+        with pytest.raises(RuntimeError, match="adapter is not forward_ready"):
             runner._start_paged_forward(
                 batch=MagicMock(),
                 prefill_reqs=[prefill],
@@ -132,9 +90,7 @@ class TestStartPagedForwardMmGate:
             )
 
     def test_raises_when_mm_with_no_adapter(self) -> None:
-        # No adapter at all: the gate still fires so the runner cannot
-        # silently produce wrong output for an mm request.
-        runner = self._runner(forward_ready=False)
+        runner = self._runner(adapter=None)
         runner._multimodal_adapter = None
         runner.encoder_cache.add_request("req-mm", [_feature("img-0")])
 
@@ -151,10 +107,30 @@ class TestStartPagedForwardMmGate:
             full_prompt_token_ids=[1, 99, 11],
         )
 
-        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
+        with pytest.raises(RuntimeError, match="adapter is not forward_ready"):
             runner._start_paged_forward(
                 batch=MagicMock(),
                 prefill_reqs=[prefill],
                 decode_reqs=[],
+                scheduler_output=self._scheduler_output(),
+            )
+
+    def test_raises_when_mm_decode_with_forward_ready_false(self) -> None:
+        adapter = MagicMock()
+        adapter.forward_ready = False
+        runner = self._runner(adapter=adapter)
+        state = RequestState(
+            token_ids=[1, 2, 3],
+            prompt_len=2,
+            cache=[],
+            sampling_params=SamplingParams(),
+            mrope_position_delta=-1,
+        )
+
+        with pytest.raises(RuntimeError, match="adapter is not forward_ready"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[],
+                decode_reqs=[("req-mm", state)],
                 scheduler_output=self._scheduler_output(),
             )

--- a/tests/v1/mm/test_paged_forward_mm_gate.py
+++ b/tests/v1/mm/test_paged_forward_mm_gate.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for paged forward multimodal gating + ctx.segment_positions field."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+from vllm_metal.paged_attention_common import PagedAttentionContext
+from vllm_metal.v1.mm import EncoderCache
+from vllm_metal.v1.model_runner import RequestState
+
+
+def _feature(identifier: str) -> MultiModalFeatureSpec:
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=0, length=1),
+    )
+
+
+class TestPagedAttentionContextSegmentPositions:
+    def test_field_defaults_to_none(self) -> None:
+        ctx = PagedAttentionContext(slot_mapping=[])
+        assert ctx.segment_positions is None
+
+    def test_field_carries_per_segment_entries(self) -> None:
+        positions = [None, mx.array([[[0, 1, 2]]] * 3, dtype=mx.int32)]
+        ctx = PagedAttentionContext(slot_mapping=[], segment_positions=positions)
+        assert ctx.segment_positions is positions
+
+
+class TestStartPagedForwardMmGate:
+    def _runner(self, *, forward_ready: bool):
+        adapter = MagicMock()
+        adapter.forward_ready = forward_ready
+        runner = make_stub_runner(
+            encoder_cache=EncoderCache(),
+            _is_vlm=True,
+            _paged_attention_backend=MagicMock(),
+            _paged_block_size=16,
+        )
+        runner._multimodal_adapter = adapter
+        runner._spec_decode_controller = MagicMock()
+        # No spec decode segments
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=[]
+        )
+        return runner
+
+    def _scheduler_output(self) -> MagicMock:
+        out = MagicMock()
+        out.scheduled_spec_decode_tokens = {}
+        return out
+
+    def test_raises_when_mm_prefill_with_forward_ready(self) -> None:
+        runner = self._runner(forward_ready=True)
+        runner.encoder_cache.add_request("req-mm", [_feature("img-0")])
+
+        from vllm_metal.v1.model_runner import PrefillRequest
+
+        prefill = PrefillRequest(
+            req_id="req-mm",
+            token_ids=[1, 99, 11],
+            sampling_params=SamplingParams(temperature=0.0),
+            block_ids=[0],
+            generator=None,
+            prompt_len=3,
+            start_pos=0,
+            full_prompt_token_ids=[1, 99, 11],
+        )
+
+        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[prefill],
+                decode_reqs=[],
+                scheduler_output=self._scheduler_output(),
+            )
+
+    def test_raises_when_mm_decode_with_forward_ready(self) -> None:
+        runner = self._runner(forward_ready=True)
+        state = RequestState(
+            token_ids=[1, 2, 3],
+            prompt_len=2,
+            cache=[],
+            sampling_params=SamplingParams(),
+            mrope_position_delta=-1,
+        )
+
+        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[],
+                decode_reqs=[("req-mm", state)],
+                scheduler_output=self._scheduler_output(),
+            )
+
+    def test_raises_when_mm_with_forward_ready_false(self) -> None:
+        # The gate is unconditional w.r.t. adapter.forward_ready — a
+        # misconfigured adapter (gate off but mm request still reaches
+        # paged forward) must not silently fall through to the text
+        # path.  Mirrors C's _prefill_single fail-fast.
+        runner = self._runner(forward_ready=False)
+        runner.encoder_cache.add_request("req-mm", [_feature("img-0")])
+
+        from vllm_metal.v1.model_runner import PrefillRequest
+
+        prefill = PrefillRequest(
+            req_id="req-mm",
+            token_ids=[1, 99, 11],
+            sampling_params=SamplingParams(temperature=0.0),
+            block_ids=[0],
+            generator=None,
+            prompt_len=3,
+            start_pos=0,
+            full_prompt_token_ids=[1, 99, 11],
+        )
+
+        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[prefill],
+                decode_reqs=[],
+                scheduler_output=self._scheduler_output(),
+            )
+
+    def test_raises_when_mm_with_no_adapter(self) -> None:
+        # No adapter at all: the gate still fires so the runner cannot
+        # silently produce wrong output for an mm request.
+        runner = self._runner(forward_ready=False)
+        runner._multimodal_adapter = None
+        runner.encoder_cache.add_request("req-mm", [_feature("img-0")])
+
+        from vllm_metal.v1.model_runner import PrefillRequest
+
+        prefill = PrefillRequest(
+            req_id="req-mm",
+            token_ids=[1, 99, 11],
+            sampling_params=SamplingParams(temperature=0.0),
+            block_ids=[0],
+            generator=None,
+            prompt_len=3,
+            start_pos=0,
+            full_prompt_token_ids=[1, 99, 11],
+        )
+
+        with pytest.raises(NotImplementedError, match="Paged forward with multimodal"):
+            runner._start_paged_forward(
+                batch=MagicMock(),
+                prefill_reqs=[prefill],
+                decode_reqs=[],
+                scheduler_output=self._scheduler_output(),
+            )

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -246,6 +246,7 @@ def prepare_sdpa_qkv(
             ctx.cu_seqlens,
             offsets=ctx.offsets if ctx.offsets else None,
             apply_keys=False,
+            positions=ctx.segment_positions,
         )
     else:
         if not packed_qkv:
@@ -280,6 +281,7 @@ def prepare_sdpa_qkv(
             keys,
             ctx.cu_seqlens,
             offsets=ctx.offsets if ctx.offsets else None,
+            positions=ctx.segment_positions,
         )
 
     kv_for_sharing = (keys, values)

--- a/vllm_metal/metal_kernel_backend/packed_prefill_compat.py
+++ b/vllm_metal/metal_kernel_backend/packed_prefill_compat.py
@@ -33,6 +33,25 @@ def _apply_mrope_segment(
     return apply_multimodal_rotary_pos_emb(q_seg, k_seg, cos, sin)
 
 
+def _apply_mrope_segment_with_positions(
+    rotary_emb: Callable[..., tuple[mx.array, mx.array]],
+    q_seg: mx.array,
+    k_seg: mx.array,
+    position_ids: mx.array,
+) -> tuple[mx.array, mx.array]:
+    """Apply M-RoPE with caller-supplied ``(3, 1, seg_len)`` positions.
+
+    Used for multimodal segments where the position policy is non-trivial
+    (image M-RoPE alignment shifts every section independently); the
+    caller computes positions through ``adapter.get_mrope_input_positions``
+    and slices the relevant chunk into this segment.
+    """
+    from mlx_vlm.models.qwen3_5.language import apply_multimodal_rotary_pos_emb
+
+    cos, sin = rotary_emb(q_seg, position_ids)  # type: ignore[operator]
+    return apply_multimodal_rotary_pos_emb(q_seg, k_seg, cos, sin)
+
+
 def apply_packed_rope(
     attn_module: object,
     queries: mx.array,
@@ -40,14 +59,24 @@ def apply_packed_rope(
     cu_seqlens: list[int],
     offsets: list[int] | None = None,
     apply_keys: bool = True,
+    *,
+    positions: list[mx.array | None] | None = None,
 ) -> tuple[mx.array, mx.array]:
     """Apply per-request RoPE for packed sequences.
 
-    Each segment delimited by ``cu_seqlens`` gets its own RoPE application
-    starting at the corresponding offset.  When *offsets* is ``None`` every
-    segment starts at position 0 (pure prefill).  For unified prefill+decode
-    batches, decode segments carry ``offset=seq_len`` while prefill segments
-    keep ``offset=0``.
+    Each segment delimited by ``cu_seqlens`` gets its own RoPE application.
+    When *offsets* is ``None`` every segment starts at position 0 (pure
+    prefill).  For unified prefill+decode batches, decode segments carry
+    ``offset=seq_len`` while prefill segments keep ``offset=0``.
+
+    When *positions* is supplied, an entry of ``positions[i]`` that is not
+    ``None`` takes precedence over ``offsets[i]`` and is fed to the
+    M-RoPE rotary embedding directly as the ``(3, 1, seg_len)`` position
+    array.  This is the path multimodal prefill takes: the caller computes
+    Qwen3-VL M-RoPE positions on the full prompt then slices the relevant
+    chunk for this segment.  Caller-supplied positions are only honored on
+    the M-RoPE path (``attn_module.rotary_emb``); the mlx_lm ``rope(x,
+    offset=)`` API has no position-array slot and raises if combined.
 
     When ``apply_keys`` is False, keys are returned unchanged (used by
     YOCO KV sharing where keys arrive already RoPE'd from a prior layer).
@@ -64,10 +93,17 @@ def apply_packed_rope(
         start = cu_seqlens[i]
         end = cu_seqlens[i + 1]
         off = offsets[i] if offsets is not None else 0
+        seg_pos = positions[i] if positions is not None else None
         q_seg = queries[:, :, start:end, :]
 
         if rope_fn is not None:
             # mlx_lm API: rope(x, offset=off) → rotated_x
+            if seg_pos is not None:
+                raise NotImplementedError(
+                    "apply_packed_rope: caller-provided positions are only "
+                    "supported for M-RoPE (rotary_emb); the mlx_lm rope(x, "
+                    "offset=) API has no position-array slot."
+                )
             q_parts.append(rope_fn(q_seg, offset=off))
             if apply_keys:
                 k_seg = keys[:, :, start:end, :]
@@ -75,7 +111,12 @@ def apply_packed_rope(
         else:
             # mlx_vlm M-RoPE API: rotary_emb(x, position_ids) → (cos, sin)
             k_seg = keys[:, :, start:end, :]
-            q_rot, k_rot = _apply_mrope_segment(rotary_emb, q_seg, k_seg, off)
+            if seg_pos is not None:
+                q_rot, k_rot = _apply_mrope_segment_with_positions(
+                    rotary_emb, q_seg, k_seg, seg_pos
+                )
+            else:
+                q_rot, k_rot = _apply_mrope_segment(rotary_emb, q_seg, k_seg, off)
             q_parts.append(q_rot)
             if apply_keys:
                 k_parts.append(k_rot)

--- a/vllm_metal/multimodal/qwen3_vl/__init__.py
+++ b/vllm_metal/multimodal/qwen3_vl/__init__.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
-from vllm_metal.multimodal.qwen3_vl.adapter import Qwen3VLMultimodalAdapter
+from vllm_metal.multimodal.qwen3_vl.adapter import (
+    Qwen3VLMultimodalAdapter,
+    Qwen3VLVisionEncodeResult,
+)
 
-__all__ = ["Qwen3VLMultimodalAdapter"]
+__all__ = ["Qwen3VLVisionEncodeResult", "Qwen3VLMultimodalAdapter"]

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -41,6 +41,11 @@ class Qwen3VLMultimodalAdapter:
         "input_embeddings",
     )
 
+    _DEEPSTACK_KWARGS: tuple[str, ...] = (
+        "visual_pos_masks",
+        "deepstack_visual_embeds",
+    )
+
     def __init__(
         self,
         *,
@@ -49,6 +54,7 @@ class Qwen3VLMultimodalAdapter:
         language_model: Any | None = None,
         embeds_kwarg: str | None = None,
         embed_tokens_fn: Callable[[Any], Any] | None = None,
+        supports_deepstack: bool = False,
     ) -> None:
         if spatial_merge_size <= 0:
             raise ValueError(
@@ -59,6 +65,7 @@ class Qwen3VLMultimodalAdapter:
         self._language_model = language_model
         self._embeds_kwarg = embeds_kwarg
         self._embed_tokens_fn = embed_tokens_fn
+        self._supports_deepstack = supports_deepstack
 
     def text_model(self) -> Any:
         """Return the loaded Qwen3-VL language model."""
@@ -72,12 +79,14 @@ class Qwen3VLMultimodalAdapter:
         spatial_merge_size = int(model.config.vision_config.spatial_merge_size)
         embeds_kwarg = cls._detect_embeds_kwarg(language_model)
         embed_tokens_fn = cls._resolve_embed_tokens(language_model)
+        supports_deepstack = cls._detect_deepstack_kwargs(language_model)
         return cls(
             spatial_merge_size=spatial_merge_size,
             vision_tower=vision_tower,
             language_model=language_model,
             embeds_kwarg=embeds_kwarg,
             embed_tokens_fn=embed_tokens_fn,
+            supports_deepstack=supports_deepstack,
         )
 
     @classmethod
@@ -133,6 +142,34 @@ class Qwen3VLMultimodalAdapter:
             f"{cls._SUPPORTED_EMBEDS_KWARGS}; mlx_vlm version drift detected. "
             f"Got parameters: {sorted(params)}"
         )
+
+    @classmethod
+    def _detect_deepstack_kwargs(cls, language_model: Any) -> bool:
+        """Return True iff the LM declares both deepstack params explicitly.
+
+        mlx-vlm 0.5.x Qwen3-VL's ``LanguageModel.__call__`` takes
+        ``visual_pos_masks`` and ``deepstack_visual_embeds`` as named
+        parameters and runs ``_deepstack_process``; 0.4.x's qwen3_5 LM
+        exposes only ``**kwargs``.  Only the explicit form counts as
+        support, so a LM with ``**kwargs`` does not silently absorb
+        deepstack arrays into a dropped catch-all.
+        """
+        try:
+            sig = inspect.signature(language_model.__call__)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Cannot inspect language_model.__call__ signature: {exc}"
+            ) from exc
+        explicit = {
+            name
+            for name, param in sig.parameters.items()
+            if param.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        }
+        return all(kw in explicit for kw in cls._DEEPSTACK_KWARGS)
 
     def embed_tokens(self, input_ids: mx.array) -> mx.array:
         """Return the language model's input embeddings for ``input_ids``.
@@ -218,6 +255,9 @@ class Qwen3VLMultimodalAdapter:
         inputs_embeds: mx.array,
         cache: list[Any],
         position_ids: mx.array,
+        *,
+        visual_pos_masks: Any | None = None,
+        deepstack_visual_embeds: Any | None = None,
     ) -> Any:
         """Invoke ``language_model`` with runner-built embeds and positions.
 
@@ -226,6 +266,13 @@ class Qwen3VLMultimodalAdapter:
         embeds keyword is the one sniffed at construction so version drift
         between ``inputs_embeds`` and ``input_embeddings`` surfaces at load
         time instead of inside attention.
+
+        ``visual_pos_masks`` and ``deepstack_visual_embeds`` are forwarded
+        only when the language model declares both deepstack parameters
+        explicitly (mlx-vlm 0.5.x).  On 0.4.x qwen3_5 the LM signature
+        exposes only ``**kwargs``; passing arrays into that catch-all
+        would silently drop them, so the adapter omits the kwargs entirely
+        instead of relying on the LM's tolerance.
         """
         if self._language_model is None:
             raise RuntimeError(
@@ -238,11 +285,16 @@ class Qwen3VLMultimodalAdapter:
                 "Qwen3VLMultimodalAdapter.from_loaded_model so the language "
                 "model signature is sniffed at load time."
             )
+        extra_kwargs: dict[str, Any] = {}
+        if self._supports_deepstack:
+            extra_kwargs["visual_pos_masks"] = visual_pos_masks
+            extra_kwargs["deepstack_visual_embeds"] = deepstack_visual_embeds
         return self._language_model(
             input_ids,
             cache=cache,
             position_ids=position_ids,
             **{self._embeds_kwarg: inputs_embeds},
+            **extra_kwargs,
         )
 
     @staticmethod

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import cache
 from types import SimpleNamespace
@@ -23,7 +23,7 @@ class Qwen3VLVisionEncodeResult:
     """Vision tower output for one Qwen3-VL multimodal feature."""
 
     hidden_states: mx.array
-    deepstack_visual_embeds: Any | None
+    deepstack_visual_embeds: Sequence[mx.array] | None
 
 
 class Qwen3VLMultimodalAdapter:
@@ -238,9 +238,11 @@ class Qwen3VLMultimodalAdapter:
         """Invoke ``language_model`` with runner-built embeds and positions.
 
         Calls ``language_model`` directly rather than through the top-level
-        ``mlx_vlm.Model.__call__``.  Deepstack kwargs are forwarded only
-        when the LM declares both as explicit parameters; otherwise they
-        are omitted to avoid silently dropping arrays into ``**kwargs``.
+        ``mlx_vlm.Model.__call__``.  Deepstack kwargs are forwarded when
+        the LM declares both as explicit parameters.  Receiving non-None
+        ``deepstack_visual_embeds`` on a LM without those parameters is a
+        mlx-vlm signature mismatch and raises rather than silently running
+        with incomplete vision residuals.
         """
         if self._language_model is None:
             raise RuntimeError(
@@ -257,6 +259,14 @@ class Qwen3VLMultimodalAdapter:
         if self._supports_deepstack:
             extra_kwargs["visual_pos_masks"] = visual_pos_masks
             extra_kwargs["deepstack_visual_embeds"] = deepstack_visual_embeds
+        elif deepstack_visual_embeds is not None:
+            raise RuntimeError(
+                "deepstack_visual_embeds were produced by the vision tower "
+                "but language_model.__call__ does not declare "
+                f"{self._DEEPSTACK_KWARGS} as explicit parameters; mlx-vlm "
+                "signature mismatch.  Refusing to drop deepstack residuals "
+                "silently."
+            )
         return self._language_model(
             input_ids,
             cache=cache,

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -90,9 +90,7 @@ class Qwen3VLMultimodalAdapter:
         )
 
     @classmethod
-    def _resolve_embed_tokens(
-        cls, language_model: Any
-    ) -> Callable[[Any], Any]:
+    def _resolve_embed_tokens(cls, language_model: Any) -> Callable[[Any], Any]:
         """Return ``language_model.model.embed_tokens`` or raise.
 
         mlx-vlm 0.4.x Qwen3-VL/Qwen3.5 routes text embedding through

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -16,6 +16,13 @@ from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 class Qwen3VLMultimodalAdapter:
     """Model-owned multimodal helpers for the Qwen3-VL execution path."""
 
+    forward_ready: bool = False
+    """Closed until the Phase 4 parity test against pure mlx_vlm/mlx_lm or
+    upstream vLLM passes (RFC #319).  ``MetalModelRunner`` consults this
+    flag to gate ``_reject_scheduled_encoder_inputs`` so future adapters
+    can land at ``False`` without disturbing the model already in
+    production."""
+
     def __init__(
         self,
         *,

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -261,15 +261,20 @@ class Qwen3VLMultimodalAdapter:
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
     ) -> tuple[mx.array, int]:
-        """Return ``((3, seq_len) int32 positions, mrope_position_delta)``.
+        """Return ``((3, 1, seq_len) int32 positions, mrope_position_delta)``.
 
         Calls upstream vLLM's mm_features-driven Qwen3-VL M-RoPE helper with a
         minimal image-only config shim, then converts the returned torch tensor
         to an MLX array.  This keeps the position-building policy upstream-owned
         while the vllm-metal runner can consume MLX arrays.
+
+        The batch axis is materialised here so ``call_lm`` receives the
+        ``(3, batch, seq_len)`` layout mlx-vlm's Qwen3-VL language model
+        expects; prefill carries batch=1 and decode reshapes to
+        ``(3, B, 1)``.
         """
         if not input_tokens:
-            return mx.zeros((3, 0), dtype=mx.int32), 0
+            return mx.zeros((3, 1, 0), dtype=mx.int32), 0
 
         self._validate_image_features(mm_features)
 
@@ -281,7 +286,8 @@ class Qwen3VLMultimodalAdapter:
             )
         )
         llm_positions = torch_positions.cpu().numpy()
-        return mx.array(llm_positions, dtype=mx.int32), int(mrope_position_delta)
+        positions = mx.array(llm_positions, dtype=mx.int32)
+        return positions[:, None, :], int(mrope_position_delta)
 
     def _validate_image_features(
         self,

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -30,11 +30,7 @@ class Qwen3VLMultimodalAdapter:
     """Model-owned multimodal helpers for the Qwen3-VL execution path."""
 
     forward_ready: bool = False
-    """Closed until the Phase 4 parity test against pure mlx_vlm/mlx_lm or
-    upstream vLLM passes (RFC #319).  ``MetalModelRunner`` consults this
-    flag to gate ``_reject_scheduled_encoder_inputs`` so future adapters
-    can land at ``False`` without disturbing the model already in
-    production."""
+    """Closed until parity against ``mlx_vlm.Model.__call__`` passes."""
 
     _SUPPORTED_EMBEDS_KWARGS: tuple[str, ...] = (
         "inputs_embeds",
@@ -93,13 +89,8 @@ class Qwen3VLMultimodalAdapter:
     def _resolve_embed_tokens(cls, language_model: Any) -> Callable[[Any], Any]:
         """Return ``language_model.model.embed_tokens`` or raise.
 
-        mlx-vlm 0.4.x Qwen3-VL/Qwen3.5 routes text embedding through
-        ``language_model.model.embed_tokens`` — the same callable the
-        top-level ``Model.get_input_embeddings`` defers to in text-only
-        mode.  Resolving here keeps the runner away from private model
-        internals (``language_model.model.*`` is not a stable public
-        surface) and converts any rename/restructure into a clear
-        load-time error instead of an attribute-error mid-forward.
+        Resolving at load time turns any rename/restructure into a clear
+        init-time error instead of an attribute-error mid-forward.
         """
         inner = getattr(language_model, "model", None)
         if inner is None:
@@ -120,10 +111,9 @@ class Qwen3VLMultimodalAdapter:
     def _detect_embeds_kwarg(cls, language_model: Any) -> str:
         """Return the embeds keyword accepted by ``language_model.__call__``.
 
-        mlx_vlm 0.4.x uses ``inputs_embeds``; sniffing the signature at adapter
-        construction lets future renames (``input_embeddings``) surface as a
-        clear init-time error rather than silently wrong attention.  RFC #319
-        risk #1.
+        Sniffing at load time turns a rename (``inputs_embeds`` →
+        ``input_embeddings``) into a clear init-time error rather than
+        silently wrong attention.
         """
         try:
             sig = inspect.signature(language_model.__call__)
@@ -145,12 +135,8 @@ class Qwen3VLMultimodalAdapter:
     def _detect_deepstack_kwargs(cls, language_model: Any) -> bool:
         """Return True iff the LM declares both deepstack params explicitly.
 
-        mlx-vlm 0.5.x Qwen3-VL's ``LanguageModel.__call__`` takes
-        ``visual_pos_masks`` and ``deepstack_visual_embeds`` as named
-        parameters and runs ``_deepstack_process``; 0.4.x's qwen3_5 LM
-        exposes only ``**kwargs``.  Only the explicit form counts as
-        support, so a LM with ``**kwargs`` does not silently absorb
-        deepstack arrays into a dropped catch-all.
+        Only the explicit form counts; a LM with just ``**kwargs`` would
+        silently absorb the arrays without injecting deepstack residuals.
         """
         try:
             sig = inspect.signature(language_model.__call__)
@@ -172,10 +158,8 @@ class Qwen3VLMultimodalAdapter:
     def embed_tokens(self, input_ids: mx.array) -> mx.array:
         """Return the language model's input embeddings for ``input_ids``.
 
-        Forwards to the callable resolved at ``from_loaded_model`` time so
-        the runner does not reach into private model internals.  Construct
-        via :meth:`from_loaded_model` for the resolution; manually built
-        instances (e.g. unit tests) must pass ``embed_tokens_fn``.
+        Construct via :meth:`from_loaded_model` so the callable is resolved
+        at load time; manually built instances must pass ``embed_tokens_fn``.
         """
         if self._embed_tokens_fn is None:
             raise RuntimeError(
@@ -191,13 +175,10 @@ class Qwen3VLMultimodalAdapter:
     ) -> list[Qwen3VLVisionEncodeResult]:
         """Run the vision tower per feature; return one result per feature.
 
-        RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__``; route
-        through ``vision_tower`` directly so the LM is not re-entered through
-        the top-level VLM dispatch.  The vision tower returns
-        ``(hidden_states, deepstack_visual_embeds)``.  mlx-vlm 0.4.x returns
-        ``None`` for deepstack because of its reference bug; preserving the
-        field here keeps the adapter contract ready for the mlx-vlm 0.5.x
-        dependency unlock without enabling multimodal forward yet.
+        Calls ``vision_tower`` directly rather than ``mlx_vlm.Model.__call__``
+        so the LM is not re-entered through the top-level VLM dispatch.
+        ``deepstack_visual_embeds`` may be ``None`` when the tower does not
+        expose per-layer residuals.
         """
         if self._vision_tower is None:
             raise RuntimeError(
@@ -224,12 +205,9 @@ class Qwen3VLMultimodalAdapter:
             pixel_values = self._as_mlx(
                 self._feature_value(feature.data, "pixel_values")
             ).astype(target_dtype)
-            # vLLM's MultiModalFieldConfig.batched delivers per-feature
-            # grid_thw as a 1D ``(3,)`` row, but the mlx_vlm vision tower
-            # indexes it as ``grid_thw[i, 1:]`` and reads
-            # ``grid_thw.shape[0]``, so reshape back to ``(1, 3)``.  One
-            # feature carries one image in this PR series; multi-image is
-            # already gated by ``_validate_image_features``.
+            # vLLM delivers per-feature grid_thw as a 1D ``(3,)`` row, but
+            # the mlx_vlm vision tower indexes ``grid_thw[i, 1:]`` and reads
+            # ``grid_thw.shape[0]``; reshape back to ``(1, 3)``.
             image_grid_thw = self._as_mlx(
                 self._feature_value(feature.data, "image_grid_thw")
             ).reshape(1, 3)
@@ -259,18 +237,10 @@ class Qwen3VLMultimodalAdapter:
     ) -> Any:
         """Invoke ``language_model`` with runner-built embeds and positions.
 
-        ``language_model`` is invoked directly rather than through the
-        top-level ``mlx_vlm.Model.__call__`` (RFC #319 hard rule #1), and the
-        embeds keyword is the one sniffed at construction so version drift
-        between ``inputs_embeds`` and ``input_embeddings`` surfaces at load
-        time instead of inside attention.
-
-        ``visual_pos_masks`` and ``deepstack_visual_embeds`` are forwarded
-        only when the language model declares both deepstack parameters
-        explicitly (mlx-vlm 0.5.x).  On 0.4.x qwen3_5 the LM signature
-        exposes only ``**kwargs``; passing arrays into that catch-all
-        would silently drop them, so the adapter omits the kwargs entirely
-        instead of relying on the LM's tolerance.
+        Calls ``language_model`` directly rather than through the top-level
+        ``mlx_vlm.Model.__call__``.  Deepstack kwargs are forwarded only
+        when the LM declares both as explicit parameters; otherwise they
+        are omitted to avoid silently dropping arrays into ``**kwargs``.
         """
         if self._language_model is None:
             raise RuntimeError(
@@ -313,15 +283,8 @@ class Qwen3VLMultimodalAdapter:
     ) -> tuple[mx.array, int]:
         """Return ``((3, 1, seq_len) int32 positions, mrope_position_delta)``.
 
-        Calls upstream vLLM's mm_features-driven Qwen3-VL M-RoPE helper with a
-        minimal image-only config shim, then converts the returned torch tensor
-        to an MLX array.  This keeps the position-building policy upstream-owned
-        while the vllm-metal runner can consume MLX arrays.
-
-        The batch axis is materialised here so ``call_lm`` receives the
-        ``(3, batch, seq_len)`` layout mlx-vlm's Qwen3-VL language model
-        expects; prefill carries batch=1 and decode reshapes to
-        ``(3, B, 1)``.
+        Delegates to upstream vLLM's Qwen3-VL M-RoPE helper, materialises
+        the batch axis, and returns an MLX array shaped for ``call_lm``.
         """
         if not input_tokens:
             return mx.zeros((3, 1, 0), dtype=mx.int32), 0
@@ -343,13 +306,12 @@ class Qwen3VLMultimodalAdapter:
         self,
         features: list[MultiModalFeatureSpec],
     ) -> None:
-        """Validate the image-only feature shape accepted by this PR series."""
+        """Validate the image-only feature shape accepted by the adapter."""
         for feature in sorted(features, key=lambda feature: feature.mm_position.offset):
             modality = feature.modality
             if modality == "video":
                 raise NotImplementedError(
-                    "Video multimodal features are out of scope for the initial "
-                    "Qwen3.5-4B multimodal PR series."
+                    "Video multimodal features are not yet supported."
                 )
             if modality != "image":
                 raise ValueError(f"Unsupported modality: {modality}")
@@ -360,10 +322,7 @@ class Qwen3VLMultimodalAdapter:
 
             t, h, w = self._grid_thw(feature.data, "image_grid_thw")
             if t != 1:
-                raise ValueError(
-                    "Multi-frame images are out of scope for the initial "
-                    f"Qwen3.5-4B multimodal PR series, got t={t}"
-                )
+                raise ValueError(f"Multi-frame images are not yet supported, got t={t}")
 
             llm_grid_h = h // self._spatial_merge_size
             llm_grid_w = w // self._spatial_merge_size

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -3,14 +3,17 @@
 
 from __future__ import annotations
 
+import inspect
 from functools import cache
 from types import SimpleNamespace
 from typing import Any
 
 import mlx.core as mx
+import torch
 from vllm.multimodal.inputs import MultiModalKwargsItem
 
 from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 
 
 class Qwen3VLMultimodalAdapter:
@@ -23,12 +26,18 @@ class Qwen3VLMultimodalAdapter:
     can land at ``False`` without disturbing the model already in
     production."""
 
+    _SUPPORTED_EMBEDS_KWARGS: tuple[str, ...] = (
+        "inputs_embeds",
+        "input_embeddings",
+    )
+
     def __init__(
         self,
         *,
         spatial_merge_size: int,
         vision_tower: Any | None = None,
         language_model: Any | None = None,
+        embeds_kwarg: str | None = None,
     ) -> None:
         if spatial_merge_size <= 0:
             raise ValueError(
@@ -37,6 +46,7 @@ class Qwen3VLMultimodalAdapter:
         self._spatial_merge_size = spatial_merge_size
         self._vision_tower = vision_tower
         self._language_model = language_model
+        self._embeds_kwarg = embeds_kwarg
 
     def text_model(self) -> Any:
         """Return the loaded Qwen3-VL language model."""
@@ -48,11 +58,134 @@ class Qwen3VLMultimodalAdapter:
         vision_tower = model.vision_tower
         language_model = model.language_model
         spatial_merge_size = int(model.config.vision_config.spatial_merge_size)
+        embeds_kwarg = cls._detect_embeds_kwarg(language_model)
         return cls(
             spatial_merge_size=spatial_merge_size,
             vision_tower=vision_tower,
             language_model=language_model,
+            embeds_kwarg=embeds_kwarg,
         )
+
+    @classmethod
+    def _detect_embeds_kwarg(cls, language_model: Any) -> str:
+        """Return the embeds keyword accepted by ``language_model.__call__``.
+
+        mlx_vlm 0.4.x uses ``inputs_embeds``; sniffing the signature at adapter
+        construction lets future renames (``input_embeddings``) surface as a
+        clear init-time error rather than silently wrong attention.  RFC #319
+        risk #1.
+        """
+        try:
+            sig = inspect.signature(language_model.__call__)
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Cannot inspect language_model.__call__ signature: {exc}"
+            ) from exc
+        params = set(sig.parameters)
+        for candidate in cls._SUPPORTED_EMBEDS_KWARGS:
+            if candidate in params:
+                return candidate
+        raise RuntimeError(
+            "language_model.__call__ accepts none of "
+            f"{cls._SUPPORTED_EMBEDS_KWARGS}; mlx_vlm version drift detected. "
+            f"Got parameters: {sorted(params)}"
+        )
+
+    def encode_multimodal(
+        self,
+        features: list[MultiModalFeatureSpec],
+    ) -> list[mx.array]:
+        """Run the vision tower per feature; return one MLX array per feature.
+
+        RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__``; route
+        through ``vision_tower`` directly so the LM is not re-entered through
+        the top-level VLM dispatch.  The vision tower returns
+        ``(hidden_states, deepstack_image_embeds)``; deepstack augmentation is
+        out of scope for the initial Qwen3.5-4B path.
+        """
+        if self._vision_tower is None:
+            raise RuntimeError(
+                "vision_tower not loaded; encode_multimodal unavailable. "
+                "Construct via Qwen3VLMultimodalAdapter.from_loaded_model."
+            )
+
+        # Match the cast that mlx_vlm.Model.get_input_embeddings performs
+        # before invoking the tower: vLLM's multimodal pipeline supplies
+        # pixel_values in fp32, but the loaded MLX vision tower may carry
+        # fp16/bf16 weights, so we align dtypes once per encode batch.
+        target_dtype = self._vision_tower.patch_embed.proj.weight.dtype
+
+        outputs: list[mx.array] = []
+        for feature in features:
+            if feature.modality != "image":
+                raise ValueError(
+                    "encode_multimodal only supports image features; got "
+                    f"modality={feature.modality!r}"
+                )
+            if feature.data is None:
+                raise ValueError("feature.data is required for vision encoding")
+
+            pixel_values = self._as_mlx(
+                self._feature_value(feature.data, "pixel_values")
+            ).astype(target_dtype)
+            # vLLM's MultiModalFieldConfig.batched delivers per-feature
+            # grid_thw as a 1D ``(3,)`` row, but the mlx_vlm vision tower
+            # indexes it as ``grid_thw[i, 1:]`` and reads
+            # ``grid_thw.shape[0]``, so reshape back to ``(1, 3)``.  One
+            # feature carries one image in this PR series; multi-image is
+            # already gated by ``_validate_image_features``.
+            image_grid_thw = self._as_mlx(
+                self._feature_value(feature.data, "image_grid_thw")
+            ).reshape(1, 3)
+
+            hidden_states, _ = self._vision_tower(pixel_values, image_grid_thw)
+            outputs.append(hidden_states)
+
+        return outputs
+
+    def call_lm(
+        self,
+        input_ids: mx.array,
+        inputs_embeds: mx.array,
+        cache: list[Any],
+        position_ids: mx.array,
+    ) -> Any:
+        """Invoke ``language_model`` with runner-built embeds and positions.
+
+        ``language_model`` is invoked directly rather than through the
+        top-level ``mlx_vlm.Model.__call__`` (RFC #319 hard rule #1), and the
+        embeds keyword is the one sniffed at construction so version drift
+        between ``inputs_embeds`` and ``input_embeddings`` surfaces at load
+        time instead of inside attention.
+        """
+        if self._language_model is None:
+            raise RuntimeError(
+                "language_model not loaded; call_lm unavailable. "
+                "Construct via Qwen3VLMultimodalAdapter.from_loaded_model."
+            )
+        if self._embeds_kwarg is None:
+            raise RuntimeError(
+                "embeds_kwarg not detected; construct via "
+                "Qwen3VLMultimodalAdapter.from_loaded_model so the language "
+                "model signature is sniffed at load time."
+            )
+        return self._language_model(
+            input_ids,
+            cache=cache,
+            position_ids=position_ids,
+            **{self._embeds_kwarg: inputs_embeds},
+        )
+
+    @staticmethod
+    def _as_mlx(value: Any) -> Any:
+        """Return ``value`` as an MLX array, converting from torch when needed.
+
+        Upstream vLLM's multimodal preprocessor stages ``MultiModalKwargsItem``
+        fields as torch tensors; vision_tower expects ``mx.array``.
+        """
+        if isinstance(value, torch.Tensor):
+            return torch_to_mlx(value)
+        return value
 
     def get_mrope_input_positions(
         self,

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cache
 from types import SimpleNamespace
@@ -47,6 +48,7 @@ class Qwen3VLMultimodalAdapter:
         vision_tower: Any | None = None,
         language_model: Any | None = None,
         embeds_kwarg: str | None = None,
+        embed_tokens_fn: Callable[[Any], Any] | None = None,
     ) -> None:
         if spatial_merge_size <= 0:
             raise ValueError(
@@ -56,6 +58,7 @@ class Qwen3VLMultimodalAdapter:
         self._vision_tower = vision_tower
         self._language_model = language_model
         self._embeds_kwarg = embeds_kwarg
+        self._embed_tokens_fn = embed_tokens_fn
 
     def text_model(self) -> Any:
         """Return the loaded Qwen3-VL language model."""
@@ -68,12 +71,43 @@ class Qwen3VLMultimodalAdapter:
         language_model = model.language_model
         spatial_merge_size = int(model.config.vision_config.spatial_merge_size)
         embeds_kwarg = cls._detect_embeds_kwarg(language_model)
+        embed_tokens_fn = cls._resolve_embed_tokens(language_model)
         return cls(
             spatial_merge_size=spatial_merge_size,
             vision_tower=vision_tower,
             language_model=language_model,
             embeds_kwarg=embeds_kwarg,
+            embed_tokens_fn=embed_tokens_fn,
         )
+
+    @classmethod
+    def _resolve_embed_tokens(
+        cls, language_model: Any
+    ) -> Callable[[Any], Any]:
+        """Return ``language_model.model.embed_tokens`` or raise.
+
+        mlx-vlm 0.4.x Qwen3-VL/Qwen3.5 routes text embedding through
+        ``language_model.model.embed_tokens`` — the same callable the
+        top-level ``Model.get_input_embeddings`` defers to in text-only
+        mode.  Resolving here keeps the runner away from private model
+        internals (``language_model.model.*`` is not a stable public
+        surface) and converts any rename/restructure into a clear
+        load-time error instead of an attribute-error mid-forward.
+        """
+        inner = getattr(language_model, "model", None)
+        if inner is None:
+            raise RuntimeError(
+                "language_model.model attribute missing; mlx_vlm version "
+                "drift detected.  Expected the bottom-level LM module that "
+                "exposes embed_tokens."
+            )
+        embed_tokens = getattr(inner, "embed_tokens", None)
+        if embed_tokens is None or not callable(embed_tokens):
+            raise RuntimeError(
+                "language_model.model.embed_tokens missing or not callable; "
+                "mlx_vlm version drift detected."
+            )
+        return embed_tokens
 
     @classmethod
     def _detect_embeds_kwarg(cls, language_model: Any) -> str:
@@ -99,6 +133,22 @@ class Qwen3VLMultimodalAdapter:
             f"{cls._SUPPORTED_EMBEDS_KWARGS}; mlx_vlm version drift detected. "
             f"Got parameters: {sorted(params)}"
         )
+
+    def embed_tokens(self, input_ids: mx.array) -> mx.array:
+        """Return the language model's input embeddings for ``input_ids``.
+
+        Forwards to the callable resolved at ``from_loaded_model`` time so
+        the runner does not reach into private model internals.  Construct
+        via :meth:`from_loaded_model` for the resolution; manually built
+        instances (e.g. unit tests) must pass ``embed_tokens_fn``.
+        """
+        if self._embed_tokens_fn is None:
+            raise RuntimeError(
+                "embed_tokens_fn not resolved; construct via "
+                "Qwen3VLMultimodalAdapter.from_loaded_model so the language "
+                "model embedding path is sniffed at load time."
+            )
+        return self._embed_tokens_fn(input_ids)
 
     def encode_multimodal(
         self,

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import inspect
+from dataclasses import dataclass
 from functools import cache
 from types import SimpleNamespace
 from typing import Any
@@ -14,6 +15,14 @@ from vllm.multimodal.inputs import MultiModalKwargsItem
 
 from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
+
+
+@dataclass(frozen=True)
+class Qwen3VLVisionEncodeResult:
+    """Vision tower output for one Qwen3-VL multimodal feature."""
+
+    hidden_states: mx.array
+    deepstack_visual_embeds: Any | None
 
 
 class Qwen3VLMultimodalAdapter:
@@ -94,14 +103,16 @@ class Qwen3VLMultimodalAdapter:
     def encode_multimodal(
         self,
         features: list[MultiModalFeatureSpec],
-    ) -> list[mx.array]:
-        """Run the vision tower per feature; return one MLX array per feature.
+    ) -> list[Qwen3VLVisionEncodeResult]:
+        """Run the vision tower per feature; return one result per feature.
 
         RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__``; route
         through ``vision_tower`` directly so the LM is not re-entered through
         the top-level VLM dispatch.  The vision tower returns
-        ``(hidden_states, deepstack_image_embeds)``; deepstack augmentation is
-        out of scope for the initial Qwen3.5-4B path.
+        ``(hidden_states, deepstack_visual_embeds)``.  mlx-vlm 0.4.x returns
+        ``None`` for deepstack because of its reference bug; preserving the
+        field here keeps the adapter contract ready for the mlx-vlm 0.5.x
+        dependency unlock without enabling multimodal forward yet.
         """
         if self._vision_tower is None:
             raise RuntimeError(
@@ -115,7 +126,7 @@ class Qwen3VLMultimodalAdapter:
         # fp16/bf16 weights, so we align dtypes once per encode batch.
         target_dtype = self._vision_tower.patch_embed.proj.weight.dtype
 
-        outputs: list[mx.array] = []
+        outputs: list[Qwen3VLVisionEncodeResult] = []
         for feature in features:
             if feature.modality != "image":
                 raise ValueError(
@@ -138,8 +149,16 @@ class Qwen3VLMultimodalAdapter:
                 self._feature_value(feature.data, "image_grid_thw")
             ).reshape(1, 3)
 
-            hidden_states, _ = self._vision_tower(pixel_values, image_grid_thw)
-            outputs.append(hidden_states)
+            hidden_states, deepstack_visual_embeds = self._vision_tower(
+                pixel_values,
+                image_grid_thw,
+            )
+            outputs.append(
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=hidden_states,
+                    deepstack_visual_embeds=deepstack_visual_embeds,
+                )
+            )
 
         return outputs
 

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -52,13 +52,10 @@ class PagedAttentionContext:
     # GDN state pool slot mapping: request batch position → stable slot ID.
     # Populated by model_runner for hybrid models; None for non-hybrid.
     gdn_slot_mapping: list[int] | None = None
-    # Per-segment caller-supplied M-RoPE positions.  Each entry is either
-    # ``None`` ("use ``offsets[i]`` with sequential arange" — text
-    # default) or an ``(3, 1, seg_len)`` MLX array overriding the policy
-    # with values the runner sliced out of the full-prompt M-RoPE
-    # positions.  Used by multimodal prefill where image placeholder
-    # positions do not follow the simple arange policy.  ``None`` (the
-    # field itself) skips per-segment handling entirely.
+    # Per-segment caller-supplied M-RoPE positions: each entry is either
+    # ``None`` (use ``offsets[i]`` with sequential arange) or an
+    # ``(3, 1, seg_len)`` array.  ``None`` for the whole field skips
+    # per-segment handling entirely.
     segment_positions: list[Any] | None = None
 
 

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -52,6 +52,14 @@ class PagedAttentionContext:
     # GDN state pool slot mapping: request batch position → stable slot ID.
     # Populated by model_runner for hybrid models; None for non-hybrid.
     gdn_slot_mapping: list[int] | None = None
+    # Per-segment caller-supplied M-RoPE positions.  Each entry is either
+    # ``None`` ("use ``offsets[i]`` with sequential arange" — text
+    # default) or an ``(3, 1, seg_len)`` MLX array overriding the policy
+    # with values the runner sliced out of the full-prompt M-RoPE
+    # positions.  Used by multimodal prefill where image placeholder
+    # positions do not follow the simple arange policy.  ``None`` (the
+    # field itself) skips per-segment handling entirely.
+    segment_positions: list[Any] | None = None
 
 
 def set_context(ctx: PagedAttentionContext) -> None:

--- a/vllm_metal/v1/mm/encoder_cache.py
+++ b/vllm_metal/v1/mm/encoder_cache.py
@@ -3,21 +3,27 @@
 
 from __future__ import annotations
 
-import mlx.core as mx
+from typing import TYPE_CHECKING
 
 from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 
+if TYPE_CHECKING:
+    from vllm_metal.v1.model_adapter import MultimodalEncodeResult
+
 
 class EncoderCache:
-    """Store multimodal features and MLX encoder outputs by request/hash.
+    """Store multimodal features and encoder-output records by request/hash.
 
-    Mirrors upstream vLLM's v1 GPU ``EncoderCache`` with the tensor type
-    changed from ``torch.Tensor`` to ``mlx.core.array``.
+    Mirrors upstream vLLM's v1 GPU ``EncoderCache``.  Stores the adapter's
+    full ``MultimodalEncodeResult`` (hidden_states + deepstack channel) so
+    downstream splice has both fields available; consumers read
+    ``.hidden_states`` for first-token splice and ``.deepstack_visual_embeds``
+    for layer-residual injection.
     """
 
     def __init__(self) -> None:
         self.mm_features: dict[str, list[MultiModalFeatureSpec]] = {}
-        self.encoder_outputs: dict[str, mx.array] = {}
+        self.encoder_outputs: dict[str, MultimodalEncodeResult] = {}
 
     def add_request(
         self, req_id: str, mm_features: list[MultiModalFeatureSpec]

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -51,6 +51,15 @@ class MultimodalRuntimeAdapter(Protocol):
     def text_model(self) -> Any:
         """Return the callable language model for text-only VLM execution."""
 
+    def embed_tokens(self, input_ids: Any) -> Any:
+        """Return the language model's input embeddings for ``input_ids``.
+
+        Resolved at adapter construction so the runner builds embeds via
+        a stable adapter method instead of reaching into private model
+        internals (``model.language_model.model.embed_tokens`` for mlx-vlm
+        0.4.x).  Returns an MLX array of shape ``(batch, seq_len, hidden)``.
+        """
+
     def get_mrope_input_positions(
         self,
         input_tokens: list[int],

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -92,12 +92,20 @@ class MultimodalRuntimeAdapter(Protocol):
         inputs_embeds: Any,
         cache: list[Any],
         position_ids: Any,
+        *,
+        visual_pos_masks: Any | None = None,
+        deepstack_visual_embeds: Any | None = None,
     ) -> Any:
         """Invoke the language model with runner-built embeds and positions.
 
         The embeds keyword is sniffed at adapter construction so version
         drift between ``inputs_embeds`` and ``input_embeddings`` surfaces
         at load time, not silently inside attention.
+
+        ``visual_pos_masks`` and ``deepstack_visual_embeds`` are forwarded
+        only on language models that declare both explicitly (mlx-vlm
+        0.5.x Qwen3-VL); LMs that take only ``**kwargs`` would silently
+        absorb the arrays, so the adapter omits these on that path.
         """
 
 

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -28,6 +28,18 @@ class TargetModelForwardOutput:
 class MultimodalRuntimeAdapter(Protocol):
     """Model-owned behavior needed for native multimodal execution."""
 
+    forward_ready: bool
+    """Whether scheduled multimodal encoder inputs may be executed.
+
+    Phase 4 flips this to ``True`` for the active adapter only after the
+    fixed prompt+image parity test passes (RFC #319).  Until then the
+    runtime gate stays closed and ``MetalModelRunner`` fails fast on
+    scheduled encoder inputs even though the runtime state is already
+    registered.  Threading the gate through the adapter rather than a
+    runner-level flag means a second adapter can land at ``False``
+    without disturbing the model already in production.
+    """
+
     def text_model(self) -> Any:
         """Return the callable language model for text-only VLM execution."""
 

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -50,6 +50,30 @@ class MultimodalRuntimeAdapter(Protocol):
     ) -> tuple[Any, int]:
         """Return model-specific M-RoPE positions for multimodal inputs."""
 
+    def encode_multimodal(
+        self,
+        features: list[MultiModalFeatureSpec],
+    ) -> list[Any]:
+        """Run the model's vision tower; return one MLX array per feature.
+
+        RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__`` —
+        the LM must not be re-entered through the top-level VLM dispatch.
+        """
+
+    def call_lm(
+        self,
+        input_ids: Any,
+        inputs_embeds: Any,
+        cache: list[Any],
+        position_ids: Any,
+    ) -> Any:
+        """Invoke the language model with runner-built embeds and positions.
+
+        The embeds keyword is sniffed at adapter construction so version
+        drift between ``inputs_embeds`` and ``input_embeddings`` surfaces
+        at load time, not silently inside attention.
+        """
+
 
 class ModelAdapter(Protocol):
     """Model-specific hooks used by runner and cache orchestration."""

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -65,7 +65,14 @@ class MultimodalRuntimeAdapter(Protocol):
         input_tokens: list[int],
         mm_features: list[MultiModalFeatureSpec],
     ) -> tuple[Any, int]:
-        """Return model-specific M-RoPE positions for multimodal inputs."""
+        """Return ``((3, 1, seq_len) positions, mrope_position_delta)``.
+
+        Positions carry an explicit batch axis so ``call_lm`` receives the
+        ``(3, batch, seq_len)`` layout mlx-vlm's Qwen3-VL language model
+        expects; decode reshapes the runtime offset to ``(3, B, 1)``.
+        ``mrope_position_delta`` is request state — the runner must stash
+        it on ``RequestState`` so decode positions stay correct.
+        """
 
     def encode_multimodal(
         self,

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -39,13 +39,9 @@ class MultimodalRuntimeAdapter(Protocol):
     forward_ready: bool
     """Whether scheduled multimodal encoder inputs may be executed.
 
-    Phase 4 flips this to ``True`` for the active adapter only after the
-    fixed prompt+image parity test passes (RFC #319).  Until then the
-    runtime gate stays closed and ``MetalModelRunner`` fails fast on
-    scheduled encoder inputs even though the runtime state is already
-    registered.  Threading the gate through the adapter rather than a
-    runner-level flag means a second adapter can land at ``False``
-    without disturbing the model already in production.
+    ``MetalModelRunner`` fails fast on scheduled encoder inputs when this
+    is ``False``, so a new adapter can land closed without disturbing the
+    model already in production.
     """
 
     def text_model(self) -> Any:
@@ -54,10 +50,7 @@ class MultimodalRuntimeAdapter(Protocol):
     def embed_tokens(self, input_ids: Any) -> Any:
         """Return the language model's input embeddings for ``input_ids``.
 
-        Resolved at adapter construction so the runner builds embeds via
-        a stable adapter method instead of reaching into private model
-        internals (``model.language_model.model.embed_tokens`` for mlx-vlm
-        0.4.x).  Returns an MLX array of shape ``(batch, seq_len, hidden)``.
+        Returns an MLX array of shape ``(batch, seq_len, hidden)``.
         """
 
     def get_mrope_input_positions(
@@ -67,11 +60,8 @@ class MultimodalRuntimeAdapter(Protocol):
     ) -> tuple[Any, int]:
         """Return ``((3, 1, seq_len) positions, mrope_position_delta)``.
 
-        Positions carry an explicit batch axis so ``call_lm`` receives the
-        ``(3, batch, seq_len)`` layout mlx-vlm's Qwen3-VL language model
-        expects; decode reshapes the runtime offset to ``(3, B, 1)``.
-        ``mrope_position_delta`` is request state — the runner must stash
-        it on ``RequestState`` so decode positions stay correct.
+        The runner stashes ``mrope_position_delta`` on ``RequestState`` so
+        decode positions stay correct.
         """
 
     def encode_multimodal(
@@ -80,8 +70,6 @@ class MultimodalRuntimeAdapter(Protocol):
     ) -> Sequence[MultimodalEncodeResult]:
         """Run the model's vision tower; return one result per feature.
 
-        RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__`` —
-        the LM must not be re-entered through the top-level VLM dispatch.
         Results may carry optional deepstack visual embeds for models whose
         language model injects vision residuals in intermediate layers.
         """
@@ -98,14 +86,10 @@ class MultimodalRuntimeAdapter(Protocol):
     ) -> Any:
         """Invoke the language model with runner-built embeds and positions.
 
-        The embeds keyword is sniffed at adapter construction so version
-        drift between ``inputs_embeds`` and ``input_embeddings`` surfaces
-        at load time, not silently inside attention.
-
         ``visual_pos_masks`` and ``deepstack_visual_embeds`` are forwarded
-        only on language models that declare both explicitly (mlx-vlm
-        0.5.x Qwen3-VL); LMs that take only ``**kwargs`` would silently
-        absorb the arrays, so the adapter omits these on that path.
+        only when the language model declares both as explicit parameters;
+        adapters omit them otherwise to avoid silently dropping the arrays
+        into a ``**kwargs`` catch-all.
         """
 
 

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -25,6 +25,13 @@ class TargetModelForwardOutput:
     hidden_states: mx.array | None = None
 
 
+class MultimodalEncodeResult(Protocol):
+    """Adapter-owned vision output for one multimodal feature."""
+
+    hidden_states: Any
+    deepstack_visual_embeds: Any | None
+
+
 class MultimodalRuntimeAdapter(Protocol):
     """Model-owned behavior needed for native multimodal execution."""
 
@@ -53,11 +60,13 @@ class MultimodalRuntimeAdapter(Protocol):
     def encode_multimodal(
         self,
         features: list[MultiModalFeatureSpec],
-    ) -> list[Any]:
-        """Run the model's vision tower; return one MLX array per feature.
+    ) -> list[MultimodalEncodeResult]:
+        """Run the model's vision tower; return one result per feature.
 
         RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__`` —
         the LM must not be re-entered through the top-level VLM dispatch.
+        Results may carry optional deepstack visual embeds for models whose
+        language model injects vision residuals in intermediate layers.
         """
 
     def call_lm(

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -3,8 +3,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import mlx.core as mx
 from vllm.logger import init_logger
@@ -60,7 +61,7 @@ class MultimodalRuntimeAdapter(Protocol):
     def encode_multimodal(
         self,
         features: list[MultiModalFeatureSpec],
-    ) -> list[MultimodalEncodeResult]:
+    ) -> Sequence[MultimodalEncodeResult]:
         """Run the model's vision tower; return one result per feature.
 
         RFC #319 hard rule #1: never invoke ``mlx_vlm.Model.__call__`` —
@@ -422,7 +423,10 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
 
         from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 
-        return Qwen3VLMultimodalAdapter.from_loaded_model(model)
+        return cast(
+            MultimodalRuntimeAdapter,
+            Qwen3VLMultimodalAdapter.from_loaded_model(model),
+        )
 
     def build_yoco_cache_mapping(
         self, args: dict[str, Any]

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -29,8 +29,8 @@ class TargetModelForwardOutput:
 class MultimodalEncodeResult(Protocol):
     """Adapter-owned vision output for one multimodal feature."""
 
-    hidden_states: Any
-    deepstack_visual_embeds: Any | None
+    hidden_states: mx.array
+    deepstack_visual_embeds: Sequence[mx.array] | None
 
 
 class MultimodalRuntimeAdapter(Protocol):

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -820,6 +820,32 @@ class MetalModelRunner:
             )
         )
 
+        # Multimodal paged-forward splice is not yet wired; an mm request
+        # reaching here would silently get a text-only forward.  The
+        # encoder gate (``_reject_scheduled_encoder_inputs``) catches the
+        # fresh-encode case but not a continuation chunk whose vision
+        # features were encoded in a prior step, so raise here too.  Mirror
+        # C's non-paged fail-fast and check unconditionally regardless of
+        # ``adapter.forward_ready`` / adapter presence — a misconfigured
+        # adapter must not silently produce wrong output.
+        mm_prefill_req_ids = [
+            pr.req_id for pr in prefill_reqs if self._is_mm_request(pr.req_id)
+        ]
+        mm_decode_req_ids = [
+            req_id
+            for req_id, state in decode_reqs
+            if state.mrope_position_delta is not None
+        ]
+        if mm_prefill_req_ids or mm_decode_req_ids:
+            raise NotImplementedError(
+                "Paged forward with multimodal requests is not wired yet. "
+                f"Affected prefill requests: {mm_prefill_req_ids}; affected "
+                f"decode requests: {mm_decode_req_ids}.  Non-paged prefill/"
+                f"decode already routes mm through adapter.call_lm; the "
+                f"paged splice + per-segment M-RoPE positions lands in a "
+                f"follow-up commit."
+            )
+
         # ---- build unified token sequence: decode first, then prefill ----
         all_token_ids: list[int] = []
 
@@ -1425,8 +1451,8 @@ class MetalModelRunner:
             prefill = entry.prefill
             full_prompt = None
 
-            needs_full_prompt = (
-                prefill.start_pos > 0 or self._is_mm_request(prefill.req_id)
+            needs_full_prompt = prefill.start_pos > 0 or self._is_mm_request(
+                prefill.req_id
             )
             if needs_full_prompt:
                 state = self._request_states.get(prefill.req_id)

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
+import numpy as np
 import torch
 from mlx_lm import stream_generate
 from vllm.config import VllmConfig
@@ -36,6 +37,8 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.config import get_config
+from vllm_metal.multimodal import merge_multimodal_embeddings
+from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 from vllm_metal.paged_attention_backend.hybrid import HybridPagedAttentionBackend
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
@@ -124,6 +127,10 @@ class RequestState:
     block_ids: list[int] = field(
         default_factory=list
     )  # Scheduler-assigned paged KV blocks
+    # M-RoPE position delta stashed by mm prefill; ``None`` for text-only
+    # requests and used by paged decode to rebuild ``(3, 1, 1)`` positions
+    # at ``len(token_ids) - 1 + delta``.
+    mrope_position_delta: int | None = None
 
 
 class PrefillRequest(NamedTuple):
@@ -207,6 +214,11 @@ class _PagedForwardState(NamedTuple):
     cu_seqlens: list[int]
     decode_segments: tuple[PagedDecodeSegment, ...]
     num_decode_tokens: int
+    # ``{req_id: mrope_position_delta}`` computed during a paged mm
+    # prefill forward.  ``_sample_paged_batch`` writes the delta onto
+    # the request's ``RequestState`` so later decode steps can rebuild
+    # M-RoPE positions; empty for text-only batches.
+    mm_prefill_deltas: dict[str, int]
 
 
 class MetalModelRunner:
@@ -884,9 +896,10 @@ class MetalModelRunner:
         # ---- forward (lazy graph + async submit) ----
         offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]
         input_ids = mx.array([all_token_ids], dtype=mx.int32)
+        mm_prefill_deltas: dict[str, int] = {}
         try:
             if has_mm:
-                model_output = self._run_mm_paged_forward(
+                model_output, mm_prefill_deltas = self._run_mm_paged_forward(
                     input_ids,
                     offset_caches,
                     prefill_reqs,
@@ -930,6 +943,7 @@ class MetalModelRunner:
             cu_seqlens=cu_seqlens,
             decode_segments=decode_segments,
             num_decode_tokens=num_decode_tokens,
+            mm_prefill_deltas=mm_prefill_deltas,
         )
 
     def _sample_paged_batch(
@@ -941,19 +955,20 @@ class MetalModelRunner:
         Consumes state stashed by ``_start_paged_forward``.
         Returns ``(batch, scheduler_output)`` for the caller to finalize.
         """
-        state = self._execute_model_state
-        assert state is not None
+        paged_state = self._execute_model_state
+        assert paged_state is not None
         self._execute_model_state = None
-        batch = state.batch
-        prefill_reqs = state.prefill_reqs
-        decode_reqs = state.decode_reqs
-        scheduler_output = state.scheduler_output
-        logits = state.logits
-        target_hidden_states = state.target_hidden_states
-        cu_seqlens = state.cu_seqlens
-        decode_segments = state.decode_segments
+        batch = paged_state.batch
+        prefill_reqs = paged_state.prefill_reqs
+        decode_reqs = paged_state.decode_reqs
+        scheduler_output = paged_state.scheduler_output
+        logits = paged_state.logits
+        target_hidden_states = paged_state.target_hidden_states
+        cu_seqlens = paged_state.cu_seqlens
+        decode_segments = paged_state.decode_segments
         num_decode_segments = len(decode_segments)
-        num_decode_tokens = state.num_decode_tokens
+        num_decode_tokens = paged_state.num_decode_tokens
+        mm_prefill_deltas = paged_state.mm_prefill_deltas
         has_scheduled_drafts = any(
             segment.draft_token_ids for segment in decode_segments
         )
@@ -1108,6 +1123,7 @@ class MetalModelRunner:
                 continue
 
             batch.set_output(entry.output_idx, [next_token], logprobs)
+            mm_delta = mm_prefill_deltas.get(prefill.req_id)
             if entry.result_mode == "new_final":
                 prompt_len = prefill.prompt_len
                 assert prompt_len is not None
@@ -1124,12 +1140,19 @@ class MetalModelRunner:
                     generator=prefill.generator,
                     generated_tokens=1,
                     block_ids=prefill.block_ids,
+                    mrope_position_delta=mm_delta,
                 )
                 continue
 
             req_state = self._request_states[prefill.req_id]
             req_state.token_ids.append(next_token)
             req_state.generated_tokens = len(req_state.token_ids) - req_state.prompt_len
+            if mm_delta is not None:
+                # cached_final for an mm request: stash the freshly
+                # computed delta so the next decode round routes through
+                # the mm path.  ``_run_mm_paged_forward`` recomputes per
+                # step, so the value is always current.
+                req_state.mrope_position_delta = mm_delta
 
         for i, (req_id, _) in enumerate(batch.paged_decode_reqs):
             logprobs = (
@@ -1269,7 +1292,7 @@ class MetalModelRunner:
         offset_caches: list[OffsetCache],
         prefill_reqs: list[PrefillRequest],
         decode_segments: tuple[PagedDecodeSegment, ...],
-    ) -> Any:
+    ) -> tuple[Any, dict[str, int]]:
         """Run paged forward through ``adapter.call_lm`` with packed splice.
 
         Builds per-segment M-RoPE positions (sliced out of the full-prompt
@@ -1462,7 +1485,11 @@ class MetalModelRunner:
         if ctx is not None:
             ctx.segment_positions = ctx_segment_positions
 
-        return adapter.call_lm(
+        mm_prefill_deltas = {
+            req_id: int(meta[1]) for req_id, meta in mm_request_meta.items()
+        }
+
+        model_output = adapter.call_lm(
             input_ids,
             inputs_embeds,
             offset_caches,
@@ -1470,6 +1497,7 @@ class MetalModelRunner:
             visual_pos_masks=visual_pos_masks,
             deepstack_visual_embeds=deepstack_visual_embeds,
         )
+        return model_output, mm_prefill_deltas
 
     def _handle_new_requests(
         self,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1320,14 +1320,34 @@ class MetalModelRunner:
         caller-supplied positions on mm segments and falls back to the
         int-offset arange path on text segments.
 
-        Spec decode mm: when ``num_query_tokens > 1`` on a decode segment
-        whose request has ``mrope_position_delta`` set, draft-row
-        positions are filled as ``arange(cache_start_pos, ...) + delta``.
+        Any speculative-decode segment in the batch is rejected up
+        front: a decode request with ``num_query_tokens > 1`` makes
+        ``prepare_unified`` append one ``cu_seqlens`` entry per query
+        token, but ``ctx.segment_positions`` carries one entry per
+        ``PagedDecodeSegment``.  The mismatch corrupts M-RoPE positions
+        for every segment packed after the draft — including text-only
+        spec decode that happens to share the batch with an mm prefill,
+        since the whole batch still routes through this method.
+        Lifting the restriction is tracked as a follow-up to RFC #319.
         """
         adapter = self._multimodal_adapter
         assert adapter is not None and adapter.forward_ready
         encoder_cache = self.encoder_cache
         assert encoder_cache is not None
+
+        for segment in decode_segments:
+            if segment.num_query_tokens > 1:
+                raise NotImplementedError(
+                    "Speculative decode is not supported on the multimodal "
+                    "paged path yet: prepare_unified() expands a decode "
+                    "segment with num_query_tokens > 1 into one cu_seqlens "
+                    "span per query token, but ctx.segment_positions stores "
+                    "one entry per PagedDecodeSegment — cu_seqlens and "
+                    "segment_positions would misalign for every segment "
+                    "packed after the draft, including text-only spec decode "
+                    "that shares the batch with an mm prefill.  Tracked as "
+                    "a follow-up to RFC #319."
+                )
 
         # Full-prompt M-RoPE positions per mm prefill request.
         mm_request_meta: dict[

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1399,17 +1399,36 @@ class MetalModelRunner:
 
             batch.paged_decode_reqs.append((req_id, state))
 
+    def _is_mm_request(self, req_id: str) -> bool:
+        """Whether the request has multimodal features registered."""
+        if self.encoder_cache is None:
+            return False
+        return bool(self.encoder_cache.mm_features.get(req_id))
+
     def _build_prefill_pack(
         self,
         batch: _ExecutionBatch,
     ) -> list[PrefillRequest]:
-        """Reconstruct full prompt context for paged prefill requests."""
+        """Reconstruct full prompt context for paged prefill requests.
+
+        Continuation chunks (``start_pos > 0``) need the full prompt so
+        sampling metadata reflects the whole prefix, not just this chunk.
+        Multimodal requests need it at every chunk including the first —
+        ``adapter.get_mrope_input_positions`` must see the whole prompt
+        to compute correct M-RoPE positions for image placeholders, then
+        a later commit slices the chunk-relevant range.  Both conditions
+        share the same two-source resolution (RequestState first, new_req
+        fallback) and the same contract-bug raises.
+        """
         prefill_pack: list[PrefillRequest] = []
         for entry in batch.paged_prefill_entries:
             prefill = entry.prefill
             full_prompt = None
 
-            if prefill.start_pos > 0:
+            needs_full_prompt = (
+                prefill.start_pos > 0 or self._is_mm_request(prefill.req_id)
+            )
+            if needs_full_prompt:
                 state = self._request_states.get(prefill.req_id)
                 if state is not None:
                     full_prompt = state.token_ids[: state.prompt_len]
@@ -1417,16 +1436,19 @@ class MetalModelRunner:
                     new_req = batch.new_reqs_by_id.get(prefill.req_id)
                     if new_req is None:
                         raise RuntimeError(
-                            f"Prefix cache hit (start_pos={prefill.start_pos}) for "
-                            f"request {prefill.req_id!r} but it has no RequestState "
-                            "and is not in new_reqs. This is a state tracking bug."
+                            f"Need full prompt (start_pos={prefill.start_pos}, "
+                            f"mm={self._is_mm_request(prefill.req_id)}) for "
+                            f"request {prefill.req_id!r} but it has no "
+                            f"RequestState and is not in new_reqs. This is a "
+                            f"state tracking bug."
                         )
                     prompt_token_ids = new_req.prompt_token_ids
                     if prompt_token_ids is None:
                         raise RuntimeError(
-                            f"Prefix cache hit (start_pos={prefill.start_pos}) for "
-                            f"request {prefill.req_id!r} but prompt_token_ids is "
-                            "missing. This is a scheduler contract bug."
+                            f"Need full prompt (start_pos={prefill.start_pos}, "
+                            f"mm={self._is_mm_request(prefill.req_id)}) for "
+                            f"request {prefill.req_id!r} but prompt_token_ids "
+                            f"is missing. This is a scheduler contract bug."
                         )
                     full_prompt = list(prompt_token_ids)
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1145,8 +1145,17 @@ class MetalModelRunner:
         self,
         scheduled_encoder_inputs: dict[str, list[int]],
     ) -> None:
-        """Fail fast until encoder execution and embedding splice are wired."""
+        """Fail fast until the active adapter signals ``forward_ready``.
+
+        Phase 4 flips ``forward_ready`` on the adapter for the parity-tested
+        model.  Phase 5+ adapters land at ``False`` and route through this
+        guard until each one's parity test passes, so partial work on a new
+        model never disturbs models already in production.
+        """
         if not scheduled_encoder_inputs:
+            return
+        adapter = self._multimodal_adapter
+        if adapter is not None and adapter.forward_ready:
             return
         raise NotImplementedError(
             "Multimodal encoder execution is not wired on Metal yet. "

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1230,10 +1230,10 @@ class MetalModelRunner:
                 if len(outputs) != 1:
                     raise RuntimeError(
                         f"encode_multimodal returned {len(outputs)} outputs "
-                        "for 1 feature; adapter must return one array per "
+                        "for 1 feature; adapter must return one result per "
                         "feature."
                     )
-                cache.encoder_outputs[feature.identifier] = outputs[0]
+                cache.encoder_outputs[feature.identifier] = outputs[0].hidden_states
 
     def _handle_new_requests(
         self,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -42,6 +42,7 @@ from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.paged_attention_common import (
     OffsetCache,
     clear_context,
+    get_context,
     prepare_unified,
 )
 from vllm_metal.stt.runtime import STTRuntimeAdapter
@@ -820,30 +821,24 @@ class MetalModelRunner:
             )
         )
 
-        # Multimodal paged-forward splice is not yet wired; an mm request
-        # reaching here would silently get a text-only forward.  The
-        # encoder gate (``_reject_scheduled_encoder_inputs``) catches the
-        # fresh-encode case but not a continuation chunk whose vision
-        # features were encoded in a prior step, so raise here too.  Mirror
-        # C's non-paged fail-fast and check unconditionally regardless of
-        # ``adapter.forward_ready`` / adapter presence — a misconfigured
-        # adapter must not silently produce wrong output.
-        mm_prefill_req_ids = [
-            pr.req_id for pr in prefill_reqs if self._is_mm_request(pr.req_id)
-        ]
-        mm_decode_req_ids = [
-            req_id
-            for req_id, state in decode_reqs
-            if state.mrope_position_delta is not None
-        ]
-        if mm_prefill_req_ids or mm_decode_req_ids:
-            raise NotImplementedError(
-                "Paged forward with multimodal requests is not wired yet. "
-                f"Affected prefill requests: {mm_prefill_req_ids}; affected "
-                f"decode requests: {mm_decode_req_ids}.  Non-paged prefill/"
-                f"decode already routes mm through adapter.call_lm; the "
-                f"paged splice + per-segment M-RoPE positions lands in a "
-                f"follow-up commit."
+        # Detect multimodal segments.  Mirror C's non-paged fail-fast: an
+        # mm request reaching here without a ``forward_ready`` adapter is
+        # a bookkeeping bug (the encoder gate only catches fresh-encode
+        # cases — a continuation chunk whose vision features were encoded
+        # in a prior step has no scheduled encoder input and would
+        # otherwise slip through to the text path).
+        has_mm_prefill = any(self._is_mm_request(pr.req_id) for pr in prefill_reqs)
+        has_mm_decode = any(
+            state.mrope_position_delta is not None for _, state in decode_reqs
+        )
+        has_mm = has_mm_prefill or has_mm_decode
+        adapter = self._multimodal_adapter
+        if has_mm and (adapter is None or not adapter.forward_ready):
+            raise RuntimeError(
+                "Paged forward saw a multimodal request but the adapter is "
+                "not forward_ready; this indicates a misconfigured adapter "
+                "or a bookkeeping bug — only forward-ready adapters should "
+                "let mm requests reach paged forward."
             )
 
         # ---- build unified token sequence: decode first, then prefill ----
@@ -876,8 +871,6 @@ class MetalModelRunner:
 
         # ---- GDN slot mapping (hybrid models) ----
         if self.is_hybrid:
-            from vllm_metal.paged_attention_common import get_context
-
             ctx = get_context()
             if ctx is not None:
                 gdn_slots = []
@@ -892,16 +885,25 @@ class MetalModelRunner:
         offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]
         input_ids = mx.array([all_token_ids], dtype=mx.int32)
         try:
-            target_output = self._target_forward(
-                input_ids,
-                cache=offset_caches,
-                collect_hidden_states=collect_target_hidden_states,
-            )
-            logits = target_output.logits
-            target_hidden_states = target_output.hidden_states
-            # Keep only logits and the optional row-major hidden states before
-            # scheduling evaluation.
-            del target_output
+            if has_mm:
+                model_output = self._run_mm_paged_forward(
+                    input_ids,
+                    offset_caches,
+                    prefill_reqs,
+                    decode_segments,
+                )
+                logits = self._extract_logits(model_output)
+                target_hidden_states = None
+                del model_output
+            else:
+                target_output = self._target_forward(
+                    input_ids,
+                    cache=offset_caches,
+                    collect_hidden_states=collect_target_hidden_states,
+                )
+                logits = target_output.logits
+                target_hidden_states = target_output.hidden_states
+                del target_output
         finally:
             clear_context()
 
@@ -1260,6 +1262,214 @@ class MetalModelRunner:
                         "feature."
                     )
                 cache.encoder_outputs[feature.identifier] = outputs[0]
+
+    def _run_mm_paged_forward(
+        self,
+        input_ids: mx.array,
+        offset_caches: list[OffsetCache],
+        prefill_reqs: list[PrefillRequest],
+        decode_segments: tuple[PagedDecodeSegment, ...],
+    ) -> Any:
+        """Run paged forward through ``adapter.call_lm`` with packed splice.
+
+        Builds per-segment M-RoPE positions (sliced out of the full-prompt
+        positions for mm prefill chunks, computed as ``cache_start_pos +
+        delta + arange(num_query_tokens)`` for mm decode), splices vision
+        embeds into the packed text embeds at placeholder positions
+        (chunk-aware: each feature only contributes the slice that lands
+        in *this* chunk), and concatenates per-layer deepstack residual
+        arrays across all mm prefill segments in packed order.
+
+        Sets ``ctx.segment_positions`` so ``apply_packed_rope`` reads
+        caller-supplied positions on mm segments and falls back to the
+        int-offset arange path on text segments.
+
+        Spec decode mm: when ``num_query_tokens > 1`` on a decode segment
+        whose request has ``mrope_position_delta`` set, draft-row
+        positions are filled as ``arange(cache_start_pos, ...) + delta``.
+        """
+        adapter = self._multimodal_adapter
+        assert adapter is not None and adapter.forward_ready
+        encoder_cache = self.encoder_cache
+        assert encoder_cache is not None
+
+        # Pre-compute full-prompt M-RoPE positions per mm prefill request.
+        # Chunked prefill of the same request would only appear once in
+        # ``prefill_reqs`` per step, so per-request caching here is for
+        # clarity rather than work avoidance.
+        mm_request_meta: dict[
+            str, tuple[mx.array, int, list[MultiModalFeatureSpec]]
+        ] = {}
+        for pr in prefill_reqs:
+            if not self._is_mm_request(pr.req_id):
+                continue
+            full_prompt = pr.full_prompt_token_ids
+            if full_prompt is None:
+                raise RuntimeError(
+                    f"mm prefill request {pr.req_id!r} reached paged forward "
+                    f"without full_prompt_token_ids; _build_prefill_pack bug."
+                )
+            mm_features = encoder_cache.mm_features.get(pr.req_id, [])
+            sorted_features = sorted(mm_features, key=lambda f: f.mm_position.offset)
+            full_positions, delta = adapter.get_mrope_input_positions(
+                full_prompt, sorted_features
+            )
+            mm_request_meta[pr.req_id] = (full_positions, delta, sorted_features)
+
+        total_len = int(input_ids.shape[1])
+        visual_pos_masks_np = np.zeros(total_len, dtype=bool)
+        mm_embeds_parts: list[mx.array] = []
+        deepstack_per_layer: list[list[mx.array]] = []
+        deepstack_present: bool | None = None
+        ctx_segment_positions: list[Any] = []
+        position_ids_parts: list[mx.array] = []
+        cursor = 0
+
+        # Decode segments come first in the packed sequence.
+        for segment in decode_segments:
+            n = segment.num_query_tokens
+            state = self._request_states.get(segment.req_id)
+            is_mm_decode = state is not None and state.mrope_position_delta is not None
+            if is_mm_decode:
+                assert state is not None and state.mrope_position_delta is not None
+                offset_arr = np.arange(
+                    segment.cache_start_pos,
+                    segment.cache_start_pos + n,
+                    dtype=np.int32,
+                )
+                offset_arr = offset_arr + state.mrope_position_delta
+            else:
+                offset_arr = np.arange(
+                    segment.cache_start_pos,
+                    segment.cache_start_pos + n,
+                    dtype=np.int32,
+                )
+            seg_positions = mx.broadcast_to(
+                mx.array(offset_arr)[None, None, :], (3, 1, n)
+            )
+            ctx_segment_positions.append(seg_positions if is_mm_decode else None)
+            position_ids_parts.append(seg_positions)
+            cursor += n
+
+        # Prefill segments follow.
+        for pr in prefill_reqs:
+            n = len(pr.token_ids)
+            if pr.req_id in mm_request_meta:
+                full_positions, _delta, sorted_features = mm_request_meta[pr.req_id]
+                seg_positions = full_positions[:, :, pr.start_pos : pr.start_pos + n]
+                ctx_segment_positions.append(seg_positions)
+                position_ids_parts.append(seg_positions)
+
+                # Splice each feature's chunk-intersecting slice.
+                for feature in sorted_features:
+                    f_start = feature.mm_position.offset
+                    f_end = f_start + feature.mm_position.length
+                    chunk_start = pr.start_pos
+                    chunk_end = pr.start_pos + n
+                    inter_start = max(f_start, chunk_start)
+                    inter_end = min(f_end, chunk_end)
+                    if inter_start >= inter_end:
+                        continue  # feature doesn't overlap this chunk
+                    length = inter_end - inter_start
+                    chunk_local = inter_start - chunk_start
+                    feature_local = inter_start - f_start
+
+                    result = encoder_cache.encoder_outputs.get(feature.identifier)
+                    if result is None:
+                        raise RuntimeError(
+                            f"Encoder output for feature {feature.identifier!r} "
+                            f"of request {pr.req_id!r} is missing; the encoder "
+                            f"gate should have populated it before prefill."
+                        )
+
+                    # Pack-coord mask range for this feature/chunk slice.
+                    packed_start = cursor + chunk_local
+                    visual_pos_masks_np[packed_start : packed_start + length] = True
+
+                    # Hidden states slice.
+                    mm_embeds_parts.append(
+                        result.hidden_states[feature_local : feature_local + length]
+                    )
+
+                    # Deepstack: same chunk-aware slice per layer; reject
+                    # mixed presence across features in this request.
+                    layers = result.deepstack_visual_embeds
+                    this_has = layers is not None
+                    if deepstack_present is None:
+                        deepstack_present = this_has
+                    elif deepstack_present != this_has:
+                        raise RuntimeError(
+                            f"Mixed deepstack presence across features for "
+                            f"request {pr.req_id!r}: either all features must "
+                            f"carry ``deepstack_visual_embeds`` or none.  "
+                            f"Partial deepstack would leave the LM with mask "
+                            f"positions that out-number the concatenated "
+                            f"residual rows."
+                        )
+                    if not this_has:
+                        continue
+                    assert layers is not None
+                    if not deepstack_per_layer:
+                        deepstack_per_layer = [
+                            [layer[feature_local : feature_local + length]]
+                            for layer in layers
+                        ]
+                    elif len(deepstack_per_layer) != len(layers):
+                        raise RuntimeError(
+                            f"Inconsistent deepstack layer count across "
+                            f"features for request {pr.req_id!r}: expected "
+                            f"{len(deepstack_per_layer)}, got {len(layers)}."
+                        )
+                    else:
+                        for layer_idx, layer in enumerate(layers):
+                            deepstack_per_layer[layer_idx].append(
+                                layer[feature_local : feature_local + length]
+                            )
+            else:
+                # text prefill: arange positions, but mark segment as None
+                # so attention falls back to the int-offset arange path.
+                offset_arr = np.arange(pr.start_pos, pr.start_pos + n, dtype=np.int32)
+                seg_positions = mx.broadcast_to(
+                    mx.array(offset_arr)[None, None, :], (3, 1, n)
+                )
+                ctx_segment_positions.append(None)
+                position_ids_parts.append(seg_positions)
+            cursor += n
+
+        # Build spliced inputs_embeds + packed position_ids.
+        inputs_embeds_text = adapter.embed_tokens(input_ids)
+        visual_pos_masks = mx.array(visual_pos_masks_np)[None, :]
+        if mm_embeds_parts:
+            inputs_embeds = merge_multimodal_embeddings(
+                inputs_embeds_text, mm_embeds_parts, visual_pos_masks
+            )
+        else:
+            inputs_embeds = inputs_embeds_text
+
+        deepstack_visual_embeds: Any | None = None
+        if deepstack_per_layer:
+            deepstack_visual_embeds = [
+                mx.concatenate(layer_parts, axis=0)
+                for layer_parts in deepstack_per_layer
+            ]
+
+        position_ids = mx.concatenate(position_ids_parts, axis=2)
+
+        # Thread per-segment positions into the paged context so
+        # ``apply_packed_rope`` reads caller-supplied positions on mm
+        # segments instead of the sequential-arange policy.
+        ctx = get_context()
+        if ctx is not None:
+            ctx.segment_positions = ctx_segment_positions
+
+        return adapter.call_lm(
+            input_ids,
+            inputs_embeds,
+            offset_caches,
+            position_ids,
+            visual_pos_masks=visual_pos_masks,
+            deepstack_visual_embeds=deepstack_visual_embeds,
+        )
 
     def _handle_new_requests(
         self,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1892,9 +1892,7 @@ class MetalModelRunner:
         # Pre-register mm_features so a new request whose first encoder input
         # lands in the same SchedulerOutput is already known to the encoder
         # cache when dispatch runs.
-        self._pre_register_new_request_mm_features(
-            scheduler_output.scheduled_new_reqs
-        )
+        self._pre_register_new_request_mm_features(scheduler_output.scheduled_new_reqs)
         self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
         if spec_decode_error is not None:
             raise spec_decode_error

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1233,7 +1233,7 @@ class MetalModelRunner:
                         "for 1 feature; adapter must return one result per "
                         "feature."
                     )
-                cache.encoder_outputs[feature.identifier] = outputs[0].hidden_states
+                cache.encoder_outputs[feature.identifier] = outputs[0]
 
     def _handle_new_requests(
         self,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1166,6 +1166,26 @@ class MetalModelRunner:
         self.encoder_cache.remove_request(req_id)
         self.encoder_cache.add_request(req_id, new_req.mm_features)
 
+    def _pre_register_new_request_mm_features(
+        self, new_reqs: list[NewRequestData]
+    ) -> None:
+        """Register mm_features for new requests before encoder dispatch.
+
+        The vLLM scheduler can place a brand-new multimodal request and its
+        first ``scheduled_encoder_inputs`` in the same ``SchedulerOutput``.
+        Encoder dispatch looks the request's mm_features up by ``req_id``,
+        so registration must happen before
+        :meth:`_reject_scheduled_encoder_inputs`, not later inside
+        :meth:`_handle_new_requests`.  Only the lightweight mm-features
+        bookkeeping is moved up; per-request prefill scheduling remains in
+        ``_handle_new_requests`` so the fail-fast checks still guard the
+        real model work.
+        """
+        if self.encoder_cache is None:
+            return
+        for new_req in new_reqs:
+            self._register_new_request_mm_features(new_req.req_id, new_req)
+
     def _remove_request_mm_features(self, req_id: str) -> None:
         """Drop request-scoped multimodal feature metadata."""
         if self.encoder_cache is not None:
@@ -1492,7 +1512,8 @@ class MetalModelRunner:
 
         for new_req in new_reqs:
             req_id = new_req.req_id
-            self._register_new_request_mm_features(req_id, new_req)
+            # mm_features were pre-registered before encoder dispatch in
+            # ``execute_model``; no further bookkeeping needed here.
             token_ids = new_req.prompt_token_ids or []
             sampling_params = new_req.sampling_params or SamplingParams()
 
@@ -1867,6 +1888,12 @@ class MetalModelRunner:
         self._cleanup_finished_requests(
             evicted_req_ids,
             materialize_gdn_state=will_fail_fast_before_model_work,
+        )
+        # Pre-register mm_features so a new request whose first encoder input
+        # lands in the same SchedulerOutput is already known to the encoder
+        # cache when dispatch runs.
+        self._pre_register_new_request_mm_features(
+            scheduler_output.scheduled_new_reqs
         )
         self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
         if spec_decode_error is not None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1145,17 +1145,20 @@ class MetalModelRunner:
         self,
         scheduled_encoder_inputs: dict[str, list[int]],
     ) -> None:
-        """Fail fast until the active adapter signals ``forward_ready``.
+        """Dispatch to vision encoders or fail fast based on adapter state.
 
-        Phase 4 flips ``forward_ready`` on the adapter for the parity-tested
-        model.  Phase 5+ adapters land at ``False`` and route through this
-        guard until each one's parity test passes, so partial work on a new
-        model never disturbs models already in production.
+        When the active adapter signals ``forward_ready``, scheduled encoder
+        inputs are routed to :meth:`_run_vision_encoders`.  Until Phase 4
+        flips that flag for the parity-tested model, the gate raises so
+        partial work on a new model never disturbs models already in
+        production.  Phase 5+ adapters land at ``False`` and route through
+        this guard until each one's parity test passes.
         """
         if not scheduled_encoder_inputs:
             return
         adapter = self._multimodal_adapter
         if adapter is not None and adapter.forward_ready:
+            self._run_vision_encoders(scheduled_encoder_inputs)
             return
         raise NotImplementedError(
             "Multimodal encoder execution is not wired on Metal yet. "
@@ -1189,6 +1192,48 @@ class MetalModelRunner:
             is_hybrid=self.is_hybrid,
             logitsprocs=self._logitsprocs,
         )
+
+    def _run_vision_encoders(
+        self,
+        scheduled_encoder_inputs: dict[str, list[int]],
+    ) -> None:
+        """Run the vision encoder for each scheduled feature, stash by identifier.
+
+        Skips features whose ``identifier`` already lives in
+        ``encoder_cache.encoder_outputs`` (cache hit; the scheduler may
+        re-list a feature across chunks).  Calls
+        ``adapter.encode_multimodal`` one feature at a time so a single bad
+        feature is reported with a precise req_id+idx rather than poisoning
+        a whole request batch.
+        """
+        adapter = self._multimodal_adapter
+        cache = self.encoder_cache
+        if adapter is None or cache is None:
+            return
+        for req_id, feature_indices in scheduled_encoder_inputs.items():
+            mm_features = cache.mm_features.get(req_id)
+            if mm_features is None:
+                raise RuntimeError(
+                    f"Scheduled encoder input for unregistered request "
+                    f"{req_id!r}; encoder cache mm_features missing."
+                )
+            for idx in feature_indices:
+                if idx < 0 or idx >= len(mm_features):
+                    raise IndexError(
+                        f"Encoder feature index {idx} out of range for "
+                        f"request {req_id!r} with {len(mm_features)} features."
+                    )
+                feature = mm_features[idx]
+                if feature.identifier in cache.encoder_outputs:
+                    continue
+                outputs = adapter.encode_multimodal([feature])
+                if len(outputs) != 1:
+                    raise RuntimeError(
+                        f"encode_multimodal returned {len(outputs)} outputs "
+                        "for 1 feature; adapter must return one array per "
+                        "feature."
+                    )
+                cache.encoder_outputs[feature.identifier] = outputs[0]
 
     def _handle_new_requests(
         self,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -127,9 +127,8 @@ class RequestState:
     block_ids: list[int] = field(
         default_factory=list
     )  # Scheduler-assigned paged KV blocks
-    # M-RoPE position delta stashed by mm prefill; ``None`` for text-only
-    # requests and used by paged decode to rebuild ``(3, 1, 1)`` positions
-    # at ``len(token_ids) - 1 + delta``.
+    # Decode reconstructs M-RoPE positions as
+    # ``len(token_ids) - 1 + mrope_position_delta``; ``None`` for text-only.
     mrope_position_delta: int | None = None
 
 
@@ -214,10 +213,8 @@ class _PagedForwardState(NamedTuple):
     cu_seqlens: list[int]
     decode_segments: tuple[PagedDecodeSegment, ...]
     num_decode_tokens: int
-    # ``{req_id: mrope_position_delta}`` computed during a paged mm
-    # prefill forward.  ``_sample_paged_batch`` writes the delta onto
-    # the request's ``RequestState`` so later decode steps can rebuild
-    # M-RoPE positions; empty for text-only batches.
+    # ``{req_id: mrope_position_delta}`` from paged mm prefill;
+    # ``_sample_paged_batch`` stashes each onto ``RequestState``.
     mm_prefill_deltas: dict[str, int]
 
 
@@ -833,12 +830,10 @@ class MetalModelRunner:
             )
         )
 
-        # Detect multimodal segments.  Mirror C's non-paged fail-fast: an
-        # mm request reaching here without a ``forward_ready`` adapter is
-        # a bookkeeping bug (the encoder gate only catches fresh-encode
-        # cases — a continuation chunk whose vision features were encoded
-        # in a prior step has no scheduled encoder input and would
-        # otherwise slip through to the text path).
+        # Fail fast on mm requests reaching the paged path without a
+        # forward-ready adapter: continuation chunks whose vision features
+        # were encoded earlier have no scheduled encoder input and would
+        # otherwise slip through to the text path.
         has_mm_prefill = any(self._is_mm_request(pr.req_id) for pr in prefill_reqs)
         has_mm_decode = any(
             state.mrope_position_delta is not None for _, state in decode_reqs
@@ -1148,10 +1143,8 @@ class MetalModelRunner:
             req_state.token_ids.append(next_token)
             req_state.generated_tokens = len(req_state.token_ids) - req_state.prompt_len
             if mm_delta is not None:
-                # cached_final for an mm request: stash the freshly
-                # computed delta so the next decode round routes through
-                # the mm path.  ``_run_mm_paged_forward`` recomputes per
-                # step, so the value is always current.
+                # Stash the freshly computed delta so the next decode round
+                # routes through the mm path.
                 req_state.mrope_position_delta = mm_delta
 
         for i, (req_id, _) in enumerate(batch.paged_decode_reqs):
@@ -1316,10 +1309,7 @@ class MetalModelRunner:
         encoder_cache = self.encoder_cache
         assert encoder_cache is not None
 
-        # Pre-compute full-prompt M-RoPE positions per mm prefill request.
-        # Chunked prefill of the same request would only appear once in
-        # ``prefill_reqs`` per step, so per-request caching here is for
-        # clarity rather than work avoidance.
+        # Full-prompt M-RoPE positions per mm prefill request.
         mm_request_meta: dict[
             str, tuple[mx.array, int, list[MultiModalFeatureSpec]]
         ] = {}
@@ -1348,7 +1338,6 @@ class MetalModelRunner:
         position_ids_parts: list[mx.array] = []
         cursor = 0
 
-        # Decode segments come first in the packed sequence.
         for segment in decode_segments:
             n = segment.num_query_tokens
             state = self._request_states.get(segment.req_id)
@@ -1374,7 +1363,6 @@ class MetalModelRunner:
             position_ids_parts.append(seg_positions)
             cursor += n
 
-        # Prefill segments follow.
         for pr in prefill_reqs:
             n = len(pr.token_ids)
             if pr.req_id in mm_request_meta:
@@ -1383,7 +1371,6 @@ class MetalModelRunner:
                 ctx_segment_positions.append(seg_positions)
                 position_ids_parts.append(seg_positions)
 
-                # Splice each feature's chunk-intersecting slice.
                 for feature in sorted_features:
                     f_start = feature.mm_position.offset
                     f_end = f_start + feature.mm_position.length
@@ -1405,17 +1392,14 @@ class MetalModelRunner:
                             f"gate should have populated it before prefill."
                         )
 
-                    # Pack-coord mask range for this feature/chunk slice.
                     packed_start = cursor + chunk_local
                     visual_pos_masks_np[packed_start : packed_start + length] = True
 
-                    # Hidden states slice.
                     mm_embeds_parts.append(
                         result.hidden_states[feature_local : feature_local + length]
                     )
 
-                    # Deepstack: same chunk-aware slice per layer; reject
-                    # mixed presence across features in this request.
+                    # Deepstack: same chunk-aware slice per layer.
                     layers = result.deepstack_visual_embeds
                     this_has = layers is not None
                     if deepstack_present is None:
@@ -1449,8 +1433,8 @@ class MetalModelRunner:
                                 layer[feature_local : feature_local + length]
                             )
             else:
-                # text prefill: arange positions, but mark segment as None
-                # so attention falls back to the int-offset arange path.
+                # text prefill: mark segment as None so attention uses the
+                # int-offset arange path.
                 offset_arr = np.arange(pr.start_pos, pr.start_pos + n, dtype=np.int32)
                 seg_positions = mx.broadcast_to(
                     mx.array(offset_arr)[None, None, :], (3, 1, n)
@@ -1459,7 +1443,6 @@ class MetalModelRunner:
                 position_ids_parts.append(seg_positions)
             cursor += n
 
-        # Build spliced inputs_embeds + packed position_ids.
         inputs_embeds_text = adapter.embed_tokens(input_ids)
         visual_pos_masks = mx.array(visual_pos_masks_np)[None, :]
         if mm_embeds_parts:
@@ -1478,9 +1461,8 @@ class MetalModelRunner:
 
         position_ids = mx.concatenate(position_ids_parts, axis=2)
 
-        # Thread per-segment positions into the paged context so
-        # ``apply_packed_rope`` reads caller-supplied positions on mm
-        # segments instead of the sequential-arange policy.
+        # Hand per-segment positions to ``apply_packed_rope`` via the
+        # paged context, overriding the sequential-arange policy.
         ctx = get_context()
         if ctx is not None:
             ctx.segment_positions = ctx_segment_positions


### PR DESCRIPTION
## Summary

Paged runner integration for Qwen3-VL: encoder-output caching by `mm_features.identifier`, embedding splice, M-RoPE positions, and LM forward on the paged KV path. Adapter stays at `forward_ready=False`; the gate flip + dependency bump + parity test land in follow-up PRs.

## Scope

**Included** (paged-core, 15 commits):

- `EncoderCache` stores the full `MultimodalEncodeResult` per `identifier` (not just hidden states), so deepstack residuals and other adapter-owned fields stay attached.
- `Qwen3VLMultimodalAdapter` gains the three runner-facing helpers: `embed_tokens` (load-time resolved), `encode_multimodal` (per-feature, never re-enters `Model.__call__`), `call_lm` (signature-sniffed `inputs_embeds` + optional deepstack kwargs).
- M-RoPE positions return `(3, 1, seq_len)` with an explicit batch axis so `call_lm` receives the layout mlx-vlm expects.
- `apply_packed_rope` accepts either an int offset (text, existing arange path) or a caller-supplied `(3, 1, seg_len)` array (mm, pre-computed positions).
- `_build_prefill_pack` carries the full prompt for mm requests at `start_pos == 0` so chunked-prefill positions stay correct from the first chunk.
- `_run_mm_paged_forward` does the actual paged splice: per-mm-request full-prompt M-RoPE precompute, chunk-aware placeholder mask, per-feature hidden-states slicing intersected with the chunk, packed `position_ids`, and `ctx.segment_positions` threaded into the attention wrapper.
- `mrope_position_delta` from mm prefill propagates onto `RequestState` (both `new_final` and `cached_final` postprocess paths) so paged decode keeps M-RoPE positions correct.
- Fail-fast: mm request reaching `_start_paged_forward` without a forward-ready adapter raises immediately rather than silently falling through to the text path.

**Not included** (split into follow-up PRs):


| Follow-up | Content                                                                                                                                                                                                                                   |
| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1         | Non-paged prefill + batched/sequential decode through `adapter.call_lm`.                                                                                                                                                                  |
| 2         | Spec-decode mm segment positions + scheduler-time `mm_features` pre-registration.                                                                                                                                                         |
| 3         | `mlx-vlm>=0.5.0` dependency bump + `forward_ready=True` flip + Qwen3-VL parity test + throughput benchmark. Blocked on a vLLM release that contains [#42150](https://github.com/vllm-project/vllm/pull/42150) (lifts `llguidance<1.4.0`). |


## Architecture

```
MetalModelRunner ─┬─ encoder_cache (per-request mm features + per-identifier outputs)
                  │
                  ├─ _run_vision_encoders ──► adapter.encode_multimodal(features)
                  │                              ↳ vision_tower(pixel_values, grid_thw)
                  │                              → Qwen3VLVisionEncodeResult
                  │                              → encoder_cache.encoder_outputs[id]
                  │
                  ├─ _run_mm_paged_forward (paged prefill, batched decode)
                  │                              ↳ per-request full-prompt M-RoPE precompute
                  │                              ↳ chunk-aware placeholder mask
                  │                              ↳ per-feature hidden-states slice
                  │                              ↳ packed deepstack concat
                  │                              ↳ ctx.segment_positions
                  │
                  └─ adapter.call_lm(input_ids, inputs_embeds, cache,
                                     position_ids, visual_pos_masks,
                                     deepstack_visual_embeds)
```

Key seams:

- **`Qwen3VLMultimodalAdapter.from_loaded_model`** sniffs `language_model.__call__` at load time and resolves `embed_tokens`, the `inputs_embeds` kwarg name, and whether the LM declares deepstack params explicitly. Renames or signature drift become init-time errors instead of mid-forward attribute errors.
- **`apply_packed_rope`** accepts either an int offset (text segment, arange path) or a caller-provided `(3, 1, seg_len)` array (mm segment, pre-computed M-RoPE).
- **`PagedAttentionContext.segment_positions`** carries per-segment caller-supplied positions through to the attention wrapper, so the M-RoPE override is local to mm segments — text segments keep the existing sequential-arange policy.
- **`forward_ready` flag** stays `False` on the adapter; runner-side code routes through the new path only when an adapter sets it. Flipping to `True` is gated on the parity test landing in PR-4.

## Test plan

Fake-LM coverage for everything the runner touches:

- `tests/v1/mm/test_encoder_cache.py` — encoder cache stores `MultimodalEncodeResult` per identifier; consumers read `.hidden_states`.
- `tests/v1/mm/test_model_runner_multimodal_cache.py` — runner registers/clears mm features per request; encoder gate fails fast when `forward_ready=False`.
- `tests/v1/mm/test_paged_forward_mm_gate.py` — `_start_paged_forward` raises on mm request with no/forward-not-ready adapter.
- `tests/v1/mm/test_paged_forward_mm.py` — single-feature prefill routes through `call_lm` with the right embeds/positions; chunked prefill slices hidden states correctly; deepstack concat across features respects per-chunk slicing; decode segment positions use `cache_start_pos + delta`; `mrope_position_delta` round-trips onto `RequestState` for both `new_final` and `cached_final` paths.
- `tests/v1/mm/test_build_prefill_pack_mm.py` — mm prefill at `start_pos==0` reads `full_prompt_token_ids` from both `RequestState` (cached) and `NewRequestData` (fresh).
- `tests/multimodal/test_qwen3_vl.py` — adapter helpers (`embed_tokens`, `get_mrope_input_positions`, `encode_multimodal`, `call_lm`) behave correctly on a fake LM, including the deepstack kwargs sniff.

Local: `pytest -m "not slow" tests/` → 846 passed, 2 skipped.

