### PR TITLE
Add Qwen3 reranker classify pooling

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -11,15 +11,16 @@ vllm-metal currently focuses on text-only language models on Apple Silicon. Mult
 | ❌ | Not supported model/feature |
 | 🟡 | Not tested or verified |
 
-## Text Embedding Pooling
+## Text Pooling
 
-Metal V1 has experimental text-only `embed` pooling support. See
-[Text Embedding Pooling](text_embedding_pooling.md) for scope, usage, and
+Metal V1 has experimental text-only pooling support. See
+[Text Pooling](text_embedding_pooling.md) for scope, usage, and
 validation guidance.
 
 | Model | Support | Runner | Evidence | Notes |
 | --- | --- | --- | --- | --- |
 | mlx-community/Qwen3-Embedding-0.6B-8bit | 🔵 | `pooling` / `embed` (paged) | `LLM.embed(["hello metal", "semantic search"])` -> `embedding-smoke-ok 2 1024` | Revision `b8d7100604f51da6d14eab4dd1805f596fa1ce3f`; validated on MacBook Air (Apple M5, 16 GB) with vLLM 0.21.0, MLX 0.31.2, `max_model_len=512` |
+| mku64/Qwen3-Reranker-0.6B-mlx-8Bit | 🔵 | `pooling` / `classify` (paged) | `LLM.score(...)` -> `reranker-offline-score-ok 2`; `/score` -> HTTP 200 with two scalar scores | Revision `ba80418a47fa1c4368a6c2287b0e449904063576`; requires Qwen3 sequence-classification `hf_overrides` |
 
 ## Text-Only Language Models
 

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -1,26 +1,38 @@
-# Text Embedding Pooling
+# Text Pooling
 
 Metal V1 has experimental text-only `embed` pooling support for compatible
 pooling models. Supported requests run as prefill-only work, return one CPU
 L2-normalized embedding tensor per finished request through vLLM's
 `pooler_output` contract, and do not sample generation tokens.
 
+It also has experimental text-only `classify` support for original Qwen3
+reranker checkpoints that vLLM converts with
+`Qwen3ForSequenceClassification`, `classifier_from_token=["no", "yes"]`, and
+`is_original_qwen3_reranker=True`. This path returns one scalar score tensor
+per request through the same `pooler_output` contract.
+
 ## Scope
 
 Current scope is intentionally narrow:
 
-- `runner="pooling"` with embedding-capable pooler configs
-  (`pooler_config.task` unset or `pooler_config.task="embed"`)
+- text `embed` requests with `runner="pooling"` and embedding-capable
+  pooler configs (`pooler_config.task` unset or `pooler_config.task="embed"`)
+- original Qwen3 reranker `classify` requests with
+  `Qwen3ForSequenceClassification`, `classifier_from_token=["no", "yes"]`,
+  and `is_original_qwen3_reranker=True`
 - decoder-style text models that expose token hidden states through the MLX
   transformer body
 - sequence embeddings from the final prompt-token hidden state with LAST
   pooling and L2 normalization on the paged Metal V1 path
+- Qwen3 reranker cross-encoder scores from the final prompt-token hidden state,
+  using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
+  embeddings are tied
 
 ## Unsupported
 
 The Metal runner rejects these cases with diagnostic errors:
 
-- classification, reranking, and late interaction
+- generic classification heads, generic reranking models, and late interaction
 - sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`, `STEP`)
 - token-level pooling
 - chunked long-input embedding aggregation (`enable_chunked_processing`)
@@ -35,9 +47,9 @@ is validated end to end.
 
 ## Usage
 
-### Offline Embeddings
+Set `VLLM_METAL_USE_PAGED_ATTENTION=1` for the current text pooling MVP.
 
-Set `VLLM_METAL_USE_PAGED_ATTENTION=1` for this MVP.
+### Offline Embeddings
 
 ```python
 from vllm import LLM
@@ -51,7 +63,7 @@ outputs = llm.embed(["hello metal", "semantic search"])
 print(len(outputs), len(outputs[0].outputs.embedding))
 ```
 
-### OpenAI-Compatible Server
+### Embedding Server
 
 ```bash
 VLLM_ENABLE_V1_MULTIPROCESSING=0 \
