### PR TITLE
[kernel] long prefill GQA kernel [2/3]

### DIFF
--- a/tests/test_primitive_and_donation.py
+++ b/tests/test_primitive_and_donation.py
@@ -35,11 +35,11 @@ def _make_cache_and_inputs(
     num_query_heads: int,
     seq_lens: list[tuple[int, int]],
     *,
+    head_size: int = HEAD_SIZE,
     dtype: mx.Dtype = DTYPE,
 ):
     """Build a populated cache and matching query/metadata tensors."""
     block_size = BLOCK_SIZE
-    head_size = HEAD_SIZE
     num_seqs = len(seq_lens)
     query_lens = [s[0] for s in seq_lens]
     kv_lens = [s[1] for s in seq_lens]
@@ -202,6 +202,63 @@ def test_primitive_vs_reference_varlen(
         block_tables=np.array(d["block_tables"]),
         scale=d["scale"],
         sliding_window=sliding_window if sliding_window >= 0 else None,
+    )
+    mx.eval(ref)
+
+    np.testing.assert_allclose(
+        np.array(out),
+        np.array(ref),
+        atol=1.5e-2,
+        rtol=1e-2,
+    )
+
+
+# ── 1b. Tiled-kernel head-size coverage ─────────────────────────────────────
+
+
+@pytest.mark.parametrize("head_size", [64, 96, 128])
+def test_tiled_kernel_head_size_parity(head_size: int) -> None:
+    """Tiled prefill kernel matches reference for every routed head size.
+
+    can_use_tiled_kernel() routes head sizes {64, 96, 128} to the BQ=32
+    flash kernel; each is a separately compiled template specialization
+    (TD = HEAD_SIZE / 8 differs).  The varlen test only exercises 128, so
+    this adds one prefill shape per head size to keep CI parity 1:1 with
+    can_use_tiled_kernel().
+    """
+    mx.random.seed(0)
+    # Prefill-only (q_len > 1 for every seq) guarantees tiled dispatch.
+    seq_lens = [(32, 512), (64, 1024)]
+    d = _make_cache_and_inputs(256, 2, 8, seq_lens, head_size=head_size)
+
+    ops = get_ops()
+    out = mx.array(0)
+    ops.paged_attention_primitive(
+        d["query"],
+        d["key_cache"],
+        d["value_cache"],
+        d["num_kv_heads"],
+        d["scale"],
+        0.0,  # softcap
+        d["block_tables"],
+        d["kv_lens_arr"],
+        d["cu_seqlens_q"],
+        BLOCK_SIZE,
+        d["max_kv_len"],
+        -1,  # sliding_window
+        out,
+    )
+    mx.eval(out)
+
+    ref = ref_paged_attn(
+        query=d["query"],
+        key_cache=d["key_cache"],
+        value_cache=d["value_cache"],
+        query_lens=d["query_lens"],
+        kv_lens=d["kv_lens"],
+        block_tables=np.array(d["block_tables"]),
+        scale=d["scale"],
+        sliding_window=None,
     )
     mx.eval(ref)
 

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -1,25 +1,47 @@
 // SPDX-License-Identifier: Apache-2.0
-// Tiled paged attention — Flash-Attention-style kernel using simdgroup 8×8 MMA.
+// Flash-Attention-2 style paged attention kernel for Apple Silicon (BQ=32).
 //
-// Separate from pagedattention.metal (the per-token kernel) to keep the two
-// implementations independent.  Both are compiled into the same Metal library
-// via the build system's source concatenation.
+// Design points:
 //
-// Requires utils.metal (provides DIVIDE_ROUND_UP, MIN, MAX) and
-// <metal_stdlib> / using namespace metal (from earlier in the concat).
+//   1. Q lives in registers for the entire KV loop (loaded ONCE).
+//   2. O accumulator lives in registers (no per-tile O_smem round-trip).
+//   3. Each simdgroup owns 8 complete Q rows (BQ=32 / NUM_SG=4 = 8).
+//   4. Online softmax done entirely in registers via simd_shuffle_xor.
+//   5. Mask applied to register S fragments (no S_smem round-trip).
+//   6. 2 barriers per KV tile (K-load and V-load) instead of 4.
+//
+// The MMA fragment layout uses Apple's 8×8 simdgroup_matrix tile.  Each lane
+// holds 2 elements of one fragment via thread_elements(); the (row, col) of
+// those 2 elements is given by frag_coord() below — derived from MLX
+// FlashAttention's MFAMMAFrag::get_coord (csrc/async_v2_kernel.metal:282).
+//
+// Paged-specific concerns vs. dense SDPA:
+//   - K/V loaded with per-token block_tables[i/BLOCK_SIZE] lookup (cannot
+//     use simdgroup_async_copy because each token may live in a different
+//     physical block).  Cooperative threadgroup load instead.
+//   - Varlen Q packing via cu_seqlens_q + binary search.
+//   - Causal mask, sliding window, softcapping applied per-frag.
+//
+// Template: <T, HEAD_SIZE, BLOCK_SIZE, BQ=32, TILE_KV=32, NUM_THREADS=128>
 
-// ========================================== Tiled Paged Attention
-// Each threadgroup processes BQ query tokens against TILE_KV KV tokens
-// per tile using simdgroup 8×8 matrix multiply-accumulate.
-//
-// Grid: (num_query_heads, total_q_blocks, 1)
-// Threadgroup: (NUM_THREADS, 1, 1)
-//
-// Q-block indexing follows the same over-allocation scheme as vLLM's
-// Triton unified attention: total_q_blocks = total_q_tokens / BQ + num_seqs.
+// Requires utils.metal (DIVIDE_ROUND_UP, MIN, MAX), <metal_stdlib>, and
+// `using namespace metal` from earlier in the source concat.
+
+// ─────────────────────────────────────────────────────────────────────────
+// Helper: thread → (row, col) inside an 8×8 simdgroup_matrix fragment.
+// Element 0 of thread_elements() lives at (fm, fn).
+// Element 1 of thread_elements() lives at (fm, fn+1).
+// Verified against simdgroup_load+store round-trip.
+// ─────────────────────────────────────────────────────────────────────────
+inline short2 frag_coord(ushort lane_id) {
+  const short qid = short(lane_id) / 4;
+  const short fm  = (qid & 4) + (short(lane_id) / 2) % 4;
+  const short fn  = (qid & 2) * 2 + (short(lane_id) % 2) * 2;
+  return short2{fn, fm};
+}
 
 template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
