### PR TITLE
[MLA] Absorb kv_b_proj into embed_q/unembed_out for single-pass kernel

### DIFF
--- a/tests/test_mla_paged_backend.py
+++ b/tests/test_mla_paged_backend.py
@@ -16,6 +16,7 @@ from vllm_metal.mlx_backend.mla_cache import MLAPagedLatentCache
 from vllm_metal.paged_attention_backend.mla import (
     MLAPagedAttentionBackend,
     MLAPagedAttentionWrapper,
+    _try_absorb_kv_b_proj_into_inner,
 )
 from vllm_metal.paged_attention_backend.protocol import PagedAttentionBackend
 
@@ -735,4 +736,218 @@ class TestSinglePassRouting:
         assert (
             MLAPagedAttentionWrapper._pick_heads_per_tg(num_heads, batch_size)
             == expected_g
+        )
+
+
+# DeepSeek-V2-Lite shape: H=16, qk_nope=128, v=128, kvr=512, group_size=64,
+# bits=4 (mlx-community/DeepSeek-V2-Lite-Chat-4bit-mlx). Used by the
+# absorption tests to exercise the same shapes as the production target.
+_DSV2_H = 16
+_DSV2_QK_NOPE = 128
+_DSV2_V = 128
+_DSV2_KVR = 512
+_DSV2_GS = 64
+_DSV2_BITS = 4
+
+
+class _DSv2LiteAbsorbableInner(nn.Module):
+    """kv_b_proj-style inner shaped like DeepSeek-V2-Lite at 4-bit, with no
+    embed_q / unembed_out. Built by quantizing per-head ground-truth k_nope
+    and v matrices, concatenating in the same layout mlx-lm produces, so
+    tests can compare the synthesized absorbed outputs against a dequant
+    reference."""
+
+    def __init__(self, seed: int = 17) -> None:
+        super().__init__()
+        self.num_heads = _DSV2_H
+        self.qk_nope_head_dim = _DSV2_QK_NOPE
+        self.v_head_dim = _DSV2_V
+        self.kv_lora_rank = _DSV2_KVR
+        self.qk_rope_head_dim = 64
+        self.q_lora_rank = None  # DeepSeek-V2-Lite has no q compression
+        self.scale = 1.0 / math.sqrt(_DSV2_KVR)
+
+        prev = mx.random.state
+        mx.random.seed(seed)
+        # Build the canonical kv_b_proj weight: rows are [k_nope_h || v_h]
+        # concatenated over heads, matching mlx-lm's output layout.
+        true_k_nope = [
+            mx.random.normal((_DSV2_QK_NOPE, _DSV2_KVR), dtype=mx.float16) * 0.1
+            for _ in range(_DSV2_H)
+        ]
+        true_v = [
+            mx.random.normal((_DSV2_V, _DSV2_KVR), dtype=mx.float16) * 0.1
+            for _ in range(_DSV2_H)
+        ]
+        full = mx.concatenate(
+            [
+                mx.concatenate([true_k_nope[h], true_v[h]], axis=0)
+                for h in range(_DSV2_H)
+            ],
+            axis=0,
+        )
+        w_q, s, b = mx.quantize(full, group_size=_DSV2_GS, bits=_DSV2_BITS)
+        kv_b = SimpleNamespace(
+            weight=w_q,
+            scales=s,
+            biases=b,
+            group_size=_DSV2_GS,
+            bits=_DSV2_BITS,
+        )
+        self.kv_b_proj = kv_b
+        # Stash the dequant-of-full reference so tests can recompute the
+        # per-head dequant slices without re-touching mlx.quantize.
+        self._reference_full_dequant = mx.dequantize(
+            w_q,
+            s,
+            b,
+            group_size=_DSV2_GS,
+            bits=_DSV2_BITS,
+        )
+        mx.random.state = prev
+
+
+class TestKvBProjAbsorption:
+    """Verifies _try_absorb_kv_b_proj_into_inner synthesizes per-head
+    embed_q / unembed_out from a kv_b_proj-style inner so the single-pass
+    MLA kernel admission gate can accept it. Exercises the production
+    shape (DeepSeek-V2-Lite at 4-bit)."""
+
+    def test_synthesizes_absorbed_pair(self) -> None:
+        inner = _DSv2LiteAbsorbableInner()
+        assert not hasattr(inner, "embed_q")
+        assert not hasattr(inner, "unembed_out")
+
+        absorbed = _try_absorb_kv_b_proj_into_inner(inner)
+
+        assert absorbed is True
+        assert hasattr(inner, "embed_q")
+        assert hasattr(inner, "unembed_out")
+
+    def test_embed_q_matches_per_head_dequant(self) -> None:
+        inner = _DSv2LiteAbsorbableInner()
+        _try_absorb_kv_b_proj_into_inner(inner)
+
+        full = inner._reference_full_dequant.reshape(
+            _DSV2_H,
+            _DSV2_QK_NOPE + _DSV2_V,
+            _DSV2_KVR,
+        )
+        ref_k_nope = full[:, :_DSV2_QK_NOPE, :]  # (H, qk_nope, kvr)
+
+        # The kernel fast path calls embed_q with shape (1, H, L, qk_nope).
+        q = mx.random.normal((1, _DSV2_H, 3, _DSV2_QK_NOPE), dtype=mx.float16)
+        y_ref = mx.stack(
+            [q[:, h] @ ref_k_nope[h] for h in range(_DSV2_H)],
+            axis=1,
+        )
+        y_got = inner.embed_q(q)
+        mx.eval(y_ref, y_got)
+        # atol=1.5e-2 covers fp16 accumulation noise over 512-wide reductions
+        # (unembed) on top of 4-bit weight reconstruction; the absorbed path
+        # and the dequant reference start from the SAME quantized weight, so
+        # the difference is purely accumulation order, not algorithmic.
+        assert bool(mx.allclose(y_got, y_ref, rtol=1e-3, atol=1.5e-2))
+
+    def test_unembed_out_matches_per_head_dequant(self) -> None:
+        inner = _DSv2LiteAbsorbableInner()
+        _try_absorb_kv_b_proj_into_inner(inner)
+
+        full = inner._reference_full_dequant.reshape(
+            _DSV2_H,
+            _DSV2_QK_NOPE + _DSV2_V,
+            _DSV2_KVR,
+        )
+        ref_v = full[:, _DSV2_QK_NOPE:, :]  # (H, v, kvr)
+
+        # The kernel fast path calls unembed_out with (1, H, L, kvr).
+        ctx = mx.random.normal((1, _DSV2_H, 3, _DSV2_KVR), dtype=mx.float16)
+        y_ref = mx.stack(
+            [ctx[:, h] @ ref_v[h].T for h in range(_DSV2_H)],
+            axis=1,
+        )
+        y_got = inner.unembed_out(ctx)
+        mx.eval(y_ref, y_got)
+        # atol=1.5e-2 covers fp16 accumulation noise over 512-wide reductions
+        # (unembed) on top of 4-bit weight reconstruction; the absorbed path
+        # and the dequant reference start from the SAME quantized weight, so
+        # the difference is purely accumulation order, not algorithmic.
+        assert bool(mx.allclose(y_got, y_ref, rtol=1e-3, atol=1.5e-2))
+
+    def test_idempotent(self) -> None:
+        inner = _DSv2LiteAbsorbableInner()
+        assert _try_absorb_kv_b_proj_into_inner(inner) is True
+        assert _try_absorb_kv_b_proj_into_inner(inner) is False
+
+    def test_no_kv_b_proj_is_noop(self) -> None:
+        class Empty(nn.Module):
+            pass
+
+        assert _try_absorb_kv_b_proj_into_inner(Empty()) is False
+
+    def test_already_absorbed_is_noop(self) -> None:
+        # A pre-absorbed inner (GLM4MoeLite-style) must not be re-wrapped.
+        inner = _KernelDimsAbsorbedInner()
+        assert _try_absorb_kv_b_proj_into_inner(inner) is False
+
+    def test_bad_kv_b_proj_shape_raises(self) -> None:
+        class Bad(nn.Module):
+            num_heads = 4
+            qk_nope_head_dim = 64
+            v_head_dim = 96
+            kv_lora_rank = 256
+            kv_b_proj = SimpleNamespace(weight=mx.zeros((100, 256)))
+
+        with pytest.raises(ValueError, match="absorption layout"):
+            _try_absorb_kv_b_proj_into_inner(Bad())
+
+    def test_wrapper_skips_absorption_when_env_off(self, monkeypatch) -> None:
+        monkeypatch.setattr("vllm_metal.envs.VLLM_METAL_MLA_ABSORB_KV_B_PROJ", False)
+        inner = _DSv2LiteAbsorbableInner()
+        cache = MLAPagedLatentCache(
+            num_layers=1,
+            latent_dim=_DSV2_KVR + 64,
+            num_blocks=4,
+            block_size=16,
+            dtype=mx.float16,
+        )
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+        assert wrapper._is_absorbed is False
+        assert not hasattr(inner, "embed_q")
+
+    def test_wrapper_absorbs_when_env_on(self, monkeypatch) -> None:
+        monkeypatch.setattr("vllm_metal.envs.VLLM_METAL_MLA_ABSORB_KV_B_PROJ", True)
+        inner = _DSv2LiteAbsorbableInner()
+        cache = MLAPagedLatentCache(
+            num_layers=1,
+            latent_dim=_DSV2_KVR + 64,
+            num_blocks=4,
+            block_size=16,
+            dtype=mx.float16,
+        )
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+        assert wrapper._is_absorbed is True
+        assert hasattr(inner, "embed_q")
+        assert hasattr(inner, "unembed_out")
+
+    def test_absorption_unlocks_kernel_admission(self, monkeypatch) -> None:
+        """End-to-end: absorbed DeepSeek-V2-Lite-shaped inner passes the
+        kernel admission gate that previously rejected its kv_b_proj-only
+        form."""
+        monkeypatch.setattr("vllm_metal.envs.VLLM_METAL_MLA_KERNEL", True)
+        monkeypatch.setattr("vllm_metal.envs.VLLM_METAL_MLA_ABSORB_KV_B_PROJ", True)
+        inner = _DSv2LiteAbsorbableInner()
+        cache = MLAPagedLatentCache(
+            num_layers=1,
+            latent_dim=_DSV2_KVR + 64,
+            num_blocks=4,
+            block_size=16,
+            dtype=mx.float16,
+        )
+        wrapper = MLAPagedAttentionWrapper(inner, layer_idx=0, latent_cache=cache)
+        assert (
+            wrapper._can_use_kernel(
+                wrapper._inner, wrapper._mla_latent_cache, _make_decode_ctx()
+            )
+            is True
         )

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
     VLLM_METAL_GDN_LAZY_KERNELS: bool = True
     VLLM_METAL_MLA_KERNEL: bool = False
