### PR TITLE
Register Gemma4 assistant config shim

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -246,6 +246,47 @@ class TestGemma4MTPConfigCompatPatch:
         assert config.text_config.num_kv_shared_layers == 0
         assert get_hf_text_config(config).model_type == "gemma4_text"
 
+    def test_missing_gemma4_config_module_does_not_stop_other_patches(
+        self,
+        monkeypatch,
+    ) -> None:
+        calls: list[str] = []
+
+        monkeypatch.setattr(compat, "_APPLIED", False)
+        monkeypatch.setattr(
+            compat,
+            "_transformers_knows_gemma4_assistant",
+            lambda _auto_config: False,
+        )
+
+        def _raise_missing_gemma4_config():
+            raise ModuleNotFoundError("No module named 'transformers.models.gemma4'")
+
+        monkeypatch.setattr(
+            compat,
+            "_gemma4_assistant_config_class",
+            _raise_missing_gemma4_config,
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_bytelevel_tokenizer_loading",
+            lambda: calls.append("bytelevel"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_qwen35_fp8_sanitize",
+            lambda: calls.append("qwen35_fp8"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_gemma4_kv_shared_sanitize",
+            lambda: calls.append("gemma4_kv"),
+        )
+
+        compat.apply_compat_patches()
+
+        assert calls == ["bytelevel", "qwen35_fp8", "gemma4_kv"]
+
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):
     mlx_pkg = ModuleType("mlx")

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -67,6 +67,33 @@ def _write_mismatched_bytelevel_tokenizer_repo(path) -> None:
     )
 
 