-          int BQ = 8, int TILE_KV = 32, int NUM_THREADS = 128>
+          int BQ = 32, int TILE_KV = 32, int NUM_THREADS = 128>
 [[kernel]] void paged_attention_tiled(
     device T *out [[buffer(2)]],
     device const T *q [[buffer(3)]],
@@ -46,13 +68,14 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
 {
   constexpr int NUM_SIMD_LANES = 32;
   constexpr int NUM_SG = NUM_THREADS / NUM_SIMD_LANES;
-  constexpr int HD_TILES = HEAD_SIZE / 8;
-  constexpr int PV_TILES_PER_SG = HD_TILES / NUM_SG;
+  constexpr int TD = HEAD_SIZE / 8;        // # of 8-wide D fragments
+  constexpr int TK = TILE_KV / 8;          // # of 8-wide K fragments
+  constexpr int ROWS_PER_SG = BQ / NUM_SG; // 8 rows per simdgroup
 
   static_assert(HEAD_SIZE % 8 == 0, "HEAD_SIZE must be a multiple of 8");
   static_assert(TILE_KV % 8 == 0, "TILE_KV must be a multiple of 8");
-  static_assert(TILE_KV <= NUM_SIMD_LANES, "TILE_KV must be <= NUM_SIMD_LANES for softmax");
-  static_assert(HD_TILES % NUM_SG == 0, "HD_TILES must be divisible by NUM_SG");
+  static_assert(BQ % NUM_SG == 0, "BQ must be divisible by NUM_SG");
+  static_assert(ROWS_PER_SG == 8, "ROWS_PER_SG must equal 8 (frag rows)");
 
   const int thread_idx = tpt.x;
   const int head_idx = tgp.x;
@@ -62,10 +85,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
   const int kv_head_idx = head_idx / num_queries_per_kv;
   const int kv_token_stride = num_kv_heads * kv_head_stride;
 
-  // === Varlen: resolve sequence and Q-block position ===
-  // Uses block-space binary search (not token-space like find_seq_idx):
-  // the predicate cu_seqlens_q[mid]/BQ + mid accounts for the per-sequence
-  // over-allocation sentinel in the Q-block grid.
+  // ─ Varlen: resolve sequence and Q-block position (binary search) ──────
   int seq_idx;
   {
     int lo = 0, hi = num_seqs;
@@ -89,21 +109,22 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
   const int context_len = seq_len - cur_batch_query_len;
   const int valid_q = min(BQ, cur_batch_query_len - q_pos_start);
 
+  // ─ Threadgroup memory layout ──────────────────────────────────────────
+  // Q_smem: BQ × HEAD_SIZE         (loaded once, then read into registers)
+  // K_smem: TILE_KV × HEAD_SIZE    (overwritten each KV tile)
+  // V_smem: TILE_KV × HEAD_SIZE    (overwritten each KV tile)
   constexpr int Q_ELEMS = BQ * HEAD_SIZE;
   constexpr int KV_ELEMS = TILE_KV * HEAD_SIZE;
-  constexpr int S_ELEMS = BQ * TILE_KV;
-  constexpr int O_ELEMS = BQ * HEAD_SIZE;
 
   threadgroup T *Q_smem = reinterpret_cast<threadgroup T *>(shared_mem);
-  threadgroup T *KV_smem = Q_smem + Q_ELEMS;
-  threadgroup float *S_smem = reinterpret_cast<threadgroup float *>(KV_smem + KV_ELEMS);
-  threadgroup float *O_smem = S_smem + S_ELEMS;
-  threadgroup float *M_smem = O_smem + O_ELEMS;
-  threadgroup float *L_smem = M_smem + BQ;
+  threadgroup T *K_smem = Q_smem + Q_ELEMS;
+  threadgroup T *V_smem = K_smem + KV_ELEMS;
 
   const float scale_log2 = scale * M_LOG2E_F;
 
-  // === Load Q into Q_smem [BQ, HEAD_SIZE] ===
+  // ─ Load Q into Q_smem [BQ, HEAD_SIZE] (cooperative) ───────────────────
+  // Rows with row >= valid_q get zero-Q (their S values will be masked
+  // anyway, but zeroing avoids garbage propagating through QK).
   const device T *q_base = q + (q_seq_start + q_pos_start) * q_stride
                              + head_idx * HEAD_SIZE;
   for (int i = thread_idx; i < Q_ELEMS; i += NUM_THREADS) {
@@ -112,172 +133,302 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     Q_smem[i] = (r < valid_q) ? q_base[r * q_stride + d] : T(0);
   }
 
-  // === Initialize O, M, L ===
-  for (int i = thread_idx; i < O_ELEMS; i += NUM_THREADS) {
-    O_smem[i] = 0.f;
-  }
-  if (thread_idx < BQ) {
-    M_smem[thread_idx] = -FLT_MAX;
-    L_smem[thread_idx] = 0.f;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // ─ Load Q into register fragments (once, reused across all KV tiles) ──
+  // Each simdgroup owns 8 contiguous rows: [sg_idx*8, sg_idx*8 + 8).
+  // For each fragment, we load Q_smem[sg_idx*8..sg_idx*8+8, d*8..d*8+8].
+  //
+  // We use vec<T,2> arrays (MLX MFAMMAFrag pattern) for register storage.
+  // simdgroup_matrix instances are materialized only at the MMA call site —
+  // this gives the compiler an unambiguous signal that the data lives in
+  // per-thread registers, not in some implicit threadgroup memory.
+  using vec2T = vec<T, 2>;
+  using vec2F = vec<float, 2>;
+  vec2T Qreg[TD];
+  #pragma unroll
+  for (int d = 0; d < TD; d++) {
+    simdgroup_matrix<T, 8, 8> tmp;
+    simdgroup_load(tmp, Q_smem + sg_idx * 8 * HEAD_SIZE + d * 8, HEAD_SIZE);
+    Qreg[d] = reinterpret_cast<thread vec2T &>(tmp.thread_elements());
   }
 
-  threadgroup_barrier(mem_flags::mem_threadgroup);
+  // ─ Initialize per-simdgroup-row online softmax state ──────────────────
+  // Each thread tracks max/sum for the row it owns inside the 8×8 frag.
+  // Lane → (fm, fn) — fm is the row this thread contributes to.
+  const short2 fc = frag_coord(ushort(lane));
+  const short fm = fc.y;   // row within the 8-row tile owned by this SG
+  const short fn = fc.x;   // col within the 8-col fragment
+
+  // Per-thread accumulator state — broadcast across lanes that share fm.
+  float max_score = -INFINITY;
+  float sum_score = 0.0f;
+
+  // O accumulator: TD fragments of (8 × 8) per simdgroup, register-resident.
+  // Each lane holds vec<float,2> per fragment.
+  vec2F Oreg[TD];
+  #pragma unroll
+  for (int d = 0; d < TD; d++) {
+    Oreg[d] = vec2F(0.0f);
+  }
 
   const device uint32_t *block_table =
       block_tables + seq_idx * max_num_blocks_per_seq;
   const int num_kv_tiles = DIVIDE_ROUND_UP(seq_len, TILE_KV);
 
-  // === Main KV tile loop (4 barriers per iteration) ===
+  // ─ MAIN KV TILE LOOP ──────────────────────────────────────────────────
   for (int tile_idx = 0; tile_idx < num_kv_tiles; tile_idx++) {
     const int tile_start = tile_idx * TILE_KV;
 
-    // Causal skip
+    // Causal skip: if the entire tile is beyond the maximum q_abs_pos this
+    // threadgroup will produce, we can stop.
     if (tile_start > context_len + q_pos_start + valid_q - 1) break;
 
-    // --- Load K: per-token block_table lookup, coalesced head reads ---
-    for (int t = sg_idx; t < TILE_KV; t += NUM_SG) {
+    // ─ Load K AND V cooperatively (paged, fused, vec2-vectorized) ─────
+    // Both K_smem and V_smem are filled in the same loop:
+    //   * block_table lookup is shared (same kv_pos for both K and V)
+    //   * memory controller interleaves K and V reads from the same
+    //     physical block, hiding K-load latency behind V-load and v.v.
+    //   * saves a barrier vs loading them separately
+    //
+    // vec<T,2> loads halve the number of load/store instructions issued.
+    // For HEAD_SIZE=64 with 32 lanes: each lane does 1 vec2 = 4 bytes per
+    // token, covering all 64 channels.  HEAD_SIZE=128: 2 vec2 per lane.
+    //
+    // Alignment: every contributing stride (kv_block_stride, kv_token_stride,
+    // kv_head_stride = HEAD_SIZE) is even because HEAD_SIZE is a multiple
+    // of 8, so `off` and `lane*VEC` are both even → 4-byte aligned vec2.
+    static_assert(HEAD_SIZE % 2 == 0, "HEAD_SIZE must be even for vec2 loads");
+    constexpr int VEC = 2;
+    using vec2T = vec<T, VEC>;
+    #pragma unroll
+    for (int t_iter = 0; t_iter < TILE_KV / NUM_SG; t_iter++) {
+      int t = sg_idx * (TILE_KV / NUM_SG) + t_iter;
       int kv_pos = tile_start + t;
       if (kv_pos < seq_len) {
         int64_t pb = int64_t(block_table[kv_pos / BLOCK_SIZE]);
-        const device T *k_ptr = k_cache + pb * kv_block_stride
+        const int64_t off = pb * kv_block_stride
             + (kv_pos % BLOCK_SIZE) * kv_token_stride
             + kv_head_idx * kv_head_stride;
-        for (int d = lane; d < HEAD_SIZE; d += NUM_SIMD_LANES)
-          KV_smem[t * HEAD_SIZE + d] = k_ptr[d];
-      } else {
-        for (int d = lane; d < HEAD_SIZE; d += NUM_SIMD_LANES)
-          KV_smem[t * HEAD_SIZE + d] = T(0);
-      }
-    }
-
-    threadgroup_barrier(mem_flags::mem_threadgroup);  // B1: K visible
-
-    // --- QK matmul: S[BQ, TILE_KV] = Q × K^T via 8×8 MMA ---
-    {
-      simdgroup_matrix<float, 8, 8> S_acc(0);
-
-#pragma unroll
-      for (int d = 0; d < HEAD_SIZE; d += 8) {
-        simdgroup_matrix<T, 8, 8> q_frag;
-        simdgroup_load(q_frag, Q_smem + d, HEAD_SIZE);
-
-        simdgroup_matrix<T, 8, 8> k_frag;
-        simdgroup_load(k_frag, KV_smem + sg_idx * 8 * HEAD_SIZE + d,
-                       HEAD_SIZE, ulong2(0), true);
-
-        simdgroup_multiply_accumulate(S_acc, q_frag, k_frag, S_acc);
-      }
-
-      simdgroup_store(S_acc, S_smem + sg_idx * 8, TILE_KV);
-    }
-
-    threadgroup_barrier(mem_flags::mem_threadgroup);  // B2: S visible
-
-    // --- Softmax (inline scale+mask) + O rescale + V load ---
-    {
-      constexpr int ROWS_PER_SG = BQ / NUM_SG;
-#pragma unroll
-      for (int ri = 0; ri < ROWS_PER_SG; ri++) {
-        const int row = sg_idx * ROWS_PER_SG + ri;
-        if (row >= BQ) continue;
-
-        const int q_abs_pos = context_len + q_pos_start + row;
-
-        float s = S_smem[row * TILE_KV + lane] * scale_log2;
-        if (softcapping > 0.0f) {
-          float s_orig = s / M_LOG2E_F;
-          s = softcapping * precise::tanh(s_orig / softcapping) * M_LOG2E_F;
+        const device T *k_ptr = k_cache + off;
+        const device T *v_ptr = v_cache + off;
+        #pragma unroll
+        for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
+          *((threadgroup vec2T *)&K_smem[t * HEAD_SIZE + d]) =
+              *((const device vec2T *)(k_ptr + d));
+          *((threadgroup vec2T *)&V_smem[t * HEAD_SIZE + d]) =
+              *((const device vec2T *)(v_ptr + d));
         }
-
-        int kv_pos = tile_start + int(lane);
-        bool masked = (kv_pos > q_abs_pos) || (kv_pos >= seq_len)
-                      || (row >= valid_q);
-        if (sliding_window >= 0)
-          masked = masked || (kv_pos < q_abs_pos + 1 - sliding_window);
-        if (masked) s = -FLT_MAX;
-
-        float block_max = simd_max(s);
-        float old_m = M_smem[row];
-        float new_m = max(old_m, block_max);
-        if (new_m == -FLT_MAX) new_m = 0.f;
-
-        float old_corr = (old_m == -FLT_MAX) ? 0.f : exp2(old_m - new_m);
-        float e = (s == -FLT_MAX) ? 0.f : exp2(s - new_m);
-        float row_sum = simd_sum(e);
-
-        L_smem[row] = L_smem[row] * old_corr + row_sum;
-        M_smem[row] = new_m;
-
-        S_smem[row * TILE_KV + lane] = e;
-
-        for (int d = lane; d < HEAD_SIZE; d += NUM_SIMD_LANES)
-          O_smem[row * HEAD_SIZE + d] *= old_corr;
-      }
-    }
-
-    // V load: writes KV_smem (separate from S_smem/O_smem, no conflict)
-    for (int t = sg_idx; t < TILE_KV; t += NUM_SG) {
-      int kv_pos = tile_start + t;
-      if (kv_pos < seq_len) {
-        int64_t pb = int64_t(block_table[kv_pos / BLOCK_SIZE]);
-        const device T *v_ptr = v_cache + pb * kv_block_stride
-            + (kv_pos % BLOCK_SIZE) * kv_token_stride
-            + kv_head_idx * kv_head_stride;
-        for (int d = lane; d < HEAD_SIZE; d += NUM_SIMD_LANES)
-          KV_smem[t * HEAD_SIZE + d] = v_ptr[d];
       } else {
-        for (int d = lane; d < HEAD_SIZE; d += NUM_SIMD_LANES)
-          KV_smem[t * HEAD_SIZE + d] = T(0);
+        const vec2T zero(T(0));
+        #pragma unroll
+        for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
+          *((threadgroup vec2T *)&K_smem[t * HEAD_SIZE + d]) = zero;
+          *((threadgroup vec2T *)&V_smem[t * HEAD_SIZE + d]) = zero;
+        }
       }
     }
 
-    threadgroup_barrier(mem_flags::mem_threadgroup);  // B3: P, O rescaled, V visible
+    threadgroup_barrier(mem_flags::mem_threadgroup);  // K & V visible
 
-    // --- PV matmul: O += P × V via 8×8 MMA ---
-    // P kept in float (S_smem); uses float×half→float mixed-precision MMA.
-#pragma unroll
-    for (int c = 0; c < PV_TILES_PER_SG; c++) {
-      int hd_start = (sg_idx * PV_TILES_PER_SG + c) * 8;
+    // ─ QK matmul: S[8, TILE_KV] = Q × K^T via 8×8 MMA ──────────────────
+    // Q is in registers (Qreg); K is read from shared memory with transpose.
+    // Each simdgroup computes the 8 rows it owns × all TILE_KV cols.
+    // S accumulator (Sreg) is float-vec<2> per lane per K-frag.
+    vec2F Sreg[TK];
+    #pragma unroll
+    for (int k = 0; k < TK; k++) {
+      Sreg[k] = vec2F(0.0f);
+    }
 
-      simdgroup_matrix<float, 8, 8> pv_acc;
-      simdgroup_load(pv_acc, O_smem + hd_start, HEAD_SIZE);
+    #pragma unroll
+    for (int d = 0; d < TD; d++) {
+      // Materialize Q fragment from register vec → simdgroup_matrix
+      simdgroup_matrix<T, 8, 8> q_frag;
+      reinterpret_cast<thread vec2T &>(q_frag.thread_elements()) = Qreg[d];
 
-#pragma unroll
-      for (int t = 0; t < TILE_KV; t += 8) {
-        simdgroup_matrix<float, 8, 8> p_frag;
-        simdgroup_load(p_frag, S_smem + t, TILE_KV);
+      #pragma unroll
+      for (int k = 0; k < TK; k++) {
+        simdgroup_matrix<T, 8, 8> k_frag;
+        simdgroup_load(k_frag,
+                       K_smem + k * 8 * HEAD_SIZE + d * 8,
+                       HEAD_SIZE, ulong2(0), /*transpose=*/true);
 
+        // Materialize S accumulator from register vec → simdgroup_matrix.
+        simdgroup_matrix<float, 8, 8> s_frag;
+        reinterpret_cast<thread vec2F &>(s_frag.thread_elements()) = Sreg[k];
+
+        simdgroup_multiply_accumulate(s_frag, q_frag, k_frag, s_frag);
+
+        // Pull result back into register vec.
+        Sreg[k] = reinterpret_cast<thread vec2F &>(s_frag.thread_elements());
+      }
+    }
+
+    // ─ Scale + apply mask + softcap (all in registers) ─────────────────
+    // Fast path: when the entire tile is "before" the causal frontier of
+    // every Q row in this threadgroup, no causal/padding mask is needed.
+    // This applies to most tiles in long-prefill (tile_start + TILE_KV - 1
+    // < min_q_abs_pos in this threadgroup; min_q_abs_pos = context_len +
+    // q_pos_start).  Saves ~16 ALU ops per element on tiles 0..N_safe-1.
+    const int q_abs_pos = context_len + q_pos_start + sg_idx * 8 + fm;
+    const bool row_masked = (sg_idx * 8 + fm) >= valid_q;
+    const int min_q_abs_pos = context_len + q_pos_start;
+    const bool tile_no_mask = (tile_start + TILE_KV - 1) < min_q_abs_pos
+                              && (tile_start + TILE_KV) <= seq_len
+                              && softcapping <= 0.0f
+                              && sliding_window < 0;
+
+    if (tile_no_mask && !row_masked) {
+      #pragma unroll
+      for (int k = 0; k < TK; k++) {
+        Sreg[k][0] *= scale_log2;
+        Sreg[k][1] *= scale_log2;
+      }
+    } else {
+      #pragma unroll
+      for (int k = 0; k < TK; k++) {
+        #pragma unroll
+        for (int jj = 0; jj < 2; jj++) {
+          float s = Sreg[k][jj] * scale_log2;
+          if (softcapping > 0.0f) {
+            float s_orig = s / M_LOG2E_F;
+            s = softcapping * precise::tanh(s_orig / softcapping) * M_LOG2E_F;
+          }
+          int kv_pos = tile_start + k * 8 + fn + jj;
+          bool masked = row_masked
+                        || (kv_pos > q_abs_pos)
+                        || (kv_pos >= seq_len);
+          if (sliding_window >= 0)
+            masked = masked || (kv_pos < q_abs_pos + 1 - sliding_window);
+          Sreg[k][jj] = masked ? -INFINITY : s;
+        }
+      }
+    }
+
+    // ─ Row max: local max across 2*TK elements, then XOR-reduce ─────────
+    float local_max = -INFINITY;
+    #pragma unroll
+    for (int k = 0; k < TK; k++) {
+      local_max = max(local_max, max(Sreg[k][0], Sreg[k][1]));
+    }
+    float row_max = local_max;
+    row_max = max(row_max, simd_shuffle_xor(row_max, ushort(1)));
+    row_max = max(row_max, simd_shuffle_xor(row_max, ushort(8)));
+
+    float new_max = max(max_score, row_max);
+    float factor;
+    if (new_max > max_score) {
+      factor = (max_score == -INFINITY) ? 0.0f
+                                        : fast::exp2(max_score - new_max);
+    } else {
+      factor = 1.0f;
+      if (max_score == -INFINITY) new_max = 0.0f;
+    }
+    max_score = new_max;
+
+    // ─ Exponentiate + row sum ───────────────────────────────────────────
+    float local_sum = 0.0f;
+    #pragma unroll
+    for (int k = 0; k < TK; k++) {
+      #pragma unroll
+      for (int jj = 0; jj < 2; jj++) {
+        float p = (Sreg[k][jj] == -INFINITY)
+                      ? 0.0f
+                      : fast::exp2(Sreg[k][jj] - new_max);
+        Sreg[k][jj] = p;
+        local_sum += p;
+      }
+    }
+    float row_sum = local_sum;
+    row_sum += simd_shuffle_xor(row_sum, ushort(1));
+    row_sum += simd_shuffle_xor(row_sum, ushort(8));
+
+    sum_score = sum_score * factor + row_sum;
+
+    // ─ Rescale O in registers ───────────────────────────────────────────
+    #pragma unroll
+    for (int d = 0; d < TD; d++) {
+      Oreg[d] *= factor;
+    }
+
+    // ─ PV matmul: O += P × V via 8×8 MMA ───────────────────────────────
+    // V was loaded above together with K — no additional barrier needed.
+    // (One barrier at the END of this iteration protects V_smem against
+    //  the next iteration's K+V load.)
+    // P is in registers (Sreg, fp32). V is in smem. O accumulator stays in
+    // registers (Oreg). Convert P to T fragment for the MMA.
+    #pragma unroll
+    for (int k = 0; k < TK; k++) {
+      simdgroup_matrix<T, 8, 8> p_frag;
+      thread auto &pf_elems = p_frag.thread_elements();
+      pf_elems[0] = T(Sreg[k][0]);
+      pf_elems[1] = T(Sreg[k][1]);
+
+      #pragma unroll
+      for (int d = 0; d < TD; d++) {
         simdgroup_matrix<T, 8, 8> v_frag;
-        simdgroup_load(v_frag, KV_smem + t * HEAD_SIZE + hd_start, HEAD_SIZE);
+        simdgroup_load(v_frag,
+                       V_smem + k * 8 * HEAD_SIZE + d * 8,
+                       HEAD_SIZE);
 
-        simdgroup_multiply_accumulate(pv_acc, p_frag, v_frag, pv_acc);
+        // Materialize O accumulator fragment from register vec.
+        simdgroup_matrix<float, 8, 8> o_frag;
+        reinterpret_cast<thread vec2F &>(o_frag.thread_elements()) = Oreg[d];
+
+        simdgroup_multiply_accumulate(o_frag, p_frag, v_frag, o_frag);
+
+        Oreg[d] = reinterpret_cast<thread vec2F &>(o_frag.thread_elements());
       }
-
-      simdgroup_store(pv_acc, O_smem + hd_start, HEAD_SIZE);
     }
 
-    threadgroup_barrier(mem_flags::mem_threadgroup);  // B4: O written
+    // Protect V_smem against the next iteration's K+V load.  PV above
+    // reads ALL rows of V_smem; the next iteration's load writes V_smem.
+    // Without this barrier, fast simdgroups can corrupt slow ones' reads.
+    threadgroup_barrier(mem_flags::mem_threadgroup);
   } // end KV tile loop
 
-  // === Final normalize + write output ===
+  // ─ Final normalize: O /= sum_score, then store ────────────────────────
+  // sum_score is broadcast-replicated across lanes with same fm.
+  float inv_sum = 1.0f / (sum_score + 1e-6f);
+  #pragma unroll
+  for (int d = 0; d < TD; d++) {
+    Oreg[d] *= inv_sum;
+  }
+
+  // Reuse Q_smem as the output staging buffer (it's no longer needed).
+  // Each simdgroup stores its 8 rows × HEAD_SIZE into Q_smem (as float).
+  threadgroup float *O_smem = reinterpret_cast<threadgroup float *>(Q_smem);
+  #pragma unroll
+  for (int d = 0; d < TD; d++) {
+    simdgroup_matrix<float, 8, 8> o_frag;
+    reinterpret_cast<thread vec2F &>(o_frag.thread_elements()) = Oreg[d];
+    simdgroup_store(o_frag,
+                    O_smem + sg_idx * 8 * HEAD_SIZE + d * 8,
+                    HEAD_SIZE);
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write to global memory, respecting valid_q.
   device T *out_base = out + (q_seq_start + q_pos_start) * q_stride
                            + head_idx * HEAD_SIZE;
-  for (int i = thread_idx; i < valid_q * HEAD_SIZE; i += NUM_THREADS) {
+  const int total = valid_q * HEAD_SIZE;
+  for (int i = thread_idx; i < total; i += NUM_THREADS) {
     int r = i / HEAD_SIZE;
     int d = i % HEAD_SIZE;
-    float val = O_smem[i] / (L_smem[r] + 1e-6f);
-    out_base[r * q_stride + d] = T(val);
+    out_base[r * q_stride + d] = T(O_smem[r * HEAD_SIZE + d]);
   }
 }
 
-// ---- Template instantiation ----
+// ─── Template instantiation ──────────────────────────────────────────────
 
-#define instantiate_paged_attention_tiled_inner(type, head_size, block_size)    \
+#define instantiate_paged_attention_tiled_inner(type, head_size, block_size)   \
   template [[host_name("paged_attention_tiled_" #type                          \
                        "_hs" #head_size "_bs" #block_size                      \
-                       "_bq8_tk32_nt128")]]                                    \
+                       "_bq32_tk32_nt128")]]                                   \
   [[kernel]] void paged_attention_tiled<type, head_size, block_size,           \
-                                        8, 32, 128>(                           \
+                                        32, 32, 128>(                          \
       device type *out [[buffer(2)]],                                          \
       device const type *q [[buffer(3)]],                                      \
       device const type *k_cache [[buffer(4)]],                                \
@@ -301,14 +452,12 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
       uint sg_idx [[simdgroup_index_in_threadgroup]],                          \
       uint lane [[thread_index_in_simdgroup]]);
 
-#define instantiate_paged_attention_tiled_heads(type, block_size)               \
+#define instantiate_paged_attention_tiled_heads(type, block_size)              \
   instantiate_paged_attention_tiled_inner(type, 64, block_size);               \
   instantiate_paged_attention_tiled_inner(type, 96, block_size);               \
-  instantiate_paged_attention_tiled_inner(type, 128, block_size);              \
-  instantiate_paged_attention_tiled_inner(type, 192, block_size);              \
-  instantiate_paged_attention_tiled_inner(type, 256, block_size);
+  instantiate_paged_attention_tiled_inner(type, 128, block_size);
 
-#define instantiate_paged_attention_tiled_all(type)                             \
+#define instantiate_paged_attention_tiled_all(type)                            \
   instantiate_paged_attention_tiled_heads(type, 8);                            \
   instantiate_paged_attention_tiled_heads(type, 16);                           \
   instantiate_paged_attention_tiled_heads(type, 32);

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -57,6 +57,33 @@ inline short2 frag_coord(ushort lane_id) {
   return short2{fn, fm};
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Reduce one row of the 8×8 fragment across the 4 lanes that share it.
+//
+// Masks {1, 8} are FORCED by the frag_coord layout above: the row index fm
+// depends on lane bits {b4,b2,b1}, so the 4 lanes of a row vary only in
+// bits {b0,b3} = XOR masks 1 and 8.  Two shuffles (log2(4)) reduce them,
+// and because XOR-shuffle is a symmetric butterfly the result is replicated
+// to all 4 lanes — the per-row online-softmax state below relies on that.
+//
+// Do NOT replace with simd_sum: all 8 rows of the fragment live in one
+// 32-lane simdgroup, so a 32-lane reduction would fold the rows together.
+//
+// Op mirrors MLX Steel BaseMMAFrag<T,8,8>::row_reduce
+// (mlx/backend/metal/kernels/steel/attn/mma.h) so this stays diff-able
+// against upstream; vendored, not #included, to keep the Metal build off
+// MLX's private steel header tree.
+// ─────────────────────────────────────────────────────────────────────────
+struct FragMax { static inline float apply(float a, float b) { return max(a, b); } };
+struct FragSum { static inline float apply(float a, float b) { return a + b; } };
+
+template <typename Op>
+inline float frag_row_reduce(float v) {
+  v = Op::apply(v, simd_shuffle_xor(v, ushort(1)));
+  v = Op::apply(v, simd_shuffle_xor(v, ushort(8)));
+  return v;
+}
+
 template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
           int BQ = 32, int TILE_KV = 32, int NUM_THREADS = 128>
 [[kernel]] void paged_attention_tiled(
@@ -329,9 +356,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     for (int k = 0; k < TK; k++) {
       local_max = max(local_max, max(Sreg[k][0], Sreg[k][1]));
     }
-    float row_max = local_max;
-    row_max = max(row_max, simd_shuffle_xor(row_max, ushort(1)));
-    row_max = max(row_max, simd_shuffle_xor(row_max, ushort(8)));
+    float row_max = frag_row_reduce<FragMax>(local_max);
 
     float new_max = max(max_score, row_max);
     float factor;
@@ -357,9 +382,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
         local_sum += p;
       }
     }
-    float row_sum = local_sum;
-    row_sum += simd_shuffle_xor(row_sum, ushort(1));
-    row_sum += simd_shuffle_xor(row_sum, ushort(8));
+    float row_sum = frag_row_reduce<FragSum>(local_sum);
 
     sum_score = sum_score * factor + row_sum;
 

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -170,12 +170,16 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
   const int context_len = seq_len - cur_batch_query_len;
   const int valid_q = min(BQ, cur_batch_query_len - q_pos_start);
 
-  // ─ Threadgroup memory layout ──────────────────────────────────────────
-  // Q_smem: BQ × HEAD_SIZE         (loaded once, then read into registers)
-  // K_smem: TILE_KV × HEAD_SIZE    (overwritten each KV tile)
-  // V_smem: TILE_KV × HEAD_SIZE    (overwritten each KV tile)
-  constexpr int Q_ELEMS = BQ * HEAD_SIZE;
-  constexpr int KV_ELEMS = TILE_KV * HEAD_SIZE;
+  // ─ Threadgroup memory layout (A1: bank-conflict padding) ──────────────
+  // Each row padded to LD = HEAD_SIZE + SMEM_PAD so the 8 columns of every
+  // 8×8 simdgroup_load/store land on distinct threadgroup-memory banks
+  // (a HEAD_SIZE power-of-two stride aliases them).  The fp32 O_smem that
+  // aliases Q_smem at exit reuses the SAME LD.
+  //   Q_smem: BQ × LD,   K_smem/V_smem: TILE_KV × LD.
+  constexpr int SMEM_PAD = 16 / sizeof(T);   // 8 elems (16 B) for fp16/bf16
+  constexpr int LD = HEAD_SIZE + SMEM_PAD;   // padded leading dim
+  constexpr int Q_ELEMS = BQ * LD;
+  constexpr int KV_ELEMS = TILE_KV * LD;
 
   threadgroup T *Q_smem = reinterpret_cast<threadgroup T *>(shared_mem);
   threadgroup T *K_smem = Q_smem + Q_ELEMS;
@@ -188,10 +192,10 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
   // anyway, but zeroing avoids garbage propagating through QK).
   const device T *q_base = q + (q_seq_start + q_pos_start) * q_stride
                              + head_idx * HEAD_SIZE;
-  for (int i = thread_idx; i < Q_ELEMS; i += NUM_THREADS) {
+  for (int i = thread_idx; i < BQ * HEAD_SIZE; i += NUM_THREADS) {
     int r = i / HEAD_SIZE;
     int d = i % HEAD_SIZE;
-    Q_smem[i] = (r < valid_q) ? q_base[r * q_stride + d] : T(0);
+    Q_smem[r * LD + d] = (r < valid_q) ? q_base[r * q_stride + d] : T(0);
   }
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -210,7 +214,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
   #pragma unroll
   for (int d = 0; d < TD; d++) {
     simdgroup_matrix<T, 8, 8> tmp;
-    simdgroup_load(tmp, Q_smem + sg_idx * 8 * HEAD_SIZE + d * 8, HEAD_SIZE);
+    simdgroup_load(tmp, Q_smem + sg_idx * 8 * LD + d * 8, LD);
     Qreg[d] = reinterpret_cast<thread vec2T &>(tmp.thread_elements());
   }
 
@@ -275,17 +279,17 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
         const device T *v_ptr = v_cache + off;
         #pragma unroll
         for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
-          *((threadgroup vec2T *)&K_smem[t * HEAD_SIZE + d]) =
+          *((threadgroup vec2T *)&K_smem[t * LD + d]) =
               *((const device vec2T *)(k_ptr + d));
-          *((threadgroup vec2T *)&V_smem[t * HEAD_SIZE + d]) =
+          *((threadgroup vec2T *)&V_smem[t * LD + d]) =
               *((const device vec2T *)(v_ptr + d));
         }
       } else {
         const vec2T zero(T(0));
         #pragma unroll
         for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
-          *((threadgroup vec2T *)&K_smem[t * HEAD_SIZE + d]) = zero;
-          *((threadgroup vec2T *)&V_smem[t * HEAD_SIZE + d]) = zero;
+          *((threadgroup vec2T *)&K_smem[t * LD + d]) = zero;
+          *((threadgroup vec2T *)&V_smem[t * LD + d]) = zero;
         }
       }
     }
@@ -312,8 +316,8 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
       for (int k = 0; k < TK; k++) {
         simdgroup_matrix<T, 8, 8> k_frag;
         simdgroup_load(k_frag,
-                       K_smem + k * 8 * HEAD_SIZE + d * 8,
-                       HEAD_SIZE, ulong2(0), /*transpose=*/true);
+                       K_smem + k * 8 * LD + d * 8,
+                       LD, ulong2(0), /*transpose=*/true);
 
         // Materialize S accumulator from register vec → simdgroup_matrix.
         simdgroup_matrix<float, 8, 8> s_frag;
@@ -428,8 +432,8 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
       for (int d = 0; d < TD; d++) {
         simdgroup_matrix<T, 8, 8> v_frag;
         simdgroup_load(v_frag,
-                       V_smem + k * 8 * HEAD_SIZE + d * 8,
-                       HEAD_SIZE);
+                       V_smem + k * 8 * LD + d * 8,
+                       LD);
 
         // Materialize O accumulator fragment from register vec.
         simdgroup_matrix<float, 8, 8> o_frag;
@@ -463,8 +467,8 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     simdgroup_matrix<float, 8, 8> o_frag;
     reinterpret_cast<thread vec2F &>(o_frag.thread_elements()) = Oreg[d];
     simdgroup_store(o_frag,
-                    O_smem + sg_idx * 8 * HEAD_SIZE + d * 8,
-                    HEAD_SIZE);
+                    O_smem + sg_idx * 8 * LD + d * 8,
+                    LD);
   }
 
   threadgroup_barrier(mem_flags::mem_threadgroup);
