### PR TITLE
Fail fast on Rosetta Python during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 ## Requirements
 
 - macOS on Apple Silicon
+- Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
 
 ## Supported Models
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,6 +3,16 @@
 ## Requirements
 
 - macOS on Apple Silicon
+- Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
+
+Verify the Python architecture before installing:
+
+```bash
+python3 -c "import platform; print(platform.machine())"
+file "$(which python3)"
+```
+
+The first command should print `arm64`. If it prints `x86_64`, switch to a native arm64 Python and remove `~/.venv-vllm-metal` before reinstalling.
 
 ## Install
 

--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,11 @@ EOF
     rm -f "$lib_tmp"
   fi
 
-  is_apple_silicon
+  if ! is_apple_silicon; then
+    error "vllm-metal requires Apple Silicon arm64. Detected: $(uname -m)."
+    exit 1
+  fi
+
   if ! ensure_uv; then
     exit 1
   fi
@@ -178,6 +182,9 @@ EOF
   fi
 
   ensure_venv "$venv"
+  if ! require_arm64_python python; then
+    exit 1
+  fi
 
   local vllm_v="0.21.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -21,6 +21,22 @@ is_apple_silicon() {
   [ "$(uname -m)" = "arm64" ]
 }
 
+# Require a native arm64 Python interpreter.
+require_arm64_python() {
+  local python_bin="${1:-python}"
+  local machine
+
+  if ! machine=$("$python_bin" -c "import platform; print(platform.machine())"); then
+    error "Failed to inspect Python architecture using ${python_bin}."
+    return 1
+  fi
+
+  if [ "$machine" != "arm64" ]; then
+    error "vllm-metal requires native arm64 Python, got ${machine}. Remove the venv and rerun install.sh from an arm64 Python."
+    return 1
+  fi
+}
+
 # Ensure uv is installed
 ensure_uv() {
   if ! command -v uv &> /dev/null; then


### PR DESCRIPTION
This PR is:

- To fail fast when the installer is run with Rosetta/x86_64 Python on Apple Silicon.
- To replace the previous silent Apple Silicon check failure with a clear installer error.
- To document that vllm-metal requires native arm64 Python 3.12.

Closes #379
