### PR TITLE
[Build] invalidate JIT cache by source hash, not mtime

### DIFF
--- a/tests/test_metal_build_cache.py
+++ b/tests/test_metal_build_cache.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the JIT-build cache invalidation in vllm_metal.metal.build."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from vllm_metal.metal import build
+
+
+@dataclass
+class _Paths:
+    src: Path
+    bld: Path
+    consts: Path
+    nb_src: Path
+    out: Path
+    hsh: Path
+    spec: "build._BuildSpec"
+
+
+@pytest.fixture
+def patched(tmp_path, monkeypatch) -> _Paths:
+    src = tmp_path / "paged_ops.cpp"
+    bld = tmp_path / "build.py"
+    consts = tmp_path / "constants.py"
+    nb_src = tmp_path / "nb_combined.cpp"
+    out = tmp_path / "_paged_ops.so"
+    hsh = tmp_path / "_paged_ops.so.sha256"
+
+    src.write_bytes(b"// source v1")
+    bld.write_bytes(b"# build v1")
+    consts.write_bytes(b"PARTITION_SIZE = 256")
+    nb_src.write_bytes(b"// nanobind combined v1")
+
+    monkeypatch.setattr(build, "_SRC", src)
+    monkeypatch.setattr(build, "_BUILD", bld)
+    monkeypatch.setattr(build, "_CONSTANTS", consts)
+    monkeypatch.setattr(build, "_OUT", out)
+    monkeypatch.setattr(build, "_HASH", hsh)
+
+    spec = build._BuildSpec(
+        cmd=["clang++", "-O2", "-Lfake/mlx/lib", "-o", str(out)],
+        nb_src=nb_src,
+        mlx_lib=Path("/fake/mlx/lib"),
+        mlx_include=Path("/fake/mlx/include"),
+        py_include="/fake/py/include",
+        mlx_version="0.31.0",
+        nb_version="2.10.0",
+    )
+    monkeypatch.setattr(build, "_build_spec", lambda: spec)
+
+    return _Paths(src, bld, consts, nb_src, out, hsh, spec)
+
+
+def test_needs_rebuild_when_so_missing(patched):
+    assert build.needs_rebuild() is True
+
+
+def test_needs_rebuild_when_hash_sidecar_missing(patched):
+    patched.out.write_bytes(b"compiled")
+    assert build.needs_rebuild() is True
+
+
+def test_needs_rebuild_when_hash_differs(patched):
+    patched.out.write_bytes(b"compiled")
+    patched.hsh.write_text("deadbeef")
+    assert build.needs_rebuild() is True
+
+
+def test_no_rebuild_when_hash_matches(patched):
+    patched.out.write_bytes(b"compiled")
+    patched.hsh.write_text(build._input_hash(patched.spec))
+    assert build.needs_rebuild() is False
+
+
+def test_old_content_with_newer_so_mtime_still_rebuilds(patched):
+    # Regression: under the old mtime-based check, a stale .so from a previous
+    # branch could shadow freshly-checked-out sources whose mtimes git set to
+    # the checkout time.
+    patched.out.write_bytes(b"compiled-from-prev-branch")
+    patched.hsh.write_text("hash-from-prev-branch")
+    older = patched.out.stat().st_mtime - 86400
+    for p in (patched.src, patched.bld, patched.consts, patched.nb_src):
+        os.utime(p, (older, older))
+    assert build.needs_rebuild() is True
+
+
+def test_hash_changes_with_source_bytes(patched):
+    h1 = build._input_hash(patched.spec)
+    patched.src.write_bytes(b"// source v2")
+    assert build._input_hash(patched.spec) != h1
+
+
+def test_hash_changes_with_constants_bytes(patched):
+    h1 = build._input_hash(patched.spec)
+    patched.consts.write_bytes(b"PARTITION_SIZE = 512")
+    assert build._input_hash(patched.spec) != h1
+
+
+def test_hash_changes_with_nb_src_bytes(patched):
+    h1 = build._input_hash(patched.spec)
+    patched.nb_src.write_bytes(b"// nanobind combined v2")
+    assert build._input_hash(patched.spec) != h1
+
+
+def test_hash_changes_with_cmd(patched):
+    # Simulates venv switch / different MLX install path.
+    h1 = build._input_hash(patched.spec)
+    s2 = dataclasses.replace(
+        patched.spec, cmd=patched.spec.cmd + ["-L/other/mlx/lib"]
+    )
+    assert build._input_hash(s2) != h1
+
+
+def test_hash_changes_with_mlx_version(patched):
+    h1 = build._input_hash(patched.spec)
+    s2 = dataclasses.replace(patched.spec, mlx_version="99.0.0")
+    assert build._input_hash(s2) != h1
+
+
+def test_hash_changes_with_nb_version(patched):
+    h1 = build._input_hash(patched.spec)
+    s2 = dataclasses.replace(patched.spec, nb_version="99.0.0")
+    assert build._input_hash(s2) != h1
+
+
+def test_hash_stable_across_calls(patched):
+    assert build._input_hash(patched.spec) == build._input_hash(patched.spec)
+
+
+def test_needs_rebuild_swallows_resolution_errors(patched, monkeypatch):
+    patched.out.write_bytes(b"compiled")
+    patched.hsh.write_text("anything")
+
+    def boom():
+        raise ImportError("mlx not installed")
+
+    monkeypatch.setattr(build, "_build_spec", boom)
+    assert build.needs_rebuild() is True

