### PR TITLE
Add Gemma4 MTP assistant KV sharing

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -406,6 +406,60 @@ class TestPrepareSDPAQKV:
         assert values is shared_v
         assert kv_for_sharing == (shared_k, shared_v)
 
+    def test_read_existing_kv_prepares_q_without_kv_projection(self) -> None:
+        # Arrange — MTP assistant layers read target K/V from paged cache, so
+        # K/V projection must not be used as a control path.
+        inner = _make_inner(with_v_proj=True)
+        inner.k_proj = _RaisingLinear(
+            inner.k_proj.weight,
+            "k_proj must not be called when reading existing KV",
+        )
+        inner.v_proj = _RaisingLinear(
+            inner.v_proj.weight,
+            "v_proj must not be called when reading existing KV",
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        # Act
+        queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
+            inner,
+            x,
+            ctx,
+            _N_HEADS,
+            _N_KV_HEADS,
+            read_existing_kv=True,
+        )
+
+        # Assert — Q is prepared normally, while K/V are local shape holders;
+        # sdpa_forward uses the explicit flag to read authoritative cache K/V.
+        mx.eval(queries, keys, values)
+        assert queries.shape == (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert keys.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert bool(mx.all(keys == 0).item())
+        assert bool(mx.all(values == 0).item())
+        assert gate is None
+        assert kv_for_sharing == (keys, values)
+
+    def test_read_existing_kv_rejects_shared_kv_pair(self) -> None:
+        inner = _make_inner(with_v_proj=True)
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        shared_k = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 1.0)
+        shared_v = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 1.0)
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            prepare_sdpa_qkv(
+                inner,
+                x,
+                ctx,
+                _N_HEADS,
+                _N_KV_HEADS,
+                shared_kv=(shared_k, shared_v),
+                read_existing_kv=True,
+            )
+
     def test_yoco_requires_rope_attribute(self) -> None:
         # Arrange — YOCO path must still reject non-RoPE models; without a
         # guard we would silently return un-rotated queries.
@@ -550,6 +604,65 @@ class TestSDPAForward:
                 inner, x, ctx, cache, layer_idx=0, shared_kv=(shared_k, shared_v)
             )
 
+        assert cache.key_caches[0] is original_k_cache
+        assert cache.value_caches[0] is original_v_cache
+        assert captured["key_cache"] is original_k_cache
+        assert captured["value_cache"] is original_v_cache
+
+    def test_read_existing_kv_path_does_not_rebind_cache_arrays(self) -> None:
+        """MTP cache-read mode must not write new K/V into the target cache."""
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        original_k_cache = cache.key_caches[0]
+        original_v_cache = cache.value_caches[0]
+
+        inner = SimpleNamespace(
+            n_heads=_N_HEADS,
+            n_kv_heads=_N_KV_HEADS,
+            scale=_HEAD_DIM**-0.5,
+            o_proj=lambda out: out,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        queries = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM))
+        keys = mx.zeros((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        values = mx.zeros((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        captured: dict[str, mx.array] = {}
+
+        class _FakeOps:
+            def paged_attention_primitive(
+                self,
+                _query,
+                key_cache,
+                value_cache,
+                *_args,
+                **_kwargs,
+            ) -> None:
+                captured["key_cache"] = key_cache
+                captured["value_cache"] = value_cache
+
+        with (
+            patch.object(
+                sdpa_mod,
+                "prepare_sdpa_qkv",
+                return_value=(queries, keys, values, None, (keys, values)),
+            ) as prepare_mock,
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)),
+            ),
+        ):
+            sdpa_forward(inner, x, ctx, cache, layer_idx=0, read_existing_kv=True)
+
+        assert prepare_mock.call_args.kwargs["read_existing_kv"] is True
         assert cache.key_caches[0] is original_k_cache
         assert cache.value_caches[0] is original_v_cache
         assert captured["key_cache"] is original_k_cache

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -494,3 +494,63 @@ class TestSDPAForward:
             sdpa_forward(inner, x, ctx, cache, layer_idx=1)
 
         assert captured["num_kv_heads"] == actual_kv_heads
+
+    def test_shared_kv_path_does_not_rebind_cache_arrays(self) -> None:
+        """Shared-KV attention must read the existing cache without writing."""
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        original_k_cache = cache.key_caches[0]
+        original_v_cache = cache.value_caches[0]
+
+        inner = SimpleNamespace(
+            n_heads=_N_HEADS,
+            n_kv_heads=_N_KV_HEADS,
+            scale=_HEAD_DIM**-0.5,
+            o_proj=lambda out: out,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        queries = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM))
+        shared_k = mx.ones((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        shared_v = mx.ones((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        captured: dict[str, mx.array] = {}
+
+        class _FakeOps:
+            def paged_attention_primitive(
+                self,
+                _query,
+                key_cache,
+                value_cache,
+                *_args,
+                **_kwargs,
+            ) -> None:
+                captured["key_cache"] = key_cache
+                captured["value_cache"] = value_cache
+
+        with (
+            patch.object(
+                sdpa_mod,
+                "prepare_sdpa_qkv",
+                return_value=(queries, shared_k, shared_v, None, (shared_k, shared_v)),
+            ),
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)),
+            ),
+        ):
+            sdpa_forward(
+                inner, x, ctx, cache, layer_idx=0, shared_kv=(shared_k, shared_v)
+            )
+
+        assert cache.key_caches[0] is original_k_cache
+        assert cache.value_caches[0] is original_v_cache
+        assert captured["key_cache"] is original_k_cache
+        assert captured["value_cache"] is original_v_cache

--- a/tests/test_gemma4_mtp_kv_sharing.py
+++ b/tests/test_gemma4_mtp_kv_sharing.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import patch
 
 import mlx.core as mx
 import pytest
@@ -17,14 +16,10 @@ from vllm_metal.metal_kernel_backend.paged_attention import (
     patch_model_attention_metal_kernel,
 )
 from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
-from vllm_metal.paged_attention_common import (
-    PagedAttentionContext,
-    clear_context,
-    set_context,
-)
 from vllm_metal.v1.gemma4_mtp import (
     Gemma4MTPAssistantMetadata,
     Gemma4MTPAssistantRuntime,
+    Gemma4MTPKVSharingBinding,
     Gemma4MTPKVSharingPlan,
     Gemma4MTPTargetMetadata,
 )
@@ -126,81 +121,40 @@ def test_kv_sharing_plan_rejects_non_tail_layout() -> None:
         )
 
 
-def test_patch_assistant_model_installs_read_only_wrappers() -> None:
+def test_kv_sharing_binding_records_runner_local_cache() -> None:
     plan = Gemma4MTPKVSharingPlan(
         assistant_layer_to_target_cache_idx=(1, 0),
         layer_types=("full_attention", "sliding_attention"),
     )
-    model = SimpleNamespace(
-        model=SimpleNamespace(
-            layers=[
-                SimpleNamespace(self_attn=object()),
-                SimpleNamespace(self_attn=object()),
-            ]
-        )
-    )
     cache = _target_cache(num_layers=2)
 
