### PR TITLE
docs: add Qwen2-7B-Instruct to supported models

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -55,3 +55,4 @@ runtime dtype. The preflight, dtype alignment, and
 | Qwen2.5-3B-Instruct | ✅ | GQA (paged) | ✅ | [#323](https://github.com/vllm-project/vllm-metal/pull/323) | Validated on MacBook Pro (Apple M1 Pro, 16 GB) on macOS 26.2; tested with `mlx-community/Qwen2.5-3B-Instruct-4bit` |
 | SmolLM3-3B | ✅ | GQA (paged) | ✅ | [#334](https://github.com/vllm-project/vllm-metal/pull/334) | Validated on MacBook Air (Apple M2, 16 GB) with `mlx-community/SmolLM3-3B-4bit` |
 | Qwen2.5-1.5B-Instruct-AWQ | ✅ | GQA (paged) | ✅ | [#340](https://github.com/vllm-project/vllm-metal/pull/340) | First HF AWQ checkpoint validated on Metal; tested with `Qwen/Qwen2.5-1.5B-Instruct-AWQ` on MacBook Pro (Apple M1 Pro, 16 GB), macOS 26.2. See AWQ note above the table |
+| Qwen2-7B-Instruct | ✅ | GQA (paged) | ✅ | [#353](https://github.com/vllm-project/vllm-metal/pull/353) | Validated on MacBook Pro (Apple M5 Pro, 48 GB) on macOS 26.4.1; tested with `mlx-community/Qwen2-7B-Instruct-4bit` |


### PR DESCRIPTION
## Summary

Validates `mlx-community/Qwen2-7B-Instruct-4bit` on vllm-metal and adds a row to `docs/supported_models.md`.

The model loads cleanly and produces coherent EN/ZH output on both `/v1/completions` and `/v1/chat/completions`. Reuses the existing Qwen2 GQA paged-attention path; no code changes required.

Refs: #289

## Environment

- **Hardware**: MacBook Pro (Apple M5 Pro, 48 GB unified memory)
- **OS**: macOS 26.4.1
- **vllm-metal**: commit 63a462a (main)
- **vllm core**: 0.20.1+cpu
- **MLX**: 0.31.2

## How to reproduce

```bash
GLOO_SOCKET_IFNAME=lo0 VLLM_HOST_IP=127.0.0.1 \
VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION=0.7 \
vllm serve mlx-community/Qwen2-7B-Instruct-4bit \
  --port 8000 --max-model-len 2048 --max-num-batched-tokens 512
```

## Smoke test results (greedy, temperature=0)

**`/v1/completions`**

prompt: `The capital of France is`
output: ` Paris. It is also the most populous city in France, with an estimated population of over 2.2 million people. Paris is located in the`
usage: 5 prompt + 30 completion tokens

**`/v1/chat/completions` (EN)**

user: `In one sentence, explain what vLLM is.`
assistant: `vLLM is a library that provides a virtual layer to manage and optimize the allocation of resources in a distributed computing environment.`
finish_reason: `stop` · usage: 30 prompt + 26 completion tokens

**`/v1/chat/completions` (ZH)**

user: `用一句中文介绍 vLLM 是什么。`
assistant: `vLLM（Vector Language Model）是一种基于向量的自然语言处理模型，它能够将语言信息转化为数值向量，以便进行更高效和精确的语义分析与理解。`
finish_reason: `stop` · usage: 29 prompt + 42 completion tokens

## Checklist

- [x] Loads without errors
- [x] Produces coherent text in EN and ZH
- [x] Chat path reaches EOS (`finish_reason=stop`)
- [x] DCO `Signed-off-by` present
- [x] Lint clean (`ruff check`, `ruff format --check`, `mypy`)

> Note: I will follow up with a tiny commit replacing the `#XXX` placeholder in the table with the actual PR number once this PR is opened (mirrors the style used in #324, #334, #347).
