### PR TITLE
Add Metal V1 embed pooling support

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -11,6 +11,16 @@ vllm-metal currently focuses on text-only language models on Apple Silicon. Mult
 | ❌ | Not supported model/feature |
 | 🟡 | Not tested or verified |
 
+## Text Embedding Pooling
+
+Metal V1 has experimental text-only `embed` pooling support. See
+[Text Embedding Pooling](text_embedding_pooling.md) for scope, usage, and
+validation guidance.
+
+| Model | Support | Runner | Evidence | Notes |
+| --- | --- | --- | --- | --- |
+| mlx-community/Qwen3-Embedding-0.6B-8bit | 🔵 | `pooling` / `embed` (paged) | `LLM.embed(["hello metal", "semantic search"])` -> `embedding-smoke-ok 2 1024` | Revision `b8d7100604f51da6d14eab4dd1805f596fa1ce3f`; validated on MacBook Air (Apple M5, 16 GB) with vLLM 0.21.0, MLX 0.31.2, `max_model_len=512` |
+
 ## Text-Only Language Models
 
 `Automatic Prefix Cache` describes the default behavior when the user does

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -1,0 +1,75 @@
+# Text Embedding Pooling
+
+Metal V1 has experimental text-only `embed` pooling support for compatible
+pooling models. Supported requests run as prefill-only work, return one CPU
+L2-normalized embedding tensor per finished request through vLLM's
+`pooler_output` contract, and do not sample generation tokens.
+
+## Scope
+
+Current scope is intentionally narrow:
+
+- `runner="pooling"` with embedding-capable pooler configs
+  (`pooler_config.task` unset or `pooler_config.task="embed"`)
+- decoder-style text models that expose token hidden states through the MLX
+  transformer body
+- sequence embeddings from the final prompt-token hidden state with LAST
+  pooling and L2 normalization on the paged Metal V1 path
+
+## Unsupported
+
+The Metal runner rejects these cases with diagnostic errors:
+
+- classification, reranking, and late interaction
+- sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`, `STEP`)
+- token-level pooling
+- chunked long-input embedding aggregation (`enable_chunked_processing`)
+- non-paged pooling execution
+- multimodal embeddings and scheduled encoder inputs
+- prompt embeddings
+- unsafe dimension requests
+
+Direct model-provided embedding tensors are intentionally out of scope for this
+MVP. Add that path only after a real model requires it and the output contract
+is validated end to end.
+
+## Usage
+
+### Offline Embeddings
+
+Set `VLLM_METAL_USE_PAGED_ATTENTION=1` for this MVP.
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="mlx-community/Qwen3-Embedding-0.6B-8bit",
+    runner="pooling",
+    max_model_len=512,
+)
+outputs = llm.embed(["hello metal", "semantic search"])
+print(len(outputs), len(outputs[0].outputs.embedding))
+```
+
+### OpenAI-Compatible Server
+
+```bash
+VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+VLLM_METAL_USE_PAGED_ATTENTION=1 \
+VLLM_METAL_MEMORY_FRACTION=auto \
+vllm serve mlx-community/Qwen3-Embedding-0.6B-8bit \
+  --runner pooling \
+  --max-model-len 512
+```
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"model":"mlx-community/Qwen3-Embedding-0.6B-8bit","input":["hello metal","semantic search"]}'
+```
+
+## Validation
+
+Do not add a model row to [Supported Models](supported_models.md) until a real
+`LLM.embed` or `/v1/embeddings` smoke passes on Apple Silicon with the model
+name, revision, command, and output dimension recorded.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -68,6 +68,7 @@ nav:
   - Models:
     - Supported Models: supported_models.md
   - Features:
+    - Text Embedding Pooling: text_embedding_pooling.md
     - Speech-to-Text: stt.md
     - Turboquant: turboquant.md
     - GPU Profiling: profiling.md

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -32,6 +32,7 @@ def make_stub_runner(
 
     defaults: dict[str, Any] = {
         "vllm_config": SimpleNamespace(speculative_config=None),
+        "model_config": SimpleNamespace(runner_type="generate"),
         "model": object(),
         "_is_stt": False,
         "_is_vlm": False,
@@ -64,6 +65,10 @@ def make_stub_runner(
         setattr(runner, k, v)
     for k, v in attrs.items():
         setattr(runner, k, v)
+    if "_is_pooling" not in attrs:
+        runner._is_pooling = (
+            getattr(runner.model_config, "runner_type", None) == "pooling"
+        )
 
     runner._cache_policy = ModelCachePolicy(runner, runner._model_adapter)
 

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+"""High-value contract tests for Metal V1 text embedding pooling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("vllm", reason="vllm not installed")
+
+from vllm.pooling_params import LateInteractionParams, PoolingParams  # noqa: E402
+
+from tests.stub_runner import make_stub_runner  # noqa: E402
+from vllm_metal.v1 import model_runner as mr  # noqa: E402
+
+
+class _SequenceModel:
+    def __init__(self, *, bad_shape: bool = False) -> None:
+        self.bad_shape = bad_shape
+
+    def __call__(self, input_ids, cache=None):
+        if self.bad_shape:
+            return mx.array([[1.0, 2.0]], dtype=mx.float32)
+
+        token_ids = np.array(input_ids).reshape(-1).tolist()
+        rows = [[float(tok), float(tok + 1), 1.0] for tok in token_ids]
+        return mx.array([rows], dtype=mx.float32)
+
+
+class _RecordingSequenceModel(_SequenceModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    def __call__(self, input_ids, cache=None):
+        self.calls += 1
+        return super().__call__(input_ids, cache=cache)
+
+
+class _PoolingModel:
+    def __init__(self, sequence_model: object | None = None) -> None:
+        self.model = sequence_model or _SequenceModel()
+
+
+def _hf_config(**overrides):
+    values = {
+        "architectures": ["Qwen3ForCausalLM"],
+        "model_type": "qwen3",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _pooler_config(**overrides):
+    values = {
+        "task": None,
+        "pooling_type": None,
+        "seq_pooling_type": "LAST",
+        "tok_pooling_type": "ALL",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _pooling_model_config(**overrides):
+    values = {
+        "runner_type": "pooling",
+        "multimodal_config": None,
+        "served_model_name": "stub-pooling-model",
+        "model": "stub-pooling-model",
+        "hf_config": _hf_config(),
+        "pooler_config": _pooler_config(),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _make_runner(
+    *,
+    paged: bool = True,
+    model: object | None = None,
+    model_config: object | None = None,
+):
+    return make_stub_runner(
+        model=model or _PoolingModel(),
+        model_config=model_config or _pooling_model_config(),
+        _paged_attention_backend=object() if paged else None,
+        _paged_block_size=4,
+        num_layers=1,
+    )
+
+
+def _pooling_params(task: str | None = None, **overrides) -> PoolingParams:
+    params = PoolingParams(task=task)
+    for key, value in overrides.items():
+        setattr(params, key, value)
+    return params
+
+
+def _new_req(
+    req_id: str,
+    token_ids: list[int],
+    *,
+    task: str | None = None,
+    num_computed_tokens: int = 0,
+    block_ids: list[int] | None = None,
+    pooling_params: PoolingParams | None = None,
+):
+    return SimpleNamespace(
+        req_id=req_id,
+        prompt_token_ids=token_ids,
+        mm_features=[],
+        sampling_params=None,
+        pooling_params=pooling_params or _pooling_params(task),
+        block_ids=(block_ids or [0, 1],),
+        num_computed_tokens=num_computed_tokens,
+        lora_request=None,
+        prompt_embeds=None,
+    )
+
+
+def _cached_req_data(req_ids: list[str], num_computed_tokens: list[int]):
+    return SimpleNamespace(
+        req_ids=req_ids,
+        resumed_req_ids=set(),
+        new_token_ids=[],
+        all_token_ids={},
+        new_block_ids=[None] * len(req_ids),
+        num_computed_tokens=num_computed_tokens,
+        num_output_tokens=[0] * len(req_ids),
+    )
+
+
+def _scheduler_output(
+    *,
+    new_reqs: list[object] | None = None,
+    cached_req_ids: list[str] | None = None,
+    cached_num_computed_tokens: list[int] | None = None,
+    num_scheduled_tokens: dict[str, int] | None = None,
+):
+    new_reqs = new_reqs or []
+    cached_req_ids = cached_req_ids or []
+    if num_scheduled_tokens is None:
+        num_scheduled_tokens = {
+            req.req_id: len(req.prompt_token_ids or []) - req.num_computed_tokens
+            for req in new_reqs
+        }
+        num_scheduled_tokens.update(dict.fromkeys(cached_req_ids, 1))
+
+    return SimpleNamespace(
+        scheduled_new_reqs=new_reqs,
+        scheduled_cached_reqs=_cached_req_data(
+            cached_req_ids,
+            cached_num_computed_tokens or [0] * len(cached_req_ids),
+        ),
+        num_scheduled_tokens=num_scheduled_tokens,
+        total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+        scheduled_spec_decode_tokens={},
+        num_invalid_spec_tokens=None,
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+        preempted_req_ids=set(),
+        has_structured_output_requests=False,
+    )
+
+
+def _expected_embedding(token_id: int) -> torch.Tensor:
+    vector = torch.tensor([float(token_id), float(token_id + 1), 1.0])
+    return vector / vector.norm()
+
+
+def _assert_embedding(tensor: torch.Tensor | None, token_id: int) -> None:
+    assert tensor is not None
+    assert tensor.device.type == "cpu"
+    assert tensor.shape == (3,)
+    assert torch.allclose(tensor, _expected_embedding(token_id), atol=1e-6)
+
+
+def _execute_pooling(runner, sched):
+    out = runner.execute_model(sched)
+    assert out is not None
+    return out
+
+
+class TestMetalPoolingCapabilities:
+    def test_supported_worker_tasks_for_last_text_embedding_model(self) -> None:
+        runner = _make_runner()
+
+        assert runner.supported_worker_tasks() == ("embed",)
+
+    def test_supported_worker_tasks_rejects_incompatible_pooling_model(self) -> None:
+        runner = make_stub_runner(
+            model=object(),
+            model_config=_pooling_model_config(),
+        )
+
+        assert runner.supported_worker_tasks() == ()
+
+    def test_supported_worker_tasks_rejects_non_paged_pooling(self) -> None:
+        runner = _make_runner(paged=False)
+
+        assert runner.supported_worker_tasks() == ()
+
+    def test_supported_worker_tasks_preserves_generation_and_stt(self) -> None:
+        gen_runner = make_stub_runner(
+            model_config=SimpleNamespace(runner_type="generate")
+        )
+        stt_runner = make_stub_runner(
+            _is_stt=True,
+            model_config=SimpleNamespace(runner_type="generate"),
+        )
+
+        assert gen_runner.supported_worker_tasks() == ("generate",)
+        assert stt_runner.supported_worker_tasks() == ("transcription",)
+
+
+class TestMetalPoolingRunnerOutput:
+    def test_paged_embed_preserves_request_order(self) -> None:
+        runner = _make_runner()
+        req_b = _new_req("req-b", [4, 5])
+        req_a = _new_req("req-a", [7, 8, 9])
+        sched = _scheduler_output(new_reqs=[req_b, req_a])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.req_ids == ["req-b", "req-a"]
+        assert out.sampled_token_ids == [[], []]
+        assert out.pooler_output is not None
+        _assert_embedding(out.pooler_output[0], 5)
+        _assert_embedding(out.pooler_output[1], 9)
+
+    def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(self) -> None:
+        runner = _make_runner()
+        req = _new_req("req-0", [1, 2, 3, 4])
+        first = _scheduler_output(
+            new_reqs=[req],
+            num_scheduled_tokens={"req-0": 2},
+        )
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            partial = _execute_pooling(runner, first)
+
+        assert partial.sampled_token_ids == [[]]
+        assert partial.pooler_output == [None]
+        assert runner._request_states["req-0"].pooling_params is not None
+
+        second = _scheduler_output(
+            cached_req_ids=["req-0"],
+            cached_num_computed_tokens=[2],
+            num_scheduled_tokens={"req-0": 2},
+        )
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            final = _execute_pooling(runner, second)
+
+        assert final.sampled_token_ids == [[]]
+        assert final.pooler_output is not None
+        _assert_embedding(final.pooler_output[0], 4)
+
+
+class TestMetalPoolingFailFast:
+    def test_non_decoder_pooling_models_fail_fast_on_execute(
+        self,
+    ) -> None:
+        runner = _make_runner(
+            model_config=_pooling_model_config(
+                hf_config=_hf_config(architectures=["Qwen3ForSequenceClassification"])
+            )
+        )
+        req = _new_req("req-0", [1, 2], task="embed")
+
+        with pytest.raises(NotImplementedError, match="decoder-style checkpoint"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_pooling_requires_paged_attention(self) -> None:
+        runner = _make_runner(paged=False)
+        req = _new_req("req-0", [1, 2], task="embed")
+
+        with pytest.raises(NotImplementedError, match="paged attention"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    @pytest.mark.parametrize(
+        "task",
+        ["classify", "score"],
+    )
+    def test_unsupported_pooling_tasks_fail_fast(self, task: str) -> None:
+        runner = _make_runner()
+        req = _new_req("req-0", [1, 2], task=task)
+
+        with pytest.raises(NotImplementedError, match="task"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    @pytest.mark.parametrize(
+        ("attr", "pooling_type"),
+        [
+            ("seq_pooling_type", "MEAN"),
+            ("pooling_type", "CLS"),
+        ],
+    )
+    def test_unsupported_pooling_strategies_fail_fast(
+        self,
+        attr: str,
+        pooling_type: str,
+    ) -> None:
+        runner = _make_runner(
+            model_config=_pooling_model_config(
+                pooler_config=_pooler_config(**{attr: pooling_type}),
+            )
+        )
+        req = _new_req("req-0", [1, 2])
+
+        with pytest.raises(NotImplementedError, match="LAST"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_late_interaction_pooling_fails_fast(self) -> None:
+        runner = _make_runner()
+        params = _pooling_params(
+            late_interaction_params=LateInteractionParams(
+                mode="cache_query",
+                query_key="query-0",
+            )
+        )
+        req = _new_req("req-0", [1, 2], pooling_params=params)
+
+        with pytest.raises(NotImplementedError, match="late-interaction"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_multimodal_pooling_fails_fast(self) -> None:
+        runner = _make_runner()
+        req = _new_req("req-0", [1, 2])
+        req.mm_features = [object()]
+
+        with pytest.raises(NotImplementedError, match="Multimodal pooling"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_prompt_embeds_pooling_fails_fast_before_forward(self) -> None:
+        runner = _make_runner()
+        req = _new_req("req-0", [1, 2])
+        req.prompt_embeds = mx.zeros((1, 2, 3), dtype=mx.float32)
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified") as prepare,
+            patch(
+                "vllm_metal.v1.model_runner.forward_sequence_hidden_states"
+            ) as forward,
+            pytest.raises(NotImplementedError, match="Prompt-embedding pooling"),
+        ):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+        prepare.assert_not_called()
+        forward.assert_not_called()
+        assert "req-0" not in runner._request_states
+
+    @pytest.mark.parametrize(
+        ("attr", "value", "message"),
+        [
+            ("requires_token_ids", True, "token-level ALL"),
+            ("use_activation", False, "use_activation=False"),
+        ],
+    )
+    def test_unsupported_pooling_options_fail_fast(
+        self,
+        attr: str,
+        value: object,
+        message: str,
+    ) -> None:
+        runner = _make_runner()
+        params = _pooling_params()
+        setattr(params, attr, value)
+        req = _new_req("req-0", [1, 2], pooling_params=params)
+
+        with pytest.raises(NotImplementedError, match=message):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_embedding_dimensions_are_rejected(self) -> None:
+        runner = _make_runner()
+        req = _new_req(
+            "req-0",
+            [1, 2],
+            pooling_params=_pooling_params(dimensions=2),
+        )
+
+        with pytest.raises(NotImplementedError, match="dimension"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_unknown_hidden_state_shape_fails_fast(self) -> None:
+        runner = _make_runner(model=_PoolingModel(_SequenceModel(bad_shape=True)))
+        req = _new_req("req-0", [1, 2])
+        sched = _scheduler_output(new_reqs=[req])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+            pytest.raises(ValueError, match="hidden states"),
+        ):
+            runner.execute_model(sched)
+
+
+class TestMetalPoolingProfileWarmup:
+    def test_profile_run_uses_pooling_forward_without_logits(self) -> None:
+        sequence_model = _RecordingSequenceModel()
+        runner = _make_runner(model=_PoolingModel(sequence_model))
+        runner.scheduler_config = SimpleNamespace(max_num_batched_tokens=3)
+        runner._extract_logits = MagicMock(side_effect=AssertionError("logits path"))
+
+        with (
+            patch.object(mr.mx, "clear_cache"),
+            patch.object(mr.mx, "get_cache_memory", side_effect=[100, 180]),
+            patch.object(mr.mx, "set_cache_limit") as set_cache_limit,
+        ):
+            overhead = runner.profile_run()
+
+        assert overhead == 80
+        assert sequence_model.calls == 1
+        runner._extract_logits.assert_not_called()
+        set_cache_limit.assert_called_once_with(80)

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -21,6 +21,7 @@ import torch
 from mlx_lm import stream_generate
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
 from vllm.utils.platform_utils import is_pin_memory_available
@@ -69,6 +70,14 @@ from vllm_metal.v1.model_adapter import (
     TargetModelForwardOutput,
 )
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
+from vllm_metal.v1.pooling import (
+    finish_paged_pooling_batch,
+    forward_sequence_hidden_states,
+    has_paged_pooling_work,
+    pooling_dummy_forward_outputs,
+    supports_embed_pooling,
+    validate_pooling_request,
+)
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
     SamplingBatch,
@@ -122,6 +131,7 @@ class RequestState:
     prompt_len: int
     cache: list[AnyCache]  # Per-layer caches (KVCache, RotatingKVCache, or ArraysCache)
     sampling_params: SamplingParams  # Sampling parameters for this request
+    pooling_params: PoolingParams | None = None
     generator: torch.Generator | None = None
     generated_tokens: int = 0
     block_ids: list[int] = field(
@@ -143,6 +153,7 @@ class PrefillRequest(NamedTuple):
     prompt_len: int | None  # full prompt length (None for intermediate chunks)
     start_pos: int  # RoPE / slot offset (0 = fresh, >0 = continuation)
     full_prompt_token_ids: list[int] | None  # full prompt for sampling metadata
+    pooling_params: PoolingParams | None = None
 
 
 @dataclass
@@ -162,6 +173,7 @@ class _ExecutionBatch:
     req_id_to_index: dict[str, int] = field(default_factory=dict)
     sampled_tokens: list[list[int]] = field(default_factory=list)
     sample_logprobs: list[LogprobsLists | None] = field(default_factory=list)
+    pooler_outputs: list[torch.Tensor | None] = field(default_factory=list)
     new_reqs_by_id: dict[str, NewRequestData] = field(default_factory=dict)
     paged_prefill_entries: list[_PendingPrefillEntry] = field(default_factory=list)
     paged_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
@@ -173,6 +185,7 @@ class _ExecutionBatch:
         req_id: str,
         token_ids: list[int],
         logprobs: LogprobsLists | None = None,
+        pooler_output: torch.Tensor | None = None,
     ) -> int:
         """Append one output slot and return its index."""
         self.req_ids.append(req_id)
@@ -180,6 +193,7 @@ class _ExecutionBatch:
         self.req_id_to_index[req_id] = output_idx
         self.sampled_tokens.append(token_ids)
         self.sample_logprobs.append(logprobs)
+        self.pooler_outputs.append(pooler_output)
         return output_idx
 
     def set_output(
@@ -187,10 +201,12 @@ class _ExecutionBatch:
         output_idx: int,
         token_ids: list[int],
         logprobs: LogprobsLists | None = None,
+        pooler_output: torch.Tensor | None = None,
     ) -> None:
         """Set tokens and logprobs for an existing output slot."""
         self.sampled_tokens[output_idx] = token_ids
         self.sample_logprobs[output_idx] = logprobs
+        self.pooler_outputs[output_idx] = pooler_output
 
     def merged_logprobs(self) -> LogprobsLists | None:
         """Merge per-output-slot logprobs for ``ModelRunnerOutput``."""
@@ -208,7 +224,7 @@ class _PagedForwardState(NamedTuple):
     prefill_reqs: list[PrefillRequest]
     decode_reqs: list[tuple[str, RequestState]]
     scheduler_output: SchedulerOutput
-    logits: mx.array
+    logits: mx.array | None
     target_hidden_states: mx.array | None
     cu_seqlens: list[int]
     decode_segments: tuple[PagedDecodeSegment, ...]
@@ -216,6 +232,7 @@ class _PagedForwardState(NamedTuple):
     # ``{req_id: mrope_position_delta}`` from paged mm prefill;
     # ``_sample_paged_batch`` stashes each onto ``RequestState``.
     mm_prefill_deltas: dict[str, int]
+    pooling_hidden_states: mx.array | None = None
 
 
 class MetalModelRunner:
@@ -253,6 +270,9 @@ class MetalModelRunner:
         self.model_args: dict[str, Any] = {}
         self._is_vlm: bool = False  # Will be set during model loading
         self._is_stt: bool = False  # Will be set during model loading
+        self._is_pooling: bool = (
+            getattr(self.model_config, "runner_type", None) == "pooling"
+        )
         self._stt_runtime_adapter: STTRuntimeAdapter | None = (
             None  # Set during STT loading
         )
@@ -272,7 +292,6 @@ class MetalModelRunner:
         self._sampler = Sampler()
 
         # Build logits processors (includes custom plugins from entry-points)
-        is_pooling_model = getattr(self.model_config, "runner_type", None) == "pooling"
         pin_memory = is_pin_memory_available()
         custom_lp = vllm_config.model_config.logits_processors
         custom_logitsprocs = tuple(custom_lp) if custom_lp is not None else ()
@@ -280,7 +299,7 @@ class MetalModelRunner:
             vllm_config,
             device,
             pin_memory,
-            is_pooling_model,
+            self._is_pooling,
             custom_logitsprocs,
         )
 
@@ -391,6 +410,12 @@ class MetalModelRunner:
         """Return worker task capabilities for the loaded model."""
         if self._is_stt:
             return ("transcription",)
+        if self._is_pooling:
+            if self._paged_attention_backend is None:
+                return ()
+            if supports_embed_pooling(self._forward_model, self.model_config):
+                return ("embed",)
+            return ()
         return ("generate",)
 
     def load_model(self) -> None:
@@ -571,10 +596,22 @@ class MetalModelRunner:
         mx.clear_cache()
         cache_before = mx.get_cache_memory()
         dummy_tokens = mx.zeros((1, warmup_len), dtype=mx.int32)
-        mx.eval(self._extract_logits(self._forward_model(dummy_tokens)))
+        mx.eval(*self._dummy_forward_outputs(dummy_tokens))
         overhead = mx.get_cache_memory() - cache_before
         mx.set_cache_limit(overhead)
         return overhead
+
+    def _dummy_forward_outputs(self, input_ids: mx.array) -> list[mx.array]:
+        if self._is_pooling:
+            return pooling_dummy_forward_outputs(
+                self._forward_model,
+                input_ids,
+                model_config=self.model_config,
+            )
+
+        output = self._forward_model(input_ids)
+        logits = self._extract_logits(output)
+        return [logits]
 
     def build_paged_attention_backend(
         self, *, block_size: int
@@ -614,9 +651,7 @@ class MetalModelRunner:
         # Run a small dummy inference (standard MLX path)
         try:
             dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
-            output = self._forward_model(dummy_tokens)
-            logits = self._extract_logits(output)
-            mx.eval(logits)
+            mx.eval(*self._dummy_forward_outputs(dummy_tokens))
             logger.info("Model warm-up complete")
         except Exception as e:
             logger.warning(f"Model warm-up failed: {e}")
@@ -854,10 +889,15 @@ class MetalModelRunner:
             self._paged_request_seq_lens,
         )
         num_decode_tokens = sum(segment.num_query_tokens for segment in decode_segments)
+        has_pooling_work = has_paged_pooling_work(prefill_reqs, decode_reqs)
+
         # prompt_len=None marks an intermediate prefill chunk; only final
-        # prefill rows can seed the next Gemma4 MTP draft step.
+        # prefill rows can seed the next Gemma4 MTP draft step. Pooling batches
+        # do not sample or draft tokens, so they never request target hidden
+        # states here.
         collect_target_hidden_states = (
-            self._spec_decode_controller.needs_target_hidden_states(
+            not has_pooling_work
+            and self._spec_decode_controller.needs_target_hidden_states(
                 decode_segments,
                 has_final_prefill=any(pr.prompt_len is not None for pr in prefill_reqs),
                 speculative_config=self.vllm_config.speculative_config,
@@ -925,9 +965,19 @@ class MetalModelRunner:
         # ---- forward (lazy graph + async submit) ----
         offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]
         input_ids = mx.array([all_token_ids], dtype=mx.int32)
+        logits: mx.array | None = None
+        target_hidden_states: mx.array | None = None
+        pooling_hidden_states: mx.array | None = None
         mm_prefill_deltas: dict[str, int] = {}
         try:
-            if has_mm:
+            if has_pooling_work:
+                pooling_hidden_states = forward_sequence_hidden_states(
+                    self._forward_model,
+                    input_ids,
+                    cache=offset_caches,
+                    model_config=self.model_config,
+                )
+            elif has_mm:
                 model_output, mm_prefill_deltas = self._run_mm_paged_forward(
                     input_ids,
                     offset_caches,
@@ -950,14 +1000,19 @@ class MetalModelRunner:
             clear_context()
 
         # Submit to GPU — returns immediately, GPU runs in background.
-        # For GDN prefill, state-cache updates are side effects that the logits
-        # graph does not necessarily force. Submit them with logits and any
-        # target hidden states retained for assistant decoding.
-        self._submit_paged_forward_outputs(
-            logits,
-            target_hidden_states=target_hidden_states,
-            has_prefill=bool(prefill_reqs),
-        )
+        if has_pooling_work:
+            assert pooling_hidden_states is not None
+            mx.async_eval(pooling_hidden_states)
+        else:
+            assert logits is not None
+            # For GDN prefill, state-cache updates are side effects that the
+            # logits graph does not necessarily force. Submit them with logits
+            # and any target hidden states retained for assistant decoding.
+            self._submit_paged_forward_outputs(
+                logits,
+                target_hidden_states=target_hidden_states,
+                has_prefill=bool(prefill_reqs),
+            )
 
         # ---- build cu_seqlens for logit extraction ----
         cu_seqlens: list[int] = [0]
@@ -973,6 +1028,7 @@ class MetalModelRunner:
             scheduler_output=scheduler_output,
             logits=logits,
             target_hidden_states=target_hidden_states,
+            pooling_hidden_states=pooling_hidden_states,
             cu_seqlens=cu_seqlens,
             decode_segments=decode_segments,
             num_decode_tokens=num_decode_tokens,
@@ -997,6 +1053,7 @@ class MetalModelRunner:
         scheduler_output = paged_state.scheduler_output
         logits = paged_state.logits
         target_hidden_states = paged_state.target_hidden_states
+        pooling_hidden_states = paged_state.pooling_hidden_states
         cu_seqlens = paged_state.cu_seqlens
         decode_segments = paged_state.decode_segments
         num_decode_segments = len(decode_segments)
@@ -1005,6 +1062,18 @@ class MetalModelRunner:
         has_scheduled_drafts = any(
             segment.draft_token_ids for segment in decode_segments
         )
+
+        if pooling_hidden_states is not None:
+            finish_paged_pooling_batch(
+                batch,
+                pooling_hidden_states,
+                cu_seqlens=cu_seqlens,
+                num_decode_segments=num_decode_segments,
+                model_config=self.model_config,
+            )
+            return batch, scheduler_output
+
+        assert logits is not None
 
         # ---- wait for MLX forward to complete ----
         if target_hidden_states is not None:
@@ -1170,6 +1239,7 @@ class MetalModelRunner:
                     prompt_len=prompt_len,
                     cache=[],
                     sampling_params=prefill.sampling_params,
+                    pooling_params=prefill.pooling_params,
                     generator=prefill.generator,
                     generated_tokens=1,
                     block_ids=prefill.block_ids,
@@ -1570,6 +1640,13 @@ class MetalModelRunner:
 
         for new_req in new_reqs:
             req_id = new_req.req_id
+            pooling_params = new_req.pooling_params
+            validate_pooling_request(
+                new_req,
+                self.model_config,
+                paged_attention_enabled=self._paged_attention_backend is not None,
+            )
+
             # mm_features were pre-registered before encoder dispatch in
             # ``execute_model``; no further bookkeeping needed here.
             token_ids = new_req.prompt_token_ids or []
@@ -1588,6 +1665,7 @@ class MetalModelRunner:
                 prompt_len = len(token_ids)
                 cur_len = computed_tokens + scheduled_tokens
                 is_intermediate = cur_len < prompt_len
+
                 output_idx = batch.add_output(req_id, [])
 
                 batch.paged_prefill_entries.append(
@@ -1597,6 +1675,7 @@ class MetalModelRunner:
                             req_id=req_id,
                             token_ids=token_ids[computed_tokens:cur_len],
                             sampling_params=sampling_params,
+                            pooling_params=pooling_params,
                             block_ids=sched_block_ids,
                             generator=generator,
                             prompt_len=prompt_len if not is_intermediate else None,
@@ -1615,6 +1694,7 @@ class MetalModelRunner:
                         prompt_len=prompt_len,
                         cache=[],
                         sampling_params=sampling_params,
+                        pooling_params=pooling_params,
                         generator=generator,
                         generated_tokens=0,
                         block_ids=sched_block_ids,
@@ -1633,6 +1713,7 @@ class MetalModelRunner:
                 prompt_len=len(token_ids),
                 cache=cache,
                 sampling_params=sampling_params,
+                pooling_params=None,
                 generator=generator,
                 generated_tokens=1,
                 block_ids=[],
@@ -1698,6 +1779,7 @@ class MetalModelRunner:
                 scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
                 target_len = computed_tokens + scheduled_tokens
                 is_intermediate = target_len < len(state.token_ids)
+
                 output_idx = batch.add_output(req_id, [])
 
                 batch.paged_prefill_entries.append(
@@ -1707,6 +1789,7 @@ class MetalModelRunner:
                             req_id=req_id,
                             token_ids=state.token_ids[computed_tokens:target_len],
                             sampling_params=state.sampling_params,
+                            pooling_params=state.pooling_params,
                             block_ids=state.block_ids,
                             generator=state.generator,
                             prompt_len=(
@@ -1782,6 +1865,7 @@ class MetalModelRunner:
                     req_id=prefill.req_id,
                     token_ids=prefill.token_ids,
                     sampling_params=prefill.sampling_params,
+                    pooling_params=prefill.pooling_params,
                     block_ids=prefill.block_ids,
                     generator=prefill.generator,
                     prompt_len=prefill.prompt_len,
@@ -1801,7 +1885,7 @@ class MetalModelRunner:
             sampled_token_ids=batch.sampled_tokens,
             logprobs=batch.merged_logprobs(),
             prompt_logprobs_dict={},
-            pooler_output=[None] * len(batch.req_ids),
+            pooler_output=batch.pooler_outputs,
         )
 
     def _run_non_paged_decode_batch(
@@ -1844,7 +1928,10 @@ class MetalModelRunner:
                 missing_req_ids.append(req_id)
                 continue
 
-            if batch.sampled_tokens[output_idx]:
+            if (
+                batch.sampled_tokens[output_idx]
+                or batch.pooler_outputs[output_idx] is not None
+            ):
                 continue
 
             state = self._request_states.get(req_id)
@@ -1983,6 +2070,11 @@ class MetalModelRunner:
                 batch.paged_decode_reqs,
                 scheduler_output,
             )
+            if self._is_pooling:
+                batch, scheduler_output = self._sample_paged_batch(None)
+                self._gdn_materialize_pending_state_cache()
+                self._validate_scheduled_outputs(batch, scheduler_output)
+                return self._build_output(batch)
             return None
 
         # Defensive invariant: the vLLM scheduler sets has_structured_output_requests
@@ -2008,7 +2100,10 @@ class MetalModelRunner:
         self._validate_scheduled_outputs(batch, scheduler_output)
         if not batch.req_ids:
             return self._build_output(batch)
-        self._pending_output = self._build_output(batch)
+        output = self._build_output(batch)
+        if self._is_pooling:
+            return output
+        self._pending_output = output
         return None
 
     def sample_tokens(

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Text embedding pooling helpers for the Metal V1 model runner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import torch
+from vllm.pooling_params import PoolingParams
+
+from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+
+_EMBED_POOLER_TASKS = (None, "embed")
+_LAST_POOLING = (None, "LAST")
+
+
+def _model_label(model_config: Any) -> str:
+    served = getattr(model_config, "served_model_name", None)
+    if isinstance(served, (list, tuple)):
+        served = served[0] if served else None
+    return str(served or getattr(model_config, "model", "unknown"))
+
+
+def _hf_config(model_config: Any) -> Any:
+    return getattr(model_config, "hf_config", None)
+
+
+def _architecture_names(model_config: Any) -> tuple[str, ...]:
+    candidates: list[str] = []
+    hf_config = _hf_config(model_config)
+    for source in (model_config, hf_config):
+        architectures = getattr(source, "architectures", None)
+        if isinstance(architectures, (list, tuple)):
+            candidates.extend(str(arch) for arch in architectures)
+    return tuple(candidates)
+
+
+def _pooler_config(model_config: Any) -> Any:
+    return getattr(model_config, "pooler_config", None)
+
+
+def _pooler_task(model_config: Any) -> str | None:
+    task = getattr(_pooler_config(model_config), "task", None)
+    return str(task) if task is not None else None
+
+
+def _sequence_pooling_types(model_config: Any) -> tuple[str | None, str | None]:
+    pooler_config = _pooler_config(model_config)
+    if pooler_config is None:
+        return (None, None)
+    seq_pooling_type = getattr(pooler_config, "seq_pooling_type", None)
+    pooling_type = getattr(pooler_config, "pooling_type", None)
+    return (
+        str(seq_pooling_type) if seq_pooling_type is not None else None,
+        str(pooling_type) if pooling_type is not None else None,
+    )
+
+
+def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
+    for pooling_type in _sequence_pooling_types(model_config):
+        if pooling_type not in _LAST_POOLING:
+            return pooling_type
+    return None
+
+
+def _pooler_activation_allows_embed(model_config: Any) -> bool:
+    pooler_config = _pooler_config(model_config)
+    if pooler_config is None:
+        return True
+    return getattr(pooler_config, "use_activation", None) is not False
+
+
+def _chunked_processing_enabled(model_config: Any) -> bool:
+    return bool(
+        getattr(_pooler_config(model_config), "enable_chunked_processing", False)
+    )
+
+
+def _reject_unsupported_pooler_config(model_config: Any) -> None:
+    task = _pooler_task(model_config)
+    if task not in _EMBED_POOLER_TASKS:
+        raise NotImplementedError(
+            "Metal embed pooling supports only pooler_config.task unset or "
+            f"'embed'; got {task!r} for model={_model_label(model_config)}."
+        )
+
+    seq_pooling_type = _unsupported_sequence_pooling_type(model_config)
+    if seq_pooling_type is not None:
+        raise NotImplementedError(
+            "Metal embed pooling currently supports only LAST sequence pooling; "
+            f"got {seq_pooling_type!r} for model={_model_label(model_config)}."
+        )
+    if _chunked_processing_enabled(model_config):
+        raise NotImplementedError(
+            "Metal embed pooling does not support "
+            "pooler_config.enable_chunked_processing=True with LAST pooling; "
+            f"model={_model_label(model_config)}."
+        )
+
+
+def _is_decoder_embedding_config(model_config: Any) -> bool:
+    architectures = _architecture_names(model_config)
+    return any(
+        arch.endswith("ForCausalLM")
+        or arch.endswith("ForTextEncoding")
+        or arch.endswith("EmbeddingModel")
+        for arch in architectures
+    )
+
+
+def sequence_model(model: Any) -> Any | None:
+    """Return the MLX transformer body when it is available."""
+    inner = getattr(model, "model", None)
+    return inner if callable(inner) else None
+
+
+def supports_embed_pooling(model: Any, model_config: Any) -> bool:
+    """Return whether this loaded model can use Metal's LAST embed path."""
+    if getattr(model_config, "multimodal_config", None) is not None:
+        return False
+    if _pooler_task(model_config) not in _EMBED_POOLER_TASKS:
+        return False
+    if _unsupported_sequence_pooling_type(model_config) is not None:
+        return False
+    if not _pooler_activation_allows_embed(model_config):
+        return False
+    if _chunked_processing_enabled(model_config):
+        return False
+    return sequence_model(model) is not None and _is_decoder_embedding_config(
+        model_config
+    )
+
+
+def _unsupported_pooling_option(
+    pooling_params: PoolingParams,
+    model_config: Any,
+) -> str | None:
+    checks = (
+        (
+            "late-interaction parameters",
+            getattr(pooling_params, "late_interaction_params", None) is not None,
+        ),
+        (
+            "token-level ALL pooling outputs",
+            getattr(pooling_params, "requires_token_ids", False),
+        ),
+        (
+            "STEP pooling parameters",
+            getattr(pooling_params, "step_tag_id", None) is not None,
+        ),
+        (
+            "returned_token_ids",
+            getattr(pooling_params, "returned_token_ids", None) is not None,
+        ),
+        (
+            "extra pooling kwargs",
+            bool(getattr(pooling_params, "extra_kwargs", None)),
+        ),
+        (
+            "use_activation=False",
+            getattr(pooling_params, "use_activation", None) is False,
+        ),
+        (
+            "embedding-dimension truncation",
+            getattr(pooling_params, "dimensions", None) is not None
+            or getattr(_pooler_config(model_config), "dimensions", None) is not None,
+        ),
+    )
+    for reason, unsupported in checks:
+        if unsupported:
+            return reason
+    return None
+
+
+def validate_pooling_params(
+    pooling_params: PoolingParams,
+    model_config: Any,
+) -> None:
+    """Validate the narrow text-only LAST `embed` pooling contract."""
+    model = _model_label(model_config)
+    if getattr(model_config, "runner_type", None) != "pooling":
+        raise NotImplementedError(
+            "Metal embed pooling requires runner_type='pooling'; got "
+            f"{getattr(model_config, 'runner_type', None)!r} for model={model}."
+        )
+    _reject_unsupported_pooler_config(model_config)
+    if not _is_decoder_embedding_config(model_config):
+        raise NotImplementedError(
+            "Metal embed pooling requires a decoder-style checkpoint; got "
+            f"architectures={_architecture_names(model_config)!r} for model="
+            f"{model}."
+        )
+
+    task = getattr(pooling_params, "task", None)
+    if task not in (None, "embed"):
+        raise NotImplementedError(
+            "Metal pooling supports only text-only task='embed' for now; "
+            f"got task={task!r} for model={model}."
+        )
+
+    unsupported_option = _unsupported_pooling_option(pooling_params, model_config)
+    if unsupported_option is not None:
+        raise NotImplementedError(
+            f"Metal embed pooling does not support {unsupported_option} "
+            f"for model={model}."
+        )
+
+
+def validate_pooling_request(
+    new_req: Any,
+    model_config: Any,
+    *,
+    paged_attention_enabled: bool,
+) -> None:
+    """Validate the request-level contract for Metal text embedding pooling."""
+    pooling_params = new_req.pooling_params
+    if pooling_params is None:
+        return
+
+    validate_pooling_params(pooling_params, model_config)
+    if new_req.mm_features:
+        raise NotImplementedError(
+            "Multimodal pooling inputs are not supported on Metal yet."
+        )
+    if getattr(new_req, "prompt_embeds", None) is not None:
+        raise NotImplementedError(
+            "Prompt-embedding pooling inputs are not supported on Metal yet."
+        )
+    if not paged_attention_enabled:
+        raise NotImplementedError(
+            "Metal embed pooling currently requires paged attention; "
+            "set VLLM_METAL_USE_PAGED_ATTENTION=1."
+        )
+    if not (new_req.prompt_token_ids or []):
+        raise ValueError(
+            "Metal embed pooling requires prompt_token_ids for "
+            f"request {new_req.req_id!r}."
+        )
+
+
+def forward_sequence_hidden_states(
+    model: Any,
+    input_ids: mx.array,
+    *,
+    cache: Any,
+    model_config: Any,
+) -> mx.array:
+    """Run the transformer body and return per-token hidden states."""
+    _reject_unsupported_pooler_config(model_config)
+    body = sequence_model(model)
+    if body is None:
+        raise NotImplementedError(
+            "Metal embed pooling requires an MLX model with a callable "
+            f"'.model' transformer body; model={_model_label(model_config)}; "
+            "task='embed'."
+        )
+
+    hidden_states = body(input_ids) if cache is None else body(input_ids, cache=cache)
+
+    if not hasattr(hidden_states, "shape") or not hasattr(hidden_states, "dtype"):
+        raise ValueError(
+            "Metal embed pooling expected MLX hidden states from model body; "
+            f"got {type(hidden_states).__name__} for model="
+            f"{_model_label(model_config)}."
+        )
+    return hidden_states
+
+
+def pooling_dummy_forward_outputs(
+    model: Any,
+    input_ids: mx.array,
+    *,
+    model_config: Any,
+) -> list[mx.array]:
+    """Return warm-up outputs for a pooling model."""
+    return [
+        forward_sequence_hidden_states(
+            model,
+            input_ids,
+            cache=None,
+            model_config=model_config,
+        )
+    ]
+
+
+def has_paged_pooling_work(
+    prefill_reqs: list[Any],
+    decode_reqs: list[Any],
+) -> bool:
+    """Return whether a paged batch is pure pooling work."""
+    pooling_prefills = [pr for pr in prefill_reqs if pr.pooling_params is not None]
+    has_pooling_work = bool(pooling_prefills)
+    if has_pooling_work and (len(pooling_prefills) != len(prefill_reqs) or decode_reqs):
+        raise NotImplementedError(
+            "Metal pooling batches cannot mix pooling requests with "
+            "generation prefill/decode requests."
+        )
+    return has_pooling_work
+
+
+def _normalize_vector(vector: mx.array) -> mx.array:
+    norm = mx.sqrt(mx.sum(vector * vector))
+    norm = mx.maximum(norm, mx.array(1e-12, dtype=mx.float32))
+    return mx.contiguous(vector / norm)
+
+
+def pool_sequence_embedding(
+    hidden_states: mx.array,
+    *,
+    token_index: int,
+    pooling_params: PoolingParams,
+    model_config: Any,
+) -> torch.Tensor:
+    """Return a normalized CPU LAST embedding for one finished request."""
+    if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
+        raise ValueError(
+            "Metal embed pooling expected hidden states with shape "
+            f"[1, tokens, hidden], got {hidden_states.shape} "
+            f"for model={_model_label(model_config)}."
+        )
+    if token_index < 0 or token_index >= hidden_states.shape[1]:
+        raise ValueError(
+            f"Metal embed pooling token index {token_index} is outside hidden "
+            f"state shape {hidden_states.shape} for model={_model_label(model_config)}."
+        )
+
+    vector = hidden_states[0, token_index, :].astype(mx.float32)
+    vector = _normalize_vector(vector)
+    tensor = mlx_to_torch(vector, device="cpu", already_contiguous=True)
+    return tensor.detach().clone()
+
+
+def pool_sequence_batch(
+    hidden_states: mx.array,
+    *,
+    token_indices: list[int | None],
+    pooling_params: list[PoolingParams],
+    model_config: Any,
+) -> list[torch.Tensor | None]:
+    """Pool a paged prefill batch; unfinished chunks return ``None``."""
+    outputs: list[torch.Tensor | None] = []
+    for token_index, params in zip(token_indices, pooling_params, strict=True):
+        if token_index is None:
+            outputs.append(None)
+            continue
+        outputs.append(
+            pool_sequence_embedding(
+                hidden_states,
+                token_index=token_index,
+                pooling_params=params,
+                model_config=model_config,
+            )
+        )
+    return outputs
+
+
+def pool_paged_prefill_batch(
+    hidden_states: mx.array,
+    *,
+    prefill_entries: list[Any],
+    cu_seqlens: list[int],
+    num_decode_segments: int,
+    model_config: Any,
+) -> list[torch.Tensor | None]:
+    """Pool a paged prefill batch; unfinished chunks return ``None``."""
+    mx.eval(hidden_states)
+
+    token_indices: list[int | None] = []
+    pooling_params: list[PoolingParams] = []
+    for i, entry in enumerate(prefill_entries):
+        pooling_params_for_req = entry.prefill.pooling_params
+        if pooling_params_for_req is None:
+            raise RuntimeError(
+                "Paged pooling batch contained a non-pooling prefill request."
+            )
+        pooling_params.append(pooling_params_for_req)
+
+        if entry.result_mode == "intermediate":
+            token_indices.append(None)
+        else:
+            token_indices.append(cu_seqlens[num_decode_segments + i + 1] - 1)
+
+    return pool_sequence_batch(
+        hidden_states,
+        token_indices=token_indices,
+        pooling_params=pooling_params,
+        model_config=model_config,
+    )
+
+
+def finish_paged_pooling_batch(
+    batch: Any,
+    hidden_states: mx.array,
+    *,
+    cu_seqlens: list[int],
+    num_decode_segments: int,
+    model_config: Any,
+) -> None:
+    """Convert final paged prefill hidden states into batch pooler outputs."""
+    pooler_outputs = pool_paged_prefill_batch(
+        hidden_states,
+        prefill_entries=batch.paged_prefill_entries,
+        cu_seqlens=cu_seqlens,
+        num_decode_segments=num_decode_segments,
+        model_config=model_config,
+    )
+    for entry, pooler_output in zip(
+        batch.paged_prefill_entries, pooler_outputs, strict=True
+    ):
+        batch.set_output(entry.output_idx, [], None, pooler_output)


### PR DESCRIPTION
Implements the first Metal V1 pooling MVP for #361: text-only `embed` support on Apple Silicon.

What this adds
- Advertises `embed` for compatible text-only pooling models on Metal V1
- Returns `ModelRunnerOutput.pooler_output` for pooling requests
- Keeps `sampled_token_ids` empty for embedding requests
- Pools the final prompt-token hidden state with LAST pooling and L2 normalization
- Fails fast for unsupported variants such as classify, score, token-level pooling, non-LAST sequence pooling, multimodal inputs, and prompt embeddings

What is intentionally out of scope
- Direct model-provided embedding tensors
- Classification / rerank / late interaction
- Multimodal embeddings
- Token-level pooling
- Sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`, `STEP`)

Validation
- `python -m pytest tests/test_v1_pooling.py -q`
- `python -m pytest tests/test_v1_worker.py tests/test_v1_pooling.py -q`
- `python -m pytest tests/test_v1_pooling.py tests/test_v1_model_runner_generate.py -q`
- `python -m pytest tests/test_v1_model_runner_generate.py tests/test_v1_worker.py tests/test_paged_attention.py tests/test_sampling.py tests/test_grammar_bitmask.py -q`
- `scripts/lint.sh`
- Offline smoke: `LLM.embed()` with `mlx-community/Qwen3-Embedding-0.6B-8bit` returned 2 embeddings of 1024 dims
- Online smoke: `POST /v1/embeddings` on `vllm serve` returned 2 embeddings of 1024 dims
