### PR TITLE
[kernel] refactor prefill kernel, add select_tile_config, to support gemma4 [3/3]

### DIFF
--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -259,7 +259,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     // threadgroup will produce, we can stop.
     if (tile_start > context_len + q_pos_start + valid_q - 1) break;
 
-    // ─ Load K AND V cooperatively (paged, fused, vec2-vectorized) ─────
+    // ─ Load K AND V cooperatively (paged, fused, wide-vectorized) ────
     // Both K_smem and V_smem are filled in the same loop:
     //   * block_table lookup is shared (same kv_pos for both K and V)
     //   * memory controller interleaves K and V reads from the same
@@ -268,9 +268,10 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     //
     // Cooperative K/V load width scales with HEAD_SIZE: 128-bit (16 B)
     // transactions for HEAD_SIZE >= 256 (Gemma 4's 256/512), 64-bit (8 B)
-    // for <= 128 (byte-identical to the prior vec<T,4> path, so the small
-    // head sizes are unchanged).  Wider-than-vec4 needs the LoadUnit byte
-    // struct because Metal has no native vec<T,8>.
+    // for <= 128.  Metal has no native vec<T,8>, so the 16 B path needs
+    // the LoadUnit byte-struct + reinterpret pattern; the 8 B path could
+    // equivalently be vec<T,4>, but we route both through LoadUnit for
+    // uniformity.
     //
     // Strided layout preserved (lane owns d=lane*VEC, stride NUM_SIMD_LANES
     // *VEC): consecutive lanes touch consecutive VEC-element runs -> reads

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -101,13 +101,15 @@ inline float frag_row_reduce(float v) {
   return v;
 }
 
-// Opaque NBYTES-wide, NBYTES-aligned load unit for the cooperative K/V copy.
-// Metal has no native vec<T,8>, so a 16-byte (128-bit) transaction can only
-// be expressed as an aligned byte struct + reinterpret (MLX steel BlockLoader
-// pattern, mlx/backend/metal/kernels/steel/attn/loader.h). NBYTES is a
-// power of two (8 or 16) so `alignas` is well-formed.
-template <int NBYTES>
-struct alignas(NBYTES) LoadUnit { uint8_t bytes[NBYTES]; };
+// Load unit for the cooperative K/V copy. Metal has no native vec<T,8>, so
+// K/V bytes are bit-copied through uint2 (64-bit) / uint4 (128-bit) — native
+// vectors that lower 1:1 to one wide load/store. A uint8_t[N] struct would
+// rely on the optimizer to coalesce (and the zero-store could degrade to a
+// memset loop). MLX steel BlockLoader pattern,
+// mlx/backend/metal/kernels/steel/attn/loader.h.
+template <int NBYTES> struct LoadUnit;
+template <> struct LoadUnit<8>  { using type = uint2; };
+template <> struct LoadUnit<16> { using type = uint4; };
 
 template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
           int BQ = 32, int TILE_KV = 32, int NUM_THREADS = 128>
@@ -279,8 +281,11 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     // both make `&[t*LD + lane*VEC]` a multiple of VEC_BYTES.
     constexpr int VEC_BYTES = (HEAD_SIZE >= 256) ? 16 : 8;
     constexpr int VEC = VEC_BYTES / int(sizeof(T));
