### PR TITLE
[Refactor] Relocate kernel warm-up out of the MHA backend

### DIFF
--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import logging
+import platform
 import re
 from pathlib import Path
 from types import ModuleType
@@ -178,3 +179,28 @@ def get_ops() -> ModuleType:
     _ops_module = mod
     logger.info("Native paged-attention Metal kernels loaded")
     return mod
+
+
+def warm_up_kernels() -> None:
+    """Front-load v2 / GDN / MLA Metal kernel compilation at startup.
+
+    :func:`get_ops` JIT-builds the C++ ``_paged_ops`` extension and eagerly
+    compiles the v2 / GDN / MLA Metal libraries: MLX's
+    ``Device::get_library`` compiles the source synchronously inside each
+    ``init_*_library`` call. Calling it here moves that cost off the first
+    request and fails fast at startup if the kernels cannot compile on this
+    macOS (e.g. an unsupported Metal language version).
+
+    The compile is process-wide with no per-cache state, which is why this
+    takes no arguments.
+    """
+    macos_version = platform.mac_ver()[0]
+    logger.info("Warming up v2 paged-attention Metal kernels...")
+    try:
+        get_ops()
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to compile paged-attention Metal kernels on "
+            f"macOS {macos_version}: {e}"
+        ) from e
+    logger.info("Paged-attention Metal kernel warm-up complete")

--- a/vllm_metal/paged_attention_backend/hybrid.py
+++ b/vllm_metal/paged_attention_backend/hybrid.py
@@ -17,6 +17,7 @@ import torch
 from vllm.logger import init_logger
 from vllm.v1.kv_cache_interface import MambaSpec
 
+from vllm_metal.metal import warm_up_kernels
 from vllm_metal.metal_kernel_backend.attention_linear import (
     GDNPagedAttentionWrapper,
     is_linear_attention,
@@ -27,7 +28,6 @@ from vllm_metal.metal_kernel_backend.paged_attention import (
     MetalKernelPagedAttentionWrapper,
 )
 from vllm_metal.mlx_backend.gdn_cache import GDNPagedStateCache
-from vllm_metal.paged_attention_backend.mha import warm_up_paged_cache
 from vllm_metal.paged_attention_common import find_attn_attr, find_layers
 
 logger = init_logger(__name__)
@@ -217,7 +217,8 @@ class HybridPagedAttentionBackend:
         return patched
 
     def warm_up(self) -> None:
-        warm_up_paged_cache(self._require_initialized("warm_up"))
+        self._require_initialized("warm_up")
+        warm_up_kernels()
 
     def num_blocks(self) -> int:
         return self._require_initialized("num_blocks").num_blocks

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -1,47 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import platform
 from typing import TYPE_CHECKING, Any
 
 import mlx.core as mx
-from vllm.logger import init_logger
 
-from vllm_metal.metal import get_ops
+from vllm_metal.metal import warm_up_kernels
 
 if TYPE_CHECKING:
     from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
-
-logger = init_logger(__name__)
-
-
-def warm_up_paged_cache(cache: MetalPagedKVCache) -> None:
-    """Front-load v2 paged-attention kernel compilation at startup.
-
-    ``get_ops()`` JIT-builds the C++ ``_paged_ops`` extension and eagerly
-    compiles the v2 / GDN / MLA Metal libraries: MLX's
-    ``Device::get_library`` compiles the source synchronously inside each
-    ``init_*_library`` call. Calling it here moves that cost off the first
-    request and fails fast at startup if the kernels cannot compile on this
-    macOS (e.g. an unsupported Metal language version).
-
-    The legacy v1 ``reshape_and_cache`` probe is gone: KV writes are now
-    MLX-native scatter, and the probe was only needed in v1 because the
-    dispatch itself was the compile trigger. Kept as the stable warm-up
-    entry point for the MHA and Hybrid backends (``hybrid.py`` /
-    ``MHAPagedAttentionBackend``); ``cache`` is intentionally unused.
-    """
-    del cache
-    macos_version = platform.mac_ver()[0]
-    logger.info("Warming up v2 paged-attention Metal kernels...")
-    try:
-        get_ops()
-    except Exception as e:
-        raise RuntimeError(
-            f"Failed to compile paged-attention Metal kernels on "
-            f"macOS {macos_version}: {e}"
-        ) from e
-    logger.info("Paged-attention Metal kernel warm-up complete")
 
 
 class MHAPagedAttentionBackend:
@@ -117,7 +84,8 @@ class MHAPagedAttentionBackend:
         )
 
     def warm_up(self) -> None:
-        warm_up_paged_cache(self._require_initialized("warm_up"))
+        self._require_initialized("warm_up")
+        warm_up_kernels()
 
     def num_blocks(self) -> int:
         return self._require_initialized("num_blocks").num_blocks

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -7,14 +7,12 @@ from typing import Any
 import mlx.core as mx
 import mlx.nn as nn
 from mlx_lm.models.base import scaled_dot_product_attention
-from vllm.logger import init_logger
 
 from vllm_metal import envs
+from vllm_metal.metal import warm_up_kernels
 from vllm_metal.metal_kernel_backend.packed_prefill_compat import apply_packed_rope
 from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
 from vllm_metal.paged_attention_common import find_attn_attr, find_layers, get_context
-
-logger = init_logger(__name__)
 
 # Default rope head dim for GLM/DeepSeek-V2 lineage models.
 # Used as fallback when qk_rope_head_dim is absent from model config.
@@ -383,8 +381,10 @@ class MLAPagedAttentionBackend:
     """Paged attention backend for MLA models.
 
     Implements the PagedAttentionBackend protocol. Uses MLX-native
-    scatter/gather (no vendored C++/Metal kernel) because MLA latents
-    do not fit the standard (num_heads, head_dim) kernel layout.
+    scatter/gather (cache I/O only; attention is MLX SDPA by default
+    or an opt-in single-pass Metal kernel, RFC #360) because MLA
+    latents do not fit the standard (num_heads, head_dim) kernel
+    layout.
     """
 
     def __init__(
@@ -444,9 +444,8 @@ class MLAPagedAttentionBackend:
         return patched
 
     def warm_up(self) -> None:
-        # MLX ops JIT-compile on first use; no Metal shader warm-up needed.
         self._require_initialized("warm_up")
-        logger.info("MLA paged attention (MLX-native): skipping Metal kernel warm-up")
+        warm_up_kernels()
 
     def num_blocks(self) -> int:
         return self._require_initialized("num_blocks").num_blocks


### PR DESCRIPTION
followup refactoring from #378 

 Move JIT kernel warm-up from `paged_attention_backend/mha.py` into `vllm_metal/metal/` next to `get_ops()` as a param-less `warm_up_kernels()`, so Hybrid no longer cross-imports from the MHA module. MLA's `warm_up()` now warms up consistently with MHA/Hybrid