### PR TITLE
perf(sampling): batch paged prefill sampler calls

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Metal sampling with vLLM Sampler integration."""
 
+from types import SimpleNamespace
+
 import mlx.core as mx
 import numpy as np
 import pytest
@@ -23,7 +25,11 @@ from vllm_metal.v1.model_runner import (
     _create_request_generator,
     _ExecutionBatch,
 )
-from vllm_metal.v1.sampling_batch import SamplingBatch, sample_from_logits
+from vllm_metal.v1.sampling_batch import (
+    SamplingBatch,
+    sample_from_logits,
+    sample_prefill_tokens,
+)
 
 VOCAB_SIZE = 1024
 MAX_NUM_PROMPT_TOKENS = 64
@@ -313,6 +319,23 @@ class TestV1SamplingBatch:
             device=torch.device("cpu"),
         )
 
+    @staticmethod
+    def _prefill_req(
+        token_ids: list[int],
+        sampling_params: SamplingParams,
+        *,
+        prompt_len: int | None,
+        full_prompt_token_ids: list[int] | None = None,
+        generator: torch.Generator | None = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            token_ids=token_ids,
+            sampling_params=sampling_params,
+            generator=generator,
+            prompt_len=prompt_len,
+            full_prompt_token_ids=full_prompt_token_ids,
+        )
+
     def test_can_use_native_greedy_requires_greedy_without_filters(self) -> None:
         assert self._batch([SamplingParams(temperature=0.0)]).can_use_native_greedy()
         assert not self._batch(
@@ -528,6 +551,138 @@ class TestV1SamplingBatch:
         assert result.logprobs.logprob_token_ids.shape == (1, 3)
         assert result.logprobs.logprob_token_ids[0, 0] == 2
         assert result.logprobs.sampled_token_ranks.tolist() == [1]
+
+    def test_prefill_sampling_batches_no_logprobs_requests(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        logits = mx.array(
+            [[[float(row)] * 4 for row in range(10)]],
+            dtype=mx.float32,
+        )
+        reqs = [
+            self._prefill_req(
+                [1, 2],
+                SamplingParams(temperature=0.8, top_p=0.9),
+                prompt_len=2,
+            ),
+            self._prefill_req(
+                [5],
+                SamplingParams(temperature=0.0),
+                prompt_len=2,
+                full_prompt_token_ids=[3, 4, 9],
+                generator=torch.Generator().manual_seed(1),
+            ),
+            self._prefill_req(
+                [7],
+                SamplingParams(temperature=1.0, top_p=0.8),
+                prompt_len=None,
+            ),
+        ]
+        calls = []
+
+        def fake_sample_from_logits(logits_2d, batch, sampler, device):
+            del sampler, device
+            calls.append((logits_2d.tolist(), batch))
+            assert [sp.temperature for sp in batch.sampling_params_list] == [
+                0.8,
+                0.0,
+                1.0,
+            ]
+            assert [sp.top_p for sp in batch.sampling_params_list] == [
+                0.9,
+                1.0,
+                0.8,
+            ]
+            assert batch.prompt_token_id_lists == [[1, 2], [3, 4, 9], [7]]
+            assert batch.output_token_id_lists == [[], [], []]
+            assert sorted(batch.generators) == [1]
+            return SimpleNamespace(token_ids=[11, 12, 13], logprobs=None)
+
+        monkeypatch.setattr(
+            "vllm_metal.v1.sampling_batch.sample_from_logits",
+            fake_sample_from_logits,
+        )
+
+        result = sample_prefill_tokens(
+            logits,
+            reqs,
+            cu_seqlens=[0, 1, 3, 6, 10],
+            num_decode=1,
+            sampler=Sampler(),
+            device=torch.device("cpu"),
+            vocab_size=4,
+        )
+
+        assert result.token_ids == [11, 12, 13]
+        assert result.logprobs is None
+        assert len(calls) == 1
+        assert calls[0][0] == [
+            [2.0, 2.0, 2.0, 2.0],
+            [5.0, 5.0, 5.0, 5.0],
+            [9.0, 9.0, 9.0, 9.0],
+        ]
+
+    def test_prefill_sampling_falls_back_when_any_request_needs_logprobs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        logits = mx.array(
+            [[[0.0, 3.0, 1.0], [2.0, 0.0, 4.0]]],
+            dtype=mx.float32,
+        )
+        reqs = [
+            self._prefill_req(
+                [1],
+                SamplingParams(temperature=0.0, logprobs=1),
+                prompt_len=1,
+            ),
+            self._prefill_req(
+                [2],
+                SamplingParams(temperature=0.0),
+                prompt_len=1,
+            ),
+        ]
+        calls = []
+
+        def fake_sample_from_logits(logits_2d, batch, sampler, device):
+            del sampler, device
+            calls.append((logits_2d.tolist(), batch))
+            if len(calls) == 1:
+                return SimpleNamespace(
+                    token_ids=[1],
+                    logprobs=LogprobsLists(
+                        logprob_token_ids=np.array([[1, 2]], dtype=np.int32),
+                        logprobs=np.array([[-0.1, -1.1]], dtype=np.float32),
+                        sampled_token_ranks=np.array([1], dtype=np.int32),
+                    ),
+                )
+            return SimpleNamespace(token_ids=[2], logprobs=None)
+
+        monkeypatch.setattr(
+            "vllm_metal.v1.sampling_batch.sample_from_logits",
+            fake_sample_from_logits,
+        )
+
+        result = sample_prefill_tokens(
+            logits,
+            reqs,
+            cu_seqlens=[0, 1, 2],
+            num_decode=0,
+            sampler=Sampler(),
+            device=torch.device("cpu"),
+            vocab_size=3,
+        )
+
+        assert result.token_ids == [1, 2]
+        assert len(calls) == 2
+        assert calls[0][0] == [[0.0, 3.0, 1.0]]
+        assert calls[1][0] == [[2.0, 0.0, 4.0]]
+        assert [len(call[1].sampling_params_list) for call in calls] == [1, 1]
+        assert result.logprobs is not None
+        assert result.logprobs.logprob_token_ids.shape == (2, 2)
+        assert result.logprobs.logprob_token_ids[0, 0] == 1
+        assert result.logprobs.logprobs[1, 0] == -float("inf")
 
     def test_model_runner_output_keeps_logprobs_slot_alignment(self) -> None:
         batch = _ExecutionBatch()

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -6,6 +6,7 @@ Pure functions: logits in, token IDs out.  No model runner state accessed.
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 
 import mlx.core as mx
 import numpy as np
@@ -333,6 +334,24 @@ def _mlx_greedy_sample(logits: mx.array) -> mx.array:
     return mx.argmax(logits, axis=-1)
 
 
+def _prefill_prompt_and_output_tokens(
+    prefill_request: Any,
+) -> tuple[list[int], list[int]]:
+    if prefill_request.full_prompt_token_ids is not None:
+        prompt_len = len(prefill_request.full_prompt_token_ids)
+    elif prefill_request.prompt_len is not None:
+        prompt_len = prefill_request.prompt_len
+    else:
+        prompt_len = len(prefill_request.token_ids)
+
+    prompt_for_meta = (
+        prefill_request.full_prompt_token_ids
+        if prefill_request.full_prompt_token_ids is not None
+        else prefill_request.token_ids
+    )
+    return prompt_for_meta[:prompt_len], prompt_for_meta[prompt_len:]
+
+
 def sample_from_logits(
     logits_2d: mx.array,
     batch: SamplingBatch,
@@ -445,30 +464,50 @@ def sample_prefill_tokens(
     Returns:
         Sampled token IDs and optional logprobs, one row per prefill request.
     """
