### PR TITLE
Fix lazy GDN conv state dtype casting

### DIFF
--- a/tests/test_gdn_lazy_decode.py
+++ b/tests/test_gdn_lazy_decode.py
@@ -248,6 +248,91 @@ class TestLazyConvDecode:
         expected_state[slot_ids] = 9
         np.testing.assert_array_equal(np.array(cache.conv_states[0]), expected_state)
 
+    def test_mixed_dtype_state_update_matches_eager_conv(self) -> None:
+        # Arrange
+        _require_metal()
+        mx.random.seed(1)
+        conv_dim = 4
+        kernel_size = 3
+        cache = _make_state_cache(conv_kernel_dim=kernel_size, conv_dim=conv_dim)
+        initial_state = mx.random.normal(cache.conv_states[0].shape).astype(mx.bfloat16)
+        cache.conv_states[0] = mx.array(initial_state)
+        weight = mx.random.normal((conv_dim, kernel_size)).astype(mx.float32)
+        inner = SimpleNamespace(
+            conv_kernel_size=kernel_size, conv1d=_DepthwiseConv1D(weight)
+        )
+        mixed_qkv = mx.random.normal((1, 2, conv_dim)).astype(mx.float32)
+        slot_ids = [1, 0]
+
+        expected_state = mx.array(initial_state)
+        expected_outputs = []
+        for req_idx, slot in enumerate(slot_ids):
+            conv_input = mx.concatenate(
+                [
+                    expected_state[slot : slot + 1],
+                    mixed_qkv[:, req_idx : req_idx + 1],
+                ],
+                axis=1,
+            )
+            expected_state[slot : slot + 1] = conv_input[
+                :, -(kernel_size - 1) :
+            ].astype(mx.bfloat16)
+            expected_outputs.append(nn.silu(inner.conv1d(conv_input))[:, -1:])
+        expected = mx.concatenate(expected_outputs, axis=1)
+
+        # Act
+        actual = GDNLazyDecodeKernels(enabled=True).try_conv_decode(
+            mixed_qkv, inner, cache, 0, slot_ids
+        )
+
+        # Assert
+        assert actual is not None
+        mx.eval(actual, expected, cache.conv_states[0], expected_state)
+        assert actual.dtype == mx.float32
+        assert cache.conv_states[0].dtype == mx.bfloat16
+        np.testing.assert_allclose(np.array(actual), np.array(expected), atol=5e-3)
+        np.testing.assert_allclose(
+            np.array(cache.conv_states[0].astype(mx.float32)),
+            np.array(expected_state.astype(mx.float32)),
+            atol=5e-3,
+        )
+
+    def test_conv_state_update_template_uses_state_dtype(self) -> None:
+        # Arrange
+        class FakeConvKernel:
+            def __init__(self) -> None:
+                self.template: list[tuple[str, Any]] | None = None
+                self.output_dtypes: list[mx.Dtype] | None = None
+
+            def __call__(self, **kwargs: Any) -> tuple[mx.array, mx.array]:
+                self.template = kwargs["template"]
+                self.output_dtypes = kwargs["output_dtypes"]
+                return (
+                    mx.ones((1, 4), dtype=mx.float32),
+                    mx.ones((1, 2, 4), dtype=mx.bfloat16),
+                )
+
+        fake_kernel = FakeConvKernel()
+        cache = _make_state_cache(max_seqs=2, conv_kernel_dim=3, conv_dim=4)
+        cache.conv_states[0] = cache.conv_states[0].astype(mx.bfloat16)
+        inner = SimpleNamespace(
+            conv_kernel_size=3,
+            conv1d=SimpleNamespace(weight=mx.ones((4, 3), dtype=mx.float32)),
+        )
+
+        # Act
+        result = GDNLazyDecodeKernels(
+            enabled=True,
+            conv_kernel=fake_kernel,
+            recurrent_kernel=_RaisingKernel(),
+        ).try_conv_decode(mx.zeros((1, 1, 4), dtype=mx.float32), inner, cache, 0, [0])
+
+        # Assert
+        assert result is not None
+        assert ("T", mx.float32) in (fake_kernel.template or [])
+        assert ("StT", mx.bfloat16) in (fake_kernel.template or [])
+        assert fake_kernel.output_dtypes == [mx.float32, mx.bfloat16]
+
 
 class TestLazyRecurrentDecode:
     def test_updates_only_active_recurrent_slots(self) -> None:

--- a/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
@@ -1,4 +1,4 @@
-// Template params: T (dtype), CONV_DIM, KERNEL_SIZE
+// Template params: T (output/input dtype), StT (state dtype), CONV_DIM, KERNEL_SIZE
 // Inputs: input, conv_state_in, weights, slot_mapping, num_requests
 // Outputs: output, conv_state_out
 // Grid: (num_requests * CONV_DIM, 1, 1) — one thread per (request, channel)
@@ -31,4 +31,4 @@ for (int t = 0; t < state_len - 1; ++t) {
     conv_state_out[state_out_base + t * CONV_DIM] =
         conv_state_in[state_base + (t + 1) * CONV_DIM];
 }
-conv_state_out[state_out_base + (state_len - 1) * CONV_DIM] = static_cast<T>(inp);
+conv_state_out[state_out_base + (state_len - 1) * CONV_DIM] = static_cast<StT>(inp);

--- a/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
+++ b/vllm_metal/metal_kernel_backend/gdn_lazy_decode.py
@@ -193,6 +193,7 @@ class GDNLazyDecodeKernels:
         ]
         template = [
             ("T", mixed_qkv.dtype),
+            ("StT", conv_state_in.dtype),
             ("CONV_DIM", conv_dim),
             ("KERNEL_SIZE", kernel_size),
         ]


### PR DESCRIPTION
## Summary

This is a small follow-up fix for the lazy GDN decode fast path added in #344.

The lazy GDN conv Metal kernel could fail to JIT compile when the activation/output dtype differs from the persisted conv state dtype. The kernel previously used the activation template dtype `T` when writing the newest token into `conv_state_out`.

This PR adds a separate `StT` template for the conv state dtype and uses it when writing state updates.

## Problem

The lazy GDN conv kernel had one dtype template:

```metal
conv_state_out[...] = static_cast<T>(inp);
```

But `T` is derived from `mixed_qkv.dtype`, while `conv_state_out` uses `conv_state_in.dtype`.

In Qwen3.5 hybrid decode, those can differ, causing Metal JIT compilation to fail with an error like:

```text
assigning to 'bfloat16_t' from incompatible type 'float'
conv_state_out[...] = static_cast<T>(inp);
```

## Changes

- Add `StT` as the Metal template dtype for conv state output.
- Pass `("StT", conv_state_in.dtype)` from the Python kernel launch.
- Cast the newest conv-state element with `static_cast<StT>(...)`.
- Add regression coverage for:
  - Python launch contract: `T` follows activation dtype, `StT` follows state dtype.
  - Real Metal mixed-dtype execution with `float32` input and `bfloat16` conv state.

## Tests

```bash
python -m ruff check \
  vllm_metal/metal_kernel_backend/gdn_lazy_decode.py \
  tests/test_gdn_lazy_decode.py

python -m py_compile \
  vllm_metal/metal_kernel_backend/gdn_lazy_decode.py \
  tests/test_gdn_lazy_decode.py

PYTHONPATH=$PWD python -m pytest \
  tests/test_gdn_lazy_decode.py \
  tests/test_attention_sdpa.py \
  tests/test_attention_dispatch.py::test_qwen35_paged_attention_hybrid \
  -q
```

Result:

```text
29 passed
```