+def _write_gemma4_assistant_config(path) -> None:
+    config = {
+        "architectures": ["Gemma4AssistantForCausalLM"],
+        "backbone_hidden_size": 1536,
+        "model_type": "gemma4_assistant",
+        "text_config": {
+            "hidden_size": 256,
+            "hidden_size_per_layer_input": 0,
+            "layer_types": [
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+            "model_type": "gemma4_text",
+            "num_attention_heads": 4,
+            "num_hidden_layers": 4,
+            "num_key_value_heads": 1,
+            "num_kv_shared_layers": 4,
+            "vocab_size_per_layer_input": 0,
+        },
+        "tie_word_embeddings": True,
+        "use_ordered_embeddings": True,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
 class _ByteLevelBackend:
     decoder = "ByteLevel(add_prefix_space=False, trim_offsets=False, use_regex=False)"
 
@@ -176,6 +203,48 @@ class TestByteLevelTokenizerCompatPatch:
         assert captured_kwargs["user_agent"] == {"vllm-metal": "test"}
         assert captured_kwargs["token"] == "secret"
         assert captured_kwargs["_commit_hash"] == "abc123"
+
+
+class TestGemma4MTPConfigCompatPatch:
+    def test_transformers_autoconfig_loads_raw_assistant_config(
+        self,
+        tmp_path,
+    ) -> None:
+        from transformers import AutoConfig
+
+        _write_gemma4_assistant_config(tmp_path)
+        compat._patch_vllm_gemma4_mtp_config_loading()
+
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        assert config.model_type == "gemma4_assistant"
+        assert config.architectures == ["Gemma4AssistantForCausalLM"]
+        assert config.backbone_hidden_size == 1536
+        assert config.text_config.model_type == "gemma4_text"
+        assert config.text_config.num_hidden_layers == 4
+        assert config.get_text_config() is config.text_config
+
+    def test_vllm_get_config_applies_existing_gemma4_mtp_override(
+        self,
+        tmp_path,
+    ) -> None:
+        from vllm.config.speculative import SpeculativeConfig
+        from vllm.transformers_utils.config import get_config, get_hf_text_config
+
+        _write_gemma4_assistant_config(tmp_path)
+        compat._patch_vllm_gemma4_mtp_config_loading()
+
+        config = get_config(
+            tmp_path,
+            trust_remote_code=False,
+            hf_overrides_fn=SpeculativeConfig.hf_config_override,
+        )
+
+        assert config.model_type == "gemma4_mtp"
+        assert config.architectures == ["Gemma4MTPModel"]
+        assert config.n_predict == 1
+        assert config.text_config.num_kv_shared_layers == 0
+        assert get_hf_text_config(config).model_type == "gemma4_text"
 
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -90,9 +90,9 @@ def _patch_vllm_gemma4_mtp_config_loading() -> None:
         return
 
     config_cls = _gemma4_assistant_config_class()
-    # TODO(transformers): remove once the pinned Transformers/vLLM stack can
-    # parse raw ``model_type=gemma4_assistant`` checkpoints without this local
-    # registration.
+    # TODO: remove once the supported dependency stack parses raw
+    # ``model_type=gemma4_assistant`` configs before vLLM's Gemma4 MTP
+    # override runs.
     AutoConfig.register("gemma4_assistant", config_cls, exist_ok=True)
     logger.debug("Registered Gemma4 assistant config compatibility")
 

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -89,7 +89,16 @@ def _patch_vllm_gemma4_mtp_config_loading() -> None:
     if _transformers_knows_gemma4_assistant(AutoConfig):
         return
 
-    config_cls = _gemma4_assistant_config_class()
+    try:
+        config_cls = _gemma4_assistant_config_class()
+    except ImportError as exc:
+        logger.warning(
+            "Could not install Gemma4 MTP config compatibility patch because "
+            "Gemma4 config classes are unavailable: %s",
+            exc,
+        )
+        return
+
     # TODO: remove once the supported dependency stack parses raw
     # ``model_type=gemma4_assistant`` configs before vLLM's Gemma4 MTP
     # override runs.

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -27,9 +27,74 @@ def apply_compat_patches() -> None:
     if _APPLIED:
         return
     _APPLIED = True
+    _patch_vllm_gemma4_mtp_config_loading()
     _patch_vllm_bytelevel_tokenizer_loading()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_mlx_lm_gemma4_kv_shared_sanitize()
+
+
+def _gemma4_assistant_config_class() -> type[Any]:
+    """Return a minimal Transformers config for raw Gemma4 assistant metadata."""
+    from transformers.configuration_utils import PretrainedConfig
+    from transformers.models.gemma4.configuration_gemma4 import Gemma4TextConfig
+
+    class Gemma4AssistantCompatConfig(PretrainedConfig):
+        model_type = "gemma4_assistant"
+        sub_configs = {"text_config": Gemma4TextConfig}
+
+        def __init__(self, text_config: Any | None = None, **kwargs: Any) -> None:
+            if text_config is None:
+                self.text_config = Gemma4TextConfig()
+            elif isinstance(text_config, Gemma4TextConfig):
+                self.text_config = text_config
+            elif isinstance(text_config, Mapping):
+                self.text_config = Gemma4TextConfig(**text_config)
+            else:
+                self.text_config = text_config
+            super().__init__(**kwargs)
+
+        def get_text_config(self, decoder: bool = False) -> Any:
+            # Match Transformers' ``PretrainedConfig.get_text_config`` API.
+            return self.text_config
+
+    return Gemma4AssistantCompatConfig
+
+
+def _transformers_knows_gemma4_assistant(auto_config: Any) -> bool:
+    try:
+        auto_config.for_model("gemma4_assistant")
+    except ValueError:
+        return False
+    return True
+
+
+def _patch_vllm_gemma4_mtp_config_loading() -> None:
+    """Register raw Gemma4 assistant config parsing for the pinned stack.
+
+    vLLM 0.21 already knows how to normalize ``gemma4_assistant`` into the
+    ``gemma4_mtp`` draft wrapper, but the pinned Transformers release cannot
+    parse the raw assistant checkpoint's ``model_type`` before that override
+    runs. Keep the shim to config loading only; model construction remains owned
+    by vLLM/vllm-metal Gemma4 MTP modules.
+    """
+    try:
+        from transformers import AutoConfig
+    except ImportError as exc:
+        logger.warning(
+            "Could not install Gemma4 MTP config compatibility patch: %s",
+            exc,
+        )
+        return
+
+    if _transformers_knows_gemma4_assistant(AutoConfig):
+        return
+
+    config_cls = _gemma4_assistant_config_class()
+    # TODO(transformers): remove once the pinned Transformers/vLLM stack can
+    # parse raw ``model_type=gemma4_assistant`` checkpoints without this local
+    # registration.
+    AutoConfig.register("gemma4_assistant", config_cls, exist_ok=True)
+    logger.debug("Registered Gemma4 assistant config compatibility")
 
 
 def _decoder_tree_contains_type(value: Any, decoder_type: str) -> bool:


### PR DESCRIPTION
Register a narrow config-loading shim for raw Gemma4 MTP assistant checkpoints.

The pinned dependency stack already has vLLM-side Gemma4 MTP normalization, but raw assistant checkpoints still fail earlier in Transformers `AutoConfig` because `model_type="gemma4_assistant"` is not recognized. This registers a minimal `AutoConfig` parser for that raw config shape so vLLM's existing `gemma4_assistant -> gemma4_mtp` override can run.