### PR TITLE
Add target verification for scheduled spec decode tokens

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -10,6 +10,7 @@ import torch
 import vllm_metal.v1.model_runner as mr
 from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1.model_adapter import DefaultModelAdapter
+from vllm_metal.v1.spec_decode import SpeculativeDecodeController
 from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
 
@@ -44,6 +45,7 @@ def make_stub_runner(
         "_pending_output": None,
         "_execute_model_state": None,
         "_model_adapter": DefaultModelAdapter(),
+        "_spec_decode_controller": SpeculativeDecodeController(),
         "kv_heads_per_layer": None,
         "head_dim_per_layer": None,
         "sliding_window_per_layer": None,

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -57,6 +57,7 @@ def _make_scheduler_output(
     """Minimal SchedulerOutput stub — no spec-decode tokens."""
     return SimpleNamespace(
         scheduled_spec_decode_tokens={},
+        num_invalid_spec_tokens=None,
         num_scheduled_tokens=dict.fromkeys(req_ids, 1),
         total_num_scheduled_tokens=len(req_ids),
         scheduled_new_reqs=[],

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -580,7 +580,18 @@ class TestSampleTokensGrammarPagedPath:
             scheduler_output=scheduler_output,
             logits=logits,
             cu_seqlens=[0, 1],
-            num_decode=1,
+            decode_segments=(
+                mr.PagedDecodeSegment(
+                    req_id="r0",
+                    input_token_ids=(1,),
+                    start_row=0,
+                    num_query_tokens=1,
+                    draft_token_ids=(),
+                    cache_start_pos=0,
+                    block_ids=(),
+                ),
+            ),
+            num_decode_tokens=1,
         )
 
         output = runner.sample_tokens(grammar_output=grammar_output)

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -103,6 +103,19 @@ class TestPrepare:
         assert ctx.offsets == [7]
         assert ctx.cu_seqlens == [0, 1]
 
+    def test_prepare_unified_spec_decode_splits_query_tokens(self):
+        # Speculative verification appends draft rows after the last token.
+        # Each row is a separate attention segment with its own position.
+        prepare_unified([([5, 6, 7], 7, 3)], [], block_size=4)
+        ctx = get_context()
+
+        assert ctx is not None
+        assert ctx.slot_mapping == [27, 28, 29]
+        assert ctx.block_tables == [[5, 6, 7], [5, 6, 7], [5, 6, 7]]
+        assert ctx.context_lens == [8, 9, 10]
+        assert ctx.offsets == [7, 8, 9]
+        assert ctx.cu_seqlens == [0, 1, 2, 3]
+
     def test_prepare_unified_mixed(self):
         # 1 decode + 1 prefill
         decode_requests = [([5, 6], 7)]  # seq_len=7

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -8,14 +8,13 @@ from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
+import torch
 from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 
 from vllm_metal.v1.spec_decode import (
     PagedDecodeSegment,
-    build_paged_decode_segments,
-    unsupported_spec_decode_reason,
-    validate_greedy_spec_decode_sampling,
-    verify_greedy_spec_decode,
+    SpeculativeDecodeController,
 )
 
 
@@ -23,8 +22,51 @@ def _state(token_ids: list[int], block_ids: list[int]) -> SimpleNamespace:
     return SimpleNamespace(token_ids=token_ids, block_ids=block_ids)
 
 
-def _request_state(temperature: float = 0.0) -> SimpleNamespace:
-    return SimpleNamespace(sampling_params=SamplingParams(temperature=temperature))
+def _request_state(
+    temperature: float = 0.0,
+    *,
+    generated_tokens: int = 1,
+    min_tokens: int = 0,
+    stop_token_ids: list[int] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        sampling_params=SamplingParams(
+            temperature=temperature,
+            min_tokens=min_tokens,
+            stop_token_ids=stop_token_ids,
+        ),
+        generated_tokens=generated_tokens,
+    )
+
+
+def _scheduler_output(
+    *,
+    scheduled_spec_decode_tokens: dict[str, list[int]],
+    num_scheduled_tokens: dict[str, int] | None = None,
+    num_invalid_spec_tokens: dict[str, int] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+        num_scheduled_tokens=num_scheduled_tokens
+        or {
+            req_id: len(tokens) + 1
+            for req_id, tokens in scheduled_spec_decode_tokens.items()
+        },
+        num_invalid_spec_tokens=num_invalid_spec_tokens,
+    )
+
+
+def _spec_logitsprocs():
+    config = SimpleNamespace(
+        speculative_config=object(),
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+    )
+    return build_logitsprocs(
+        config,
+        torch.device("cpu"),
+        is_pin_memory=False,
+        is_pooling_model=False,
+    )
 
 
 def _logits(token_ids: list[int], vocab_size: int = 16) -> mx.array:
@@ -60,7 +102,7 @@ class TestPagedDecodeSegment:
 
 class TestBuildPagedDecodeSegments:
     def test_single_row_decode_matches_current_shape(self) -> None:
-        segments = build_paged_decode_segments(
+        segments = SpeculativeDecodeController().build_decode_segments(
             [("r0", _state([5, 9], [41, 42]))],
             scheduled_spec_decode_tokens={},
             paged_request_seq_lens={"r0": 7},
@@ -79,7 +121,7 @@ class TestBuildPagedDecodeSegments:
         assert segment.bonus_row == 0
 
     def test_single_row_decode_uses_len_minus_one_fallback(self) -> None:
-        segments = build_paged_decode_segments(
+        segments = SpeculativeDecodeController().build_decode_segments(
             [("r0", _state([5, 9, 17], [41, 42]))],
             scheduled_spec_decode_tokens=None,
             paged_request_seq_lens={},
@@ -88,7 +130,7 @@ class TestBuildPagedDecodeSegments:
         assert segments[0].cache_start_pos == 2
 
     def test_draft_tokens_expand_the_row_span(self) -> None:
-        segments = build_paged_decode_segments(
+        segments = SpeculativeDecodeController().build_decode_segments(
             [("r0", _state([5, 9], [41, 42]))],
             scheduled_spec_decode_tokens={"r0": [23, 24]},
             paged_request_seq_lens={"r0": 7},
@@ -103,7 +145,7 @@ class TestBuildPagedDecodeSegments:
         assert segment.bonus_row == 2
 
     def test_mixed_batch_uses_cumulative_start_rows(self) -> None:
-        segments = build_paged_decode_segments(
+        segments = SpeculativeDecodeController().build_decode_segments(
             [
                 ("r0", _state([1, 2], [10])),
                 ("r1", _state([3, 4, 5], [11])),
@@ -123,47 +165,145 @@ class TestBuildPagedDecodeSegments:
         assert segments[2].draft_verification_rows == (4,)
         assert segments[2].bonus_row == 5
 
+    def test_rejects_handoff_for_request_outside_decode_set(self) -> None:
+        with pytest.raises(ValueError, match="outside the current decode set"):
+            SpeculativeDecodeController().build_decode_segments(
+                [("r0", _state([1, 2], [10]))],
+                scheduled_spec_decode_tokens={"missing": [3]},
+                paged_request_seq_lens={"r0": 1},
+            )
+
     def test_rejects_invalid_draft_token_sentinel(self) -> None:
         with pytest.raises(NotImplementedError, match="invalid draft-token"):
-            build_paged_decode_segments(
-                [("r0", _state([10, 11], [0]))],
+            SpeculativeDecodeController().build_decode_segments(
+                [("r0", _state([1, 2], [10]))],
                 scheduled_spec_decode_tokens={"r0": [-1]},
-                paged_request_seq_lens={},
+                paged_request_seq_lens={"r0": 1},
             )
 
 
 class TestSpecDecodePolicy:
     def test_empty_scheduled_tokens_are_supported(self) -> None:
-        assert (
-            unsupported_spec_decode_reason(
-                {"r0": []},
-                paged_attention_enabled=False,
-                is_hybrid=True,
-            )
-            is None
+        SpeculativeDecodeController().validate_supported(
+            _scheduler_output(scheduled_spec_decode_tokens={}),
+            (),
+            paged_attention_enabled=False,
+            is_hybrid=True,
+            logitsprocs=None,
         )
 
     def test_non_paged_scheduled_tokens_are_rejected(self) -> None:
-        assert (
-            unsupported_spec_decode_reason(
-                {"r0": [1]},
+        with pytest.raises(NotImplementedError, match="requires paged attention"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
+                [("r0", _request_state())],
                 paged_attention_enabled=False,
                 is_hybrid=False,
+                logitsprocs=None,
             )
-            == "Speculative decode verification on Metal requires paged "
-            "attention so draft-token rows can share scheduler-assigned KV slots."
-        )
 
     def test_hybrid_scheduled_tokens_are_rejected(self) -> None:
-        assert (
-            unsupported_spec_decode_reason(
-                {"r0": [1]},
+        with pytest.raises(NotImplementedError, match="hybrid GDN"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
+                [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=True,
+                logitsprocs=None,
             )
-            == "Speculative decode verification is not supported for hybrid "
-            "GDN models on Metal yet."
+
+    def test_rejects_invalid_draft_token_sentinel(self) -> None:
+        with pytest.raises(NotImplementedError, match="invalid draft-token"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(scheduled_spec_decode_tokens={"r0": [-1]}),
+                [("r0", _request_state())],
+                paged_attention_enabled=True,
+                is_hybrid=False,
+                logitsprocs=None,
+            )
+
+    def test_rejects_scheduler_invalid_spec_tokens(self) -> None:
+        with pytest.raises(NotImplementedError, match="scheduler-invalid"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(
+                    scheduled_spec_decode_tokens={"r0": [-1]},
+                    num_invalid_spec_tokens={"r0": 1},
+                ),
+                [("r0", _request_state())],
+                paged_attention_enabled=True,
+                is_hybrid=False,
+                logitsprocs=None,
+            )
+
+    def test_rejects_handoff_for_request_outside_decode_set(self) -> None:
+        with pytest.raises(ValueError, match="outside the current decode set"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(scheduled_spec_decode_tokens={"missing": [1]}),
+                [("r0", _request_state())],
+                paged_attention_enabled=True,
+                is_hybrid=False,
+                logitsprocs=None,
+            )
+
+    def test_rejects_empty_handoff_for_request_outside_decode_set(self) -> None:
+        with pytest.raises(ValueError, match="outside the current decode set"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(scheduled_spec_decode_tokens={"missing": []}),
+                [("r0", _request_state())],
+                paged_attention_enabled=True,
+                is_hybrid=False,
+                logitsprocs=None,
+            )
+
+    def test_rejects_mismatched_scheduler_token_accounting(self) -> None:
+        with pytest.raises(ValueError, match="inconsistent token accounting"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(
+                    scheduled_spec_decode_tokens={"r0": [1, 2]},
+                    num_scheduled_tokens={"r0": 2},
+                ),
+                [("r0", _request_state())],
+                paged_attention_enabled=True,
+                is_hybrid=False,
+                logitsprocs=None,
+            )
+
+    def test_allows_inactive_min_tokens_processor_from_speculative_config(self) -> None:
+        SpeculativeDecodeController().validate_supported(
+            _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
+            [
+                (
+                    "r0",
+                    _request_state(
+                        generated_tokens=2,
+                        min_tokens=1,
+                        stop_token_ids=[2],
+                    ),
+                )
+            ],
+            paged_attention_enabled=True,
+            is_hybrid=False,
+            logitsprocs=_spec_logitsprocs(),
         )
+
+    def test_rejects_active_min_tokens_constraint(self) -> None:
+        with pytest.raises(NotImplementedError, match="active min_tokens"):
+            SpeculativeDecodeController().validate_supported(
+                _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
+                [
+                    (
+                        "r0",
+                        _request_state(
+                            generated_tokens=0,
+                            min_tokens=3,
+                            stop_token_ids=[2],
+                        ),
+                    )
+                ],
+                paged_attention_enabled=True,
+                is_hybrid=False,
+                logitsprocs=_spec_logitsprocs(),
+            )
 
 
 class TestVerifyGreedySpecDecode:
@@ -178,11 +318,11 @@ class TestVerifyGreedySpecDecode:
             block_ids=(0,),
         )
 
-        output = verify_greedy_spec_decode(
+        output = SpeculativeDecodeController().verify_greedy(
             _logits([7, 8, 9]),
             [("r0", _request_state())],
             (segment,),
-            num_decode_tokens=3,
+            logitsprocs=None,
         )
 
         assert output == [[7, 8, 9]]
@@ -198,11 +338,11 @@ class TestVerifyGreedySpecDecode:
             block_ids=(0,),
         )
 
-        output = verify_greedy_spec_decode(
+        output = SpeculativeDecodeController().verify_greedy(
             _logits([7, 5, 9]),
             [("r0", _request_state())],
             (segment,),
-            num_decode_tokens=3,
+            logitsprocs=None,
         )
 
         assert output == [[7, 5]]
@@ -219,16 +359,32 @@ class TestVerifyGreedySpecDecode:
         )
 
         with pytest.raises(NotImplementedError, match="greedy sampling"):
-            verify_greedy_spec_decode(
+            SpeculativeDecodeController().verify_greedy(
                 _logits([7, 9]),
                 [("r0", _request_state(temperature=0.7))],
                 (segment,),
-                num_decode_tokens=2,
+                logitsprocs=None,
             )
 
     def test_rejects_logits_processors_that_can_change_argmax(self) -> None:
+        class _NonArgmaxProcessor:
+            def is_argmax_invariant(self) -> bool:
+                return False
+
         with pytest.raises(NotImplementedError, match="logits processors"):
-            validate_greedy_spec_decode_sampling(
+            SpeculativeDecodeController().verify_greedy(
+                _logits([7, 9]),
                 [("r0", _request_state())],
-                logitsprocs=SimpleNamespace(non_argmax_invariant=[object()]),
+                (
+                    PagedDecodeSegment(
+                        req_id="r0",
+                        input_token_ids=(6, 7),
+                        start_row=0,
+                        num_query_tokens=2,
+                        draft_token_ids=(7,),
+                        cache_start_pos=1,
+                        block_ids=(0,),
+                    ),
+                ),
+                logitsprocs=LogitsProcessors([_NonArgmaxProcessor()]),
             )

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -6,16 +6,34 @@ from __future__ import annotations
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 
+import mlx.core as mx
 import pytest
+from vllm.sampling_params import SamplingParams
 
 from vllm_metal.v1.spec_decode import (
     PagedDecodeSegment,
     build_paged_decode_segments,
+    unsupported_spec_decode_reason,
+    validate_greedy_spec_decode_sampling,
+    verify_greedy_spec_decode,
 )
 
 
 def _state(token_ids: list[int], block_ids: list[int]) -> SimpleNamespace:
     return SimpleNamespace(token_ids=token_ids, block_ids=block_ids)
+
+
+def _request_state(temperature: float = 0.0) -> SimpleNamespace:
+    return SimpleNamespace(sampling_params=SamplingParams(temperature=temperature))
+
+
+def _logits(token_ids: list[int], vocab_size: int = 16) -> mx.array:
+    rows = []
+    for token_id in token_ids:
+        row = [0.0] * vocab_size
+        row[token_id] = 10.0
+        rows.append(row)
+    return mx.array([rows])
 
 
 class TestPagedDecodeSegment:
@@ -104,3 +122,113 @@ class TestBuildPagedDecodeSegments:
         assert segments[1].bonus_row == 3
         assert segments[2].draft_verification_rows == (4,)
         assert segments[2].bonus_row == 5
+
+    def test_rejects_invalid_draft_token_sentinel(self) -> None:
+        with pytest.raises(NotImplementedError, match="invalid draft-token"):
+            build_paged_decode_segments(
+                [("r0", _state([10, 11], [0]))],
+                scheduled_spec_decode_tokens={"r0": [-1]},
+                paged_request_seq_lens={},
+            )
+
+
+class TestSpecDecodePolicy:
+    def test_empty_scheduled_tokens_are_supported(self) -> None:
+        assert (
+            unsupported_spec_decode_reason(
+                {"r0": []},
+                paged_attention_enabled=False,
+                is_hybrid=True,
+            )
+            is None
+        )
+
+    def test_non_paged_scheduled_tokens_are_rejected(self) -> None:
+        assert (
+            unsupported_spec_decode_reason(
+                {"r0": [1]},
+                paged_attention_enabled=False,
+                is_hybrid=False,
+            )
+            == "Speculative decode verification on Metal requires paged "
+            "attention so draft-token rows can share scheduler-assigned KV slots."
+        )
+
+    def test_hybrid_scheduled_tokens_are_rejected(self) -> None:
+        assert (
+            unsupported_spec_decode_reason(
+                {"r0": [1]},
+                paged_attention_enabled=True,
+                is_hybrid=True,
+            )
+            == "Speculative decode verification is not supported for hybrid "
+            "GDN models on Metal yet."
+        )
+
+
+class TestVerifyGreedySpecDecode:
+    def test_accepts_all_drafts_and_emits_bonus_token(self) -> None:
+        segment = PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7, 8),
+            start_row=0,
+            num_query_tokens=3,
+            draft_token_ids=(7, 8),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+
+        output = verify_greedy_spec_decode(
+            _logits([7, 8, 9]),
+            [("r0", _request_state())],
+            (segment,),
+            num_decode_tokens=3,
+        )
+
+        assert output == [[7, 8, 9]]
+
+    def test_rejects_first_mismatched_draft_and_stops_before_bonus(self) -> None:
+        segment = PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7, 8),
+            start_row=0,
+            num_query_tokens=3,
+            draft_token_ids=(7, 8),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+
+        output = verify_greedy_spec_decode(
+            _logits([7, 5, 9]),
+            [("r0", _request_state())],
+            (segment,),
+            num_decode_tokens=3,
+        )
+
+        assert output == [[7, 5]]
+
+    def test_rejects_non_greedy_sampling(self) -> None:
+        segment = PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7),
+            start_row=0,
+            num_query_tokens=2,
+            draft_token_ids=(7,),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+
+        with pytest.raises(NotImplementedError, match="greedy sampling"):
+            verify_greedy_spec_decode(
+                _logits([7, 9]),
+                [("r0", _request_state(temperature=0.7))],
+                (segment,),
+                num_decode_tokens=2,
+            )
+
+    def test_rejects_logits_processors_that_can_change_argmax(self) -> None:
+        with pytest.raises(NotImplementedError, match="logits processors"):
+            validate_greedy_spec_decode_sampling(
+                [("r0", _request_state())],
+                logitsprocs=SimpleNamespace(non_argmax_invariant=[object()]),
+            )

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.sampling_params import SamplingParams
 from vllm.v1.outputs import ModelRunnerOutput
 
 import vllm_metal.v1.model_runner as mr
@@ -129,16 +133,424 @@ class TestV1MetalModelRunnerSampleTokens:
         assert out is None
 
 
+class TestV1MetalModelRunnerSpecDecodeVerification:
+    def _make_runner(self) -> mr.MetalModelRunner:
+        return make_stub_runner(model_args={"vocab_size": 16})
+
+    def _make_state(
+        self,
+        token_ids: list[int],
+        *,
+        temperature: float = 0.0,
+    ) -> mr.RequestState:
+        return mr.RequestState(
+            token_ids=token_ids,
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(temperature=temperature),
+            generator=None,
+            generated_tokens=len(token_ids) - 1,
+        )
+
+    def _make_logits(self, token_ids: list[int]) -> mx.array:
+        rows = []
+        for token_id in token_ids:
+            row = [0.0] * 16
+            row[token_id] = 10.0
+            rows.append(row)
+        return mx.array([rows])
+
+    def _make_scheduler_output(
+        self,
+        num_scheduled_tokens: dict[str, int],
+        scheduled_spec_decode_tokens: dict[str, list[int]],
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            finished_req_ids=set(),
+        )
+
+    def _make_grammar_output(
+        self,
+        req_ids: list[str],
+        allowed_token_id: int,
+    ) -> SimpleNamespace:
+        bitmask = np.zeros((len(req_ids), 1), dtype=np.int32)
+        for row in range(len(req_ids)):
+            bitmask[row, 0] = 1 << allowed_token_id
+        return SimpleNamespace(
+            structured_output_request_ids=req_ids,
+            grammar_bitmask=bitmask,
+        )
+
+    def _install_paged_state(
+        self,
+        runner: mr.MetalModelRunner,
+        decode_reqs: list[tuple[str, mr.RequestState]],
+        decode_segments: tuple[mr.PagedDecodeSegment, ...],
+        logits: mx.array,
+        scheduler_output: SimpleNamespace,
+    ) -> None:
+        batch = mr._ExecutionBatch()
+        batch.paged_decode_reqs = decode_reqs
+        runner._execute_model_state = mr._PagedForwardState(
+            batch=batch,
+            prefill_reqs=[],
+            decode_reqs=decode_reqs,
+            scheduler_output=scheduler_output,
+            logits=logits,
+            cu_seqlens=[
+                0,
+                *[s.start_row + s.num_query_tokens for s in decode_segments],
+            ],
+            decode_segments=decode_segments,
+            num_decode_tokens=sum(s.num_query_tokens for s in decode_segments),
+        )
+
+    def test_start_paged_forward_includes_scheduled_drafts(self, monkeypatch) -> None:
+        runner = self._make_runner()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+        runner._paged_request_seq_lens["r0"] = 1
+
+        captured: dict[str, object] = {}
+
+        def fake_prepare_unified(decode_info, prefill_info, block_size):
+            captured["decode_info"] = decode_info
+            captured["prefill_info"] = prefill_info
+            captured["block_size"] = block_size
+
+        def fake_forward_model(input_ids, *, cache):
+            del cache
+            captured["input_ids"] = input_ids.tolist()
+            return mx.zeros((1, 3, 16))
+
+        monkeypatch.setattr(mr, "prepare_unified", fake_prepare_unified)
+        runner.model = fake_forward_model
+        runner._extract_logits = lambda model_output: model_output
+
+        req_state = self._make_state([1, 6])
+        req_state.block_ids = [0, 1]
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 3},
+            {"r0": [7, 8]},
+        )
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[],
+            decode_reqs=[("r0", req_state)],
+            scheduler_output=scheduler_output,
+        )
+
+        assert captured["input_ids"] == [[6, 7, 8]]
+        assert captured["decode_info"] == [([0, 1], 1, 3)]
+        assert captured["prefill_info"] == []
+        assert captured["block_size"] == 4
+        assert runner._execute_model_state is not None
+        assert runner._execute_model_state.cu_seqlens == [0, 3]
+
+    def test_start_paged_forward_rejects_non_argmax_logits_processors(
+        self,
+        monkeypatch,
+    ) -> None:
+        runner = self._make_runner()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+        runner._logitsprocs = SimpleNamespace(non_argmax_invariant=[object()])
+
+        monkeypatch.setattr(
+            mr,
+            "prepare_unified",
+            lambda *args, **kwargs: pytest.fail("prepare_unified should not run"),
+        )
+        runner.model = lambda *args, **kwargs: pytest.fail("model should not run")
+
+        req_state = self._make_state([1, 6])
+        req_state.block_ids = [0]
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 2},
+            {"r0": [7]},
+        )
+
+        with pytest.raises(NotImplementedError, match="logits processors"):
+            runner._start_paged_forward(
+                mr._ExecutionBatch(),
+                prefill_reqs=[],
+                decode_reqs=[("r0", req_state)],
+                scheduler_output=scheduler_output,
+            )
+
+        assert runner._execute_model_state is None
+
+    def test_start_paged_forward_rejects_invalid_draft_token_sentinel(
+        self,
+        monkeypatch,
+    ) -> None:
+        runner = self._make_runner()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+
+        monkeypatch.setattr(
+            mr,
+            "prepare_unified",
+            lambda *args, **kwargs: pytest.fail("prepare_unified should not run"),
+        )
+        runner.model = lambda *args, **kwargs: pytest.fail("model should not run")
+
+        req_state = self._make_state([1, 6])
+        req_state.block_ids = [0]
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 2},
+            {"r0": [-1]},
+        )
+
+        with pytest.raises(NotImplementedError, match="invalid draft-token"):
+            runner._start_paged_forward(
+                mr._ExecutionBatch(),
+                prefill_reqs=[],
+                decode_reqs=[("r0", req_state)],
+                scheduler_output=scheduler_output,
+            )
+
+        assert runner._execute_model_state is None
+
+    def test_accepts_all_drafts_and_emits_bonus_token(self) -> None:
+        runner = self._make_runner()
+        req_state = self._make_state([1, 6])
+        decode_reqs = [("r0", req_state)]
+        segment = mr.PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7, 8),
+            start_row=0,
+            num_query_tokens=3,
+            draft_token_ids=(7, 8),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 3},
+            {"r0": [7, 8]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            (segment,),
+            self._make_logits([7, 8, 9]),
+            scheduler_output,
+        )
+
+        output = runner.sample_tokens(grammar_output=None)
+
+        assert output is not None
+        assert output.sampled_token_ids == [[7, 8, 9]]
+        assert req_state.token_ids == [1, 6, 7, 8, 9]
+        assert req_state.generated_tokens == 4
+        assert runner._paged_request_seq_lens["r0"] == 4
+
+    def test_rejects_first_mismatched_draft_and_stops_before_bonus(self) -> None:
+        runner = self._make_runner()
+        req_state = self._make_state([1, 6])
+        decode_reqs = [("r0", req_state)]
+        segment = mr.PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7, 8),
+            start_row=0,
+            num_query_tokens=3,
+            draft_token_ids=(7, 8),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 3},
+            {"r0": [7, 8]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            (segment,),
+            self._make_logits([7, 5, 9]),
+            scheduler_output,
+        )
+
+        output = runner.sample_tokens(grammar_output=None)
+
+        assert output is not None
+        assert output.sampled_token_ids == [[7, 5]]
+        assert req_state.token_ids == [1, 6, 7, 5]
+        assert req_state.generated_tokens == 3
+        assert runner._paged_request_seq_lens["r0"] == 3
+
+    def test_mixed_batch_keeps_plain_decode_request(self) -> None:
+        runner = self._make_runner()
+        draft_state = self._make_state([1, 6])
+        plain_state = self._make_state([2, 3])
+        decode_reqs = [("draft", draft_state), ("plain", plain_state)]
+        segments = (
+            mr.PagedDecodeSegment(
+                req_id="draft",
+                input_token_ids=(6, 7),
+                start_row=0,
+                num_query_tokens=2,
+                draft_token_ids=(7,),
+                cache_start_pos=1,
+                block_ids=(0,),
+            ),
+            mr.PagedDecodeSegment(
+                req_id="plain",
+                input_token_ids=(3,),
+                start_row=2,
+                num_query_tokens=1,
+                draft_token_ids=(),
+                cache_start_pos=1,
+                block_ids=(1,),
+            ),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"draft": 2, "plain": 1},
+            {"draft": [7]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            segments,
+            self._make_logits([7, 9, 4]),
+            scheduler_output,
+        )
+
+        output = runner.sample_tokens(grammar_output=None)
+
+        assert output is not None
+        assert output.req_ids == ["draft", "plain"]
+        assert output.sampled_token_ids == [[7, 9], [4]]
+        assert draft_state.token_ids == [1, 6, 7, 9]
+        assert plain_state.token_ids == [2, 3, 4]
+
+    def test_structured_output_plain_spec_decode_request_is_allowed(self) -> None:
+        runner = self._make_runner()
+        structured_state = self._make_state([1, 6])
+        draft_state = self._make_state([2, 3])
+        decode_reqs = [("structured", structured_state), ("draft", draft_state)]
+        segments = (
+            mr.PagedDecodeSegment(
+                req_id="structured",
+                input_token_ids=(6,),
+                start_row=0,
+                num_query_tokens=1,
+                draft_token_ids=(),
+                cache_start_pos=1,
+                block_ids=(0,),
+            ),
+            mr.PagedDecodeSegment(
+                req_id="draft",
+                input_token_ids=(3, 7),
+                start_row=1,
+                num_query_tokens=2,
+                draft_token_ids=(7,),
+                cache_start_pos=1,
+                block_ids=(1,),
+            ),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"structured": 1, "draft": 2},
+            {"draft": [7]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            segments,
+            self._make_logits([0, 7, 9]),
+            scheduler_output,
+        )
+
+        output = runner.sample_tokens(
+            grammar_output=self._make_grammar_output(["structured"], 5),
+        )
+
+        assert output is not None
+        assert output.req_ids == ["structured", "draft"]
+        assert output.sampled_token_ids == [[5], [7, 9]]
+        assert structured_state.token_ids == [1, 6, 5]
+        assert draft_state.token_ids == [2, 3, 7, 9]
+
+    def test_structured_output_rejects_same_request_spec_decode(self) -> None:
+        runner = self._make_runner()
+        req_state = self._make_state([1, 6])
+        decode_reqs = [("r0", req_state)]
+        segment = mr.PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7),
+            start_row=0,
+            num_query_tokens=2,
+            draft_token_ids=(7,),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 2},
+            {"r0": [7]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            (segment,),
+            self._make_logits([7, 9]),
+            scheduler_output,
+        )
+
+        with pytest.raises(NotImplementedError, match="speculative decoding"):
+            runner.sample_tokens(grammar_output=self._make_grammar_output(["r0"], 5))
+
+        assert req_state.token_ids == [1, 6]
+
+    def test_rejects_non_greedy_spec_decode_verification(self) -> None:
+        runner = self._make_runner()
+        req_state = self._make_state([1, 6], temperature=0.7)
+        decode_reqs = [("r0", req_state)]
+        segment = mr.PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7),
+            start_row=0,
+            num_query_tokens=2,
+            draft_token_ids=(7,),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 2},
+            {"r0": [7]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            (segment,),
+            self._make_logits([7, 9]),
+            scheduler_output,
+        )
+
+        with pytest.raises(NotImplementedError, match="greedy sampling"):
+            runner.sample_tokens(grammar_output=None)
+
+        assert req_state.token_ids == [1, 6]
+
+
 class TestV1MetalModelRunnerExecuteModel:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner()
 
     def _make_scheduler_output(
-        self, cached_req_ids: list[str] | None = None
+        self,
+        cached_req_ids: list[str] | None = None,
+        *,
+        finished_req_ids: set[str] | None = None,
+        scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
+        scheduled_new_reqs: list[SimpleNamespace] | None = None,
     ) -> SimpleNamespace:
         req_ids = cached_req_ids or []
         return SimpleNamespace(
-            scheduled_new_reqs=[],
+            scheduled_new_reqs=scheduled_new_reqs or [],
             scheduled_cached_reqs=SimpleNamespace(
                 req_ids=req_ids,
                 resumed_req_ids=set(),
@@ -150,10 +562,10 @@ class TestV1MetalModelRunnerExecuteModel:
             ),
             num_scheduled_tokens=dict.fromkeys(req_ids, 1),
             total_num_scheduled_tokens=len(req_ids),
-            scheduled_spec_decode_tokens={},
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens or {},
             scheduled_encoder_inputs={},
             num_common_prefix_blocks=[],
-            finished_req_ids=set(),
+            finished_req_ids=finished_req_ids or set(),
             free_encoder_mm_hashes=[],
             preempted_req_ids=set(),
             has_structured_output_requests=False,
@@ -182,6 +594,28 @@ class TestV1MetalModelRunnerExecuteModel:
         assert pending.req_id_to_index == {"req-0": 0}
         assert pending.sampled_token_ids == [[0]]
         assert runner._pending_output is None
+
+    def test_non_paged_spec_decode_fails_after_cleanup_before_new_state(self) -> None:
+        runner = self._make_runner()
+        runner._request_states["done"] = mr.RequestState(
+            token_ids=[1],
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(),
+            generator=None,
+            generated_tokens=0,
+        )
+        scheduler_output = self._make_scheduler_output(
+            finished_req_ids={"done"},
+            scheduled_spec_decode_tokens={"req-0": [7]},
+            scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+        )
+
+        with pytest.raises(NotImplementedError, match="requires paged attention"):
+            runner.execute_model(scheduler_output)
+
+        assert "done" not in runner._request_states
+        assert "new" not in runner._request_states
 
 
 class TestRunnerMlaProperties:

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -475,6 +475,53 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         assert structured_state.token_ids == [1, 6, 5]
         assert draft_state.token_ids == [2, 3, 7, 9]
 
+    def test_structured_output_after_spec_decode_uses_segment_start_row(self) -> None:
+        runner = self._make_runner()
+        draft_state = self._make_state([1, 6])
+        structured_state = self._make_state([2, 3])
+        decode_reqs = [("draft", draft_state), ("structured", structured_state)]
+        segments = (
+            mr.PagedDecodeSegment(
+                req_id="draft",
+                input_token_ids=(6, 7),
+                start_row=0,
+                num_query_tokens=2,
+                draft_token_ids=(7,),
+                cache_start_pos=1,
+                block_ids=(0,),
+            ),
+            mr.PagedDecodeSegment(
+                req_id="structured",
+                input_token_ids=(3,),
+                start_row=2,
+                num_query_tokens=1,
+                draft_token_ids=(),
+                cache_start_pos=1,
+                block_ids=(1,),
+            ),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"draft": 2, "structured": 1},
+            {"draft": [7]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            segments,
+            self._make_logits([7, 9, 0]),
+            scheduler_output,
+        )
+
+        output = runner.sample_tokens(
+            grammar_output=self._make_grammar_output(["structured"], 5),
+        )
+
+        assert output is not None
+        assert output.req_ids == ["draft", "structured"]
+        assert output.sampled_token_ids == [[7, 9], [5]]
+        assert draft_state.token_ids == [1, 6, 7, 9]
+        assert structured_state.token_ids == [2, 3, 5]
+
     def test_structured_output_rejects_same_request_spec_decode(self) -> None:
         runner = self._make_runner()
         req_state = self._make_state([1, 6])

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -164,11 +164,13 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         self,
         num_scheduled_tokens: dict[str, int],
         scheduled_spec_decode_tokens: dict[str, list[int]],
+        num_invalid_spec_tokens: dict[str, int] | None = None,
     ) -> SimpleNamespace:
         return SimpleNamespace(
             num_scheduled_tokens=num_scheduled_tokens,
             total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            num_invalid_spec_tokens=num_invalid_spec_tokens,
             finished_req_ids=set(),
         )
 
