### PR TITLE
[STT] Fix Qwen3-ASR serving

### DIFF
--- a/tests/test_qwen3_asr.py
+++ b/tests/test_qwen3_asr.py
@@ -168,6 +168,16 @@ class TestAudioEncoderShapes:
 class TestQwen3Attention:
     """Tests for GQA with QK normalization."""
 
+    @staticmethod
+    def _rope_inputs(
+        config: Qwen3ASRTextConfig, seq: int, offset: int = 0
+    ) -> tuple[Qwen3InterleavedMRoPE, mx.array, mx.array]:
+        rope = Qwen3InterleavedMRoPE.from_config(config)
+        positions = mx.arange(offset, offset + seq)[None, :]
+        position_ids = mx.stack([positions, positions, positions], axis=1)
+        cos, sin = rope(position_ids, dtype=mx.float32)
+        return rope, cos, sin
+
     def test_mrope_outputs_shape(self) -> None:
         """Interleaved MRoPE should produce decoder cos/sin tensors."""
         rope = Qwen3InterleavedMRoPE(
@@ -182,6 +192,22 @@ class TestQwen3Attention:
 
         assert cos.shape == (1, 3, 16)
         assert sin.shape == (1, 3, 16)
+
+    def test_mrope_from_config_uses_rope_scaling(self) -> None:
+        """Interleaved MRoPE should use checkpoint rope_scaling metadata."""
+        config = Qwen3ASRTextConfig(
+            hidden_size=64,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            intermediate_size=128,
+            vocab_size=100,
+            rope_scaling={"mrope_section": [3, 3, 2]},
+        )
+
+        rope = Qwen3InterleavedMRoPE.from_config(config)
+
+        assert rope.mrope_section == [3, 3, 2]
 
     def test_head_counts(self) -> None:
         """GQA should have correct head counts."""
@@ -210,7 +236,8 @@ class TestQwen3Attention:
         )
         attn = Qwen3Attention(config, dtype=mx.float32)
         x = mx.random.normal((1, 5, 64))
-        out, cache = attn(x)
+        rope, cos, sin = self._rope_inputs(config, seq=5)
+        out, cache = attn(x, rope=rope, cos=cos, sin=sin)
         mx.eval(out)
         assert out.shape == (1, 5, 64)
         assert cache[0].shape == (1, 2, 5, 16)  # k: (B, n_kv_heads, L, head_dim)
@@ -227,10 +254,12 @@ class TestQwen3Attention:
         )
         attn = Qwen3Attention(config, dtype=mx.float32)
         x = mx.random.normal((1, 5, 64))
-        _, cache = attn(x)
+        rope, cos, sin = self._rope_inputs(config, seq=5)
+        _, cache = attn(x, rope=rope, cos=cos, sin=sin)
 
         x2 = mx.random.normal((1, 1, 64))
-        out2, cache2 = attn(x2, cache=cache)
+        _, cos2, sin2 = self._rope_inputs(config, seq=1, offset=5)
+        out2, cache2 = attn(x2, rope=rope, cos=cos2, sin=sin2, cache=cache)
         mx.eval(out2)
         assert out2.shape == (1, 1, 64)
         assert cache2[0].shape == (1, 2, 6, 16)  # 5 + 1 = 6

--- a/tests/test_qwen3_asr.py
+++ b/tests/test_qwen3_asr.py
@@ -26,6 +26,7 @@ from vllm_metal.stt.qwen3_asr.model import (
     AudioEncoder,
     Qwen3ASRModel,
     Qwen3Attention,
+    Qwen3InterleavedMRoPE,
     Qwen3LM,
 )
 from vllm_metal.stt.qwen3_asr.transcriber import Qwen3ASRTranscriber
@@ -62,6 +63,10 @@ class TestQwen3ASRConfigAdaptation:
                     vocab_size=151936,
                     rms_norm_eps=1e-6,
                     rope_theta=1000000.0,
+                    rope_scaling={
+                        "mrope_section": [24, 20, 20],
+                        "mrope_interleaved": True,
+                    },
                     tie_word_embeddings=True,
                 ),
                 audio_token_id=151676,