-    using vecLoadT = LoadUnit<VEC_BYTES>;
-    static_assert(HEAD_SIZE % VEC == 0, "HEAD_SIZE must be divisible by VEC");
+    using vecLoadT = typename LoadUnit<VEC_BYTES>::type;  // uint2 / uint4
+    // Guards the alignment claimed above: LD%VEC==0 keeps every
+    // &K_smem[t*LD + lane*VEC] a multiple of VEC_BYTES (device side is
+    // aligned via `off`, a multiple of HEAD_SIZE).
+    static_assert(LD % VEC == 0, "smem row stride LD must be VEC-aligned");
     #pragma unroll
     for (int t_iter = 0; t_iter < TILE_KV / NUM_SG; t_iter++) {
       int t = sg_idx * (TILE_KV / NUM_SG) + t_iter;
@@ -300,7 +305,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
               *((const device vecLoadT *)(v_ptr + d));
         }
       } else {
-        const vecLoadT zero = {};
+        const vecLoadT zero = {};  // all-zero bits == +0.0 in half/bf16
         #pragma unroll
         for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
           *((threadgroup vecLoadT *)&K_smem[t * LD + d]) = zero;

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -101,6 +101,14 @@ inline float frag_row_reduce(float v) {
   return v;
 }
 
+// Opaque NBYTES-wide, NBYTES-aligned load unit for the cooperative K/V copy.
+// Metal has no native vec<T,8>, so a 16-byte (128-bit) transaction can only
+// be expressed as an aligned byte struct + reinterpret (MLX steel BlockLoader
+// pattern, mlx/backend/metal/kernels/steel/attn/loader.h). NBYTES is a
+// power of two (8 or 16) so `alignas` is well-formed.
+template <int NBYTES>
+struct alignas(NBYTES) LoadUnit { uint8_t bytes[NBYTES]; };
+
 template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
           int BQ = 32, int TILE_KV = 32, int NUM_THREADS = 128>
 [[kernel]] void paged_attention_tiled(
@@ -256,17 +264,23 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     //     physical block, hiding K-load latency behind V-load and v.v.
     //   * saves a barrier vs loading them separately
     //
-    // vec<T,4> loads halve the load instruction count vs vec<T,2>.
-    // For HEAD_SIZE=128 with 32 lanes: each lane does 1 vec4 = 8 bytes per
-    // token, covering all 128 channels in one go.  HEAD_SIZE=256: 2 vec4
-    // per lane.  HEAD_SIZE=512: 4 vec4 per lane.
+    // Cooperative K/V load width scales with HEAD_SIZE: 128-bit (16 B)
+    // transactions for HEAD_SIZE >= 256 (Gemma 4's 256/512), 64-bit (8 B)
+    // for <= 128 (byte-identical to the prior vec<T,4> path, so the small
+    // head sizes are unchanged).  Wider-than-vec4 needs the LoadUnit byte
+    // struct because Metal has no native vec<T,8>.
     //
-    // Alignment: every contributing stride (kv_block_stride, kv_token_stride,
-    // kv_head_stride = HEAD_SIZE) is even because HEAD_SIZE is a multiple
-    // of 8, so `off` and `lane*VEC` are 8-byte aligned for vec4.
-    static_assert(HEAD_SIZE % 4 == 0, "HEAD_SIZE must be /4 for vec4 loads");
-    constexpr int VEC = 4;
-    using vecLoadT = vec<T, VEC>;
+    // Strided layout preserved (lane owns d=lane*VEC, stride NUM_SIMD_LANES
+    // *VEC): consecutive lanes touch consecutive VEC-element runs -> reads
+    // stay coalesced, and all 32 lanes stay active at 256/512.
+    //
+    // Alignment (verified for HEAD_SIZE in {64,96,128,256,512}): device
+    // `off` is a multiple of HEAD_SIZE elems; smem stride LD=HEAD_SIZE+8;
+    // both make `&[t*LD + lane*VEC]` a multiple of VEC_BYTES.
+    constexpr int VEC_BYTES = (HEAD_SIZE >= 256) ? 16 : 8;
+    constexpr int VEC = VEC_BYTES / int(sizeof(T));
+    using vecLoadT = LoadUnit<VEC_BYTES>;
+    static_assert(HEAD_SIZE % VEC == 0, "HEAD_SIZE must be divisible by VEC");
     #pragma unroll
     for (int t_iter = 0; t_iter < TILE_KV / NUM_SG; t_iter++) {
       int t = sg_idx * (TILE_KV / NUM_SG) + t_iter;
@@ -286,7 +300,7 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
               *((const device vecLoadT *)(v_ptr + d));
         }
       } else {
-        const vecLoadT zero(T(0));
+        const vecLoadT zero = {};
         #pragma unroll
         for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
           *((threadgroup vecLoadT *)&K_smem[t * LD + d]) = zero;

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -486,12 +486,13 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
 
 // ─── Template instantiation ──────────────────────────────────────────────
 
-#define instantiate_paged_attention_tiled_inner(type, head_size, block_size)   \
+#define instantiate_paged_attention_tiled_inner(type, head_size, block_size,   \
+                                                bq, tkv, nt)                   \
   template [[host_name("paged_attention_tiled_" #type                          \
                        "_hs" #head_size "_bs" #block_size                      \
-                       "_bq32_tk32_nt128")]]                                   \
+                       "_bq" #bq "_tk" #tkv "_nt" #nt)]]                       \
   [[kernel]] void paged_attention_tiled<type, head_size, block_size,           \
-                                        32, 32, 128>(                          \
+                                        bq, tkv, nt>(                          \
       device type *out [[buffer(2)]],                                          \
       device const type *q [[buffer(3)]],                                      \
       device const type *k_cache [[buffer(4)]],                                \
@@ -515,10 +516,14 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
       uint sg_idx [[simdgroup_index_in_threadgroup]],                          \
       uint lane [[thread_index_in_simdgroup]]);
 
+// Each entry must match a (head_size -> TileConfig) row in select_tile_config
+// in vllm_metal/metal/paged_ops.cpp.
 #define instantiate_paged_attention_tiled_heads(type, block_size)              \
-  instantiate_paged_attention_tiled_inner(type, 64, block_size);               \
-  instantiate_paged_attention_tiled_inner(type, 96, block_size);               \
-  instantiate_paged_attention_tiled_inner(type, 128, block_size);
+  instantiate_paged_attention_tiled_inner(type, 64,  block_size, 32, 32, 128); \
+  instantiate_paged_attention_tiled_inner(type, 96,  block_size, 32, 32, 128); \
+  instantiate_paged_attention_tiled_inner(type, 128, block_size, 32, 32, 128); \
+  instantiate_paged_attention_tiled_inner(type, 256, block_size, 16, 16,  64); \
+  instantiate_paged_attention_tiled_inner(type, 512, block_size,  8,  8,  32);
 
 #define instantiate_paged_attention_tiled_all(type)                            \
   instantiate_paged_attention_tiled_heads(type, 8);                            \

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -256,16 +256,17 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     //     physical block, hiding K-load latency behind V-load and v.v.
     //   * saves a barrier vs loading them separately
     //
-    // vec<T,2> loads halve the number of load/store instructions issued.
-    // For HEAD_SIZE=64 with 32 lanes: each lane does 1 vec2 = 4 bytes per
-    // token, covering all 64 channels.  HEAD_SIZE=128: 2 vec2 per lane.
+    // vec<T,4> loads halve the load instruction count vs vec<T,2>.
+    // For HEAD_SIZE=128 with 32 lanes: each lane does 1 vec4 = 8 bytes per
+    // token, covering all 128 channels in one go.  HEAD_SIZE=256: 2 vec4
+    // per lane.  HEAD_SIZE=512: 4 vec4 per lane.
     //
     // Alignment: every contributing stride (kv_block_stride, kv_token_stride,
     // kv_head_stride = HEAD_SIZE) is even because HEAD_SIZE is a multiple
-    // of 8, so `off` and `lane*VEC` are both even → 4-byte aligned vec2.
-    static_assert(HEAD_SIZE % 2 == 0, "HEAD_SIZE must be even for vec2 loads");
-    constexpr int VEC = 2;
-    using vec2T = vec<T, VEC>;
+    // of 8, so `off` and `lane*VEC` are 8-byte aligned for vec4.
+    static_assert(HEAD_SIZE % 4 == 0, "HEAD_SIZE must be /4 for vec4 loads");
+    constexpr int VEC = 4;
+    using vecLoadT = vec<T, VEC>;
     #pragma unroll
     for (int t_iter = 0; t_iter < TILE_KV / NUM_SG; t_iter++) {
       int t = sg_idx * (TILE_KV / NUM_SG) + t_iter;
@@ -279,17 +280,17 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
         const device T *v_ptr = v_cache + off;
         #pragma unroll
         for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
-          *((threadgroup vec2T *)&K_smem[t * LD + d]) =
-              *((const device vec2T *)(k_ptr + d));
-          *((threadgroup vec2T *)&V_smem[t * LD + d]) =
-              *((const device vec2T *)(v_ptr + d));
+          *((threadgroup vecLoadT *)&K_smem[t * LD + d]) =
+              *((const device vecLoadT *)(k_ptr + d));
+          *((threadgroup vecLoadT *)&V_smem[t * LD + d]) =
+              *((const device vecLoadT *)(v_ptr + d));
         }
       } else {
-        const vec2T zero(T(0));
+        const vecLoadT zero(T(0));
         #pragma unroll
         for (int d = lane * VEC; d < HEAD_SIZE; d += NUM_SIMD_LANES * VEC) {
-          *((threadgroup vec2T *)&K_smem[t * LD + d]) = zero;
-          *((threadgroup vec2T *)&V_smem[t * LD + d]) = zero;
+          *((threadgroup vecLoadT *)&K_smem[t * LD + d]) = zero;
+          *((threadgroup vecLoadT *)&V_smem[t * LD + d]) = zero;
         }
       }
     }

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -9,6 +9,7 @@
 // RTTI matching which fails due to hidden symbol visibility in libmlx.
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -184,17 +185,44 @@ static void bind_paged_attn_buffers(
 }
 
 // Tiled kernel: Flash-Attention-style with simdgroup 8×8 MMA.