-    patched = plan.patch_assistant_model(
-        model,
+    binding = Gemma4MTPKVSharingBinding.from_plan(
+        plan,
         target_kv_cache=cache,
         block_size=_BLOCK_SIZE,
     )
 
-    assert patched == 2
-    wrappers = [layer.self_attn for layer in model.model.layers]
-    assert all(
-        isinstance(wrapper, MetalKernelPagedAttentionWrapper) for wrapper in wrappers
-    )
-    assert [wrapper._mk_cache_idx for wrapper in wrappers] == [1, 0]
-    assert all(wrapper._mk_force_shared_kv for wrapper in wrappers)
+    assert binding.plan is plan
+    assert binding.target_kv_cache is cache
+    assert binding.block_size == _BLOCK_SIZE
 
 
-def test_patch_assistant_model_rejects_missing_target_cache_slot() -> None:
+def test_kv_sharing_binding_rejects_missing_target_cache_slot() -> None:
     plan = Gemma4MTPKVSharingPlan(
         assistant_layer_to_target_cache_idx=(1,),
         layer_types=("full_attention",),
     )
-    model = SimpleNamespace(
-        model=SimpleNamespace(layers=[SimpleNamespace(self_attn=object())])
-    )
     cache = _target_cache(num_layers=1)
 
     with pytest.raises(ValueError, match="outside target cache"):
-        plan.patch_assistant_model(
-            model,
+        Gemma4MTPKVSharingBinding.from_plan(
+            plan,
             target_kv_cache=cache,
             block_size=_BLOCK_SIZE,
         )
 
 
-def test_patch_assistant_model_validates_before_mutating() -> None:
-    original_attn = object()
-    plan = Gemma4MTPKVSharingPlan(
-        assistant_layer_to_target_cache_idx=(0, 1),
-        layer_types=("sliding_attention", "full_attention"),
-    )
-    model = SimpleNamespace(
-        model=SimpleNamespace(
-            layers=[
-                SimpleNamespace(self_attn=original_attn),
-                SimpleNamespace(),
-            ]
-        )
-    )
-    cache = _target_cache(num_layers=2)
-
-    with pytest.raises(ValueError, match="has no attention module"):
-        plan.patch_assistant_model(
-            model,
-            target_kv_cache=cache,
-            block_size=_BLOCK_SIZE,
-        )
-
-    assert model.model.layers[0].self_attn is original_attn
-
-
-def test_runtime_patches_real_assistant_model_layers() -> None:
+def test_runtime_keeps_cached_assistant_model_unpatched() -> None:
     from vllm_metal.v1.gemma4_mtp_model import (
         Gemma4MTPAssistantModel,
         Gemma4MTPAssistantModelArgs,
@@ -243,6 +197,7 @@ def test_runtime_patches_real_assistant_model_layers() -> None:
         ),
     )
     cache = _target_cache(num_layers=2)
+    original_attn = [layer.self_attn for layer in model.model.layers]
 
     wired = runtime.with_target_kv_sharing(
         target_metadata=Gemma4MTPTargetMetadata(
@@ -256,76 +211,56 @@ def test_runtime_patches_real_assistant_model_layers() -> None:
 
     assert runtime.kv_sharing_plan is None
     assert wired.kv_sharing_plan is not None
+    assert wired.kv_sharing is not None
+    assert wired.kv_sharing.target_kv_cache is cache
     assert wired.forward_ready is False
-    assert [layer.self_attn._mk_force_shared_kv for layer in model.model.layers] == [
-        True,
-        True,
-    ]
+    assert all(
+        layer.self_attn is original_attn[idx]
+        for idx, layer in enumerate(model.model.layers)
+    )
+    assert not any(
+        isinstance(layer.self_attn, MetalKernelPagedAttentionWrapper)
+        for layer in model.model.layers
+    )
 
 
-def test_force_shared_kv_wrapper_injects_layer_shaped_sentinel() -> None:
-    cache = MetalPagedKVCache(
-        num_layers=1,
-        num_kv_heads=3,
-        head_dim=5,
-        num_blocks=1,
+def test_runtime_kv_binding_is_not_process_global() -> None:
+    layer_types = ("full_attention",)
+    model = SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(self_attn=object())])
+    )
+    runtime = Gemma4MTPAssistantRuntime(
+        model_name="/assistant",
+        model=model,
+        metadata=_assistant_metadata(layer_types),
+    )
+    target_metadata = _target_metadata(layer_types)
+    cache1 = _target_cache(num_layers=1)
+    cache2 = _target_cache(num_layers=1)
+
+    wired1 = runtime.with_target_kv_sharing(
+        target_metadata=target_metadata,
+        target_kv_cache=cache1,
         block_size=_BLOCK_SIZE,
-        dtype=mx.float16,
-        kv_heads_per_layer=[3],
-        head_dim_per_layer=[5],
     )
-    wrapper = MetalKernelPagedAttentionWrapper(
-        SimpleNamespace(n_kv_heads=2, head_dim=4),
-        layer_idx=0,
-        kv_cache=cache,
+    wired2 = runtime.with_target_kv_sharing(
+        target_metadata=target_metadata,
+        target_kv_cache=cache2,
         block_size=_BLOCK_SIZE,
-        cache_idx=0,
-        force_shared_kv=True,
     )
-    ctx = PagedAttentionContext(
-        slot_mapping=[0, 1],
-        block_tables=[[0]],
-        context_lens=[2],
-        offsets=[0],
-        cu_seqlens=[0, 2],
+
+    assert runtime.kv_sharing is None
+    assert wired1.kv_sharing is not None
+    assert wired2.kv_sharing is not None
+    assert wired1.kv_sharing.target_kv_cache is cache1
+    assert wired2.kv_sharing.target_kv_cache is cache2
+    assert not isinstance(
+        model.model.layers[0].self_attn,
+        MetalKernelPagedAttentionWrapper,
     )
-    x = mx.ones((1, 2, 7), dtype=mx.float16)
-    captured: dict[str, tuple[int, ...]] = {}
-
-    def fake_sdpa_forward(
-        _inner: object,
-        _x: mx.array,
-        _ctx: PagedAttentionContext,
-        _cache: MetalPagedKVCache,
-        _layer_idx: int,
-        *,
-        shared_kv: tuple[mx.array, mx.array] | None = None,
-    ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
-        assert shared_kv is not None
-        captured["key_shape"] = shared_kv[0].shape
-        return mx.zeros_like(_x), shared_kv
-
-    set_context(ctx)
-    try:
-        with patch(
-            "vllm_metal.metal_kernel_backend.paged_attention.sdpa_forward",
-            fake_sdpa_forward,
-        ):
-            caller_kv = (
-                mx.zeros((1, 1, 2, 1), dtype=mx.float16),
-                mx.zeros((1, 1, 2, 1), dtype=mx.float16),
-            )
-            output, kv_pair, offset = wrapper(x, shared_kv=caller_kv)
-    finally:
-        clear_context()
-
-    assert captured["key_shape"] == (1, 2, 2, 4)
-    assert kv_pair[0].shape == (1, 2, 2, 4)
-    assert output.shape == x.shape
-    assert offset == 0
 
 
-def test_normal_patch_resets_reused_wrapper_shared_kv_mode() -> None:
+def test_reused_wrapper_rebinds_cache_through_owner_method() -> None:
     old_cache = _target_cache(num_layers=2)
     new_cache = _target_cache(num_layers=2)
     wrapper = MetalKernelPagedAttentionWrapper(
@@ -334,7 +269,6 @@ def test_normal_patch_resets_reused_wrapper_shared_kv_mode() -> None:
         kv_cache=old_cache,
         block_size=_BLOCK_SIZE,
         cache_idx=0,
-        force_shared_kv=True,
     )
     model = SimpleNamespace(
         model=SimpleNamespace(layers=[SimpleNamespace(self_attn=wrapper)])
@@ -350,7 +284,6 @@ def test_normal_patch_resets_reused_wrapper_shared_kv_mode() -> None:
     assert patched == 1
     assert wrapper._mk_kv_cache is new_cache
     assert wrapper._mk_cache_idx == 1
-    assert wrapper._mk_force_shared_kv is False
 
 
 def test_cache_policy_installs_gemma4_mtp_kv_sharing() -> None:

--- a/tests/test_gemma4_mtp_kv_sharing.py
+++ b/tests/test_gemma4_mtp_kv_sharing.py
@@ -1,0 +1,427 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Gemma4 MTP assistant KV sharing on Metal."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import mlx.core as mx
+import pytest
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
+from vllm_metal.metal_kernel_backend.paged_attention import (
+    MetalKernelPagedAttentionWrapper,
+    patch_model_attention_metal_kernel,
+)
+from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
+from vllm_metal.paged_attention_common import (
+    PagedAttentionContext,
+    clear_context,
+    set_context,
+)
+from vllm_metal.v1.gemma4_mtp import (
+    Gemma4MTPAssistantMetadata,
+    Gemma4MTPAssistantRuntime,
+    Gemma4MTPKVSharingPlan,
+    Gemma4MTPTargetMetadata,
+)
+
+_BLOCK_SIZE = 8
+
+
+def _assistant_metadata(
+    layer_types: tuple[str, ...],
+) -> Gemma4MTPAssistantMetadata:
+    return Gemma4MTPAssistantMetadata(
+        model_type="gemma4_assistant",
+        architectures=("Gemma4AssistantForCausalLM",),
+        vocab_size=262144,
+        hidden_size=256,
+        backbone_hidden_size=1536,
+        tie_word_embeddings=True,
+        num_hidden_layers=len(layer_types),
+        layer_types=layer_types,
+        use_ordered_embeddings=True,
+    )
+
+
+def _target_metadata(
+    layer_types: tuple[str, ...],
+) -> Gemma4MTPTargetMetadata:
+    return Gemma4MTPTargetMetadata(
+        vocab_size=262144,
+        hidden_size=1536,
+        non_shared_layer_types=layer_types,
+    )
+
+
+def _target_args(
+    layer_types: list[str] | None = None,
+) -> dict[str, Any]:
+    if layer_types is None:
+        layer_types = [
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ]
+    return {
+        "model_type": "gemma4_text",
+        "vocab_size": 262144,
+        "hidden_size": 1536,
+        "num_hidden_layers": len(layer_types),
+        "num_kv_shared_layers": 0,
+        "layer_types": layer_types,
+    }
+
+
+def _target_cache(num_layers: int) -> MetalPagedKVCache:
+    return MetalPagedKVCache(
+        num_layers=num_layers,
+        num_kv_heads=1,
+        head_dim=4,
+        num_blocks=1,
+        block_size=_BLOCK_SIZE,
+        dtype=mx.float16,
+    )
+
+
+def test_kv_sharing_plan_uses_last_non_shared_target_layer_by_type() -> None:
+    assistant = _assistant_metadata(
+        (
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        )
+    )
+    target = _target_metadata(
+        (
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        )
+    )
+
+    plan = Gemma4MTPKVSharingPlan.from_metadata(
+        assistant=assistant,
+        target=target,
+    )
+
+    assert plan.assistant_layer_to_target_cache_idx == (3, 3, 4)
+    assert plan.layer_types == assistant.layer_types
+
+
+def test_kv_sharing_plan_rejects_non_tail_layout() -> None:
+    assistant = _assistant_metadata(("full_attention",))
+    target = _target_metadata(("full_attention", "sliding_attention"))
+
+    with pytest.raises(ValueError, match="tail-match"):
+        Gemma4MTPKVSharingPlan.from_metadata(
+            assistant=assistant,
+            target=target,
+        )
+
+
+def test_patch_assistant_model_installs_read_only_wrappers() -> None:
+    plan = Gemma4MTPKVSharingPlan(
+        assistant_layer_to_target_cache_idx=(1, 0),
+        layer_types=("full_attention", "sliding_attention"),
+    )
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[
+                SimpleNamespace(self_attn=object()),
+                SimpleNamespace(self_attn=object()),
+            ]
+        )
+    )
+    cache = _target_cache(num_layers=2)
+
+    patched = plan.patch_assistant_model(
+        model,
+        target_kv_cache=cache,
+        block_size=_BLOCK_SIZE,
+    )
+
+    assert patched == 2
+    wrappers = [layer.self_attn for layer in model.model.layers]
+    assert all(
+        isinstance(wrapper, MetalKernelPagedAttentionWrapper) for wrapper in wrappers
+    )
+    assert [wrapper._mk_cache_idx for wrapper in wrappers] == [1, 0]
+    assert all(wrapper._mk_force_shared_kv for wrapper in wrappers)
+
+
+def test_patch_assistant_model_rejects_missing_target_cache_slot() -> None:
+    plan = Gemma4MTPKVSharingPlan(
+        assistant_layer_to_target_cache_idx=(1,),
+        layer_types=("full_attention",),
+    )
+    model = SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(self_attn=object())])
+    )
+    cache = _target_cache(num_layers=1)
+
+    with pytest.raises(ValueError, match="outside target cache"):
+        plan.patch_assistant_model(
+            model,
+            target_kv_cache=cache,
+            block_size=_BLOCK_SIZE,
+        )
+
+
+def test_patch_assistant_model_validates_before_mutating() -> None:
+    original_attn = object()
+    plan = Gemma4MTPKVSharingPlan(
+        assistant_layer_to_target_cache_idx=(0, 1),
+        layer_types=("sliding_attention", "full_attention"),
+    )
+    model = SimpleNamespace(
+        model=SimpleNamespace(
+            layers=[
+                SimpleNamespace(self_attn=original_attn),
+                SimpleNamespace(),
+            ]
+        )
+    )
+    cache = _target_cache(num_layers=2)
+
+    with pytest.raises(ValueError, match="has no attention module"):
+        plan.patch_assistant_model(
+            model,
+            target_kv_cache=cache,
+            block_size=_BLOCK_SIZE,
+        )
+
+    assert model.model.layers[0].self_attn is original_attn
+
+
+def test_runtime_patches_real_assistant_model_layers() -> None:
+    from vllm_metal.v1.gemma4_mtp_model import (
+        Gemma4MTPAssistantModel,
+        Gemma4MTPAssistantModelArgs,
+    )
+
+    layer_types = ("sliding_attention", "full_attention")
+    text_config = {
+        "model_type": "gemma4_text",
+        "vocab_size": 16,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "head_dim": 4,
+        "global_head_dim": 4,
+        "num_hidden_layers": 2,
+        "layer_types": list(layer_types),
+        "hidden_size_per_layer_input": 0,
+    }
+    model = Gemma4MTPAssistantModel(
+        Gemma4MTPAssistantModelArgs(
+            vocab_size=16,
+            backbone_hidden_size=12,
+            text_config=text_config,
+        )
+    )
+    runtime = Gemma4MTPAssistantRuntime(
+        model_name="/assistant",
+        model=model,
+        metadata=Gemma4MTPAssistantMetadata(
+            model_type="gemma4_assistant",
+            architectures=("Gemma4AssistantForCausalLM",),
+            vocab_size=16,
+            hidden_size=8,
+            backbone_hidden_size=12,
+            tie_word_embeddings=True,
+            num_hidden_layers=2,
+            layer_types=layer_types,
+            use_ordered_embeddings=False,
+        ),
+    )
+    cache = _target_cache(num_layers=2)
+
+    wired = runtime.with_target_kv_sharing(
+        target_metadata=Gemma4MTPTargetMetadata(
+            vocab_size=16,
+            hidden_size=12,
+            non_shared_layer_types=layer_types,
+        ),
+        target_kv_cache=cache,
+        block_size=_BLOCK_SIZE,
+    )
+
+    assert runtime.kv_sharing_plan is None
+    assert wired.kv_sharing_plan is not None
+    assert wired.forward_ready is False
+    assert [layer.self_attn._mk_force_shared_kv for layer in model.model.layers] == [
+        True,
+        True,
+    ]
+
+
+def test_force_shared_kv_wrapper_injects_layer_shaped_sentinel() -> None:
+    cache = MetalPagedKVCache(
+        num_layers=1,
+        num_kv_heads=3,
+        head_dim=5,
+        num_blocks=1,
+        block_size=_BLOCK_SIZE,
+        dtype=mx.float16,
+        kv_heads_per_layer=[3],
+        head_dim_per_layer=[5],
+    )
+    wrapper = MetalKernelPagedAttentionWrapper(
+        SimpleNamespace(n_kv_heads=2, head_dim=4),
+        layer_idx=0,
+        kv_cache=cache,
+        block_size=_BLOCK_SIZE,
+        cache_idx=0,
+        force_shared_kv=True,
+    )
+    ctx = PagedAttentionContext(
+        slot_mapping=[0, 1],
+        block_tables=[[0]],
+        context_lens=[2],
+        offsets=[0],
+        cu_seqlens=[0, 2],
+    )
+    x = mx.ones((1, 2, 7), dtype=mx.float16)
+    captured: dict[str, tuple[int, ...]] = {}
+
+    def fake_sdpa_forward(
+        _inner: object,
+        _x: mx.array,
+        _ctx: PagedAttentionContext,
+        _cache: MetalPagedKVCache,
+        _layer_idx: int,
+        *,
+        shared_kv: tuple[mx.array, mx.array] | None = None,
+    ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
+        assert shared_kv is not None
+        captured["key_shape"] = shared_kv[0].shape
+        return mx.zeros_like(_x), shared_kv
+
+    set_context(ctx)
+    try:
+        with patch(
+            "vllm_metal.metal_kernel_backend.paged_attention.sdpa_forward",
+            fake_sdpa_forward,
+        ):
+            caller_kv = (
+                mx.zeros((1, 1, 2, 1), dtype=mx.float16),
+                mx.zeros((1, 1, 2, 1), dtype=mx.float16),
+            )
+            output, kv_pair, offset = wrapper(x, shared_kv=caller_kv)
+    finally:
+        clear_context()
+
+    assert captured["key_shape"] == (1, 2, 2, 4)
+    assert kv_pair[0].shape == (1, 2, 2, 4)
+    assert output.shape == x.shape
+    assert offset == 0
+
+
+def test_normal_patch_resets_reused_wrapper_shared_kv_mode() -> None:
+    old_cache = _target_cache(num_layers=2)
+    new_cache = _target_cache(num_layers=2)
+    wrapper = MetalKernelPagedAttentionWrapper(
+        object(),
+        layer_idx=0,
+        kv_cache=old_cache,
+        block_size=_BLOCK_SIZE,
+        cache_idx=0,
+        force_shared_kv=True,
+    )
+    model = SimpleNamespace(
+        model=SimpleNamespace(layers=[SimpleNamespace(self_attn=wrapper)])
+    )
+
+    patched = patch_model_attention_metal_kernel(
+        model,
+        new_cache,
+        _BLOCK_SIZE,
+        cache_idx_map={0: 1},
+    )
+
+    assert patched == 1
+    assert wrapper._mk_kv_cache is new_cache
+    assert wrapper._mk_cache_idx == 1
+    assert wrapper._mk_force_shared_kv is False
+
+
+def test_cache_policy_installs_gemma4_mtp_kv_sharing() -> None:
+    backend = MHAPagedAttentionBackend(
+        num_layers=3,
+        num_kv_heads=1,
+        head_dim=4,
+        block_size=_BLOCK_SIZE,
+        dtype=mx.float16,
+    )
+    backend.initialize(num_blocks=1)
+    installed = object()
+
+    class _AssistantRuntime:
+        def with_target_kv_sharing(
+            self,
+            *,
+            target_metadata: Gemma4MTPTargetMetadata,
+            target_kv_cache: MetalPagedKVCache,
+            block_size: int,
+        ) -> object:
+            assert target_metadata.non_shared_layer_types == (
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            )
+            assert target_kv_cache is backend.kv_cache
+            assert block_size == _BLOCK_SIZE
+            return installed
+
+    layer_types = [
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ]
+    runner = make_stub_runner(
+        model_args={
+            "vocab_size": 262144,
+            "hidden_size": 1536,
+        },
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                text_config=SimpleNamespace(
+                    model_type="gemma4_text",
+                    vocab_size=262144,
+                    hidden_size=1536,
+                    num_hidden_layers=3,
+                    num_kv_shared_layers=0,
+                    layer_types=layer_types,
+                )
+            )
+        ),
+        _gemma4_mtp_assistant=_AssistantRuntime(),
+    )
+
+    runner._cache_policy._install_gemma4_mtp_kv_sharing(
+        backend,
+        block_size=_BLOCK_SIZE,
+    )
+
+    assert runner._gemma4_mtp_assistant is installed
+
+
+def test_cache_policy_rejects_gemma4_mtp_without_mha_backend() -> None:
+    runner = make_stub_runner(
+        model_args=_target_args(),
+        _gemma4_mtp_assistant=object(),
+    )
+
+    with pytest.raises(NotImplementedError, match="requires the MHA paged"):
+        runner._cache_policy._install_gemma4_mtp_kv_sharing(
+            object(),
+            block_size=_BLOCK_SIZE,
+        )