@@ -68,8 +80,58 @@ curl http://localhost:8000/v1/embeddings \
   -d '{"model":"mlx-community/Qwen3-Embedding-0.6B-8bit","input":["hello metal","semantic search"]}'
 ```
 
+### Offline Qwen3 Reranking
+
+Original Qwen3 reranker checkpoints need vLLM's sequence-classification
+overrides. `LLM.score` can format the query/document pair for this checkpoint
+without a separate local template file.
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="mku64/Qwen3-Reranker-0.6B-mlx-8Bit",
+    revision="ba80418a47fa1c4368a6c2287b0e449904063576",
+    runner="pooling",
+    max_model_len=512,
+    hf_overrides={
+        "architectures": ["Qwen3ForSequenceClassification"],
+        "classifier_from_token": ["no", "yes"],
+        "is_original_qwen3_reranker": True,
+    },
+)
+outputs = llm.score(
+    ["What is the capital of China?"],
+    ["The capital of China is Beijing."],
+)
+print(outputs[0].outputs.score)
+```
+
+### Qwen3 Reranking Server
+
+```bash
+VLLM_ENABLE_V1_MULTIPROCESSING=0 \
+VLLM_METAL_USE_PAGED_ATTENTION=1 \
+VLLM_METAL_MEMORY_FRACTION=auto \
+vllm serve mku64/Qwen3-Reranker-0.6B-mlx-8Bit \
+  --revision ba80418a47fa1c4368a6c2287b0e449904063576 \
+  --runner pooling \
+  --max-model-len 512 \
+  --hf-overrides '{
+    "architectures": ["Qwen3ForSequenceClassification"],
+    "classifier_from_token": ["no", "yes"],
+    "is_original_qwen3_reranker": true
+  }'
+```
+
+```bash
+curl http://localhost:8000/score \
+  -H "Content-Type: application/json" \
+  -d '{"text_1":["What is the capital of China?"],"text_2":["The capital of China is Beijing."]}'
+```
+
 ## Validation
 
 Do not add a model row to [Supported Models](supported_models.md) until a real
-`LLM.embed` or `/v1/embeddings` smoke passes on Apple Silicon with the model
-name, revision, command, and output dimension recorded.
+`LLM.embed`, `/v1/embeddings`, `LLM.score`, or `/score` smoke passes on Apple
+Silicon with the model name, revision, command, and output shape recorded.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -68,7 +68,7 @@ nav:
   - Models:
     - Supported Models: supported_models.md
   - Features:
-    - Text Embedding Pooling: text_embedding_pooling.md
+    - Text Pooling: text_embedding_pooling.md
     - Speech-to-Text: stt.md
     - Turboquant: turboquant.md
     - GPU Profiling: profiling.md

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""High-value contract tests for Metal V1 text embedding pooling."""
+"""High-value contract tests for Metal V1 text pooling."""
 
 from __future__ import annotations
 
@@ -17,6 +17,7 @@ from vllm.pooling_params import LateInteractionParams, PoolingParams  # noqa: E4
 
 from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
+from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
 
 class _SequenceModel:
@@ -30,6 +31,45 @@ class _SequenceModel:
         token_ids = np.array(input_ids).reshape(-1).tolist()
         rows = [[float(tok), float(tok + 1), 1.0] for tok in token_ids]
         return mx.array([rows], dtype=mx.float32)
+
+
+class _TiedEmbedding:
+    def as_linear(self, vector):
+        logits = mx.zeros((8,), dtype=mx.float32)
+        return mx.concatenate(
+            [
+                mx.stack([vector[0], vector[0] * 2.0]),
+                logits[2:],
+            ]
+        )
+
+
+class _UntiedLmHead:
+    def __call__(self, vector):
+        logits = mx.zeros((8,), dtype=mx.float32)
+        return mx.concatenate(
+            [
+                mx.stack([vector[0] * 0.0, vector[0] + 10.0]),
+                logits[2:],
+            ]
+        )
+
+
+class _BadTiedEmbedding:
+    def as_linear(self, vector):
+        return mx.zeros((2, 2), dtype=mx.float32)
+
+
+class _ClassifierSequenceModel(_SequenceModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed_tokens = _TiedEmbedding()
+
+
+class _BadClassifierSequenceModel(_SequenceModel):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embed_tokens = _BadTiedEmbedding()
 
 
 class _RecordingSequenceModel(_SequenceModel):
@@ -47,6 +87,23 @@ class _PoolingModel:
         self.model = sequence_model or _SequenceModel()
 
 
+class _UntiedClassifierModel(_PoolingModel):
+    def __init__(self) -> None:
+        super().__init__(_ClassifierSequenceModel())
+        self.args = SimpleNamespace(tie_word_embeddings=False)
+        self.lm_head = _UntiedLmHead()
+
+
+class _ClassifierTokenizer:
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return {"no": 0, "yes": 1}.get(token)
+
+    def encode(self, token: str, add_special_tokens: bool = False) -> list[int]:
+        assert not add_special_tokens
+        token_id = self.convert_tokens_to_ids(token)
+        return [] if token_id is None else [token_id]
+
+
 def _hf_config(**overrides):
     values = {
         "architectures": ["Qwen3ForCausalLM"],
@@ -54,6 +111,18 @@ def _hf_config(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def _qwen3_reranker_hf_config(**overrides):
+    values = {
+        "architectures": ["Qwen3ForSequenceClassification"],
+        "classifier_from_token": ["no", "yes"],
+        "is_original_qwen3_reranker": True,
+        "num_labels": 1,
+        "tie_word_embeddings": True,
+    }
+    values.update(overrides)
+    return _hf_config(**values)
 
 
 def _pooler_config(**overrides):
@@ -80,15 +149,26 @@ def _pooling_model_config(**overrides):
     return SimpleNamespace(**values)
 
 
+def _classification_model_config(**overrides):
+    values = {
+        "hf_config": _qwen3_reranker_hf_config(),
+        "pooler_config": _pooler_config(),
+    }
+    values.update(overrides)
+    return _pooling_model_config(**values)
+
+
 def _make_runner(
     *,
     paged: bool = True,
     model: object | None = None,
     model_config: object | None = None,
+    tokenizer: object | None = None,
 ):
     return make_stub_runner(
         model=model or _PoolingModel(),
         model_config=model_config or _pooling_model_config(),
+        tokenizer=tokenizer,
         _paged_attention_backend=object() if paged else None,
         _paged_block_size=4,
         num_layers=1,
@@ -183,6 +263,23 @@ def _assert_embedding(tensor: torch.Tensor | None, token_id: int) -> None:
     assert torch.allclose(tensor, _expected_embedding(token_id), atol=1e-6)
 
 
+def _expected_score(token_id: int, *, activated: bool = True) -> torch.Tensor:
+    raw = torch.tensor([float(token_id)])
+    return torch.sigmoid(raw) if activated else raw
+
+
+def _assert_score(
+    tensor: torch.Tensor | None,
+    token_id: int,
+    *,
+    activated: bool = True,
+) -> None:
+    assert tensor is not None
+    assert tensor.device.type == "cpu"
+    assert tensor.shape == (1,)
+    assert torch.allclose(tensor, _expected_score(token_id, activated=activated))
+
+
 def _execute_pooling(runner, sched):
     out = runner.execute_model(sched)
     assert out is not None
@@ -199,6 +296,97 @@ class TestMetalPoolingCapabilities:
         runner = make_stub_runner(
             model=object(),
             model_config=_pooling_model_config(),
+        )
+
+        assert runner.supported_worker_tasks() == ()
+
+    def test_supported_worker_tasks_for_qwen3_reranker_classify_model(self) -> None:
+        runner = _make_runner(
+            model=_PoolingModel(_ClassifierSequenceModel()),
+            model_config=_classification_model_config(),
+            tokenizer=_ClassifierTokenizer(),
+        )
+
+        assert runner.supported_worker_tasks() == ("classify",)
+
+    def test_supported_worker_tasks_for_untied_qwen3_reranker_model(self) -> None:
+        runner = _make_runner(
+            model=_UntiedClassifierModel(),
+            model_config=_classification_model_config(
+                hf_config=_qwen3_reranker_hf_config(tie_word_embeddings=False)
+            ),
+            tokenizer=_ClassifierTokenizer(),
+        )
+
+        assert runner.supported_worker_tasks() == ("classify",)
+
+    @pytest.mark.parametrize(
+        ("model", "model_config", "tokenizer"),
+        [
+            (
+                _PoolingModel(_ClassifierSequenceModel()),
+                _classification_model_config(
+                    hf_config=_qwen3_reranker_hf_config(
+                        classifier_from_token=["no", "maybe"],
+                    )
+                ),
+                _ClassifierTokenizer(),
+            ),
+            (
+                _PoolingModel(_ClassifierSequenceModel()),
+                _classification_model_config(
+                    hf_config=_qwen3_reranker_hf_config(
+                        is_original_qwen3_reranker=False,
+                    )
+                ),
+                _ClassifierTokenizer(),
+            ),
+            (
+                _PoolingModel(_ClassifierSequenceModel()),
+                _classification_model_config(
+                    hf_config=_qwen3_reranker_hf_config(tie_word_embeddings=False)
+                ),
+                _ClassifierTokenizer(),
+            ),
+            (
+                _PoolingModel(_ClassifierSequenceModel()),
+                _classification_model_config(
+                    hf_config=_qwen3_reranker_hf_config(tie_word_embeddings=None)
+                ),
+                _ClassifierTokenizer(),
+            ),
+            (
+                SimpleNamespace(
+                    model=_ClassifierSequenceModel(),
+                    lm_head=_UntiedLmHead(),
+                ),
+                _classification_model_config(
+                    hf_config=_qwen3_reranker_hf_config(tie_word_embeddings=None)
+                ),
+                _ClassifierTokenizer(),
+            ),
+            (
+                _PoolingModel(_SequenceModel()),
+                _classification_model_config(),
+                _ClassifierTokenizer(),
+            ),
+            (
+                _PoolingModel(_ClassifierSequenceModel()),
+                _classification_model_config(),
+                object(),
+            ),
+        ],
+    )
+    def test_supported_worker_tasks_rejects_incomplete_qwen3_reranker_contract(
+        self,
+        model: object,
+        model_config: object,
+        tokenizer: object,
+    ) -> None:
+        runner = _make_runner(
+            model=model,
+            model_config=model_config,
+            tokenizer=tokenizer,
         )
 
         assert runner.supported_worker_tasks() == ()
@@ -273,6 +461,97 @@ class TestMetalPoolingRunnerOutput:
         assert final.pooler_output is not None
         _assert_embedding(final.pooler_output[0], 4)
 
+    def test_paged_classify_returns_qwen3_reranker_scores(self) -> None:
+        runner = _make_runner(
+            model=_PoolingModel(_ClassifierSequenceModel()),
+            model_config=_classification_model_config(),
+            tokenizer=_ClassifierTokenizer(),
+        )
+        req_b = _new_req("req-b", [4, 5], task="classify")
+        req_a = _new_req("req-a", [7, 8, 9], task="classify")
+        sched = _scheduler_output(new_reqs=[req_b, req_a])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.req_ids == ["req-b", "req-a"]
+        assert out.sampled_token_ids == [[], []]
+        assert out.pooler_output is not None
+        _assert_score(out.pooler_output[0], 5)
+        _assert_score(out.pooler_output[1], 9)
+
+    def test_paged_classify_can_return_raw_qwen3_reranker_scores(self) -> None:
+        runner = _make_runner(
+            model=_PoolingModel(_ClassifierSequenceModel()),
+            model_config=_classification_model_config(),
+            tokenizer=_ClassifierTokenizer(),
+        )
+        req = _new_req(
+            "req-0",
+            [2, 3],
+            pooling_params=_pooling_params(task="classify", use_activation=False),
+        )
+        sched = _scheduler_output(new_reqs=[req])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.pooler_output is not None
+        _assert_score(out.pooler_output[0], 3, activated=False)
+
+    def test_paged_classify_uses_lm_head_for_untied_qwen3_reranker(self) -> None:
+        runner = _make_runner(
+            model=_UntiedClassifierModel(),
+            model_config=_classification_model_config(
+                hf_config=_qwen3_reranker_hf_config(tie_word_embeddings=False)
+            ),
+            tokenizer=_ClassifierTokenizer(),
+        )
+        req = _new_req(
+            "req-0",
+            [2, 3],
+            pooling_params=_pooling_params(task="classify", use_activation=False),
+        )
+        sched = _scheduler_output(new_reqs=[req])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.pooler_output is not None
+        assert torch.allclose(out.pooler_output[0], torch.tensor([13.0]))
+
+    def test_paged_classify_applies_logit_calibration(self) -> None:
+        runner = _make_runner(
+            model=_PoolingModel(_ClassifierSequenceModel()),
+            model_config=_classification_model_config(
+                pooler_config=_pooler_config(logit_mean=1.0, logit_sigma=2.0)
+            ),
+            tokenizer=_ClassifierTokenizer(),
+        )
+        req = _new_req("req-0", [2, 3], task="classify")
+        sched = _scheduler_output(new_reqs=[req])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.pooler_output is not None
+        assert torch.allclose(
+            out.pooler_output[0],
+            torch.sigmoid(torch.tensor([(3.0 - 1.0) / 2.0])),
+        )
+
 
 class TestMetalPoolingFailFast:
     def test_non_decoder_pooling_models_fail_fast_on_execute(
@@ -297,7 +576,7 @@ class TestMetalPoolingFailFast:
 
     @pytest.mark.parametrize(
         "task",
-        ["classify", "score"],
+        ["score", "token_embed", "token_classify", "plugin"],
     )
     def test_unsupported_pooling_tasks_fail_fast(self, task: str) -> None:
         runner = _make_runner()
@@ -305,6 +584,28 @@ class TestMetalPoolingFailFast:
 
         with pytest.raises(NotImplementedError, match="task"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_classify_hidden_state_shape_fails_fast(self) -> None:
+        with pytest.raises(ValueError, match="hidden states with shape"):
+            pool_sequence_classification(
+                mx.array([[1.0, 2.0]], dtype=mx.float32),
+                token_index=0,
+                model=_PoolingModel(_ClassifierSequenceModel()),
+                tokenizer=_ClassifierTokenizer(),
+                pooling_params=_pooling_params(task="classify"),
+                model_config=_classification_model_config(),
+            )
+
+    def test_classify_logits_shape_fails_fast(self) -> None:
+        with pytest.raises(ValueError, match="classifier logits with shape"):
+            pool_sequence_classification(
+                mx.array([[[1.0, 2.0, 3.0]]], dtype=mx.float32),
+                token_index=0,
+                model=_PoolingModel(_BadClassifierSequenceModel()),
+                tokenizer=_ClassifierTokenizer(),
+                pooling_params=_pooling_params(task="classify"),
+                model_config=_classification_model_config(),
+            )
 
     @pytest.mark.parametrize(
         ("attr", "pooling_type"),

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -75,7 +75,7 @@ from vllm_metal.v1.pooling import (
     forward_sequence_hidden_states,
     has_paged_pooling_work,
     pooling_dummy_forward_outputs,
-    supports_embed_pooling,
+    supported_pooling_tasks,
     validate_pooling_request,
 )
 from vllm_metal.v1.sampling_batch import (
@@ -413,9 +413,9 @@ class MetalModelRunner:
         if self._is_pooling:
             if self._paged_attention_backend is None:
                 return ()
-            if supports_embed_pooling(self._forward_model, self.model_config):
-                return ("embed",)
-            return ()
+            return supported_pooling_tasks(
+                self._forward_model, self.model_config, self.tokenizer
+            )
         return ("generate",)
 
     def load_model(self) -> None:
@@ -1069,6 +1069,8 @@ class MetalModelRunner:
                 pooling_hidden_states,
                 cu_seqlens=cu_seqlens,
                 num_decode_segments=num_decode_segments,
+                model=self._forward_model,
+                tokenizer=self.tokenizer,
                 model_config=self.model_config,
             )
             return batch, scheduler_output

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Text embedding pooling helpers for the Metal V1 model runner."""
+"""Text pooling helpers for the Metal V1 model runner."""
 
 from __future__ import annotations
 
