### PR TITLE
Cap mlx-vlm before llguidance conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
     # Bump after verifying the JIT build against the new MLX minor release.
     "mlx>=0.31.0,<0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    # 0.5.0 fixes Qwen3-VL deepstack reference outputs; older releases overwrite
-    # them with mx.eval(...)=None and cannot validate deepstack parity.
-    "mlx-vlm>=0.5.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # Keep below 0.5.0 while vLLM 0.20.1 requires llguidance<1.4.0.
+    # mlx-vlm 0.5.0 requires llguidance>=1.7.0.
+    "mlx-vlm>=0.4.0,<0.5.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
     # Lower bound aligned with vllm 0.20.1's exclude list in requirements/common.txt
     "transformers>=5.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
     # Bump after verifying the JIT build against the new MLX minor release.
     "mlx>=0.31.0,<0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "mlx-vlm>=0.4.0; platform_system == 'Darwin' and platform_machine == 'arm64'",  # Vision-language model support
+    # 0.5.0 fixes Qwen3-VL deepstack reference outputs; older releases overwrite
+    # them with mx.eval(...)=None and cannot validate deepstack parity.
+    "mlx-vlm>=0.5.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
     # Lower bound aligned with vllm 0.20.1's exclude list in requirements/common.txt
     "transformers>=5.5.1",


### PR DESCRIPTION
Keep mlx-vlm below 0.5.0 while vLLM 0.20.1 requires llguidance<1.4.0.

mlx-vlm 0.5.0 is the first release with the Qwen3-VL deepstack reference fix, but its published metadata requires llguidance>=1.7.0. That conflicts with vLLM 0.20.1 on Apple Silicon, where vLLM requires llguidance>=1.3.0,<1.4.0. Allowing mlx-vlm 0.5.0 in the supported install path can either fail dependency resolution or upgrade llguidance outside vLLM's supported range.

This PR therefore caps mlx-vlm at <0.5.0 for now. Qwen3-VL deepstack parity should be handled after vLLM and mlx-vlm have compatible llguidance requirements, or with a separate isolated reference setup that does not affect the vllm-metal install path.