+    if not prefill_reqs:
+        return _SamplingResult([])
+
+    if all(pr.sampling_params.logprobs is None for pr in prefill_reqs):
+        last_logits_rows: list[mx.array] = []
+        sampling_params_list: list[SamplingParams] = []
+        prompt_token_ids_list: list[list[int]] = []
+        output_token_ids_list: list[list[int]] = []
+        generators: dict[int, torch.Generator] = {}
+
+        for j, pr in enumerate(prefill_reqs):
+            last_idx = cu_seqlens[num_decode + j + 1] - 1
+            last_logits_rows.append(logits[0, last_idx, :])
+            prompt_token_ids, output_token_ids = _prefill_prompt_and_output_tokens(pr)
+
+            sampling_params_list.append(pr.sampling_params)
+            prompt_token_ids_list.append(prompt_token_ids)
+            output_token_ids_list.append(output_token_ids)
+            if pr.generator is not None:
+                generators[j] = pr.generator
+
+        batch = SamplingBatch(
+            sampling_params_list,
+            prompt_token_ids_list,
+            output_token_ids_list,
+            vocab_size=vocab_size,
+            device=device,
+            logitsprocs=logitsprocs,
+            generators=generators,
+        )
+        return sample_from_logits(mx.stack(last_logits_rows), batch, sampler, device)
+
     prefill_next_tokens: list[int] = []
     logprobs_rows: list[LogprobsLists | None] = []
     for j, pr in enumerate(prefill_reqs):
         last_idx = cu_seqlens[num_decode + j + 1] - 1
         last_logits = logits[0, last_idx : last_idx + 1, :]  # (1, vocab)
