### PR TITLE
Capture target hidden states for Gemma4 MTP

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import torch
@@ -30,6 +31,7 @@ def make_stub_runner(
     _model_args = model_args or {}
 
     defaults: dict[str, Any] = {
+        "vllm_config": SimpleNamespace(speculative_config=None),
         "model": object(),
         "_is_stt": False,
         "_is_vlm": False,

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -580,6 +580,7 @@ class TestSampleTokensGrammarPagedPath:
             decode_reqs=decode_reqs,
             scheduler_output=scheduler_output,
             logits=logits,
+            target_hidden_states=None,
             cu_seqlens=[0, 1],
             decode_segments=(
                 mr.PagedDecodeSegment(

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -3,12 +3,16 @@
 
 from types import SimpleNamespace
 
+import mlx.core as mx
 import pytest
 
 import vllm_metal.envs as envs
 from vllm_metal.config import reset_config
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
-from vllm_metal.v1.model_adapter import DefaultModelAdapter
+from vllm_metal.v1.model_adapter import (
+    DefaultModelAdapter,
+    TargetModelForwardOutput,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -114,6 +118,104 @@ class TestShouldForceTextBackbone:
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(None)
         assert result is False
+
+
+class TestTargetForward:
+    def test_plain_forward_extracts_logits_without_hidden_states(self) -> None:
+        class Model:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0]]])
+
+        output = DefaultModelAdapter().target_forward(
+            Model(),
+            mx.array([[1]]),
+            cache=[],
+            collect_hidden_states=False,
+        )
+
+        assert isinstance(output, TargetModelForwardOutput)
+        assert output.logits.tolist() == [[[1.0, 2.0]]]
+        assert output.hidden_states is None
+
+    def test_collects_hidden_states_and_recomputes_logits(self) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[-2.0, 0.0, 2.0]]])
+
+        class Head:
+            def __call__(self, hidden_states):
+                return hidden_states * 3.0
+
+        model = SimpleNamespace(
+            model=Backbone(),
+            lm_head=Head(),
+            final_logit_softcapping=2.0,
+        )
+
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[1]]),
+            cache=[],
+            collect_hidden_states=True,
+        )
+
+        expected_logits = mx.tanh(mx.array([[[-2.0, 0.0, 2.0]]]) * 3.0 / 2.0) * 2.0
+        mx.eval(output.logits, expected_logits)
+        assert output.hidden_states.tolist() == [[-2.0, 0.0, 2.0]]
+        assert mx.allclose(output.logits, expected_logits).item()
+
+    def test_collects_hidden_states_with_model_owned_compute_logits(self) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0]]])
+
+        class Model:
+            def __init__(self) -> None:
+                self.model = Backbone()
+                self.final_logit_softcapping = 2.0
+
+            def compute_logits(self, hidden_states):
+                return hidden_states * 3.0
+
+        output = DefaultModelAdapter().target_forward(
+            Model(),
+            mx.array([[1]]),
+            cache=[],
+            collect_hidden_states=True,
+        )
+
+        assert output.hidden_states.tolist() == [[1.0, 2.0]]
+        assert output.logits.tolist() == [[[3.0, 6.0]]]
+
+    def test_collects_hidden_states_with_gemma4_tied_embedding_logits(self) -> None:
+        class Embedding:
+            def as_linear(self, hidden_states):
+                return hidden_states + 5.0
+
+        class Backbone:
+            def __init__(self) -> None:
+                self.embed_tokens = Embedding()
+
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0]]])
+
+        model = SimpleNamespace(model=Backbone(), final_logit_softcapping=2.0)
+
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[1]]),
+            cache=[],
+            collect_hidden_states=True,
+        )
+
+        expected_logits = mx.tanh((mx.array([[[1.0, 2.0]]]) + 5.0) / 2.0) * 2.0
+        mx.eval(output.logits, expected_logits)
+        assert output.hidden_states.tolist() == [[1.0, 2.0]]
+        assert mx.allclose(output.logits, expected_logits).item()
 
 
 class TestNormalizeModelConfig:

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -217,6 +217,26 @@ class TestTargetForward:
         assert output.hidden_states.tolist() == [[1.0, 2.0]]
         assert mx.allclose(output.logits, expected_logits).item()
 
+    def test_rejects_batched_target_hidden_states(self) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.zeros((2, 1, 4))
+
+        class Head:
+            def __call__(self, hidden_states):
+                return hidden_states
+
+        model = SimpleNamespace(model=Backbone(), lm_head=Head())
+
+        with pytest.raises(ValueError, match="row-major"):
+            DefaultModelAdapter().target_forward(
+                model,
+                mx.array([[1]]),
+                cache=[],
+                collect_hidden_states=True,
+            )
+
 
 class TestNormalizeModelConfig:
     """Tests for normalize_model_config()."""

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -73,7 +73,10 @@ def _gemma4_mtp_speculative_config() -> SimpleNamespace:
     return SimpleNamespace(
         method="mtp",
         draft_model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(model_type="gemma4_mtp")
+            hf_config=SimpleNamespace(
+                model_type="gemma4_assistant",
+                architectures=["Gemma4AssistantForCausalLM"],
+            )
         ),
     )
 