@@ -251,71 +253,6 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         assert captured["block_size"] == 4
         assert runner._execute_model_state is not None
         assert runner._execute_model_state.cu_seqlens == [0, 3]
-
-    def test_start_paged_forward_rejects_non_argmax_logits_processors(
-        self,
-        monkeypatch,
-    ) -> None:
-        runner = self._make_runner()
-        runner.num_layers = 0
-        runner._paged_block_size = 4
-        runner._logitsprocs = SimpleNamespace(non_argmax_invariant=[object()])
-
-        monkeypatch.setattr(
-            mr,
-            "prepare_unified",
-            lambda *args, **kwargs: pytest.fail("prepare_unified should not run"),
-        )
-        runner.model = lambda *args, **kwargs: pytest.fail("model should not run")
-
-        req_state = self._make_state([1, 6])
-        req_state.block_ids = [0]
-        scheduler_output = self._make_scheduler_output(
-            {"r0": 2},
-            {"r0": [7]},
-        )
-
-        with pytest.raises(NotImplementedError, match="logits processors"):
-            runner._start_paged_forward(
-                mr._ExecutionBatch(),
-                prefill_reqs=[],
-                decode_reqs=[("r0", req_state)],
-                scheduler_output=scheduler_output,
-            )
-
-        assert runner._execute_model_state is None
-
-    def test_start_paged_forward_rejects_invalid_draft_token_sentinel(
-        self,
-        monkeypatch,
-    ) -> None:
-        runner = self._make_runner()
-        runner.num_layers = 0
-        runner._paged_block_size = 4
-
-        monkeypatch.setattr(
-            mr,
-            "prepare_unified",
-            lambda *args, **kwargs: pytest.fail("prepare_unified should not run"),
-        )
-        runner.model = lambda *args, **kwargs: pytest.fail("model should not run")
-
-        req_state = self._make_state([1, 6])
-        req_state.block_ids = [0]
-        scheduler_output = self._make_scheduler_output(
-            {"r0": 2},
-            {"r0": [-1]},
-        )
-
-        with pytest.raises(NotImplementedError, match="invalid draft-token"):
-            runner._start_paged_forward(
-                mr._ExecutionBatch(),
-                prefill_reqs=[],
-                decode_reqs=[("r0", req_state)],
-                scheduler_output=scheduler_output,
-            )
-
-        assert runner._execute_model_state is None
 
     def test_accepts_all_drafts_and_emits_bonus_token(self) -> None:
         runner = self._make_runner()
