### PR TITLE
Bump vLLM to 0.20.1

### DIFF
--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -23,4 +23,4 @@ vllm-rs serve Qwen/Qwen3-0.6B
 
 ## Caveat: integration direction
 
-Use `vllm-rs serve` (Rust binary spawns Python engine) on bundled vllm 0.20.0. The reverse direction `VLLM_USE_RUST_FRONTEND=1 vllm serve` requires an upstream vLLM hook that has not landed yet.
+Use `vllm-rs serve` (Rust binary spawns Python engine) on bundled vllm 0.20.1. The reverse direction `VLLM_USE_RUST_FRONTEND=1 vllm serve` requires an upstream vLLM hook that has not landed yet.

--- a/install.sh
+++ b/install.sh
@@ -179,7 +179,7 @@ EOF
 
   ensure_venv "$venv"
 
-  local vllm_v="0.20.0"
+  local vllm_v="0.20.1"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   curl -OL $url_base/v$vllm_v/$filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-vlm>=0.4.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
     # Model loading and weights
-    # Lower bound aligned with vllm 0.20.0's exclude list in requirements/common.txt
+    # Lower bound aligned with vllm 0.20.1's exclude list in requirements/common.txt
     "transformers>=5.5.1",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",


### PR DESCRIPTION
Bump vLLM to 0.20.1
This keeps vllm-metal aligned with the latest supported upstream vLLM 0.20.x patch release.

 `Qwen/Qwen3-0.6B`, sonnet dataset, 100 prompts, `--temperature 0`, second warm run on each version:

  | Metric | vLLM 0.20.0 | vLLM 0.20.1 | Delta |
  | --- | ---: | ---: | ---: |
  | Output tok/s | 1213.63 | 1261.38 | +3.9% |
  | Total tok/s | 5603.40 | 5823.90 | +3.9% |
  | Mean TTFT | 1896.30 ms | 1626.76 ms | -14.2% |
  | Mean TPOT | 70.17 ms | 68.84 ms | -1.9% |
  | P99 TPOT | 70.17 ms | 68.85 ms | -1.9% |
  | Duration | 12.36 s | 11.89 s | -3.8% |