@@ -276,6 +279,28 @@ class TestBuildPagedDecodeSegments:
         )
 
         assert not controller.needs_target_hidden_states(
+            segments,
+            speculative_config=speculative_config,
+        )
+
+    def test_target_hidden_states_detect_mapped_gemma4_mtp_architecture(self) -> None:
+        controller = SpeculativeDecodeController()
+        speculative_config = SimpleNamespace(
+            method="mtp",
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    model_type="unknown",
+                    architectures=["Gemma4MTPModel"],
+                )
+            ),
+        )
+        segments = controller.build_decode_segments(
+            [("r0", _state([1, 2], [10]))],
+            scheduled_spec_decode_tokens={"r0": [3]},
+            paged_request_seq_lens={"r0": 1},
+        )
+
+        assert controller.needs_target_hidden_states(
             segments,
             speculative_config=speculative_config,
         )

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -69,6 +69,15 @@ def _spec_logitsprocs():
     )
 
 
+def _gemma4_mtp_speculative_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        method="mtp",
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="gemma4_mtp")
+        ),
+    )
+
+
 def _logits(token_ids: list[int], vocab_size: int = 16) -> mx.array:
     rows = []
     for token_id in token_ids:
@@ -180,6 +189,96 @@ class TestBuildPagedDecodeSegments:
                 scheduled_spec_decode_tokens={"r0": [-1]},
                 paged_request_seq_lens={"r0": 1},
             )
+
+    def test_target_hidden_states_follow_gemma4_mtp_config(self) -> None:
+        controller = SpeculativeDecodeController()
+
+        plain_segments = controller.build_decode_segments(
+            [("r0", _state([1, 2], [10]))],
+            scheduled_spec_decode_tokens={},
+            paged_request_seq_lens={"r0": 1},
+        )
+        draft_segments = controller.build_decode_segments(
+            [("r0", _state([1, 2], [10]))],
+            scheduled_spec_decode_tokens={"r0": [3]},
+            paged_request_seq_lens={"r0": 1},
+        )
+
+        assert not controller.needs_target_hidden_states(plain_segments)
+        assert not controller.needs_target_hidden_states(draft_segments)
+        assert controller.needs_target_hidden_states(
+            draft_segments,
+            speculative_config=_gemma4_mtp_speculative_config(),
+        )
+
+    def test_target_hidden_states_are_needed_for_gemma4_mtp_first_step(self) -> None:
+        controller = SpeculativeDecodeController()
+        segments = controller.build_decode_segments(
+            [("r0", _state([1, 2], [10]))],
+            scheduled_spec_decode_tokens={},
+            paged_request_seq_lens={"r0": 1},
+        )
+
+        assert controller.needs_target_hidden_states(
+            segments,
+            speculative_config=_gemma4_mtp_speculative_config(),
+        )
+
+    def test_target_hidden_states_are_needed_for_gemma4_mtp_final_prefill(
+        self,
+    ) -> None:
+        controller = SpeculativeDecodeController()
+
+        assert controller.needs_target_hidden_states(
+            (),
+            has_final_prefill=True,
+            speculative_config=_gemma4_mtp_speculative_config(),
+        )
+
+    def test_target_hidden_states_skip_gemma4_mtp_intermediate_prefill(self) -> None:
+        controller = SpeculativeDecodeController()
+
+        assert not controller.needs_target_hidden_states(
+            (),
+            has_final_prefill=False,
+            speculative_config=_gemma4_mtp_speculative_config(),
+        )
+
+    def test_target_hidden_states_are_not_needed_for_non_gemma4_spec(self) -> None:
+        controller = SpeculativeDecodeController()
+        speculative_config = SimpleNamespace(
+            method="ngram",
+            draft_model_config=None,
+        )
+        segments = controller.build_decode_segments(
+            [("r0", _state([1, 2], [10]))],
+            scheduled_spec_decode_tokens={"r0": [3]},
+            paged_request_seq_lens={"r0": 1},
+        )
+
+        assert not controller.needs_target_hidden_states(
+            segments,
+            speculative_config=speculative_config,
+        )
+
+    def test_target_hidden_states_are_not_needed_for_non_gemma4_mtp(self) -> None:
+        controller = SpeculativeDecodeController()
+        speculative_config = SimpleNamespace(
+            method="mtp",
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type="eagle")
+            ),
+        )
+        segments = controller.build_decode_segments(
+            [("r0", _state([1, 2], [10]))],
+            scheduled_spec_decode_tokens={"r0": [3]},
+            paged_request_seq_lens={"r0": 1},
+        )
+
+        assert not controller.needs_target_hidden_states(
+            segments,
+            speculative_config=speculative_config,
+        )
 
 
 class TestSpecDecodePolicy:

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -174,6 +174,16 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             finished_req_ids=set(),
         )
 