@@ -427,6 +364,60 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         assert output.sampled_token_ids == [[7, 9], [4]]
         assert draft_state.token_ids == [1, 6, 7, 9]
         assert plain_state.token_ids == [2, 3, 4]
+
+    def test_mixed_batch_routes_plain_request_through_sampler(
+        self, monkeypatch
+    ) -> None:
+        runner = self._make_runner()
+        draft_state = self._make_state([1, 6])
+        plain_state = self._make_state([2, 3], temperature=0.7)
+        decode_reqs = [("draft", draft_state), ("plain", plain_state)]
+        segments = (
+            mr.PagedDecodeSegment(
+                req_id="draft",
+                input_token_ids=(6, 7),
+                start_row=0,
+                num_query_tokens=2,
+                draft_token_ids=(7,),
+                cache_start_pos=1,
+                block_ids=(0,),
+            ),
+            mr.PagedDecodeSegment(
+                req_id="plain",
+                input_token_ids=(3,),
+                start_row=2,
+                num_query_tokens=1,
+                draft_token_ids=(),
+                cache_start_pos=1,
+                block_ids=(1,),
+            ),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"draft": 2, "plain": 1},
+            {"draft": [7]},
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            segments,
+            self._make_logits([7, 9, 4]),
+            scheduler_output,
+        )
+        sampled_rows = []
+
+        def fake_sample_from_logits(logits_2d, batch, sampler, device):
+            del sampler, device
+            sampled_rows.append(logits_2d.tolist())
+            assert [sp.temperature for sp in batch.sampling_params_list] == [0.7]
+            return mr._SamplingResult([4])
+
+        monkeypatch.setattr(mr, "sample_from_logits", fake_sample_from_logits)
+
+        output = runner.sample_tokens(grammar_output=None)
+
+        assert output is not None
+        assert output.sampled_token_ids == [[7, 9], [4]]
+        assert sampled_rows == [[[0.0] * 4 + [10.0] + [0.0] * 11]]
 
     def test_structured_output_plain_spec_decode_request_is_allowed(self) -> None:
         runner = self._make_runner()
