### PR TITLE
perf(sampling): skip penalty tensor allocation when no penalties

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -342,6 +342,66 @@ class TestV1SamplingBatch:
             [SamplingParams(temperature=0.0), SamplingParams(temperature=0.8, top_k=4)]
         )
 
+    def test_sampling_metadata_skips_penalty_allocation_when_no_penalties(
+        self,
+    ) -> None:
+        """When the batch has no penalties, the per-request penalty tensors
+        should be zero-length placeholders rather than ``batch_size`` allocations.
+
+        Both ``Sampler.apply_penalties`` and ``RejectionSampler`` short-circuit
+        on ``no_penalties=True`` before reading these fields, so skipping the
+        allocations is safe and removes 3 redundant ``torch.tensor(...)`` calls
+        per decode step on hot paths.
+        """
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0),
+                SamplingParams(temperature=0.8),
+                SamplingParams(temperature=1.0, top_k=10),
+            ],
+            [[1, 2, 3], [4, 5], [6]],
+            [[], [], []],
+            vocab_size=VOCAB_SIZE,
+            device=torch.device("cpu"),
+        )
+        assert batch.no_penalties
+
+        metadata = batch.make_sampling_metadata()
+
+        assert metadata.no_penalties is True
+        assert metadata.frequency_penalties.numel() == 0
+        assert metadata.presence_penalties.numel() == 0
+        assert metadata.repetition_penalties.numel() == 0
+        assert metadata.frequency_penalties.dtype == torch.float32
+        assert metadata.presence_penalties.dtype == torch.float32
+        assert metadata.repetition_penalties.dtype == torch.float32
+
+    def test_sampling_metadata_allocates_penalty_tensors_when_penalized(
+        self,
+    ) -> None:
+        """Regression: ensure penalty tensors are still built per-request when
+        any request opts into a non-default penalty value.
+        """
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0),
+                SamplingParams(temperature=0.8, frequency_penalty=0.5),
+                SamplingParams(temperature=0.8, repetition_penalty=1.2),
+            ],
+            [[1], [2], [3]],
+            [[], [], []],
+            vocab_size=VOCAB_SIZE,
+            device=torch.device("cpu"),
+        )
+        assert not batch.no_penalties
+
+        metadata = batch.make_sampling_metadata()
+
+        assert metadata.no_penalties is False
+        assert metadata.frequency_penalties.tolist() == pytest.approx([0.0, 0.5, 0.0])
+        assert metadata.presence_penalties.tolist() == pytest.approx([0.0, 0.0, 0.0])
+        assert metadata.repetition_penalties.tolist() == pytest.approx([1.0, 1.0, 1.2])
+
     def test_sampling_metadata_uses_requested_logprobs(self) -> None:
         batch = SamplingBatch(
             [SamplingParams(temperature=0.0, logprobs=5)],

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -228,6 +228,17 @@ class SamplingBatch:
     def _make_penalty_tensors(
         self,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Build per-request penalty tensors.
+
+        When the batch has no penalties, the vLLM ``Sampler`` and
+        ``RejectionSampler`` short-circuit on ``no_penalties=True`` before
+        touching these tensors, so we can return zero-length placeholders and
+        avoid allocating ``batch_size`` tensors three times every step.
+        """
+        if self.no_penalties:
+            empty = torch.empty(0, dtype=torch.float32, device=self.device)
+            return empty, empty, empty
+
         frequency_penalties = torch.tensor(
             [
                 sampling_params.frequency_penalty


### PR DESCRIPTION
## Summary

`SamplingBatch._make_penalty_tensors` was unconditionally building three `batch_size` float32 tensors every decode step, even when the batch has no penalties at all. These tensors are never read: both `Sampler.apply_penalties` and `RejectionSampler` (the only two consumers in vLLM core) short-circuit on `sampling_metadata.no_penalties=True` before touching `frequency_penalties` / `presence_penalties` / `repetition_penalties`.

This PR returns three zero-length float32 placeholders on the device when `no_penalties` is true, removing three `torch.tensor(...)` constructions per decode step on a path that fires for every greedy / temperature-only request.

This is a dead-work removal, not a measurable end-to-end speedup — see the "Performance" section below.

## Why this is safe

I traced every reader of these three fields in vLLM 0.20.1:

1. `vllm/v1/sample/sampler.py` `apply_penalties` — guards with `if sampling_metadata.no_penalties: return logits` before reading any penalty field.
2. `vllm/v1/sample/rejection_sampler.py:341` — guards with the same `if sampling_metadata.no_penalties: return logits` check before indexing into `presence_penalties` / `frequency_penalties` / `repetition_penalties`.

There are no other readers under `vllm/v1/`. With `no_penalties=True` set correctly, the placeholder tensors are never inspected, so their length is irrelevant.

A zero-length `torch.Tensor` is used (rather than `None`) so the placeholders still satisfy the `SamplingMetadata` dataclass field type (`torch.Tensor`, not `Optional[torch.Tensor]`).

## Behavior change

**Before** (no_penalties batch):
```python
frequency_penalties = torch.tensor([0.0]*N, dtype=float32, device=device)   # 3 allocations of size N
presence_penalties  = torch.tensor([0.0]*N, dtype=float32, device=device)
repetition_penalties= torch.tensor([1.0]*N, dtype=float32, device=device)
```

**After** (no_penalties batch):
```python
empty = torch.empty(0, dtype=float32, device=device)
frequency_penalties = presence_penalties = repetition_penalties = empty
```

When **any** request opts into a non-default penalty (`no_penalties=False`), the existing per-request construction path is unchanged.

## Performance

This is dead-work removal, not a measurable end-to-end speedup. The 3 `torch.tensor(...)` calls run on every decode step on a hot path, so removing them produces a small per-step win (rough order: tens of µs for 3 small MPS tensor constructions) — invisible at the tok/s level for 7B+ models, but the work was unconditional and the result was never read.

The motivation is correctness/cleanliness rather than benchmark numbers:
- removes a redundant allocation that downstream guards already prove is unread,
- keeps the sampling fast path easier to reason about for follow-up work on issue #343 (native MLX sampling), where reducing PyTorch-side work is a prerequisite for a clean before/after comparison.

Happy to add a microbenchmark if a reviewer wants one.

## Tests

- New: `test_sampling_metadata_skips_penalty_allocation_when_no_penalties` — locks in that the three fields are zero-length placeholders when the batch has no penalties, while `no_penalties=True` is still set.
- New: `test_sampling_metadata_allocates_penalty_tensors_when_penalized` — regression guard that values are still computed per-request when at least one request enables a penalty.
- Existing tests pass:
  - `TestV1SamplingBatch` — 10/10
  - Full `tests/test_sampling.py` — 34/34
  - `TestV1PenaltyTokenAccounting` (the active penalty path) — 6/6

## Lint

`ruff check`, `ruff format --check`, `mypy vllm_metal` all clean.

## Environment

- Hardware: MacBook Pro (Apple M5 Pro, 48 GB)
- macOS 26.4.1
- vllm-metal: this branch off main `63a462a`
- vllm core: 0.20.1+cpu
- MLX: 0.31.2

## Related

- Refs #289 (the model validation effort I’ve been working on; this came out of profiling the sampling path while testing #353 / #354).
- Loosely related to #343 (native MLX sampling): cleaning the `SamplingMetadata` construction path makes the future torch→mlx migration easier to measure cleanly.