@@ -71,6 +76,10 @@ class TestQwen3ASRConfigAdaptation:
 
         assert config.audio_token_id == 151676
         assert config.eos_token_id == 151643
+        assert config.text_config.rope_scaling == {
+            "mrope_section": [24, 20, 20],
+            "mrope_interleaved": True,
+        }
 
 
 class TestCNNOutputLengths:
@@ -158,6 +167,21 @@ class TestAudioEncoderShapes:
 
 class TestQwen3Attention:
     """Tests for GQA with QK normalization."""
+
+    def test_mrope_outputs_shape(self) -> None:
+        """Interleaved MRoPE should produce decoder cos/sin tensors."""
+        rope = Qwen3InterleavedMRoPE(
+            head_dim=16,
+            rope_theta=1000000.0,
+            mrope_section=[3, 3, 2],
+        )
+        pos = mx.array([[[0, 1, 2], [0, 1, 2], [0, 1, 2]]], dtype=mx.int32)
+
+        cos, sin = rope(pos, dtype=mx.float32)
+        mx.eval(cos, sin)
+
+        assert cos.shape == (1, 3, 16)
+        assert sin.shape == (1, 3, 16)
 
     def test_head_counts(self) -> None:
         """GQA should have correct head counts."""

--- a/tests/test_stt_serve.py
+++ b/tests/test_stt_serve.py
@@ -42,6 +42,19 @@ class TestSTTServeRequestAdapter:
         assert normalized.prompt_token_ids == (1, 2)
         assert normalized.input_features is mel
 
+    def test_normalizes_qwen3_asr_vllm_feature_payload(self) -> None:
+        mel = np.zeros((128, 3000), dtype=np.float32)
+        field_elem = SimpleNamespace(data=mel)
+        feature_spec = SimpleNamespace(
+            data=UserDict({"input_audio_features": field_elem})
+        )
+
+        normalized = VLLMSTTRequestAdapter.from_vllm_request(
+            self._make_request(prompt_token_ids=[1, 2], mm_features=[feature_spec])
+        )
+
+        assert normalized.input_features is mel
+
     def test_rejects_empty_mm_features(self) -> None:
         request = self._make_request(req_id="broken-req", mm_features=[])
 