@@ -593,6 +584,7 @@ class TestV1MetalModelRunnerExecuteModel:
         *,
         finished_req_ids: set[str] | None = None,
         scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
+        num_invalid_spec_tokens: dict[str, int] | None = None,
         scheduled_new_reqs: list[SimpleNamespace] | None = None,
     ) -> SimpleNamespace:
         req_ids = cached_req_ids or []
@@ -610,6 +602,7 @@ class TestV1MetalModelRunnerExecuteModel:
             num_scheduled_tokens=dict.fromkeys(req_ids, 1),
             total_num_scheduled_tokens=len(req_ids),
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens or {},
+            num_invalid_spec_tokens=num_invalid_spec_tokens,
             scheduled_encoder_inputs={},
             num_common_prefix_blocks=[],
             finished_req_ids=finished_req_ids or set(),
@@ -662,6 +655,35 @@ class TestV1MetalModelRunnerExecuteModel:
             runner.execute_model(scheduler_output)
 
         assert "done" not in runner._request_states
+        assert "new" not in runner._request_states
+
+    def test_paged_spec_decode_failure_does_not_mutate_request_setup(self) -> None:
+        runner = self._make_runner()
+        runner._paged_attention_backend = object()
+        req_state = mr.RequestState(
+            token_ids=[1, 6],
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(),
+            generator=None,
+            generated_tokens=1,
+            block_ids=[0],
+        )
+        runner._request_states["r0"] = req_state
+        scheduler_output = self._make_scheduler_output(
+            ["r0"],
+            scheduled_spec_decode_tokens={"r0": [-1]},
+            num_invalid_spec_tokens={"r0": 1},
+            scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+        )
+        scheduler_output.num_scheduled_tokens = {"r0": 2, "new": 1}
+        scheduler_output.total_num_scheduled_tokens = 3
+        scheduler_output.scheduled_cached_reqs.new_block_ids = [[[99]]]
+
+        with pytest.raises(NotImplementedError, match="scheduler-invalid"):
+            runner.execute_model(scheduler_output)
+
+        assert req_state.block_ids == [0]
         assert "new" not in runner._request_states
 
 