--- a/tests/test_metal_build_cache.py
+++ b/tests/test_metal_build_cache.py
@@ -21,7 +21,7 @@ class _Paths:
     nb_src: Path
     out: Path
     hsh: Path
-    spec: "build._BuildSpec"
+    spec: build._BuildSpec
 
 
 @pytest.fixture
@@ -112,9 +112,7 @@ def test_hash_changes_with_nb_src_bytes(patched):
 def test_hash_changes_with_cmd(patched):
     # Simulates venv switch / different MLX install path.
     h1 = build._input_hash(patched.spec)
-    s2 = dataclasses.replace(
-        patched.spec, cmd=patched.spec.cmd + ["-L/other/mlx/lib"]
-    )
+    s2 = dataclasses.replace(patched.spec, cmd=patched.spec.cmd + ["-L/other/mlx/lib"])
     assert build._input_hash(s2) != h1
 
 

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -11,6 +11,7 @@ import hashlib
 import logging
 import subprocess
 import sysconfig
+from dataclasses import dataclass
 from pathlib import Path
 
 from vllm_metal.metal.constants import PARTITION_SIZE
@@ -21,22 +22,11 @@ _THIS_DIR = Path(__file__).resolve().parent
 _SRC = _THIS_DIR / "paged_ops.cpp"
 _BUILD = _THIS_DIR / "build.py"
 _CONSTANTS = _THIS_DIR / "constants.py"
-_INPUTS = (_SRC, _BUILD, _CONSTANTS)
 _EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
 _CACHE_DIR = Path.home() / ".cache" / "vllm-metal"
 _CACHE_DIR.mkdir(parents=True, exist_ok=True)
 _OUT = _CACHE_DIR / f"_paged_ops{_EXT_SUFFIX}"
 _HASH = _OUT.with_suffix(_OUT.suffix + ".sha256")
-
-
-def _input_hash() -> str:
-    h = hashlib.sha256()
-    for p in _INPUTS:
-        h.update(p.name.encode())
-        h.update(b"\0")
-        h.update(p.read_bytes())
-        h.update(b"\0")
-    return h.hexdigest()
 
 
 def _find_package_path(name: str) -> Path:
@@ -53,42 +43,33 @@ def _find_package_path(name: str) -> Path:
     raise RuntimeError(f"Cannot locate package '{name}'")
 
 