+    VLLM_METAL_MLA_ABSORB_KV_B_PROJ: bool = False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
@@ -86,6 +87,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # qk_rope_head_dim=64, block_size ∈ {16, 32}, fp16/bf16,
     # decode-only).
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
+    # Opt-in absorption of kv_b_proj-style MLA inners (DeepSeek-V2,
+    # MiniCPM3) into the embed_q / unembed_out form required by the
+    # single-pass MLA kernel. Off by default. Slices kv_b_proj along
+    # the output axis at wrapper construction; quant groups live on
+    # the input axis so output-axis slicing preserves the scheme with
+    # no requant noise.
+    "VLLM_METAL_MLA_ABSORB_KV_B_PROJ": lambda: (
+        os.getenv("VLLM_METAL_MLA_ABSORB_KV_B_PROJ", "0") == "1"
+    ),
 }
 
 

--- a/vllm_metal/paged_attention_backend/mla.py
+++ b/vllm_metal/paged_attention_backend/mla.py
@@ -19,6 +19,155 @@ from vllm_metal.paged_attention_common import find_attn_attr, find_layers, get_c
 MLA_DEFAULT_QK_ROPE_HEAD_DIM = 64
 
 
+class _AbsorbedEmbedQ(nn.Module):
+    """Per-head q_nope -> kv_lora_rank projection synthesized from a
+    kv_b_proj's k_nope slice. Uses quantized_matmul(transpose=False) so
+    the slice stays in its original storage (rows = qk_nope_head_dim,
+    packed cols = kv_lora_rank) and no dequant+transpose+requant is
+    needed."""
+
+    def __init__(
+        self,
+        weight: mx.array,
+        scales: mx.array,
+        biases: mx.array,
+        group_size: int,
+        bits: int,
+    ) -> None:
+        super().__init__()
+        self.weight = weight
+        self.scales = scales
+        self.biases = biases
+        self.group_size = group_size
+        self.bits = bits
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.quantized_matmul(
+            x,
+            self.weight,
+            self.scales,
+            self.biases,
+            transpose=False,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+
+
+class _AbsorbedUnembedOut(nn.Module):
+    """Per-head kv_lora_rank -> v_head_dim projection synthesized from a
+    kv_b_proj's v slice. Standard quantized-linear orientation (storage
+    matches nn.QuantizedLinear), so transpose=True (the default)."""
+
+    def __init__(
+        self,
+        weight: mx.array,
+        scales: mx.array,
+        biases: mx.array,
+        group_size: int,
+        bits: int,
+    ) -> None:
+        super().__init__()
+        self.weight = weight
+        self.scales = scales
+        self.biases = biases
+        self.group_size = group_size
+        self.bits = bits
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.quantized_matmul(
+            x,
+            self.weight,
+            self.scales,
+            self.biases,
+            transpose=True,
+            group_size=self.group_size,
+            bits=self.bits,
+        )
+
+
+class _UnquantAbsorbedEmbedQ(nn.Module):
+    def __init__(self, weight: mx.array) -> None:
+        super().__init__()
+        self.weight = weight  # (H, qk_nope_head_dim, kv_lora_rank)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight
+
+
+class _UnquantAbsorbedUnembedOut(nn.Module):
+    def __init__(self, weight: mx.array) -> None:
+        super().__init__()
+        self.weight = weight  # (H, v_head_dim, kv_lora_rank)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight.swapaxes(-1, -2)
+
+
+def _try_absorb_kv_b_proj_into_inner(inner: nn.Module) -> bool:
+    """If ``inner`` exposes ``kv_b_proj`` but not the absorbed pair
+    (``embed_q`` / ``unembed_out``), synthesize per-head ``embed_q`` and
+    ``unembed_out`` by slicing ``kv_b_proj`` along the output axis.
+
+    DeepSeek-V2 / MiniCPM3 keep a single ``kv_b_proj = nn.Linear(kvr,
+    H*(qk_nope+v))``; the single-pass MLA kernel requires the absorbed
+    form that GLM4MoeLite ships natively. Quant groups in mlx live on
+    the input axis (``kv_lora_rank``), so slicing per-head along the
+    output axis preserves the quantization scheme — no requant noise.
+
+    No-op (returns False) when the inner is already absorbed or has no
+    ``kv_b_proj``. Idempotent. Raises ``ValueError`` if the kv_b_proj
+    output dimension does not match ``H * (qk_nope_head_dim +
+    v_head_dim)``.
+    """
+    if hasattr(inner, "embed_q") and hasattr(inner, "unembed_out"):
+        return False
+    kv_b = getattr(inner, "kv_b_proj", None)
+    if kv_b is None:
+        return False
+
+    n_heads = inner.num_heads
+    qk_nope = inner.qk_nope_head_dim
+    v = inner.v_head_dim
+    kvr = inner.kv_lora_rank
+
+    w = kv_b.weight
+    expected_rows = n_heads * (qk_nope + v)
+    if w.shape[0] != expected_rows:
+        raise ValueError(
+            f"kv_b_proj.weight rows {w.shape[0]} != n_heads*(qk_nope_head_dim+"
+            f"v_head_dim) = {n_heads}*{qk_nope + v}; absorption layout "
+            f"assumption violated for this model"
+        )
+
+    if hasattr(kv_b, "scales"):
+        s = kv_b.scales
+        b = kv_b.biases
+        pack = w.shape[1]
+        w_per_head = w.reshape(n_heads, qk_nope + v, pack)
+        s_per_head = s.reshape(n_heads, qk_nope + v, s.shape[1])
+        b_per_head = b.reshape(n_heads, qk_nope + v, b.shape[1])
+        inner.embed_q = _AbsorbedEmbedQ(
+            w_per_head[:, :qk_nope, :],
+            s_per_head[:, :qk_nope, :],
+            b_per_head[:, :qk_nope, :],
+            kv_b.group_size,
+            kv_b.bits,
+        )
+        inner.unembed_out = _AbsorbedUnembedOut(
+            w_per_head[:, qk_nope:, :],
+            s_per_head[:, qk_nope:, :],
+            b_per_head[:, qk_nope:, :],
+            kv_b.group_size,
+            kv_b.bits,
+        )
+    else:
+        w_per_head = w.reshape(n_heads, qk_nope + v, kvr)
+        inner.embed_q = _UnquantAbsorbedEmbedQ(w_per_head[:, :qk_nope, :])
+        inner.unembed_out = _UnquantAbsorbedUnembedOut(w_per_head[:, qk_nope:, :])
+
+    return True
+
+
 class MLAPagedAttentionWrapper(nn.Module):
     """Wraps an MLA attention module to use a paged latent cache.
 
@@ -54,6 +203,8 @@ class MLAPagedAttentionWrapper(nn.Module):
         object.__setattr__(self, "_inner", inner)
         object.__setattr__(self, "_mla_layer_idx", layer_idx)
         object.__setattr__(self, "_mla_latent_cache", latent_cache)
+        if envs.VLLM_METAL_MLA_ABSORB_KV_B_PROJ:
+            _try_absorb_kv_b_proj_into_inner(inner)
         is_absorbed = hasattr(inner, "embed_q") and hasattr(inner, "unembed_out")
         object.__setattr__(self, "_is_absorbed", is_absorbed)
         if is_absorbed:


### PR DESCRIPTION
The single-pass MLA Metal kernel requires an absorbed-MLA inner exposing per-head `embed_q` / `unembed_out`. mlx-lm's `glm4_moe_lite` ships this layout natively, but `deepseek_v2` and `minicpm3` keep a single `kv_b_proj = nn.Linear(kv_lora_rank, H * (qk_nope_head_dim + v_head_dim))`, so even when their dims sit inside the kernel envelope `_can_use_kernel` rejects them (`_is_absorbed=False`) and the wrapper falls back to the MLX SDPA `_apply_kv_b_proj_attention` slow path.

This PR adds an env-gated load-time slice that synthesizes per-head `embed_q` / `unembed_out` from `kv_b_proj.weight`, so kv_b_proj-style inners (DeepSeek-V2 / DeepSeek-V2-Lite) hit the single-pass kernel without any change to mlx-lm or the kernel itself.

## Mechanism

`kv_b_proj.weight` has shape `(H * (qk_nope_head_dim + v_head_dim), kv_lora_rank)`, laid out as `[k_nope_h || v_h]` rows per head. Per-head `embed_q` and `unembed_out` are output-axis slices of this tensor that absorb `W_k_nope_h` and `W_v_h` respectively. mlx's quantization groups live on the **input** axis (`kv_lora_rank`), so the slice preserves the quant scheme with no requant noise.

## Routing

Single env gate (`VLLM_METAL_MLA_ABSORB_KV_B_PROJ`, off by default), applied in `MLAPagedAttentionWrapper.__init__` right before the existing `is_absorbed` check. Idempotent: no-op when env is off, when the inner is already absorbed (GLM4MoeLite), or when there is no `kv_b_proj` to slice. Downstream `_can_use_kernel` admission gate is unchanged — `kv_lora_rank=512`, `qk_rope_head_dim=64`, decode-only, block_size ∈ {16, 32}, fp16/bf16 still have to hold.

## Token parity (DeepSeek-V2-Lite-Chat-4bit-mlx, 4 prompts × 16 tokens, temp=0)

Three configs, fresh `vllm.LLM` each: **A** baseline (`ABSORB=0 KERNEL=0`, slow path), **B** absorbed slow path (`ABSORB=1 KERNEL=0`, validates absorption math), **C** kernel via absorption (`ABSORB=1 KERNEL=1`).

| Prompt | B=A | C=A | A baseline text |
| --- | --- | --- | --- |
| `"The capital of France is"` | ✅ | ✅ | `" Paris.\nThe official language of France is French.\nThe currency of France"` |
| `"def quicksort(arr):"` | ✅ | ⚠️ diverge @ tok 12 | `"\nlenarr = len(arr)\nif lenarr <= 1:"` → kernel: `"...if lenarr < 2:"` |
| `"Once upon a time"` | ✅ | ✅ | `", in a land far, far away, there lived a young boy named Jack"` |
| `"One plus one equals"` | ✅ | ✅ | `" two.\nTwo plus two equals four.\nFour plus four equals eight."` |

**Absorbed math (B=A): 4/4 token-for-token** — slice is mathematically exact. **Kernel (C=A): 3/4 + 1 semantic equivalent** — `def quicksort(arr):` flips `<= 1` → `< 2`, both correctly express "fewer than 2 elements". The fp32 accumulator on the kernel path lands the argmax on a near-equal logit at a low-confidence position.

## Performance (M1 Pro 16 GB, max_model_len=512, enforce_eager=True)

In-process `vllm.LLM` timing, warmed per-shape, `ignore_eos=True`, `temperature=0`.

| B   | gen | A wall    | B wall    | C wall    | A→B   | A→C   | B→C   | A tput     | B tput     | C tput     |
| --- | ---:|----------:|----------:|----------:|------:|------:|------:|-----------:|-----------:|-----------:|
| 1   | 256 |   11.60 s |   10.11 s |   10.31 s | 1.15× | 1.12× | 0.98× |   22.1 t/s |   25.3 t/s |   24.8 t/s |
| 2   | 256 |   16.56 s |   13.67 s |   13.28 s | 1.21× | 1.25× | 1.03× |   30.9 t/s |   37.5 t/s |   38.6 t/s |
| 4   | 256 |   25.90 s |   19.23 s |   18.35 s | **1.35×** | **1.41×** | 1.05× |   39.5 t/s |   53.2 t/s |   55.8 t/s |

Mean: A→B **1.24×**, A→C **1.26×**, B→C 1.02×. The dominant win is **A→B** (eliminating per-token K/V materialization in `_apply_kv_b_proj_attention`, keeping attention in `kv_lora_rank` space) and it scales with batch (1.15× → 1.35× from B=1 to B=4). The incremental kernel win B→C is small on this hardware/model (0.98-1.05×); hardware with more compute headroom widens it — see M5 Max below.

## Performance (M5 Max 36 GB, two profiles, enforce_eager=True)

### M5 Max @ M1 Pro profile (B∈{1,2,4} × gen=256, max_model_len=512)

| B   | gen | A wall    | B wall    | C wall    | A→B   | A→C   | B→C   | A tput     | B tput     | C tput     |
| --- | ---:|----------:|----------:|----------:|------:|------:|------:|-----------:|-----------:|-----------:|
| 1   | 256 |    4.01 s |    4.05 s |    3.82 s | 0.99× | 1.05× | 1.06× |   63.9 t/s |   63.3 t/s |   67.0 t/s |
| 2   | 256 |    5.30 s |    5.11 s |    4.66 s | 1.04× | 1.14× | 1.10× |   96.5 t/s |  100.2 t/s |  109.9 t/s |
| 4   | 256 |    6.83 s |    6.38 s |    5.72 s | 1.07× | **1.19×** | **1.12×** |  149.8 t/s |  160.4 t/s |  178.9 t/s |

Mean: A→B 1.03×, A→C 1.13×, B→C 1.09×. ~3× wall speedup over M1 Pro baseline; A→B compresses (faster baseline absorbs the slow path's per-step K/V cost) while B→C widens — kernel wins more headroom on this hardware.

### M5 Max @ M5 Max profile (B∈{1,2,4,8} × gen=1024, max_model_len=2048)

| B   | gen  | A wall    | B wall    | C wall    | A→B   | A→C       | B→C   | A tput     | B tput     | C tput     |
| --- | ----:|----------:|----------:|----------:|------:|----------:|------:|-----------:|-----------:|-----------:|
| 1   | 1024 |   19.59 s |   17.93 s |   16.86 s | 1.09× | 1.16×     | 1.06× |   52.3 t/s |   57.1 t/s |   60.7 t/s |
| 2   | 1024 |   27.19 s |   23.19 s |   21.22 s | 1.17× | 1.28×     | 1.09× |   75.3 t/s |   88.3 t/s |   96.5 t/s |
| 4   | 1024 |   43.28 s |   29.70 s |   26.39 s | 1.46× | 1.64×     | 1.13× |   94.6 t/s |  137.9 t/s |  155.2 t/s |
| 8   | 1024 |   85.07 s |   46.25 s |   38.97 s | **1.84×** | **2.18×** | **1.19×** |   96.3 t/s |  177.1 t/s |  210.2 t/s |

Mean: A→B 1.39×, A→C 1.57×, B→C 1.12×. Long sequences and larger batches make per-token K/V materialization accumulate, so A→B re-asserts (peaks at **1.84×** at B=8/gen=1024). Baseline throughput stalls at ~96 t/s past B=4 (slow path can't amortize batch growth); C reaches 210 t/s, **2.18×** the baseline ceiling. Token parity on M5 Max matches M1 Pro exactly (same `def quicksort` semantic-equivalence divergence).