--- a/vllm_metal/paged_attention_common.py
+++ b/vllm_metal/paged_attention_common.py
@@ -153,20 +153,22 @@ def find_attn_attr(layer: Any) -> str | None:
 
 
 def prepare_unified(
-    decode_requests: list[tuple[list[int], int]],
+    decode_requests: list[tuple[list[int], int] | tuple[list[int], int, int]],
     prefill_requests: list[tuple[list[int], int, int]],
     block_size: int,
 ) -> None:
     """Compute metadata for a unified prefill + decode forward pass.
 
-    Packs decode tokens (1 per request) followed by prefill tokens into a
-    single flattened sequence.  ``cu_seqlens`` marks request boundaries so
-    the varlen kernel handles both decode (length-1) and prefill (length-N)
-    subsequences in one dispatch.
+    Packs decode tokens followed by prefill tokens into a single flattened
+    sequence. ``cu_seqlens`` marks attention segments so the varlen kernel
+    handles decode and prefill subsequences in one dispatch.
 
     Args:
-        decode_requests: list of ``(block_ids, seq_len)`` for decode requests.
-            ``seq_len`` = tokens already cached before this step.
+        decode_requests: list of ``(block_ids, seq_len)`` or
+            ``(block_ids, seq_len, num_tokens)`` for decode requests.
+            ``seq_len`` = tokens already cached before this step. ``num_tokens``
+            defaults to 1 and expands the decode row span for speculative
+            verification.
         prefill_requests: list of ``(block_ids, num_tokens, start_pos)`` for
             prefill.  ``start_pos`` is the position of the first token in this
             chunk (0 for a fresh prefill, >0 for continuation chunks).
@@ -178,16 +180,22 @@ def prepare_unified(
     context_lens: list[int] = []
     offsets: list[int] = []
 
-    # Decode requests first (1 token each)
-    for block_ids, seq_len in decode_requests:
-        new_pos = seq_len
-        block_idx = block_ids[new_pos // block_size]
-        slot = block_idx * block_size + (new_pos % block_size)
-        slot_mapping.append(slot)
-        cu_seqlens.append(cu_seqlens[-1] + 1)
-        block_tables.append(block_ids)
-        context_lens.append(seq_len + 1)  # including new token
-        offsets.append(seq_len)  # RoPE position
+    # Decode requests first.
+    for decode_request in decode_requests:
+        if len(decode_request) == 2:
+            block_ids, seq_len = decode_request
+            num_tokens = 1
+        else:
+            block_ids, seq_len, num_tokens = decode_request
+
+        for pos in range(seq_len, seq_len + num_tokens):
+            block_idx = block_ids[pos // block_size]
+            slot = block_idx * block_size + (pos % block_size)
+            slot_mapping.append(slot)
+            cu_seqlens.append(cu_seqlens[-1] + 1)
+            block_tables.append(block_ids)
+            context_lens.append(pos + 1)  # including this decode token
+            offsets.append(pos)  # RoPE position
 
     # Prefill requests (variable tokens each, starting at start_pos)
     for block_ids, num_tokens, start_pos in prefill_requests:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -72,6 +72,13 @@ from vllm_metal.v1.sampling_batch import (
     sample_from_logits,
     sample_prefill_tokens,
 )
+from vllm_metal.v1.spec_decode import (
+    PagedDecodeSegment,
+    build_paged_decode_segments,
+    unsupported_spec_decode_reason,
+    validate_greedy_spec_decode_sampling,
+    verify_greedy_spec_decode,
+)
 from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
 logger = init_logger(__name__)
@@ -198,7 +205,8 @@ class _PagedForwardState(NamedTuple):
     scheduler_output: SchedulerOutput
     logits: mx.array
     cu_seqlens: list[int]
-    num_decode: int
+    decode_segments: tuple[PagedDecodeSegment, ...]
+    num_decode_tokens: int
 
 
 class MetalModelRunner:
@@ -786,26 +794,47 @@ class MetalModelRunner:
         Stashes all state needed by ``sample_tokens`` in
         ``_execute_model_state`` (mirrors upstream's pattern).
         """
-        num_decode = len(decode_reqs)
+        decode_segments = build_paged_decode_segments(
+            decode_reqs,
+            scheduler_output.scheduled_spec_decode_tokens,
+            self._paged_request_seq_lens,
+        )
+        num_decode_tokens = sum(segment.num_query_tokens for segment in decode_segments)
+        has_scheduled_drafts = any(
+            segment.draft_token_ids for segment in decode_segments
+        )
+        if has_scheduled_drafts and self.is_hybrid:
+            raise NotImplementedError(
+                "Speculative decode verification is not supported for hybrid "
+                "GDN models on Metal yet."
+            )
+        if has_scheduled_drafts:
+            validate_greedy_spec_decode_sampling(
+                decode_reqs,
+                logitsprocs=self._logitsprocs,
+            )
 
         # ---- build unified token sequence: decode first, then prefill ----
         all_token_ids: list[int] = []
 
-        # Decode: last token per request
-        last_tokens = [
-            state.token_ids[-1] if state.token_ids else 0 for _, state in decode_reqs
-        ]
-        all_token_ids.extend(last_tokens)
+        # Decode: last token plus any scheduled draft tokens per request.
+        for segment in decode_segments:
+            all_token_ids.extend(segment.input_token_ids)
 
         # Prefill: tokens per request
         for pr in prefill_reqs:
             all_token_ids.extend(pr.token_ids)
 
         # ---- build metadata for prepare_unified ----
-        decode_info: list[tuple[list[int], int]] = []
-        for req_id, state in decode_reqs:
-            seq_len = self._paged_request_seq_lens.get(req_id, len(state.token_ids) - 1)
-            decode_info.append((state.block_ids, seq_len))
+        decode_info: list[tuple[list[int], int, int]] = []
+        for segment in decode_segments:
+            decode_info.append(
+                (
+                    list(segment.block_ids),
+                    segment.cache_start_pos,
+                    segment.num_query_tokens,
+                )
+            )
 
         prefill_info: list[tuple[list[int], int, int]] = []
         for pr in prefill_reqs:
@@ -846,8 +875,8 @@ class MetalModelRunner:
 
         # ---- build cu_seqlens for logit extraction ----
         cu_seqlens: list[int] = [0]
-        for _ in decode_reqs:
-            cu_seqlens.append(cu_seqlens[-1] + 1)
+        for segment in decode_segments:
+            cu_seqlens.append(cu_seqlens[-1] + segment.num_query_tokens)
         for pr in prefill_reqs:
             cu_seqlens.append(cu_seqlens[-1] + len(pr.token_ids))
 
@@ -858,7 +887,8 @@ class MetalModelRunner:
             scheduler_output=scheduler_output,
             logits=logits,
             cu_seqlens=cu_seqlens,
-            num_decode=num_decode,
+            decode_segments=decode_segments,
+            num_decode_tokens=num_decode_tokens,
         )
 
     def _sample_paged_batch(
@@ -879,7 +909,12 @@ class MetalModelRunner:
         scheduler_output = state.scheduler_output
         logits = state.logits
         cu_seqlens = state.cu_seqlens
-        num_decode = state.num_decode
+        decode_segments = state.decode_segments
+        num_decode_segments = len(decode_segments)
+        num_decode_tokens = state.num_decode_tokens
+        has_scheduled_drafts = any(
+            segment.draft_token_ids for segment in decode_segments
+        )
 
         # ---- wait for MLX forward to complete ----
         mx.eval(logits)
@@ -892,27 +927,39 @@ class MetalModelRunner:
                 decode_reqs,
                 prefill_reqs,
                 cu_seqlens,
-                num_decode,
+                num_decode_segments,
                 logits,
             )
 
         # ---- sample tokens ----
         vocab_size = self._vocab_size
         logitsprocs = self._logitsprocs