-def needs_rebuild() -> bool:
-    if not _OUT.exists() or not _HASH.exists():
-        return True
-    try:
-        return _HASH.read_text().strip() != _input_hash()
-    except OSError:
-        return True
+def _package_version(name: str) -> str:
+    import importlib
+
+    mod = importlib.import_module(name)
+    return str(getattr(mod, "__version__", ""))
 
 
-def build() -> Path:
-    """JIT-build the native extension, returning the path to the .so."""
-    if not needs_rebuild():
-        return _OUT
+@dataclass(frozen=True)
+class _BuildSpec:
+    cmd: list[str]
+    nb_src: Path
+    mlx_lib: Path
+    mlx_include: Path
+    py_include: str
+    mlx_version: str
+    nb_version: str
 
-    logger.info("Building native paged-attention extension ...")
 
+def _build_spec() -> _BuildSpec:
+    """Resolve every input that affects the produced .so."""
     py_include = sysconfig.get_paths()["include"]
     nb_path = _find_package_path("nanobind")
     mlx_path = _find_package_path("mlx")
     mlx_include = mlx_path / "include"
     mlx_lib = mlx_path / "lib"
     metal_cpp = mlx_include / "metal_cpp"
-
-    # Verify critical paths exist
-    for p, label in [
-        (py_include, "Python include"),
-        (nb_path, "nanobind"),
-        (mlx_include, "MLX include"),
-        (mlx_lib / "libmlx.dylib", "MLX lib"),
-    ]:
-        if not Path(p).exists():
-            raise FileNotFoundError(f"{label} not found: {p}")
-
     nb_src = nb_path / "src" / "nb_combined.cpp"
-    if not nb_src.exists():
-        raise FileNotFoundError(f"nanobind source not found: {nb_src}")
 
     cmd = [
         "clang++",
@@ -121,8 +102,67 @@ def build() -> Path:
         str(_OUT),
     ]
 