--- a/vllm_metal/metal_kernel_backend/attention_sdpa.py
+++ b/vllm_metal/metal_kernel_backend/attention_sdpa.py
@@ -152,6 +152,8 @@ def prepare_sdpa_qkv(
     n_heads: int,
     n_kv_heads: int,
     shared_kv: tuple[mx.array, mx.array] | None = None,
+    *,
+    read_existing_kv: bool = False,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array | None, tuple[mx.array, mx.array]]:
     """Project ``x`` into Q/K/V with norms, RoPE and Gemma4 variants.
 
@@ -159,6 +161,8 @@ def prepare_sdpa_qkv(
 
     - **YOCO** (``shared_kv`` given): reuse K/V from a prior layer; skip
       projection and only apply Q norm + RoPE.
+    - **Read-existing KV** (``read_existing_kv=True``): prepare Q only and
+      let the paged-attention kernel read K/V already present in the cache.
     - **K-eq-V** (no ``inner.v_proj``): 26B/31B checkpoints share the
       projection so ``values`` references the same tensor as ``keys``.
     - **v_norm** (``inner.v_norm`` present): apply per-head RMSNorm to
@@ -173,6 +177,7 @@ def prepare_sdpa_qkv(
         n_kv_heads: K/V head count.
         shared_kv: Optional ``(keys, values)`` from a reference layer,
             already normed and RoPE'd, in ``(B, H, L, head_dim)`` layout.
+        read_existing_kv: If true, skip K/V projection and cache writes.
 
     Returns:
         Tuple ``(queries, keys, values, gate, kv_for_sharing)``:
@@ -189,9 +194,16 @@ def prepare_sdpa_qkv(
             ``rotary_emb`` (only RoPE-based models are supported).
     """
     B, L, _ = x.shape  # noqa: N806