-// Used for non-TurboQuant, non-FP8 paths when HEAD_SIZE ∈ {64, 96, 128, 192, 256}.
-static bool can_use_tiled_kernel(int head_size, bool use_turboquant,
-                                 Dtype query_dtype, Dtype k_cache_dtype) {
-  if (use_turboquant) return false;
-  if (query_dtype == float32) return false;
-  if (query_dtype != k_cache_dtype) return false;
-  // BQ=32 flash kernel: 80, 112 fail HD_TILES % NUM_SG(4)==0; 192, 256 exceed
-  // 32 KB threadgroup memory budget with separate K_smem and V_smem buffers.
+// One TileConfig per supported HEAD_SIZE. NUM_THREADS = NUM_SG * 32.
+struct TileConfig {
+  int BQ;
+  int TILE_KV;
+  int NUM_THREADS;
+};
+
+// ─ How to add a new HEAD_SIZE ────────────────────────────────────────────
+// Budget: smem <= 32 KB (Apple Silicon per-threadgroup memory limit, M1-M4).
+// Formula:
+//   smem = (BQ + 2*TILE_KV) * (HEAD_SIZE + 8) * 2 bytes
+//   where  BQ+2*TILE_KV = Q-rows + K-rows + V-rows
+//          HEAD_SIZE+8  = row stride (+8 = SMEM_PAD for bank-conflict
+//                                     avoidance; see pagedattention_tiled.metal)
+//          *2           = sizeof(bf16/half); fp8 KV would change this
+//
+// Constraints on (BQ, TILE_KV):
+//   BQ <= 2*TILE_KV       (O_smem fp32 reuses Q+K+V region at kernel exit)
+//   BQ / NUM_SG == 8      (each simdgroup owns 8 Q rows; 8x8 MMA fragment)
+//   HEAD_SIZE, TILE_KV multiples of 8
+// NUM_THREADS = NUM_SG * 32 (one Apple simdgroup = 32 lanes).
+//
+// HEAD_SIZE -> (BQ, TILE_KV, NUM_THREADS, NUM_SG, smem):
+//   64, 96, 128 -> (32, 32, 128, 4, 24-26 KB)
+//   256         -> (16, 16,  64, 2,   25.3 KB)
+//   512         -> ( 8,  8,  32, 1,   24.9 KB)  // no in-threadgroup SG parallelism
+// 80, 112 excluded by HD_TILES % NUM_SG(4) == 0.
+// ─────────────────────────────────────────────────────────────────────────
+static std::optional<TileConfig> select_tile_config(int head_size) {
   switch (head_size) {
-    case 64: case 96: case 128: return true;
-    default: return false;
+    case 64: case 96: case 128:
+      return TileConfig{32, 32, 128};
+    case 256:
+      return TileConfig{16, 16, 64};
+    case 512:
+      return TileConfig{8, 8, 32};
+    default:
+      return std::nullopt;
   }
 }
 
@@ -204,38 +232,38 @@ static void dispatch_paged_attention_tiled(
     int num_kv_heads, float scale, float softcap,
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
-    int block_size, int max_seq_len, int sliding_window, Stream s) {
+    int block_size, int max_seq_len, int sliding_window,
+    TileConfig cfg, Stream s) {
   auto& d = metal::device(s.device);
 
   int total_q_tokens = static_cast<int>(query.shape(0));
   int head_size  = static_cast<int>(query.shape(2));
   int num_seqs   = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
 
-  constexpr int BQ = 32;
-  int total_q_blocks = total_q_tokens / BQ + num_seqs;
+  int total_q_blocks = total_q_tokens / cfg.BQ + num_seqs;
 
   auto dt = dtype_to_metal(query.dtype());
   std::string kname =
       "paged_attention_tiled_" + dt +
       "_hs" + std::to_string(head_size) +
       "_bs" + std::to_string(block_size) +
-      "_bq32_tk32_nt128";
+      "_bq" + std::to_string(cfg.BQ) +
+      "_tk" + std::to_string(cfg.TILE_KV) +
+      "_nt" + std::to_string(cfg.NUM_THREADS);
 
   auto* lib = d.get_library("paged_attention_v2_kern");
   auto* kernel = d.get_kernel(kname, lib, kname, {});
 
-  constexpr int NUM_THREADS = 128;
-  constexpr int TILE_KV = 32;
-  constexpr int t_size = 2;  // half or bfloat16
+  const int t_size = static_cast<int>(query.itemsize());
   // S, O, m, l are register-resident, so no S/O/M/L threadgroup buffers.
   // Output staging reuses Q_smem as fp32 O_smem at exit; fits because
-  // BQ*LD*4 <= (BQ+2*TILE_KV)*LD*2  <=>  BQ <= 2*TILE_KV (32 <= 64).
+  // BQ*LD*4 <= (BQ+2*TILE_KV)*LD*2  <=>  BQ <= 2*TILE_KV.
   // A1: leading dim padded by 16 B for bank-conflict avoidance —
   // smem_pad/ld MUST match SMEM_PAD/LD in pagedattention_tiled.metal.
-  const int smem_pad = 16 / t_size;            // 8 elems for half/bf16
-  const int ld       = head_size + smem_pad;   // padded leading dim
+  const int smem_pad = 16 / t_size;
+  const int ld       = head_size + smem_pad;
   size_t shmem = static_cast<size_t>(
-      (BQ + 2 * TILE_KV) * ld * t_size);       // Q + K + V, padded
+      (cfg.BQ + 2 * cfg.TILE_KV) * ld * t_size);  // Q + K + V, padded
 
   int num_heads = static_cast<int>(query.shape(1));
   auto& enc = get_command_encoder_compat(d, s);
@@ -249,7 +277,7 @@ static void dispatch_paged_attention_tiled(
 
   enc.dispatch_threadgroups(
       MTL::Size::Make(num_heads, total_q_blocks, 1),
-      MTL::Size::Make(NUM_THREADS, 1, 1));
+      MTL::Size::Make(cfg.NUM_THREADS, 1, 1));
 }
 
 static void dispatch_paged_attention_v2_online(
@@ -275,14 +303,17 @@ static void dispatch_paged_attention_v2_online(
   int total_q_tokens = static_cast<int>(query.shape(0));
   int num_seqs = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
   bool has_prefill = total_q_tokens > num_seqs;
-  if (has_prefill && can_use_tiled_kernel(head_size, use_turboquant,
-                                          query.dtype(), key_cache.dtype())) {
-    dispatch_paged_attention_tiled(
-        out, query, key_cache, value_cache,
-        num_kv_heads, scale, softcap,
-        block_tables, seq_lens, cu_seqlens_q,
-        block_size, max_seq_len, sliding_window, s);
-    return;
+  bool dtype_ok = query.dtype() != float32
+               && query.dtype() == key_cache.dtype();
+  if (has_prefill && !use_turboquant && dtype_ok) {
+    if (auto cfg = select_tile_config(head_size)) {
+      dispatch_paged_attention_tiled(
+          out, query, key_cache, value_cache,
+          num_kv_heads, scale, softcap,
+          block_tables, seq_lens, cu_seqlens_q,
+          block_size, max_seq_len, sliding_window, *cfg, s);
+      return;
+    }
   }
 
   // Fallback: original per-token kernel


### PR DESCRIPTION
## Summary



 - `select_tile_config` (replaces the boolean `can_use_tiled_kernel`) routes Gemma 4's HD=256 and HD=512 through the tiled flash-attention prefill kernel instead of the per-token fallback.
 - Cooperative K/V load width now scales with head size: 128-bit (`uint4`) transactions for HD≥256, unchanged 64-bit for HD≤128 (byte-identical to `main` for existing head sizes).



## Parity test

HD=256/512 tiled path produces token-identical output to main's v2 kernel on gemma-4-E4B, 6 prompts × 48 greedy tokens.

## Benchmark

<details>
<summary>Reproduce the benchmark</summary>

M2 Max 64 GB · vLLM 0.21.0 · sonnet dataset. One model + one workload at a time; kill the server and clear the JIT cache between branch switches.

```bash
# one-time: dataset
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/main/benchmarks/sonnet.txt -o sonnet.txt

# pick branch, then rebuild the native ext from that branch's source:
git checkout main          # or: git checkout <this-PR-branch>
rm -f ~/.cache/vllm-metal/_paged_ops*

# server (one of: Qwen/Qwen3-0.6B | google/gemma-4-E4B-it)
PYTHONPATH=. \
VLLM_METAL_USE_PAGED_ATTENTION=1 \
VLLM_METAL_MEMORY_FRACTION=0.6 \
vllm serve <MODEL> --max-model-len 8704 --host 127.0.0.1 --port 8000

# client — long-prefill workload
vllm bench serve --backend vllm --base-url http://127.0.0.1:8000 \
  --model <MODEL> --endpoint /v1/completions \
  --dataset-name sonnet --dataset-path sonnet.txt \
  --sonnet-input-len 8192 --sonnet-output-len 10 \
  --num-prompts 20 --request-rate 10 --max-concurrency 32

# client — standard workload
vllm bench serve --backend vllm --base-url http://127.0.0.1:8000 \
  --model <MODEL> --endpoint /v1/completions \
  --dataset-name sonnet --dataset-path sonnet.txt \
  --sonnet-input-len 1024 --sonnet-output-len 128 \
  --num-prompts 100 --request-rate 10 --max-concurrency 32
```

Correctness gate (HD≤128 byte-equivalence vs `main`):

```bash
VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION=0.3 \
  python -m pytest tests/test_paged_deterministic.py -q -m slow
```
</details>

**Setup:** M2 Max 64 GB · vLLM 0.21.0 · `VLLM_METAL_USE_PAGED_ATTENTION=1`· `VLLM_METAL_MEMORY_FRACTION=0.6` · `--max-model-len 8704` · sonnet dataset · request-rate 10 · max-concurrency 32. Each cell: clean JIT rebuild per branch, all requests succeeded (0 failures on both branches).

**Total token throughput (tok/s), this PR vs `main`:**

| Model | Workload | main | this PR | Δ |
|---|---|---:|---:|---:|
| Gemma 4 E4B | long prefill (8192+10, 20 req) | 300.8 | **408.7** | **+35.9%** |
| Gemma 4 E4B | standard (1024+128, 100 req) | 614.9 | **644.8** | **+4.9%** |
| Qwen3-0.6B | long prefill (8192+10, 20 req) | 1614.8 | **1803.1** | **+11.7%** |
| Qwen3-0.6B | standard (1024+128, 100 req) | 2157.9 | **2192.4** | **+1.6%** |

**Latency (long-prefill cells, where the change is largest):**

| Model | Metric | main | this PR | Δ |
|---|---|---:|---:|---:|
| Gemma 4 E4B | Mean TTFT (ms) | 283 359 | 211 124 | −25.5% |
| Gemma 4 E4B | Mean TPOT (ms) | 6 072 | 4 437 | −26.9% |
| Qwen3-0.6B | Mean TTFT (ms) | 51 985 | 46 510 | −10.5% |
| Qwen3-0.6B | Mean TPOT (ms) | 1 140 | 1 021 | −10.5% |

**Reading the results:**
- **Gemma 4 long prefill (+36%)** is the headline: those layers move off  the v2 per-token path onto the tiled kernel with 128-bit K/V loads.
- **Qwen3 long prefill (+12%)** — HD=128 was already tiled; this gain is  purely the wider K/V load. Confirms the load-width change helps existing  models, not just Gemma.
- **Standard workloads (+5% / +1.6%)** are decode-dominated, so attention  prefill is a small fraction — small but consistently positive, no  regression.

## Future work
- gemma4's large head_dim (256/512) kernel optimization is still not ideal ...
- test_gemma4_gold need to be updated. 