-    logger.info("  %s", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    return _BuildSpec(
+        cmd=cmd,
+        nb_src=nb_src,
+        mlx_lib=mlx_lib,
+        mlx_include=mlx_include,
+        py_include=py_include,
+        mlx_version=_package_version("mlx.core"),
+        nb_version=_package_version("nanobind"),
+    )
+
+
+def _input_hash(spec: _BuildSpec) -> str:
+    h = hashlib.sha256()
+    # Resolved compile invocation captures MLX/nanobind/Python paths and
+    # compile-time defines like PARTITION_SIZE.
+    h.update("\0".join(spec.cmd).encode())
+    h.update(b"\0")
+    # Versions catch in-place upgrades where the install path is reused.
+    h.update(f"mlx={spec.mlx_version}\0nb={spec.nb_version}\0".encode())
+    for p in (_SRC, _BUILD, _CONSTANTS, spec.nb_src):
+        h.update(p.name.encode())
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def needs_rebuild() -> bool:
+    if not _OUT.exists() or not _HASH.exists():
+        return True
+    try:
+        spec = _build_spec()
+        return _HASH.read_text().strip() != _input_hash(spec)
+    except (OSError, ImportError, RuntimeError):
+        return True
+
+
+def build() -> Path:
+    """JIT-build the native extension, returning the path to the .so."""
+    spec = _build_spec()
+    expected_hash = _input_hash(spec)
+    if _OUT.exists() and _HASH.exists():
+        try:
+            if _HASH.read_text().strip() == expected_hash:
+                return _OUT
+        except OSError:
+            pass
+
+    logger.info("Building native paged-attention extension ...")
+
+    for p, label in [
+        (spec.py_include, "Python include"),
+        (spec.mlx_include, "MLX include"),
+        (spec.mlx_lib / "libmlx.dylib", "MLX lib"),
+        (spec.nb_src, "nanobind source"),
+    ]:
+        if not Path(p).exists():
+            raise FileNotFoundError(f"{label} not found: {p}")
+
+    logger.info("  %s", " ".join(spec.cmd))
+    result = subprocess.run(spec.cmd, capture_output=True, text=True)
 
     if result.returncode != 0:
         raise RuntimeError(
@@ -131,6 +171,6 @@ def build() -> Path:
             f"stderr:\n{result.stderr}"
         )
 
-    _HASH.write_text(_input_hash())
+    _HASH.write_text(expected_hash)
     logger.info("Built %s", _OUT)
     return _OUT

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -7,6 +7,7 @@ Metal shaders through MLX's own command encoder.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import subprocess
 import sysconfig
@@ -20,10 +21,22 @@ _THIS_DIR = Path(__file__).resolve().parent
 _SRC = _THIS_DIR / "paged_ops.cpp"
 _BUILD = _THIS_DIR / "build.py"
 _CONSTANTS = _THIS_DIR / "constants.py"
+_INPUTS = (_SRC, _BUILD, _CONSTANTS)
 _EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
 _CACHE_DIR = Path.home() / ".cache" / "vllm-metal"
 _CACHE_DIR.mkdir(parents=True, exist_ok=True)
 _OUT = _CACHE_DIR / f"_paged_ops{_EXT_SUFFIX}"
+_HASH = _OUT.with_suffix(_OUT.suffix + ".sha256")
+
+
+def _input_hash() -> str:
+    h = hashlib.sha256()
+    for p in _INPUTS:
+        h.update(p.name.encode())
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
 
 
 def _find_package_path(name: str) -> Path:
@@ -41,15 +54,12 @@ def _find_package_path(name: str) -> Path:
 
 
 def needs_rebuild() -> bool:
-    """Return True if the .so is missing or older than the source."""
-    if not _OUT.exists():
+    if not _OUT.exists() or not _HASH.exists():
         return True
-    latest_input_mtime = max(
-        _SRC.stat().st_mtime,
-        _BUILD.stat().st_mtime,
-        _CONSTANTS.stat().st_mtime,
-    )
-    return _OUT.stat().st_mtime < latest_input_mtime
+    try:
+        return _HASH.read_text().strip() != _input_hash()
+    except OSError:
+        return True
 
 
 def build() -> Path:
@@ -121,5 +131,6 @@ def build() -> Path:
             f"stderr:\n{result.stderr}"
         )
 
+    _HASH.write_text(_input_hash())
     logger.info("Built %s", _OUT)
     return _OUT


### PR DESCRIPTION
## Summary

The paged-attention extension is JIT-built into `~/.cache/vllm-metal/_paged_ops*.so`. `needs_rebuild()` compared the cached `.so` mtime against source mtimes; this is unsafe and incomplete:

- The cache lives outside the repo and persists across branches. After a `git checkout` that moves `paged_ops.cpp` / `build.py` / `constants.py` backwards in history, source mtimes are set to the checkout time (older than a `.so` produced on a previous branch), so the stale `.so` is reused and the runtime hits missing-symbol errors (e.g. old `paged_attention_tiled_*` after the rewrite to `paged_attention_v2_online`).
- The `.so` also depends on resolved build inputs that don't appear in source mtimes — the MLX install path/version we link and rpath against, nanobind src, `PARTITION_SIZE`, the Python include. Switching virtualenvs or upgrading MLX in place could keep the source identical while invalidating the linked dylib.

This switches to a content hash stored in a sidecar next to the `.so`. `needs_rebuild()` compares the recomputed hash against the sidecar; mtime is not consulted.

The hash covers:

- bytes of `paged_ops.cpp`, `build.py`, `constants.py`, `nb_combined.cpp`
- the fully-resolved `clang++` invocation (Python include, nanobind paths, MLX `-L`/`-I`/`-rpath`, `PARTITION_SIZE` define, output path)
- `mlx.core.__version__` and `nanobind.__version__` (for in-place upgrades where the install path is reused)

`_build_spec()` centralizes the resolution; `build()` and the hash share it, so the cache key cannot drift from what we actually compile.

Existing caches without a sidecar trigger one rebuild on first run, then hash-based invalidation from then on.