### PR TITLE
[Kernel] MLA absorbed-decode kernels (RFC #360 Phase 1, kernel-layer)

### DIFF
--- a/tests/test_mla_kernel.py
+++ b/tests/test_mla_kernel.py
@@ -1,0 +1,833 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Direct unit tests for the MLA Metal kernel (RFC #360).
+
+Single-pass decode kernel. The kernel handles ``ctx_len`` of any size
+that fits the caller-provided block_tables row, with two-pass softmax
+and a cross-simdgroup merge.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from vllm_metal.metal import metal_mla_paged_attention
+
+# Production shapes — only kv_lora_rank=512, qk_rope_head_dim=64 are
+# instantiated in mla.metal.
+_KV_LORA_RANK = 512
+_QK_ROPE_HEAD_DIM = 64
+_LATENT_DIM = _KV_LORA_RANK + _QK_ROPE_HEAD_DIM
+
+
+def _tolerance(dtype: mx.Dtype) -> tuple[float, float]:
+    """Per-dtype (rtol, atol).
+
+    bf16 has 7 mantissa bits — 1 ULP near magnitude 1.0 is ~7.8e-3, so a
+    512-dim dot product accumulated through fp32 then cast back to bf16
+    routinely shows 1–2 ULP drift vs an einsum-ordered reference. fp16
+    has 10 mantissa bits and is much tighter.
+    """
+    if dtype == mx.bfloat16:
+        return 1e-2, 2e-2
+    return 1e-3, 1e-3
+
+
+def _absorbed_mla_dense_reference(
+    q_nope: mx.array,  # [num_q, num_heads, kv_lora_rank], fp32
+    q_pe: mx.array,  # [num_q, num_heads, qk_rope_head_dim], fp32
+    kv_norm: mx.array,  # [num_q, ctx_len, kv_lora_rank], fp32
+    k_pe: mx.array,  # [num_q, ctx_len, qk_rope_head_dim], fp32
+    scale: float,
+) -> mx.array:
+    """Pure-MLX absorbed-MLA single attention step.
+
+    All inputs are expected fp32. Returns fp32 output of shape
+    [num_q, num_heads, kv_lora_rank].
+    """
+    nope_scores = mx.einsum("qhd,qtd->qht", q_nope, kv_norm)
+    pe_scores = mx.einsum("qhd,qtd->qht", q_pe, k_pe)
+    scores = scale * (nope_scores + pe_scores)
+    weights = mx.softmax(scores, axis=-1)
+    out = mx.einsum("qht,qtd->qhd", weights, kv_norm)
+    return out
+
+
+def _make_inputs(
+    *,
+    num_seqs: int,
+    num_heads: int,
+    ctx_len: int,
+    block_size: int,
+    dtype: mx.Dtype,
+    seed: int = 0,
+):
+    """Build a decode input set that fits ``ctx_len`` worth of valid
+    context per sequence. Each sequence is allocated
+    ``ceil(ctx_len / block_size)`` blocks; out-of-context slots in the
+    last block hold garbage that the kernel must ignore via the ctx_len
+    bound. Block tables are contiguous per-seq for simplicity."""
+    mx.random.seed(seed)
+
+    n_blocks_per_seq = max(1, (ctx_len + block_size - 1) // block_size)
+    num_blocks = n_blocks_per_seq * num_seqs
+
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    q_nope = mx.random.normal(shape=(num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal(shape=(num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(
+        dtype
+    )
+    latent_cache = mx.random.normal(shape=(num_blocks, block_size, _LATENT_DIM)).astype(
+        dtype
+    )
+
+    block_tables_np = np.arange(num_blocks, dtype=np.int32).reshape(
+        num_seqs, n_blocks_per_seq
+    )
+    block_tables = mx.array(block_tables_np)
+
+    context_lens = mx.array([ctx_len] * num_seqs, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+
+    return (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    )
+
+
+def _expected_output(
+    q_nope: mx.array,
+    q_pe: mx.array,
+    latent_cache: mx.array,
+    block_tables_np: np.ndarray,
+    ctx_lens: list[int],
+    scale: float,
+) -> mx.array:
+    """Run the dense reference per-request, gathering the valid-context
+    window across however many blocks the request occupies. Casts to
+    fp32 for the reference math then back to the original dtype."""
+    num_seqs = q_nope.shape[0]
+    block_size = latent_cache.shape[1]
+    in_dtype = q_nope.dtype
+
+    outs = []
+    for i in range(num_seqs):
+        ctx_len = ctx_lens[i]
+        n_blocks = (ctx_len + block_size - 1) // block_size
+        # Concatenate all valid blocks then slice down to ctx_len.
+        gathered = mx.concatenate(
+            [latent_cache[int(block_tables_np[i, b]), :, :] for b in range(n_blocks)],
+            axis=0,
+        )[:ctx_len, :].astype(mx.float32)
+        kv_norm = gathered[:, :_KV_LORA_RANK].reshape(1, ctx_len, _KV_LORA_RANK)
+        k_pe = gathered[:, _KV_LORA_RANK:].reshape(1, ctx_len, _QK_ROPE_HEAD_DIM)
+        out_i = _absorbed_mla_dense_reference(
+            q_nope[i : i + 1, :, :].astype(mx.float32),
+            q_pe[i : i + 1, :, :].astype(mx.float32),
+            kv_norm,
+            k_pe,
+            scale,
+        )
+        outs.append(out_i)
+    return mx.concatenate(outs, axis=0).astype(in_dtype)
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+def test_decode_single_block(dtype: mx.Dtype, block_size: int) -> None:
+    """ctx_len strictly less than block_size — exercises the masked-tail
+    code path: out-of-context slots in the BLOCK_SIZE-wide score buffer
+    must not contribute to the softmax."""
+    ctx_len = max(1, block_size // 2)  # 8 or 16
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=4,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"single-block mismatch (dtype={dtype}, block_size={block_size}, "
+        f"ctx_len={ctx_len}): max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+def test_decode_full_block(dtype: mx.Dtype, block_size: int) -> None:
+    """ctx_len == block_size — every slot in the block is valid context.
+    Catches off-by-one errors in the ctx_len boundary check."""
+    ctx_len = block_size
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=3,
+        num_heads=4,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len] * 3,
+        scale=0.125,
+    )
+
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"full-block mismatch (dtype={dtype}, block_size={block_size}): "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_single_token_context(dtype: mx.Dtype = mx.float16) -> None:
+    """ctx_len = 1 — degenerate case. softmax of a single score is
+    always 1.0, output should equal kv_norm[0, :]. Catches obviously-wrong
+    softmax / accumulation bugs."""
+    block_size = 16
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=1,
+        num_heads=2,
+        ctx_len=1,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    # Expected: out[0, h, :] = kv_norm[block_idx, 0, :KV_LORA_RANK] for all h
+    expected_row = latent_cache[
+        int(block_tables_np[0, 0]), 0, :_KV_LORA_RANK
+    ]  # [KV_LORA_RANK]
+    expected = mx.broadcast_to(
+        expected_row.reshape(1, 1, _KV_LORA_RANK), out.shape
+    ).astype(dtype)
+
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+def test_decode_two_blocks_with_partial_tail(dtype: mx.Dtype, block_size: int) -> None:
+    """ctx_len = block_size + 1 — minimal multi-block case. Exercises the
+    block-table walk (vs. step 7's hardcoded block 0), the partial last
+    block, and the cross-warp merge with one warp doing real work and
+    seven idle (their state must be the identity element)."""
+    ctx_len = block_size + 1
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=4,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"two-block mismatch (dtype={dtype}, block_size={block_size}, "
+        f"ctx_len={ctx_len}): max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+def test_decode_one_block_per_warp(dtype: mx.Dtype, block_size: int) -> None:
+    """ctx_len = block_size * NUM_WARPS — every warp processes exactly one
+    block, all NUM_WARPS=8 warp states participate in the merge."""
+    num_warps = 8
+    ctx_len = block_size * num_warps
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=1,
+        num_heads=4,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len],
+        scale=0.125,
+    )
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_decode_many_blocks_per_warp(dtype: mx.Dtype) -> None:
+    """ctx_len = 4096 — each warp does ctx_len / (block_size * NUM_WARPS)
+    iterations, tests the warp-strided loop's iteration count and the
+    online softmax accumulator stability over many blocks."""
+    block_size = 32
+    ctx_len = 4096
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=1,
+        num_heads=2,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len],
+        scale=0.125,
+    )
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"long-context mismatch (dtype={dtype}, ctx_len={ctx_len}): "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_mixed_ctx_batch() -> None:
+    """Batch with three sequences at different ctx_lens — exercises the
+    per-seq context_lens read and ensures the kernel doesn't accidentally
+    use one sequence's ctx_len for another (which would happen if the
+    block-iteration bound was hoisted out of the threadgroup-local lookup)."""
+    block_size = 32
+    ctx_lens = [1, 200, 1024]  # single-block, multi-block, many-warp
+    max_ctx = max(ctx_lens)
+    n_blocks_per_seq = (max_ctx + block_size - 1) // block_size
+    num_seqs = len(ctx_lens)
+    num_heads = 4
+    dtype = mx.float16
+
+    mx.random.seed(13)
+    num_blocks = n_blocks_per_seq * num_seqs
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    q_nope = mx.random.normal(shape=(num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal(shape=(num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(
+        dtype
+    )
+    latent_cache = mx.random.normal(shape=(num_blocks, block_size, _LATENT_DIM)).astype(
+        dtype
+    )
+    block_tables_np = np.arange(num_blocks, dtype=np.int32).reshape(
+        num_seqs, n_blocks_per_seq
+    )
+    block_tables = mx.array(block_tables_np)
+    context_lens = mx.array(ctx_lens, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+    mx.synchronize()
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=ctx_lens,
+        scale=0.125,
+    )
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+def test_rejects_multi_token_query() -> None:
+    """Step 7 supports decode only (one query token per sequence). Any
+    request with >1 query tokens must raise — without the guard the
+    kernel mis-aligns q_token_idx with seq_idx and reads OOB metadata."""
+    block_size = 16
+    (
+        out_unused,
+        q_nope_unused,
+        q_pe_unused,
+        latent_cache,
+        block_tables,
+        context_lens,
+        _cu_unused,
+        _bt_np,
+    ) = _make_inputs(
+        num_seqs=1,
+        num_heads=2,
+        ctx_len=4,
+        block_size=block_size,
+        dtype=mx.float16,
+    )
+    # 1 sequence with 2 query tokens (prefill of length 2).
+    cu_seqlens_q = mx.array([0, 2], dtype=mx.int32)
+    out = mx.zeros((2, 2, _KV_LORA_RANK), dtype=mx.float16)
+    q_nope = mx.zeros((2, 2, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((2, 2, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+
+    with pytest.raises(NotImplementedError, match="one query token per sequence"):
+        metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )
+
+
+def test_rejects_undersized_block_tables() -> None:
+    """If block_tables.shape[1] is too narrow to cover the requested
+    ctx_len, the kernel would read past the row into the next sequence's
+    row (or off the end of the buffer). The wrapper must catch this
+    before dispatch — programmer error, ValueError."""
+    block_size = 16
+    ctx_len = block_size * 3  # needs 3 blocks per seq
+    num_seqs = 1
+    num_heads = 2
+    dtype = mx.float16
+
+    mx.random.seed(0)
+    # Allocate a too-narrow block_tables: only 1 column, but ctx_len needs 3.
+    num_blocks = 8  # plenty of physical blocks; the issue is row width
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    q_nope = mx.random.normal(shape=(num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal(shape=(num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(
+        dtype
+    )
+    latent_cache = mx.random.normal(shape=(num_blocks, block_size, _LATENT_DIM)).astype(
+        dtype
+    )
+    block_tables = mx.zeros((num_seqs, 1), dtype=mx.int32)  # one column!
+    context_lens = mx.array([ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+
+    with pytest.raises(ValueError, match="block_tables row width"):
+        metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )
+
+
+def test_unsupported_kv_lora_rank_raises() -> None:
+    """Phase 1 only instantiates kv_lora_rank=512. Anything else must
+    raise at dispatch time, not silently dispatch a wrong kernel."""
+    out = mx.zeros((1, 2, 16), dtype=mx.float16)
+    q_nope = mx.zeros((1, 2, 16), dtype=mx.float16)
+    q_pe = mx.zeros((1, 2, 4), dtype=mx.float16)
+    latent_cache = mx.zeros((1, 16, 20), dtype=mx.float16)
+    block_tables = mx.zeros((1, 1), dtype=mx.int32)
+    context_lens = mx.array([1], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+
+    with pytest.raises(RuntimeError, match="kv_lora_rank=512"):
+        metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cross-head amortization (HEADS_PER_TG > 1)
+# ---------------------------------------------------------------------------
+# G=4 packs 4 query heads into one threadgroup so each K/V load is reused
+# across 4 dot products (4× KV bandwidth amortization). num_heads must be
+# divisible by G; num_threads is 256 instead of 1024 so the per-thread
+# register footprint stays comparable.
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+@pytest.mark.parametrize("num_heads", [4, 8, 128])
+def test_g4_matches_dense(dtype: mx.Dtype, block_size: int, num_heads: int) -> None:
+    """G=4 single-pass kernel must match the dense reference within fp16
+    tolerance — same as G=1, just with a different parallelism layout."""
+    ctx_len = 384  # spans multiple blocks at both bs=16 and bs=32
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=num_heads,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+        heads_per_tg=4,
+    )
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"G=4 mismatch (dtype={dtype}, bs={block_size}, H={num_heads}): "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_g4_matches_g1() -> None:
+    """G=4 and G=1 must produce identical outputs (up to fp32 rounding) on
+    the same workload — different parallelism, same math."""
+    ctx_len = 1024
+    (
+        out_g4,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        _,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=128,
+        ctx_len=ctx_len,
+        block_size=16,
+        dtype=mx.float16,
+    )
+    out_g1 = mx.zeros_like(out_g4)
+
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_g4,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+        heads_per_tg=4,
+    )
+    metal_mla_paged_attention(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_g1,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+        heads_per_tg=1,
+    )
+
+    diff = mx.abs(out_g4.astype(mx.float32) - out_g1.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    # Same dtype, same data, same math — only parallelism differs. Reduction
+    # order can differ (different number of simdgroups merging), so allow
+    # a small tolerance from accumulation reordering.
+    assert max_abs < 1e-2, f"G=4 vs G=1 divergence: max_abs_diff={max_abs:.5f}"
+
+
+def test_g_invalid_raises() -> None:
+    """num_heads not divisible by G should raise at the dispatch boundary,
+    not silently produce garbage."""
+    out = mx.zeros((1, 5, _KV_LORA_RANK), dtype=mx.float16)
+    q_nope = mx.zeros((1, 5, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((1, 5, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+    latent_cache = mx.zeros((1, 16, _LATENT_DIM), dtype=mx.float16)
+    block_tables = mx.zeros((1, 1), dtype=mx.int32)
+    context_lens = mx.array([1], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+
+    with pytest.raises(RuntimeError, match="divisible by heads_per_tg"):
+        metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+            heads_per_tg=4,  # 5 % 4 != 0
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mixed-dtype rejection: every MLA dispatcher picks one Metal specialization
+# from q_nope.dtype() but the kernel template binds the same `T` to all
+# fp16/bf16 buffers (q_nope, q_pe, latent_cache, out, tmp_out). If they
+# disagree the shader silently reinterprets bytes — e.g. a bf16 cache read
+# as fp16 — and produces corrupt attention. Validate that we reject up
+# front instead.
+# ---------------------------------------------------------------------------
+
+
+def _mixed_dtype_inputs(dtype_q: mx.Dtype, dtype_kv: mx.Dtype):
+    """Build a minimal valid input set with mismatched query / cache dtypes.
+    Production shapes (kv_lora_rank=512) so the dispatcher gets past the
+    shape check and reaches dtype validation."""
+    block_size = 16
+    num_seqs = 1
+    num_heads = 4
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype_q)
+    q_nope = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype_q)
+    q_pe = mx.zeros((num_seqs, num_heads, _QK_ROPE_HEAD_DIM), dtype=dtype_q)
+    latent_cache = mx.zeros((1, block_size, _LATENT_DIM), dtype=dtype_kv)
+    block_tables = mx.zeros((num_seqs, 1), dtype=mx.int32)
+    context_lens = mx.array([1], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    return out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q
+
+
+def test_mla_rejects_mixed_dtypes_single_pass() -> None:
+    """fp16 queries vs bf16 latent cache must raise, not silently corrupt."""
+    out, q_nope, q_pe, latent_cache, btab, ctx_lens, cu_q = _mixed_dtype_inputs(
+        dtype_q=mx.float16, dtype_kv=mx.bfloat16
+    )
+    with pytest.raises(RuntimeError, match="must share the same dtype"):
+        metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=btab,
+            context_lens=ctx_lens,
+            cu_seqlens_q=cu_q,
+            scale=0.125,
+        )
+
+
+def test_mla_rejects_out_dtype_mismatch() -> None:
+    """Catches the case where everything reads correctly but the output
+    buffer has the wrong dtype — the kernel would write fp16 bytes into a
+    bf16 buffer (or vice versa)."""
+    block_size = 16
+    num_seqs = 1
+    num_heads = 4
+    q_nope = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((num_seqs, num_heads, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+    latent_cache = mx.zeros((1, block_size, _LATENT_DIM), dtype=mx.float16)
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.bfloat16)  # mismatch
+    block_tables = mx.zeros((num_seqs, 1), dtype=mx.int32)
+    context_lens = mx.array([1], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    with pytest.raises(RuntimeError, match="must share the same dtype"):
+        metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )

--- a/tests/test_mla_kernel.py
+++ b/tests/test_mla_kernel.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Direct unit tests for the MLA Metal kernel (RFC #360).
 
-Single-pass + split-K decode kernels. The single-pass kernel handles
-``ctx_len`` of any size that fits the caller-provided block_tables row;
-the partitioned (split-K) variant chunks ctx across multiple TGs and
-merges partials with the reduce kernel.
+Single-pass + split-K + 2pass decode kernels. The single-pass kernel
+handles ``ctx_len`` of any size that fits the caller-provided
+block_tables row; the partitioned (split-K) variant chunks ctx across
+multiple TGs and merges partials with the reduce kernel; the 2pass
+variant uses an MLX sdpa_vector_2pass-style cross-head amortized layout.
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import pytest
 from vllm_metal.metal import (
     MLA_PARTITION_SIZE,
     metal_mla_paged_attention,
+    metal_mla_paged_attention_decode_2pass,
     metal_mla_paged_attention_partitioned,
 )
 
@@ -1043,6 +1045,201 @@ def test_g_invalid_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Decode 2pass kernel — MLX sdpa_vector_2pass-style cross-head amortization.
+# ---------------------------------------------------------------------------
+# One TG per (seq, partition) with 32*num_heads threads. All H heads share
+# K cache reads — total KV bandwidth amortized H× across the launch.
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+@pytest.mark.parametrize("num_heads", [8, 32, 96, 128])
+def test_decode_2pass_matches_dense(
+    dtype: mx.Dtype, block_size: int, num_heads: int
+) -> None:
+    """2pass kernel must match the dense reference for all production head
+    counts within fp16 / bf16 tolerance."""
+    ctx_len = 768
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=num_heads,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention_decode_2pass(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"2pass mismatch (dtype={dtype}, bs={block_size}, H={num_heads}): "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("partition_size", [64, 128, 256, 512])
+def test_decode_2pass_partition_sizes_match(partition_size: int) -> None:
+    """Each instantiated PARTITION_SIZE must produce the correct output
+    on the same workload — different ctx-split, same math."""
+    ctx_len = 1536
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=32,
+        ctx_len=ctx_len,
+        block_size=16,
+        dtype=mx.float16,
+    )
+
+    metal_mla_paged_attention_decode_2pass(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+        partition_size=partition_size,
+    )
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert max_abs < 5e-3, (
+        f"2pass partition_size={partition_size} mismatch: max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_2pass_mixed_ctx_lens() -> None:
+    """Mixed ctx_lens — short / medium / long sequences. Empty-tail
+    partitions must contribute nothing to the reduce."""
+    ctx_lens = [128, 1024, 2500, 64]
+    num_seqs = len(ctx_lens)
+    num_heads = 32
+    block_size = 16
+    max_ctx = max(ctx_lens)
+    n_blocks_per_seq = (max_ctx + block_size - 1) // block_size
+    num_blocks = n_blocks_per_seq * num_seqs
+
+    mx.random.seed(0)
+    q_nope = mx.random.normal(shape=(num_seqs, num_heads, _KV_LORA_RANK)).astype(
+        mx.float16
+    )
+    q_pe = mx.random.normal(shape=(num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(
+        mx.float16
+    )
+    latent_cache = mx.random.normal(shape=(num_blocks, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+
+    block_tables_np = np.arange(num_blocks, dtype=np.int32).reshape(
+        num_seqs, n_blocks_per_seq
+    )
+    block_tables = mx.array(block_tables_np)
+    context_lens = mx.array(ctx_lens, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+
+    metal_mla_paged_attention_decode_2pass(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=ctx_lens,
+        scale=0.125,
+    )
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    rtol, atol = _tolerance(mx.float16)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), (
+        f"2pass mixed-ctx mismatch: max_abs_diff={max_abs:.5f}, ctx_lens={ctx_lens}"
+    )
+
+
+def test_decode_2pass_rejects_multi_token_query() -> None:
+    """Same decode-only contract as the other entries."""
+    out = mx.zeros((2, 8, _KV_LORA_RANK), dtype=mx.float16)
+    q_nope = mx.zeros((2, 8, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((2, 8, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+    latent_cache = mx.zeros((1, 16, _LATENT_DIM), dtype=mx.float16)
+    block_tables = mx.zeros((1, 1), dtype=mx.int32)
+    context_lens = mx.array([1], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 2], dtype=mx.int32)
+
+    with pytest.raises(NotImplementedError, match="decode only"):
+        metal_mla_paged_attention_decode_2pass(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Mixed-dtype rejection: every MLA dispatcher picks one Metal specialization
 # from q_nope.dtype() but the kernel template binds the same `T` to all
 # fp16/bf16 buffers (q_nope, q_pe, latent_cache, out, tmp_out). If they
@@ -1093,6 +1290,23 @@ def test_mla_rejects_mixed_dtypes_partitioned() -> None:
     )
     with pytest.raises(RuntimeError, match="must share the same dtype"):
         metal_mla_paged_attention_partitioned(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=btab,
+            context_lens=ctx_lens,
+            cu_seqlens_q=cu_q,
+            scale=0.125,
+        )
+
+
+def test_mla_rejects_mixed_dtypes_decode_2pass() -> None:
+    out, q_nope, q_pe, latent_cache, btab, ctx_lens, cu_q = _mixed_dtype_inputs(
+        dtype_q=mx.float16, dtype_kv=mx.bfloat16
+    )
+    with pytest.raises(RuntimeError, match="must share the same dtype"):
+        metal_mla_paged_attention_decode_2pass(
             q_nope=q_nope,
             q_pe=q_pe,
             latent_cache=latent_cache,

--- a/tests/test_mla_kernel.py
+++ b/tests/test_mla_kernel.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Direct unit tests for the MLA Metal kernel (RFC #360).
 
-Single-pass decode kernel. The kernel handles ``ctx_len`` of any size
-that fits the caller-provided block_tables row, with two-pass softmax
-and a cross-simdgroup merge.
+Single-pass + split-K decode kernels. The single-pass kernel handles
+``ctx_len`` of any size that fits the caller-provided block_tables row;
+the partitioned (split-K) variant chunks ctx across multiple TGs and
+merges partials with the reduce kernel.
 """
 
 from __future__ import annotations
@@ -12,7 +13,11 @@ import mlx.core as mx
 import numpy as np
 import pytest
 
-from vllm_metal.metal import metal_mla_paged_attention
+from vllm_metal.metal import (
+    MLA_PARTITION_SIZE,
+    metal_mla_paged_attention,
+    metal_mla_paged_attention_partitioned,
+)
 
 # Production shapes — only kv_lora_rank=512, qk_rope_head_dim=64 are
 # instantiated in mla.metal.
@@ -619,6 +624,231 @@ def test_unsupported_kv_lora_rank_raises() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Split-K + reduce (RFC #360 Phase 3): metal_mla_paged_attention_partitioned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_partitioned_single_partition_matches_dense(dtype: mx.Dtype) -> None:
+    """ctx_len ≤ PARTITION_SIZE — only one partition runs and the reduce
+    kernel hits its single-partition fast path (plain copy from tmp_out).
+    Output must match the dense reference, just like the non-partitioned
+    kernel."""
+    ctx_len = MLA_PARTITION_SIZE  # exactly one partition (boundary case)
+    block_size = 32
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=1,
+        num_heads=4,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+
+    expected = _expected_output(
+        q_nope, q_pe, latent_cache, block_tables_np, ctx_lens=[ctx_len], scale=0.125
+    )
+
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("block_size", [16, 32])
+def test_partitioned_two_partitions_matches_dense(
+    dtype: mx.Dtype, block_size: int
+) -> None:
+    """ctx_len spanning two partitions — exercises the reduce kernel's full
+    online-softmax merge path. Each partition computes its own (max, lse,
+    partial out); reduce normalizes against the global max."""
+    ctx_len = MLA_PARTITION_SIZE + block_size  # 528 (bs=16) or 544 (bs=32)
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=1,
+        num_heads=8,
+        ctx_len=ctx_len,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+
+    expected = _expected_output(
+        q_nope, q_pe, latent_cache, block_tables_np, ctx_lens=[ctx_len], scale=0.125
+    )
+
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_partitioned_many_partitions_matches_dense(dtype: mx.Dtype) -> None:
+    """Long context spanning many partitions — stresses the reduce kernel's
+    cross-partition merge across a large max_num_partitions count."""
+    ctx_len = MLA_PARTITION_SIZE * 6 + 17  # 3089 — last partition is partial
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=8,
+        ctx_len=ctx_len,
+        block_size=16,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_partitioned_mixed_ctx_lens_matches_dense(dtype: mx.Dtype) -> None:
+    """Mixed ctx_lens — sequences with different partition counts in one
+    batch. Each seq's reduce kernel sees only its own num_partitions; the
+    unused partition slots in the scratch buffers must be zero-init
+    sentinels."""
+    ctx_lens = [100, MLA_PARTITION_SIZE * 2, MLA_PARTITION_SIZE - 1, 1500]
+    block_size = 16
+    num_seqs = len(ctx_lens)
+    num_heads = 4
+    dtype_in = dtype
+
+    mx.random.seed(0)
+    max_ctx = max(ctx_lens)
+    n_blocks_per_seq = (max_ctx + block_size - 1) // block_size
+    num_blocks = n_blocks_per_seq * num_seqs
+
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype_in)
+    q_nope = mx.random.normal(shape=(num_seqs, num_heads, _KV_LORA_RANK)).astype(
+        dtype_in
+    )
+    q_pe = mx.random.normal(shape=(num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(
+        dtype_in
+    )
+    latent_cache = mx.random.normal(shape=(num_blocks, block_size, _LATENT_DIM)).astype(
+        dtype_in
+    )
+    block_tables_np = np.arange(num_blocks, dtype=np.int32).reshape(
+        num_seqs, n_blocks_per_seq
+    )
+    block_tables = mx.array(block_tables_np)
+    context_lens = mx.array(ctx_lens, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+
+    metal_mla_paged_attention_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+    )
+
+    expected = _expected_output(
+        q_nope, q_pe, latent_cache, block_tables_np, ctx_lens=ctx_lens, scale=0.125
+    )
+
+    rtol, atol = _tolerance(dtype)
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item()
+
+
+def test_partitioned_rejects_multi_token_query() -> None:
+    """Same decode-only guard as the non-partitioned entry."""
+    block_size = 16
+    latent_cache = mx.zeros((4, block_size, _LATENT_DIM), dtype=mx.float16)
+    block_tables = mx.zeros((1, 4), dtype=mx.int32)
+    context_lens = mx.array([8], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 2], dtype=mx.int32)
+    out = mx.zeros((2, 2, _KV_LORA_RANK), dtype=mx.float16)
+    q_nope = mx.zeros((2, 2, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((2, 2, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+
+    with pytest.raises(NotImplementedError, match="one query token per sequence"):
+        metal_mla_paged_attention_partitioned(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Cross-head amortization (HEADS_PER_TG > 1)
 # ---------------------------------------------------------------------------
 # G=4 packs 4 query heads into one threadgroup so each K/V load is reused
@@ -736,6 +966,57 @@ def test_g4_matches_g1() -> None:
     assert max_abs < 1e-2, f"G=4 vs G=1 divergence: max_abs_diff={max_abs:.5f}"
 
 
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_g4_partitioned_matches_dense(dtype: mx.Dtype) -> None:
+    """G=4 + split-K (Phase 3 long-ctx infra) — must match the dense
+    reference, mirroring the G=1 partitioned tests above."""
+    ctx_len = 1536  # 3 partitions at PARTITION_SIZE=512
+    (
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_tables_np,
+    ) = _make_inputs(
+        num_seqs=2,
+        num_heads=8,
+        ctx_len=ctx_len,
+        block_size=16,
+        dtype=dtype,
+    )
+
+    metal_mla_paged_attention_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=0.125,
+        heads_per_tg=4,
+    )
+
+    expected = _expected_output(
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables_np,
+        ctx_lens=[ctx_len, ctx_len],
+        scale=0.125,
+    )
+
+    rtol, atol = _tolerance(dtype)
+    diff = mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    max_abs = mx.max(diff).item()
+    assert mx.allclose(
+        out.astype(mx.float32), expected.astype(mx.float32), rtol=rtol, atol=atol
+    ).item(), f"G=4 partitioned mismatch (dtype={dtype}): max_abs_diff={max_abs:.5f}"
+
+
 def test_g_invalid_raises() -> None:
     """num_heads not divisible by G should raise at the dispatch boundary,
     not silently produce garbage."""
@@ -795,6 +1076,23 @@ def test_mla_rejects_mixed_dtypes_single_pass() -> None:
     )
     with pytest.raises(RuntimeError, match="must share the same dtype"):
         metal_mla_paged_attention(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=btab,
+            context_lens=ctx_lens,
+            cu_seqlens_q=cu_q,
+            scale=0.125,
+        )
+
+
+def test_mla_rejects_mixed_dtypes_partitioned() -> None:
+    out, q_nope, q_pe, latent_cache, btab, ctx_lens, cu_q = _mixed_dtype_inputs(
+        dtype_q=mx.bfloat16, dtype_kv=mx.float16
+    )
+    with pytest.raises(RuntimeError, match="must share the same dtype"):
+        metal_mla_paged_attention_partitioned(
             q_nope=q_nope,
             q_pe=q_pe,
             latent_cache=latent_cache,

--- a/tests/test_mla_kernel.py
+++ b/tests/test_mla_kernel.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """Direct unit tests for the MLA Metal kernel (RFC #360).
 
-Single-pass + split-K + 2pass decode kernels. The single-pass kernel
-handles ``ctx_len`` of any size that fits the caller-provided
+Single-pass + split-K + 2pass + FA decode kernels. The single-pass
+kernel handles ``ctx_len`` of any size that fits the caller-provided
 block_tables row; the partitioned (split-K) variant chunks ctx across
 multiple TGs and merges partials with the reduce kernel; the 2pass
-variant uses an MLX sdpa_vector_2pass-style cross-head amortized layout.
+variant uses an MLX sdpa_vector_2pass-style cross-head amortized layout;
+the FA variant uses ``simdgroup_matrix<T, 8, 8>`` MMAs over the same
+paged latent cache.
 """
 
 from __future__ import annotations
+
+import math
 
 import mlx.core as mx
 import numpy as np
@@ -18,8 +22,24 @@ from vllm_metal.metal import (
     MLA_PARTITION_SIZE,
     metal_mla_paged_attention,
     metal_mla_paged_attention_decode_2pass,
+    metal_mla_paged_attention_decode_fa,
+    metal_mla_paged_attention_decode_fa_partitioned,
     metal_mla_paged_attention_partitioned,
+    mla_bf16_fa_available,
 )
+
+
+def _skip_if_no_bf16_fa(dtype: mx.Dtype) -> None:
+    """Skip a bf16 FA test on devices without native bfloat support.
+    The bf16 FA kernels are gated at metallib compile time on such
+    devices (mla.metal `#if defined(__HAVE_BFLOAT__)`); the Python /
+    C++ wrappers reject bf16 FA calls up-front so callers do not hit a
+    raw `get_kernel` miss. Tests that parametrize over `dtype` should
+    call this at function entry to mark bf16 as `skipped` rather than
+    `failed` on those targets."""
+    if dtype == mx.bfloat16 and not mla_bf16_fa_available():
+        pytest.skip("bf16 FA kernels require native bfloat support on the Metal device")
+
 
 # Production shapes — only kv_lora_rank=512, qk_rope_head_dim=64 are
 # instantiated in mla.metal.
@@ -1314,6 +1334,826 @@ def test_mla_rejects_mixed_dtypes_decode_2pass() -> None:
             block_tables=btab,
             context_lens=ctx_lens,
             cu_seqlens_q=cu_q,
+            scale=0.125,
+        )
+
+
+# ============================================================
+# Paged FA decode kernel.
+# Single-block tests cover ctx == BK == 32 (one single-iter K-tile,
+# no multi-block online softmax). Multi-block tests cover the production
+# online-softmax merge path.
+# ============================================================
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_decode_fa_matches_dense_single_block(dtype: mx.Dtype) -> None:
+    """Stage 3a parity: B=1, H=8, ctx == BK == 16 (one page). Kernel's
+    QK + softmax + SV must match the dense reference within the
+    standard tolerance."""
+    _skip_if_no_bf16_fa(dtype)
+    block_size = 16
+    num_seqs = 1
+    num_heads = 8
+    ctx_len = 16  # == BK
+    n_blocks = ctx_len // block_size
+
+    mx.random.seed(7)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(dtype)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(dtype)
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    block_tables = mx.array([[0]], dtype=mx.int32)
+    context_lens = mx.array([ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+    mx.eval(out)
+    assert bool(mx.all(mx.isfinite(out)).item())
+
+    # Dense reference: gather the two blocks into a contiguous
+    # [num_seqs, ctx_len, latent_dim] tensor, split kv_norm + k_pe,
+    # and run the same math the wrapper's slow path does.
+    flat = latent_cache.reshape(n_blocks * block_size, _LATENT_DIM)
+    gathered = flat[:ctx_len].reshape(num_seqs, ctx_len, _LATENT_DIM)
+    kv_norm = gathered[:, :, :_KV_LORA_RANK]
+    k_pe = gathered[:, :, _KV_LORA_RANK:]
+    expected = _absorbed_mla_dense_reference(
+        q_nope.astype(mx.float32),
+        q_pe.astype(mx.float32),
+        kv_norm.astype(mx.float32),
+        k_pe.astype(mx.float32),
+        scale,
+    ).astype(dtype)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(dtype)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA single-block mismatch (dtype={dtype}): max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_fa_multi_head_group_and_multi_seq() -> None:
+    """Stage 3a parity at non-degenerate grid: 2 seqs × (H=16 → 2 head
+    groups) = 4 TGs. Catches grid-index swaps (seq vs head_group) and
+    cross-TG aliasing in the buffer indexing."""
+    block_size = 16
+    num_seqs = 2
+    num_heads = 16  # 2 head groups
+    ctx_len = 16
+    n_blocks = num_seqs  # one block per seq
+
+    mx.random.seed(19)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(mx.float16)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(mx.float16)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    block_tables = mx.array([[0], [1]], dtype=mx.int32)
+    context_lens = mx.array([ctx_len, ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1, 2], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+    mx.eval(out)
+
+    # Per-seq dense reference.
+    flat = latent_cache.reshape(n_blocks * block_size, _LATENT_DIM)
+    kv_norm = mx.stack(
+        [
+            flat[i * block_size : (i + 1) * block_size, :_KV_LORA_RANK]
+            for i in range(num_seqs)
+        ],
+        axis=0,
+    )
+    k_pe = mx.stack(
+        [
+            flat[i * block_size : (i + 1) * block_size, _KV_LORA_RANK:]
+            for i in range(num_seqs)
+        ],
+        axis=0,
+    )
+    expected = _absorbed_mla_dense_reference(
+        q_nope.astype(mx.float32),
+        q_pe.astype(mx.float32),
+        kv_norm.astype(mx.float32),
+        k_pe.astype(mx.float32),
+        scale,
+    ).astype(mx.float16)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(mx.float16)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA multi-TG mismatch: max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("ctx_len", [24, 32, 64, 128])
+def test_decode_fa_matches_dense_multi_block(dtype: mx.Dtype, ctx_len: int) -> None:
+    """Stage 3b parity: multi-block ctx with online softmax merge across
+    K tiles. ``ctx_len`` choices cover both an exact-multiple of BK=16
+    (32, 64, 128) and a partial tail (24 → one full tile + 8 valid
+    cols in the second tile). The partial-tail case stresses the
+    in-kernel mask that zeroes out S cols beyond ctx_len."""
+    _skip_if_no_bf16_fa(dtype)
+    block_size = 16
+    num_seqs = 1
+    num_heads = 8
+    n_blocks = (ctx_len + block_size - 1) // block_size
+
+    mx.random.seed(101 + ctx_len)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(dtype)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(dtype)
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    block_tables = mx.array([list(range(n_blocks))], dtype=mx.int32)
+    context_lens = mx.array([ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+    mx.eval(out)
+    assert bool(mx.all(mx.isfinite(out)).item())
+
+    flat = latent_cache.reshape(n_blocks * block_size, _LATENT_DIM)
+    gathered = flat[:ctx_len].reshape(num_seqs, ctx_len, _LATENT_DIM)
+    kv_norm = gathered[:, :, :_KV_LORA_RANK]
+    k_pe = gathered[:, :, _KV_LORA_RANK:]
+    expected = _absorbed_mla_dense_reference(
+        q_nope.astype(mx.float32),
+        q_pe.astype(mx.float32),
+        kv_norm.astype(mx.float32),
+        k_pe.astype(mx.float32),
+        scale,
+    ).astype(dtype)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(dtype)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA multi-block mismatch (dtype={dtype}, ctx={ctx_len}): max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("num_heads", [64, 128])
+def test_decode_fa_matches_dense_production_shape(num_heads: int) -> None:
+    """Stage 3b parity on the production grid: B=4 × H ∈ {64, 128} ×
+    ctx=2048, fp16. This is the cell where the sdpa_vector-style
+    kernels lose 0.4× to MLX (status doc §1.3) — getting parity here
+    means the FA kernel is ready for the Stage 4 bench."""
+    block_size = 16
+    num_seqs = 4
+    ctx_len = 2048
+    n_blocks_per_seq = ctx_len // block_size
+    n_blocks = n_blocks_per_seq * num_seqs
+
+    mx.random.seed(2048 + num_heads)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(mx.float16)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(mx.float16)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    bt_np = np.arange(n_blocks, dtype=np.int32).reshape(num_seqs, n_blocks_per_seq)
+    block_tables = mx.array(bt_np)
+    context_lens = mx.array([ctx_len] * num_seqs, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+    mx.eval(out)
+
+    # Per-seq reference.
+    outs = []
+    for i in range(num_seqs):
+        flat = mx.concatenate(
+            [latent_cache[int(bt_np[i, b])] for b in range(n_blocks_per_seq)],
+            axis=0,
+        )
+        kv_norm = flat[:, :_KV_LORA_RANK].reshape(1, ctx_len, _KV_LORA_RANK)
+        k_pe = flat[:, _KV_LORA_RANK:].reshape(1, ctx_len, _QK_ROPE_HEAD_DIM)
+        ref_i = _absorbed_mla_dense_reference(
+            q_nope[i : i + 1].astype(mx.float32),
+            q_pe[i : i + 1].astype(mx.float32),
+            kv_norm.astype(mx.float32),
+            k_pe.astype(mx.float32),
+            scale,
+        )
+        outs.append(ref_i)
+    expected = mx.concatenate(outs, axis=0).astype(mx.float16)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(mx.float16)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA production-shape mismatch (H={num_heads}, ctx={ctx_len}): "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_fa_matches_dense_mixed_ctx_batch() -> None:
+    """Multi-seq batch with different ctx_lens per request. Confirms
+    that each TG reads its own seq's context_lens / block_tables row
+    independently and doesn't leak state across seqs. Padding entries
+    past each seq's valid blocks are set to -1 (0xFFFFFFFF on the
+    Metal uint32_t side) so any unclamped pbi -> OOB load on
+    latent_cache trips a GPU fault rather than silently aliasing to
+    block 0."""
+    block_size = 16
+    num_seqs = 3
+    num_heads = 8
+    ctx_lens = [16, 48, 24]
+    max_blocks = max((c + block_size - 1) // block_size for c in ctx_lens)
+    pool_blocks = sum((c + block_size - 1) // block_size for c in ctx_lens)
+
+    mx.random.seed(307)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(mx.float16)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(mx.float16)
+    latent_cache = mx.random.normal((pool_blocks, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+
+    # Pack block tables — each seq gets its own contiguous range, with
+    # padding entries past its valid blocks set to -1 to force the
+    # k_base_for clamp to use num_valid_blocks (not max_num_blocks_per_seq).
+    bt_np = np.full((num_seqs, max_blocks), -1, dtype=np.int32)
+    cursor = 0
+    for i, c in enumerate(ctx_lens):
+        n = (c + block_size - 1) // block_size
+        bt_np[i, :n] = np.arange(cursor, cursor + n)
+        cursor += n
+    block_tables = mx.array(bt_np)
+    context_lens = mx.array(ctx_lens, dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1, 2, 3], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+    mx.eval(out)
+
+    # Per-seq reference (each seq has its own ctx_len, gathers its own blocks).
+    outs = []
+    for i, c in enumerate(ctx_lens):
+        n = (c + block_size - 1) // block_size
+        seq_blocks = mx.concatenate(
+            [latent_cache[int(bt_np[i, b])] for b in range(n)], axis=0
+        )[:c, :]
+        kv_norm = seq_blocks[:, :_KV_LORA_RANK].reshape(1, c, _KV_LORA_RANK)
+        k_pe = seq_blocks[:, _KV_LORA_RANK:].reshape(1, c, _QK_ROPE_HEAD_DIM)
+        ref_i = _absorbed_mla_dense_reference(
+            q_nope[i : i + 1].astype(mx.float32),
+            q_pe[i : i + 1].astype(mx.float32),
+            kv_norm.astype(mx.float32),
+            k_pe.astype(mx.float32),
+            scale,
+        )
+        outs.append(ref_i)
+    expected = mx.concatenate(outs, axis=0).astype(mx.float16)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(mx.float16)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA mixed-ctx mismatch: max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_fa_indirect_block_tables() -> None:
+    """Block table points at a non-zero physical block. Catches absolute-
+    vs-relative block index bugs in the K loader."""
+    block_size = 16
+    num_seqs = 1
+    num_heads = 8
+    ctx_len = 16
+    num_blocks_pool = 8  # bigger than what the seq needs
+
+    mx.random.seed(31)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(mx.float16)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(mx.float16)
+    latent_cache = mx.random.normal((num_blocks_pool, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    # Seq's logical block 0 lives at physical block 5.
+    block_tables = mx.array([[5]], dtype=mx.int32)
+    context_lens = mx.array([ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+    mx.eval(out)
+
+    # Reference reads from physical block 5.
+    referenced = latent_cache[5].reshape(1, block_size, _LATENT_DIM)
+    kv_norm = referenced[:, :, :_KV_LORA_RANK]
+    k_pe = referenced[:, :, _KV_LORA_RANK:]
+    expected = _absorbed_mla_dense_reference(
+        q_nope.astype(mx.float32),
+        q_pe.astype(mx.float32),
+        kv_norm.astype(mx.float32),
+        k_pe.astype(mx.float32),
+        scale,
+    ).astype(mx.float16)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(mx.float16)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA indirect block_tables mismatch: max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize(
+    "ctx_len,partition_size",
+    [(64, 64), (128, 64), (256, 128), (2048, 128), (4096, 512)],
+)
+def test_decode_fa_partitioned_matches_dense(
+    dtype: mx.Dtype, ctx_len: int, partition_size: int
+) -> None:
+    """Stage 6.2 parity: partitioned FA + reduce kernel chain matches
+    the dense reference. Cells span:
+    - ctx=64, ps=64 (single partition)
+    - ctx=128, ps=64 (2 partitions)
+    - ctx=256, ps=128 (2 partitions)
+    - ctx=2048, ps=128 (16 partitions — main long-ctx target)
+    - ctx=4096, ps=512 (8 partitions, sanity at production scale)
+    """
+    _skip_if_no_bf16_fa(dtype)
+    block_size = 16
+    num_seqs = 1
+    num_heads = 8
+    n_blocks = (ctx_len + block_size - 1) // block_size
+
+    mx.random.seed(401 + ctx_len + partition_size)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(dtype)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(dtype)
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    block_tables = mx.array([list(range(n_blocks))], dtype=mx.int32)
+    context_lens = mx.array([ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        partition_size=partition_size,
+    )
+    mx.eval(out)
+    assert bool(mx.all(mx.isfinite(out)).item())
+
+    flat = latent_cache.reshape(n_blocks * block_size, _LATENT_DIM)
+    gathered = flat[:ctx_len].reshape(num_seqs, ctx_len, _LATENT_DIM)
+    kv_norm = gathered[:, :, :_KV_LORA_RANK]
+    k_pe = gathered[:, :, _KV_LORA_RANK:]
+    expected = _absorbed_mla_dense_reference(
+        q_nope.astype(mx.float32),
+        q_pe.astype(mx.float32),
+        kv_norm.astype(mx.float32),
+        k_pe.astype(mx.float32),
+        scale,
+    ).astype(dtype)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(dtype)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA partitioned mismatch (dtype={dtype}, ctx={ctx_len}, ps={partition_size}): "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_fa_partitioned_matches_non_partitioned() -> None:
+    """The partitioned FA + reduce chain must produce numerically
+    equivalent output to the non-partitioned FA on the same input
+    (within numerical noise from the partition-then-merge softmax)."""
+    block_size = 16
+    num_seqs = 2
+    num_heads = 16
+    ctx_len = 512
+    n_blocks_per_seq = (ctx_len + block_size - 1) // block_size
+    n_blocks = n_blocks_per_seq * num_seqs
+
+    mx.random.seed(509)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(mx.float16)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(mx.float16)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+    bt_np = np.arange(n_blocks, dtype=np.int32).reshape(num_seqs, n_blocks_per_seq)
+    block_tables = mx.array(bt_np)
+    context_lens = mx.array([ctx_len] * num_seqs, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    out_partitioned = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    metal_mla_paged_attention_decode_fa_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_partitioned,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        partition_size=128,
+    )
+
+    out_non_partitioned = mx.zeros(
+        (num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16
+    )
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_non_partitioned,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+    )
+
+    mx.eval(out_partitioned, out_non_partitioned)
+    rtol, atol = _tolerance(mx.float16)
+    max_abs = mx.max(
+        mx.abs(
+            out_partitioned.astype(mx.float32) - out_non_partitioned.astype(mx.float32)
+        )
+    ).item()
+    assert bool(
+        mx.allclose(out_partitioned, out_non_partitioned, rtol=rtol, atol=atol).item()
+    ), f"FA partitioned vs non-partitioned mismatch: max_abs_diff={max_abs:.5f}"
+
+
+def test_decode_fa_partitioned_mixed_ctx_with_poison_padding() -> None:
+    """Partitioned FA counterpart to test_decode_fa_matches_dense_mixed_ctx_batch:
+    different ctx_lens per request, block_tables padded with -1 past each
+    seq's valid blocks. Exercises the partitioned k_base_for clamp — an
+    unclamped pbi would dereference 0xFFFFFFFF as a physical-block index
+    and OOB load on latent_cache."""
+    block_size = 16
+    num_seqs = 3
+    num_heads = 8
+    ctx_lens = [64, 192, 128]
+    partition_size = 64
+    max_blocks = max((c + block_size - 1) // block_size for c in ctx_lens)
+    pool_blocks = sum((c + block_size - 1) // block_size for c in ctx_lens)
+
+    mx.random.seed(613)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(mx.float16)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(mx.float16)
+    latent_cache = mx.random.normal((pool_blocks, block_size, _LATENT_DIM)).astype(
+        mx.float16
+    )
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+
+    bt_np = np.full((num_seqs, max_blocks), -1, dtype=np.int32)
+    cursor = 0
+    for i, c in enumerate(ctx_lens):
+        n = (c + block_size - 1) // block_size
+        bt_np[i, :n] = np.arange(cursor, cursor + n)
+        cursor += n
+    block_tables = mx.array(bt_np)
+    context_lens = mx.array(ctx_lens, dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1, 2, 3], dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    metal_mla_paged_attention_decode_fa_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        partition_size=partition_size,
+    )
+    mx.eval(out)
+    assert bool(mx.all(mx.isfinite(out)).item())
+
+    outs = []
+    for i, c in enumerate(ctx_lens):
+        n = (c + block_size - 1) // block_size
+        seq_blocks = mx.concatenate(
+            [latent_cache[int(bt_np[i, b])] for b in range(n)], axis=0
+        )[:c, :]
+        kv_norm = seq_blocks[:, :_KV_LORA_RANK].reshape(1, c, _KV_LORA_RANK)
+        k_pe = seq_blocks[:, _KV_LORA_RANK:].reshape(1, c, _QK_ROPE_HEAD_DIM)
+        ref_i = _absorbed_mla_dense_reference(
+            q_nope[i : i + 1].astype(mx.float32),
+            q_pe[i : i + 1].astype(mx.float32),
+            kv_norm.astype(mx.float32),
+            k_pe.astype(mx.float32),
+            scale,
+        )
+        outs.append(ref_i)
+    expected = mx.concatenate(outs, axis=0).astype(mx.float16)
+    mx.eval(expected)
+
+    rtol, atol = _tolerance(mx.float16)
+    max_abs = mx.max(
+        mx.abs(out.astype(mx.float32) - expected.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out, expected, rtol=rtol, atol=atol).item()), (
+        f"FA partitioned mixed-ctx (poison padding) mismatch: "
+        f"max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize(
+    "num_heads,ctx_len",
+    [
+        (8, 128),  # short ctx, single head_group
+        (16, 512),  # short ctx boundary
+        (16, 2048),  # long ctx
+        (40, 1024),  # MiniCPM3 H + mid ctx
+        (96, 2048),  # GLM-full H + long ctx
+        (128, 2048),  # DeepSeek H + long ctx
+    ],
+)
+def test_decode_fa_wide_matches_narrow(
+    num_heads: int, ctx_len: int, dtype: mx.Dtype
+) -> None:
+    """The wide (BK=64, WN=8) FA instantiation must match the narrow
+    (BK=32, WN=4) anchor across the production grid. Output equivalence
+    within fp16/bf16 noise — the two tile shapes process the same SV
+    math, just with different per-iter K throughput."""
+    _skip_if_no_bf16_fa(dtype)
+    block_size = 16
+    num_seqs = 2
+    n_blocks_per_seq = (ctx_len + block_size - 1) // block_size
+    n_blocks = n_blocks_per_seq * num_seqs
+
+    mx.random.seed(1117)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(dtype)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(dtype)
+    bt_np = np.arange(n_blocks, dtype=np.int32).reshape(num_seqs, n_blocks_per_seq)
+    block_tables = mx.array(bt_np)
+    context_lens = mx.array([ctx_len] * num_seqs, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    out_narrow = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_narrow,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        use_wide=False,
+    )
+    out_wide = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    metal_mla_paged_attention_decode_fa(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_wide,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        use_wide=True,
+    )
+    mx.eval(out_narrow, out_wide)
+    rtol, atol = _tolerance(dtype)
+    max_abs = mx.max(
+        mx.abs(out_narrow.astype(mx.float32) - out_wide.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out_narrow, out_wide, rtol=rtol, atol=atol).item()), (
+        f"FA wide vs narrow mismatch: max_abs_diff={max_abs:.5f}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize(
+    "num_heads,ctx_len,partition_size",
+    [
+        (16, 512, 128),
+        (16, 2048, 128),
+        (96, 4096, 512),
+        (128, 2048, 128),
+    ],
+)
+def test_decode_fa_partitioned_wide_matches_narrow(
+    num_heads: int, ctx_len: int, partition_size: int, dtype: mx.Dtype
+) -> None:
+    """Partitioned FA wide (BK=64/WN=8) vs narrow (BK=32/WN=4) parity.
+    Reduce kernel is shared so the only diff is per-partition tile
+    shape; output should match within reduction-merge noise."""
+    _skip_if_no_bf16_fa(dtype)
+    block_size = 16
+    num_seqs = 2
+    n_blocks_per_seq = (ctx_len + block_size - 1) // block_size
+    n_blocks = n_blocks_per_seq * num_seqs
+
+    mx.random.seed(2222)
+    q_nope = mx.random.normal((num_seqs, num_heads, _KV_LORA_RANK)).astype(dtype)
+    q_pe = mx.random.normal((num_seqs, num_heads, _QK_ROPE_HEAD_DIM)).astype(dtype)
+    latent_cache = mx.random.normal((n_blocks, block_size, _LATENT_DIM)).astype(dtype)
+    bt_np = np.arange(n_blocks, dtype=np.int32).reshape(num_seqs, n_blocks_per_seq)
+    block_tables = mx.array(bt_np)
+    context_lens = mx.array([ctx_len] * num_seqs, dtype=mx.uint32)
+    cu_seqlens_q = mx.array(list(range(num_seqs + 1)), dtype=mx.int32)
+    scale = 1.0 / math.sqrt(_KV_LORA_RANK + _QK_ROPE_HEAD_DIM)
+
+    out_narrow = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    metal_mla_paged_attention_decode_fa_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_narrow,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        partition_size=partition_size,
+        use_wide=False,
+    )
+    out_wide = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=dtype)
+    metal_mla_paged_attention_decode_fa_partitioned(
+        q_nope=q_nope,
+        q_pe=q_pe,
+        latent_cache=latent_cache,
+        out=out_wide,
+        block_tables=block_tables,
+        context_lens=context_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        scale=scale,
+        partition_size=partition_size,
+        use_wide=True,
+    )
+    mx.eval(out_narrow, out_wide)
+    rtol, atol = _tolerance(dtype)
+    max_abs = mx.max(
+        mx.abs(out_narrow.astype(mx.float32) - out_wide.astype(mx.float32))
+    ).item()
+    assert bool(mx.allclose(out_narrow, out_wide, rtol=rtol, atol=atol).item()), (
+        f"FA partitioned wide vs narrow mismatch: max_abs_diff={max_abs:.5f}"
+    )
+
+
+def test_decode_fa_partitioned_rejects_unsupported_partition_size() -> None:
+    """FA partitioned only instantiates ps ∈ {64, 128, 512}. Caller
+    passing ps=256 (which is an MLA 2pass-supported size, easy to
+    confuse) must be rejected at the Python wrapper with a clear error
+    rather than slipping through to a C++ `get_kernel` miss."""
+    block_size = 16
+    num_seqs = 1
+    num_heads = 8
+    ctx_len = 64
+    q_nope = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((num_seqs, num_heads, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+    latent_cache = mx.zeros((1, block_size, _LATENT_DIM), dtype=mx.float16)
+    out = mx.zeros((num_seqs, num_heads, _KV_LORA_RANK), dtype=mx.float16)
+    block_tables = mx.zeros((num_seqs, 4), dtype=mx.int32)
+    context_lens = mx.array([ctx_len], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    with pytest.raises(ValueError, match="partition_size must be in"):
+        metal_mla_paged_attention_decode_fa_partitioned(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+            partition_size=256,  # not in _MLA_DECODE_FA_PARTITION_SIZES
+        )
+
+
+def test_decode_fa_rejects_unsupported_num_heads() -> None:
+    """``num_heads`` not a multiple of BQ=8 must raise — the kernel has
+    no partial-tile handling along the M axis."""
+    block_size = 16
+    q_nope = mx.zeros((1, 7, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((1, 7, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+    latent_cache = mx.zeros((1, block_size, _LATENT_DIM), dtype=mx.float16)
+    out = mx.zeros((1, 7, _KV_LORA_RANK), dtype=mx.float16)
+    block_tables = mx.zeros((1, 1), dtype=mx.int32)
+    context_lens = mx.array([block_size], dtype=mx.uint32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+
+    with pytest.raises(ValueError, match="multiple of 8"):
+        metal_mla_paged_attention_decode_fa(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            scale=0.125,
+        )
+
+
+def test_decode_fa_rejects_multi_token_query() -> None:
+    """Same decode-only contract as the other MLA kernels."""
+    block_size = 16
+    q_nope = mx.zeros((2, 8, _KV_LORA_RANK), dtype=mx.float16)
+    q_pe = mx.zeros((2, 8, _QK_ROPE_HEAD_DIM), dtype=mx.float16)
+    latent_cache = mx.zeros((1, block_size, _LATENT_DIM), dtype=mx.float16)
+    out = mx.zeros((2, 8, _KV_LORA_RANK), dtype=mx.float16)
+    block_tables = mx.zeros((1, 1), dtype=mx.int32)
+    context_lens = mx.array([block_size], dtype=mx.uint32)
+    # Single request with 2 query tokens — fails the cu_seqlens delta=1 check.
+    cu_seqlens_q = mx.array([0, 2], dtype=mx.int32)
+
+    with pytest.raises(NotImplementedError, match="decode only"):
+        metal_mla_paged_attention_decode_fa(
+            q_nope=q_nope,
+            q_pe=q_pe,
+            latent_cache=latent_cache,
+            out=out,
+            block_tables=block_tables,
+            context_lens=context_lens,
+            cu_seqlens_q=cu_seqlens_q,
             scale=0.125,
         )
 

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -300,6 +300,120 @@ def metal_mla_paged_attention(
     mx.synchronize()
 
 
+# Hard-coded for now: matches the only instantiated reduce kernel
+# (see kernels_v2/mla.metal). If we add more PARTITION_SIZE specializations
+# later, this becomes a parameter.
+MLA_PARTITION_SIZE = 512
+
+
+def metal_mla_paged_attention_partitioned(
+    q_nope,  # [total_q_tokens, num_heads, kv_lora_rank]
+    q_pe,  # [total_q_tokens, num_heads, qk_rope_head_dim]
+    latent_cache,  # [num_blocks, block_size, kv_lora_rank + qk_rope_head_dim]
+    out,  # [total_q_tokens, num_heads, kv_lora_rank]
+    block_tables,  # [num_seqs, max_blocks_per_seq], int32
+    context_lens,  # [num_seqs], uint32
+    cu_seqlens_q,  # [num_seqs + 1], int32
+    scale: float,
+    heads_per_tg: int = 1,
+) -> None:
+    """Paged MLA with split-K + reduce (RFC #360 Phase 3 — for long contexts /
+    low-batch decode where the single-pass kernel under-fills the GPU).
+
+    Same shape contract and decode-only constraints as
+    ``metal_mla_paged_attention``. Internally allocates per-partition
+    ``exp_sums`` / ``max_logits`` / ``tmp_out`` scratch and dispatches the
+    main kernel with ``PARTITION_SIZE=512`` followed by the reduce kernel.
+
+    Caller is responsible for the partitioning routing decision (e.g., based
+    on max ctx_len and total threadgroup count); this function unconditionally
+    runs the partitioned path.
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    # Shape contract — identical to the non-partitioned entry.
+    if q_nope.shape[2] != latent_cache.shape[2] - q_pe.shape[2]:
+        raise ValueError(
+            f"MLA shape mismatch: q_nope.shape[2]={q_nope.shape[2]} must equal "
+            f"latent_cache.shape[2] ({latent_cache.shape[2]}) - "
+            f"q_pe.shape[2] ({q_pe.shape[2]})"
+        )
+
+    block_size = latent_cache.shape[1]
+    if MLA_PARTITION_SIZE % block_size != 0:
+        raise ValueError(
+            f"MLA partitioned: PARTITION_SIZE ({MLA_PARTITION_SIZE}) must be "
+            f"divisible by block_size ({block_size})."
+        )
+
+    mx.eval(out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q)
+
+    cu_q = np.asarray(cu_seqlens_q)
+    deltas = np.diff(cu_q)
+    if np.any(deltas != 1):
+        bad = int(np.argmax(deltas != 1))
+        raise NotImplementedError(
+            "MLA partitioned kernel (P1) supports decode only — one query "
+            f"token per sequence. Got request {bad} with {int(deltas[bad])} "
+            "query tokens."
+        )
+
+    ctx = np.asarray(context_lens)
+    max_blocks_per_seq = int(block_tables.shape[1])
+    required_blocks = (ctx + block_size - 1) // block_size
+    if np.any(required_blocks > max_blocks_per_seq):
+        bad = int(np.argmax(required_blocks > max_blocks_per_seq))
+        raise ValueError(
+            f"MLA partitioned: block_tables row width ({max_blocks_per_seq}) "
+            f"too small for request {bad}: ctx_len={int(ctx[bad])} requires "
+            f"{int(required_blocks[bad])} blocks at block_size={block_size}."
+        )
+
+    total_q_tokens = int(q_nope.shape[0])
+    num_heads = int(q_nope.shape[1])
+    kv_lora_rank = int(q_nope.shape[2])
+    max_ctx = int(ctx.max())
+    max_num_partitions = max(
+        1, (max_ctx + MLA_PARTITION_SIZE - 1) // MLA_PARTITION_SIZE
+    )
+
+    # Scratch buffers. Zero-initialized so partitions that return early (no
+    # blocks to process for their seq) leave a no-op contribution.
+    exp_sums = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions), dtype=mx.float32
+    )
+    max_logits = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions), dtype=mx.float32
+    )
+    tmp_out = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions, kv_lora_rank),
+        dtype=q_nope.dtype,
+    )
+    mx.eval(exp_sums, max_logits, tmp_out)
+
+    ops = get_ops()
+    _ensure_mla_library(ops)
+    ops.mla_paged_attention_partitioned(
+        out,
+        exp_sums,
+        max_logits,
+        tmp_out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_size,
+        scale,
+        MLA_PARTITION_SIZE,
+        max_num_partitions,
+        heads_per_tg,
+    )
+    mx.synchronize()
+
+
 def get_ops() -> ModuleType:
     """JIT-build and import the native paged_ops extension.
 

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -414,6 +414,139 @@ def metal_mla_paged_attention_partitioned(
     mx.synchronize()
 
 
+# Decode-2pass kernel partition sizes (mirrored in mla.metal as
+# instantiate_mla_2pass + the matching reduce specializations).
+# 256 is kept as a bench knob between 128 and 512; auto-pick still
+# returns {64, 128}.
+_MLA_DECODE_2PASS_SIZES = (64, 128, 256, 512)
+
+
+def _pick_mla_decode_2pass_partition(max_ctx: int) -> int:
+    """Pick PARTITION_SIZE for the 2pass decode kernel.
+
+    Smaller partition → more TGs → better GPU fill on small ctx. Larger
+    partition → less reduce overhead at long ctx. Mirrors MLX's choice in
+    `mlx/backend/metal/scaled_dot_product_attention.cpp::sdpa_vector_2pass`
+    (devc=='s' branch): 64 by default, 128 once ctx > 1024."""
+    if max_ctx <= 1024:
+        return 64
+    return 128
+
+
+def metal_mla_paged_attention_decode_2pass(
+    q_nope,  # [total_q_tokens, num_heads, kv_lora_rank]
+    q_pe,  # [total_q_tokens, num_heads, qk_rope_head_dim]
+    latent_cache,  # [num_blocks, block_size, kv_lora_rank + qk_rope_head_dim]
+    out,  # [total_q_tokens, num_heads, kv_lora_rank]
+    block_tables,  # [num_seqs, max_blocks_per_seq], int32
+    context_lens,  # [num_seqs], uint32
+    cu_seqlens_q,  # [num_seqs + 1], int32  (only used for decode-only validation)
+    scale: float,
+    partition_size: int | None = None,
+) -> None:
+    """MLX sdpa_vector_2pass-style cross-head amortization for absorbed MLA
+    decode (RFC #360, follow-up to the G-batched single-pass kernel).
+
+    Each TG handles one (seq, ctx-partition) pair with 32*num_heads threads
+    arranged as 32-lane × num_heads-head simdgroups. All heads in the TG
+    read the same K cache tokens — the L1/L2 cache serves the H-1 repeats
+    so total KV bandwidth is amortized H× across the whole launch.
+
+    Same shape contract and decode-only constraints as
+    `metal_mla_paged_attention`. Internally allocates `exp_sums` /
+    `max_logits` / `tmp_out` scratch and dispatches the main kernel
+    followed by the existing reduce kernel.
+
+    `partition_size` defaults to a heuristic based on max ctx_len; pass an
+    explicit value to override.
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    if q_nope.shape[2] != latent_cache.shape[2] - q_pe.shape[2]:
+        raise ValueError(
+            f"MLA shape mismatch: q_nope.shape[2]={q_nope.shape[2]} must equal "
+            f"latent_cache.shape[2] ({latent_cache.shape[2]}) - "
+            f"q_pe.shape[2] ({q_pe.shape[2]})"
+        )
+
+    block_size = latent_cache.shape[1]
+
+    mx.eval(out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q)
+
+    cu_q = np.asarray(cu_seqlens_q)
+    deltas = np.diff(cu_q)
+    if np.any(deltas != 1):
+        bad = int(np.argmax(deltas != 1))
+        raise NotImplementedError(
+            "MLA decode-2pass kernel supports decode only — one query token "
+            f"per sequence. Got request {bad} with {int(deltas[bad])} query "
+            "tokens."
+        )
+
+    ctx = np.asarray(context_lens)
+    max_blocks_per_seq = int(block_tables.shape[1])
+    required_blocks = (ctx + block_size - 1) // block_size
+    if np.any(required_blocks > max_blocks_per_seq):
+        bad = int(np.argmax(required_blocks > max_blocks_per_seq))
+        raise ValueError(
+            f"MLA decode-2pass: block_tables row width ({max_blocks_per_seq}) "
+            f"too small for request {bad}: ctx_len={int(ctx[bad])} requires "
+            f"{int(required_blocks[bad])} blocks at block_size={block_size}."
+        )
+
+    total_q_tokens = int(q_nope.shape[0])
+    num_heads = int(q_nope.shape[1])
+    kv_lora_rank = int(q_nope.shape[2])
+    max_ctx = int(ctx.max())
+
+    if partition_size is None:
+        partition_size = _pick_mla_decode_2pass_partition(max_ctx)
+    if partition_size not in _MLA_DECODE_2PASS_SIZES:
+        raise ValueError(
+            f"MLA decode-2pass: partition_size must be in "
+            f"{_MLA_DECODE_2PASS_SIZES}; got {partition_size}"
+        )
+    if partition_size % block_size != 0:
+        raise ValueError(
+            f"MLA decode-2pass: partition_size ({partition_size}) must be "
+            f"divisible by block_size ({block_size})."
+        )
+
+    max_num_partitions = max(1, (max_ctx + partition_size - 1) // partition_size)
+
+    exp_sums = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions), dtype=mx.float32
+    )
+    max_logits = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions), dtype=mx.float32
+    )
+    tmp_out = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions, kv_lora_rank),
+        dtype=q_nope.dtype,
+    )
+    mx.eval(exp_sums, max_logits, tmp_out)
+
+    ops = get_ops()
+    _ensure_mla_library(ops)
+    ops.mla_paged_attention_decode_2pass(
+        out,
+        exp_sums,
+        max_logits,
+        tmp_out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        block_size,
+        scale,
+        partition_size,
+        max_num_partitions,
+    )
+    mx.synchronize()
+
+
 def get_ops() -> ModuleType:
     """JIT-build and import the native paged_ops extension.
 

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -39,6 +39,12 @@ _ops_module: ModuleType | None = None
 # paged-attention user, so non-MLA models pay the compile cost and a
 # compile error in MLA would block unrelated paged-attention paths.
 _mla_library_initialized: bool = False
+# Cached result of the runtime probe for bf16 FA kernel availability.
+# On targets without native bfloat support, mla.metal gates the bfloat16_t
+# FA instantiations away (simdgroup_matrix can't take the fallback struct),
+# so calling FA with bf16 must be rejected up-front rather than tripping a
+# bare get_kernel error inside C++.
+_bf16_fa_available: bool | None = None
 
 
 def _read_metal_source(path: Path) -> str:
@@ -419,6 +425,11 @@ def metal_mla_paged_attention_partitioned(
 # 256 is kept as a bench knob between 128 and 512; auto-pick still
 # returns {64, 128}.
 _MLA_DECODE_2PASS_SIZES = (64, 128, 256, 512)
+# FA partitioned only instantiates ps ∈ {64, 128, 512} (no ps=256). Reusing
+# _MLA_DECODE_2PASS_SIZES for FA validation would let ps=256 through Python
+# and fail at C++ get_kernel; this set keeps the rejection at the Python
+# boundary.
+_MLA_DECODE_FA_PARTITION_SIZES = (64, 128, 512)
 
 
 def _pick_mla_decode_2pass_partition(max_ctx: int) -> int:
@@ -547,6 +558,232 @@ def metal_mla_paged_attention_decode_2pass(
     mx.synchronize()
 
 
+def metal_mla_paged_attention_decode_fa(
+    q_nope,  # [total_q_tokens, num_heads, kv_lora_rank]
+    q_pe,  # [total_q_tokens, num_heads, qk_rope_head_dim]
+    latent_cache,  # [num_blocks, block_size, kv_lora_rank + qk_rope_head_dim]
+    out,  # [total_q_tokens, num_heads, kv_lora_rank]
+    block_tables,  # [num_seqs, max_blocks_per_seq], int32
+    context_lens,  # [num_seqs], uint32
+    cu_seqlens_q,  # [num_seqs + 1], int32 (decode-only validation)
+    scale: float,
+    use_wide: bool = False,
+) -> None:
+    """Paged Flash-Attention decode kernel using ``simdgroup_matrix<T, 8, 8>``
+    MMAs.
+
+    Full FA pipeline (Q load → simdgroup_matrix QK →
+    online softmax merged across BK tiles → SV → normalize) with
+    multi-block context. Partial tail (last K-tile with valid_cols <
+    BK) is handled inside the kernel.
+
+    Shape and decode-only contract match
+    ``metal_mla_paged_attention_decode_2pass``. Additionally
+    ``num_heads`` must be a multiple of 8 (one ``simdgroup_matrix`` M
+    dim).
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    if q_nope.shape[2] != latent_cache.shape[2] - q_pe.shape[2]:
+        raise ValueError(
+            f"MLA shape mismatch: q_nope.shape[2]={q_nope.shape[2]} must equal "
+            f"latent_cache.shape[2] ({latent_cache.shape[2]}) - "
+            f"q_pe.shape[2] ({q_pe.shape[2]})"
+        )
+
+    block_size = latent_cache.shape[1]
+    num_heads = int(q_nope.shape[1])
+    if num_heads % 8 != 0:
+        raise ValueError(
+            f"MLA FA decode kernel: num_heads ({num_heads}) must be a "
+            "multiple of 8 (the simdgroup_matrix M dim)."
+        )
+
+    mx.eval(out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q)
+
+    cu_q = np.asarray(cu_seqlens_q)
+    deltas = np.diff(cu_q)
+    if np.any(deltas != 1):
+        bad = int(np.argmax(deltas != 1))
+        raise NotImplementedError(
+            "MLA FA decode kernel supports decode only — one query token "
+            f"per sequence. Got request {bad} with {int(deltas[bad])} query "
+            "tokens."
+        )
+
+    ctx = np.asarray(context_lens)
+    max_blocks_per_seq = int(block_tables.shape[1])
+    required_blocks = (ctx + block_size - 1) // block_size
+    if np.any(required_blocks > max_blocks_per_seq):
+        bad = int(np.argmax(required_blocks > max_blocks_per_seq))
+        raise ValueError(
+            f"MLA FA decode kernel: block_tables row width "
+            f"({max_blocks_per_seq}) too small for request {bad}: "
+            f"ctx_len={int(ctx[bad])} requires "
+            f"{int(required_blocks[bad])} blocks at block_size={block_size}."
+        )
+
+    if np.any(ctx <= 0):
+        bad = int(np.argmax(ctx <= 0))
+        raise ValueError(
+            "MLA FA decode kernel: every context_len must be positive; "
+            f"got ctx_len={int(ctx[bad])} for request {bad}."
+        )
+
+    ops = get_ops()
+    _ensure_mla_library(ops)
+    if q_nope.dtype == mx.bfloat16 and not mla_bf16_fa_available():
+        raise ValueError(
+            "MLA FA decode kernel: bfloat16 inputs require native bfloat "
+            "support on the Metal device; the running device falls back to "
+            "a struct representation that simdgroup_matrix cannot use, so "
+            "the bf16 FA kernels were gated out at metallib compile time. "
+            "Use float16, or wait for the routing follow-up that picks an "
+            "alternate route for bf16."
+        )
+    ops.mla_paged_attention_decode_fa(
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_size,
+        scale,
+        use_wide,
+    )
+    mx.synchronize()
+
+
+def metal_mla_paged_attention_decode_fa_partitioned(
+    q_nope,  # [total_q_tokens, num_heads, kv_lora_rank]
+    q_pe,  # [total_q_tokens, num_heads, qk_rope_head_dim]
+    latent_cache,  # [num_blocks, block_size, kv_lora_rank + qk_rope_head_dim]
+    out,  # [total_q_tokens, num_heads, kv_lora_rank]
+    block_tables,  # [num_seqs, max_blocks_per_seq], int32
+    context_lens,  # [num_seqs], uint32
+    cu_seqlens_q,  # [num_seqs + 1], int32 (decode-only validation)
+    scale: float,
+    partition_size: int | None = None,
+    use_wide: bool = False,
+) -> None:
+    """Split-K + reduce variant of the paged FA decode kernel. Each
+    (seq, head_group, partition) threadgroup processes one
+    ``partition_size``-token slice of ctx and writes a normalized partial;
+    the same reduce kernel used by ``metal_mla_paged_attention_decode_2pass``
+    merges across partitions.
+
+    Targets long-ctx decode where the non-partitioned FA is
+    bandwidth-bound on the K stream. Same shape + decode-only contract
+    as the other FA / 2pass entries.
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    if q_nope.shape[2] != latent_cache.shape[2] - q_pe.shape[2]:
+        raise ValueError(
+            f"MLA shape mismatch: q_nope.shape[2]={q_nope.shape[2]} must equal "
+            f"latent_cache.shape[2] ({latent_cache.shape[2]}) - "
+            f"q_pe.shape[2] ({q_pe.shape[2]})"
+        )
+
+    block_size = latent_cache.shape[1]
+    num_heads = int(q_nope.shape[1])
+    if num_heads % 8 != 0:
+        raise ValueError(
+            f"MLA FA partitioned kernel: num_heads ({num_heads}) must be a "
+            "multiple of 8 (the simdgroup_matrix M dim)."
+        )
+
+    mx.eval(out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q)
+
+    cu_q = np.asarray(cu_seqlens_q)
+    deltas = np.diff(cu_q)
+    if np.any(deltas != 1):
+        bad = int(np.argmax(deltas != 1))
+        raise NotImplementedError(
+            "MLA FA partitioned kernel supports decode only — one query token "
+            f"per sequence. Got request {bad} with {int(deltas[bad])} query "
+            "tokens."
+        )
+
+    ctx = np.asarray(context_lens)
+    max_blocks_per_seq = int(block_tables.shape[1])
+    required_blocks = (ctx + block_size - 1) // block_size
+    if np.any(required_blocks > max_blocks_per_seq):
+        bad = int(np.argmax(required_blocks > max_blocks_per_seq))
+        raise ValueError(
+            f"MLA FA partitioned: block_tables row width ({max_blocks_per_seq}) "
+            f"too small for request {bad}: ctx_len={int(ctx[bad])} requires "
+            f"{int(required_blocks[bad])} blocks at block_size={block_size}."
+        )
+
+    if np.any(ctx <= 0):
+        bad = int(np.argmax(ctx <= 0))
+        raise ValueError(
+            "MLA FA partitioned: every context_len must be positive; got "
+            f"ctx_len={int(ctx[bad])} for request {bad}."
+        )
+
+    total_q_tokens = int(q_nope.shape[0])
+    kv_lora_rank = int(q_nope.shape[2])
+    max_ctx = int(ctx.max())
+
+    # Mirrors _pick_mla_decode_2pass_partition: 64 for ctx ≤ 1024, 128
+    # for longer. Caller can override — but FA partitioned only
+    # instantiates {64, 128, 512}, not the full 2pass set.
+    if partition_size is None:
+        partition_size = _pick_mla_decode_2pass_partition(max_ctx)
+    if partition_size not in _MLA_DECODE_FA_PARTITION_SIZES:
+        raise ValueError(
+            f"MLA FA partitioned: partition_size must be in "
+            f"{_MLA_DECODE_FA_PARTITION_SIZES}; got {partition_size}"
+        )
+
+    max_num_partitions = max(1, (max_ctx + partition_size - 1) // partition_size)
+
+    exp_sums = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions), dtype=mx.float32
+    )
+    max_logits = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions), dtype=mx.float32
+    )
+    tmp_out = mx.zeros(
+        (total_q_tokens, num_heads, max_num_partitions, kv_lora_rank),
+        dtype=q_nope.dtype,
+    )
+    mx.eval(exp_sums, max_logits, tmp_out)
+
+    ops = get_ops()
+    _ensure_mla_library(ops)
+    if q_nope.dtype == mx.bfloat16 and not mla_bf16_fa_available():
+        raise ValueError(
+            "MLA FA partitioned: bfloat16 inputs require native bfloat "
+            "support on the Metal device; see metal_mla_paged_attention_"
+            "decode_fa for details. Use float16, or wait for the routing "
+            "follow-up that picks an alternate route for bf16."
+        )
+    ops.mla_paged_attention_decode_fa_partitioned(
+        out,
+        exp_sums,
+        max_logits,
+        tmp_out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        block_size,
+        scale,
+        partition_size,
+        max_num_partitions,
+        use_wide,
+    )
+    mx.synchronize()
+
+
 def get_ops() -> ModuleType:
     """JIT-build and import the native paged_ops extension.
 
@@ -609,3 +846,15 @@ def _ensure_mla_library(mod: ModuleType) -> None:
     mod.init_mla_library(mla_src)
     _mla_library_initialized = True
     logger.info("MLA paged-attention Metal kernels loaded")
+
+
+def mla_bf16_fa_available() -> bool:
+    """Returns True if the bf16 FA kernels were instantiated in the loaded
+    paged_mla_kern library. Cached after the first probe. Initialises the
+    MLA library if needed."""
+    global _bf16_fa_available
+    if _bf16_fa_available is None:
+        ops = get_ops()
+        _ensure_mla_library(ops)
+        _bf16_fa_available = bool(ops.mla_has_bfloat_fa_kernel())
+    return _bf16_fa_available

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -33,6 +33,13 @@ _KERNELS_V2_DIR = _THIS_DIR / "kernels_v2"
 # paged_ops.cpp is newer than the .so).
 _ops_module: ModuleType | None = None
 
+# The MLA paged-attention shader set is loaded lazily on the first MLA
+# entrypoint call (see _ensure_mla_library). Initialising it inside
+# get_ops() would compile experimental MLA Metal source for every
+# paged-attention user, so non-MLA models pay the compile cost and a
+# compile error in MLA would block unrelated paged-attention paths.
+_mla_library_initialized: bool = False
+
 
 def _read_metal_source(path: Path) -> str:
     """Read a .metal file and strip local #include directives."""
@@ -85,6 +92,15 @@ def _build_gdn_source() -> str:
     parts = [
         _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "gdn_linear_attention.metal"),
+    ]
+    return "\n".join(parts)
+
+
+def _build_mla_paged_attention_source() -> str:
+    """Concatenate utils + mla into a single source for the MLA library."""
+    parts = [
+        _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "mla.metal"),
     ]
     return "\n".join(parts)
 
@@ -191,6 +207,99 @@ def metal_unified_attention(
         mx.synchronize()
 
 
+def metal_mla_paged_attention(
+    q_nope,  # [total_q_tokens, num_heads, kv_lora_rank]
+    q_pe,  # [total_q_tokens, num_heads, qk_rope_head_dim]
+    latent_cache,  # [num_blocks, block_size, kv_lora_rank + qk_rope_head_dim]
+    out,  # [total_q_tokens, num_heads, kv_lora_rank]
+    block_tables,  # [num_seqs, max_blocks_per_seq], int32
+    context_lens,  # [num_seqs], uint32
+    cu_seqlens_q,  # [num_seqs + 1], int32
+    scale: float,
+    heads_per_tg: int = 1,
+) -> None:
+    """Paged Multi-head Latent Attention (RFC #360).
+
+    Phase 1 step 8 (multi-block decode): the kernel iterates the per-sequence
+    block table with NUM_WARPS-strided online softmax and a cross-warp merge,
+    so any ``ctx_len`` that fits into the allocated block_tables row is fine.
+    Decode-only is still required (one query token per sequence) — varlen
+    prefill lands in P2.
+
+    Q is expected to be already projected through ``embed_q`` (so q_nope is
+    in kv_lora_rank space) and ``q_pe`` is RoPE-applied. The caller is
+    responsible for ``unembed_out`` on the result to recover v_head_dim.
+
+    ``heads_per_tg`` (G) controls cross-head KV amortization: each
+    threadgroup processes ``G`` consecutive query heads sharing the same
+    latent KV. Total dispatched threadgroups drop from ``B×H`` to
+    ``B×ceil(H/G)``, so total KV bandwidth is amortized G×. ``num_heads``
+    must be divisible by G. Currently instantiated for G ∈ {1, 4}; G=1 is
+    the existing single-head-per-TG kernel.
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    # Shape contract — fail fast at the Python boundary so the C++ error
+    # path isn't the only line of defence.
+    if q_nope.shape[2] != latent_cache.shape[2] - q_pe.shape[2]:
+        raise ValueError(
+            f"MLA shape mismatch: q_nope.shape[2]={q_nope.shape[2]} must equal "
+            f"latent_cache.shape[2] ({latent_cache.shape[2]}) - "
+            f"q_pe.shape[2] ({q_pe.shape[2]})"
+        )
+
+    block_size = latent_cache.shape[1]
+
+    mx.eval(out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q)
+
+    # P1 decode-only guard: q_token_idx == seq_idx is hard-wired in the
+    # kernel. Reading cu_seqlens_q back to host is cheap (tens of int32 per
+    # layer per step) and the guard goes away when P2 makes the kernel
+    # cu_seqlens_q-aware via find_seq_idx.
+    cu_q = np.asarray(cu_seqlens_q)
+    deltas = np.diff(cu_q)
+    if np.any(deltas != 1):
+        bad = int(np.argmax(deltas != 1))
+        raise NotImplementedError(
+            "MLA kernel (P1) supports decode only — one query token per "
+            f"sequence. Got request {bad} with {int(deltas[bad])} query "
+            "tokens. Multi-token prefill / varlen support lands in P2."
+        )
+
+    # block_tables row-width guard. The kernel walks block_table_row[0..
+    # num_context_blocks-1] for each sequence; if the caller-allocated row
+    # is too narrow we'd silently read into the next sequence's row or off
+    # the end of the buffer. Caller-side capacity bug (ValueError, not
+    # NotImplementedError — this isn't a feature gap).
+    ctx = np.asarray(context_lens)
+    max_blocks_per_seq = int(block_tables.shape[1])
+    required_blocks = (ctx + block_size - 1) // block_size
+    if np.any(required_blocks > max_blocks_per_seq):
+        bad = int(np.argmax(required_blocks > max_blocks_per_seq))
+        raise ValueError(
+            f"MLA: block_tables row width ({max_blocks_per_seq}) too small "
+            f"for request {bad}: ctx_len={int(ctx[bad])} requires "
+            f"{int(required_blocks[bad])} blocks at block_size={block_size}."
+        )
+
+    ops = get_ops()
+    _ensure_mla_library(ops)
+    ops.mla_paged_attention(
+        out,
+        q_nope,
+        q_pe,
+        latent_cache,
+        block_tables,
+        context_lens,
+        cu_seqlens_q,
+        block_size,
+        scale,
+        heads_per_tg,
+    )
+    mx.synchronize()
+
+
 def get_ops() -> ModuleType:
     """JIT-build and import the native paged_ops extension.
 
@@ -231,6 +340,25 @@ def get_ops() -> ModuleType:
     gdn_src = _build_gdn_source()
     mod.init_gdn_library(gdn_src)
 
+    # The MLA paged-attention library is loaded lazily on first use via
+    # _ensure_mla_library so non-MLA paged-attention users do not pay the
+    # experimental MLA shader compile cost, and a compile error in the
+    # experimental MLA shader cannot block unrelated paged-attention paths.
+
     _ops_module = mod
     logger.info("Native paged-attention Metal kernels loaded")
     return mod
+
+
+def _ensure_mla_library(mod: ModuleType) -> None:
+    """Lazy-init the MLA shader library so non-MLA paged-attention users
+    do not pay the experimental MLA shader compile cost; called from
+    each MLA direct entrypoint before its first C++ dispatch.
+    """
+    global _mla_library_initialized
+    if _mla_library_initialized:
+        return
+    mla_src = _build_mla_paged_attention_source()
+    mod.init_mla_library(mla_src)
+    _mla_library_initialized = True
+    logger.info("MLA paged-attention Metal kernels loaded")

--- a/vllm_metal/metal/kernels_v2/mla.metal
+++ b/vllm_metal/metal/kernels_v2/mla.metal
@@ -479,6 +479,240 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   }
 }
 
+// ========================================== Decode 2pass main kernel
+//
+// MLX-style cross-head amortization for absorbed-MLA decode (mirrors
+// mlx/backend/metal/kernels/sdpa_vector.h sdpa_vector_2pass_1, ml-explore/
+// mlx@v0.31.2):
+//
+//   - Threadgroup layout: (32, HEADS_PER_TG, 1) — 32 lanes × HEADS_PER_TG
+//     heads per TG. One simdgroup per query head. ALL heads in the TG read
+//     the same K-cache token addresses (coalesced / L1-served), so KV
+//     bandwidth is amortized HEADS_PER_TG× per TG.
+//   - HEADS_PER_TG ≤ 32 because Apple Metal caps total threads per TG at
+//     1024. For num_heads > HEADS_PER_TG the host dispatches multiple
+//     head-groups along grid.z; the L2 cache then amortizes across them
+//     (different head-groups for the same (seq, partition) read identical
+//     K addresses on subsequent waves).
+//   - Grid: (num_seqs, num_partitions, ceil(num_heads / HEADS_PER_TG)).
+//   - Per-thread state: q_nope_local (16 T), q_pe_local (2 T), v_local
+//     (16 fp32). Q/K kept as T (fp16/bf16) since Apple GPU's mixed
+//     T×T→fp32 FMA is native — promoting Q at load time only inflates
+//     register footprint with no throughput benefit. num_heads scales by
+//     adding more simdgroups, NOT by adding per-thread state.
+//   - No cross-simdgroup merge for V: each simdgroup is one head and owns
+//     its full output independently.
+//
+// num_heads_total is passed via constant buffer; head_idx for this thread
+// is `head_group_idx * HEADS_PER_TG + thread_position_in_threadgroup.y`.
+// Threads with head_idx >= num_heads_total bail (last head-group may be
+// partial when num_heads is not a multiple of HEADS_PER_TG).
+//
+// Buffer layout (matches paged_mla_attention partitioned mode):
+//   0: exp_sums    [num_seqs, num_heads, num_partitions]  fp32
+//   1: max_logits  [num_seqs, num_heads, num_partitions]  fp32
+//   2: tmp_out     [num_seqs, num_heads, num_partitions, KV_LORA_RANK] T
+//                  (NORMALIZED partial — divided by partition_sum;
+//                  reduce kernel re-weights by exp_sums.)
+//   3: q_nope      [total_q_tokens, num_heads, KV_LORA_RANK] T
+//   4: q_pe        [total_q_tokens, num_heads, QK_ROPE_HEAD_DIM] T
+//   5: latent_cache [num_blocks, BLOCK_SIZE, KV_LORA_RANK + QK_ROPE_HEAD_DIM] T
+//   6: block_tables [num_seqs, max_num_blocks_per_seq] uint32
+//   7: context_lens [num_seqs] uint32
+//   8: max_num_blocks_per_seq (constant int)
+//   9: num_heads_total          (constant int)
+//  10: scale (constant float)
+//
+// Reuses the existing paged_mla_attention_reduce kernel (same partial
+// contract).
+
+template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
+          int PARTITION_SIZE, int HEADS_PER_TG>
+[[kernel]] void paged_mla_attention_decode_2pass_1(
+    device float *exp_sums [[buffer(0)]],
+    device float *max_logits [[buffer(1)]],
+    device T *tmp_out [[buffer(2)]],
+    device const T *q_nope [[buffer(3)]],
+    device const T *q_pe [[buffer(4)]],
+    device const T *latent_cache [[buffer(5)]],
+    device const uint32_t *block_tables [[buffer(6)]],
+    device const uint32_t *context_lens [[buffer(7)]],
+    const constant int &max_num_blocks_per_seq [[buffer(8)]],
+    const constant int &num_heads_total [[buffer(9)]],
+    const constant float &scale [[buffer(10)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint3 threadgroups_per_grid [[threadgroups_per_grid]],
+    uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int LATENT_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM;
+  constexpr int BD = 32;
+  constexpr int QK_PER_THREAD = KV_LORA_RANK / BD;
+  constexpr int QPE_PER_THREAD = QK_ROPE_HEAD_DIM / BD;
+  constexpr int V_PER_THREAD = KV_LORA_RANK / BD;
+  static_assert(KV_LORA_RANK % BD == 0,
+                "KV_LORA_RANK must be divisible by 32");
+  static_assert(QK_ROPE_HEAD_DIM % BD == 0,
+                "QK_ROPE_HEAD_DIM must be divisible by 32");
+  static_assert(PARTITION_SIZE % BLOCK_SIZE == 0,
+                "PARTITION_SIZE must be divisible by BLOCK_SIZE");
+  static_assert(HEADS_PER_TG >= 1 && HEADS_PER_TG <= 32,
+                "HEADS_PER_TG must be in [1, 32]. M5 Max g17s caps every "
+                "kernel at 1024 threads/TG (verified by querying "
+                "PSO::maxTotalThreadsPerThreadgroup on a trivial kernel and "
+                "on MLX's own sdpa_vector_2pass_1 — both report 1024). "
+                "BD * HEADS_PER_TG = 32 * 32 = 1024 is the ceiling.");
+
+  const int seq_idx = (int)threadgroup_position_in_grid.x;
+  const int partition_idx = (int)threadgroup_position_in_grid.y;
+  const int head_group_idx = (int)threadgroup_position_in_grid.z;
+  const int num_partitions = (int)threadgroups_per_grid.y;
+  const int head_idx_in_tg = (int)thread_position_in_threadgroup.y;
+  const int head_idx = head_group_idx * HEADS_PER_TG + head_idx_in_tg;
+  const int num_heads = num_heads_total;
+  const int lane = (int)simd_lid;
+
+  // Last head-group may be partial when num_heads is not a multiple of
+  // HEADS_PER_TG — out-of-range threads bail out.
+  if (head_idx >= num_heads) {
+    return;
+  }
+
+  const int ctx_len = (int)context_lens[seq_idx];
+  const int token_start = partition_idx * PARTITION_SIZE;
+  const int token_end = min(token_start + PARTITION_SIZE, ctx_len);
+
+  // Empty partition: emit -INF / 0 sentinels so the reduce sees a no-op
+  // contribution. (Caller is responsible for zero-init of tmp_out.)
+  if (token_start >= ctx_len) {
+    if (lane == 0) {
+      max_logits[(seq_idx * num_heads + head_idx) * num_partitions +
+                 partition_idx] = -INFINITY;
+      exp_sums[(seq_idx * num_heads + head_idx) * num_partitions +
+               partition_idx] = 0.0f;
+    }
+    return;
+  }
+
+  // Load Q for this (seq, head); pre-scale by `scale` so we save one mul
+  // per token in the inner loop. Q is held in T (fp16/bf16) registers, not
+  // fp32 — Apple GPU's mixed-precision FMA (T × T → fp32) is native, so
+  // promoting Q at load time only inflates register footprint without any
+  // throughput benefit. Halving Q register state is a meaningful lever for
+  // raising Apple's per-kernel maxTotalThreadsPerThreadgroup cap.
+  const device T *q_nope_ptr =
+      q_nope + (seq_idx * num_heads + head_idx) * KV_LORA_RANK +
+      lane * QK_PER_THREAD;
+  const device T *q_pe_ptr =
+      q_pe + (seq_idx * num_heads + head_idx) * QK_ROPE_HEAD_DIM +
+      lane * QPE_PER_THREAD;
+
+  T q_nope_local[QK_PER_THREAD];
+#pragma unroll
+  for (int i = 0; i < QK_PER_THREAD; i++) {
+    q_nope_local[i] = T(scale * float(q_nope_ptr[i]));
+  }
+  T q_pe_local[QPE_PER_THREAD];
+#pragma unroll
+  for (int i = 0; i < QPE_PER_THREAD; i++) {
+    q_pe_local[i] = T(scale * float(q_pe_ptr[i]));
+  }
+
+  // Combined acc registers. `o` doubles as the V accumulator and is
+  // initialized to 0 — keeping it as a single named array (instead of
+  // splitting v_norm vs v_pe state) keeps the compiler's register-residence
+  // analysis simpler; smaller live state has been shown to lift Apple
+  // GPU's per-kernel maxTotalThreadsPerThreadgroup cap.
+  float v_local[V_PER_THREAD];
+#pragma unroll
+  for (int i = 0; i < V_PER_THREAD; i++) {
+    v_local[i] = 0.0f;
+  }
+
+  float max_score = -INFINITY;
+  float sum_exp_score = 0.0f;
+
+  const device uint32_t *block_table_row =
+      block_tables + (uint64_t)seq_idx * max_num_blocks_per_seq;
+
+  // Token loop within partition, block-major: hoist block_table_row lookup
+  // and physical-block base pointer arithmetic out of the inner per-token
+  // body. Eliminates BLOCK_SIZE-1 redundant block_table_row reads and
+  // div/mod operations per outer iteration. K loads still go through L1
+  // (all heads read the same address — shared for free).
+  const int kb_first = token_start / BLOCK_SIZE;
+  const int kb_last_excl = (token_end + BLOCK_SIZE - 1) / BLOCK_SIZE;
+  for (int kb = kb_first; kb < kb_last_excl; kb++) {
+    const uint32_t physical_block = block_table_row[kb];
+    const device T *block_base =
+        latent_cache + (uint64_t)physical_block * BLOCK_SIZE * LATENT_DIM;
+    const int t_block_start = max(token_start, kb * BLOCK_SIZE);
+    const int t_block_end = min(token_end, (kb + 1) * BLOCK_SIZE);
+    for (int t = t_block_start; t < t_block_end; t++) {
+      const int block_offset = t - kb * BLOCK_SIZE;
+      const device T *token_ptr = block_base + block_offset * LATENT_DIM;
+
+      // K read in T (fp16/bf16). Mixed-precision FMA below keeps fp32
+      // accumulation precision without ever materializing K as fp32.
+      T k_norm_local[QK_PER_THREAD];
+#pragma unroll
+      for (int j = 0; j < QK_PER_THREAD; j++) {
+        k_norm_local[j] = token_ptr[lane * QK_PER_THREAD + j];
+      }
+
+      // Score = q · k (Q is pre-scaled). Per-lane partial then simd_sum.
+      // Mixed precision: T*T promoted to fp32 for the FMA, free on Apple GPU.
+      // PE contribution uses short-lived k_pe loads (no persistent
+      // k_pe_local across inner body) so the compiler can pack the loads
+      // alongside k_norm and reuse registers.
+      float partial = 0.0f;
+#pragma unroll
+      for (int j = 0; j < QK_PER_THREAD; j++) {
+        partial += float(q_nope_local[j]) * float(k_norm_local[j]);
+      }
+#pragma unroll
+      for (int j = 0; j < QPE_PER_THREAD; j++) {
+        partial += float(q_pe_local[j]) *
+                   float(token_ptr[KV_LORA_RANK + lane * QPE_PER_THREAD + j]);
+      }
+      const float score = simd_sum(partial);
+
+      // Online softmax + V accumulation. fast::exp matches MLX's choice —
+      // ~ULP off scalar exp, but much cheaper.
+      const float new_max = max(max_score, score);
+      const float factor =
+          (max_score == -INFINITY) ? 0.0f : fast::exp(max_score - new_max);
+      const float exp_score = fast::exp(score - new_max);
+      max_score = new_max;
+      sum_exp_score = sum_exp_score * factor + exp_score;
+
+      // V == kv_norm in absorbed MLA, so reuse k_norm_local — saves a load.
+#pragma unroll
+      for (int j = 0; j < V_PER_THREAD; j++) {
+        v_local[j] = v_local[j] * factor + exp_score * float(k_norm_local[j]);
+      }
+    }
+  }
+
+  // Write per-partition (max, sum) and the NORMALIZED partial output. The
+  // reduce kernel re-weights by exp_sums so partition_sum cancels out.
+  if (lane == 0) {
+    max_logits[(seq_idx * num_heads + head_idx) * num_partitions +
+               partition_idx] = max_score;
+    exp_sums[(seq_idx * num_heads + head_idx) * num_partitions +
+             partition_idx] = sum_exp_score;
+  }
+
+  const float inv_sum = (sum_exp_score > 0.0f) ? (1.0f / sum_exp_score) : 0.0f;
+  device T *out_ptr =
+      tmp_out + ((seq_idx * num_heads + head_idx) * num_partitions +
+                 partition_idx) * KV_LORA_RANK +
+      lane * V_PER_THREAD;
+#pragma unroll
+  for (int i = 0; i < V_PER_THREAD; i++) {
+    out_ptr[i] = T(v_local[i] * inv_sum);
+  }
+}
+
 // ========================================== Instantiations
 //
 // Single-pass main kernel: dtype × block_size × heads_per_tg × partition_size.
@@ -565,3 +799,79 @@ instantiate_mla(bfloat16_t, 512, 64, 32, 4, 256, 512);
 
 instantiate_mla_reduce(half, 512, 512);
 instantiate_mla_reduce(bfloat16_t, 512, 512);
+
+// Decode 2pass kernel — MLX sdpa_vector_2pass-style cross-head amortization.
+#define instantiate_mla_2pass(type, kv_lora_rank, qk_rope_head_dim,            \
+                              block_size, partition_size, heads_per_tg)        \
+  template [[host_name("paged_mla_attention_decode_2pass_1_" #type "_kvr"      \
+                       #kv_lora_rank "_pe" #qk_rope_head_dim "_bs"             \
+                       #block_size "_ps" #partition_size "_hpt"                \
+                       #heads_per_tg)]] [[kernel]] void                        \
+  paged_mla_attention_decode_2pass_1<type, kv_lora_rank, qk_rope_head_dim,     \
+                                     block_size, partition_size,               \
+                                     heads_per_tg>(                            \
+      device float * exp_sums [[buffer(0)]],                                   \
+      device float *max_logits [[buffer(1)]],                                  \
+      device type *tmp_out [[buffer(2)]],                                      \
+      device const type *q_nope [[buffer(3)]],                                 \
+      device const type *q_pe [[buffer(4)]],                                   \
+      device const type *latent_cache [[buffer(5)]],                           \
+      device const uint32_t *block_tables [[buffer(6)]],                       \
+      device const uint32_t *context_lens [[buffer(7)]],                       \
+      const constant int &max_num_blocks_per_seq [[buffer(8)]],                \
+      const constant int &num_heads_total [[buffer(9)]],                       \
+      const constant float &scale [[buffer(10)]],                              \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],     \
+      uint3 threadgroups_per_grid [[threadgroups_per_grid]],                   \
+      uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]], \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+// HEADS_PER_TG=32 is the maximum (Apple's 1024 threads/TG cap = 32 lanes ×
+// 32 simdgroups). 8 covers small models (e.g. MiniCPM3 H=40 → uses 8 + a
+// partial last group, net 5 TGs/seq/partition; close to the H=8 ceiling
+// most decode workloads sit at). PARTITION_SIZE specializations let the
+// dispatcher pick a finer split for small ctx and a coarser split for
+// long ctx.
+instantiate_mla_2pass(half, 512, 64, 16, 64, 32);
+instantiate_mla_2pass(half, 512, 64, 16, 128, 32);
+instantiate_mla_2pass(half, 512, 64, 16, 256, 32);
+instantiate_mla_2pass(half, 512, 64, 16, 512, 32);
+instantiate_mla_2pass(half, 512, 64, 32, 64, 32);
+instantiate_mla_2pass(half, 512, 64, 32, 128, 32);
+instantiate_mla_2pass(half, 512, 64, 32, 256, 32);
+instantiate_mla_2pass(half, 512, 64, 32, 512, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 64, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 128, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 256, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 512, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 64, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 128, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 256, 32);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 512, 32);
+
+instantiate_mla_2pass(half, 512, 64, 16, 64, 8);
+instantiate_mla_2pass(half, 512, 64, 16, 128, 8);
+instantiate_mla_2pass(half, 512, 64, 16, 256, 8);
+instantiate_mla_2pass(half, 512, 64, 16, 512, 8);
+instantiate_mla_2pass(half, 512, 64, 32, 64, 8);
+instantiate_mla_2pass(half, 512, 64, 32, 128, 8);
+instantiate_mla_2pass(half, 512, 64, 32, 256, 8);
+instantiate_mla_2pass(half, 512, 64, 32, 512, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 64, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 128, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 256, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 16, 512, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 64, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 128, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 256, 8);
+instantiate_mla_2pass(bfloat16_t, 512, 64, 32, 512, 8);
+
+// Reduce kernel instantiations to cover the 2pass partition sizes.
+// ps=512 is already instantiated above for the G-batched single-pass
+// kernel's partitioned path; reuse here.
+instantiate_mla_reduce(half, 512, 64);
+instantiate_mla_reduce(half, 512, 128);
+instantiate_mla_reduce(half, 512, 256);
+instantiate_mla_reduce(bfloat16_t, 512, 64);
+instantiate_mla_reduce(bfloat16_t, 512, 128);
+instantiate_mla_reduce(bfloat16_t, 512, 256);

--- a/vllm_metal/metal/kernels_v2/mla.metal
+++ b/vllm_metal/metal/kernels_v2/mla.metal
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Paged Multi-head Latent Attention (MLA) kernel.
+//
+// Tracks RFC https://github.com/vllm-project/vllm-metal/issues/360.
+//
+// Two kernels in this file:
+//   - paged_mla_attention         — fused score+softmax+V over a single
+//                                   threadgroup per (head_group, q_token).
+//                                   With PARTITION_SIZE > 0, each
+//                                   (head_group, q_token, partition) handles
+//                                   a ctx slice and writes its partial
+//                                   (max, lse, normalized output) to scratch
+//                                   buffers; the reduce kernel merges across
+//                                   partitions.
+//   - paged_mla_attention_reduce  — cross-partition online-softmax merge,
+//                                   mirroring kernels_v2/pagedattention.metal
+//                                   paged_attention_v2_reduce.
+//
+// Decode kernel parallelism scheme mirrors MLX's sdpa_vector
+// (mlx/backend/metal/kernels/sdpa_vector.h, ml-explore/mlx@v0.31.2):
+//   - Threadgroup: BN simdgroups × BD lanes = NUM_THREADS threads.
+//   - simd_lid (lane) holds a contiguous dim-slice of Q (KV_LORA_RANK / BD
+//     elements) and the V output accumulator (same slice).
+//   - simd_gid (simdgroup) strides over KV tokens — each simdgroup processes
+//     one token at a time, all BD lanes cooperate on the dot product via
+//     simd_sum. BN simdgroups process BN tokens in parallel per "wave".
+//   - Online softmax state lives in registers per simdgroup; cross-simdgroup
+//     merge at the end uses a transpose-via-shmem trick + simd_sum.
+//
+// Cross-head amortization (HEADS_PER_TG > 1):
+//   One threadgroup processes HEADS_PER_TG query heads sharing the same
+//   latent KV. K is loaded once per simdgroup wave and reused for G dot
+//   products. Per-thread state grows G× (Q_local, V_local hold G heads
+//   worth of dim slice), so NUM_THREADS is reduced in lockstep so the
+//   register budget per TG stays roughly constant. Total launches drop
+//   from B×H to B×ceil(H/G), so KV bandwidth is amortized G×.
+//
+// This is structurally different from kernels_v2/pagedattention.metal which
+// puts each lane on a single token's full dot product. For MLA the dim
+// (KV_LORA_RANK=512) is too large for that to be efficient — distributing
+// across lanes is the only way to match MLX SDPA's per-token throughput.
+
+#include "utils.metal"
+#include <metal_simdgroup>
+#include <metal_stdlib>
+
+using namespace metal;
+
+// ========================================== Function constants
+
+constant bool mla_use_partitioning [[function_constant(10)]];
+constant bool mla_use_alibi        [[function_constant(20)]];
+constant bool mla_use_fp8_scales   [[function_constant(30)]];
+constant bool mla_use_sinks        [[function_constant(40)]];
+constant bool mla_use_turboquant   [[function_constant(50)]];
+
+// ========================================== Main kernel
+//
+// Buffer layout:
+//
+//   0: exp_sums    [num_seqs, num_heads, max_num_partitions]  fp32
+//                  (only when mla_use_partitioning)
+//   1: max_logits  [num_seqs, num_heads, max_num_partitions]  fp32
+//                  (only when mla_use_partitioning)
+//   2: out / tmp_out
+//        non-partitioned: [total_q_tokens, num_heads, KV_LORA_RANK] T
+//        partitioned    : [num_seqs, num_heads, max_num_partitions, KV_LORA_RANK] T
+//   3: q_nope       [total_q_tokens, num_heads, KV_LORA_RANK] T  (post-embed_q)
+//   4: q_pe         [total_q_tokens, num_heads, QK_ROPE_HEAD_DIM] T  (post-RoPE)
+//   5: latent_cache [num_blocks, BLOCK_SIZE, KV_LORA_RANK + QK_ROPE_HEAD_DIM] T
+//   6: block_tables [num_seqs, max_num_blocks_per_seq] uint32
+//   7: context_lens [num_seqs] uint32
+//   8: cu_seqlens_q [num_seqs + 1] int32  (P1 trivial: [0,1,...,num_seqs])
+//   9: num_seqs (constant int)
+//  10: max_num_blocks_per_seq (constant int)
+//  11: scale (constant float)
+//
+// Grid:
+//   non-partitioned: (num_heads / HEADS_PER_TG, total_q_tokens, 1)
+//   partitioned    : (num_heads / HEADS_PER_TG, total_q_tokens,
+//                     max_num_partitions)
+//
+// Per-thread register state (BD=NUM_SIMD_LANES=32 typical):
+//   q_nope_local : HEADS_PER_TG * KV_LORA_RANK / BD       fp32
+//   q_pe_local   : HEADS_PER_TG * QK_ROPE_HEAD_DIM / BD   fp32
+//   v_local      : HEADS_PER_TG * KV_LORA_RANK / BD       fp32   (V acc)
+// Threadgroup memory:
+//   max_scores[HEADS_PER_TG * BN]      fp32
+//   sum_exp_scores[HEADS_PER_TG * BN]  fp32
+//   outputs[BD * BD]                   fp32  (transpose buffer for cross-
+//                                             simdgroup O reduce, reused
+//                                             across heads. Sized for the
+//                                             write index `lane*BD + sg`,
+//                                             which reaches (BD-1)*BD +
+//                                             (BN-1) for any BN ≤ BD.)
+
+template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
+          int HEADS_PER_TG, int NUM_THREADS, int NUM_SIMD_LANES,
+          int PARTITION_SIZE = 0>
+[[kernel, max_total_threads_per_threadgroup(NUM_THREADS)]] void paged_mla_attention(
+    device float *exp_sums
+    [[buffer(0), function_constant(mla_use_partitioning)]],
+    device float *max_logits
+    [[buffer(1), function_constant(mla_use_partitioning)]],
+    device T *out [[buffer(2)]],
+    device const T *q_nope [[buffer(3)]],
+    device const T *q_pe [[buffer(4)]],
+    device const T *latent_cache [[buffer(5)]],
+    device const uint32_t *block_tables [[buffer(6)]],
+    device const uint32_t *context_lens [[buffer(7)]],
+    device const int32_t *cu_seqlens_q [[buffer(8)]],
+    const constant int &num_seqs [[buffer(9)]],
+    const constant int &max_num_blocks_per_seq [[buffer(10)]],
+    const constant float &scale [[buffer(11)]],
+    threadgroup char *shared_mem [[threadgroup(0)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint3 threadgroups_per_grid [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  (void)cu_seqlens_q;
+  (void)num_seqs;
+
+  constexpr int LATENT_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM;
+  constexpr int BD = NUM_SIMD_LANES;          // lanes per simdgroup
+  constexpr int BN = NUM_THREADS / BD;        // simdgroups per threadgroup
+  constexpr int QK_PER_THREAD = KV_LORA_RANK / BD;
+  constexpr int QPE_PER_THREAD = QK_ROPE_HEAD_DIM / BD;
+  constexpr int V_PER_THREAD = KV_LORA_RANK / BD;
+  constexpr bool USE_PARTITIONING = PARTITION_SIZE > 0;
+  static_assert(KV_LORA_RANK % BD == 0,
+                "KV_LORA_RANK must be divisible by NUM_SIMD_LANES");
+  static_assert(QK_ROPE_HEAD_DIM % BD == 0,
+                "QK_ROPE_HEAD_DIM must be divisible by NUM_SIMD_LANES");
+  static_assert(BN <= BD,
+                "Cross-simdgroup merge needs BN<=BD (lane indexes the BN axis)");
+  static_assert(!USE_PARTITIONING || PARTITION_SIZE % BLOCK_SIZE == 0,
+                "PARTITION_SIZE must be divisible by BLOCK_SIZE");
+
+  const int q_token_idx = threadgroup_position_in_grid.y;
+  const int head_group_idx = threadgroup_position_in_grid.x;
+  const int num_head_groups = threadgroups_per_grid.x;
+  const int num_heads = num_head_groups * HEADS_PER_TG;
+  const int head_idx_base = head_group_idx * HEADS_PER_TG;
+  const int partition_idx = threadgroup_position_in_grid.z;
+  const int max_num_partitions = threadgroups_per_grid.z;
+  const int lane = (int)simd_lid;
+  const int sg = (int)simd_gid;
+
+  // P1 decode: q_token_idx == seq_idx (wrapper-enforced).
+  const int seq_idx = q_token_idx;
+  const int ctx_len = (int)context_lens[seq_idx];
+
+  const int token_start =
+      USE_PARTITIONING ? partition_idx * PARTITION_SIZE : 0;
+  const int token_end =
+      USE_PARTITIONING ? min(token_start + PARTITION_SIZE, ctx_len) : ctx_len;
+
+  // Partition has no work — early-out (caller pre-zeros partial buffers).
+  if (USE_PARTITIONING && token_start >= ctx_len) {
+    return;
+  }
+
+  // ---- Phase A: load Q for HEADS_PER_TG heads into per-lane registers ----
+  // Layout: q_nope_local[h * QK_PER_THREAD + j] holds head h's dim slice
+  // [lane * QK_PER_THREAD + j]. With G=1 this is identical to the previous
+  // single-head kernel.
+  float q_nope_local[HEADS_PER_TG * QK_PER_THREAD];
+  float q_pe_local[HEADS_PER_TG * QPE_PER_THREAD];
+  float v_local[HEADS_PER_TG * V_PER_THREAD];
+  float max_score[HEADS_PER_TG];
+  float sum_exp_score[HEADS_PER_TG];
+
+#pragma unroll
+  for (int h = 0; h < HEADS_PER_TG; h++) {
+    const int head_idx = head_idx_base + h;
+    const device T *q_nope_ptr =
+        q_nope + (q_token_idx * num_heads + head_idx) * KV_LORA_RANK +
+        lane * QK_PER_THREAD;
+    const device T *q_pe_ptr =
+        q_pe + (q_token_idx * num_heads + head_idx) * QK_ROPE_HEAD_DIM +
+        lane * QPE_PER_THREAD;
+#pragma unroll
+    for (int j = 0; j < QK_PER_THREAD; j++) {
+      q_nope_local[h * QK_PER_THREAD + j] = float(q_nope_ptr[j]);
+    }
+#pragma unroll
+    for (int j = 0; j < QPE_PER_THREAD; j++) {
+      q_pe_local[h * QPE_PER_THREAD + j] = float(q_pe_ptr[j]);
+    }
+#pragma unroll
+    for (int j = 0; j < V_PER_THREAD; j++) {
+      v_local[h * V_PER_THREAD + j] = 0.0f;
+    }
+    max_score[h] = -INFINITY;
+    sum_exp_score[h] = 0.0f;
+  }
+
+  // ---- Phase B: simdgroup-strided token loop ----
+  // Each simdgroup processes one token at a time. K is loaded ONCE per
+  // simdgroup wave and reused for HEADS_PER_TG dot products — this is the
+  // KV-bandwidth amortization.
+  const device uint32_t *block_table_row =
+      block_tables + (uint64_t)seq_idx * max_num_blocks_per_seq;
+
+  for (int t = token_start + sg; t < token_end; t += BN) {
+    const int block_idx = t / BLOCK_SIZE;
+    const int block_offset = t % BLOCK_SIZE;
+    const uint32_t physical_block = block_table_row[block_idx];
+    const device T *token_ptr =
+        latent_cache + (uint64_t)physical_block * BLOCK_SIZE * LATENT_DIM +
+        block_offset * LATENT_DIM;
+
+    // Load this lane's slice of K_norm and K_pe from cache (shared across
+    // all HEADS_PER_TG heads).
+    float k_norm_local[QK_PER_THREAD];
+#pragma unroll
+    for (int j = 0; j < QK_PER_THREAD; j++) {
+      k_norm_local[j] = float(token_ptr[lane * QK_PER_THREAD + j]);
+    }
+    float k_pe_local[QPE_PER_THREAD];
+#pragma unroll
+    for (int j = 0; j < QPE_PER_THREAD; j++) {
+      k_pe_local[j] =
+          float(token_ptr[KV_LORA_RANK + lane * QPE_PER_THREAD + j]);
+    }
+
+    // Per-head: partial dot product → simd_sum → score → online softmax →
+    // V accumulation. The simd_sum is once per head; can't fold across
+    // heads since each head has its own score.
+#pragma unroll
+    for (int h = 0; h < HEADS_PER_TG; h++) {
+      float partial = 0.0f;
+#pragma unroll
+      for (int j = 0; j < QK_PER_THREAD; j++) {
+        partial += q_nope_local[h * QK_PER_THREAD + j] * k_norm_local[j];
+      }
+#pragma unroll
+      for (int j = 0; j < QPE_PER_THREAD; j++) {
+        partial += q_pe_local[h * QPE_PER_THREAD + j] * k_pe_local[j];
+      }
+      const float score = simd_sum(partial) * scale;
+
+      const float new_max = max(max_score[h], score);
+      // fast::exp + conditional division guards match the newer kernels
+      // (2pass main, FA, pr_mma). Mixing exp vs fast::exp across kernels
+      // — or eps-add vs conditional in the divisor — diverges on hardware
+      // where fast::exp's approximation order or the eps bias compounds
+      // across reductions; the reduce-side mismatch was the root cause of
+      // the macos-15 2pass parity failures on the first push of this PR.
+      const float factor = (max_score[h] == -INFINITY) ? 0.0f
+                                                       : fast::exp(max_score[h] - new_max);
+      const float exp_score = fast::exp(score - new_max);
+      max_score[h] = new_max;
+      sum_exp_score[h] = sum_exp_score[h] * factor + exp_score;
+
+      // V == kv_norm in absorbed MLA, so reuse k_norm_local — saves a load.
+#pragma unroll
+      for (int j = 0; j < V_PER_THREAD; j++) {
+        v_local[h * V_PER_THREAD + j] =
+            v_local[h * V_PER_THREAD + j] * factor + exp_score * k_norm_local[j];
+      }
+    }
+  }
+
+  // ---- Phase C: cross-simdgroup merge ----
+  // Per head: each simdgroup writes its (max, sum_exp) to shmem, lane `l`
+  // reads simdgroup `l`'s value, computes the global rescale factor, and
+  // uses a transpose-via-shmem trick to reduce each dim slice across
+  // simdgroups via a single simd_sum.
+
+  threadgroup float *max_scores = (threadgroup float *)shared_mem;
+  threadgroup float *sum_exp_scores = max_scores + HEADS_PER_TG * BN;
+  threadgroup float *outputs = sum_exp_scores + HEADS_PER_TG * BN;
+
+  if (lane == 0) {
+#pragma unroll
+    for (int h = 0; h < HEADS_PER_TG; h++) {
+      max_scores[h * BN + sg] = max_score[h];
+      sum_exp_scores[h * BN + sg] = sum_exp_score[h];
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Per-head merge. The transpose-via-shmem buffer (`outputs`) is reused
+  // across heads; the trailing barrier in the inner loop synchronizes the
+  // next head's first write.
+  //
+  // Coverage requires BN simdgroups to between them produce all KV_LORA_RANK
+  // output dims. The "natural" trick (each simdgroup owns one V_PER_THREAD
+  // = KV_LORA_RANK/BD slice) only covers BN*V_PER_THREAD = (BN/BD)*KV_LORA_RANK
+  // dims. When BN < BD (e.g. NUM_THREADS=256 → BN=8, BD=32), each simdgroup
+  // must cover NUM_PASSES = BD/BN slices to reach full coverage. NUM_PASSES=1
+  // for the BN=BD=32 default.
+  constexpr int NUM_PASSES = BD / BN;
+  static_assert(BD % BN == 0, "BD must be divisible by BN");
+#pragma unroll
+  for (int h = 0; h < HEADS_PER_TG; h++) {
+    const float my_simdgroup_max =
+        (lane < BN) ? max_scores[h * BN + lane] : -INFINITY;
+    const float global_max = simd_max(my_simdgroup_max);
+    const float rescale =
+        (my_simdgroup_max == -INFINITY) ? 0.0f
+                                        : fast::exp(my_simdgroup_max - global_max);
+    const float global_sum =
+        simd_sum((lane < BN) ? sum_exp_scores[h * BN + lane] * rescale : 0.0f);
+    const float inv_global = (global_sum > 0.0f) ? (1.0f / global_sum) : 0.0f;
+
+    // Transpose-via-shmem merge across simdgroups.
+    //   write: outputs[lane * BD + sg] = v_local[i]
+    //          → entry at offset (lane * BD + sg) holds simdgroup-sg lane-lane's
+    //            partial for dim (lane * V_PER_THREAD + i). Only sg in [0, BN)
+    //            is written, so the BN-wide dim of `outputs` is sparse when
+    //            BN<BD.
+    //   read:  outputs[(p * BN + sg) * BD + lane]
+    //          → simdgroup sg's lane `l` picks up source-lane (p*BN+sg)
+    //            simdgroup-l's partial; simd_sum across lanes-of-reader sums
+    //            across source-simdgroups for that fixed source-lane. Only
+    //            lanes l < BN have valid data in shmem; lanes l >= BN must
+    //            contribute 0 to the simd_sum.
+    // After simd_sum, simdgroup `sg` holds final values for dim slice
+    // [(p * BN + sg) * V_PER_THREAD, (p * BN + sg + 1) * V_PER_THREAD).
+    // We write to device memory immediately rather than buffering
+    // NUM_PASSES * V_PER_THREAD floats per thread — the v_final[] register
+    // array would push G=4 over the per-thread register budget.
+    const int head_idx = head_idx_base + h;
+    device T *out_base = USE_PARTITIONING
+        ? (out +
+           ((q_token_idx * num_heads + head_idx) * max_num_partitions +
+            partition_idx) * KV_LORA_RANK)
+        : (out + (q_token_idx * num_heads + head_idx) * KV_LORA_RANK);
+#pragma unroll
+    for (int p = 0; p < NUM_PASSES; p++) {
+#pragma unroll
+      for (int i = 0; i < V_PER_THREAD; i++) {
+        outputs[lane * BD + sg] = v_local[h * V_PER_THREAD + i];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float other =
+            (lane < BN) ? outputs[(p * BN + sg) * BD + lane] : 0.0f;
+        const float final_val = simd_sum(other * rescale) * inv_global;
+        if (lane == 0) {
+          out_base[(p * BN + sg) * V_PER_THREAD + i] = T(final_val);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+      }
+    }
+
+    // ---- Phase D: per-head LSE / max metadata for the partitioned reduce ----
+    if (USE_PARTITIONING) {
+      if (lane == 0 && sg == 0) {
+        max_logits[(q_token_idx * num_heads + head_idx) * max_num_partitions +
+                   partition_idx] = global_max;
+        // exp_sums stores l (sum-of-exps at global_max) so reduce kernel can
+        // weight partitions correctly.
+        exp_sums[(q_token_idx * num_heads + head_idx) * max_num_partitions +
+                 partition_idx] = global_sum;
+      }
+    }
+  }
+}
+
+
+// ========================================== Instantiations
+//
+// Single-pass main kernel: dtype × block_size × heads_per_tg.
+//   G=1 → NUM_THREADS=1024 (32 simdgroups, current sdpa_vector layout).
+//   G=2 → NUM_THREADS=512  (16 simdgroups, 2× KV-bandwidth amortization).
+//   G=4 → NUM_THREADS=256  (8 simdgroups, 4× the per-thread arithmetic;
+//                           register footprint per TG stays roughly constant).
+
+#define instantiate_mla(type, kv_lora_rank, qk_rope_head_dim, block_size,      \
+                        heads_per_tg, num_threads, partition_size)             \
+  template [[host_name("paged_mla_attention_" #type "_kvr" #kv_lora_rank       \
+                       "_pe" #qk_rope_head_dim "_bs" #block_size "_g"          \
+                       #heads_per_tg "_nt" #num_threads "_nsl32_ps"            \
+                       #partition_size)]] [[kernel]] void                      \
+  paged_mla_attention<type, kv_lora_rank, qk_rope_head_dim, block_size,        \
+                      heads_per_tg, num_threads, 32, partition_size>(          \
+      device float * exp_sums                                                  \
+      [[buffer(0), function_constant(mla_use_partitioning)]],                  \
+      device float *max_logits                                                 \
+      [[buffer(1), function_constant(mla_use_partitioning)]],                  \
+      device type *out [[buffer(2)]],                                          \
+      device const type *q_nope [[buffer(3)]],                                 \
+      device const type *q_pe [[buffer(4)]],                                   \
+      device const type *latent_cache [[buffer(5)]],                           \
+      device const uint32_t *block_tables [[buffer(6)]],                       \
+      device const uint32_t *context_lens [[buffer(7)]],                       \
+      device const int32_t *cu_seqlens_q [[buffer(8)]],                        \
+      const constant int &num_seqs [[buffer(9)]],                              \
+      const constant int &max_num_blocks_per_seq [[buffer(10)]],               \
+      const constant float &scale [[buffer(11)]],                              \
+      threadgroup char *shared_mem [[threadgroup(0)]],                         \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],     \
+      uint3 threadgroups_per_grid [[threadgroups_per_grid]],                   \
+      uint simd_gid [[simdgroup_index_in_threadgroup]],                        \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+// G=1 (single-head per TG, NUM_THREADS=1024).
+instantiate_mla(half, 512, 64, 16, 1, 1024, 0);
+instantiate_mla(half, 512, 64, 32, 1, 1024, 0);
+instantiate_mla(bfloat16_t, 512, 64, 16, 1, 1024, 0);
+instantiate_mla(bfloat16_t, 512, 64, 32, 1, 1024, 0);
+
+// G=2 (2 heads per TG, NUM_THREADS=512). 2× KV-bandwidth amortization.
+instantiate_mla(half, 512, 64, 16, 2, 512, 0);
+instantiate_mla(half, 512, 64, 32, 2, 512, 0);
+instantiate_mla(bfloat16_t, 512, 64, 16, 2, 512, 0);
+instantiate_mla(bfloat16_t, 512, 64, 32, 2, 512, 0);
+
+// G=4 (4 heads per TG, NUM_THREADS=256). 4× KV-bandwidth amortization.
+instantiate_mla(half, 512, 64, 16, 4, 256, 0);
+instantiate_mla(half, 512, 64, 32, 4, 256, 0);
+instantiate_mla(bfloat16_t, 512, 64, 16, 4, 256, 0);
+instantiate_mla(bfloat16_t, 512, 64, 32, 4, 256, 0);

--- a/vllm_metal/metal/kernels_v2/mla.metal
+++ b/vllm_metal/metal/kernels_v2/mla.metal
@@ -359,14 +359,134 @@ template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
   }
 }
 
+// ========================================== Reduce kernel
+//
+// Cross-partition online-softmax merge. One threadgroup per (head, q_token).
+// Unchanged from the previous version — partial outputs from the new main
+// kernel still follow the same (max, lse, normalized partial) contract, and
+// the reduce kernel is per-head (so HEADS_PER_TG doesn't propagate here).
+//
+// Buffer layout:
+//   0: out         [total_q_tokens, num_heads, HEAD_SIZE] T
+//   1: exp_sums    [num_seqs, num_heads, max_num_partitions] fp32
+//   2: max_logits  [num_seqs, num_heads, max_num_partitions] fp32
+//   3: tmp_out     [num_seqs, num_heads, max_num_partitions, HEAD_SIZE] T
+//   4: context_lens [num_seqs] uint32
+//   5: max_num_partitions (constant int)
+
+template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
+          int PARTITION_SIZE>
+[[kernel]] void paged_mla_attention_reduce(
+    device T *out [[buffer(0)]],
+    const device float *exp_sums [[buffer(1)]],
+    const device float *max_logits [[buffer(2)]],
+    const device T *tmp_out [[buffer(3)]],
+    const device uint32_t *context_lens [[buffer(4)]],
+    const constant int &max_num_partitions [[buffer(5)]],
+    threadgroup char *shared_mem [[threadgroup(0)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint3 threadgroups_per_grid [[threadgroups_per_grid]],
+    uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]],
+    uint simd_tid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  const int head_idx = threadgroup_position_in_grid.x;
+  const int q_token_idx = threadgroup_position_in_grid.y;
+  const int num_heads = threadgroups_per_grid.x;
+  const int thread_idx = thread_position_in_threadgroup.x;
+  constexpr int NUM_WARPS = NUM_THREADS / NUM_SIMD_LANES;
+  const int warp_idx = (int)simd_tid;
+  const int lane = (int)simd_lid;
+
+  const int seq_idx = q_token_idx;
+  const int ctx_len = (int)context_lens[seq_idx];
+  const int num_partitions =
+      (ctx_len + PARTITION_SIZE - 1) / PARTITION_SIZE;
+
+  threadgroup float *shared_max_logits = (threadgroup float *)shared_mem;
+  threadgroup float *shared_exp_sums = shared_max_logits + max_num_partitions;
+  threadgroup float *red_smem = shared_exp_sums + max_num_partitions;
+
+  device T *out_ptr =
+      out + (q_token_idx * num_heads + head_idx) * HEAD_SIZE;
+  const device T *tmp_out_ptr =
+      tmp_out +
+      (q_token_idx * num_heads + head_idx) * max_num_partitions * HEAD_SIZE;
+
+  if (num_partitions == 1) {
+    for (int d = thread_idx; d < HEAD_SIZE; d += NUM_THREADS) {
+      out_ptr[d] = tmp_out_ptr[d];
+    }
+    return;
+  }
+
+  const device float *max_logits_ptr =
+      max_logits +
+      (q_token_idx * num_heads + head_idx) * max_num_partitions;
+  float thread_max = -INFINITY;
+  for (int i = thread_idx; i < num_partitions; i += NUM_THREADS) {
+    const float l = max_logits_ptr[i];
+    shared_max_logits[i] = l;
+    thread_max = max(thread_max, l);
+  }
+#pragma unroll
+  for (int mask = NUM_SIMD_LANES / 2; mask >= 1; mask /= 2) {
+    thread_max = max(thread_max, simd_shuffle_xor(thread_max, mask));
+  }
+  if (lane == 0) {
+    red_smem[warp_idx] = thread_max;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  thread_max = (lane < NUM_WARPS) ? red_smem[lane] : -INFINITY;
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    thread_max = max(thread_max, simd_shuffle_xor(thread_max, mask));
+  }
+  const float global_max = simd_shuffle(thread_max, 0);
+
+  const device float *exp_sums_ptr =
+      exp_sums + (q_token_idx * num_heads + head_idx) * max_num_partitions;
+  float thread_exp_sum = 0.0f;
+  for (int i = thread_idx; i < num_partitions; i += NUM_THREADS) {
+    const float l = shared_max_logits[i];
+    const float rescaled = exp_sums_ptr[i] * fast::exp(l - global_max);
+    shared_exp_sums[i] = rescaled;
+    thread_exp_sum += rescaled;
+  }
+#pragma unroll
+  for (int mask = NUM_SIMD_LANES / 2; mask >= 1; mask /= 2) {
+    thread_exp_sum += simd_shuffle_xor(thread_exp_sum, mask);
+  }
+  if (lane == 0) {
+    red_smem[NUM_WARPS + warp_idx] = thread_exp_sum;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  thread_exp_sum = (lane < NUM_WARPS) ? red_smem[NUM_WARPS + lane] : 0.0f;
+#pragma unroll
+  for (int mask = NUM_WARPS / 2; mask >= 1; mask /= 2) {
+    thread_exp_sum += simd_shuffle_xor(thread_exp_sum, mask);
+  }
+  const float global_exp_sum = simd_shuffle(thread_exp_sum, 0);
+  const float inv_global =
+      (global_exp_sum > 0.0f) ? (1.0f / global_exp_sum) : 0.0f;
+
+  for (int d = thread_idx; d < HEAD_SIZE; d += NUM_THREADS) {
+    float acc = 0.0f;
+    for (int j = 0; j < num_partitions; j++) {
+      acc += float(tmp_out_ptr[j * HEAD_SIZE + d]) * shared_exp_sums[j] *
+             inv_global;
+    }
+    out_ptr[d] = T(acc);
+  }
+}
 
 // ========================================== Instantiations
 //
-// Single-pass main kernel: dtype × block_size × heads_per_tg.
+// Single-pass main kernel: dtype × block_size × heads_per_tg × partition_size.
 //   G=1 → NUM_THREADS=1024 (32 simdgroups, current sdpa_vector layout).
 //   G=2 → NUM_THREADS=512  (16 simdgroups, 2× KV-bandwidth amortization).
 //   G=4 → NUM_THREADS=256  (8 simdgroups, 4× the per-thread arithmetic;
 //                           register footprint per TG stays roughly constant).
+// Reduce kernel: dtype × partition_size, NUM_THREADS=256.
 
 #define instantiate_mla(type, kv_lora_rank, qk_rope_head_dim, block_size,      \
                         heads_per_tg, num_threads, partition_size)             \
@@ -396,20 +516,52 @@ template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
       uint simd_gid [[simdgroup_index_in_threadgroup]],                        \
       uint simd_lid [[thread_index_in_simdgroup]]);
 
+#define instantiate_mla_reduce(type, head_size, partition_size)                \
+  template [[host_name("paged_mla_attention_reduce_" #type "_hs" #head_size    \
+                       "_nt256_nsl32_ps" #partition_size)]] [[kernel]] void    \
+  paged_mla_attention_reduce<type, head_size, 256, 32, partition_size>(        \
+      device type * out [[buffer(0)]],                                         \
+      const device float *exp_sums [[buffer(1)]],                              \
+      const device float *max_logits [[buffer(2)]],                            \
+      const device type *tmp_out [[buffer(3)]],                                \
+      const device uint32_t *context_lens [[buffer(4)]],                       \
+      const constant int &max_num_partitions [[buffer(5)]],                    \
+      threadgroup char *shared_mem [[threadgroup(0)]],                         \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],     \
+      uint3 threadgroups_per_grid [[threadgroups_per_grid]],                   \
+      uint3 thread_position_in_threadgroup [[thread_position_in_threadgroup]], \
+      uint simd_tid [[simdgroup_index_in_threadgroup]],                        \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
 // G=1 (single-head per TG, NUM_THREADS=1024).
 instantiate_mla(half, 512, 64, 16, 1, 1024, 0);
 instantiate_mla(half, 512, 64, 32, 1, 1024, 0);
 instantiate_mla(bfloat16_t, 512, 64, 16, 1, 1024, 0);
 instantiate_mla(bfloat16_t, 512, 64, 32, 1, 1024, 0);
+instantiate_mla(half, 512, 64, 16, 1, 1024, 512);
+instantiate_mla(half, 512, 64, 32, 1, 1024, 512);
+instantiate_mla(bfloat16_t, 512, 64, 16, 1, 1024, 512);
+instantiate_mla(bfloat16_t, 512, 64, 32, 1, 1024, 512);
 
 // G=2 (2 heads per TG, NUM_THREADS=512). 2× KV-bandwidth amortization.
 instantiate_mla(half, 512, 64, 16, 2, 512, 0);
 instantiate_mla(half, 512, 64, 32, 2, 512, 0);
 instantiate_mla(bfloat16_t, 512, 64, 16, 2, 512, 0);
 instantiate_mla(bfloat16_t, 512, 64, 32, 2, 512, 0);
+instantiate_mla(half, 512, 64, 16, 2, 512, 512);
+instantiate_mla(half, 512, 64, 32, 2, 512, 512);
+instantiate_mla(bfloat16_t, 512, 64, 16, 2, 512, 512);
+instantiate_mla(bfloat16_t, 512, 64, 32, 2, 512, 512);
 
 // G=4 (4 heads per TG, NUM_THREADS=256). 4× KV-bandwidth amortization.
 instantiate_mla(half, 512, 64, 16, 4, 256, 0);
 instantiate_mla(half, 512, 64, 32, 4, 256, 0);
 instantiate_mla(bfloat16_t, 512, 64, 16, 4, 256, 0);
 instantiate_mla(bfloat16_t, 512, 64, 32, 4, 256, 0);
+instantiate_mla(half, 512, 64, 16, 4, 256, 512);
+instantiate_mla(half, 512, 64, 32, 4, 256, 512);
+instantiate_mla(bfloat16_t, 512, 64, 16, 4, 256, 512);
+instantiate_mla(bfloat16_t, 512, 64, 32, 4, 256, 512);
+
+instantiate_mla_reduce(half, 512, 512);
+instantiate_mla_reduce(bfloat16_t, 512, 512);

--- a/vllm_metal/metal/kernels_v2/mla.metal
+++ b/vllm_metal/metal/kernels_v2/mla.metal
@@ -713,6 +713,639 @@ template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
   }
 }
 
+// ========================================== Paged FA decode kernel
+//
+// simdgroup_matrix-based paged FA kernel.
+// Multi-block ctx with online softmax merged across BK tiles: each
+// outer iteration loads BK K-tokens, computes one QK tile, merges its
+// row_max / row_sum into the persistent state, rescales the V
+// accumulators by `factor = exp(old_max - new_max)`, and accumulates
+// the SV contribution. Partial tail (last K tile with valid_cols <
+// BK) is handled by setting out-of-range S cols to -INF before
+// softmax and to 0 in S_smem before the SV pass.
+//
+// Threadgroup geometry: WM × WN × 32 = WN × 32 threads (WM=1). One TG
+// owns one (seq, head_group) tile of BQ consecutive query heads. The
+// WN simdgroups partition the N axis of QK (each owns an 8-token tile
+// of S) and the D axis of SV (each owns 1/WN of KV_LORA_RANK in V_accum).
+//
+// Buffer layout (mirrors single-pass paged_mla_attention sans the
+// partitioning-only buffers):
+//   0: out          [total_q_tokens, num_heads, KV_LORA_RANK] T
+//   1: q_nope       [total_q_tokens, num_heads, KV_LORA_RANK] T
+//   2: q_pe         [total_q_tokens, num_heads, QK_ROPE_HEAD_DIM] T
+//   3: latent_cache [num_blocks, BLOCK_SIZE, KV_LORA_RANK + QK_ROPE_HEAD_DIM] T
+//   4: block_tables [num_seqs, max_num_blocks_per_seq] uint32
+//   5: context_lens [num_seqs] uint32
+//   6: cu_seqlens_q [num_seqs + 1] int32 (decode-only host-side validation)
+//   7: max_num_blocks_per_seq (constant int)
+//   8: num_heads_total          (constant int)
+//   9: scale (constant float)
+
+template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
+          int BQ, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM * WN * 32)]] void
+paged_mla_attention_decode_fa(
+    device T *out [[buffer(0)]],
+    device const T *q_nope [[buffer(1)]],
+    device const T *q_pe [[buffer(2)]],
+    device const T *latent_cache [[buffer(3)]],
+    device const uint32_t *block_tables [[buffer(4)]],
+    device const uint32_t *context_lens [[buffer(5)]],
+    device const int32_t *cu_seqlens_q [[buffer(6)]],
+    const constant int &max_num_blocks_per_seq [[buffer(7)]],
+    const constant int &num_heads_total [[buffer(8)]],
+    const constant float &scale [[buffer(9)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BQ == 8, "FA decode supports BQ=8 (one simdgroup_matrix M).");
+  static_assert(BK % 8 == 0, "BK must be a multiple of the 8x8 frag size.");
+  static_assert(KV_LORA_RANK % 8 == 0,
+                "KV_LORA_RANK must divide the 8-wide D tile.");
+  static_assert(QK_ROPE_HEAD_DIM % 8 == 0,
+                "QK_ROPE_HEAD_DIM must divide the 8-wide D tile.");
+  static_assert(BK % WN == 0,
+                "WN simdgroups partition BK along N; BK must be divisible by WN.");
+  static_assert(KV_LORA_RANK % (WN * 8) == 0,
+                "WN simdgroups partition KV_LORA_RANK along D in V_accum; "
+                "KV_LORA_RANK must be divisible by WN * 8.");
+  static_assert(WN <= BQ,
+                "Softmax assigns BQ rows to WN simdgroups (BQ / WN per group).");
+  // cu_seqlens_q is host-side validated.
+  (void)cu_seqlens_q;
+
+  constexpr int LATENT_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM;
+  constexpr int FRAG = 8;
+  constexpr int THREADS_PER_TG = WM * WN * 32;
+  // Q is the only buffer that pays off in shmem: it's loaded once and
+  // read 72 times per outer block iter. K_smem at BK=32 would overflow
+  // Apple's 32 KB per-TG cap, so K is streamed directly from device
+  // memory via simdgroup_load. Each TG's K reads hit L2 from sibling
+  // head-group TGs servicing the same (seq, K) pair, so the working
+  // set is amortized across head_groups within a TG launch.
+  constexpr int PAD_T = 16 / sizeof(T);
+  constexpr int LD_Q = LATENT_DIM + PAD_T;
+  constexpr int LD_S = BK + FRAG;  // fp32, padded by one frag width
+
+  constexpr int D_NOPE_TILES = KV_LORA_RANK / FRAG;
+  constexpr int D_PE_TILES = QK_ROPE_HEAD_DIM / FRAG;
+  constexpr int D_TILES = D_NOPE_TILES + D_PE_TILES;
+  constexpr int K_TILES = BK / FRAG;
+  // Each simdgroup owns 1/WN of KV_LORA_RANK in V_accum.
+  constexpr int V_TILES_PER_SG = KV_LORA_RANK / FRAG / WN;
+  // Rows handled by each simdgroup during the softmax phase.
+  constexpr int ROWS_PER_SG = BQ / WN;
+  static_assert(ROWS_PER_SG >= 1, "Need at least 1 softmax row per simdgroup.");
+  // Softmax distributes one row's BK columns across the 32 lanes of a
+  // simdgroup; each lane handles BK_CHUNKS columns (at BK=32 one chunk
+  // covers the row; at BK=64 each lane sweeps two strided columns).
+  constexpr int LANES_PER_CHUNK = 32;
+  constexpr int BK_CHUNKS = (BK + LANES_PER_CHUNK - 1) / LANES_PER_CHUNK;
+  static_assert(BK <= LANES_PER_CHUNK * 2,
+                "Softmax fast-path supports BK ≤ 64 (≤ 2 chunks per lane).");
+
+  threadgroup T Q_smem[BQ * LD_Q];
+  threadgroup float S_smem[BQ * LD_S];
+  threadgroup float row_max_smem[BQ];
+  threadgroup float row_sum_smem[BQ];
+  threadgroup float factor_smem[BQ];
+
+  const int tid = simd_gid * 32 + simd_lid;
+
+  const int seq_idx = (int)threadgroup_position_in_grid.x;
+  const int head_group_idx = (int)threadgroup_position_in_grid.y;
+  const int q_head_offset = head_group_idx * BQ;
+  if (q_head_offset >= num_heads_total) {
+    return;
+  }
+
+  const int ctx_len = (int)context_lens[seq_idx];
+  if (ctx_len <= 0) {
+    return;
+  }
+
+  // ===== Load Q into shmem (pre-scaled) =====
+  const device T *q_nope_base =
+      q_nope +
+      (uint64_t)(seq_idx * num_heads_total + q_head_offset) * KV_LORA_RANK;
+  const device T *q_pe_base =
+      q_pe +
+      (uint64_t)(seq_idx * num_heads_total + q_head_offset) * QK_ROPE_HEAD_DIM;
+  for (int idx = tid; idx < BQ * LATENT_DIM; idx += THREADS_PER_TG) {
+    const int row = idx / LATENT_DIM;
+    const int col = idx % LATENT_DIM;
+    const int head = q_head_offset + row;
+    float v;
+    if (head < num_heads_total) {
+      if (col < KV_LORA_RANK) {
+        v = float(q_nope_base[row * KV_LORA_RANK + col]) * scale;
+      } else {
+        v = float(q_pe_base[row * QK_ROPE_HEAD_DIM + (col - KV_LORA_RANK)]) *
+            scale;
+      }
+    } else {
+      v = 0.0f;
+    }
+    Q_smem[row * LD_Q + col] = T(v);
+  }
+
+  // ===== Init running softmax state =====
+  if (tid < BQ) {
+    row_max_smem[tid] = -INFINITY;
+    row_sum_smem[tid] = 0.0f;
+  }
+
+  // ===== Init V accumulators (persistent across blocks) =====
+  simdgroup_matrix<float, FRAG, FRAG> V_accum[V_TILES_PER_SG];
+  for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+    V_accum[vt] = simdgroup_matrix<float, FRAG, FRAG>(0.0f);
+  }
+
+  const device uint32_t *block_table_row =
+      block_tables + (uint64_t)seq_idx * max_num_blocks_per_seq;
+  const int num_k_blocks = (ctx_len + BK - 1) / BK;
+  // Clamp pbi against *this* seq's valid blocks, not max_num_blocks_per_seq.
+  // Otherwise a mixed-length batch reads padded block_tables entries for
+  // the simdgroup slice that lands past ctx_len (softmax masks the result
+  // to zero, but the OOB load itself is undefined behaviour).
+  const int num_valid_blocks = (ctx_len + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+  // BaseMMAFrag lane → (row, col) layout. Each lane owns 2 elements at
+  // (fm, fn) and (fm, fn+1) in any 8x8 simdgroup_matrix tile we touch.
+  const short qid = simd_lid / 4;
+  const short fm = (qid & 4) + ((simd_lid / 2) % 4);
+  const short fn = (qid & 2) * 2 + (simd_lid % 2) * 2;
+
+  // Helper: device-pointer for an 8-token K-frag starting at absolute
+  // token index `abs_k`. pbi is clamped to `num_valid_blocks - 1` so we
+  // never dereference a padded block_tables entry, even when the column
+  // is later masked to zero by the softmax.
+  auto k_base_for = [&](int abs_k) -> const device T * {
+    const int pbi_raw = abs_k / BLOCK_SIZE;
+    const int pbi = pbi_raw < num_valid_blocks ? pbi_raw : num_valid_blocks - 1;
+    const int offset = abs_k % BLOCK_SIZE;
+    const uint32_t pb = block_table_row[pbi];
+    return latent_cache + (uint64_t)pb * BLOCK_SIZE * LATENT_DIM +
+           (uint64_t)offset * LATENT_DIM;
+  };
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // ===== Block loop =====
+  for (int kb = 0; kb < num_k_blocks; kb++) {
+    const int k_global_start = kb * BK;
+    const int k_global_end = min(k_global_start + BK, ctx_len);
+    const int valid_cols = k_global_end - k_global_start;
+
+    // ----- QK matmul (K_frag streamed from device) -----
+    // Each simdgroup owns one 8-token slice of S. The 8 tokens are
+    // guaranteed to share a single physical block: BK ≤ 2 × block_size
+    // here, but the per-simdgroup slice is exactly FRAG=8 ≤ block_size.
+    simdgroup_matrix<float, FRAG, FRAG> S_tile(0.0f);
+    const int qk_local_k_start = simd_gid * FRAG;
+    const int qk_abs_k_start = k_global_start + qk_local_k_start;
+    const device T *qk_k_base = k_base_for(qk_abs_k_start);
+    for (int d_tile = 0; d_tile < D_TILES; d_tile++) {
+      const int d_start = d_tile * FRAG;
+      simdgroup_matrix<T, FRAG, FRAG> Q_frag;
+      simdgroup_matrix<T, FRAG, FRAG> K_frag;
+      simdgroup_load(Q_frag, &Q_smem[d_start], LD_Q);
+      // K device layout is (BK rows of K-tokens × LATENT_DIM); transpose
+      // gives the (D, K_tokens) view simdgroup_multiply_accumulate wants
+      // for B in C = A * B + D.
+      simdgroup_load(K_frag, qk_k_base + d_start, LATENT_DIM, ulong2(0, 0),
+                     /*transpose=*/true);
+      simdgroup_multiply_accumulate(S_tile, Q_frag, K_frag, S_tile);
+    }
+
+    // Dump S to shmem so all simdgroups can softmax row-wise across BK.
+    simdgroup_store(S_tile, &S_smem[qk_local_k_start], LD_S);
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ----- Online softmax merge across blocks -----
+    // Each simdgroup owns ROWS_PER_SG rows. Within a row, the BK
+    // columns are split across the 32 lanes in BK_CHUNKS strided
+    // groups (BK_CHUNKS=1 at BK=32, BK_CHUNKS=2 at BK=64). simd_max
+    // and simd_sum reduce across the 32 lanes; the local_x / exp_x
+    // arrays carry each lane's chunk values across the two passes.
+    for (int local_row = 0; local_row < ROWS_PER_SG; local_row++) {
+      const int r = simd_gid * ROWS_PER_SG + local_row;
+
+      float local_x[BK_CHUNKS];
+      float local_max = -INFINITY;
+      for (int c = 0; c < BK_CHUNKS; c++) {
+        const int col = c * LANES_PER_CHUNK + (int)simd_lid;
+        const bool col_in_block = (col < BK);
+        const bool col_in_ctx = col_in_block && (col < valid_cols);
+        const float x_raw =
+            col_in_block ? S_smem[r * LD_S + col] : -INFINITY;
+        const float x = col_in_ctx ? x_raw : -INFINITY;
+        local_x[c] = x;
+        local_max = max(local_max, x);
+      }
+      const float block_max = simd_max(local_max);
+      const float old_max = row_max_smem[r];
+      const float new_max = max(old_max, block_max);
+      const float factor =
+          (old_max == -INFINITY) ? 0.0f : fast::exp(old_max - new_max);
+
+      float exp_x[BK_CHUNKS];
+      float local_sum = 0.0f;
+      for (int c = 0; c < BK_CHUNKS; c++) {
+        const int col = c * LANES_PER_CHUNK + (int)simd_lid;
+        const bool col_in_ctx = (col < BK) && (col < valid_cols);
+        exp_x[c] = col_in_ctx ? fast::exp(local_x[c] - new_max) : 0.0f;
+        local_sum += exp_x[c];
+      }
+      const float block_sum = simd_sum(local_sum);
+      const float new_sum = row_sum_smem[r] * factor + block_sum;
+
+      for (int c = 0; c < BK_CHUNKS; c++) {
+        const int col = c * LANES_PER_CHUNK + (int)simd_lid;
+        if (col < BK) {
+          S_smem[r * LD_S + col] = exp_x[c];
+        }
+      }
+      if (simd_lid == 0) {
+        factor_smem[r] = factor;
+        row_max_smem[r] = new_max;
+        row_sum_smem[r] = new_sum;
+      }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ----- Rescale V_accum by per-row factor -----
+    const float factor_for_lane = factor_smem[fm];
+    for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+      V_accum[vt].thread_elements()[0] *= factor_for_lane;
+      V_accum[vt].thread_elements()[1] *= factor_for_lane;
+    }
+
+    // ----- SV matmul: V_accum += softmaxed_S @ V (V streamed from device) -----
+    // Each simdgroup spans the full BK on the K-axis, so V is read
+    // K_TILES times. The K-tile starts cross block boundaries when
+    // BK > BLOCK_SIZE; one device pointer per K-tile, hoisted out of
+    // the V-tile inner loop.
+    //
+    // Loop order is (vt outer, kt inner) by experiment — swapping kt
+    // outermost regresses 20-35% at long ctx. The original order keeps
+    // the same 32 K-token rows resident across all V_TILES_PER_SG D
+    // tiles per vt (warm L1/L2 reuse), which outweighs the savings
+    // from hoisting the S_frag load out of the inner loop. Pre-loading
+    // S_frag into registers (vt-outer order preserved) is neutral —
+    // S_smem reads were already hidden behind V loads + MAC.
+    const device T *v_k_base[K_TILES];
+    for (int kt = 0; kt < K_TILES; kt++) {
+      v_k_base[kt] = k_base_for(k_global_start + kt * FRAG);
+    }
+    for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+      const int d_start = (simd_gid * V_TILES_PER_SG + vt) * FRAG;
+      for (int kt = 0; kt < K_TILES; kt++) {
+        const int k_inner = kt * FRAG;
+        simdgroup_matrix<float, FRAG, FRAG> S_frag;
+        simdgroup_matrix<T, FRAG, FRAG> V_frag;
+        simdgroup_load(S_frag, &S_smem[k_inner], LD_S);
+        // V_frag wants (K_tokens, D) — non-transposed. V == kv_norm
+        // is the first KV_LORA_RANK cols of latent_cache rows.
+        simdgroup_load(V_frag, v_k_base[kt] + d_start, LATENT_DIM);
+        simdgroup_multiply_accumulate(V_accum[vt], S_frag, V_frag, V_accum[vt]);
+      }
+    }
+
+    // Simdgroups in a TG advance independently. SV reads S_smem; the
+    // next iter's QK writes S_smem (via simdgroup_store of the new
+    // S_tile). Without this barrier, a fast simdgroup can clobber
+    // S_smem before a slow one finishes the SV multiply on the prior
+    // iter's S values — non-deterministic / wrong output at ctx > BK.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // ===== Final normalize and write =====
+  const int head = q_head_offset + fm;
+  if (head < num_heads_total) {
+    const float inv_sum =
+        (row_sum_smem[fm] > 0.0f) ? (1.0f / row_sum_smem[fm]) : 0.0f;
+    device T *out_row =
+        out + (uint64_t)(seq_idx * num_heads_total + head) * KV_LORA_RANK;
+    for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+      const int d_start = (simd_gid * V_TILES_PER_SG + vt) * FRAG;
+      out_row[d_start + fn] =
+          T(float(V_accum[vt].thread_elements()[0]) * inv_sum);
+      out_row[d_start + fn + 1] =
+          T(float(V_accum[vt].thread_elements()[1]) * inv_sum);
+    }
+  }
+}
+
+// ========================================== Partitioned FA decode kernel
+//
+// Split-K + reduce variant of the FA decode kernel for long-ctx
+// workloads. Same inner pipeline as
+// `paged_mla_attention_decode_fa`, but each TG processes a single
+// PARTITION_SIZE slice of the K axis and writes (max, sum, normalized
+// partial) to scratch buffers that the existing
+// `paged_mla_attention_reduce` kernel merges across partitions.
+//
+// Grid: (num_seqs, num_head_groups, num_partitions).
+//
+// Buffer layout (matches metal_mla_paged_attention_decode_2pass):
+//   0: exp_sums    [num_seqs, num_heads, num_partitions]                       fp32
+//   1: max_logits  [num_seqs, num_heads, num_partitions]                       fp32
+//   2: tmp_out     [num_seqs, num_heads, num_partitions, KV_LORA_RANK]         T
+//   3: q_nope      [total_q_tokens, num_heads, KV_LORA_RANK]                   T
+//   4: q_pe        [total_q_tokens, num_heads, QK_ROPE_HEAD_DIM]               T
+//   5: latent_cache [num_blocks, BLOCK_SIZE, KV_LORA_RANK+QK_ROPE_HEAD_DIM]    T
+//   6: block_tables [num_seqs, max_num_blocks_per_seq]                         uint32
+//   7: context_lens [num_seqs]                                                 uint32
+//   8: max_num_blocks_per_seq                                                  constant int
+//   9: num_heads_total                                                         constant int
+//  10: scale                                                                   constant float
+
+template <typename T, int KV_LORA_RANK, int QK_ROPE_HEAD_DIM, int BLOCK_SIZE,
+          int BQ, int BK, int WM, int WN, int PARTITION_SIZE>
+[[kernel, max_total_threads_per_threadgroup(WM * WN * 32)]] void
+paged_mla_attention_decode_fa_partitioned(
+    device float *exp_sums [[buffer(0)]],
+    device float *max_logits [[buffer(1)]],
+    device T *tmp_out [[buffer(2)]],
+    device const T *q_nope [[buffer(3)]],
+    device const T *q_pe [[buffer(4)]],
+    device const T *latent_cache [[buffer(5)]],
+    device const uint32_t *block_tables [[buffer(6)]],
+    device const uint32_t *context_lens [[buffer(7)]],
+    const constant int &max_num_blocks_per_seq [[buffer(8)]],
+    const constant int &num_heads_total [[buffer(9)]],
+    const constant float &scale [[buffer(10)]],
+    uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],
+    uint3 threadgroups_per_grid [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  static_assert(BQ == 8, "FA partitioned decode supports BQ=8.");
+  static_assert(BK % 8 == 0, "BK must be a multiple of the 8x8 frag size.");
+  static_assert(KV_LORA_RANK % 8 == 0,
+                "KV_LORA_RANK must divide the 8-wide D tile.");
+  static_assert(QK_ROPE_HEAD_DIM % 8 == 0,
+                "QK_ROPE_HEAD_DIM must divide the 8-wide D tile.");
+  static_assert(BK % WN == 0,
+                "WN simdgroups partition BK along N; BK must be divisible by WN.");
+  static_assert(KV_LORA_RANK % (WN * 8) == 0,
+                "WN simdgroups partition KV_LORA_RANK along D in V_accum.");
+  static_assert(WN <= BQ,
+                "Softmax assigns BQ rows to WN simdgroups (BQ / WN per group).");
+  static_assert(PARTITION_SIZE % BK == 0,
+                "PARTITION_SIZE must be a multiple of BK.");
+
+  constexpr int LATENT_DIM = KV_LORA_RANK + QK_ROPE_HEAD_DIM;
+  constexpr int FRAG = 8;
+  constexpr int THREADS_PER_TG = WM * WN * 32;
+  constexpr int PAD_T = 16 / sizeof(T);
+  constexpr int LD_Q = LATENT_DIM + PAD_T;
+  constexpr int LD_S = BK + FRAG;
+  constexpr int D_NOPE_TILES = KV_LORA_RANK / FRAG;
+  constexpr int D_PE_TILES = QK_ROPE_HEAD_DIM / FRAG;
+  constexpr int D_TILES = D_NOPE_TILES + D_PE_TILES;
+  constexpr int K_TILES = BK / FRAG;
+  constexpr int V_TILES_PER_SG = KV_LORA_RANK / FRAG / WN;
+  constexpr int ROWS_PER_SG = BQ / WN;
+  static_assert(ROWS_PER_SG >= 1, "Need at least 1 softmax row per simdgroup.");
+  // Softmax distributes one row's BK columns across the 32 lanes of a
+  // simdgroup; each lane handles BK_CHUNKS columns — see decode_fa.
+  constexpr int LANES_PER_CHUNK = 32;
+  constexpr int BK_CHUNKS = (BK + LANES_PER_CHUNK - 1) / LANES_PER_CHUNK;
+  static_assert(BK <= LANES_PER_CHUNK * 2,
+                "Softmax fast-path supports BK ≤ 64 (≤ 2 chunks per lane).");
+
+  threadgroup T Q_smem[BQ * LD_Q];
+  threadgroup float S_smem[BQ * LD_S];
+  threadgroup float row_max_smem[BQ];
+  threadgroup float row_sum_smem[BQ];
+  threadgroup float factor_smem[BQ];
+
+  const int tid = simd_gid * 32 + simd_lid;
+
+  const int seq_idx = (int)threadgroup_position_in_grid.x;
+  const int head_group_idx = (int)threadgroup_position_in_grid.y;
+  const int partition_idx = (int)threadgroup_position_in_grid.z;
+  const int num_partitions = (int)threadgroups_per_grid.z;
+  const int q_head_offset = head_group_idx * BQ;
+  if (q_head_offset >= num_heads_total) {
+    return;
+  }
+
+  const int ctx_len = (int)context_lens[seq_idx];
+  const int p_start = partition_idx * PARTITION_SIZE;
+  const int p_end = min(p_start + PARTITION_SIZE, ctx_len);
+
+  // Empty partition: emit -INF/0 sentinels so the reduce kernel sees a
+  // zero-contribution partial. Caller is expected to zero-init tmp_out
+  // (Python entry does), so we only need to write the bookkeeping.
+  if (p_start >= ctx_len) {
+    if (simd_gid == 0 && simd_lid < BQ) {
+      const int head = q_head_offset + simd_lid;
+      if (head < num_heads_total) {
+        const uint64_t bookkeep =
+            (uint64_t)(seq_idx * num_heads_total + head) * num_partitions +
+            (uint64_t)partition_idx;
+        max_logits[bookkeep] = -INFINITY;
+        exp_sums[bookkeep] = 0.0f;
+      }
+    }
+    return;
+  }
+
+  // ===== Load Q into shmem (pre-scaled) =====
+  const device T *q_nope_base =
+      q_nope +
+      (uint64_t)(seq_idx * num_heads_total + q_head_offset) * KV_LORA_RANK;
+  const device T *q_pe_base =
+      q_pe +
+      (uint64_t)(seq_idx * num_heads_total + q_head_offset) * QK_ROPE_HEAD_DIM;
+  for (int idx = tid; idx < BQ * LATENT_DIM; idx += THREADS_PER_TG) {
+    const int row = idx / LATENT_DIM;
+    const int col = idx % LATENT_DIM;
+    const int head = q_head_offset + row;
+    float v;
+    if (head < num_heads_total) {
+      if (col < KV_LORA_RANK) {
+        v = float(q_nope_base[row * KV_LORA_RANK + col]) * scale;
+      } else {
+        v = float(q_pe_base[row * QK_ROPE_HEAD_DIM + (col - KV_LORA_RANK)]) *
+            scale;
+      }
+    } else {
+      v = 0.0f;
+    }
+    Q_smem[row * LD_Q + col] = T(v);
+  }
+
+  if (tid < BQ) {
+    row_max_smem[tid] = -INFINITY;
+    row_sum_smem[tid] = 0.0f;
+  }
+
+  simdgroup_matrix<float, FRAG, FRAG> V_accum[V_TILES_PER_SG];
+  for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+    V_accum[vt] = simdgroup_matrix<float, FRAG, FRAG>(0.0f);
+  }
+
+  const device uint32_t *block_table_row =
+      block_tables + (uint64_t)seq_idx * max_num_blocks_per_seq;
+  const int num_k_blocks = (p_end - p_start + BK - 1) / BK;
+  // Same rationale as non-partitioned FA: clamp pbi against *this* seq's
+  // valid blocks (not max_num_blocks_per_seq) to avoid OOB loads on
+  // padded block_tables entries in mixed-length batches.
+  const int num_valid_blocks = (ctx_len + BLOCK_SIZE - 1) / BLOCK_SIZE;
+
+  const short qid = simd_lid / 4;
+  const short fm = (qid & 4) + ((simd_lid / 2) % 4);
+  const short fn = (qid & 2) * 2 + (simd_lid % 2) * 2;
+
+  auto k_base_for = [&](int abs_k) -> const device T * {
+    const int pbi_raw = abs_k / BLOCK_SIZE;
+    const int pbi = pbi_raw < num_valid_blocks ? pbi_raw : num_valid_blocks - 1;
+    const int offset = abs_k % BLOCK_SIZE;
+    const uint32_t pb = block_table_row[pbi];
+    return latent_cache + (uint64_t)pb * BLOCK_SIZE * LATENT_DIM +
+           (uint64_t)offset * LATENT_DIM;
+  };
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  for (int kb = 0; kb < num_k_blocks; kb++) {
+    const int k_global_start = p_start + kb * BK;
+    const int k_global_end = min(k_global_start + BK, p_end);
+    const int valid_cols = k_global_end - k_global_start;
+
+    simdgroup_matrix<float, FRAG, FRAG> S_tile(0.0f);
+    const int qk_local_k_start = simd_gid * FRAG;
+    const int qk_abs_k_start = k_global_start + qk_local_k_start;
+    const device T *qk_k_base = k_base_for(qk_abs_k_start);
+    for (int d_tile = 0; d_tile < D_TILES; d_tile++) {
+      const int d_start = d_tile * FRAG;
+      simdgroup_matrix<T, FRAG, FRAG> Q_frag;
+      simdgroup_matrix<T, FRAG, FRAG> K_frag;
+      simdgroup_load(Q_frag, &Q_smem[d_start], LD_Q);
+      simdgroup_load(K_frag, qk_k_base + d_start, LATENT_DIM, ulong2(0, 0),
+                     /*transpose=*/true);
+      simdgroup_multiply_accumulate(S_tile, Q_frag, K_frag, S_tile);
+    }
+
+    simdgroup_store(S_tile, &S_smem[qk_local_k_start], LD_S);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // BK_CHUNKS-strided softmax — see decode_fa for the rationale.
+    for (int local_row = 0; local_row < ROWS_PER_SG; local_row++) {
+      const int r = simd_gid * ROWS_PER_SG + local_row;
+
+      float local_x[BK_CHUNKS];
+      float local_max = -INFINITY;
+      for (int c = 0; c < BK_CHUNKS; c++) {
+        const int col = c * LANES_PER_CHUNK + (int)simd_lid;
+        const bool col_in_block = (col < BK);
+        const bool col_in_ctx = col_in_block && (col < valid_cols);
+        const float x_raw =
+            col_in_block ? S_smem[r * LD_S + col] : -INFINITY;
+        const float x = col_in_ctx ? x_raw : -INFINITY;
+        local_x[c] = x;
+        local_max = max(local_max, x);
+      }
+      const float block_max = simd_max(local_max);
+      const float old_max = row_max_smem[r];
+      const float new_max = max(old_max, block_max);
+      const float factor =
+          (old_max == -INFINITY) ? 0.0f : fast::exp(old_max - new_max);
+
+      float exp_x[BK_CHUNKS];
+      float local_sum = 0.0f;
+      for (int c = 0; c < BK_CHUNKS; c++) {
+        const int col = c * LANES_PER_CHUNK + (int)simd_lid;
+        const bool col_in_ctx = (col < BK) && (col < valid_cols);
+        exp_x[c] = col_in_ctx ? fast::exp(local_x[c] - new_max) : 0.0f;
+        local_sum += exp_x[c];
+      }
+      const float block_sum = simd_sum(local_sum);
+      const float new_sum = row_sum_smem[r] * factor + block_sum;
+
+      for (int c = 0; c < BK_CHUNKS; c++) {
+        const int col = c * LANES_PER_CHUNK + (int)simd_lid;
+        if (col < BK) {
+          S_smem[r * LD_S + col] = exp_x[c];
+        }
+      }
+      if (simd_lid == 0) {
+        factor_smem[r] = factor;
+        row_max_smem[r] = new_max;
+        row_sum_smem[r] = new_sum;
+      }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const float factor_for_lane = factor_smem[fm];
+    for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+      V_accum[vt].thread_elements()[0] *= factor_for_lane;
+      V_accum[vt].thread_elements()[1] *= factor_for_lane;
+    }
+
+    const device T *v_k_base[K_TILES];
+    for (int kt = 0; kt < K_TILES; kt++) {
+      v_k_base[kt] = k_base_for(k_global_start + kt * FRAG);
+    }
+    for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+      const int d_start = (simd_gid * V_TILES_PER_SG + vt) * FRAG;
+      for (int kt = 0; kt < K_TILES; kt++) {
+        const int k_inner = kt * FRAG;
+        simdgroup_matrix<float, FRAG, FRAG> S_frag;
+        simdgroup_matrix<T, FRAG, FRAG> V_frag;
+        simdgroup_load(S_frag, &S_smem[k_inner], LD_S);
+        simdgroup_load(V_frag, v_k_base[kt] + d_start, LATENT_DIM);
+        simdgroup_multiply_accumulate(V_accum[vt], S_frag, V_frag, V_accum[vt]);
+      }
+    }
+
+    // See decode_fa: SV reads S_smem; next iter's QK writes S_smem.
+    // Barrier prevents a fast simdgroup from clobbering S_smem mid-SV.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // ===== Write per-partition (max, sum, normalized_partial) =====
+  // Lane assignment: each lane owns 2 elements at (fm, fn), (fm, fn+1)
+  // in each V_accum tile. inv_sum is per-row (per head) — read from
+  // row_sum_smem[fm].
+  const int head = q_head_offset + fm;
+  if (head < num_heads_total) {
+    const float inv_sum =
+        (row_sum_smem[fm] > 0.0f) ? (1.0f / row_sum_smem[fm]) : 0.0f;
+    const uint64_t tmp_base =
+        (uint64_t)(seq_idx * num_heads_total + head) * num_partitions *
+            KV_LORA_RANK +
+        (uint64_t)partition_idx * KV_LORA_RANK;
+    for (int vt = 0; vt < V_TILES_PER_SG; vt++) {
+      const int d_start = (simd_gid * V_TILES_PER_SG + vt) * FRAG;
+      tmp_out[tmp_base + d_start + fn] =
+          T(float(V_accum[vt].thread_elements()[0]) * inv_sum);
+      tmp_out[tmp_base + d_start + fn + 1] =
+          T(float(V_accum[vt].thread_elements()[1]) * inv_sum);
+    }
+  }
+
+  // One lane per head writes (max, sum) bookkeeping.
+  if (simd_gid == 0 && simd_lid < BQ) {
+    const int hd = q_head_offset + simd_lid;
+    if (hd < num_heads_total) {
+      const uint64_t bookkeep =
+          (uint64_t)(seq_idx * num_heads_total + hd) * num_partitions +
+          (uint64_t)partition_idx;
+      max_logits[bookkeep] = row_max_smem[simd_lid];
+      exp_sums[bookkeep] = row_sum_smem[simd_lid];
+    }
+  }
+}
+
+
 // ========================================== Instantiations
 //
 // Single-pass main kernel: dtype × block_size × heads_per_tg × partition_size.
@@ -875,3 +1508,106 @@ instantiate_mla_reduce(half, 512, 256);
 instantiate_mla_reduce(bfloat16_t, 512, 64);
 instantiate_mla_reduce(bfloat16_t, 512, 128);
 instantiate_mla_reduce(bfloat16_t, 512, 256);
+
+// Paged FA decode kernel.
+// Tile anchor: BQ=8, BK=32, WM=1, WN=4 → 128 threads/TG. Single
+// instantiation per (dtype, block_size); additional tile variants are
+// instantiated below when routing needs them.
+#define instantiate_mla_fa(type, kv_lora_rank, qk_rope_head_dim, block_size,   \
+                           bq, bk, wm, wn)                                     \
+  template [[host_name("paged_mla_attention_decode_fa_" #type "_kvr"           \
+                       #kv_lora_rank "_pe" #qk_rope_head_dim "_bs"             \
+                       #block_size "_bq" #bq "_bk" #bk "_wm" #wm "_wn"         \
+                       #wn)]] [[kernel]] void                                  \
+  paged_mla_attention_decode_fa<type, kv_lora_rank, qk_rope_head_dim,          \
+                                block_size, bq, bk, wm, wn>(                   \
+      device type * out [[buffer(0)]],                                         \
+      device const type *q_nope [[buffer(1)]],                                 \
+      device const type *q_pe [[buffer(2)]],                                   \
+      device const type *latent_cache [[buffer(3)]],                           \
+      device const uint32_t *block_tables [[buffer(4)]],                       \
+      device const uint32_t *context_lens [[buffer(5)]],                       \
+      device const int32_t *cu_seqlens_q [[buffer(6)]],                        \
+      const constant int &max_num_blocks_per_seq [[buffer(7)]],                \
+      const constant int &num_heads_total [[buffer(8)]],                       \
+      const constant float &scale [[buffer(9)]],                               \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],     \
+      uint simd_gid [[simdgroup_index_in_threadgroup]],                        \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+// Tile anchor: BQ=8, BK=32, WM=1, WN=4 → 128 threads/TG. Stage 6.1
+// drops K_smem (would overflow Apple's 32 KB per-TG cap at BK=32) and
+// streams K from device via simdgroup_load. WN=4 matches
+// BK / FRAG = 32/8 = 4
+// N-tiles so every simdgroup has QK work, and halves V_TILES_PER_SG
+// from 32 → 16, easing register pressure on V_accum.
+instantiate_mla_fa(half, 512, 64, 16, 8, 32, 1, 4);
+// FA's simdgroup_matrix<T> / simdgroup_multiply_accumulate intrinsics need
+// native bfloat support — on targets where __HAVE_BFLOAT__ is undefined,
+// MLX falls back to a struct _MLX_BFloat16 that the MMA path can't accept,
+// and instantiating these kernels would fail the whole paged_mla_kern
+// library compile (taking the fp16 paths down with them).
+#if defined(__HAVE_BFLOAT__)
+instantiate_mla_fa(bfloat16_t, 512, 64, 16, 8, 32, 1, 4);
+#endif
+
+// Wide variant: BQ=8, BK=64, WM=1, WN=8 → 256 threads/TG. Halves
+// the outer block count again vs BK=32 (doubles the per-iter K
+// streamed) and doubles the per-TG simdgroup count. V_TILES_PER_SG
+// drops to 8 (was 16), trading register pressure for more concurrent
+// V streams. ROWS_PER_SG = 1 (was 2) — each simdgroup softmaxes one
+// row, with BK_CHUNKS=2 lanes processing the 64 columns.
+instantiate_mla_fa(half, 512, 64, 16, 8, 64, 1, 8);
+#if defined(__HAVE_BFLOAT__)
+instantiate_mla_fa(bfloat16_t, 512, 64, 16, 8, 64, 1, 8);
+#endif
+
+// Partitioned FA — split-K + reduce variant for long-ctx workloads.
+#define instantiate_mla_fa_part(type, kv_lora_rank, qk_rope_head_dim,           \
+                                block_size, bq, bk, wm, wn, ps)                 \
+  template [[host_name("paged_mla_attention_decode_fa_partitioned_" #type       \
+                       "_kvr" #kv_lora_rank "_pe" #qk_rope_head_dim "_bs"       \
+                       #block_size "_bq" #bq "_bk" #bk "_wm" #wm "_wn" #wn      \
+                       "_ps" #ps)]] [[kernel]] void                             \
+  paged_mla_attention_decode_fa_partitioned<type, kv_lora_rank,                 \
+                                            qk_rope_head_dim, block_size, bq,   \
+                                            bk, wm, wn, ps>(                    \
+      device float *exp_sums [[buffer(0)]],                                     \
+      device float *max_logits [[buffer(1)]],                                   \
+      device type *tmp_out [[buffer(2)]],                                       \
+      device const type *q_nope [[buffer(3)]],                                  \
+      device const type *q_pe [[buffer(4)]],                                    \
+      device const type *latent_cache [[buffer(5)]],                            \
+      device const uint32_t *block_tables [[buffer(6)]],                        \
+      device const uint32_t *context_lens [[buffer(7)]],                        \
+      const constant int &max_num_blocks_per_seq [[buffer(8)]],                 \
+      const constant int &num_heads_total [[buffer(9)]],                        \
+      const constant float &scale [[buffer(10)]],                               \
+      uint3 threadgroup_position_in_grid [[threadgroup_position_in_grid]],      \
+      uint3 threadgroups_per_grid [[threadgroups_per_grid]],                    \
+      uint simd_gid [[simdgroup_index_in_threadgroup]],                         \
+      uint simd_lid [[thread_index_in_simdgroup]]);
+
+// Partition sizes mirror metal_mla_paged_attention_decode_2pass:
+// ps=64 for ctx≤1024, ps=128 for ctx>1024; ps=512 kept for long ctx.
+instantiate_mla_fa_part(half, 512, 64, 16, 8, 32, 1, 4, 64);
+instantiate_mla_fa_part(half, 512, 64, 16, 8, 32, 1, 4, 128);
+instantiate_mla_fa_part(half, 512, 64, 16, 8, 32, 1, 4, 512);
+// Bfloat FA partitioned — same native-bfloat requirement as the
+// non-partitioned FA kernel above.
+#if defined(__HAVE_BFLOAT__)
+instantiate_mla_fa_part(bfloat16_t, 512, 64, 16, 8, 32, 1, 4, 64);
+instantiate_mla_fa_part(bfloat16_t, 512, 64, 16, 8, 32, 1, 4, 128);
+instantiate_mla_fa_part(bfloat16_t, 512, 64, 16, 8, 32, 1, 4, 512);
+#endif
+
+// Wide variant: BK=64, WN=8 — see decode_fa wide variant comment.
+// Partition sizes restricted to those divisible by BK=64.
+instantiate_mla_fa_part(half, 512, 64, 16, 8, 64, 1, 8, 64);
+instantiate_mla_fa_part(half, 512, 64, 16, 8, 64, 1, 8, 128);
+instantiate_mla_fa_part(half, 512, 64, 16, 8, 64, 1, 8, 512);
+#if defined(__HAVE_BFLOAT__)
+instantiate_mla_fa_part(bfloat16_t, 512, 64, 16, 8, 64, 1, 8, 64);
+instantiate_mla_fa_part(bfloat16_t, 512, 64, 16, 8, 64, 1, 8, 128);
+instantiate_mla_fa_part(bfloat16_t, 512, 64, 16, 8, 64, 1, 8, 512);
+#endif

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1574,6 +1574,209 @@ void mla_paged_attention_partitioned_impl(
       default_stream(Device::gpu));
 }
 
+
+// Decode 2pass dispatch — MLX sdpa_vector_2pass-style cross-head amortization.
+//
+// Threadgroup layout: (32, num_heads, 1). One simdgroup per query head; ALL
+// heads share each K-cache token read so total KV bandwidth is amortized
+// `num_heads`× across the TG. Splits the ctx dim across `num_partitions`
+// TGs per (seq), then reduces partials with the existing reduce kernel.
+//
+// Caller pre-allocates exp_sums [num_seqs, num_heads, max_num_partitions]
+// fp32, max_logits same shape, tmp_out [num_seqs, num_heads,
+// max_num_partitions, kv_lora_rank] T (zero-initialized).
+//
+// partition_size must be one of the instantiated values (64, 128, 256, 512).
+static void dispatch_mla_paged_attention_decode_2pass(
+    array& out,
+    array& exp_sums,
+    array& max_logits,
+    array& tmp_out,
+    const array& q_nope,
+    const array& q_pe,
+    const array& latent_cache,
+    const array& block_tables,
+    const array& context_lens,
+    int block_size,
+    float scale,
+    int partition_size,
+    int max_num_partitions,
+    Stream s,
+    bool from_primitive = false) {
+  auto& d = metal::device(s.device);
+
+  int total_q_tokens = static_cast<int>(q_nope.shape(0));
+  int num_heads = static_cast<int>(q_nope.shape(1));
+  int kv_lora_rank = static_cast<int>(q_nope.shape(2));
+  int qk_rope_head_dim = static_cast<int>(q_pe.shape(2));
+  int max_num_blocks_per_seq = static_cast<int>(block_tables.shape(1));
+
+  if (kv_lora_rank != 512) {
+    throw std::runtime_error(
+        "MLA 2pass kernel: only kv_lora_rank=512 is instantiated; got " +
+        std::to_string(kv_lora_rank));
+  }
+  if (qk_rope_head_dim != 64) {
+    throw std::runtime_error(
+        "MLA 2pass kernel: only qk_rope_head_dim=64 is instantiated; got " +
+        std::to_string(qk_rope_head_dim));
+  }
+  if (block_size != 16 && block_size != 32) {
+    throw std::runtime_error(
+        "MLA 2pass kernel: only block_size in {16, 32} is instantiated; got " +
+        std::to_string(block_size));
+  }
+  if (partition_size != 64 && partition_size != 128 &&
+      partition_size != 256 && partition_size != 512) {
+    throw std::runtime_error(
+        "MLA 2pass kernel: only partition_size in {64, 128, 256, 512} is "
+        "instantiated; got " +
+        std::to_string(partition_size));
+  }
+  if (partition_size % block_size != 0) {
+    throw std::runtime_error(
+        "MLA 2pass kernel: partition_size (" +
+        std::to_string(partition_size) + ") must be divisible by block_size (" +
+        std::to_string(block_size) + ").");
+  }
+  mla_validate_t_dtypes("MLA 2pass kernel", {
+      {"q_nope", &q_nope},
+      {"q_pe", &q_pe},
+      {"latent_cache", &latent_cache},
+      {"out", &out},
+      {"tmp_out", &tmp_out},
+  });
+
+  // HEADS_PER_TG=8 is the portable default. The 2pass main kernel's
+  // per-thread register footprint (q_nope_local[16] + q_pe_local[2] +
+  // v_local[16 fp32] + transient k_norm_local) can push the PSO's
+  // maxTotalThreadsPerThreadgroup below 1024 on Apple Silicon variants
+  // with smaller per-core register files than M5 Max (observed on the
+  // macos-15 GitHub Actions runners). When that happens, dispatching
+  // (32 lanes × 32 heads = 1024 threads/TG) silently fails and tmp_out
+  // stays at its zero-init value — surfacing as ~max-magnitude diffs
+  // against the dense reference. HPT=8 (32 × 8 = 256 threads/TG) is
+  // well within the PSO cap on every Apple chip we have evidence for.
+  //
+  // Follow-up: a runtime PSO::maxTotalThreadsPerThreadgroup query can
+  // re-enable HPT=32 on hardware that supports it (M5 Max recovers the
+  // cross-head K amortization win). Keeping the picker fixed for now
+  // to minimize the change surface for the CI green-up.
+  int heads_per_tg = 8;
+  int num_head_groups = (num_heads + heads_per_tg - 1) / heads_per_tg;
+
+  auto dt = dtype_to_metal(q_nope.dtype());
+  std::string kname = "paged_mla_attention_decode_2pass_1_" + dt + "_kvr" +
+                      std::to_string(kv_lora_rank) + "_pe" +
+                      std::to_string(qk_rope_head_dim) + "_bs" +
+                      std::to_string(block_size) + "_ps" +
+                      std::to_string(partition_size) + "_hpt" +
+                      std::to_string(heads_per_tg);
+
+  auto* lib = d.get_library("paged_mla_kern");
+  auto* kernel = d.get_kernel(kname, lib, kname, {});
+
+  auto& enc = get_command_encoder_compat(d, s);
+  enc.set_compute_pipeline_state(kernel);
+
+  enc.set_output_array(exp_sums, 0);
+  enc.set_output_array(max_logits, 1);
+  enc.set_output_array(tmp_out, 2);
+  enc.set_input_array(q_nope, 3);
+  enc.set_input_array(q_pe, 4);
+  enc.set_input_array(latent_cache, 5);
+  enc.set_input_array(block_tables, 6);
+  enc.set_input_array(context_lens, 7);
+
+  int32_t max_blocks_i = static_cast<int32_t>(max_num_blocks_per_seq);
+  int32_t num_heads_i = static_cast<int32_t>(num_heads);
+  enc.set_bytes(max_blocks_i, 8);
+  enc.set_bytes(num_heads_i, 9);
+  enc.set_bytes(scale, 10);
+
+  // Grid: (num_seqs, num_partitions, num_head_groups).
+  // TG:   (32, heads_per_tg, 1) — capped at 1024 threads/TG. For
+  // num_heads > 32 the head dim spans grid.z; cross-head-group
+  // amortization happens via L2 cache hits (different head-groups for the
+  // same (seq, partition) read identical K addresses).
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(total_q_tokens, max_num_partitions, num_head_groups),
+      MTL::Size::Make(32, heads_per_tg, 1));
+
+  // Reduce kernel — same as partitioned dispatch.
+  constexpr int REDUCE_NUM_THREADS = 256;
+  constexpr int REDUCE_NUM_WARPS = REDUCE_NUM_THREADS / 32;
+  std::string reduce_kname = "paged_mla_attention_reduce_" + dt + "_hs" +
+                             std::to_string(kv_lora_rank) + "_nt256_nsl32_ps" +
+                             std::to_string(partition_size);
+  auto* reduce_kernel = d.get_kernel(reduce_kname, lib, reduce_kname, {});
+
+  size_t reduce_shmem = static_cast<size_t>(
+      (2 * max_num_partitions + 2 * REDUCE_NUM_WARPS) * sizeof(float));
+
+  enc.set_compute_pipeline_state(reduce_kernel);
+  enc.set_threadgroup_memory_length(reduce_shmem, 0);
+
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(context_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, 1),
+      MTL::Size::Make(REDUCE_NUM_THREADS, 1, 1));
+
+  // Scratch (exp_sums / max_logits / tmp_out) is always tracked: in
+  // primitive mode it's stack-local to eval_gpu (encoder must keep
+  // buffers alive past frame exit); in eager mode it's Python-owned
+  // but still needs encoder lifetime extension.
+  add_temporary_compat(enc, exp_sums, d, s);
+  add_temporary_compat(enc, max_logits, d, s);
+  add_temporary_compat(enc, tmp_out, d, s);
+  if (!from_primitive) {
+    add_temporary_compat(enc, out, d, s);
+    add_temporary_compat(enc, q_nope, d, s);
+    add_temporary_compat(enc, q_pe, d, s);
+    add_temporary_compat(enc, latent_cache, d, s);
+    add_temporary_compat(enc, block_tables, d, s);
+    add_temporary_compat(enc, context_lens, d, s);
+  }
+}
+
+void mla_paged_attention_decode_2pass_impl(
+    nb::handle out_h,
+    nb::handle exp_sums_h,
+    nb::handle max_logits_h,
+    nb::handle tmp_out_h,
+    nb::handle q_nope_h,
+    nb::handle q_pe_h,
+    nb::handle latent_cache_h,
+    nb::handle block_tables_h,
+    nb::handle context_lens_h,
+    int block_size,
+    float scale,
+    int partition_size,
+    int max_num_partitions) {
+  auto& out = *nb::inst_ptr<array>(out_h);
+  auto& exp_sums = *nb::inst_ptr<array>(exp_sums_h);
+  auto& max_logits = *nb::inst_ptr<array>(max_logits_h);
+  auto& tmp_out = *nb::inst_ptr<array>(tmp_out_h);
+  auto& q_nope = *nb::inst_ptr<array>(q_nope_h);
+  auto& q_pe = *nb::inst_ptr<array>(q_pe_h);
+  auto& latent_cache = *nb::inst_ptr<array>(latent_cache_h);
+  auto& block_tables = *nb::inst_ptr<array>(block_tables_h);
+  auto& context_lens = *nb::inst_ptr<array>(context_lens_h);
+
+  dispatch_mla_paged_attention_decode_2pass(
+      out, exp_sums, max_logits, tmp_out, q_nope, q_pe, latent_cache,
+      block_tables, context_lens, block_size, scale, partition_size,
+      max_num_partitions, default_stream(Device::gpu));
+}
+
+
 void gdn_linear_attention_impl(
     nb::handle q_h, nb::handle k_h, nb::handle v_h,
     nb::handle g_h, nb::handle beta_h,
@@ -1855,4 +2058,17 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("partition_size"), nb::arg("max_num_partitions"),
         nb::arg("heads_per_tg") = 1,
         "Paged MLA attention with split-K + reduce (RFC #360 Phase 3).");
+
+  m.def("mla_paged_attention_decode_2pass",
+        &mla_paged_attention_decode_2pass_impl,
+        nb::arg("out"),
+        nb::arg("exp_sums"), nb::arg("max_logits"), nb::arg("tmp_out"),
+        nb::arg("q_nope"), nb::arg("q_pe"),
+        nb::arg("latent_cache"),
+        nb::arg("block_tables"), nb::arg("context_lens"),
+        nb::arg("block_size"), nb::arg("scale"),
+        nb::arg("partition_size"), nb::arg("max_num_partitions"),
+        "MLX sdpa_vector_2pass-style cross-head amortization for absorbed "
+        "MLA decode. One TG per (seq, partition) with 32*num_heads threads, "
+        "all heads sharing K cache reads.");
 }

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1341,6 +1341,239 @@ void mla_paged_attention_impl(
       heads_per_tg,
       default_stream(Device::gpu));
 }
+
+// Partitioned MLA dispatch: split-K main kernel + reduce.
+//
+// Caller pre-allocates exp_sums [num_seqs, num_heads, max_num_partitions]
+// fp32, max_logits same shape, tmp_out [num_seqs, num_heads,
+// max_num_partitions, kv_lora_rank] T (zero-initialized — partitions with no
+// work return early without writing).
+//
+// partition_size must be one of the instantiated values (currently 512).
+static void dispatch_mla_paged_attention_partitioned(
+    array& out,
+    array& exp_sums,
+    array& max_logits,
+    array& tmp_out,
+    const array& q_nope,
+    const array& q_pe,
+    const array& latent_cache,
+    const array& block_tables,
+    const array& context_lens,
+    const array& cu_seqlens_q,
+    int block_size,
+    float scale,
+    int partition_size,
+    int max_num_partitions,
+    int heads_per_tg,
+    Stream s) {
+  auto& d = metal::device(s.device);
+
+  int total_q_tokens = static_cast<int>(q_nope.shape(0));
+  int num_heads = static_cast<int>(q_nope.shape(1));
+  int kv_lora_rank = static_cast<int>(q_nope.shape(2));
+  int qk_rope_head_dim = static_cast<int>(q_pe.shape(2));
+  int max_num_blocks_per_seq = static_cast<int>(block_tables.shape(1));
+  int num_seqs = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
+
+  // Shape sanity — match the instantiated specializations.
+  if (kv_lora_rank != 512) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: only kv_lora_rank=512 is instantiated; got " +
+        std::to_string(kv_lora_rank));
+  }
+  if (qk_rope_head_dim != 64) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: only qk_rope_head_dim=64 is instantiated; got " +
+        std::to_string(qk_rope_head_dim));
+  }
+  if (block_size != 16 && block_size != 32) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: only block_size in {16, 32} is instantiated; got " +
+        std::to_string(block_size));
+  }
+  if (partition_size != 512) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: only partition_size=512 is instantiated; got " +
+        std::to_string(partition_size));
+  }
+  if (partition_size % block_size != 0) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: partition_size (" +
+        std::to_string(partition_size) + ") must be divisible by block_size (" +
+        std::to_string(block_size) + ").");
+  }
+  int num_threads = mla_num_threads_for_g(heads_per_tg);
+  if (num_threads == 0) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: heads_per_tg must be in {1, 4}; got " +
+        std::to_string(heads_per_tg));
+  }
+  if (num_heads % heads_per_tg != 0) {
+    throw std::runtime_error(
+        "MLA partitioned kernel: num_heads (" + std::to_string(num_heads) +
+        ") must be divisible by heads_per_tg (" +
+        std::to_string(heads_per_tg) + ")");
+  }
+  mla_validate_t_dtypes("MLA partitioned kernel", {
+      {"q_nope", &q_nope},
+      {"q_pe", &q_pe},
+      {"latent_cache", &latent_cache},
+      {"out", &out},
+      {"tmp_out", &tmp_out},
+  });
+
+  auto dt = dtype_to_metal(q_nope.dtype());
+  std::string kname = "paged_mla_attention_" + dt + "_kvr" +
+                      std::to_string(kv_lora_rank) + "_pe" +
+                      std::to_string(qk_rope_head_dim) + "_bs" +
+                      std::to_string(block_size) + "_g" +
+                      std::to_string(heads_per_tg) + "_nt" +
+                      std::to_string(num_threads) + "_nsl32_ps" +
+                      std::to_string(partition_size);
+
+  bool use_partitioning = true;
+  bool use_alibi = false;
+  bool use_fp8_scales = false;
+  bool use_sinks = false;
+  bool use_turboquant = false;
+
+  std::string hash_name = kname + "_part" + (use_partitioning ? "1" : "0") +
+                          "_alibi0_fp80_sinks0_tq0";
+
+  auto* lib = d.get_library("paged_mla_kern");
+  auto* kernel = d.get_kernel(
+      kname,
+      lib,
+      hash_name,
+      {{&use_partitioning, MTL::DataType::DataTypeBool, NS::UInteger(10)},
+       {&use_alibi, MTL::DataType::DataTypeBool, NS::UInteger(20)},
+       {&use_fp8_scales, MTL::DataType::DataTypeBool, NS::UInteger(30)},
+       {&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_turboquant, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
+
+  // Threadgroup memory: same layout as the non-partitioned path. See the
+  // comment in dispatch_mla_paged_attention.
+  const int BD = 32;
+  const int BN = num_threads / BD;
+  size_t shmem =
+      static_cast<size_t>((2 * heads_per_tg * BN + BD * BD) * sizeof(float));
+
+  auto& enc = get_command_encoder_compat(d, s);
+  enc.set_compute_pipeline_state(kernel);
+  enc.set_threadgroup_memory_length(shmem, 0);
+
+  enc.set_output_array(exp_sums, 0);
+  enc.set_output_array(max_logits, 1);
+  enc.set_output_array(tmp_out, 2);
+  enc.set_input_array(q_nope, 3);
+  enc.set_input_array(q_pe, 4);
+  enc.set_input_array(latent_cache, 5);
+  enc.set_input_array(block_tables, 6);
+  enc.set_input_array(context_lens, 7);
+  enc.set_input_array(cu_seqlens_q, 8);
+
+  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
+  int32_t max_blocks_i = static_cast<int32_t>(max_num_blocks_per_seq);
+  enc.set_bytes(num_seqs_i, 9);
+  enc.set_bytes(max_blocks_i, 10);
+  enc.set_bytes(scale, 11);
+
+  // Grid: (num_heads / G, total_q_tokens, max_num_partitions). Empty
+  // partitions return early in the kernel body.
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads / heads_per_tg, total_q_tokens,
+                      max_num_partitions),
+      MTL::Size::Make(num_threads, 1, 1));
+
+  // Reduce kernel: merges per-partition (max, lse, partial out) into final out.
+  // Reduce work is small (one merge per (head, query) over max_num_partitions
+  // floats + max_num_partitions × HEAD_SIZE values), so 256 threads is enough.
+  // The reduce kernel template is instantiated at NUM_THREADS=256 — keep this
+  // constant in sync with `instantiate_mla_reduce` in mla.metal.
+  constexpr int REDUCE_NUM_THREADS = 256;
+  constexpr int REDUCE_NUM_WARPS = REDUCE_NUM_THREADS / 32;
+  std::string reduce_kname = "paged_mla_attention_reduce_" + dt + "_hs" +
+                             std::to_string(kv_lora_rank) + "_nt256_nsl32_ps" +
+                             std::to_string(partition_size);
+  auto* reduce_kernel = d.get_kernel(reduce_kname, lib, reduce_kname, {});
+
+  size_t reduce_shmem = static_cast<size_t>(
+      (2 * max_num_partitions + 2 * REDUCE_NUM_WARPS) * sizeof(float));
+
+  enc.set_compute_pipeline_state(reduce_kernel);
+  enc.set_threadgroup_memory_length(reduce_shmem, 0);
+
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(context_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, 1),
+      MTL::Size::Make(REDUCE_NUM_THREADS, 1, 1));
+
+  add_temporary_compat(enc, out, d, s);
+  add_temporary_compat(enc, exp_sums, d, s);
+  add_temporary_compat(enc, max_logits, d, s);
+  add_temporary_compat(enc, tmp_out, d, s);
+  add_temporary_compat(enc, q_nope, d, s);
+  add_temporary_compat(enc, q_pe, d, s);
+  add_temporary_compat(enc, latent_cache, d, s);
+  add_temporary_compat(enc, block_tables, d, s);
+  add_temporary_compat(enc, context_lens, d, s);
+  add_temporary_compat(enc, cu_seqlens_q, d, s);
+}
+
+void mla_paged_attention_partitioned_impl(
+    nb::handle out_h,
+    nb::handle exp_sums_h,
+    nb::handle max_logits_h,
+    nb::handle tmp_out_h,
+    nb::handle q_nope_h,
+    nb::handle q_pe_h,
+    nb::handle latent_cache_h,
+    nb::handle block_tables_h,
+    nb::handle context_lens_h,
+    nb::handle cu_seqlens_q_h,
+    int block_size,
+    float scale,
+    int partition_size,
+    int max_num_partitions,
+    int heads_per_tg) {
+  auto& out = *nb::inst_ptr<array>(out_h);
+  auto& exp_sums = *nb::inst_ptr<array>(exp_sums_h);
+  auto& max_logits = *nb::inst_ptr<array>(max_logits_h);
+  auto& tmp_out = *nb::inst_ptr<array>(tmp_out_h);
+  auto& q_nope = *nb::inst_ptr<array>(q_nope_h);
+  auto& q_pe = *nb::inst_ptr<array>(q_pe_h);
+  auto& latent_cache = *nb::inst_ptr<array>(latent_cache_h);
+  auto& block_tables = *nb::inst_ptr<array>(block_tables_h);
+  auto& context_lens = *nb::inst_ptr<array>(context_lens_h);
+  auto& cu_seqlens_q = *nb::inst_ptr<array>(cu_seqlens_q_h);
+
+  dispatch_mla_paged_attention_partitioned(
+      out,
+      exp_sums,
+      max_logits,
+      tmp_out,
+      q_nope,
+      q_pe,
+      latent_cache,
+      block_tables,
+      context_lens,
+      cu_seqlens_q,
+      block_size,
+      scale,
+      partition_size,
+      max_num_partitions,
+      heads_per_tg,
+      default_stream(Device::gpu));
+}
+
 void gdn_linear_attention_impl(
     nb::handle q_h, nb::handle k_h, nb::handle v_h,
     nb::handle g_h, nb::handle beta_h,
@@ -1610,4 +1843,16 @@ NB_MODULE(_paged_ops, m) {
         "Paged MLA (single-pass), eager in-place dispatch. Kept for "
         "bench / tests; production wrapper uses the primitive variant.");
 
+  m.def("mla_paged_attention_partitioned",
+        &mla_paged_attention_partitioned_impl,
+        nb::arg("out"),
+        nb::arg("exp_sums"), nb::arg("max_logits"), nb::arg("tmp_out"),
+        nb::arg("q_nope"), nb::arg("q_pe"),
+        nb::arg("latent_cache"),
+        nb::arg("block_tables"), nb::arg("context_lens"),
+        nb::arg("cu_seqlens_q"),
+        nb::arg("block_size"), nb::arg("scale"),
+        nb::arg("partition_size"), nb::arg("max_num_partitions"),
+        nb::arg("heads_per_tg") = 1,
+        "Paged MLA attention with split-K + reduce (RFC #360 Phase 3).");
 }

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1075,6 +1075,32 @@ void init_mla_library(const std::string& src) {
   d.get_library("paged_mla_kern", [&]() { return mla_source_; });
 }
 
+// Runtime probe: are the bf16 FA kernel instantiations present in the
+// loaded paged_mla_kern library? On targets without native bfloat
+// (__HAVE_BFLOAT__ undefined), mla.metal gates the bfloat16_t FA
+// instantiations away because simdgroup_matrix<T> cannot accept MLX's
+// fallback _MLX_BFloat16 struct, so any bf16 FA call would otherwise
+// trip get_kernel deep inside dispatch. Cached after the first probe.
+// Caller is expected to have invoked init_mla_library beforehand.
+bool mla_has_bfloat_fa_kernel() {
+  static bool checked = false;
+  static bool available = false;
+  if (checked) return available;
+  auto& d = metal::device(Device::gpu);
+  auto* lib = d.get_library("paged_mla_kern");
+  try {
+    // Probe one bf16 FA kernel name (narrow tile variant).
+    d.get_kernel(
+        "paged_mla_attention_decode_fa_bfloat16_t_kvr512_pe64_bs16_bq8_bk32_wm1_wn4",
+        lib);
+    available = true;
+  } catch (...) {
+    available = false;
+  }
+  checked = true;
+  return available;
+}
+
 // Dispatch the MLA paged attention kernel.
 //
 // Buffer slot map (must match kernels_v2/mla.metal):
@@ -1776,6 +1802,336 @@ void mla_paged_attention_decode_2pass_impl(
       max_num_partitions, default_stream(Device::gpu));
 }
 
+// Paged FA decode kernel.
+// Tile anchor: BQ=8, BK=32, WM=1, WN=4 → 128 threads/TG. The body
+// reads/writes the same paged latent cache as the single-pass and
+// 2pass kernels; wide/narrow tile variants differ only in BK/WN.
+//
+// `use_wide` selects the alternate (BQ=8, BK=64, WM=1, WN=8 → 256
+// threads/TG) instantiation that halves V_TILES_PER_SG and doubles
+// per-iter K throughput.
+static void dispatch_mla_paged_attention_decode_fa(
+    array& out,
+    const array& q_nope,
+    const array& q_pe,
+    const array& latent_cache,
+    const array& block_tables,
+    const array& context_lens,
+    const array& cu_seqlens_q,
+    int block_size,
+    float scale,
+    bool use_wide,
+    Stream s,
+    bool from_primitive = false) {
+  auto& d = metal::device(s.device);
+
+  int total_q_tokens = static_cast<int>(q_nope.shape(0));
+  int num_heads = static_cast<int>(q_nope.shape(1));
+  int kv_lora_rank = static_cast<int>(q_nope.shape(2));
+  int qk_rope_head_dim = static_cast<int>(q_pe.shape(2));
+  int max_num_blocks_per_seq = static_cast<int>(block_tables.shape(1));
+
+  // Tile shape — see decode_fa wide variant comment in mla.metal.
+  // BK=32/WN=4 is the narrow anchor; BK=64/WN=8 is the wide variant.
+  const int BQ = 8;
+  const int BK = use_wide ? 64 : 32;
+  const int WM = 1;
+  const int WN = use_wide ? 8 : 4;
+  const int THREADS_PER_TG = WM * WN * 32;
+
+  if (kv_lora_rank != 512) {
+    throw std::runtime_error(
+        "MLA FA decode kernel: only kv_lora_rank=512 is instantiated; got " +
+        std::to_string(kv_lora_rank));
+  }
+  if (qk_rope_head_dim != 64) {
+    throw std::runtime_error(
+        "MLA FA decode kernel: only qk_rope_head_dim=64 is instantiated; got " +
+        std::to_string(qk_rope_head_dim));
+  }
+  if (block_size != 16) {
+    throw std::runtime_error(
+        "MLA FA decode kernel: only block_size=16 is instantiated; got " +
+        std::to_string(block_size));
+  }
+  if (num_heads % BQ != 0) {
+    throw std::runtime_error(
+        "MLA FA decode kernel: num_heads (" + std::to_string(num_heads) +
+        ") must be a multiple of BQ=" + std::to_string(BQ));
+  }
+  mla_validate_t_dtypes("MLA FA decode kernel", {
+      {"q_nope", &q_nope},
+      {"q_pe", &q_pe},
+      {"latent_cache", &latent_cache},
+      {"out", &out},
+  });
+
+  int num_head_groups = num_heads / BQ;
+
+  auto dt = dtype_to_metal(q_nope.dtype());
+  if (dt == "bfloat16_t" && !mla_has_bfloat_fa_kernel()) {
+    throw std::runtime_error(
+        "MLA FA decode kernel: bfloat16 is not supported on this Metal "
+        "device — bf16 FA instantiations are gated on native bfloat "
+        "(__HAVE_BFLOAT__) and the running device falls back to a "
+        "struct representation incompatible with simdgroup_matrix. Use "
+        "float16, or wait for the routing follow-up that picks an "
+        "alternate route for bf16.");
+  }
+  std::string kname = "paged_mla_attention_decode_fa_" + dt + "_kvr" +
+                      std::to_string(kv_lora_rank) + "_pe" +
+                      std::to_string(qk_rope_head_dim) + "_bs" +
+                      std::to_string(block_size) + "_bq" + std::to_string(BQ) +
+                      "_bk" + std::to_string(BK) + "_wm" + std::to_string(WM) +
+                      "_wn" + std::to_string(WN);
+
+  auto* lib = d.get_library("paged_mla_kern");
+  auto* kernel = d.get_kernel(kname, lib, kname, {});
+
+  auto& enc = get_command_encoder_compat(d, s);
+  enc.set_compute_pipeline_state(kernel);
+
+  enc.set_output_array(out, 0);
+  enc.set_input_array(q_nope, 1);
+  enc.set_input_array(q_pe, 2);
+  enc.set_input_array(latent_cache, 3);
+  enc.set_input_array(block_tables, 4);
+  enc.set_input_array(context_lens, 5);
+  enc.set_input_array(cu_seqlens_q, 6);
+
+  int32_t max_blocks_i = static_cast<int32_t>(max_num_blocks_per_seq);
+  int32_t num_heads_i = static_cast<int32_t>(num_heads);
+  enc.set_bytes(max_blocks_i, 7);
+  enc.set_bytes(num_heads_i, 8);
+  enc.set_bytes(scale, 9);
+
+  // Grid: (total_q_tokens, num_head_groups, 1). Threads/TG = WN * 32
+  // (WM=1 collapses the M-axis simdgroup dim).
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(total_q_tokens, num_head_groups, 1),
+      MTL::Size::Make(THREADS_PER_TG, 1, 1));
+
+  if (!from_primitive) {
+    add_temporary_compat(enc, out, d, s);
+    add_temporary_compat(enc, q_nope, d, s);
+    add_temporary_compat(enc, q_pe, d, s);
+    add_temporary_compat(enc, latent_cache, d, s);
+    add_temporary_compat(enc, block_tables, d, s);
+    add_temporary_compat(enc, context_lens, d, s);
+    add_temporary_compat(enc, cu_seqlens_q, d, s);
+  }
+}
+
+// Partitioned FA decode kernel.
+// Same per-partition pipeline as dispatch_mla_paged_attention_decode_fa
+// above, but each TG handles one PARTITION_SIZE slice of ctx and writes
+// (max, sum, normalized partial). The existing
+// paged_mla_attention_reduce kernel does the cross-partition merge —
+// same contract as decode_2pass.
+static void dispatch_mla_paged_attention_decode_fa_partitioned(
+    array& out,
+    array& exp_sums,
+    array& max_logits,
+    array& tmp_out,
+    const array& q_nope,
+    const array& q_pe,
+    const array& latent_cache,
+    const array& block_tables,
+    const array& context_lens,
+    int block_size,
+    float scale,
+    int partition_size,
+    int max_num_partitions,
+    bool use_wide,
+    Stream s,
+    bool from_primitive = false) {
+  auto& d = metal::device(s.device);
+
+  int total_q_tokens = static_cast<int>(q_nope.shape(0));
+  int num_heads = static_cast<int>(q_nope.shape(1));
+  int kv_lora_rank = static_cast<int>(q_nope.shape(2));
+  int qk_rope_head_dim = static_cast<int>(q_pe.shape(2));
+  int max_num_blocks_per_seq = static_cast<int>(block_tables.shape(1));
+
+  // See decode_fa wide variant comment in mla.metal.
+  const int BQ = 8;
+  const int BK = use_wide ? 64 : 32;
+  const int WM = 1;
+  const int WN = use_wide ? 8 : 4;
+  const int THREADS_PER_TG = WM * WN * 32;
+
+  if (kv_lora_rank != 512) {
+    throw std::runtime_error(
+        "MLA FA partitioned kernel: only kv_lora_rank=512 is instantiated; "
+        "got " +
+        std::to_string(kv_lora_rank));
+  }
+  if (qk_rope_head_dim != 64) {
+    throw std::runtime_error(
+        "MLA FA partitioned kernel: only qk_rope_head_dim=64 is instantiated; "
+        "got " +
+        std::to_string(qk_rope_head_dim));
+  }
+  if (block_size != 16) {
+    throw std::runtime_error(
+        "MLA FA partitioned kernel: only block_size=16 is instantiated; got " +
+        std::to_string(block_size));
+  }
+  if (partition_size != 64 && partition_size != 128 && partition_size != 512) {
+    throw std::runtime_error(
+        "MLA FA partitioned kernel: partition_size must be in {64, 128, 512}; "
+        "got " +
+        std::to_string(partition_size));
+  }
+  if (num_heads % BQ != 0) {
+    throw std::runtime_error(
+        "MLA FA partitioned kernel: num_heads (" + std::to_string(num_heads) +
+        ") must be a multiple of BQ=" + std::to_string(BQ));
+  }
+  mla_validate_t_dtypes("MLA FA partitioned kernel", {
+      {"q_nope", &q_nope},
+      {"q_pe", &q_pe},
+      {"latent_cache", &latent_cache},
+      {"out", &out},
+      {"tmp_out", &tmp_out},
+  });
+
+  int num_head_groups = num_heads / BQ;
+
+  auto dt = dtype_to_metal(q_nope.dtype());
+  if (dt == "bfloat16_t" && !mla_has_bfloat_fa_kernel()) {
+    throw std::runtime_error(
+        "MLA FA partitioned kernel: bfloat16 is not supported on this "
+        "Metal device — see dispatch_mla_paged_attention_decode_fa for "
+        "details. Use float16, or wait for the routing follow-up.");
+  }
+  std::string kname =
+      "paged_mla_attention_decode_fa_partitioned_" + dt + "_kvr" +
+      std::to_string(kv_lora_rank) + "_pe" + std::to_string(qk_rope_head_dim) +
+      "_bs" + std::to_string(block_size) + "_bq" + std::to_string(BQ) + "_bk" +
+      std::to_string(BK) + "_wm" + std::to_string(WM) + "_wn" +
+      std::to_string(WN) + "_ps" + std::to_string(partition_size);
+
+  auto* lib = d.get_library("paged_mla_kern");
+  auto* kernel = d.get_kernel(kname, lib, kname, {});
+
+  auto& enc = get_command_encoder_compat(d, s);
+  enc.set_compute_pipeline_state(kernel);
+
+  enc.set_output_array(exp_sums, 0);
+  enc.set_output_array(max_logits, 1);
+  enc.set_output_array(tmp_out, 2);
+  enc.set_input_array(q_nope, 3);
+  enc.set_input_array(q_pe, 4);
+  enc.set_input_array(latent_cache, 5);
+  enc.set_input_array(block_tables, 6);
+  enc.set_input_array(context_lens, 7);
+
+  int32_t max_blocks_i = static_cast<int32_t>(max_num_blocks_per_seq);
+  int32_t num_heads_i = static_cast<int32_t>(num_heads);
+  enc.set_bytes(max_blocks_i, 8);
+  enc.set_bytes(num_heads_i, 9);
+  enc.set_bytes(scale, 10);
+
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(total_q_tokens, num_head_groups, max_num_partitions),
+      MTL::Size::Make(THREADS_PER_TG, 1, 1));
+
+  // Reuse the same reduce kernel as 2pass — same partial contract.
+  constexpr int REDUCE_NUM_THREADS = 256;
+  constexpr int REDUCE_NUM_WARPS = REDUCE_NUM_THREADS / 32;
+  std::string reduce_kname = "paged_mla_attention_reduce_" + dt + "_hs" +
+                             std::to_string(kv_lora_rank) + "_nt256_nsl32_ps" +
+                             std::to_string(partition_size);
+  auto* reduce_kernel = d.get_kernel(reduce_kname, lib, reduce_kname, {});
+
+  size_t reduce_shmem = static_cast<size_t>(
+      (2 * max_num_partitions + 2 * REDUCE_NUM_WARPS) * sizeof(float));
+
+  enc.set_compute_pipeline_state(reduce_kernel);
+  enc.set_threadgroup_memory_length(reduce_shmem, 0);
+
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(context_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, 1),
+      MTL::Size::Make(REDUCE_NUM_THREADS, 1, 1));
+
+  if (!from_primitive) {
+    add_temporary_compat(enc, out, d, s);
+    add_temporary_compat(enc, exp_sums, d, s);
+    add_temporary_compat(enc, max_logits, d, s);
+    add_temporary_compat(enc, tmp_out, d, s);
+    add_temporary_compat(enc, q_nope, d, s);
+    add_temporary_compat(enc, q_pe, d, s);
+    add_temporary_compat(enc, latent_cache, d, s);
+    add_temporary_compat(enc, block_tables, d, s);
+    add_temporary_compat(enc, context_lens, d, s);
+  }
+}
+
+
+void mla_paged_attention_decode_fa_partitioned_impl(
+    nb::handle out_h,
+    nb::handle exp_sums_h,
+    nb::handle max_logits_h,
+    nb::handle tmp_out_h,
+    nb::handle q_nope_h,
+    nb::handle q_pe_h,
+    nb::handle latent_cache_h,
+    nb::handle block_tables_h,
+    nb::handle context_lens_h,
+    int block_size,
+    float scale,
+    int partition_size,
+    int max_num_partitions,
+    bool use_wide) {
+  auto& out = *nb::inst_ptr<array>(out_h);
+  auto& exp_sums = *nb::inst_ptr<array>(exp_sums_h);
+  auto& max_logits = *nb::inst_ptr<array>(max_logits_h);
+  auto& tmp_out = *nb::inst_ptr<array>(tmp_out_h);
+  auto& q_nope = *nb::inst_ptr<array>(q_nope_h);
+  auto& q_pe = *nb::inst_ptr<array>(q_pe_h);
+  auto& latent_cache = *nb::inst_ptr<array>(latent_cache_h);
+  auto& block_tables = *nb::inst_ptr<array>(block_tables_h);
+  auto& context_lens = *nb::inst_ptr<array>(context_lens_h);
+
+  dispatch_mla_paged_attention_decode_fa_partitioned(
+      out, exp_sums, max_logits, tmp_out, q_nope, q_pe, latent_cache,
+      block_tables, context_lens, block_size, scale, partition_size,
+      max_num_partitions, use_wide, default_stream(Device::gpu));
+}
+
+void mla_paged_attention_decode_fa_impl(
+    nb::handle out_h,
+    nb::handle q_nope_h,
+    nb::handle q_pe_h,
+    nb::handle latent_cache_h,
+    nb::handle block_tables_h,
+    nb::handle context_lens_h,
+    nb::handle cu_seqlens_q_h,
+    int block_size,
+    float scale,
+    bool use_wide) {
+  auto& out = *nb::inst_ptr<array>(out_h);
+  auto& q_nope = *nb::inst_ptr<array>(q_nope_h);
+  auto& q_pe = *nb::inst_ptr<array>(q_pe_h);
+  auto& latent_cache = *nb::inst_ptr<array>(latent_cache_h);
+  auto& block_tables = *nb::inst_ptr<array>(block_tables_h);
+  auto& context_lens = *nb::inst_ptr<array>(context_lens_h);
+  auto& cu_seqlens_q = *nb::inst_ptr<array>(cu_seqlens_q_h);
+
+  dispatch_mla_paged_attention_decode_fa(
+      out, q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q,
+      block_size, scale, use_wide, default_stream(Device::gpu));
+}
+
 
 void gdn_linear_attention_impl(
     nb::handle q_h, nb::handle k_h, nb::handle v_h,
@@ -2035,6 +2391,11 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("src"),
         "JIT-compile the MLA paged attention Metal shader (RFC #360).");
 
+  m.def("mla_has_bfloat_fa_kernel", &mla_has_bfloat_fa_kernel,
+        "Runtime probe for bf16 FA kernel availability. Returns false on "
+        "targets without native bfloat support (where mla.metal gates the "
+        "bf16 FA instantiations away). Library must be initialized first.");
+
   m.def("mla_paged_attention", &mla_paged_attention_impl,
         nb::arg("out"),
         nb::arg("q_nope"), nb::arg("q_pe"),
@@ -2071,4 +2432,30 @@ NB_MODULE(_paged_ops, m) {
         "MLX sdpa_vector_2pass-style cross-head amortization for absorbed "
         "MLA decode. One TG per (seq, partition) with 32*num_heads threads, "
         "all heads sharing K cache reads.");
+
+  m.def("mla_paged_attention_decode_fa",
+        &mla_paged_attention_decode_fa_impl,
+        nb::arg("out"),
+        nb::arg("q_nope"), nb::arg("q_pe"),
+        nb::arg("latent_cache"),
+        nb::arg("block_tables"), nb::arg("context_lens"),
+        nb::arg("cu_seqlens_q"),
+        nb::arg("block_size"), nb::arg("scale"),
+        nb::arg("use_wide") = false,
+        "Paged FA decode kernel using simdgroup_matrix<T, 8, 8> MMAs.");
+
+  m.def("mla_paged_attention_decode_fa_partitioned",
+        &mla_paged_attention_decode_fa_partitioned_impl,
+        nb::arg("out"),
+        nb::arg("exp_sums"), nb::arg("max_logits"), nb::arg("tmp_out"),
+        nb::arg("q_nope"), nb::arg("q_pe"),
+        nb::arg("latent_cache"),
+        nb::arg("block_tables"), nb::arg("context_lens"),
+        nb::arg("block_size"), nb::arg("scale"),
+        nb::arg("partition_size"), nb::arg("max_num_partitions"),
+        nb::arg("use_wide") = false,
+        "Partitioned (split-K + reduce) variant of the FA decode kernel "
+        "for long-ctx workloads. Same per-partition pipeline as "
+        "mla_paged_attention_decode_fa; reuses the same reduce kernel "
+        "as the 2pass entry.");
 }

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -113,6 +113,33 @@ static std::string dtype_to_metal(Dtype dt) {
   }
 }
 
+// MLA dispatchers pick a single Metal specialization from one tensor's
+// dtype (q_nope) but the kernel template binds the same `T` to every
+// fp16/bf16 buffer (q_nope, q_pe, latent_cache, out, tmp_out). If they
+// disagree the shader will reinterpret bytes — e.g. read a bf16 cache
+// as fp16 — and silently corrupt attention. Validate up front.
+static void mla_validate_t_dtypes(
+    const char* dispatcher_name,
+    std::initializer_list<std::pair<const char*, const array*>> tensors) {
+  if (tensors.size() == 0) return;
+  Dtype expected = tensors.begin()->second->dtype();
+  if (expected != float16 && expected != bfloat16) {
+    throw std::runtime_error(
+        std::string(dispatcher_name) +
+        ": T buffers must be fp16 or bf16; got " +
+        dtype_to_metal(expected) + " on " + tensors.begin()->first);
+  }
+  for (const auto& [name, arr] : tensors) {
+    if (arr->dtype() != expected) {
+      throw std::runtime_error(
+          std::string(dispatcher_name) +
+          ": all T buffers must share the same dtype; got " +
+          dtype_to_metal(expected) + " on " + tensors.begin()->first +
+          " but " + dtype_to_metal(arr->dtype()) + " on " + name);
+    }
+  }
+}
+
 static int get_bits(const std::string& quant_type) {
   static const std::unordered_map<std::string, int> BITS = {
       {"q8_0", 8}, {"int8", 8}, {"uint8", 8},
@@ -1036,6 +1063,284 @@ void init_gdn_library(const std::string& src) {
   d.get_library("gdn_kern", [&]() { return gdn_source_; });
 }
 
+// ---------------------------------------------------------------------------
+// MLA paged attention (RFC #360)
+// ---------------------------------------------------------------------------
+
+static std::string mla_source_;
+
+void init_mla_library(const std::string& src) {
+  mla_source_ = src;
+  auto& d = metal::device(Device::gpu);
+  d.get_library("paged_mla_kern", [&]() { return mla_source_; });
+}
+
+// Dispatch the MLA paged attention kernel.
+//
+// Buffer slot map (must match kernels_v2/mla.metal):
+//   2: out          [total_q_tokens, num_heads, KV_LORA_RANK]
+//   3: q_nope       [total_q_tokens, num_heads, KV_LORA_RANK]
+//   4: q_pe         [total_q_tokens, num_heads, QK_ROPE_HEAD_DIM]
+//   5: latent_cache [num_blocks, BLOCK_SIZE, KV_LORA_RANK + QK_ROPE_HEAD_DIM]
+//   6: block_tables 7: context_lens 8: cu_seqlens_q
+//   9: num_seqs 10: max_num_blocks_per_seq 11: scale
+// Map heads_per_tg → NUM_THREADS. Each variant keeps the per-thread register
+// footprint roughly constant (NUM_THREADS scaled inversely to G).
+//   G=1 → NUM_THREADS=1024 (32 simdgroups, current sdpa_vector layout).
+//   G=4 → NUM_THREADS=256  (8  simdgroups, 4× cross-head amortization).
+// Returns 0 for an unsupported G so callers can validate.
+static int mla_num_threads_for_g(int heads_per_tg) {
+  switch (heads_per_tg) {
+    case 1: return 1024;
+    case 2: return 512;
+    case 4: return 256;
+    default: return 0;
+  }
+}
+
+static void dispatch_mla_paged_attention(
+    array& out,
+    const array& q_nope,
+    const array& q_pe,
+    const array& latent_cache,
+    const array& block_tables,
+    const array& context_lens,
+    const array& cu_seqlens_q,
+    int block_size,
+    float scale,
+    int heads_per_tg,
+    Stream s,
+    bool from_primitive = false) {
+  auto& d = metal::device(s.device);
+
+  int total_q_tokens = static_cast<int>(q_nope.shape(0));
+  int num_heads = static_cast<int>(q_nope.shape(1));
+  int kv_lora_rank = static_cast<int>(q_nope.shape(2));
+  int qk_rope_head_dim = static_cast<int>(q_pe.shape(2));
+  int max_num_blocks_per_seq = static_cast<int>(block_tables.shape(1));
+  int num_seqs = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
+
+  // Shape sanity — these must match what the kernel template was instantiated for.
+  if (kv_lora_rank != 512) {
+    throw std::runtime_error(
+        "MLA kernel: only kv_lora_rank=512 is instantiated; got " +
+        std::to_string(kv_lora_rank));
+  }
+  if (qk_rope_head_dim != 64) {
+    throw std::runtime_error(
+        "MLA kernel: only qk_rope_head_dim=64 is instantiated; got " +
+        std::to_string(qk_rope_head_dim));
+  }
+  if (block_size != 16 && block_size != 32) {
+    throw std::runtime_error(
+        "MLA kernel: only block_size in {16, 32} is instantiated; got " +
+        std::to_string(block_size));
+  }
+  int num_threads = mla_num_threads_for_g(heads_per_tg);
+  if (num_threads == 0) {
+    throw std::runtime_error(
+        "MLA kernel: heads_per_tg must be in {1, 2, 4}; got " +
+        std::to_string(heads_per_tg));
+  }
+  if (num_heads % heads_per_tg != 0) {
+    throw std::runtime_error(
+        "MLA kernel: num_heads (" + std::to_string(num_heads) +
+        ") must be divisible by heads_per_tg (" +
+        std::to_string(heads_per_tg) + ")");
+  }
+  mla_validate_t_dtypes("MLA kernel", {
+      {"q_nope", &q_nope},
+      {"q_pe", &q_pe},
+      {"latent_cache", &latent_cache},
+      {"out", &out},
+  });
+
+  auto dt = dtype_to_metal(q_nope.dtype());
+  std::string kname = "paged_mla_attention_" + dt + "_kvr" +
+                      std::to_string(kv_lora_rank) + "_pe" +
+                      std::to_string(qk_rope_head_dim) + "_bs" +
+                      std::to_string(block_size) + "_g" +
+                      std::to_string(heads_per_tg) + "_nt" +
+                      std::to_string(num_threads) + "_nsl32_ps0";
+
+  bool use_partitioning = false;
+  bool use_alibi = false;
+  bool use_fp8_scales = false;
+  bool use_sinks = false;
+  bool use_turboquant = false;
+
+  std::string hash_name = kname + "_part" + (use_partitioning ? "1" : "0") +
+                          "_alibi0_fp80_sinks0_tq0";
+
+  auto* lib = d.get_library("paged_mla_kern");
+  auto* kernel = d.get_kernel(
+      kname,
+      lib,
+      hash_name,
+      {{&use_partitioning, MTL::DataType::DataTypeBool, NS::UInteger(10)},
+       {&use_alibi, MTL::DataType::DataTypeBool, NS::UInteger(20)},
+       {&use_fp8_scales, MTL::DataType::DataTypeBool, NS::UInteger(30)},
+       {&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_turboquant, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
+
+  // Threadgroup memory:
+  //   max_scores[G * BN] + sum_exp_scores[G * BN] + outputs[BD * BD]
+  // The outputs buffer must be sized for the maximum write offset
+  // `lane*BD + sg`, which reaches (BD-1)*BD + (BN-1). Using BD*BD always
+  // (rather than BN*BD) gives enough room across all G; on G=1 (BN=BD=32)
+  // they coincide.
+  // For G=1, NT=1024: 2*32 + 32*32 = 1088 fp32 ≈ 4.3 KB.
+  // For G=4, NT=256:  2*4*8 + 32*32 = 1088 fp32 ≈ 4.3 KB.
+  const int BD = 32;
+  const int BN = num_threads / BD;
+  size_t shmem =
+      static_cast<size_t>((2 * heads_per_tg * BN + BD * BD) * sizeof(float));
+
+  auto& enc = get_command_encoder_compat(d, s);
+  enc.set_compute_pipeline_state(kernel);
+  enc.set_threadgroup_memory_length(shmem, 0);
+
+  enc.set_output_array(out, 2);
+  enc.set_input_array(q_nope, 3);
+  enc.set_input_array(q_pe, 4);
+  enc.set_input_array(latent_cache, 5);
+  enc.set_input_array(block_tables, 6);
+  enc.set_input_array(context_lens, 7);
+  enc.set_input_array(cu_seqlens_q, 8);
+
+  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
+  int32_t max_blocks_i = static_cast<int32_t>(max_num_blocks_per_seq);
+  enc.set_bytes(num_seqs_i, 9);
+  enc.set_bytes(max_blocks_i, 10);
+  enc.set_bytes(scale, 11);
+
+  // Grid: (num_heads / G, total_q_tokens, 1). Each TG owns G consecutive
+  // query heads sharing the same latent KV.
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads / heads_per_tg, total_q_tokens, 1),
+      MTL::Size::Make(num_threads, 1, 1));
+
+  // See dispatch_reshape_and_cache: inside a primitive, MLX manages array
+  // lifetimes via the completion handler; add_temporary would defeat
+  // fence-based sync across the command buffer boundary.
+  if (!from_primitive) {
+    add_temporary_compat(enc, out, d, s);
+    add_temporary_compat(enc, q_nope, d, s);
+    add_temporary_compat(enc, q_pe, d, s);
+    add_temporary_compat(enc, latent_cache, d, s);
+    add_temporary_compat(enc, block_tables, d, s);
+    add_temporary_compat(enc, context_lens, d, s);
+    add_temporary_compat(enc, cu_seqlens_q, d, s);
+  }
+}
+
+// MLA single-pass paged attention as a proper MLX Primitive so that the
+// kernel dispatch joins the wrapper's lazy graph instead of forcing a
+// mx.eval boundary inside the Python entry. The eager
+// ``mla_paged_attention`` binding is kept for backward-compat callers
+// (bench tools, tests); ``_kernel_fast_path`` switches to the
+// primitive variant.
+//
+// Why this matters: at B=1 H=16 ctx=128 the kernel itself is ~170 μs
+// but the wrapper end-to-end is ~700 μs — the gap is ~3-4 per-call
+// MLX dispatch boundaries (each ~200 μs at this small workload). The
+// kernel-entry mx.eval (which materialises q_nope, q_pe, etc. before
+// our in-place dispatch) is one of those boundaries. As a Primitive
+// the kernel call lives in the lazy graph; MLX evaluates everything
+// at the wrapper's terminal mx.eval and the per-dispatch overhead
+// folds into the wrapper's existing sync.
+class MlaPagedAttentionPrimitive : public UnaryPrimitive {
+ public:
+  MlaPagedAttentionPrimitive(
+      Stream stream, int block_size, float scale, int heads_per_tg)
+      : UnaryPrimitive(stream),
+        block_size_(block_size),
+        scale_(scale),
+        heads_per_tg_(heads_per_tg) {}
+
+  void eval_cpu(const std::vector<array>&, array&) override {
+    throw std::runtime_error("MlaPagedAttentionPrimitive only supports GPU");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, array& out) override {
+    // Inputs match the single-pass dispatcher's positional order:
+    //   [q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q]
+    out.set_data(allocator::malloc(out.nbytes()));
+    dispatch_mla_paged_attention(
+        out,
+        inputs[0], inputs[1], inputs[2],
+        inputs[3], inputs[4], inputs[5],
+        block_size_, scale_, heads_per_tg_,
+        stream(),
+        /*from_primitive=*/true);
+  }
+
+  const char* name() const override { return "MlaPagedAttention"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* rhs = dynamic_cast<const MlaPagedAttentionPrimitive*>(&other);
+    return rhs && rhs->block_size_ == block_size_
+        && rhs->scale_ == scale_ && rhs->heads_per_tg_ == heads_per_tg_;
+  }
+
+ private:
+  int block_size_;
+  float scale_;
+  int heads_per_tg_;
+};
+
+static array mla_paged_attention_primitive_fn(
+    const array& q_nope,
+    const array& q_pe,
+    const array& latent_cache,
+    const array& block_tables,
+    const array& context_lens,
+    const array& cu_seqlens_q,
+    int block_size,
+    float scale,
+    int heads_per_tg) {
+  auto prim = std::make_shared<MlaPagedAttentionPrimitive>(
+      default_stream(Device::gpu), block_size, scale, heads_per_tg);
+  // Output shape matches q_nope: (total_q_tokens, num_heads, kv_lora_rank).
+  return array(
+      q_nope.shape(),
+      q_nope.dtype(),
+      std::move(prim),
+      {q_nope, q_pe, latent_cache, block_tables, context_lens, cu_seqlens_q});
+}
+
+void mla_paged_attention_impl(
+    nb::handle out_h,
+    nb::handle q_nope_h,
+    nb::handle q_pe_h,
+    nb::handle latent_cache_h,
+    nb::handle block_tables_h,
+    nb::handle context_lens_h,
+    nb::handle cu_seqlens_q_h,
+    int block_size,
+    float scale,
+    int heads_per_tg) {
+  auto& out = *nb::inst_ptr<array>(out_h);
+  auto& q_nope = *nb::inst_ptr<array>(q_nope_h);
+  auto& q_pe = *nb::inst_ptr<array>(q_pe_h);
+  auto& latent_cache = *nb::inst_ptr<array>(latent_cache_h);
+  auto& block_tables = *nb::inst_ptr<array>(block_tables_h);
+  auto& context_lens = *nb::inst_ptr<array>(context_lens_h);
+  auto& cu_seqlens_q = *nb::inst_ptr<array>(cu_seqlens_q_h);
+
+  dispatch_mla_paged_attention(
+      out,
+      q_nope,
+      q_pe,
+      latent_cache,
+      block_tables,
+      context_lens,
+      cu_seqlens_q,
+      block_size,
+      scale,
+      heads_per_tg,
+      default_stream(Device::gpu));
+}
 void gdn_linear_attention_impl(
     nb::handle q_h, nb::handle k_h, nb::handle v_h,
     nb::handle g_h, nb::handle beta_h,
@@ -1104,7 +1409,6 @@ void gdn_linear_attention_impl(
   add_temporary_compat(enc, slot_mapping, d, s);
   add_temporary_compat(enc, y, d, s);
 }
-
 // ---------------------------------------------------------------------------
 // nanobind module
 // ---------------------------------------------------------------------------
@@ -1290,4 +1594,20 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("slot_mapping"), nb::arg("y"),
         nb::arg("Hk"), nb::arg("Hv"), nb::arg("Dk"), nb::arg("Dv"),
         "GDN linear attention with in-place paged state management.");
+
+  m.def("init_mla_library", &init_mla_library,
+        nb::arg("src"),
+        "JIT-compile the MLA paged attention Metal shader (RFC #360).");
+
+  m.def("mla_paged_attention", &mla_paged_attention_impl,
+        nb::arg("out"),
+        nb::arg("q_nope"), nb::arg("q_pe"),
+        nb::arg("latent_cache"),
+        nb::arg("block_tables"), nb::arg("context_lens"),
+        nb::arg("cu_seqlens_q"),
+        nb::arg("block_size"), nb::arg("scale"),
+        nb::arg("heads_per_tg") = 1,
+        "Paged MLA (single-pass), eager in-place dispatch. Kept for "
+        "bench / tests; production wrapper uses the primitive variant.");
+
 }


### PR DESCRIPTION
Tracking RFC: #360

Implements the **kernel layer** of RFC #360 Phase 1: absorbed-MLA decode kernels for paged latent cache, with direct eager bindings and kernel-direct parity tests. Routing, env gate, real-model wrapper parity, benchmarks, and the supported-model docs row are split out into follow-up PRs.

This PR has been scoped down at @LxYuan0420's request (#362 review): the previous bundle (kernels + C++ + MLX primitives + routing + benchmarks + tests + docs) is now four kernel-only commits, each containing one kernel variant plus its direct parity tests. UnaryPrimitive MLX-graph wrappers, runtime routing, env gate, benchmarks, docs row, and the `pr_mma` kernel are deferred to follow-up PRs.

## Scope

| In this PR | Deferred |
|---|---|
| 4 kernel variants in `mla.metal` (single-pass, split-K reduce, 2pass, FA) | `pr_mma` kernel (no direct parity tests yet) |
| C++ dispatchers in `paged_ops.cpp` (one per kernel) | UnaryPrimitive MLX-graph wrappers (C++ side) |
| Eager Python wrappers in `vllm_metal/metal/__init__.py` | UnaryPrimitive Python wrappers (`*_primitive`) |
| `_ensure_mla_library` lazy shader-library init | bench-only `*_main_only` / `*_reduce_only` dispatchers |
| Direct parity tests in `tests/test_mla_kernel.py` | Routing (`paged_attention_backend/mla.py`, env gate, routing tests) |
| | Wrapper-grid benchmarks (`tools/benchmark/mla_*`) |
| | Real-model E2E wrapper parity (per-route) |
| | `docs/supported_models.md` row |

The eager Python wrappers and `_ensure_mla_library` are retained as the minimum surface required for the direct parity tests to exercise the kernels. They are not MLX `UnaryPrimitive` subclasses — they are thin shims over the C++ dispatcher and the lazy `init_mla_library(src)` call that feeds `mla.metal` source to MLX's metal device under `paged_mla_kern`. Without them the C++ `d.get_library("paged_mla_kern")` lookup fails before any kernel can be dispatched from a test.

## Commits

| # | Commit | Adds |
|---|---|---|
| 1 | `metal: add MLA single-pass decode kernel` | `paged_mla_attention` template (G=1/2/4 cross-head amortization × bs ∈ {16, 32} × {fp16, bf16}) + `dispatch_mla_paged_attention` + `metal_mla_paged_attention` eager wrapper + `_ensure_mla_library` + single-pass direct parity / guard tests |
| 2 | `metal: add MLA split-K reduce path` | `paged_mla_attention_reduce` template + `dispatch_mla_paged_attention_partitioned` + `metal_mla_paged_attention_partitioned` wrapper + `MLA_PARTITION_SIZE=512` + partitioned-mode parity tests (single / two / many / mixed-ctx partitions, G=4 partitioned) |
| 3 | `metal: add MLA 2pass decode kernel` | `paged_mla_attention_decode_2pass_1` template (HPT ∈ {8, 32} × PS ∈ {64, 128, 256, 512}) + `dispatch_mla_paged_attention_decode_2pass` + `metal_mla_paged_attention_decode_2pass` wrapper + `_pick_mla_decode_2pass_partition` helper + 2pass parity tests across head counts / partition sizes / mixed-ctx / decode-only |
| 4 | `metal: add MLA FA decode kernel` | `paged_mla_attention_decode_fa` (non-partitioned) + `paged_mla_attention_decode_fa_partitioned` (split-K, reuses C2's reduce) + both dispatchers + both eager wrappers + FA direct parity tests (single-block, multi-block, production shapes, mixed ctx, indirect block tables, partitioned vs non-partitioned, wide-narrow cross-check) |

Each commit is self-contained: kernels compile, lint is clean, and the parity tests scoped to that commit pass independently.

## Included kernel entrypoints

| Kernel | Eager entrypoint | Intended follow-up use | Validated shapes (direct parity) |
|---|---|---|---|
| single-pass | `metal_mla_paged_attention` | Default decode path; non-partitioned mode for short-ctx and small-H workloads | G ∈ {1, 2, 4} × bs ∈ {16, 32} × dtype ∈ {fp16, bf16}; H ∈ {1, 4, 16}; ctx ∈ {1 token, sub-block, single block, two blocks, many blocks, mixed-ctx batch}; guard tests for multi-token query / undersized block tables / unsupported `kv_lora_rank` / mixed dtypes / output dtype mismatch / invalid G |
| split-K reduce | `metal_mla_paged_attention_partitioned` | Long-ctx single-pass with `PARTITION_SIZE=512`; same dense reference as non-partitioned | Single / two / many partitions, mixed-ctx-lens batch, G=4 cross-head; multi-token query reject; mixed-dtype reject |
| 2pass | `metal_mla_paged_attention_decode_2pass` | Cross-head K-cache amortization for H ≥ 8 decode (mid/long-ctx) | Dense parity across head counts × partition sizes ∈ {64, 128, 256, 512}; mixed ctx_lens; multi-token-query reject; mixed-dtype reject |
| FA | `metal_mla_paged_attention_decode_fa`, `metal_mla_paged_attention_decode_fa_partitioned` | simdgroup_matrix MMA path for high-H decode (production shapes); split-K variant for long-ctx | Single-block / multi-block / production shapes (H ∈ {16, 64, 128}) / mixed-ctx batches / indirect block tables / partitioned-vs-non-partitioned / wide-narrow tile cross-check; unsupported `num_heads` reject; multi-token-query reject |

## Follow-up plan

The split that @LxYuan0420 suggested: kernel/C++ layer with direct parity tests first, then runtime routing route-by-route once each route has wrapper-level real-model parity and benchmark evidence.

1. Single-pass route — `paged_attention_backend/mla.py` predicate + `VLLM_METAL_MLA_KERNEL` env gate + real-model wrapper parity (DeepSeek-V2-Lite, GLM-4.7-Flash — both route through single-pass at H ∈ {16, 20}; results already gathered, see comments below) + per-route wrapper benchmark
2. FA route — predicate + real-model parity at H ∈ {16, 64, 128} + benchmark
3. 2pass route — first resolve the dynamic PSO `maxTotalThreadsPerThreadgroup` query so `HEADS_PER_TG=32` re-enables on capable hardware (HPT=8 portability fix that landed in C3 currently leaves a few H=96 B=8 ctx=8192 cells below MLX SDPA on M5 Max); then predicate + real-model parity + benchmark
4. `pr_mma` kernel — direct parity tests first (this PR drops `pr_mma` because it had no kernel-direct dense parity coverage), then dispatcher + routing + parity + benchmark
5. `docs/supported_models.md` — DeepSeek-V2-Lite row after route #1 lands

## Test plan

- [x] `uv run pytest tests/test_mla_kernel.py -v --tb=short`: 124/124
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy vllm_metal`: clean
- [x] Each commit independently green for its scoped tests + lint + mypy
- [x] Full CI green on macos-15 (re-running after force-push)