--- a/vllm_metal/stt/qwen3_asr/config.py
+++ b/vllm_metal/stt/qwen3_asr/config.py
@@ -8,6 +8,7 @@ shape helpers during planning/registration without pulling in the model stack.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from vllm.transformers_utils.configs.qwen3_asr import (
     Qwen3ASRConfig as VllmQwen3ASRConfig,
@@ -66,6 +67,7 @@ class Qwen3ASRTextConfig:
     vocab_size: int = 151936
     rms_norm_eps: float = 1e-6
     rope_theta: float = 1000000.0
+    rope_scaling: dict[str, Any] | None = None
     tie_word_embeddings: bool = True
 
 
@@ -111,6 +113,7 @@ class Qwen3ASRConfig:
             vocab_size=text.vocab_size,
             rms_norm_eps=text.rms_norm_eps,
             rope_theta=text.rope_theta,
+            rope_scaling=getattr(text, "rope_scaling", None),
             tie_word_embeddings=text.tie_word_embeddings,
         )
         config_kwargs = {

--- a/vllm_metal/stt/qwen3_asr/model.py
+++ b/vllm_metal/stt/qwen3_asr/model.py
@@ -11,10 +11,13 @@ import math
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 
 from .config import Qwen3ASRAudioConfig, Qwen3ASRConfig, Qwen3ASRTextConfig
+
+_DEFAULT_MROPE_SECTION = [24, 20, 20]
 
 # ===========================================================================
 # Audio Encoder Components
@@ -248,44 +251,93 @@ class Qwen3RMSNorm(nn.Module):
         return mx.fast.rms_norm(x, self.weight, self.eps)
 
 
-class Qwen3RotaryEmbedding(nn.Module):
-    """Rotary position embedding with interleaved application."""
+class Qwen3InterleavedMRoPE(nn.Module):
+    """Qwen3-ASR interleaved multi-dimensional rotary embedding.
 
-    def __init__(self, head_dim: int, rope_theta: float = 1000000.0):
+    Qwen3-ASR checkpoints use Qwen's 3D MRoPE layout with interleaved
+    frequency assignment across temporal/height/width dimensions. For ASR text
+    decoding the three position streams are identical, but the frequency
+    assignment still differs from the simple adjacent-pair RoPE used by a
+    vanilla Qwen3 decoder.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        rope_theta: float = 1000000.0,
+        mrope_section: list[int] | None = None,
+    ):
         super().__init__()
         self.head_dim = head_dim
         self.rope_theta = rope_theta
-        # Precompute inverse frequencies
+        self.half_dim = head_dim // 2
+        self.mrope_section = mrope_section or self._default_mrope_section()
+        if sum(self.mrope_section) != self.half_dim:
+            raise ValueError(
+                "mrope_section must sum to head_dim // 2; "
+                f"got {self.mrope_section} for head_dim={head_dim}"
+            )
+
         inv_freq = 1.0 / (
             rope_theta ** (mx.arange(0, head_dim, 2).astype(mx.float32) / head_dim)
         )
         self._inv_freq = inv_freq
 
-    def __call__(self, x: mx.array, offset: int = 0) -> mx.array:
-        """Apply rotary embedding to x.
+        masks = []
+        for dim, offset in enumerate((1, 2), start=1):
+            stop = min(self.mrope_section[dim] * 3, self.half_dim)
+            indices = np.arange(offset, stop, 3, dtype=np.int32)
+            mask = np.zeros(self.half_dim, dtype=bool)
+            mask[indices] = True
+            masks.append(mx.array(mask[None, None, :]))
+        self._overwrite_masks = masks
 
-        Args:
-            x: (batch, n_heads, seq_len, head_dim)
-            offset: position offset for cached decoding.
-        """
-        seq_len = x.shape[2]
-        positions = mx.arange(offset, offset + seq_len, dtype=mx.float32)
-        freqs = positions[:, None] * self._inv_freq[None, :]  # (seq, head_dim/2)
-        # Interleaved: apply cos/sin to consecutive pairs
-        cos_f = mx.cos(freqs).astype(x.dtype)
-        sin_f = mx.sin(freqs).astype(x.dtype)
+    def _default_mrope_section(self) -> list[int]:
+        if self.half_dim == sum(_DEFAULT_MROPE_SECTION):
+            return list(_DEFAULT_MROPE_SECTION)
 
-        # Reshape for interleaved application
-        # x pairs: (x0, x1), (x2, x3), ...
-        x1 = x[..., 0::2]  # even indices
-        x2 = x[..., 1::2]  # odd indices
+        first = self.half_dim // 3
+        second = self.half_dim // 3
+        third = self.half_dim - first - second
+        return [first, second, third]
 
-        # Rotate
-        o1 = x1 * cos_f - x2 * sin_f
-        o2 = x1 * sin_f + x2 * cos_f
+    def __call__(
+        self, position_ids: mx.array, dtype: mx.Dtype
+    ) -> tuple[mx.array, mx.array]:
+        """Return cos/sin tensors for ``position_ids`` of shape ``(B, 3, L)``."""
+        pos = position_ids.astype(mx.float32).transpose(1, 0, 2)[..., None]
+        freqs = pos * self._inv_freq[None, None, None, :]
+        freqs_t = freqs[0]
+        for dim, mask in enumerate(self._overwrite_masks, start=1):
+            freqs_t = mx.where(mask, freqs[dim], freqs_t)
 
-        # Interleave back: stack pairs then reshape
-        return mx.stack([o1, o2], axis=-1).reshape(x.shape)
+        emb = mx.concatenate([freqs_t, freqs_t], axis=-1)
+        return mx.cos(emb).astype(dtype), mx.sin(emb).astype(dtype)
+
+
+def _rotate_half(x: mx.array) -> mx.array:
+    mid = x.shape[-1] // 2
+    return mx.concatenate([-x[..., mid:], x[..., :mid]], axis=-1)
+
+
+def _apply_rotary_pos_emb(
+    q: mx.array,
+    k: mx.array,
+    cos: mx.array,
+    sin: mx.array,
+) -> tuple[mx.array, mx.array]:
+    cos = cos[:, None, :, :]
+    sin = sin[:, None, :, :]
+    return q * cos + _rotate_half(q) * sin, k * cos + _rotate_half(k) * sin
+
+
+def _mrope_section_from_config(config: Qwen3ASRTextConfig) -> list[int] | None:
+    rope_scaling = config.rope_scaling
+    if isinstance(rope_scaling, dict):
+        section = rope_scaling.get("mrope_section")
+        if section:
+            return list(section)
+    return None
 
 
 class Qwen3Attention(nn.Module):
@@ -315,12 +367,18 @@ class Qwen3Attention(nn.Module):
         self.q_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
-        self.rope = Qwen3RotaryEmbedding(self.head_dim, config.rope_theta)
+        self.rope = Qwen3InterleavedMRoPE(
+            self.head_dim,
+            config.rope_theta,
+            _mrope_section_from_config(config),
+        )
         self.scale = self.head_dim**-0.5
 
     def __call__(
         self,
         x: mx.array,
+        cos: mx.array | None = None,
+        sin: mx.array | None = None,
         mask: mx.array | None = None,
         cache: tuple[mx.array, mx.array] | None = None,
     ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
@@ -339,10 +397,12 @@ class Qwen3Attention(nn.Module):
         k = k.transpose(0, 2, 1, 3)
         v = v.transpose(0, 2, 1, 3)
 
-        # Apply RoPE
         offset = cache[0].shape[2] if cache is not None else 0
-        q = self.rope(q, offset=offset)
-        k = self.rope(k, offset=offset)
+        if cos is None or sin is None:
+            positions = mx.arange(offset, offset + seq)[None, :]
+            position_ids = mx.stack([positions, positions, positions], axis=1)
+            cos, sin = self.rope(position_ids, dtype=x.dtype)
+        q, k = _apply_rotary_pos_emb(q, k, cos, sin)
 
         # KV cache
         if cache is not None:
@@ -398,10 +458,18 @@ class Qwen3DecoderLayer(nn.Module):
     def __call__(
         self,
         x: mx.array,
+        cos: mx.array | None = None,
+        sin: mx.array | None = None,
         mask: mx.array | None = None,
         cache: tuple[mx.array, mx.array] | None = None,
     ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
-        r, new_cache = self.self_attn(self.input_layernorm(x), mask=mask, cache=cache)
+        r, new_cache = self.self_attn(
+            self.input_layernorm(x),
+            cos=cos,
+            sin=sin,
+            mask=mask,
+            cache=cache,
+        )
         x = x + r
         x = x + self.mlp(self.post_attention_layernorm(x))
         return x, new_cache
@@ -423,6 +491,11 @@ class Qwen3LM(nn.Module):
             self.lm_head = None
         else:
             self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.rope = Qwen3InterleavedMRoPE(
+            config.head_dim,
+            config.rope_theta,
+            _mrope_section_from_config(config),
+        )
 
     def embed(self, token_ids: mx.array) -> mx.array:
         """Convert token IDs to embeddings."""
@@ -443,6 +516,9 @@ class Qwen3LM(nn.Module):
         else:
             offset = 0
         total_len = offset + seq
+        positions = mx.arange(offset, offset + seq)[None, :]
+        position_ids = mx.stack([positions, positions, positions], axis=1)
+        cos, sin = self.rope(position_ids, dtype=h.dtype)
         if seq > 1:
             mask = nn.MultiHeadAttention.create_additive_causal_mask(total_len)
             mask = mask.astype(h.dtype)
@@ -455,7 +531,7 @@ class Qwen3LM(nn.Module):
 
         new_cache = []
         for i, layer in enumerate(self.layers):
-            h, layer_cache = layer(h, mask=mask, cache=cache[i])
+            h, layer_cache = layer(h, cos=cos, sin=sin, mask=mask, cache=cache[i])
             new_cache.append(layer_cache)
 
         h = self.norm(h)

--- a/vllm_metal/stt/qwen3_asr/model.py
+++ b/vllm_metal/stt/qwen3_asr/model.py
@@ -314,30 +314,42 @@ class Qwen3InterleavedMRoPE(nn.Module):
         emb = mx.concatenate([freqs_t, freqs_t], axis=-1)
         return mx.cos(emb).astype(dtype), mx.sin(emb).astype(dtype)
 
+    @classmethod
+    def from_config(cls, config: Qwen3ASRTextConfig) -> Qwen3InterleavedMRoPE:
+        """Build RoPE from Qwen3-ASR text config."""
+        return cls(
+            config.head_dim,
+            config.rope_theta,
+            cls._mrope_section_from_config(config),
+        )
 
-def _rotate_half(x: mx.array) -> mx.array:
-    mid = x.shape[-1] // 2
-    return mx.concatenate([-x[..., mid:], x[..., :mid]], axis=-1)
+    def apply(
+        self,
+        q: mx.array,
+        k: mx.array,
+        cos: mx.array,
+        sin: mx.array,
+    ) -> tuple[mx.array, mx.array]:
+        """Apply this RoPE instance to query/key tensors."""
+        cos = cos[:, None, :, :]
+        sin = sin[:, None, :, :]
+        return q * cos + self._rotate_half(q) * sin, k * cos + self._rotate_half(
+            k
+        ) * sin
 
+    @staticmethod
+    def _rotate_half(x: mx.array) -> mx.array:
+        mid = x.shape[-1] // 2
+        return mx.concatenate([-x[..., mid:], x[..., :mid]], axis=-1)
 
-def _apply_rotary_pos_emb(
-    q: mx.array,
-    k: mx.array,
-    cos: mx.array,
-    sin: mx.array,
-) -> tuple[mx.array, mx.array]:
-    cos = cos[:, None, :, :]
-    sin = sin[:, None, :, :]
-    return q * cos + _rotate_half(q) * sin, k * cos + _rotate_half(k) * sin
-
-
-def _mrope_section_from_config(config: Qwen3ASRTextConfig) -> list[int] | None:
-    rope_scaling = config.rope_scaling
-    if isinstance(rope_scaling, dict):
-        section = rope_scaling.get("mrope_section")
-        if section:
-            return list(section)
-    return None
+    @staticmethod
+    def _mrope_section_from_config(config: Qwen3ASRTextConfig) -> list[int] | None:
+        rope_scaling = config.rope_scaling
+        if isinstance(rope_scaling, dict):
+            section = rope_scaling.get("mrope_section")
+            if section:
+                return list(section)
+        return None
 
 
 class Qwen3Attention(nn.Module):
@@ -367,18 +379,14 @@ class Qwen3Attention(nn.Module):
         self.q_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
 
-        self.rope = Qwen3InterleavedMRoPE(
-            self.head_dim,
-            config.rope_theta,
-            _mrope_section_from_config(config),
-        )
         self.scale = self.head_dim**-0.5
 
     def __call__(
         self,
         x: mx.array,
-        cos: mx.array | None = None,
-        sin: mx.array | None = None,
+        rope: Qwen3InterleavedMRoPE,
+        cos: mx.array,
+        sin: mx.array,
         mask: mx.array | None = None,
         cache: tuple[mx.array, mx.array] | None = None,
     ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
@@ -397,12 +405,7 @@ class Qwen3Attention(nn.Module):
         k = k.transpose(0, 2, 1, 3)
         v = v.transpose(0, 2, 1, 3)
 
-        offset = cache[0].shape[2] if cache is not None else 0
-        if cos is None or sin is None:
-            positions = mx.arange(offset, offset + seq)[None, :]
-            position_ids = mx.stack([positions, positions, positions], axis=1)
-            cos, sin = self.rope(position_ids, dtype=x.dtype)
-        q, k = _apply_rotary_pos_emb(q, k, cos, sin)
+        q, k = rope.apply(q, k, cos, sin)
 
         # KV cache
         if cache is not None:
@@ -458,13 +461,15 @@ class Qwen3DecoderLayer(nn.Module):
     def __call__(
         self,
         x: mx.array,
-        cos: mx.array | None = None,
-        sin: mx.array | None = None,
+        rope: Qwen3InterleavedMRoPE,
+        cos: mx.array,
+        sin: mx.array,
         mask: mx.array | None = None,
         cache: tuple[mx.array, mx.array] | None = None,
     ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
         r, new_cache = self.self_attn(
             self.input_layernorm(x),
+            rope=rope,
             cos=cos,
             sin=sin,
             mask=mask,
@@ -491,11 +496,7 @@ class Qwen3LM(nn.Module):
             self.lm_head = None
         else:
             self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
-        self.rope = Qwen3InterleavedMRoPE(
-            config.head_dim,
-            config.rope_theta,
-            _mrope_section_from_config(config),
-        )
+        self.rope = Qwen3InterleavedMRoPE.from_config(config)
 
     def embed(self, token_ids: mx.array) -> mx.array:
         """Convert token IDs to embeddings."""
@@ -531,7 +532,14 @@ class Qwen3LM(nn.Module):
 
         new_cache = []
         for i, layer in enumerate(self.layers):
-            h, layer_cache = layer(h, cos=cos, sin=sin, mask=mask, cache=cache[i])
+            h, layer_cache = layer(
+                h,
+                rope=self.rope,
+                cos=cos,
+                sin=sin,
+                mask=mask,
+                cache=cache[i],
+            )
             new_cache.append(layer_cache)
 
         h = self.norm(h)

--- a/vllm_metal/stt/serve.py
+++ b/vllm_metal/stt/serve.py
@@ -43,6 +43,7 @@ class VLLMSTTRequestAdapter:
         For STT, we currently assume one audio feature per request and unwrap:
 
         - `mm_features[0].data["input_features"].data`
+        - `mm_features[0].data["input_audio_features"].data`
 
         Each `.data` layer may be `None` (e.g. cached/absent), so we treat any
         missing/None value as an invalid STT request and raise a request-scoped
@@ -52,9 +53,16 @@ class VLLMSTTRequestAdapter:
             raise ValueError(f"STT request {req_id!r} must include mm_features.")
 
         payload = mm_features[0].data
-        field_elem = payload.get("input_features") if payload else None
+        field_elem = None
+        if payload:
+            field_elem = payload.get("input_features")
+            if field_elem is None:
+                field_elem = payload.get("input_audio_features")
         input_features = field_elem.data if field_elem is not None else None
         if input_features is None:
-            raise ValueError(f"STT request {req_id!r} must include input_features.")
+            raise ValueError(
+                f"STT request {req_id!r} must include input_features "
+                "or input_audio_features."
+            )
 
         return input_features


### PR DESCRIPTION
## Summary
- accept vLLM Qwen3-ASR `input_audio_features` payloads at the STT serve boundary
- preserve Qwen3-ASR `rope_scaling` when adapting the vLLM config
- use Qwen3-ASR interleaved MRoPE for MLX text decoding

## Why
The public STT documentation says vllm-metal supports OpenAI-compatible STT with Qwen3-ASR on Apple Silicon and lists `Qwen/Qwen3-ASR-0.6B` under supported models: https://docs.vllm.ai/projects/vllm-metal/en/latest/stt/

Following that documented path currently fails for Qwen3-ASR: the STT server rejects vLLM's `input_audio_features` payload, and after accepting it, MLX decoding still needs Qwen3-ASR interleaved MRoPE to avoid bad text.

## Root cause
The STT server adapter only accepted `input_features`, but vLLM's Qwen3-ASR multimodal pipeline emits `input_audio_features`. After that is fixed, the local MLX Qwen3 decoder still needs the checkpoint's interleaved MRoPE layout; using plain RoPE produces bad decoded text.

## Testing
- `python -m ruff check vllm_metal/stt/serve.py vllm_metal/stt/qwen3_asr/config.py vllm_metal/stt/qwen3_asr/model.py tests/test_stt_serve.py tests/test_qwen3_asr.py`
- `python -m pytest tests/test_stt_serve.py tests/test_qwen3_asr.py -q`
- manual: `vllm serve Qwen/Qwen3-ASR-0.6B --port 8125 --host 127.0.0.1` plus POST `/v1/audio/transcriptions` returned HTTP 200 on a 10s WAV