+    def _make_gemma4_mtp_config(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            speculative_config=SimpleNamespace(
+                method="mtp",
+                draft_model_config=SimpleNamespace(
+                    hf_config=SimpleNamespace(model_type="gemma4_mtp")
+                ),
+            )
+        )
+
     def _make_grammar_output(
         self,
         req_ids: list[str],
@@ -203,6 +213,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             decode_reqs=decode_reqs,
             scheduler_output=scheduler_output,
             logits=logits,
+            target_hidden_states=None,
             cu_seqlens=[
                 0,
                 *[s.start_row + s.num_query_tokens for s in decode_segments],
@@ -213,6 +224,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
 
     def test_start_paged_forward_includes_scheduled_drafts(self, monkeypatch) -> None:
         runner = self._make_runner()
+        runner.vllm_config = self._make_gemma4_mtp_config()
         runner.num_layers = 0
         runner._paged_block_size = 4
         runner._paged_request_seq_lens["r0"] = 1
@@ -224,14 +236,17 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_forward_model(input_ids, *, cache):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
             del cache
             captured["input_ids"] = input_ids.tolist()
-            return mx.zeros((1, 3, 16))
+            captured["collect_hidden_states"] = collect_hidden_states
+            return mr.TargetModelForwardOutput(
+                logits=mx.zeros((1, 3, 16)),
+                hidden_states=mx.ones((3, 4)),
+            )
 
         monkeypatch.setattr(mr, "prepare_unified", fake_prepare_unified)
-        runner.model = fake_forward_model
-        runner._extract_logits = lambda model_output: model_output
+        monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
 
         req_state = self._make_state([1, 6])
         req_state.block_ids = [0, 1]
@@ -248,11 +263,214 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         )
 
         assert captured["input_ids"] == [[6, 7, 8]]
+        assert captured["collect_hidden_states"] is True
         assert captured["decode_info"] == [([0, 1], 1, 3)]
         assert captured["prefill_info"] == []
         assert captured["block_size"] == 4
         assert runner._execute_model_state is not None
+        assert runner._execute_model_state.target_hidden_states is not None
         assert runner._execute_model_state.cu_seqlens == [0, 3]
+
+    def test_start_paged_forward_skips_hidden_states_without_drafts(
+        self, monkeypatch
+    ) -> None:
+        runner = self._make_runner()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+        runner._paged_request_seq_lens["r0"] = 1
+
+        captured: dict[str, object] = {}
+
+        def fake_prepare_unified(decode_info, prefill_info, block_size):
+            captured["decode_info"] = decode_info
+            captured["prefill_info"] = prefill_info
+            captured["block_size"] = block_size
+
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+            del cache
+            captured["input_ids"] = input_ids.tolist()
+            captured["collect_hidden_states"] = collect_hidden_states
+            return mr.TargetModelForwardOutput(logits=mx.zeros((1, 1, 16)))
+
+        monkeypatch.setattr(mr, "prepare_unified", fake_prepare_unified)
+        monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
+
+        req_state = self._make_state([1, 6])
+        req_state.block_ids = [0, 1]
+        scheduler_output = self._make_scheduler_output({"r0": 1}, {})
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[],
+            decode_reqs=[("r0", req_state)],
+            scheduler_output=scheduler_output,
+        )
+
+        assert captured["input_ids"] == [[6]]
+        assert captured["collect_hidden_states"] is False
+        assert captured["decode_info"] == [([0, 1], 1, 1)]
+        assert captured["prefill_info"] == []
+        assert captured["block_size"] == 4
+        assert runner._execute_model_state is not None
+        assert runner._execute_model_state.target_hidden_states is None
+        assert runner._execute_model_state.cu_seqlens == [0, 1]
+
+    def test_start_paged_forward_collects_hidden_states_for_gemma4_mtp(
+        self, monkeypatch
+    ) -> None:
+        runner = self._make_runner()
+        runner.vllm_config = self._make_gemma4_mtp_config()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+        runner._paged_request_seq_lens["r0"] = 1
+
+        captured: dict[str, object] = {}
+
+        def fake_prepare_unified(decode_info, prefill_info, block_size):
+            captured["decode_info"] = decode_info
+            captured["prefill_info"] = prefill_info
+            captured["block_size"] = block_size
+
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+            del cache
+            captured["input_ids"] = input_ids.tolist()
+            captured["collect_hidden_states"] = collect_hidden_states
+            return mr.TargetModelForwardOutput(
+                logits=mx.zeros((1, 1, 16)),
+                hidden_states=mx.ones((1, 4)),
+            )
+
+        monkeypatch.setattr(mr, "prepare_unified", fake_prepare_unified)
+        monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
+
+        req_state = self._make_state([1, 6])
+        req_state.block_ids = [0, 1]
+        scheduler_output = self._make_scheduler_output({"r0": 1}, {})
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[],
+            decode_reqs=[("r0", req_state)],
+            scheduler_output=scheduler_output,
+        )
+
+        assert captured["input_ids"] == [[6]]
+        assert captured["collect_hidden_states"] is True
+        assert captured["decode_info"] == [([0, 1], 1, 1)]
+        assert captured["prefill_info"] == []
+        assert captured["block_size"] == 4
+        assert runner._execute_model_state is not None
+        assert runner._execute_model_state.target_hidden_states is not None
+        assert runner._execute_model_state.cu_seqlens == [0, 1]
+
+    def test_start_paged_forward_collects_hidden_states_for_gemma4_mtp_prefill(
+        self, monkeypatch
+    ) -> None:
+        runner = self._make_runner()
+        runner.vllm_config = self._make_gemma4_mtp_config()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+
+        captured: dict[str, object] = {}
+
+        def fake_prepare_unified(decode_info, prefill_info, block_size):
+            captured["decode_info"] = decode_info
+            captured["prefill_info"] = prefill_info
+            captured["block_size"] = block_size
+
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+            del cache
+            captured["input_ids"] = input_ids.tolist()
+            captured["collect_hidden_states"] = collect_hidden_states
+            return mr.TargetModelForwardOutput(
+                logits=mx.zeros((1, 2, 16)),
+                hidden_states=mx.ones((2, 4)),
+            )
+
+        monkeypatch.setattr(mr, "prepare_unified", fake_prepare_unified)
+        monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
+
+        scheduler_output = self._make_scheduler_output({"r0": 2}, {})
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[
+                mr.PrefillRequest(
+                    req_id="r0",
+                    token_ids=[5, 6],
+                    sampling_params=SamplingParams(),
+                    block_ids=[0],
+                    generator=None,
+                    prompt_len=2,
+                    start_pos=0,
+                    full_prompt_token_ids=None,
+                )
+            ],
+            decode_reqs=[],
+            scheduler_output=scheduler_output,
+        )
+
+        assert captured["input_ids"] == [[5, 6]]
+        assert captured["collect_hidden_states"] is True
+        assert captured["decode_info"] == []
+        assert captured["prefill_info"] == [([0], 2, 0)]
+        assert captured["block_size"] == 4
+        assert runner._execute_model_state is not None
+        assert runner._execute_model_state.target_hidden_states is not None
+        assert runner._execute_model_state.cu_seqlens == [0, 2]
+
+    def test_start_paged_forward_skips_hidden_states_for_intermediate_prefill(
+        self, monkeypatch
+    ) -> None:
+        runner = self._make_runner()
+        runner.vllm_config = self._make_gemma4_mtp_config()
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+
+        captured: dict[str, object] = {}
+
+        def fake_prepare_unified(decode_info, prefill_info, block_size):
+            captured["decode_info"] = decode_info
+            captured["prefill_info"] = prefill_info
+            captured["block_size"] = block_size
+
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+            del cache
+            captured["input_ids"] = input_ids.tolist()
+            captured["collect_hidden_states"] = collect_hidden_states
+            return mr.TargetModelForwardOutput(logits=mx.zeros((1, 2, 16)))
+
+        monkeypatch.setattr(mr, "prepare_unified", fake_prepare_unified)
+        monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
+
+        scheduler_output = self._make_scheduler_output({"r0": 2}, {})
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[
+                mr.PrefillRequest(
+                    req_id="r0",
+                    token_ids=[5, 6],
+                    sampling_params=SamplingParams(),
+                    block_ids=[0],
+                    generator=None,
+                    prompt_len=None,
+                    start_pos=0,
+                    full_prompt_token_ids=None,
+                )
+            ],
+            decode_reqs=[],
+            scheduler_output=scheduler_output,
+        )
+
+        assert captured["input_ids"] == [[5, 6]]
+        assert captured["collect_hidden_states"] is False
+        assert captured["decode_info"] == []
+        assert captured["prefill_info"] == [([0], 2, 0)]
+        assert captured["block_size"] == 4
+        assert runner._execute_model_state is not None
+        assert runner._execute_model_state.target_hidden_states is None
+        assert runner._execute_model_state.cu_seqlens == [0, 2]
 
     def test_accepts_all_drafts_and_emits_bonus_token(self) -> None:
         runner = self._make_runner()

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -179,7 +179,10 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             speculative_config=SimpleNamespace(
                 method="mtp",
                 draft_model_config=SimpleNamespace(
-                    hf_config=SimpleNamespace(model_type="gemma4_mtp")
+                    hf_config=SimpleNamespace(
+                        model_type="gemma4_assistant",
+                        architectures=["Gemma4AssistantForCausalLM"],
+                    )
                 ),
             )
         )

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
+import mlx.core as mx
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -13,6 +15,14 @@ if TYPE_CHECKING:
     from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class TargetModelForwardOutput:
+    """Target-model forward output needed by sampling and speculative decode."""
+
+    logits: Any
+    hidden_states: Any | None = None
 
 
 class MultimodalRuntimeAdapter(Protocol):
@@ -54,6 +64,19 @@ class ModelAdapter(Protocol):
 
     def text_model(self, model: Any) -> Any:
         """Return the callable model used for text-only execution."""
+
+    def target_forward(
+        self,
+        model: Any,
+        input_ids: Any,
+        *,
+        cache: Any | None = None,
+        collect_hidden_states: bool = False,
+    ) -> TargetModelForwardOutput:
+        """Run the target text model and optionally retain target hidden states."""
+
+    def extract_logits(self, model_output: Any) -> Any:
+        """Extract logits from raw model output."""
 
     def build_multimodal_adapter(
         self, model: Any, hf_config: Any
@@ -231,6 +254,99 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         if hasattr(model, "language_model"):
             return model.language_model
         return model
+
+    def target_forward(
+        self,
+        model: Any,
+        input_ids: Any,
+        *,
+        cache: Any | None = None,
+        collect_hidden_states: bool = False,
+    ) -> TargetModelForwardOutput:
+        """Run the target model and return logits plus optional hidden states."""
+        if not collect_hidden_states:
+            output = model(input_ids, cache=cache)
+            return TargetModelForwardOutput(
+                logits=self.extract_logits(output),
+                hidden_states=None,
+            )
+
+        hidden_states = self._forward_target_hidden_states(
+            model,
+            input_ids,
+            cache=cache,
+        )
+        logits = self._compute_target_logits(model, hidden_states)
+        return TargetModelForwardOutput(
+            logits=logits,
+            hidden_states=self._flatten_target_hidden_states(hidden_states),
+        )
+
+    def extract_logits(self, model_output: Any) -> Any:
+        """Extract logits from mlx-lm arrays or mlx-vlm model outputs."""
+        if isinstance(model_output, TargetModelForwardOutput):
+            return model_output.logits
+        if hasattr(model_output, "logits"):
+            return model_output.logits
+        return model_output
+
+    def _forward_target_hidden_states(
+        self,
+        model: Any,
+        input_ids: Any,
+        *,
+        cache: Any | None,
+    ) -> Any:
+        backbone = getattr(model, "model", None)
+        if backbone is None:
+            raise NotImplementedError(
+                "Target hidden states require a text model with a `model` "
+                "backbone; this model output does not expose hidden states."
+            )
+        return backbone(input_ids, cache=cache)
+
+    def _compute_target_logits(self, model: Any, hidden_states: Any) -> Any:
+        if hasattr(model, "compute_logits"):
+            return model.compute_logits(hidden_states)
+
+        args = getattr(model, "args", None)
+        tie_word_embeddings = bool(
+            getattr(model, "tie_word_embeddings", False)
+            or getattr(args, "tie_word_embeddings", False)
+        )
+        if tie_word_embeddings:
+            logits = self._compute_tied_embedding_logits(model, hidden_states)
+            return self._apply_target_logit_postprocessing(model, logits)
+
+        lm_head = getattr(model, "lm_head", None)
+        if lm_head is not None:
+            logits = lm_head(hidden_states)
+            return self._apply_target_logit_postprocessing(model, logits)
+
+        logits = self._compute_tied_embedding_logits(model, hidden_states)
+        return self._apply_target_logit_postprocessing(model, logits)
+
+    def _compute_tied_embedding_logits(self, model: Any, hidden_states: Any) -> Any:
+        backbone = getattr(model, "model", None)
+        embed_tokens = getattr(backbone, "embed_tokens", None)
+        as_linear = getattr(embed_tokens, "as_linear", None)
+        if as_linear is None:
+            raise NotImplementedError(
+                "Target hidden states require either `lm_head` or tied "
+                "`model.embed_tokens.as_linear` logits projection."
+            )
+        return as_linear(hidden_states)
+
+    def _flatten_target_hidden_states(self, hidden_states: Any) -> Any:
+        if len(hidden_states.shape) == 3 and hidden_states.shape[0] == 1:
+            return hidden_states[0]
+        return hidden_states
+
+    def _apply_target_logit_postprocessing(self, model: Any, logits: Any) -> Any:
+        softcap = getattr(model, "final_logit_softcapping", None)
+        if softcap is None:
+            return logits
+        return mx.tanh(logits / softcap) * softcap
 
     def build_multimodal_adapter(
         self, model: Any, hf_config: Any

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -21,8 +21,8 @@ logger = init_logger(__name__)
 class TargetModelForwardOutput:
     """Target-model forward output needed by sampling and speculative decode."""
 
-    logits: Any
-    hidden_states: Any | None = None
+    logits: mx.array
+    hidden_states: mx.array | None = None
 
 
 class MultimodalRuntimeAdapter(Protocol):
@@ -68,14 +68,14 @@ class ModelAdapter(Protocol):
     def target_forward(
         self,
         model: Any,
-        input_ids: Any,
+        input_ids: mx.array,
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
     ) -> TargetModelForwardOutput:
         """Run the target text model and optionally retain target hidden states."""
 
-    def extract_logits(self, model_output: Any) -> Any:
+    def extract_logits(self, model_output: Any) -> mx.array:
         """Extract logits from raw model output."""
 
     def build_multimodal_adapter(
@@ -258,7 +258,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
     def target_forward(
         self,
         model: Any,
-        input_ids: Any,
+        input_ids: mx.array,
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
@@ -282,7 +282,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             hidden_states=self._flatten_target_hidden_states(hidden_states),
         )
 
-    def extract_logits(self, model_output: Any) -> Any:
+    def extract_logits(self, model_output: Any) -> mx.array:
         """Extract logits from mlx-lm arrays or mlx-vlm model outputs."""
         if isinstance(model_output, TargetModelForwardOutput):
             return model_output.logits
@@ -293,10 +293,10 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
     def _forward_target_hidden_states(
         self,
         model: Any,
-        input_ids: Any,
+        input_ids: mx.array,
         *,
         cache: Any | None,
-    ) -> Any:
+    ) -> mx.array:
         backbone = getattr(model, "model", None)
         if backbone is None:
             raise NotImplementedError(
@@ -305,7 +305,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             )
         return backbone(input_ids, cache=cache)
 
-    def _compute_target_logits(self, model: Any, hidden_states: Any) -> Any:
+    def _compute_target_logits(self, model: Any, hidden_states: mx.array) -> mx.array:
         if hasattr(model, "compute_logits"):
             return model.compute_logits(hidden_states)
 
@@ -323,10 +323,15 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             logits = lm_head(hidden_states)
             return self._apply_target_logit_postprocessing(model, logits)
 
+        # Some Gemma4-compatible MLX loaders expose tied embedding projection
+        # without setting tie_word_embeddings on the wrapper; try that shape
+        # explicitly, then fail inside _compute_tied_embedding_logits if absent.
         logits = self._compute_tied_embedding_logits(model, hidden_states)
         return self._apply_target_logit_postprocessing(model, logits)
 
-    def _compute_tied_embedding_logits(self, model: Any, hidden_states: Any) -> Any:
+    def _compute_tied_embedding_logits(
+        self, model: Any, hidden_states: mx.array
+    ) -> mx.array:
         backbone = getattr(model, "model", None)
         embed_tokens = getattr(backbone, "embed_tokens", None)
         as_linear = getattr(embed_tokens, "as_linear", None)
@@ -337,12 +342,20 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             )
         return as_linear(hidden_states)
 
-    def _flatten_target_hidden_states(self, hidden_states: Any) -> Any:
-        if len(hidden_states.shape) == 3 and hidden_states.shape[0] == 1:
+    def _flatten_target_hidden_states(self, hidden_states: mx.array) -> mx.array:
+        ndim = len(hidden_states.shape)
+        if ndim == 2:
+            return hidden_states
+        if ndim == 3 and hidden_states.shape[0] == 1:
             return hidden_states[0]
-        return hidden_states
+        raise ValueError(
+            "Target hidden states must be row-major [num_tokens, hidden_size] "
+            "or single-batch [1, num_tokens, hidden_size]."
+        )
 
-    def _apply_target_logit_postprocessing(self, model: Any, logits: Any) -> Any:
+    def _apply_target_logit_postprocessing(
+        self, model: Any, logits: mx.array
+    ) -> mx.array:
         softcap = getattr(model, "final_logit_softcapping", None)
         if softcap is None:
             return logits

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -62,6 +62,7 @@ from vllm_metal.v1.model_adapter import (
     DefaultModelAdapter,
     ModelAdapter,
     MultimodalRuntimeAdapter,
+    TargetModelForwardOutput,
 )
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 from vllm_metal.v1.sampling_batch import (
@@ -201,6 +202,7 @@ class _PagedForwardState(NamedTuple):
     decode_reqs: list[tuple[str, RequestState]]
     scheduler_output: SchedulerOutput
     logits: mx.array
+    target_hidden_states: mx.array | None
     cu_seqlens: list[int]
     decode_segments: tuple[PagedDecodeSegment, ...]
     num_decode_tokens: int
@@ -458,11 +460,21 @@ class MetalModelRunner:
         Returns:
             Logits array
         """
-        if hasattr(model_output, "logits"):
-            # mlx-vlm returns LanguageModelOutput
-            return model_output.logits
-        # mlx-lm returns logits directly
-        return model_output
+        return self._model_adapter.extract_logits(model_output)
+
+    def _target_forward(
+        self,
+        input_ids: mx.array,
+        *,
+        cache: Any | None = None,
+        collect_hidden_states: bool = False,
+    ) -> TargetModelForwardOutput:
+        return self._model_adapter.target_forward(
+            self._forward_model,
+            input_ids,
+            cache=cache,
+            collect_hidden_states=collect_hidden_states,
+        )
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Get KV cache specification.
@@ -798,6 +810,13 @@ class MetalModelRunner:
             self._paged_request_seq_lens,
         )
         num_decode_tokens = sum(segment.num_query_tokens for segment in decode_segments)
+        collect_target_hidden_states = (
+            self._spec_decode_controller.needs_target_hidden_states(
+                decode_segments,
+                has_final_prefill=any(pr.prompt_len is not None for pr in prefill_reqs),
+                speculative_config=self.vllm_config.speculative_config,
+            )
+        )
 
         # ---- build unified token sequence: decode first, then prefill ----
         all_token_ids: list[int] = []
@@ -845,18 +864,24 @@ class MetalModelRunner:
         offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]
         input_ids = mx.array([all_token_ids], dtype=mx.int32)
         try:
-            model_output = self._forward_model(input_ids, cache=offset_caches)
-            logits = self._extract_logits(model_output)
-            # MLX uses lazy evaluation — model_output holds the entire
-            # computation graph.  Dropping it before mx.eval lets MLX
-            # free intermediate buffers (per-layer Q/K/V, MLP outputs)
-            # as the graph evaluates, rather than pinning them all.
-            del model_output
+            target_output = self._target_forward(
+                input_ids,
+                cache=offset_caches,
+                collect_hidden_states=collect_target_hidden_states,
+            )
+            logits = target_output.logits
+            target_hidden_states = target_output.hidden_states
+            # Keep only logits and the optional row-major hidden states before
+            # scheduling evaluation.
+            del target_output
         finally:
             clear_context()
 
         # Submit to GPU — returns immediately, GPU runs in background
-        mx.async_eval(logits)
+        if target_hidden_states is not None:
+            mx.async_eval(logits, target_hidden_states)
+        else:
+            mx.async_eval(logits)
 
         # ---- build cu_seqlens for logit extraction ----
         cu_seqlens: list[int] = [0]
@@ -871,6 +896,7 @@ class MetalModelRunner:
             decode_reqs=decode_reqs,
             scheduler_output=scheduler_output,
             logits=logits,
+            target_hidden_states=target_hidden_states,
             cu_seqlens=cu_seqlens,
             decode_segments=decode_segments,
             num_decode_tokens=num_decode_tokens,
@@ -893,6 +919,7 @@ class MetalModelRunner:
         decode_reqs = state.decode_reqs
         scheduler_output = state.scheduler_output
         logits = state.logits
+        target_hidden_states = state.target_hidden_states
         cu_seqlens = state.cu_seqlens
         decode_segments = state.decode_segments
         num_decode_segments = len(decode_segments)
@@ -902,7 +929,10 @@ class MetalModelRunner:
         )
 
         # ---- wait for MLX forward to complete ----
-        mx.eval(logits)
+        if target_hidden_states is not None:
+            mx.eval(logits, target_hidden_states)
+        else:
+            mx.eval(logits)
 
         # ---- apply structured output bitmask if present ----
         if grammar_output is not None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -810,6 +810,8 @@ class MetalModelRunner:
             self._paged_request_seq_lens,
         )
         num_decode_tokens = sum(segment.num_query_tokens for segment in decode_segments)
+        # prompt_len=None marks an intermediate prefill chunk; only final
+        # prefill rows can seed the next Gemma4 MTP draft step.
         collect_target_hidden_states = (
             self._spec_decode_controller.needs_target_hidden_states(
                 decode_segments,
@@ -930,6 +932,8 @@ class MetalModelRunner:
 
         # ---- wait for MLX forward to complete ----
         if target_hidden_states is not None:
+            # The Gemma4 MTP assistant drafter will consume these rows after
+            # sampling; evaluate them with logits so the retained state is ready.
             mx.eval(logits, target_hidden_states)
         else:
             mx.eval(logits)

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -17,6 +17,11 @@ from vllm_metal.v1.sampling_batch import GREEDY_TEMPERATURE_EPS
 if TYPE_CHECKING:
     from vllm.config.speculative import SpeculativeConfig
 
+_GEMMA4_MTP_DRAFT_MODEL_TYPES = frozenset({"gemma4_assistant", "gemma4_mtp"})
+_GEMMA4_MTP_DRAFT_ARCHITECTURES = frozenset(
+    {"Gemma4AssistantForCausalLM", "Gemma4MTPModel"}
+)
+
 
 class _PagedDecodeStateLike(Protocol):
     token_ids: Sequence[int]
@@ -204,11 +209,18 @@ class SpeculativeDecodeController:
             return False
 
         draft_model_config = speculative_config.draft_model_config
-        return (
-            draft_model_config is not None
-            and getattr(draft_model_config.hf_config, "model_type", None)
-            == "gemma4_mtp"
-        )
+        if draft_model_config is None:
+            return False
+
+        hf_config = draft_model_config.hf_config
+        model_type = getattr(hf_config, "model_type", None)
+        if model_type in _GEMMA4_MTP_DRAFT_MODEL_TYPES:
+            return True
+
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        if isinstance(architectures, str):
+            architectures = (architectures,)
+        return any(arch in _GEMMA4_MTP_DRAFT_ARCHITECTURES for arch in architectures)
 
     def verify_greedy(
         self,

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -17,6 +17,9 @@ from vllm_metal.v1.sampling_batch import GREEDY_TEMPERATURE_EPS
 if TYPE_CHECKING:
     from vllm.config.speculative import SpeculativeConfig
 
+# Raw Gemma4 assistant checkpoints use the HF/Transformers identifiers;
+# upstream vLLM maps them to the Gemma4MTP wrapper identifiers during config
+# normalization. Accept both so this gate works before and after that mapping.
 _GEMMA4_MTP_DRAFT_MODEL_TYPES = frozenset({"gemma4_assistant", "gemma4_mtp"})
 _GEMMA4_MTP_DRAFT_ARCHITECTURES = frozenset(
     {"Gemma4AssistantForCausalLM", "Gemma4MTPModel"}
@@ -198,7 +201,12 @@ class SpeculativeDecodeController:
         has_final_prefill: bool = False,
         speculative_config: SpeculativeConfig | None = None,
     ) -> bool:
-        """Return whether target hidden states are needed for draft follow-up."""
+        """Return whether target hidden states are needed for draft follow-up.
+
+        Gemma4 MTP needs the previous target step's hidden states even for
+        plain decode or final prefill rows, because the assistant consumes
+        those rows to draft the next tokens.
+        """
         if not decode_segments and not has_final_prefill:
             return False
         return self._uses_gemma4_mtp(speculative_config)
@@ -217,6 +225,8 @@ class SpeculativeDecodeController:
         if model_type in _GEMMA4_MTP_DRAFT_MODEL_TYPES:
             return True
 
+        # Architectures may be absent, None, or already rewritten by upstream
+        # vLLM, so normalize this optional HF field defensively.
         architectures = getattr(hf_config, "architectures", ()) or ()
         if isinstance(architectures, str):
             architectures = (architectures,)

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import mlx.core as mx
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -13,6 +13,9 @@ from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 
 from vllm_metal.v1.sampling_batch import GREEDY_TEMPERATURE_EPS
+
+if TYPE_CHECKING:
+    from vllm.config.speculative import SpeculativeConfig
 
 
 class _PagedDecodeStateLike(Protocol):
@@ -182,6 +185,30 @@ class SpeculativeDecodeController:
             start_row += segment.num_query_tokens
 
         return tuple(segments)
+
+    def needs_target_hidden_states(
+        self,
+        decode_segments: Sequence[PagedDecodeSegment],
+        *,
+        has_final_prefill: bool = False,
+        speculative_config: SpeculativeConfig | None = None,
+    ) -> bool:
+        """Return whether target hidden states are needed for draft follow-up."""
+        if not decode_segments and not has_final_prefill:
+            return False
+        return self._uses_gemma4_mtp(speculative_config)
+
+    @staticmethod
+    def _uses_gemma4_mtp(speculative_config: SpeculativeConfig | None) -> bool:
+        if speculative_config is None or speculative_config.method != "mtp":
+            return False
+
+        draft_model_config = speculative_config.draft_model_config
+        return (
+            draft_model_config is not None
+            and getattr(draft_model_config.hf_config, "model_type", None)
+            == "gemma4_mtp"
+        )
 
     def verify_greedy(
         self,


### PR DESCRIPTION
This is PR 2 in the Gemma 4 MTP stack.

It adds target hidden-state capture on the paged target path so the later Gemma 4 MTP assistant can consume target model states without adding model-specific logic to `MetalModelRunner`.

Changes:
- Add `ModelAdapter.target_forward()` as the model-owned boundary for logits + optional hidden states.
- Recompute logits from captured hidden states for Gemma 4-style tied embedding / lm_head paths.
- Collect target hidden states only for Gemma 4 MTP decode and final prefill steps.
- Keep ordinary decode, ngram spec decode, and non-Gemma 4 MTP paths unchanged.
- Store hidden states in the paged forward state for the next PRs.