-
-        if pr.full_prompt_token_ids is not None:
-            prompt_len = len(pr.full_prompt_token_ids)
-        elif pr.prompt_len is not None:
-            prompt_len = pr.prompt_len
-        else:
-            prompt_len = len(pr.token_ids)
-
-        prompt_for_meta = (
-            pr.full_prompt_token_ids
-            if pr.full_prompt_token_ids is not None
-            else pr.token_ids
-        )
+        prompt_token_ids, output_token_ids = _prefill_prompt_and_output_tokens(pr)
         generators = {} if pr.generator is None else {0: pr.generator}
 
         batch = SamplingBatch(
             [pr.sampling_params],
-            [prompt_for_meta[:prompt_len]],
-            [prompt_for_meta[prompt_len:]],
+            [prompt_token_ids],
+            [output_token_ids],
             vocab_size=vocab_size,
             device=device,
             logitsprocs=logitsprocs,


### PR DESCRIPTION
## Summary

Batch paged prefill sampling when no request asks for sample logprobs.

Before this change, `sample_prefill_tokens()` sampled each prefill request independently. For non-greedy requests, that repeated `mx.eval()` + `mlx_to_torch()` + vLLM sampler dispatch once per prefill row.

This PR gathers the last-logit row for each prefill request, stacks them into one `(num_prefill, vocab)` tensor, and calls the existing `SamplingBatch` / vLLM sampler once.

The logprobs path keeps the previous per-request fallback to avoid changing logprob row semantics.

## Scope

In:
- paged prefill sampling
- no-logprobs fast path
- existing `SamplingBatch` and vLLM sampler semantics

Out:
- native MLX non-greedy sampling
- logprobs-path vectorization
- non-paged path changes

Related to #343, but intentionally narrower: this removes repeated sampler bridge work before any native MLX sampler rewrite.

## Performance

Local microbenchmark on Apple M5 / 16GB, vLLM 0.21.0, MLX 0.31.2, vocab=151,936, `temperature=0.8`, `top_p=0.9`:

| batch | old loop | batched prefill sampling | speedup |
| ---: | ---: | ---: | ---: |
| 1 | 2.766 ms | 1.461 ms | 1.89x |
| 4 | 5.881 ms | 2.738 ms | 2.15x |
| 8 | 11.653 ms | 4.692 ms | 2.48x |
| 16 | 23.270 ms | 8.897 ms | 2.62x |

This is a sampling-overhead improvement, not an end-to-end throughput claim.

## Validation

- `python -m pytest tests/test_sampling.py tests/test_v1_model_runner_generate.py -q`
  - `70 passed`
- `python -m ruff check vllm_metal/v1/sampling_batch.py tests/test_sampling.py`
- `python -m ruff format --check vllm_metal/v1/sampling_batch.py tests/test_sampling.py`
- `mypy vllm_metal`
- Real e2e smoke:
  - model: `Qwen/Qwen3-0.6B`
  - Metal paged attention enabled
  - 4 prompt batch
  - `temperature=0.8`, `top_p=0.9`, `max_tokens=8`
  - result: `paged-prefill-sampling-e2e-ok Qwen/Qwen3-0.6B 4`