+    if shared_kv is not None and read_existing_kv:
+        raise ValueError("shared_kv and read_existing_kv are mutually exclusive")
 
     gate: mx.array | None = None
     packed_qkv = _has_packed_qkv_sdpa_contract(inner)
+    if read_existing_kv and packed_qkv:
+        raise NotImplementedError(
+            "read_existing_kv requires split Q/K/V projections so Q can be "
+            "prepared without projecting new K/V tensors."
+        )
     # head_dim has two architectural sources in our supported models:
     #   - self.head_dim instance attr (gemma*, llama, mistral, qwen3_5+, phi3)
     #   - k_proj.weight.shape (qwen3, qwen3_moe never set self.head_dim)
@@ -228,9 +240,16 @@ def prepare_sdpa_qkv(
         else:
             queries = q_proj_out.reshape(B, L, n_heads, -1)
 
-    if shared_kv is not None:
-        # YOCO: reuse K/V from a reference layer.  Q still needs norm + RoPE.
-        keys, values = shared_kv
+    if shared_kv is not None or read_existing_kv:
+        # YOCO/reuse-cache paths: Q still needs norm + RoPE, but K/V
+        # projection is skipped.  For read_existing_kv, local K/V tensors
+        # only satisfy RoPE/padding shape contracts; sdpa_forward uses the
+        # explicit flag to read the authoritative K/V from the paged cache.
+        if shared_kv is None:
+            keys = mx.zeros((B, n_kv_heads, L, head_dim), dtype=x.dtype)
+            values = keys
+        else:
+            keys, values = shared_kv
         if hasattr(inner, "q_norm"):
             queries = inner.q_norm(queries)
         queries = queries.transpose(0, 2, 1, 3)
@@ -382,6 +401,8 @@ def sdpa_forward(
     kv_cache: MetalPagedKVCache,
     layer_idx: int,
     shared_kv: tuple[mx.array, mx.array] | None = None,
+    *,
+    read_existing_kv: bool = False,
 ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
     """Full SDPA forward pass: project → norm → RoPE → Metal kernel.
 
@@ -402,7 +423,13 @@ def sdpa_forward(
     n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
 
     queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
-        inner, x, ctx, n_heads, n_kv_heads, shared_kv
+        inner,
+        x,
+        ctx,
+        n_heads,
+        n_kv_heads,
+        shared_kv,
+        read_existing_kv=read_existing_kv,
     )
 
     # --- Metal kernel dispatch ---
@@ -439,13 +466,10 @@ def sdpa_forward(
         ctx.block_tables, kv_cache.block_size
     )
 
-    if shared_kv is not None:
-        # YOCO shared layer: the reference layer already scattered the
-        # authoritative K/V (and, under TurboQuant, the scale/zero caches
-        # too).  Skip the write to avoid (a) redundant compute and (b)
-        # silent byte-drift if this layer's raw K/V differs marginally
-        # from the reference's — re-encoding would produce non-identical
-        # packed bytes.
+    if shared_kv is not None or read_existing_kv:
+        # YOCO shared layer / MTP read-existing layer: the authoritative K/V
+        # already lives in the paged cache.  Skip writes to avoid redundant
+        # compute and to keep the target cache read-only for assistant use.
         new_k_cache = kv_cache.key_caches[layer_idx]
         new_v_cache = kv_cache.value_caches[layer_idx]
         if kv_cache.turboquant:

--- a/vllm_metal/metal_kernel_backend/paged_attention.py
+++ b/vllm_metal/metal_kernel_backend/paged_attention.py
@@ -60,6 +60,7 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         block_size: int,
         *,
         cache_idx: int | None = None,
+        force_shared_kv: bool = False,
     ) -> None:
         super().__init__()
         object.__setattr__(self, "_inner", inner)
@@ -71,6 +72,46 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         object.__setattr__(
             self, "_mk_cache_idx", cache_idx if cache_idx is not None else layer_idx
         )
+        object.__setattr__(self, "_mk_force_shared_kv", force_shared_kv)
+
+    def _shared_kv_sentinel(self, x: mx.array) -> tuple[mx.array, mx.array]:
+        """Build dummy K/V tensors for layers that read cache-only K/V."""
+        if len(x.shape) != 3:
+            raise ValueError(
+                "Paged attention shared-KV sentinel expects input shaped "
+                f"(batch, tokens, hidden), got {x.shape}"
+            )
+
+        cache = self._mk_kv_cache
+        cache_idx = self._mk_cache_idx
+        if cache_idx < 0 or cache_idx >= cache.num_layers:
+            raise ValueError(
+                f"cache_idx={cache_idx} is outside target KV cache with "
+                f"{cache.num_layers} layers"
+            )
+
+        inner = self._inner
+        num_kv_heads = (
+            getattr(inner, "n_kv_heads", None)
+            or getattr(inner, "num_key_value_heads", None)
+            or cache.kv_heads_per_layer[cache_idx]
+        )
+        head_dim = getattr(inner, "head_dim", None)
+        k_proj = getattr(inner, "k_proj", None)
+        if head_dim is None and k_proj is not None:
+            head_dim = k_proj.weight.shape[0] // num_kv_heads
+        if head_dim is None:
+            head_dim = cache.head_dim_per_layer[cache_idx]
+
+        batch_size, seq_len, _ = x.shape
+        shape = (
+            batch_size,
+            int(num_kv_heads),
+            seq_len,
+            int(head_dim),
+        )
+        sentinel = mx.zeros(shape, dtype=x.dtype)
+        return sentinel, sentinel
 
     def __call__(
         self,
@@ -96,7 +137,16 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         # SDPA attention via Metal kernel.
         # Pass shared_kv for YOCO KV sharing (Gemma4: later layers reuse
         # K/V from earlier same-type layers instead of projecting their own).
-        shared_kv = kwargs.get("shared_kv")
+        if self._mk_force_shared_kv:
+            # Cross-model shared layers always read from this wrapper's mapped
+            # target cache slot; ignore any caller-propagated placeholder from
+            # a previous assistant layer.
+            shared_kv = self._shared_kv_sentinel(x)
+            has_shared_kv = True
+        else:
+            has_shared_kv = "shared_kv" in kwargs
+            shared_kv = kwargs.get("shared_kv")
+
         output, kv_pair = sdpa_forward(
             inner,
             x,
@@ -107,8 +157,9 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         )
 
         # YOCO models (Gemma4) expect (output, shared_kv, offset) return.
-        # Key off shared_kv presence — it's the definitive YOCO indicator.
-        if "shared_kv" in kwargs:
+        # Key off shared_kv presence, including cache-only shared layers whose
+        # K/V are read directly from the target paged cache.
+        if has_shared_kv:
             return (output, kv_pair, kwargs.get("offset", 0))
 
         return output
@@ -157,18 +208,20 @@ def patch_model_attention_metal_kernel(
             continue
 
         attn = getattr(layer, attn_attr)
-        if isinstance(attn, MetalKernelPagedAttentionWrapper):
-            # Already patched — update cache reference
-            object.__setattr__(attn, "_mk_kv_cache", kv_cache)
-            object.__setattr__(attn, "_mk_block_size", block_size)
-            patched += 1
-            continue
-
         cache_idx = (
             cache_idx_map[layer_idx]
             if cache_idx_map is not None and layer_idx in cache_idx_map
             else layer_idx
         )
+        if isinstance(attn, MetalKernelPagedAttentionWrapper):
+            # Already patched — update cache reference
+            object.__setattr__(attn, "_mk_kv_cache", kv_cache)
+            object.__setattr__(attn, "_mk_block_size", block_size)
+            object.__setattr__(attn, "_mk_cache_idx", cache_idx)
+            object.__setattr__(attn, "_mk_force_shared_kv", False)
+            patched += 1
+            continue
+
         wrapper = MetalKernelPagedAttentionWrapper(
             attn, layer_idx, kv_cache, block_size, cache_idx=cache_idx
         )

--- a/vllm_metal/metal_kernel_backend/paged_attention.py
+++ b/vllm_metal/metal_kernel_backend/paged_attention.py
@@ -60,7 +60,6 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         block_size: int,
         *,
         cache_idx: int | None = None,
-        force_shared_kv: bool = False,
     ) -> None:
         super().__init__()
         object.__setattr__(self, "_inner", inner)
@@ -72,46 +71,22 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         object.__setattr__(
             self, "_mk_cache_idx", cache_idx if cache_idx is not None else layer_idx
         )
-        object.__setattr__(self, "_mk_force_shared_kv", force_shared_kv)
 
-    def _shared_kv_sentinel(self, x: mx.array) -> tuple[mx.array, mx.array]:
-        """Build dummy K/V tensors for layers that read cache-only K/V."""
-        if len(x.shape) != 3:
-            raise ValueError(
-                "Paged attention shared-KV sentinel expects input shaped "
-                f"(batch, tokens, hidden), got {x.shape}"
-            )
-
-        cache = self._mk_kv_cache
-        cache_idx = self._mk_cache_idx
-        if cache_idx < 0 or cache_idx >= cache.num_layers:
-            raise ValueError(
-                f"cache_idx={cache_idx} is outside target KV cache with "
-                f"{cache.num_layers} layers"
-            )
-
-        inner = self._inner
-        num_kv_heads = (
-            getattr(inner, "n_kv_heads", None)
-            or getattr(inner, "num_key_value_heads", None)
-            or cache.kv_heads_per_layer[cache_idx]
+    def rebind_cache(
+        self,
+        kv_cache: MetalPagedKVCache,
+        block_size: int,
+        *,
+        cache_idx: int | None = None,
+    ) -> None:
+        """Rebind wrapper-owned paged-cache state in one place."""
+        object.__setattr__(self, "_mk_kv_cache", kv_cache)
+        object.__setattr__(self, "_mk_block_size", block_size)
+        object.__setattr__(
+            self,
+            "_mk_cache_idx",
+            cache_idx if cache_idx is not None else self._mk_layer_idx,
         )
-        head_dim = getattr(inner, "head_dim", None)
-        k_proj = getattr(inner, "k_proj", None)
-        if head_dim is None and k_proj is not None:
-            head_dim = k_proj.weight.shape[0] // num_kv_heads
-        if head_dim is None:
-            head_dim = cache.head_dim_per_layer[cache_idx]
-
-        batch_size, seq_len, _ = x.shape
-        shape = (
-            batch_size,
-            int(num_kv_heads),
-            seq_len,
-            int(head_dim),
-        )
-        sentinel = mx.zeros(shape, dtype=x.dtype)
-        return sentinel, sentinel
 
     def __call__(
         self,
@@ -137,15 +112,8 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         # SDPA attention via Metal kernel.
         # Pass shared_kv for YOCO KV sharing (Gemma4: later layers reuse
         # K/V from earlier same-type layers instead of projecting their own).
-        if self._mk_force_shared_kv:
-            # Cross-model shared layers always read from this wrapper's mapped
-            # target cache slot; ignore any caller-propagated placeholder from
-            # a previous assistant layer.
-            shared_kv = self._shared_kv_sentinel(x)
-            has_shared_kv = True
-        else:
-            has_shared_kv = "shared_kv" in kwargs
-            shared_kv = kwargs.get("shared_kv")
+        has_shared_kv = "shared_kv" in kwargs
+        shared_kv = kwargs.get("shared_kv")
 
         output, kv_pair = sdpa_forward(
             inner,
@@ -157,8 +125,8 @@ class MetalKernelPagedAttentionWrapper(nn.Module):
         )
 
         # YOCO models (Gemma4) expect (output, shared_kv, offset) return.
-        # Key off shared_kv presence, including cache-only shared layers whose
-        # K/V are read directly from the target paged cache.
+        # Key off shared_kv presence to match mlx_lm's fixed attention
+        # signature for Gemma4 YOCO layers.
         if has_shared_kv:
             return (output, kv_pair, kwargs.get("offset", 0))
 
@@ -215,10 +183,7 @@ def patch_model_attention_metal_kernel(
         )
         if isinstance(attn, MetalKernelPagedAttentionWrapper):
             # Already patched — update cache reference
-            object.__setattr__(attn, "_mk_kv_cache", kv_cache)
-            object.__setattr__(attn, "_mk_block_size", block_size)
-            object.__setattr__(attn, "_mk_cache_idx", cache_idx)
-            object.__setattr__(attn, "_mk_force_shared_kv", False)
+            attn.rebind_cache(kv_cache, block_size, cache_idx=cache_idx)
             patched += 1
             continue
 

--- a/vllm_metal/paged_attention_backend/hybrid.py
+++ b/vllm_metal/paged_attention_backend/hybrid.py
@@ -188,10 +188,8 @@ class HybridPagedAttentionBackend:
 
             if isinstance(attn, MetalKernelPagedAttentionWrapper):
                 # Already patched (cached model reuse) — refresh cache refs
-                object.__setattr__(attn, "_mk_kv_cache", kv_cache)
-                object.__setattr__(attn, "_mk_block_size", self._block_size)
                 cache_idx = sdpa_cache_map.get(layer_idx, layer_idx)
-                object.__setattr__(attn, "_mk_cache_idx", cache_idx)
+                attn.rebind_cache(kv_cache, self._block_size, cache_idx=cache_idx)
                 patched += 1
             elif isinstance(attn, GDNPagedAttentionWrapper):
                 # Already patched — refresh state cache ref

--- a/vllm_metal/paged_attention_backend/mha.py
+++ b/vllm_metal/paged_attention_backend/mha.py
@@ -89,3 +89,7 @@ class MHAPagedAttentionBackend:
 
     def num_blocks(self) -> int:
         return self._require_initialized("num_blocks").num_blocks
+
+    @property
+    def kv_cache(self) -> MetalPagedKVCache:
+        return self._require_initialized("kv_cache")

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -38,6 +38,7 @@ from vllm_metal.stt.policy import (
     STT_SCHED_BLOCK_BYTES,
     STT_SCHED_NOMINAL_HEAD_SIZE,
 )
+from vllm_metal.v1.gemma4_mtp import Gemma4MTPTargetMetadata
 from vllm_metal.v1.model_adapter import ModelAdapter
 
 if TYPE_CHECKING:
@@ -360,6 +361,32 @@ class ModelCachePolicy:
             return self._build_mla_backend(block_size)
         return self._build_mha_backend(block_size)
 
+    def _install_gemma4_mtp_kv_sharing(
+        self,
+        backend: PagedAttentionBackend,
+        *,
+        block_size: int,
+    ) -> None:
+        """Wire Gemma4 MTP assistant layers to the target paged KV cache."""
+        assistant = self._runner._gemma4_mtp_assistant
+        if assistant is None:
+            return
+        if not isinstance(backend, MHAPagedAttentionBackend):
+            raise NotImplementedError(
+                "Gemma4 MTP assistant KV sharing requires the MHA paged "
+                "attention backend on Metal."
+            )
+        model_config = getattr(self._runner, "model_config", None)
+        target_metadata = Gemma4MTPTargetMetadata.from_configs(
+            target_hf_config=getattr(model_config, "hf_config", None),
+            target_model_args=self._runner.model_args,
+        )
+        self._runner._gemma4_mtp_assistant = assistant.with_target_kv_sharing(
+            target_metadata=target_metadata,
+            target_kv_cache=backend.kv_cache,
+            block_size=block_size,
+        )
+
     def estimate_one_sequence_kv_bytes(
         self, *, max_model_len: int, block_size: int
     ) -> int:
@@ -586,6 +613,10 @@ class WorkerCachePlanner:
             block_size=plan.block_size
         )
         backend.initialize(plan.num_blocks)
+        self._worker.model_runner._cache_policy._install_gemma4_mtp_kv_sharing(
+            backend,
+            block_size=plan.block_size,
+        )
         n_patched = backend.patch_model(self._worker.model_runner.model)
         config = get_config()
         if config.kv_sharing_fast_prefill:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -376,9 +376,8 @@ class ModelCachePolicy:
                 "Gemma4 MTP assistant KV sharing requires the MHA paged "
                 "attention backend on Metal."
             )
-        model_config = getattr(self._runner, "model_config", None)
         target_metadata = Gemma4MTPTargetMetadata.from_configs(
-            target_hf_config=getattr(model_config, "hf_config", None),
+            target_hf_config=self._runner.model_config.hf_config,
             target_model_args=self._runner.model_args,
         )
         self._runner._gemma4_mtp_assistant = assistant.with_target_kv_sharing(

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -5,18 +5,21 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from json import JSONDecodeError, loads
 from numbers import Integral
 from pathlib import Path
 from threading import Lock
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from vllm.logger import init_logger
 
 from vllm_metal.v1.mlx_lm_paths import mlx_lm_compatible_model_path
 
 logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from vllm_metal.metal_kernel_backend.cache import MetalPagedKVCache
 
 GEMMA4_MTP_DEFAULT_NUM_CENTROIDS = 2048
 GEMMA4_MTP_DEFAULT_CENTROID_TOP_K = 32
@@ -39,12 +42,136 @@ _ASSISTANT_DOWNLOAD_ALLOW_PATTERNS = [
 
 @dataclass(frozen=True, slots=True)
 class Gemma4MTPAssistantRuntime:
-    """Loaded assistant runtime owned by the model lifecycle."""
+    """Loaded assistant runtime owned by the model lifecycle.
+
+    KV sharing can be installed before the assistant forward/scheduler handoff
+    is enabled; ``forward_ready`` remains false until that later runtime path
+    lands.
+    """
 
     model_name: str
     model: Any
     metadata: Gemma4MTPAssistantMetadata
+    kv_sharing_plan: Gemma4MTPKVSharingPlan | None = None
     forward_ready: bool = False
+
+    def with_target_kv_sharing(
+        self,
+        *,
+        target_metadata: Gemma4MTPTargetMetadata,
+        target_kv_cache: MetalPagedKVCache,
+        block_size: int,
+    ) -> Gemma4MTPAssistantRuntime:
+        """Return a runtime whose assistant layers read target paged KV."""
+        plan = Gemma4MTPKVSharingPlan.from_metadata(
+            assistant=self.metadata,
+            target=target_metadata,
+        )
+        patched = plan.patch_assistant_model(
+            self.model,
+            target_kv_cache=target_kv_cache,
+            block_size=block_size,
+        )
+        if patched != len(plan.assistant_layer_to_target_cache_idx):
+            raise RuntimeError(
+                "Gemma4 MTP KV sharing patched an unexpected number of layers: "
+                f"patched={patched}, expected="
+                f"{len(plan.assistant_layer_to_target_cache_idx)}"
+            )
+        return replace(self, kv_sharing_plan=plan)
+
+
+@dataclass(frozen=True, slots=True)
+class Gemma4MTPKVSharingPlan:
+    """Assistant layer to target paged-KV cache mapping."""
+
+    assistant_layer_to_target_cache_idx: tuple[int, ...]
+    layer_types: tuple[str, ...]
+
+    @classmethod
+    def from_metadata(
+        cls,
+        *,
+        assistant: Gemma4MTPAssistantMetadata,
+        target: Gemma4MTPTargetMetadata,
+    ) -> Gemma4MTPKVSharingPlan:
+        assistant.validate_compatible_with(target)
+        type_to_target_idx: dict[str, int] = {}
+        for target_idx, layer_type in enumerate(target.non_shared_layer_types):
+            # Match upstream Gemma4Proposer: use the last non-shared target
+            # layer of the same attention type as the sharing source.
+            type_to_target_idx[layer_type] = target_idx
+
+        mapping = tuple(
+            type_to_target_idx[layer_type] for layer_type in assistant.layer_types
+        )
+        return cls(
+            assistant_layer_to_target_cache_idx=mapping,
+            layer_types=assistant.layer_types,
+        )
+
+    def patch_assistant_model(
+        self,
+        model: Any,
+        *,
+        target_kv_cache: MetalPagedKVCache,
+        block_size: int,
+    ) -> int:
+        """Patch assistant attention layers to read target KV cache slots."""
+        from vllm_metal.metal_kernel_backend.paged_attention import (
+            MetalKernelPagedAttentionWrapper,
+        )
+        from vllm_metal.paged_attention_common import find_attn_attr, find_layers
+
+        layers = find_layers(model)
+        if len(layers) != len(self.assistant_layer_to_target_cache_idx):
+            raise ValueError(
+                "Gemma4 MTP assistant layer count must match KV sharing plan: "
+                f"layers={len(layers)}, plan="
+                f"{len(self.assistant_layer_to_target_cache_idx)}"
+            )
+
+        entries: list[tuple[int, Any, str, int]] = []
+        for layer_idx, (layer, cache_idx) in enumerate(
+            zip(
+                layers,
+                self.assistant_layer_to_target_cache_idx,
+                strict=True,
+            )
+        ):
+            if cache_idx < 0 or cache_idx >= target_kv_cache.num_layers:
+                raise ValueError(
+                    "Gemma4 MTP assistant KV sharing target is outside target "
+                    f"cache: assistant_layer={layer_idx}, cache_idx={cache_idx}, "
+                    f"num_cache_layers={target_kv_cache.num_layers}"
+                )
+            attn_attr = find_attn_attr(layer)
+            if attn_attr is None:
+                raise ValueError(
+                    f"Gemma4 MTP assistant layer {layer_idx} has no attention module"
+                )
+            entries.append((layer_idx, layer, attn_attr, cache_idx))
+
+        patched = 0
+        for layer_idx, layer, attn_attr, cache_idx in entries:
+            attn = getattr(layer, attn_attr)
+            if isinstance(attn, MetalKernelPagedAttentionWrapper):
+                object.__setattr__(attn, "_mk_kv_cache", target_kv_cache)
+                object.__setattr__(attn, "_mk_block_size", block_size)
+                object.__setattr__(attn, "_mk_cache_idx", cache_idx)
+                object.__setattr__(attn, "_mk_force_shared_kv", True)
+            else:
+                attn = MetalKernelPagedAttentionWrapper(
+                    attn,
+                    layer_idx,
+                    target_kv_cache,
+                    block_size,
+                    cache_idx=cache_idx,
+                    force_shared_kv=True,
+                )
+                setattr(layer, attn_attr, attn)
+            patched += 1
+        return patched
 
 
 class Gemma4MTPAssistantLoader:

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -52,8 +52,12 @@ class Gemma4MTPAssistantRuntime:
     model_name: str
     model: Any
     metadata: Gemma4MTPAssistantMetadata
-    kv_sharing_plan: Gemma4MTPKVSharingPlan | None = None
+    kv_sharing: Gemma4MTPKVSharingBinding | None = None
     forward_ready: bool = False
+
+    @property
+    def kv_sharing_plan(self) -> Gemma4MTPKVSharingPlan | None:
+        return self.kv_sharing.plan if self.kv_sharing is not None else None
 
     def with_target_kv_sharing(
         self,
@@ -62,23 +66,52 @@ class Gemma4MTPAssistantRuntime:
         target_kv_cache: MetalPagedKVCache,
         block_size: int,
     ) -> Gemma4MTPAssistantRuntime:
-        """Return a runtime whose assistant layers read target paged KV."""
+        """Return a runner-local runtime binding for target paged KV.
+
+        The loaded assistant model is cached process-wide by the loader.  Keep
+        that cached model unpatched here; the per-runner target KV cache lives
+        only in the returned immutable binding.
+        """
         plan = Gemma4MTPKVSharingPlan.from_metadata(
             assistant=self.metadata,
             target=target_metadata,
         )
-        patched = plan.patch_assistant_model(
-            self.model,
+        return replace(
+            self,
+            kv_sharing=Gemma4MTPKVSharingBinding.from_plan(
+                plan,
+                target_kv_cache=target_kv_cache,
+                block_size=block_size,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Gemma4MTPKVSharingBinding:
+    """Runner-local target KV binding for a cached assistant runtime."""
+
+    plan: Gemma4MTPKVSharingPlan
+    target_kv_cache: MetalPagedKVCache
+    block_size: int
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan: Gemma4MTPKVSharingPlan,
+        *,
+        target_kv_cache: MetalPagedKVCache,
+        block_size: int,
+    ) -> Gemma4MTPKVSharingBinding:
+        if block_size <= 0:
+            raise ValueError(
+                f"Gemma4 MTP KV sharing block_size must be positive, got {block_size}"
+            )
+        plan.validate_target_cache(target_kv_cache)
+        return cls(
+            plan=plan,
             target_kv_cache=target_kv_cache,
             block_size=block_size,
         )
-        if patched != len(plan.assistant_layer_to_target_cache_idx):
-            raise RuntimeError(
-                "Gemma4 MTP KV sharing patched an unexpected number of layers: "
-                f"patched={patched}, expected="
-                f"{len(plan.assistant_layer_to_target_cache_idx)}"
-            )
-        return replace(self, kv_sharing_plan=plan)
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,68 +143,15 @@ class Gemma4MTPKVSharingPlan:
             layer_types=assistant.layer_types,
         )
 
-    def patch_assistant_model(
-        self,
-        model: Any,
-        *,
-        target_kv_cache: MetalPagedKVCache,
-        block_size: int,
-    ) -> int:
-        """Patch assistant attention layers to read target KV cache slots."""
-        from vllm_metal.metal_kernel_backend.paged_attention import (
-            MetalKernelPagedAttentionWrapper,
-        )
-        from vllm_metal.paged_attention_common import find_attn_attr, find_layers
-
-        layers = find_layers(model)
-        if len(layers) != len(self.assistant_layer_to_target_cache_idx):
-            raise ValueError(
-                "Gemma4 MTP assistant layer count must match KV sharing plan: "
-                f"layers={len(layers)}, plan="
-                f"{len(self.assistant_layer_to_target_cache_idx)}"
-            )
-
-        entries: list[tuple[int, Any, str, int]] = []
-        for layer_idx, (layer, cache_idx) in enumerate(
-            zip(
-                layers,
-                self.assistant_layer_to_target_cache_idx,
-                strict=True,
-            )
-        ):
+    def validate_target_cache(self, target_kv_cache: MetalPagedKVCache) -> None:
+        """Validate that the target paged cache has every mapped layer slot."""
+        for layer_idx, cache_idx in enumerate(self.assistant_layer_to_target_cache_idx):
             if cache_idx < 0 or cache_idx >= target_kv_cache.num_layers:
                 raise ValueError(
                     "Gemma4 MTP assistant KV sharing target is outside target "
                     f"cache: assistant_layer={layer_idx}, cache_idx={cache_idx}, "
                     f"num_cache_layers={target_kv_cache.num_layers}"
                 )
-            attn_attr = find_attn_attr(layer)
-            if attn_attr is None:
-                raise ValueError(
-                    f"Gemma4 MTP assistant layer {layer_idx} has no attention module"
-                )
-            entries.append((layer_idx, layer, attn_attr, cache_idx))
-
-        patched = 0
-        for layer_idx, layer, attn_attr, cache_idx in entries:
-            attn = getattr(layer, attn_attr)
-            if isinstance(attn, MetalKernelPagedAttentionWrapper):
-                object.__setattr__(attn, "_mk_kv_cache", target_kv_cache)
-                object.__setattr__(attn, "_mk_block_size", block_size)
-                object.__setattr__(attn, "_mk_cache_idx", cache_idx)
-                object.__setattr__(attn, "_mk_force_shared_kv", True)
-            else:
-                attn = MetalKernelPagedAttentionWrapper(
-                    attn,
-                    layer_idx,
-                    target_kv_cache,
-                    block_size,
-                    cache_idx=cache_idx,
-                    force_shared_kv=True,
-                )
-                setattr(layer, attn_attr, attn)
-            patched += 1
-        return patched
 
 
 class Gemma4MTPAssistantLoader:


### PR DESCRIPTION
Prepare Gemma4 MTP assistant KV sharing on Metal.

This is PR 4 in the Gemma4 MTP stack. It keeps the runner out of the model-specific policy: Gemma4 owns the assistant-to-target KV mapping, the cache policy installs a runner-local KV sharing binding after target paged KV allocation, and SDPA exposes the read-existing-KV path for the next assistant forward PR.

- Add `Gemma4MTPKVSharingPlan` for assistant layer -> target cache index mapping.
- Match upstream Gemma4 proposer behavior by mapping each assistant layer to the last non-shared target layer of the same attention type.
- Install a runner-local `Gemma4MTPKVSharingBinding` without patching the cached assistant model.
- Expose the initialized MHA paged KV cache through the MHA backend owner.
- Keep wrapper cache rebinding owned by `MetalKernelPagedAttentionWrapper`.
- Keep `forward_ready=False`; assistant forward and `take_draft_token_ids()` remain follow-up PRs.