### PR TITLE
[Refactor] Refactor model runner, mv stt to separated file

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -34,7 +34,6 @@ def make_stub_runner(
         "vllm_config": SimpleNamespace(speculative_config=None),
         "model_config": SimpleNamespace(runner_type="generate"),
         "model": object(),
-        "_is_stt": False,
         "_is_vlm": False,
         "_multimodal_adapter": None,
         "_gemma4_mtp_assistant": None,

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -711,31 +711,20 @@ class TestModelLifecycle:
         assert runner.num_layers == 32
         assert runner.head_dim == 128
 
-    def test_load_reuses_cached_stt_model(
+    def test_load_stt_model_reuses_cached_model(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        adapter = object()
         fake_model = SimpleNamespace(
-            create_runtime_adapter=lambda model_name: (adapter, model_name)
+            create_runtime_adapter=lambda model_name: (object(), model_name)
         )
         monkeypatch.setattr(
             model_lifecycle,
             "_MODEL_CACHE",
             {model_lifecycle._stt_cache_key("stub-model"): (fake_model, None)},
         )
-        monkeypatch.setattr(model_lifecycle, "is_stt_model", lambda _model_name: True)
-        lifecycle, runner = _make_lifecycle()
 
-        lifecycle.load()
-
-        assert runner.model is fake_model
-        assert runner.tokenizer is None
-        assert runner.model_args == {}
-        assert runner.kv_cache_dtype is None
-        assert runner._is_vlm is False
-        assert runner._is_stt is True
-        assert runner._stt_runtime_adapter == (adapter, "stub-model")
+        assert model_lifecycle.load_stt_model("stub-model") is fake_model
 
     @pytest.mark.parametrize(
         "is_awq", [True, False], ids=["awq-checkpoint", "non-awq-checkpoint"]

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -396,17 +396,12 @@ class TestMetalPoolingCapabilities:
 
         assert runner.supported_worker_tasks() == ()
 
-    def test_supported_worker_tasks_preserves_generation_and_stt(self) -> None:
+    def test_supported_worker_tasks_preserves_generation(self) -> None:
         gen_runner = make_stub_runner(
             model_config=SimpleNamespace(runner_type="generate")
         )
-        stt_runner = make_stub_runner(
-            _is_stt=True,
-            model_config=SimpleNamespace(runner_type="generate"),
-        )
 
         assert gen_runner.supported_worker_tasks() == ("generate",)
-        assert stt_runner.supported_worker_tasks() == ("transcription",)
 
 
 class TestMetalPoolingRunnerOutput:

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -403,8 +403,12 @@ class TestSTTRunnerWorkerContract:
         monkeypatch.setattr(smr, "load_stt_model", lambda _name: fake_model)
         monkeypatch.setattr(smr, "get_model_download_path", lambda _m: "resolved-path")
 
-        runner = smr.STTModelRunner.__new__(smr.STTModelRunner)
-        runner.model_config = SimpleNamespace(model="some-model")
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(model="some-model"),
+            cache_config=SimpleNamespace(),
+            scheduler_config=SimpleNamespace(),
+        )
+        runner = smr.STTModelRunner(vllm_config, device=torch.device("cpu"))
         runner.load_model()
 
         assert runner.model is fake_model

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for v1 STT integration in MetalModelRunner."""
+"""Tests for v1 STT integration in STTModelRunner."""
 
 from __future__ import annotations
 
@@ -25,29 +25,24 @@ from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.qwen3_asr.adapter import Qwen3ASRRuntimeAdapter
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.whisper.adapter import WhisperRuntimeAdapter
-from vllm_metal.v1.cache_policy import ModelCachePolicy
-from vllm_metal.v1.model_adapter import DefaultModelAdapter
-from vllm_metal.v1.model_runner import MetalModelRunner
+from vllm_metal.v1.stt_model_runner import STTModelRunner
 
 
 class _StubRunner:
-    """Lightweight concrete test double for MetalModelRunner (STT path only).
+    """Lightweight concrete test double for STTModelRunner (one-shot path).
 
     Inherits ``_execute_stt`` from the real class so class invariants
     (assert, attribute access) are exercised without MagicMock rebinding.
     Only the fields consumed by ``_execute_stt`` are initialised.
     """
 
-    _execute_stt = MetalModelRunner._execute_stt
+    _execute_stt = STTModelRunner._execute_stt
 
     def __init__(self, runtime_adapter: STTRuntimeAdapter) -> None:
-        self._is_stt = True
         self.model = runtime_adapter.model
         self._request_states: dict = {}
         self._pending_output = None
         self._stt_runtime_adapter = runtime_adapter
-        self._model_adapter = DefaultModelAdapter()
-        self._cache_policy = ModelCachePolicy(self, self._model_adapter)
 
 
 def _make_whisper_runtime_adapter() -> STTRuntimeAdapter:
@@ -389,7 +384,7 @@ class TestKVCacheSTT:
         runner.cache_config = MagicMock()
         runner.cache_config.block_size = 16
 
-        runner.get_kv_cache_spec = MetalModelRunner.get_kv_cache_spec.__get__(runner)
+        runner.get_kv_cache_spec = STTModelRunner.get_kv_cache_spec.__get__(runner)
         spec = runner.get_kv_cache_spec()
 
         assert len(spec) == 1
@@ -400,9 +395,36 @@ class TestKVCacheSTT:
         runner = _make_runner()
 
         runner.get_cache_block_size_bytes = (
-            MetalModelRunner.get_cache_block_size_bytes.__get__(runner)
+            STTModelRunner.get_cache_block_size_bytes.__get__(runner)
         )
         assert runner.get_cache_block_size_bytes() == STT_SCHED_BLOCK_BYTES
+
+
+class TestSTTRunnerWorkerContract:
+    """STTModelRunner worker-facing contract (task reporting + load wiring)."""
+
+    def test_supported_worker_tasks_returns_transcription(self) -> None:
+        runner = _make_runner()
+        bound = STTModelRunner.supported_worker_tasks.__get__(runner)
+        assert bound() == ("transcription",)
+
+    def test_load_model_wires_model_and_adapter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import vllm_metal.v1.stt_model_runner as smr
+
+        adapter = object()
+        fake_model = SimpleNamespace(create_runtime_adapter=lambda _name: adapter)
+        monkeypatch.setattr(smr, "load_stt_model", lambda _name: fake_model)
+        monkeypatch.setattr(smr, "get_model_download_path", lambda _m: "resolved-path")
+
+        runner = smr.STTModelRunner.__new__(smr.STTModelRunner)
+        runner.model_config = SimpleNamespace(model="some-model")
+        runner.load_model()
+
+        assert runner.model is fake_model
+        assert runner.tokenizer is None
+        assert runner._stt_runtime_adapter is adapter
 
 
 class TestWhisperRuntimeAdapterTranscriberCaching:

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -40,7 +40,6 @@ class _StubRunner:
 
     def __init__(self, runtime_adapter: STTRuntimeAdapter) -> None:
         self.model = runtime_adapter.model
-        self._request_states: dict = {}
         self._pending_output = None
         self._stt_runtime_adapter = runtime_adapter
 
@@ -270,20 +269,6 @@ class TestExecuteSTTProtocol:
         # Both cached requests should get EOT
         for tokens in output.sampled_token_ids:
             assert tokens == [50257]
-
-    def test_finished_reqs_cleaned_from_state(self) -> None:
-        """finished_req_ids should be removed from _request_states."""
-        runner = _make_runner()
-        runner._request_states = {"old-1": "state", "old-2": "state"}
-        sched = _make_scheduler_output(
-            new_reqs=[_make_new_req(mm_features=_make_valid_mm_features())],
-            finished_req_ids={"old-1"},
-        )
-
-        self._run_stt(runner, sched)
-
-        assert "old-1" not in runner._request_states
-        assert "old-2" in runner._request_states
 
     def test_empty_batch_returns_empty_output(self) -> None:
         """No new and no cached requests should return empty ModelRunnerOutput."""

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -33,11 +33,7 @@ from vllm_metal.paged_attention_backend.mha import MHAPagedAttentionBackend
 from vllm_metal.paged_attention_backend.mla import MLAPagedAttentionBackend
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 from vllm_metal.pytorch_backend.tensor_bridge import MLX_TO_TORCH_DTYPE
-from vllm_metal.stt.policy import (
-    STT_SCHED_AVAILABLE_BYTES,
-    STT_SCHED_BLOCK_BYTES,
-    STT_SCHED_NOMINAL_HEAD_SIZE,
-)
+from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPTargetMetadata
 from vllm_metal.v1.model_adapter import ModelAdapter
 
@@ -195,7 +191,7 @@ class ModelCachePolicy:
 
     def should_setup_paged_attention(self) -> bool:
         """Whether worker-side paged-attention setup should run."""
-        return not self._runner._is_stt
+        return True
 
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
@@ -216,26 +212,14 @@ class ModelCachePolicy:
 
     def scheduler_memory_reporting_mode(
         self, *, paged_attention_enabled: bool
-    ) -> Literal["stt_nominal", "paged_attention_capacity", "single_sequence_estimate"]:
+    ) -> Literal["paged_attention_capacity", "single_sequence_estimate"]:
         """Return which scheduler memory-reporting mode worker should use."""
-        if self._runner._is_stt:
-            return "stt_nominal"
         if paged_attention_enabled:
             return "paged_attention_capacity"
         return "single_sequence_estimate"
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Build the scheduler-visible KV cache specification."""
-        if self._runner._is_stt:
-            return {
-                "layers.0.self_attn": FullAttentionSpec(
-                    block_size=self._runner.cache_config.block_size,
-                    num_kv_heads=1,
-                    head_size=STT_SCHED_NOMINAL_HEAD_SIZE,
-                    dtype=torch.float16,
-                ),
-            }
-
         self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
@@ -305,9 +289,6 @@ class ModelCachePolicy:
         For per-layer shapes, sums each layer's contribution individually.
         For uniform shapes, reduces to the existing product formula.
         """
-        if self._runner._is_stt:
-            return STT_SCHED_BLOCK_BYTES
-
         self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         dtype_size = self._require_kv_cache_dtype().size

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -189,10 +189,6 @@ class ModelCachePolicy:
         self._runner = runner
         self._model_adapter = model_adapter
 
-    def should_setup_paged_attention(self) -> bool:
-        """Whether worker-side paged-attention setup should run."""
-        return True
-
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
         self._require_supported_per_layer_shapes()

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -17,7 +17,6 @@ from vllm_metal.compat import apply_compat_patches
 from vllm_metal.paged_attention_backend.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
-from vllm_metal.stt.detection import is_stt_model
 from vllm_metal.utils import get_model_download_path
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
 from vllm_metal.v1.mlx_lm_paths import (
@@ -65,6 +64,37 @@ def _stt_cache_key(model_name: str) -> tuple[str, str]:
     return (model_name, "stt")
 
 
+def load_stt_model(model_name: str) -> Any:
+    """Load an STT model, reusing the process-level model cache.
+
+    Returns the loaded STT model. The caller (``STTModelRunner``) builds the
+    per-model runtime adapter and wires it onto the runner. Shares
+    ``_MODEL_CACHE`` with generation loads so ``reset_model_cache`` clears it.
+    """
+    start_time = time.time()
+    cache_key = _stt_cache_key(model_name)
+
+    with _MODEL_CACHE_LOCK:
+        cached = _MODEL_CACHE.get(cache_key)
+    if cached is not None:
+        model, _ = cached
+        logger.info(
+            "STT model loaded from cache in %.3fs: %s",
+            time.time() - start_time,
+            model_name,
+        )
+        return model
+
+    from vllm_metal.stt.loader import load_model as stt_load_model
+
+    logger.info("Loading STT model: %s", model_name)
+    model = stt_load_model(model_name)
+    with _MODEL_CACHE_LOCK:
+        _MODEL_CACHE[cache_key] = (model, None)
+    logger.info("STT model loaded in %.2fs: %s", time.time() - start_time, model_name)
+    return model
+
+
 class ModelLifecycle:
     def __init__(
         self,
@@ -77,9 +107,6 @@ class ModelLifecycle:
     def load(self) -> None:
         runner = self._runner
         model_name = get_model_download_path(runner.model_config.model)
-        if is_stt_model(model_name):
-            self._load_stt(model_name)
-            return
 
         model_config = runner.model_config
         # vLLM model_config shape varies across backends.
@@ -93,8 +120,6 @@ class ModelLifecycle:
         runner.model = model
         runner.tokenizer = tokenizer
         runner._is_vlm = is_vlm
-        runner._is_stt = False
-        runner._stt_runtime_adapter = None
         multimodal_adapter = (
             self._model_adapter.build_multimodal_adapter(model, hf_config)
             if is_vlm
@@ -186,41 +211,6 @@ class ModelLifecycle:
             _MODEL_CACHE[cache_key] = (model, tokenizer)
         logger.info("Model loaded in %.2fs: %s", time.time() - start_time, model_name)
         return model, tokenizer
-
-    def _load_stt(self, model_name: str) -> None:
-        start_time = time.time()
-        cache_key = _stt_cache_key(model_name)
-
-        with _MODEL_CACHE_LOCK:
-            cached = _MODEL_CACHE.get(cache_key)
-        if cached is not None:
-            model, _ = cached
-            load_time = time.time() - start_time
-            logger.info(
-                "STT model loaded from cache in %.3fs: %s",
-                load_time,
-                model_name,
-            )
-        else:
-            from vllm_metal.stt.loader import load_model as stt_load_model
-
-            logger.info("Loading STT model: %s", model_name)
-            model = stt_load_model(model_name)
-            with _MODEL_CACHE_LOCK:
-                _MODEL_CACHE[cache_key] = (model, None)
-            load_time = time.time() - start_time
-            logger.info("STT model loaded in %.2fs: %s", load_time, model_name)
-
-        self._runner.model = model
-        self._runner.tokenizer = None
-        self._runner.model_args = {}
-        self._runner.kv_cache_dtype = None
-        self._runner._is_vlm = False
-        self._runner._is_stt = True
-        self._runner._stt_runtime_adapter = model.create_runtime_adapter(model_name)
-        self._runner._multimodal_adapter = None
-        self._runner._gemma4_mtp_assistant = None
-        self._runner.encoder_cache = None
 
     def resolve_model_dims(self) -> None:
         args = self._runner.model_args

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -379,14 +379,6 @@ class MetalModelRunner:
             self.model_args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
         )
 
-    def should_setup_paged_attention(self) -> bool:
-        """Whether worker-side paged-attention setup should run.
-
-        STT models own their runtime path and do not use the paged-attention
-        cache path that the text/VLM runner uses.
-        """
-        return self._cache_policy.should_setup_paged_attention()
-
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
         self._cache_policy.validate_paged_attention_support()

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -49,8 +49,6 @@ from vllm_metal.paged_attention_common import (
     get_context,
     prepare_unified,
 )
-from vllm_metal.stt.runtime import STTRuntimeAdapter
-from vllm_metal.stt.serve import VLLMSTTRequestAdapter
 from vllm_metal.v1 import contiguous_cache
 from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1.contiguous_cache import (
@@ -270,12 +268,8 @@ class MetalModelRunner:
         self.tokenizer: Any = None
         self.model_args: dict[str, Any] = {}
         self._is_vlm: bool = False  # Will be set during model loading
-        self._is_stt: bool = False  # Will be set during model loading
         self._is_pooling: bool = (
             getattr(self.model_config, "runner_type", None) == "pooling"
-        )
-        self._stt_runtime_adapter: STTRuntimeAdapter | None = (
-            None  # Set during STT loading
         )
         self._multimodal_adapter: MultimodalRuntimeAdapter | None = None
         self._gemma4_mtp_assistant: Gemma4MTPAssistantRuntime | None = None
@@ -411,8 +405,6 @@ class MetalModelRunner:
 
     def supported_worker_tasks(self) -> tuple[SupportedTask, ...]:
         """Return worker task capabilities for the loaded model."""
-        if self._is_stt:
-            return ("transcription",)
         if self._is_pooling:
             if self._paged_attention_backend is None:
                 return ()
@@ -651,13 +643,6 @@ class MetalModelRunner:
         """
         if self.model is None:
             logger.warning("Model not loaded, skipping warm-up")
-            return
-
-        if self._is_stt:
-            assert self._stt_runtime_adapter is not None
-            logger.info("Warming up STT model...")
-            self._stt_runtime_adapter.warm_up()
-            logger.info("STT model warm-up complete")
             return
 
         logger.info("Warming up model...")
@@ -2090,9 +2075,6 @@ class MetalModelRunner:
         if self.model is None:
             raise RuntimeError("Model not loaded")
 
-        if self._is_stt:
-            return self._execute_stt(scheduler_output)
-
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
         has_scheduled_encoder_inputs = bool(scheduler_output.scheduled_encoder_inputs)
@@ -2218,81 +2200,6 @@ class MetalModelRunner:
         logger.error(
             "sample_tokens called with no pending state — "
             "neither _execute_model_state nor _pending_output was set."
-        )
-        return None
-
-    # ------------------------------------------------------------------
-    # STT (Speech-to-Text) helpers
-    # ------------------------------------------------------------------
-
-    def _execute_stt(
-        self, scheduler_output: SchedulerOutput
-    ) -> ModelRunnerOutput | None:
-        """Execute STT inference for all new requests in the batch.
-
-        Raises:
-            ValueError: If a request uses non-greedy sampling params.
-        """
-        assert self._stt_runtime_adapter is not None
-
-        req_ids: list[str] = []
-        req_id_to_index: dict[str, int] = {}
-        sampled_tokens: list[list[int]] = []
-
-        eot_token = self._stt_runtime_adapter.eot_token
-
-        for new_req in scheduler_output.scheduled_new_reqs:
-            stt_request = VLLMSTTRequestAdapter.from_vllm_request(new_req)
-            sampling_params = new_req.sampling_params or SamplingParams()
-
-            # Only greedy decoding is supported for STT
-            if sampling_params.temperature > 0:
-                raise ValueError(
-                    "STT models only support greedy decoding (temperature=0). "
-                    f"Got temperature={sampling_params.temperature}"
-                )
-
-            audio_features = self._stt_runtime_adapter.extract_audio_features(
-                stt_request.input_features
-            )
-            tokens = self._stt_runtime_adapter.decode_tokens(
-                audio_features, list(stt_request.prompt_token_ids)
-            )
-
-            req_ids.append(stt_request.req_id)
-            req_id_to_index[stt_request.req_id] = len(req_ids) - 1
-            sampled_tokens.append(tokens)
-
-        # Handle cached requests: STT processes everything in one shot,
-        # so any "cached" (decode-phase) request just gets an EOT to finish.
-        cached_req_ids = list(scheduler_output.scheduled_cached_reqs.req_ids)
-        for req_id in cached_req_ids:
-            req_ids.append(req_id)
-            req_id_to_index[req_id] = len(req_ids) - 1
-            sampled_tokens.append([eot_token])
-
-        # Clean up finished requests
-        if scheduler_output.finished_req_ids:
-            for req_id in scheduler_output.finished_req_ids:
-                self._request_states.pop(req_id, None)
-
-        if not req_ids:
-            return ModelRunnerOutput(
-                req_ids=[],
-                req_id_to_index={},
-                sampled_token_ids=[],
-                logprobs=None,
-                prompt_logprobs_dict={},
-                pooler_output=[],
-            )
-
-        self._pending_output = ModelRunnerOutput(
-            req_ids=req_ids,
-            req_id_to_index=req_id_to_index,
-            sampled_token_ids=sampled_tokens,
-            logprobs=None,
-            prompt_logprobs_dict={},
-            pooler_output=[None] * len(req_ids),
         )
         return None
 

--- a/vllm_metal/v1/stt_model_runner.py
+++ b/vllm_metal/v1/stt_model_runner.py
@@ -53,9 +53,6 @@ class STTModelRunner:
         self.tokenizer: Any = None
         self._stt_runtime_adapter: STTRuntimeAdapter | None = None
 
-        # STT transcribes a request in one shot; request state is only used to
-        # drop finished ids, mirroring the generation runner's bookkeeping.
-        self._request_states: dict[str, Any] = {}
         # execute_model stashes the output here; sample_tokens returns it,
         # matching the engine's execute -> sample handoff.
         self._pending_output: ModelRunnerOutput | None = None
@@ -89,10 +86,6 @@ class STTModelRunner:
     def supported_worker_tasks(self) -> tuple[SupportedTask, ...]:
         """STT models only serve transcription."""
         return ("transcription",)
-
-    def should_setup_paged_attention(self) -> bool:
-        """STT owns its runtime path and never uses paged attention."""
-        return False
 
     def validate_paged_attention_support(self) -> None:
         """No-op: STT does not run on the paged-attention path."""
@@ -216,11 +209,6 @@ class STTModelRunner:
             req_ids.append(req_id)
             req_id_to_index[req_id] = len(req_ids) - 1
             sampled_tokens.append([eot_token])
-
-        # Clean up finished requests
-        if scheduler_output.finished_req_ids:
-            for req_id in scheduler_output.finished_req_ids:
-                self._request_states.pop(req_id, None)
 
         if not req_ids:
             return ModelRunnerOutput(

--- a/vllm_metal/v1/stt_model_runner.py
+++ b/vllm_metal/v1/stt_model_runner.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One-shot speech-to-text (STT) model runner for the vLLM v1 engine.
+
+STT checkpoints (Whisper, Qwen3-ASR) run a black-box transcribe in a single
+``execute_model`` call: the runtime adapter owns audio-feature extraction and
+the full greedy decode, returning the transcript tokens in one shot. That
+execution model shares nothing with token generation — no paged-attention KV
+cache, no sampler, no iterative decode loop — so it lives in a dedicated runner
+instead of branching inside :class:`MetalModelRunner`.
+
+The worker selects this runner for STT models (see ``MetalWorker.init_device``).
+Everything here implements the worker-facing runner contract for that one-shot
+path only; the heavy generation/pooling machinery is intentionally absent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import torch
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.sampling_params import SamplingParams
+from vllm.tasks import SupportedTask
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+)
+from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
+
+from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES, STT_SCHED_NOMINAL_HEAD_SIZE
+from vllm_metal.stt.runtime import STTRuntimeAdapter
+from vllm_metal.stt.serve import VLLMSTTRequestAdapter
+from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.model_lifecycle import load_stt_model
+
+logger = init_logger(__name__)
+
+
+class STTModelRunner:
+    """Model runner for one-shot speech-to-text transcription on Metal."""
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device) -> None:
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.device = device
+
+        self.model: Any = None
+        self.tokenizer: Any = None
+        self._stt_runtime_adapter: STTRuntimeAdapter | None = None
+
+        # STT transcribes a request in one shot; request state is only used to
+        # drop finished ids, mirroring the generation runner's bookkeeping.
+        self._request_states: dict[str, Any] = {}
+        # execute_model stashes the output here; sample_tokens returns it,
+        # matching the engine's execute -> sample handoff.
+        self._pending_output: ModelRunnerOutput | None = None
+
+    # ------------------------------------------------------------------
+    # Load / warm-up
+    # ------------------------------------------------------------------
+
+    def load_model(self) -> None:
+        """Load the STT model and build its per-model runtime adapter."""
+        model_name = get_model_download_path(self.model_config.model)
+        model = load_stt_model(model_name)
+        self.model = model
+        self.tokenizer = None
+        self._stt_runtime_adapter = model.create_runtime_adapter(model_name)
+
+    def warm_up(self) -> None:
+        """Run a dummy encode so the model JIT-compiles before serving."""
+        if self.model is None:
+            logger.warning("Model not loaded, skipping warm-up")
+            return
+        assert self._stt_runtime_adapter is not None
+        logger.info("Warming up STT model...")
+        self._stt_runtime_adapter.warm_up()
+        logger.info("STT model warm-up complete")
+
+    # ------------------------------------------------------------------
+    # Worker task + memory-reporting contract
+    # ------------------------------------------------------------------
+
+    def supported_worker_tasks(self) -> tuple[SupportedTask, ...]:
+        """STT models only serve transcription."""
+        return ("transcription",)
+
+    def should_setup_paged_attention(self) -> bool:
+        """STT owns its runtime path and never uses paged attention."""
+        return False
+
+    def validate_paged_attention_support(self) -> None:
+        """No-op: STT does not run on the paged-attention path."""
+        return None
+
+    def scheduler_memory_reporting_mode(
+        self, *, paged_attention_enabled: bool
+    ) -> Literal["stt_nominal"]:
+        """STT allocates no KV cache, so report nominal scheduler memory."""
+        return "stt_nominal"
+
+    def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
+        """Return a minimal placeholder spec.
+
+        STT allocates no real KV cache; this only satisfies vLLM scheduler
+        initialization, which expects at least one attention layer spec.
+        """
+        return {
+            "layers.0.self_attn": FullAttentionSpec(
+                block_size=self.cache_config.block_size,
+                num_kv_heads=1,
+                head_size=STT_SCHED_NOMINAL_HEAD_SIZE,
+                dtype=torch.float16,
+            ),
+        }
+
+    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        """Accept the engine KV cache config for API compatibility (no cache)."""
+        logger.info(
+            "KV cache config received: %d blocks (STT uses no KV cache)",
+            kv_cache_config.num_blocks,
+        )
+
+    def get_cache_block_size_bytes(self) -> int:
+        """Minimal block size; STT holds no real KV cache."""
+        return STT_SCHED_BLOCK_BYTES
+
+    # ------------------------------------------------------------------
+    # Multimodal / draft hooks (STT has neither)
+    # ------------------------------------------------------------------
+
+    def reset_mm_cache(self) -> None:
+        """No-op: STT keeps no profiling-time multimodal cache."""
+        return None
+
+    def reset_encoder_cache(self) -> None:
+        """No-op: STT keeps no cached encoder outputs."""
+        return None
+
+    def take_draft_token_ids(self) -> DraftTokenIds | None:
+        """STT does not run speculative decoding."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Execution (one-shot transcribe)
+    # ------------------------------------------------------------------
+
+    def execute_model(
+        self, scheduler_output: SchedulerOutput
+    ) -> ModelRunnerOutput | None:
+        """Transcribe every new request in the batch in a single shot."""
+        if self.model is None:
+            raise RuntimeError("Model not loaded")
+        return self._execute_stt(scheduler_output)
+
+    def sample_tokens(
+        self, grammar_output: GrammarOutput | None
+    ) -> ModelRunnerOutput | None:
+        """Return the transcript built by ``execute_model``.
+
+        STT produces all tokens during ``execute_model`` and stashes them in
+        ``_pending_output``; this simply hands them back on the engine's
+        follow-up call.
+        """
+        output = self._pending_output
+        self._pending_output = None
+        return output
+
+    def _execute_stt(
+        self, scheduler_output: SchedulerOutput
+    ) -> ModelRunnerOutput | None:
+        """Execute STT inference for all new requests in the batch.
+
+        Raises:
+            ValueError: If a request uses non-greedy sampling params.
+        """
+        assert self._stt_runtime_adapter is not None
+
+        req_ids: list[str] = []
+        req_id_to_index: dict[str, int] = {}
+        sampled_tokens: list[list[int]] = []
+
+        eot_token = self._stt_runtime_adapter.eot_token
+
+        for new_req in scheduler_output.scheduled_new_reqs:
+            stt_request = VLLMSTTRequestAdapter.from_vllm_request(new_req)
+            sampling_params = new_req.sampling_params or SamplingParams()
+
+            # Only greedy decoding is supported for STT
+            if sampling_params.temperature > 0:
+                raise ValueError(
+                    "STT models only support greedy decoding (temperature=0). "
+                    f"Got temperature={sampling_params.temperature}"
+                )
+
+            audio_features = self._stt_runtime_adapter.extract_audio_features(
+                stt_request.input_features
+            )
+            tokens = self._stt_runtime_adapter.decode_tokens(
+                audio_features, list(stt_request.prompt_token_ids)
+            )
+
+            req_ids.append(stt_request.req_id)
+            req_id_to_index[stt_request.req_id] = len(req_ids) - 1
+            sampled_tokens.append(tokens)
+
+        # Handle cached requests: STT processes everything in one shot,
+        # so any "cached" (decode-phase) request just gets an EOT to finish.
+        cached_req_ids = list(scheduler_output.scheduled_cached_reqs.req_ids)
+        for req_id in cached_req_ids:
+            req_ids.append(req_id)
+            req_id_to_index[req_id] = len(req_ids) - 1
+            sampled_tokens.append([eot_token])
+
+        # Clean up finished requests
+        if scheduler_output.finished_req_ids:
+            for req_id in scheduler_output.finished_req_ids:
+                self._request_states.pop(req_id, None)
+
+        if not req_ids:
+            return ModelRunnerOutput(
+                req_ids=[],
+                req_id_to_index={},
+                sampled_token_ids=[],
+                logprobs=None,
+                prompt_logprobs_dict={},
+                pooler_output=[],
+            )
+
+        self._pending_output = ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
+            sampled_token_ids=sampled_tokens,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[None] * len(req_ids),
+        )
+        return None

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -30,6 +30,7 @@ from vllm_metal.v1.cache_policy import WorkerCachePlanner
 if TYPE_CHECKING:
     from vllm_metal.profiler.wrapper import MetalProfilerWrapper
     from vllm_metal.v1.model_runner import MetalModelRunner
+    from vllm_metal.v1.stt_model_runner import STTModelRunner
 
 logger = init_logger(__name__)
 
@@ -65,7 +66,7 @@ class MetalWorker(WorkerBase):
     """
 
     # Override model_runner type from base class
-    model_runner: MetalModelRunner  # type: ignore[assignment]
+    model_runner: MetalModelRunner | STTModelRunner  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -133,14 +134,27 @@ class MetalWorker(WorkerBase):
         # Set random seed
         set_random_seed(self.model_config.seed)
 
-        # Import here to avoid circular imports
-        from vllm_metal.v1.model_runner import MetalModelRunner
+        # STT checkpoints run a one-shot transcribe that shares none of the
+        # generation runner's machinery, so they use a dedicated runner. Detect
+        # here using the same predicate as the generation load path and pick the
+        # runner before construction. Imports are local to avoid circular imports.
+        from vllm_metal.stt.detection import is_stt_model
+        from vllm_metal.utils import get_model_download_path
 
-        # Create model runner
-        self.model_runner = MetalModelRunner(
-            vllm_config=self.vllm_config,
-            device=self.device,
-        )
+        if is_stt_model(get_model_download_path(self.model_config.model)):
+            from vllm_metal.v1.stt_model_runner import STTModelRunner
+
+            self.model_runner = STTModelRunner(
+                vllm_config=self.vllm_config,
+                device=self.device,
+            )
+        else:
+            from vllm_metal.v1.model_runner import MetalModelRunner
+
+            self.model_runner = MetalModelRunner(
+                vllm_config=self.vllm_config,
+                device=self.device,
+            )
 
     def load_model(self) -> None:
         """Load the model onto the Metal device."""

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -30,7 +30,6 @@ from vllm_metal.v1.cache_policy import WorkerCachePlanner
 if TYPE_CHECKING:
     from vllm_metal.profiler.wrapper import MetalProfilerWrapper
     from vllm_metal.v1.model_runner import MetalModelRunner
-    from vllm_metal.v1.stt_model_runner import STTModelRunner
 
 logger = init_logger(__name__)
 
@@ -65,8 +64,10 @@ class MetalWorker(WorkerBase):
     using MLX as the primary compute backend.
     """
 
-    # Override model_runner type from base class
-    model_runner: MetalModelRunner | STTModelRunner  # type: ignore[assignment]
+    # Override model_runner type from base class. Typed as MetalModelRunner
+    # because its worker-facing method set is a superset of STTModelRunner's;
+    # STT models are assigned an STTModelRunner at runtime (see init_device).
+    model_runner: MetalModelRunner  # type: ignore[assignment]
 
     def __init__(
         self,


### PR DESCRIPTION

## Why
STT (Whisper / Qwen3-ASR) is a one-shot transcribe: the model's runtime adapter runs the entire decode in a single `execute_model` call. It has no real KV cache and never runs on the paged path — it sits on the non-paged (contiguous-cache) side and only *fakes* vLLM's iterative scheduler contract (nominal memory, a placeholder KV spec, and an EOT token for each "cached" decode-phase request).

Bolting that onto the generation `MetalModelRunner` scattered `_is_stt` branches and fine-grained per-model inspection (config.json sniffing) across the runner, `cache_policy`, and `model_lifecycle` — knowledge that doesn't belong in the generic runner.

## What
- Extract the one-shot path into a dedicated `STTModelRunner`   (`vllm_metal/v1/stt_model_runner.py`); `_execute_stt` moved **verbatim**. - Select the runner once, at the worker (`init_device` via `is_stt_model`). 
- Drop every `_is_stt` branch from `MetalModelRunner`, `cache_policy`, and   `model_lifecycle`; the generation runner no longer knows STT exists.

## Verified
End-to-end via `vllm serve openai/whisper-tiny` → `/v1/audio/transcriptions`:
**byte-identical transcript vs `main`** on both explicit-language and auto-detect paths. No behavior change.