@@ -8,11 +8,15 @@ from typing import Any
 import mlx.core as mx
 import torch
 from vllm.pooling_params import PoolingParams
+from vllm.tasks import SupportedTask
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 
 _EMBED_POOLER_TASKS = (None, "embed")
+_CLASSIFY_POOLER_TASKS = (None, "classify")
+_SUPPORTED_POOLER_TASKS = (None, "embed", "classify")
 _LAST_POOLING = (None, "LAST")
+_QWEN3_RERANKER_TOKENS = ("no", "yes")
 
 
 def _model_label(model_config: Any) -> str:
@@ -77,23 +81,31 @@ def _chunked_processing_enabled(model_config: Any) -> bool:
     )
 
 
+def _classifier_tokens(model_config: Any) -> tuple[str, str] | None:
+    hf_config = _hf_config(model_config)
+    tokens = getattr(hf_config, "classifier_from_token", None)
+    if not isinstance(tokens, (list, tuple)) or len(tokens) != 2:
+        return None
+    return (str(tokens[0]), str(tokens[1]))
+
+
 def _reject_unsupported_pooler_config(model_config: Any) -> None:
     task = _pooler_task(model_config)
-    if task not in _EMBED_POOLER_TASKS:
+    if task not in _SUPPORTED_POOLER_TASKS:
         raise NotImplementedError(
-            "Metal embed pooling supports only pooler_config.task unset or "
-            f"'embed'; got {task!r} for model={_model_label(model_config)}."
+            "Metal pooling supports only pooler_config.task unset, 'embed', "
+            f"or 'classify'; got {task!r} for model={_model_label(model_config)}."
         )
 
     seq_pooling_type = _unsupported_sequence_pooling_type(model_config)
     if seq_pooling_type is not None:
         raise NotImplementedError(
-            "Metal embed pooling currently supports only LAST sequence pooling; "
+            "Metal pooling currently supports only LAST sequence pooling; "
             f"got {seq_pooling_type!r} for model={_model_label(model_config)}."
         )
     if _chunked_processing_enabled(model_config):
         raise NotImplementedError(
-            "Metal embed pooling does not support "
+            "Metal pooling does not support "
             "pooler_config.enable_chunked_processing=True with LAST pooling; "
             f"model={_model_label(model_config)}."
         )