-        decode_result = sample_decode_tokens(
-            logits,
-            decode_reqs,
-            num_decode,
-            self._sampler,
-            self.device,
-            vocab_size=vocab_size,
-            logitsprocs=logitsprocs,
-        )
+        decode_logprobs: LogprobsLists | None = None
+        if has_scheduled_drafts:
+            decode_token_ids = verify_greedy_spec_decode(
+                logits,
+                decode_reqs,
+                decode_segments,
+                num_decode_tokens,
+                logitsprocs=logitsprocs,
+            )
+        else:
+            decode_result = sample_decode_tokens(
+                logits,
+                decode_reqs,
+                num_decode_tokens,
+                self._sampler,
+                self.device,
+                vocab_size=vocab_size,
+                logitsprocs=logitsprocs,
+            )
+            decode_token_ids = [[token_id] for token_id in decode_result.token_ids]
+            decode_logprobs = decode_result.logprobs
         prefill_result = sample_prefill_tokens(
             logits,
             prefill_reqs,
             cu_seqlens,
-            num_decode,
+            num_decode_segments,
             self._sampler,
             self.device,
             vocab_size=vocab_size,
@@ -921,11 +968,13 @@ class MetalModelRunner:
 
         # ---- update decode state ----
         for i, (req_id, state) in enumerate(decode_reqs):
-            state.token_ids.append(decode_result.token_ids[i])
-            state.generated_tokens += 1
-            self._paged_request_seq_lens[req_id] = (
-                self._paged_request_seq_lens.get(req_id, len(state.token_ids) - 2) + 1
-            )
+            sampled_ids = decode_token_ids[i]
+            state.token_ids.extend(sampled_ids)
+            state.generated_tokens += len(sampled_ids)
+            self._paged_request_seq_lens[req_id] = self._paged_request_seq_lens.get(
+                req_id,
+                len(state.token_ids) - len(sampled_ids) - 1,
+            ) + len(sampled_ids)
 
         # ---- update prefill seq lens ----
         for pr in prefill_reqs:
@@ -971,11 +1020,11 @@ class MetalModelRunner:
 
         for i, (req_id, _) in enumerate(batch.paged_decode_reqs):
             logprobs = (
-                decode_result.logprobs.slice_request(i, 1)
-                if decode_result.logprobs is not None
+                decode_logprobs.slice_request(i, 1)
+                if decode_logprobs is not None
                 else None
             )
-            batch.add_output(req_id, [decode_result.token_ids[i]], logprobs)
+            batch.add_output(req_id, decode_token_ids[i], logprobs)
 
         return batch, scheduler_output
 
@@ -1018,6 +1067,16 @@ class MetalModelRunner:
             "Multimodal encoder execution is not wired on Metal yet. "
             "Metal currently registers multimodal runtime state, but image "
             "encoding and embedding splice are not connected to the runner."
+        )
+
+    def _unsupported_spec_decode_reason(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> str | None:
+        return unsupported_spec_decode_reason(
+            scheduler_output.scheduled_spec_decode_tokens,
+            paged_attention_enabled=self._paged_attention_backend is not None,
+            is_hybrid=self.is_hybrid,
         )
 
     def _handle_new_requests(
@@ -1363,23 +1422,34 @@ class MetalModelRunner:
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
         has_scheduled_encoder_inputs = bool(scheduler_output.scheduled_encoder_inputs)
+        unsupported_spec_decode_reason = self._unsupported_spec_decode_reason(
+            scheduler_output
+        )
+        has_unsupported_non_paged_structured_output = (
+            self._paged_attention_backend is None
+            and scheduler_output.has_structured_output_requests
+        )
+        will_fail_fast_before_model_work = (
+            has_scheduled_encoder_inputs
+            or unsupported_spec_decode_reason is not None
+            or has_unsupported_non_paged_structured_output
+        )
 
         # Scheduler cleanup is independent of whether this step's work is
         # supported. If the next check raises, old request state must still be
         # evicted and any pending GDN release must be materialized now.
         self._cleanup_finished_requests(
             evicted_req_ids,
-            materialize_gdn_state=has_scheduled_encoder_inputs,
+            materialize_gdn_state=will_fail_fast_before_model_work,
         )
         self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
+        if unsupported_spec_decode_reason is not None:
+            raise NotImplementedError(unsupported_spec_decode_reason)
 
         # Fail fast before any model work runs.  On the non-paged path,
         # _handle_new_requests immediately calls _prefill_single for new
         # requests, so the guard must come before it — not after.
-        if (
-            self._paged_attention_backend is None
-            and scheduler_output.has_structured_output_requests
-        ):
+        if has_unsupported_non_paged_structured_output:
             raise NotImplementedError(
                 "Grammar/structured-output constraints are not supported on "
                 "the non-paged (legacy) Metal path. "

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -74,10 +74,7 @@ from vllm_metal.v1.sampling_batch import (
 )
 from vllm_metal.v1.spec_decode import (
     PagedDecodeSegment,
-    build_paged_decode_segments,
-    unsupported_spec_decode_reason,
-    validate_greedy_spec_decode_sampling,
-    verify_greedy_spec_decode,
+    SpeculativeDecodeController,
 )
 from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
@@ -237,6 +234,7 @@ class MetalModelRunner:
         self._model_adapter: ModelAdapter = DefaultModelAdapter()
         self._cache_policy = ModelCachePolicy(self, self._model_adapter)
         self._model_lifecycle = ModelLifecycle(self, self._model_adapter)
+        self._spec_decode_controller = SpeculativeDecodeController()
 
         self.model: Any = None
         self.tokenizer: Any = None
@@ -794,25 +792,12 @@ class MetalModelRunner:
         Stashes all state needed by ``sample_tokens`` in
         ``_execute_model_state`` (mirrors upstream's pattern).
         """
-        decode_segments = build_paged_decode_segments(
+        decode_segments = self._spec_decode_controller.build_decode_segments(
             decode_reqs,
             scheduler_output.scheduled_spec_decode_tokens,
             self._paged_request_seq_lens,
         )
         num_decode_tokens = sum(segment.num_query_tokens for segment in decode_segments)
-        has_scheduled_drafts = any(
-            segment.draft_token_ids for segment in decode_segments
-        )
-        if has_scheduled_drafts and self.is_hybrid:
-            raise NotImplementedError(
-                "Speculative decode verification is not supported for hybrid "
-                "GDN models on Metal yet."
-            )
-        if has_scheduled_drafts:
-            validate_greedy_spec_decode_sampling(
-                decode_reqs,
-                logitsprocs=self._logitsprocs,
-            )
 
         # ---- build unified token sequence: decode first, then prefill ----
         all_token_ids: list[int] = []
@@ -934,15 +919,80 @@ class MetalModelRunner:
         # ---- sample tokens ----
         vocab_size = self._vocab_size
         logitsprocs = self._logitsprocs
-        decode_logprobs: LogprobsLists | None = None
+        decode_token_ids: list[list[int]] = [[] for _ in decode_reqs]
+        decode_logprobs_rows: list[LogprobsLists | None] = [None for _ in decode_reqs]
         if has_scheduled_drafts:
-            decode_token_ids = verify_greedy_spec_decode(
-                logits,
-                decode_reqs,
-                decode_segments,
-                num_decode_tokens,
-                logitsprocs=logitsprocs,
-            )
+            spec_items = [
+                (i, req, segment)
+                for i, (req, segment) in enumerate(
+                    zip(decode_reqs, decode_segments, strict=True)
+                )
+                if segment.draft_token_ids
+            ]
+            if spec_items:
+                spec_token_ids = self._spec_decode_controller.verify_greedy(
+                    logits,
+                    [req for _, req, _ in spec_items],
+                    [segment for _, _, segment in spec_items],
+                    logitsprocs=logitsprocs,
+                )
+                for (decode_index, _, _), sampled_ids in zip(
+                    spec_items,
+                    spec_token_ids,
+                    strict=True,
+                ):
+                    decode_token_ids[decode_index] = sampled_ids
+
+            plain_items = [
+                (i, req, segment)
+                for i, (req, segment) in enumerate(
+                    zip(decode_reqs, decode_segments, strict=True)
+                )
+                if not segment.draft_token_ids
+            ]
+            if plain_items:
+                plain_logits = mx.stack(
+                    [logits[0, segment.start_row, :] for _, _, segment in plain_items]
+                )
+                plain_reqs = [req for _, req, _ in plain_items]
+                sampling_params_list = [
+                    state.sampling_params for _, state in plain_reqs
+                ]
+                prompt_token_ids_list = [
+                    state.token_ids[: state.prompt_len] for _, state in plain_reqs
+                ]
+                output_tokens_list = [
+                    state.token_ids[state.prompt_len :] for _, state in plain_reqs
+                ]
+                generators = {
+                    i: state.generator
+                    for i, (_, state) in enumerate(plain_reqs)
+                    if state.generator is not None
+                }
+                plain_batch = SamplingBatch(
+                    sampling_params_list,
+                    prompt_token_ids_list,
+                    output_tokens_list,
+                    vocab_size=vocab_size,
+                    device=self.device,
+                    logitsprocs=logitsprocs,
+                    generators=generators,
+                )
+                plain_result = sample_from_logits(
+                    plain_logits,
+                    plain_batch,
+                    self._sampler,
+                    self.device,
+                )
+                for plain_index, (decode_index, _, _) in enumerate(plain_items):
+                    decode_token_ids[decode_index] = [
+                        plain_result.token_ids[plain_index]
+                    ]
+                    if plain_result.logprobs is not None:
+                        decode_logprobs_rows[decode_index] = (
+                            plain_result.logprobs.slice_request(plain_index, 1)
+                        )
+            decode_logprobs = SamplingBatch.merge_logprobs_rows(decode_logprobs_rows)
         else:
             decode_result = sample_decode_tokens(
                 logits,
@@ -1069,14 +1119,31 @@ class MetalModelRunner:
             "encoding and embedding splice are not connected to the runner."
         )
 
-    def _unsupported_spec_decode_reason(
+    def _spec_decode_preflight_reqs(
         self,
         scheduler_output: SchedulerOutput,
-    ) -> str | None:
-        return unsupported_spec_decode_reason(
-            scheduler_output.scheduled_spec_decode_tokens,
+    ) -> tuple[tuple[str, RequestState], ...]:
+        """Return current decode requests without mutating runner state."""
+        if self._paged_attention_backend is None:
+            return ()
+
+        decode_reqs: list[tuple[str, RequestState]] = []
+        for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
+            state = self._request_states.get(req_id)
+            if state is not None and state.generated_tokens > 0:
+                decode_reqs.append((req_id, state))
+        return tuple(decode_reqs)
+
+    def _validate_spec_decode_supported(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        self._spec_decode_controller.validate_supported(
+            scheduler_output,
+            self._spec_decode_preflight_reqs(scheduler_output),
             paged_attention_enabled=self._paged_attention_backend is not None,
             is_hybrid=self.is_hybrid,
+            logitsprocs=self._logitsprocs,
         )
 
     def _handle_new_requests(
@@ -1422,16 +1489,18 @@ class MetalModelRunner:
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
         has_scheduled_encoder_inputs = bool(scheduler_output.scheduled_encoder_inputs)
-        unsupported_spec_decode_reason = self._unsupported_spec_decode_reason(
-            scheduler_output
-        )
+        spec_decode_error: Exception | None = None
+        try:
+            self._validate_spec_decode_supported(scheduler_output)
+        except (NotImplementedError, ValueError) as exc:
+            spec_decode_error = exc
         has_unsupported_non_paged_structured_output = (
             self._paged_attention_backend is None
             and scheduler_output.has_structured_output_requests
         )
         will_fail_fast_before_model_work = (
             has_scheduled_encoder_inputs
-            or unsupported_spec_decode_reason is not None
+            or spec_decode_error is not None
             or has_unsupported_non_paged_structured_output
         )
 
@@ -1443,8 +1512,8 @@ class MetalModelRunner:
             materialize_gdn_state=will_fail_fast_before_model_work,
         )
         self._reject_scheduled_encoder_inputs(scheduler_output.scheduled_encoder_inputs)
-        if unsupported_spec_decode_reason is not None:
-            raise NotImplementedError(unsupported_spec_decode_reason)
+        if spec_decode_error is not None:
+            raise spec_decode_error
 
         # Fail fast before any model work runs.  On the non-paged path,
         # _handle_new_requests immediately calls _prefill_single for new

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Paged decode metadata helpers for speculative token row spans."""
+"""Speculative decode ownership for the Metal paged target path."""
 
 from __future__ import annotations
 
@@ -8,6 +8,9 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 import mlx.core as mx
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 
 from vllm_metal.v1.sampling_batch import GREEDY_TEMPERATURE_EPS
 
@@ -19,6 +22,7 @@ class _PagedDecodeStateLike(Protocol):
 
 class _SpecDecodeRequestStateLike(Protocol):
     sampling_params: Any
+    generated_tokens: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,164 +62,235 @@ class PagedDecodeSegment:
         return self.start_row + len(self.draft_token_ids)
 
 
-def build_paged_decode_segments(
-    decode_reqs: Sequence[tuple[str, _PagedDecodeStateLike]],
-    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
-    paged_request_seq_lens: Mapping[str, int],
-) -> tuple[PagedDecodeSegment, ...]:
-    """Build row-span metadata for paged decode requests.
+class SpeculativeDecodeController:
+    """Owns Metal's current target-side speculative decode contract."""
 
-    The returned metadata mirrors the current no-draft decode shape when a
-    request has no scheduled draft tokens.
-    """
-    spec_tokens = scheduled_spec_decode_tokens or {}
-    segments: list[PagedDecodeSegment] = []
-    start_row = 0
+    def validate_supported(
+        self,
+        scheduler_output: SchedulerOutput,
+        decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
+        *,
+        paged_attention_enabled: bool,
+        is_hybrid: bool,
+        logitsprocs: LogitsProcessors | None,
+    ) -> None:
+        """Fail fast for unsupported or inconsistent scheduler handoffs."""
+        spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+        invalid_counts = scheduler_output.num_invalid_spec_tokens or {}
+        if not spec_tokens and not invalid_counts:
+            return
 
-    for req_id, state in decode_reqs:
-        token_ids = tuple(state.token_ids)
-        block_ids = tuple(state.block_ids)
-        draft_token_ids = tuple(spec_tokens.get(req_id, ()))
-        if any(token_id < 0 for token_id in draft_token_ids):
+        active_spec_tokens = {
+            req_id: tuple(tokens) for req_id, tokens in spec_tokens.items() if tokens
+        }
+        has_invalid_spec_tokens = any(count > 0 for count in invalid_counts.values())
+
+        if (
+            active_spec_tokens or has_invalid_spec_tokens
+        ) and not paged_attention_enabled:
+            raise NotImplementedError(
+                "Speculative decode verification on Metal requires paged "
+                "attention so draft-token rows can share scheduler-assigned "
+                "KV slots."
+            )
+        if (active_spec_tokens or has_invalid_spec_tokens) and is_hybrid:
+            raise NotImplementedError(
+                "Speculative decode verification is not supported for hybrid "
+                "GDN models on Metal yet."
+            )
+
+        decode_req_ids = {req_id for req_id, _ in decode_reqs}
+        unexpected_req_ids = sorted(set(spec_tokens) - decode_req_ids)
+        if unexpected_req_ids:
+            raise ValueError(
+                "Speculative decode scheduler handoff referenced requests "
+                f"outside the current decode set: {unexpected_req_ids}"
+            )
+
+        if has_invalid_spec_tokens:
             raise NotImplementedError(
                 "Speculative decode verification on Metal does not support "
-                "invalid draft-token sentinels yet."
+                "scheduler-invalid draft-token sentinels yet."
             )
-        last_token = token_ids[-1] if token_ids else 0
-        input_token_ids = (last_token, *draft_token_ids)
-        cache_start_pos = paged_request_seq_lens.get(req_id, len(token_ids) - 1)
 
-        segment = PagedDecodeSegment(
-            req_id=req_id,
-            input_token_ids=input_token_ids,
-            start_row=start_row,
-            num_query_tokens=len(input_token_ids),
-            draft_token_ids=draft_token_ids,
-            cache_start_pos=cache_start_pos,
-            block_ids=block_ids,
+        if not active_spec_tokens:
+            return
+
+        request_by_id = dict(decode_reqs)
+        draft_reqs: list[tuple[str, _SpecDecodeRequestStateLike]] = []
+        for req_id, draft_token_ids in active_spec_tokens.items():
+            if any(token_id < 0 for token_id in draft_token_ids):
+                raise NotImplementedError(
+                    "Speculative decode verification on Metal does not support "
+                    "invalid draft-token sentinels yet."
+                )
+
+            expected_num_scheduled = len(draft_token_ids) + 1
+            actual_num_scheduled = scheduler_output.num_scheduled_tokens.get(req_id)
+            if actual_num_scheduled != expected_num_scheduled:
+                raise ValueError(
+                    "Speculative decode scheduler handoff has inconsistent "
+                    f"token accounting for {req_id!r}: expected "
+                    f"{expected_num_scheduled}, got {actual_num_scheduled}"
+                )
+            draft_reqs.append((req_id, request_by_id[req_id]))
+
+        self._validate_greedy_sampling(draft_reqs, logitsprocs=logitsprocs)
+
+    def build_decode_segments(
+        self,
+        decode_reqs: Sequence[tuple[str, _PagedDecodeStateLike]],
+        scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
+        paged_request_seq_lens: Mapping[str, int],
+    ) -> tuple[PagedDecodeSegment, ...]:
+        """Build row-span metadata for paged decode requests."""
+        spec_tokens = scheduled_spec_decode_tokens or {}
+        decode_req_ids = {req_id for req_id, _ in decode_reqs}
+        unexpected_req_ids = sorted(set(spec_tokens) - decode_req_ids)
+        if unexpected_req_ids:
+            raise ValueError(
+                "Speculative decode scheduler handoff referenced requests "
+                f"outside the current decode set: {unexpected_req_ids}"
+            )
+
+        segments: list[PagedDecodeSegment] = []
+        start_row = 0
+
+        for req_id, state in decode_reqs:
+            token_ids = tuple(state.token_ids)
+            block_ids = tuple(state.block_ids)
+            draft_token_ids = tuple(spec_tokens.get(req_id, ()))
+            if any(token_id < 0 for token_id in draft_token_ids):
+                raise NotImplementedError(
+                    "Speculative decode verification on Metal does not support "
+                    "invalid draft-token sentinels yet."
+                )
+            last_token = token_ids[-1] if token_ids else 0
+            input_token_ids = (last_token, *draft_token_ids)
+            cache_start_pos = paged_request_seq_lens.get(req_id, len(token_ids) - 1)
+
+            segment = PagedDecodeSegment(
+                req_id=req_id,
+                input_token_ids=input_token_ids,
+                start_row=start_row,
+                num_query_tokens=len(input_token_ids),
+                draft_token_ids=draft_token_ids,
+                cache_start_pos=cache_start_pos,
+                block_ids=block_ids,
+            )
+            segments.append(segment)
+            start_row += segment.num_query_tokens
+
+        return tuple(segments)
+
+    def verify_greedy(
+        self,
+        logits: mx.array,
+        decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
+        decode_segments: Sequence[PagedDecodeSegment],
+        *,
+        logitsprocs: LogitsProcessors | None,
+    ) -> list[list[int]]:
+        """Verify scheduled draft tokens with greedy target logits."""
+        if len(decode_reqs) != len(decode_segments):
+            raise ValueError("decode_reqs and decode_segments must have equal length")
+
+        if not decode_segments:
+            return []
+
+        for (req_id, _), segment in zip(decode_reqs, decode_segments, strict=True):
+            if req_id != segment.req_id:
+                raise ValueError(
+                    "Speculative decode verification received mismatched request "
+                    f"metadata: {req_id!r} != {segment.req_id!r}"
+                )
+
+        self._validate_greedy_sampling(decode_reqs, logitsprocs=logitsprocs)
+
+        num_decode_rows = max(
+            segment.start_row + segment.num_query_tokens for segment in decode_segments
         )
-        segments.append(segment)
-        start_row += segment.num_query_tokens
+        target_tokens = mx.argmax(logits[0, :num_decode_rows, :], axis=-1)
+        mx.eval(target_tokens)
+        flat_target_tokens: list[int] = target_tokens.tolist()  # type: ignore[assignment]
 
-    return tuple(segments)
+        sampled_token_ids: list[list[int]] = []
+        for segment in decode_segments:
+            row_tokens = flat_target_tokens[
+                segment.start_row : segment.start_row + segment.num_query_tokens
+            ]
+            output_ids: list[int] = []
+            rejected = False
 
+            for draft_index, draft_token_id in enumerate(segment.draft_token_ids):
+                target_token_id = int(row_tokens[draft_index])
+                if target_token_id == draft_token_id:
+                    output_ids.append(draft_token_id)
+                    continue
 
-def has_scheduled_spec_decode_tokens(
-    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
-) -> bool:
-    """Return whether this scheduler output contains draft tokens."""
-    if not scheduled_spec_decode_tokens:
-        return False
-    return any(bool(tokens) for tokens in scheduled_spec_decode_tokens.values())
+                output_ids.append(target_token_id)
+                rejected = True
+                break
 
+            if not rejected:
+                output_ids.append(int(row_tokens[len(segment.draft_token_ids)]))
+            sampled_token_ids.append(output_ids)
 
-def unsupported_spec_decode_reason(
-    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
-    *,
-    paged_attention_enabled: bool,
-    is_hybrid: bool,
-) -> str | None:
-    """Return why this scheduled spec-decode step is unsupported, if any."""
-    if not has_scheduled_spec_decode_tokens(scheduled_spec_decode_tokens):
-        return None
+        return sampled_token_ids
 
-    if not paged_attention_enabled:
-        return (
-            "Speculative decode verification on Metal requires paged "
-            "attention so draft-token rows can share scheduler-assigned "
-            "KV slots."
-        )
-    if is_hybrid:
-        return (
-            "Speculative decode verification is not supported for hybrid "
-            "GDN models on Metal yet."
-        )
-    return None
+    def _validate_greedy_sampling(
+        self,
+        decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
+        *,
+        logitsprocs: LogitsProcessors | None,
+    ) -> None:
+        for _, request_state in decode_reqs:
+            sampling_params = request_state.sampling_params
+            unsupported = (
+                sampling_params.temperature >= GREEDY_TEMPERATURE_EPS
+                or sampling_params.top_k > 0
+                or sampling_params.top_p != 1.0
+                or sampling_params.frequency_penalty != 0.0
+                or sampling_params.presence_penalty != 0.0
+                or sampling_params.repetition_penalty != 1.0
+                or sampling_params.logprobs is not None
+                or bool(sampling_params.allowed_token_ids)
+                or bool(sampling_params.bad_words_token_ids)
+            )
+            if unsupported:
+                raise NotImplementedError(
+                    "Speculative decode verification on Metal currently "
+                    "supports greedy sampling only (temperature=0, no "
+                    "penalties, constraints, or logprobs)."
+                )
 
+            if (
+                sampling_params.min_tokens
+                and request_state.generated_tokens < sampling_params.min_tokens
+                and sampling_params.all_stop_token_ids
+            ):
+                raise NotImplementedError(
+                    "Speculative decode verification on Metal does not support "
+                    "active min_tokens constraints yet."
+                )
 
-def validate_greedy_spec_decode_sampling(
-    decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
-    *,
-    logitsprocs: Any | None = None,
-) -> None:
-    """Raise if this batch needs sampling behavior beyond greedy argmax."""
-    if getattr(logitsprocs, "non_argmax_invariant", ()):
-        raise NotImplementedError(
-            "Speculative decode verification on Metal currently supports "
-            "greedy sampling only; logits processors that can change argmax "
-            "are not supported."
-        )
+        if logitsprocs is None:
+            return
 
-    for _, request_state in decode_reqs:
-        sampling_params = request_state.sampling_params
-        unsupported = (
-            sampling_params.temperature >= GREEDY_TEMPERATURE_EPS
-            or sampling_params.top_k > 0
-            or sampling_params.top_p != 1.0
-            or sampling_params.frequency_penalty != 0.0
-            or sampling_params.presence_penalty != 0.0
-            or sampling_params.repetition_penalty != 1.0
-            or sampling_params.logprobs is not None
-            or bool(sampling_params.allowed_token_ids)
-            or bool(sampling_params.bad_words_token_ids)
-        )
-        if unsupported:
+        unsupported_processors = [
+            processor
+            for processor in logitsprocs.non_argmax_invariant
+            if not isinstance(processor, MinTokensLogitsProcessor)
+        ]
+        if unsupported_processors:
             raise NotImplementedError(
                 "Speculative decode verification on Metal currently supports "
-                "greedy sampling only (temperature=0, no penalties, "
-                "constraints, or logprobs)."
+                "greedy sampling only; non-argmax logits processors are not "
+                "supported."
             )
-
-
-def verify_greedy_spec_decode(
-    logits: mx.array,
-    decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
-    decode_segments: Sequence[PagedDecodeSegment],
-    num_decode_tokens: int,
-    *,
-    logitsprocs: Any | None = None,
-) -> list[list[int]]:
-    """Verify scheduled draft tokens with greedy target logits.
-
-    The target rows verify each draft token in order. If every draft token is
-    accepted, the final target row becomes the bonus token.
-    """
-    validate_greedy_spec_decode_sampling(decode_reqs, logitsprocs=logitsprocs)
-
-    target_tokens = mx.argmax(logits[0, :num_decode_tokens, :], axis=-1)
-    mx.eval(target_tokens)
-    flat_target_tokens: list[int] = target_tokens.tolist()  # type: ignore[assignment]
-
-    sampled_token_ids: list[list[int]] = []
-    for segment in decode_segments:
-        row_tokens = flat_target_tokens[
-            segment.start_row : segment.start_row + segment.num_query_tokens
-        ]
-        output_ids: list[int] = []
-        rejected = False
-
-        for draft_index, draft_token_id in enumerate(segment.draft_token_ids):
-            target_token_id = int(row_tokens[draft_index])
-            if target_token_id == draft_token_id:
-                output_ids.append(draft_token_id)
-                continue
-
-            output_ids.append(target_token_id)
-            rejected = True
-            break
-
-        if not rejected:
-            output_ids.append(int(row_tokens[len(segment.draft_token_ids)]))
-        sampled_token_ids.append(output_ids)
-
-    return sampled_token_ids
 
 
 __all__ = [
     "PagedDecodeSegment",
-    "build_paged_decode_segments",
-    "has_scheduled_spec_decode_tokens",
-    "unsupported_spec_decode_reason",
-    "validate_greedy_spec_decode_sampling",
-    "verify_greedy_spec_decode",
+    "SpeculativeDecodeController",
 ]

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
+
+import mlx.core as mx
+
+from vllm_metal.v1.sampling_batch import GREEDY_TEMPERATURE_EPS
 
 
 class _PagedDecodeStateLike(Protocol):
@@ -13,9 +17,19 @@ class _PagedDecodeStateLike(Protocol):
     block_ids: Sequence[int]
 
 
+class _SpecDecodeRequestStateLike(Protocol):
+    sampling_params: Any
+
+
 @dataclass(frozen=True, slots=True)
 class PagedDecodeSegment:
-    """Logits-row metadata for one paged decode request."""
+    """Logits-row metadata for one paged decode request.
+
+    ``input_token_ids`` is the target-model verification span:
+    ``[last_token, *draft_token_ids]``. Each input token produces one logits
+    row; draft rows verify scheduled draft tokens, and the final row is the
+    bonus token if all drafts are accepted.
+    """
 
     req_id: str
     input_token_ids: tuple[int, ...]
@@ -62,6 +76,11 @@ def build_paged_decode_segments(
         token_ids = tuple(state.token_ids)
         block_ids = tuple(state.block_ids)
         draft_token_ids = tuple(spec_tokens.get(req_id, ()))
+        if any(token_id < 0 for token_id in draft_token_ids):
+            raise NotImplementedError(
+                "Speculative decode verification on Metal does not support "
+                "invalid draft-token sentinels yet."
+            )
         last_token = token_ids[-1] if token_ids else 0
         input_token_ids = (last_token, *draft_token_ids)
         cache_start_pos = paged_request_seq_lens.get(req_id, len(token_ids) - 1)
@@ -81,7 +100,122 @@ def build_paged_decode_segments(
     return tuple(segments)
 
 
+def has_scheduled_spec_decode_tokens(
+    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
+) -> bool:
+    """Return whether this scheduler output contains draft tokens."""
+    if not scheduled_spec_decode_tokens:
+        return False
+    return any(bool(tokens) for tokens in scheduled_spec_decode_tokens.values())
+
+
+def unsupported_spec_decode_reason(
+    scheduled_spec_decode_tokens: Mapping[str, Sequence[int]] | None,
+    *,
+    paged_attention_enabled: bool,
+    is_hybrid: bool,
+) -> str | None:
+    """Return why this scheduled spec-decode step is unsupported, if any."""
+    if not has_scheduled_spec_decode_tokens(scheduled_spec_decode_tokens):
+        return None
+
+    if not paged_attention_enabled:
+        return (
+            "Speculative decode verification on Metal requires paged "
+            "attention so draft-token rows can share scheduler-assigned "
+            "KV slots."
+        )
+    if is_hybrid:
+        return (
+            "Speculative decode verification is not supported for hybrid "
+            "GDN models on Metal yet."
+        )
+    return None
+
+
+def validate_greedy_spec_decode_sampling(
+    decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
+    *,
+    logitsprocs: Any | None = None,
+) -> None:
+    """Raise if this batch needs sampling behavior beyond greedy argmax."""
+    if getattr(logitsprocs, "non_argmax_invariant", ()):
+        raise NotImplementedError(
+            "Speculative decode verification on Metal currently supports "
+            "greedy sampling only; logits processors that can change argmax "
+            "are not supported."
+        )
+
+    for _, request_state in decode_reqs:
+        sampling_params = request_state.sampling_params
+        unsupported = (
+            sampling_params.temperature >= GREEDY_TEMPERATURE_EPS
+            or sampling_params.top_k > 0
+            or sampling_params.top_p != 1.0
+            or sampling_params.frequency_penalty != 0.0
+            or sampling_params.presence_penalty != 0.0
+            or sampling_params.repetition_penalty != 1.0
+            or sampling_params.logprobs is not None
+            or bool(sampling_params.allowed_token_ids)
+            or bool(sampling_params.bad_words_token_ids)
+        )
+        if unsupported:
+            raise NotImplementedError(
+                "Speculative decode verification on Metal currently supports "
+                "greedy sampling only (temperature=0, no penalties, "
+                "constraints, or logprobs)."
+            )
+
+
+def verify_greedy_spec_decode(
+    logits: mx.array,
+    decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
+    decode_segments: Sequence[PagedDecodeSegment],
+    num_decode_tokens: int,
+    *,
+    logitsprocs: Any | None = None,
+) -> list[list[int]]:
+    """Verify scheduled draft tokens with greedy target logits.
+
+    The target rows verify each draft token in order. If every draft token is
+    accepted, the final target row becomes the bonus token.
+    """
+    validate_greedy_spec_decode_sampling(decode_reqs, logitsprocs=logitsprocs)
+
+    target_tokens = mx.argmax(logits[0, :num_decode_tokens, :], axis=-1)
+    mx.eval(target_tokens)
+    flat_target_tokens: list[int] = target_tokens.tolist()  # type: ignore[assignment]
+
+    sampled_token_ids: list[list[int]] = []
+    for segment in decode_segments:
+        row_tokens = flat_target_tokens[
+            segment.start_row : segment.start_row + segment.num_query_tokens
+        ]
+        output_ids: list[int] = []
+        rejected = False
+
+        for draft_index, draft_token_id in enumerate(segment.draft_token_ids):
+            target_token_id = int(row_tokens[draft_index])
+            if target_token_id == draft_token_id:
+                output_ids.append(draft_token_id)
+                continue
+
+            output_ids.append(target_token_id)
+            rejected = True
+            break
+
+        if not rejected:
+            output_ids.append(int(row_tokens[len(segment.draft_token_ids)]))
+        sampled_token_ids.append(output_ids)
+
+    return sampled_token_ids
+
+
 __all__ = [
     "PagedDecodeSegment",
     "build_paged_decode_segments",
+    "has_scheduled_spec_decode_tokens",
+    "unsupported_spec_decode_reason",
+    "validate_greedy_spec_decode_sampling",
+    "verify_greedy_spec_decode",
 ]

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -45,7 +45,7 @@ class MetalStructuredOutputApplier:
         """Apply grammar bitmask to paged-path logits of shape (1, total_tokens, vocab).
 
         Only the sample positions are constrained:
-        - Decode request i  → row i of logits[0]
+        - Decode request i  → row cu_seqlens[i] of logits[0]
         - Prefill request j → last-token row per sequence (from cu_seqlens)
 
         The CPU/xgrammar bridge copies only the constrained rows (n_constrained × vocab)
@@ -58,9 +58,9 @@ class MetalStructuredOutputApplier:
             grammar_output: Grammar bitmask and structured-output request IDs.
             decode_reqs: (req_id, RequestState) pairs in decode-batch order.
             prefill_reqs: PrefillRequest objects in prefill order.
-            cu_seqlens: Cumulative token counts: [0, 1, …, num_decode,
-                num_decode+len(pr0), …].  Used to locate last-token rows.
-            num_decode: Number of decode requests (prefix of the token dimension).
+            cu_seqlens: Cumulative token counts for decode verification spans
+                and prefill chunks. Used to locate sample rows.
+            num_decode: Number of decode requests/segments.
             logits: Full paged logits, shape (1, total_tokens, vocab).
 
         Returns:
@@ -103,8 +103,9 @@ class MetalStructuredOutputApplier:
         ):
             return logits
 
-        # cu_seqlens must be exactly [0, 1*decode, ..., +prefill_lens...]: one entry
-        # per decode token plus one per prefill sequence, plus the leading zero.
+        # cu_seqlens has one entry per decode segment plus one per prefill
+        # sequence, plus the leading zero. Decode segment lengths may be >1
+        # when earlier requests verify scheduled draft tokens.
         assert len(cu_seqlens) == num_decode + len(prefill_reqs) + 1, (
             f"cu_seqlens length {len(cu_seqlens)}, "
             f"expected num_decode={num_decode} + prefill_count={len(prefill_reqs)} + 1"
@@ -113,7 +114,7 @@ class MetalStructuredOutputApplier:
         # Build req_id → sample row index in logits[0].
         req_id_to_row: dict[str, int] = {}
         for i, (req_id, _) in enumerate(decode_reqs):
-            req_id_to_row[req_id] = i
+            req_id_to_row[req_id] = cu_seqlens[i]
         for j, pr in enumerate(prefill_reqs):
             # cu_seqlens[num_decode + j + 1] - 1 is the last token of prefill seq j.
             last_row = cu_seqlens[num_decode + j + 1] - 1


### PR DESCRIPTION
This adds target-side verification for scheduler-provided speculative decode tokens on the Metal paged decode path.

The PR does not add a drafter/assistant model yet. It only teaches the target model path how to consume `scheduled_spec_decode_tokens`, run verification rows for `[last_token, *draft_tokens]`, and emit the accepted draft tokens plus the bonus token when applicable.



- Add `vllm_metal/v1/spec_decode.py` for paged spec-decode metadata and greedy verification helpers.
- Extend `prepare_unified()` so decode requests can describe multiple verification rows.
- Update paged sampling to append multiple emitted tokens and keep paged sequence lengths in sync.
  - hybrid GDN models
  - non-greedy sampling / penalties / logprobs / constraints
  - logits processors that can change argmax
  - invalid draft-token sentinels
- Add focused tests for mixed plain/spec batches, accept/reject behavior, bonus tokens, structured-output interaction, and metadata row spans.