@@ -476,7 +480,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
   for (int i = thread_idx; i < total; i += NUM_THREADS) {
     int r = i / HEAD_SIZE;
     int d = i % HEAD_SIZE;
-    out_base[r * q_stride + d] = T(O_smem[r * HEAD_SIZE + d]);
+    out_base[r * q_stride + d] = T(O_smem[r * LD + d]);
   }
 }
 

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -32,6 +32,23 @@
 // Element 0 of thread_elements() lives at (fm, fn).
 // Element 1 of thread_elements() lives at (fm, fn+1).
 // Verified against simdgroup_load+store round-trip.
+//
+// Per-lane ownership of the 8×8 fragment (Lk = lane k; each lane owns 2
+// horizontally-adjacent cells of one row):
+//
+//          c0    c1    c2    c3    c4    c5    c6    c7
+// row0 │   L0    L0    L1    L1    L8    L8    L9    L9
+// row1 │   L2    L2    L3    L3    L10   L10   L11   L11
+// row2 │   L4    L4    L5    L5    L12   L12   L13   L13
+// row3 │   L6    L6    L7    L7    L14   L14   L15   L15
+// row4 │   L16   L16   L17   L17   L24   L24   L25   L25
+// row5 │   L18   L18   L19   L19   L26   L26   L27   L27
+// row6 │   L20   L20   L21   L21   L28   L28   L29   L29
+// row7 │   L22   L22   L23   L23   L30   L30   L31   L31
+//
+// Each row is split over exactly 4 lanes — e.g. row0 → {L0, L1, L8, L9}.
+// Those 4 differ only in lane-id bits 0 and 3, which is exactly why the
+// per-row softmax reduction below is simd_shuffle_xor with masks 1 then 8.
 // ─────────────────────────────────────────────────────────────────────────
 inline short2 frag_coord(ushort lane_id) {
   const short qid = short(lane_id) / 4;

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -414,13 +414,15 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     // (One barrier at the END of this iteration protects V_smem against
     //  the next iteration's K+V load.)
     // P is in registers (Sreg, fp32). V is in smem. O accumulator stays in
-    // registers (Oreg). Convert P to T fragment for the MMA.
+    // registers (Oreg).  P is kept fp32 into the MMA (mixed float×T→float),
+    // matching the pre-PR kernel exactly — this PR is precision-neutral.
+    // Sreg is already vec2F, so this is the same MFAMMAFrag reinterpret used
+    // for Q/S/O (no downcast).  Narrowing P to T is a separate,
+    // benchmark-gated follow-up, not bundled into this perf migration.
     #pragma unroll
     for (int k = 0; k < TK; k++) {
-      simdgroup_matrix<T, 8, 8> p_frag;
-      thread auto &pf_elems = p_frag.thread_elements();
-      pf_elems[0] = T(Sreg[k][0]);
-      pf_elems[1] = T(Sreg[k][1]);
+      simdgroup_matrix<float, 8, 8> p_frag;
+      reinterpret_cast<thread vec2F &>(p_frag.thread_elements()) = Sreg[k];
 
       #pragma unroll
       for (int d = 0; d < TD; d++) {

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -66,6 +66,23 @@ inline short2 frag_coord(ushort lane_id) {
 // and because XOR-shuffle is a symmetric butterfly the result is replicated
 // to all 4 lanes — the per-row online-softmax state below relies on that.
 //
+// Worked example — row 0 lives in lanes {0,1,8,9}; each lane starts with
+// the max over its own 2 columns:
+//
+//             L0    L1    L8    L9
+// start:       3     7     2     5            (true row max = 7; goal: all four = 7)
+//
+// step A:  x = max(x, simd_shuffle_xor(x, 1))      partner = lane ^ 1
+//          L0↔L1   (0^1=1, 1^1=0)   L8↔L9  (8^1=9, 9^1=8)
+//          L0 = max(3,7)=7   L1 = max(7,3)=7   L8 = max(2,5)=5   L9 = max(5,2)=5
+//                  └── pair {0,1} now both 7 ──┘  └── pair {8,9} now both 5 ──┘
+//
+// step B:  x = max(x, simd_shuffle_xor(x, 8))      partner = lane ^ 8
+//          L0↔L8   (0^8=8, 8^8=0)   L1↔L9  (1^8=9, 9^8=1)
+//          L0 = max(7,5)=7   L8 = max(5,7)=7   L1 = max(7,5)=7   L9 = max(5,7)=7
+//
+// end:        7     7     7     7            ✓ every lane of the row holds the max
+//
 // Do NOT replace with simd_sum: all 8 rows of the fragment live in one
 // 32-lane simdgroup, so a 32-lane reduction would fold the rows together.
 //

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -422,12 +422,14 @@ static void dispatch_paged_attention_tiled(
   constexpr int TILE_KV = 32;
   constexpr int t_size = 2;  // half or bfloat16
   // S, O, m, l are register-resident, so no S/O/M/L threadgroup buffers.
-  // Output staging reuses Q_smem as float at exit; fits because the float
-  // buffer (BQ*HEAD*4) stays within Q+K+V (BQ <= 2*TILE_KV, i.e. 32 <= 64).
+  // Output staging reuses Q_smem as fp32 O_smem at exit; fits because
+  // BQ*LD*4 <= (BQ+2*TILE_KV)*LD*2  <=>  BQ <= 2*TILE_KV (32 <= 64).
+  // A1: leading dim padded by 16 B for bank-conflict avoidance —
+  // smem_pad/ld MUST match SMEM_PAD/LD in pagedattention_tiled.metal.
+  const int smem_pad = 16 / t_size;            // 8 elems for half/bf16
+  const int ld       = head_size + smem_pad;   // padded leading dim
   size_t shmem = static_cast<size_t>(
-      BQ * head_size * t_size           // Q_smem
-      + TILE_KV * head_size * t_size    // K_smem
-      + TILE_KV * head_size * t_size);  // V_smem
+      (BQ + 2 * TILE_KV) * ld * t_size);       // Q + K + V, padded
 
   int num_heads = static_cast<int>(query.shape(1));
   auto& enc = get_command_encoder_compat(d, s);

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -420,10 +420,10 @@ static void dispatch_paged_attention_tiled(
 
   constexpr int NUM_THREADS = 128;
   constexpr int TILE_KV = 32;
-  int t_size = 2;  // half or bfloat16
-  // BQ=32 flash layout: Q_smem (T) + K_smem (T) + V_smem (T) only.
-  // S, O, m, l are register-resident.  Output staging reuses Q_smem as float
-  // at exit; fits because BQ <= 2*TILE_KV (32 <= 64).
+  constexpr int t_size = 2;  // half or bfloat16
+  // S, O, m, l are register-resident, so no S/O/M/L threadgroup buffers.
+  // Output staging reuses Q_smem as float at exit; fits because the float
+  // buffer (BQ*HEAD*4) stays within Q+K+V (BQ <= 2*TILE_KV, i.e. 32 <= 64).
   size_t shmem = static_cast<size_t>(
       BQ * head_size * t_size           // Q_smem
       + TILE_KV * head_size * t_size    // K_smem

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -383,9 +383,10 @@ static bool can_use_tiled_kernel(int head_size, bool use_turboquant,
   if (use_turboquant) return false;
   if (query_dtype == float32) return false;
   if (query_dtype != k_cache_dtype) return false;
-  // 80, 112: HD_TILES % NUM_SG(4) != 0.  512: exceeds 32KB threadgroup memory.
+  // BQ=32 flash kernel: 80, 112 fail HD_TILES % NUM_SG(4)==0; 192, 256 exceed
+  // 32 KB threadgroup memory budget with separate K_smem and V_smem buffers.
   switch (head_size) {
-    case 64: case 96: case 128: case 192: case 256: return true;
+    case 64: case 96: case 128: return true;
     default: return false;
   }
 }
@@ -404,7 +405,7 @@ static void dispatch_paged_attention_tiled(
   int head_size  = static_cast<int>(query.shape(2));
   int num_seqs   = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
 
-  constexpr int BQ = 8;
+  constexpr int BQ = 32;
   int total_q_blocks = total_q_tokens / BQ + num_seqs;
 
   auto dt = dtype_to_metal(query.dtype());
@@ -412,7 +413,7 @@ static void dispatch_paged_attention_tiled(
       "paged_attention_tiled_" + dt +
       "_hs" + std::to_string(head_size) +
       "_bs" + std::to_string(block_size) +
-      "_bq8_tk32_nt128";
+      "_bq32_tk32_nt128";
 
   auto* lib = d.get_library("paged_attention_v2_kern");
   auto* kernel = d.get_kernel(kname, lib, kname, {});
@@ -420,12 +421,13 @@ static void dispatch_paged_attention_tiled(
   constexpr int NUM_THREADS = 128;
   constexpr int TILE_KV = 32;
   int t_size = 2;  // half or bfloat16
+  // BQ=32 flash layout: Q_smem (T) + K_smem (T) + V_smem (T) only.
+  // S, O, m, l are register-resident.  Output staging reuses Q_smem as float
+  // at exit; fits because BQ <= 2*TILE_KV (32 <= 64).
   size_t shmem = static_cast<size_t>(
-      BQ * head_size * t_size          // Q_smem
-      + TILE_KV * head_size * t_size   // KV_smem
-      + BQ * TILE_KV * 4               // S_smem (float); P aliases in-place
-      + BQ * head_size * 4             // O_smem (float)
-      + 2 * BQ * 4);                   // M, L (float)
+      BQ * head_size * t_size           // Q_smem
+      + TILE_KV * head_size * t_size    // K_smem
+      + TILE_KV * head_size * t_size);  // V_smem
 
   int num_heads = static_cast<int>(query.shape(1));
   auto& enc = get_command_encoder_compat(d, s);


### PR DESCRIPTION


### What changed

- **BQ 8 → 32, column-parallel → row-parallel.** Each simdgroup now owns 8   complete Q rows (`BQ / NUM_SG = 32 / 4`) instead of a column slice.
- **Q, O accumulator, and online-softmax state (m/l) are register-resident**   for the entire KV loop. Q is loaded into `Q_smem` once, hoisted to register   fragments, and `Q_smem` is never read again (reused as the float output   staging buffer at exit). No per-tile `S_smem`/`O_smem` round-trips. 
- **Per-row softmax reduction is a register-only `simd_shuffle_xor{1,8}`  butterfly** (the 4 lanes that share a fragment row), replacing the   `S_smem`-staged reduction.
- add Threadgroup memory padding (bank conflict avoidance)

- **Barriers: 4 → 2 per KV tile.**







### Benchmark (Sonnet 8192+10, 20 prompts, rate=10, conc=32 · Qwen3-0.6B · M1 Pro 32 GB · mem-fraction 0.4)


**Server** (terminal 1):
```bash
PYTHONPATH=. \
VLLM_METAL_USE_PAGED_ATTENTION=1 \
VLLM_METAL_MEMORY_FRACTION=0.4 \
vllm serve Qwen/Qwen3-0.6B \
  --max-model-len 8704 \
  --host 127.0.0.1 --port 8000
```
Client (terminal 2, once /health is green):
```bash
vllm bench serve \
  --backend vllm \
  --base-url http://127.0.0.1:8000 \
  --model Qwen/Qwen3-0.6B \
  --endpoint /v1/completions \
  --dataset-name sonnet --dataset-path sonnet.txt \
  --sonnet-input-len 8192 --sonnet-output-len 10 \
  --num-prompts 20 --request-rate 10 --max-concurrency 32
```

| Metric | main | this PR | Change | Speedup |
|---|---:|---:|---:|---:|
| Total tok/s | 243.09 | 674.87 | +177.6% | 2.78× |
| Mean TTFT (ms) | 351,811 | 126,021 | −64.2% | 2.79× faster |
| Mean TPOT (ms) | 7,449 | 2,725 | −63.4% | 2.73× faster |
| Duration (s) | 672.0 | 242.1 | −64.0% | 2.78× faster |

≈2.68× across the board on 8K long prefill.

### Behavioral changes / caveats

**head_size 192/256 no longer route to the tiled kernel** (BQ=32 raises the  shmem budget past the threadgroup limit with separate K/V buffers). They   fall through to the existing per-token v2 path — correct, just not  accelerated. 64/96/128 unaffected. large head_size  falls through to per-token v2 path. 
 
In other words, this optimized new kernel does not applicable to gemma4 models (256 & 512 head_dim), same with the mlx_lm.

The root cause is, apple has a 32KB small budget for threadgroup, far smaller than cuda counterpart. 

**Will address this issue in the next PR, but tuning BQ to smaller number to accommodate larger head_dim.**