@@ -109,10 +121,51 @@ def _is_decoder_embedding_config(model_config: Any) -> bool:
     )
 
 
+def _is_qwen3_token_logit_classifier(model_config: Any) -> bool:
+    hf_config = _hf_config(model_config)
+    return (
+        "Qwen3ForSequenceClassification" in _architecture_names(model_config)
+        and getattr(hf_config, "is_original_qwen3_reranker", False) is True
+        and _classifier_tokens(model_config) == _QWEN3_RERANKER_TOKENS
+    )
+
+
 def sequence_model(model: Any) -> Any | None:
     """Return the MLX transformer body when it is available."""
     inner = getattr(model, "model", None)
     return inner if callable(inner) else None
+
+
+def _word_embeddings_tied(model: Any, model_config: Any) -> bool | None:
+    for source in (model, getattr(model, "args", None), _hf_config(model_config)):
+        value = getattr(source, "tie_word_embeddings", None)
+        if value is not None:
+            return bool(value)
+    return None
+
+
+def _tied_embedding_logits_fn(model: Any) -> Any | None:
+    body = sequence_model(model)
+    if body is None:
+        return None
+    embed_tokens = getattr(body, "embed_tokens", None)
+    as_linear = getattr(embed_tokens, "as_linear", None)
+    return as_linear if callable(as_linear) else None
+
+
+def _classifier_logits_fn(model: Any, model_config: Any) -> Any | None:
+    if sequence_model(model) is None:
+        return None
+
+    lm_head = getattr(model, "lm_head", None)
+    tied_embedding_logits = _tied_embedding_logits_fn(model)
+    tied = _word_embeddings_tied(model, model_config)
+
+    if tied is False:
+        return lm_head if callable(lm_head) else None
+    if tied is True:
+        return tied_embedding_logits
+    return None
 
 
 def supports_embed_pooling(model: Any, model_config: Any) -> bool:
@@ -130,6 +183,75 @@ def supports_embed_pooling(model: Any, model_config: Any) -> bool:
     return sequence_model(model) is not None and _is_decoder_embedding_config(
         model_config
     )
+
+
+def _resolve_token_id(tokenizer: Any, token: str) -> int | None:
+    if tokenizer is None:
+        return None
+
+    convert = getattr(tokenizer, "convert_tokens_to_ids", None)
+    if callable(convert):
+        token_id = convert(token)
+        if isinstance(token_id, int) and token_id >= 0:
+            return token_id
+
+    encode = getattr(tokenizer, "encode", None)
+    if callable(encode):
+        token_ids = encode(token, add_special_tokens=False)
+        if isinstance(token_ids, list) and len(token_ids) == 1:
+            return int(token_ids[0])
+
+    return None
+
+
+def _classifier_token_ids(
+    tokenizer: Any,
+    model_config: Any,
+) -> tuple[int, int] | None:
+    tokens = _classifier_tokens(model_config)
+    if tokens is None:
+        return None
+    token_ids = tuple(_resolve_token_id(tokenizer, token) for token in tokens)
+    if any(token_id is None for token_id in token_ids):
+        return None
+    no_id, yes_id = token_ids
+    assert no_id is not None and yes_id is not None
+    return (no_id, yes_id)
+
+
+def supports_classify_pooling(
+    model: Any,
+    model_config: Any,
+    tokenizer: Any,
+) -> bool:
+    """Return whether this model can use the narrow Qwen3 reranker path."""
+    if getattr(model_config, "multimodal_config", None) is not None:
+        return False
+    if _pooler_task(model_config) not in _CLASSIFY_POOLER_TASKS:
+        return False
+    if _unsupported_sequence_pooling_type(model_config) is not None:
+        return False
+    if _chunked_processing_enabled(model_config):
+        return False
+    return (
+        _is_qwen3_token_logit_classifier(model_config)
+        and _classifier_logits_fn(model, model_config) is not None
+        and _classifier_token_ids(tokenizer, model_config) is not None
+    )
+
+
+def supported_pooling_tasks(
+    model: Any,
+    model_config: Any,
+    tokenizer: Any,
+) -> tuple[SupportedTask, ...]:
+    """Return Metal pooling tasks supported by this loaded model."""
+    tasks: list[SupportedTask] = []
+    if supports_embed_pooling(model, model_config):
+        tasks.append("embed")
+    if supports_classify_pooling(model, model_config, tokenizer):
+        tasks.append("classify")
+    return tuple(tasks)
 
 
 def _unsupported_pooling_option(
@@ -159,7 +281,8 @@ def _unsupported_pooling_option(
         ),
         (
             "use_activation=False",
-            getattr(pooling_params, "use_activation", None) is False,
+            getattr(pooling_params, "task", None) != "classify"
+            and getattr(pooling_params, "use_activation", None) is False,
         ),
         (
             "embedding-dimension truncation",
@@ -177,33 +300,44 @@ def validate_pooling_params(
     pooling_params: PoolingParams,
     model_config: Any,
 ) -> None:
-    """Validate the narrow text-only LAST `embed` pooling contract."""
+    """Validate the narrow text-only LAST pooling contract."""
     model = _model_label(model_config)
     if getattr(model_config, "runner_type", None) != "pooling":
         raise NotImplementedError(
-            "Metal embed pooling requires runner_type='pooling'; got "
+            "Metal pooling requires runner_type='pooling'; got "
             f"{getattr(model_config, 'runner_type', None)!r} for model={model}."
         )
     _reject_unsupported_pooler_config(model_config)
-    if not _is_decoder_embedding_config(model_config):
-        raise NotImplementedError(
-            "Metal embed pooling requires a decoder-style checkpoint; got "
-            f"architectures={_architecture_names(model_config)!r} for model="
-            f"{model}."
-        )
 
     task = getattr(pooling_params, "task", None)
-    if task not in (None, "embed"):
+    if task in (None, "embed"):
+        if not _is_decoder_embedding_config(model_config):
+            raise NotImplementedError(
+                "Metal embed pooling requires a decoder-style checkpoint; got "
+                f"architectures={_architecture_names(model_config)!r} for model="
+                f"{model}."
+            )
+    elif task == "classify":
+        if not _is_qwen3_token_logit_classifier(model_config):
+            raise NotImplementedError(
+                "Metal classify pooling currently supports only original Qwen3 "
+                "reranker checkpoints converted with "
+                "Qwen3ForSequenceClassification and classifier_from_token="
+                "['no', 'yes']; "
+                f"architectures={_architecture_names(model_config)!r} for model="
+                f"{model}."
+            )
+    else:
         raise NotImplementedError(
-            "Metal pooling supports only text-only task='embed' for now; "
+            "Metal pooling supports only text-only task='embed' and the "
+            "Qwen3 reranker task='classify' for now; "
             f"got task={task!r} for model={model}."
         )
 
     unsupported_option = _unsupported_pooling_option(pooling_params, model_config)
     if unsupported_option is not None:
         raise NotImplementedError(
-            f"Metal embed pooling does not support {unsupported_option} "
-            f"for model={model}."
+            f"Metal pooling does not support {unsupported_option} for model={model}."
         )
 
 
@@ -213,7 +347,7 @@ def validate_pooling_request(
     *,
     paged_attention_enabled: bool,
 ) -> None:
-    """Validate the request-level contract for Metal text embedding pooling."""
+    """Validate the request-level contract for Metal text pooling."""
     pooling_params = new_req.pooling_params
     if pooling_params is None:
         return
@@ -229,13 +363,12 @@ def validate_pooling_request(
         )
     if not paged_attention_enabled:
         raise NotImplementedError(
-            "Metal embed pooling currently requires paged attention; "
+            "Metal pooling currently requires paged attention; "
             "set VLLM_METAL_USE_PAGED_ATTENTION=1."
         )
     if not (new_req.prompt_token_ids or []):
         raise ValueError(
-            "Metal embed pooling requires prompt_token_ids for "
-            f"request {new_req.req_id!r}."
+            f"Metal pooling requires prompt_token_ids for request {new_req.req_id!r}."
         )
 
 
@@ -251,16 +384,16 @@ def forward_sequence_hidden_states(
     body = sequence_model(model)
     if body is None:
         raise NotImplementedError(
-            "Metal embed pooling requires an MLX model with a callable "
+            "Metal pooling requires an MLX model with a callable "
             f"'.model' transformer body; model={_model_label(model_config)}; "
-            "task='embed'."
+            "runner='pooling'."
         )
 
     hidden_states = body(input_ids) if cache is None else body(input_ids, cache=cache)
 
     if not hasattr(hidden_states, "shape") or not hasattr(hidden_states, "dtype"):
         raise ValueError(
-            "Metal embed pooling expected MLX hidden states from model body; "
+            "Metal pooling expected MLX hidden states from model body; "
             f"got {type(hidden_states).__name__} for model="
             f"{_model_label(model_config)}."
         )
@@ -331,11 +464,84 @@ def pool_sequence_embedding(
     return tensor.detach().clone()
 
 
+def _classifier_use_activation(
+    pooling_params: PoolingParams,
+    model_config: Any,
+) -> bool:
+    request_value = getattr(pooling_params, "use_activation", None)
+    if request_value is not None:
+        return bool(request_value)
+    pooler_value = getattr(_pooler_config(model_config), "use_activation", None)
+    if pooler_value is not None:
+        return bool(pooler_value)
+    return True
+
+
+def pool_sequence_classification(
+    hidden_states: mx.array,
+    *,
+    token_index: int,
+    model: Any,
+    tokenizer: Any,
+    pooling_params: PoolingParams,
+    model_config: Any,
+) -> torch.Tensor:
+    """Return one CPU Qwen3 reranker score for a finished request."""
+    if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
+        raise ValueError(
+            "Metal classify pooling expected hidden states with shape "
+            f"[1, tokens, hidden], got {hidden_states.shape} "
+            f"for model={_model_label(model_config)}."
+        )
+    if token_index < 0 or token_index >= hidden_states.shape[1]:
+        raise ValueError(
+            f"Metal classify pooling token index {token_index} is outside hidden "
+            f"state shape {hidden_states.shape} for model={_model_label(model_config)}."
+        )
+
+    token_ids = _classifier_token_ids(tokenizer, model_config)
+    logits_fn = _classifier_logits_fn(model, model_config)
+    if token_ids is None or logits_fn is None:
+        raise NotImplementedError(
+            "Metal classify pooling requires original Qwen3 reranker "
+            "classifier_from_token=['no', 'yes'] and either lm_head for "
+            "untied checkpoints or embed_tokens.as_linear for tied "
+            "checkpoints."
+        )
+
+    no_id, yes_id = token_ids
+    vector = hidden_states[0, token_index, :].astype(mx.float32)
+    vocab_logits = mx.squeeze(logits_fn(vector).astype(mx.float32))
+    if vocab_logits.ndim != 1:
+        raise ValueError(
+            "Metal classify pooling expected classifier logits with shape "
+            f"[vocab], got {vocab_logits.shape} for model="
+            f"{_model_label(model_config)}."
+        )
+
+    token_logits = vocab_logits[mx.array([no_id, yes_id], dtype=mx.int32)]
+    score = token_logits[1] - token_logits[0]
+    pooler_config = _pooler_config(model_config)
+    logit_mean = getattr(pooler_config, "logit_mean", None)
+    logit_sigma = getattr(pooler_config, "logit_sigma", None)
+    if logit_mean is not None:
+        score = score - float(logit_mean)
+    if logit_sigma is not None:
+        score = score / float(logit_sigma)
+    if _classifier_use_activation(pooling_params, model_config):
+        score = mx.sigmoid(score)
+
+    tensor = mlx_to_torch(score.reshape((1,)), device="cpu")
+    return tensor.detach().clone()
+
+
 def pool_sequence_batch(
     hidden_states: mx.array,
     *,
     token_indices: list[int | None],
     pooling_params: list[PoolingParams],
+    model: Any,
+    tokenizer: Any,
     model_config: Any,
 ) -> list[torch.Tensor | None]:
     """Pool a paged prefill batch; unfinished chunks return ``None``."""
@@ -344,14 +550,33 @@ def pool_sequence_batch(
         if token_index is None:
             outputs.append(None)
             continue
-        outputs.append(
-            pool_sequence_embedding(
-                hidden_states,
-                token_index=token_index,
-                pooling_params=params,
-                model_config=model_config,
+        task = getattr(params, "task", None)
+        if task in (None, "embed"):
+            outputs.append(
+                pool_sequence_embedding(
+                    hidden_states,
+                    token_index=token_index,
+                    pooling_params=params,
+                    model_config=model_config,
+                )
             )
-        )
+        elif task == "classify":
+            outputs.append(
+                pool_sequence_classification(
+                    hidden_states,
+                    token_index=token_index,
+                    model=model,
+                    tokenizer=tokenizer,
+                    pooling_params=params,
+                    model_config=model_config,
+                )
+            )
+        else:
+            raise NotImplementedError(
+                "Metal pooling supports only text-only task='embed' and the "
+                "Qwen3 reranker task='classify' for now; "
+                f"got task={task!r} for model={_model_label(model_config)}."
+            )
     return outputs
 
 
@@ -361,6 +586,8 @@ def pool_paged_prefill_batch(
     prefill_entries: list[Any],
     cu_seqlens: list[int],
     num_decode_segments: int,
+    model: Any,
+    tokenizer: Any,
     model_config: Any,
 ) -> list[torch.Tensor | None]:
     """Pool a paged prefill batch; unfinished chunks return ``None``."""
@@ -385,6 +612,8 @@ def pool_paged_prefill_batch(
         hidden_states,
         token_indices=token_indices,
         pooling_params=pooling_params,
+        model=model,
+        tokenizer=tokenizer,
         model_config=model_config,
     )
 
@@ -395,6 +624,8 @@ def finish_paged_pooling_batch(
     *,
     cu_seqlens: list[int],
     num_decode_segments: int,
+    model: Any,
+    tokenizer: Any,
     model_config: Any,
 ) -> None:
     """Convert final paged prefill hidden states into batch pooler outputs."""
@@ -403,6 +634,8 @@ def finish_paged_pooling_batch(
         prefill_entries=batch.paged_prefill_entries,
         cu_seqlens=cu_seqlens,
         num_decode_segments=num_decode_segments,
+        model=model,
+        tokenizer=tokenizer,
         model_config=model_config,
     )
     for entry, pooler_output in zip(


### PR DESCRIPTION
## Summary

Adds a narrow Metal V1 text pooling follow-up for original Qwen3 reranker `classify` support.

This PR supports only the Qwen3 reranker contract:

- `Qwen3ForSequenceClassification`
- `classifier_from_token=["no", "yes"]`
- `is_original_qwen3_reranker=True`
- tied `model.model.embed_tokens.as_linear`
- paged pooling path

The score is computed from the final prompt-token hidden state using `yes_logit - no_logit`, with optional `logit_mean` / `logit_sigma` calibration and `use_activation` handling.

## Scope

This intentionally does not add generic classification or reranking support. Generic classification heads, generic reranking models, late interaction, token-level pooling, multimodal pooling, direct embedding tensors, and non-paged pooling remain unsupported.

## Changes

- Adds Qwen3 reranker `classify` pooling helpers in `pooling.py`
- Keeps `model_runner.py` as a thin router/delegator
- Adds contract tests for task advertisement, output order, raw/activated scores, calibration, and fail-fast behavior
- Updates text pooling docs and supported model evidence

## Validation

- `git diff --check`
- `.venv-vllm-metal/bin/python -m pytest tests/test_v1_pooling.py -q`
  - `32 passed`
- `.venv-vllm-metal/bin/python -m pytest tests/test_v1_model_runner_generate.py tests/test_v1_worker.py tests/test_paged_attention.py tests/test_sampling.py tests/test_grammar_bitmask.py -q`
  - `119 passed`
- `scripts/lint.sh`
  - shellcheck, ruff, ruff format check, and mypy passed

Real Qwen3 reranker smoke:

- Offline `LLM.score` on `mku64/Qwen3-Reranker-0.6B-mlx-8Bit`
  - revision `ba80418a47fa1c4368a6c2287b0e449904063576`
  - `reranker-offline-score-ok 2 [0.973079, 0.931326]`
- Server `/score`
  - `/health` returned HTTP 200
  - `/score` returned HTTP 200 with two scalar scores

Refs #361