### PR TITLE
[Bugfix] Improve hybrid GDN OOM diagnostics for paged attention

### DIFF
--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -14,7 +14,10 @@ pytest.importorskip("vllm", reason="vllm not installed")
 from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
-from vllm_metal.v1.cache_policy import ModelCachePolicy  # noqa: E402
+from vllm_metal.v1.cache_policy import (  # noqa: E402
+    ModelCachePolicy,
+    WorkerCachePlanner,
+)
 from vllm_metal.v1.model_adapter import DefaultModelAdapter  # noqa: E402
 from vllm_metal.v1.worker import MetalWorker  # noqa: E402
 
@@ -308,3 +311,88 @@ class TestOneSequenceKvBytes:
 
         expected = 2 * 24 * 2048 * 4 * 256 * 2
         assert result == expected
+
+
+class TestPagedAttentionPlanDiagnostics:
+    def _make_planner(
+        self,
+        model_runner: object,
+        *,
+        memory_fraction: float,
+        block_size: int = 16,
+        per_block_bytes: int = 1,
+    ) -> WorkerCachePlanner:
+        worker = _make_worker(model_runner, use_paged_attention=True)
+        worker.cache_config.block_size = block_size
+        worker.metal_config.is_auto_memory = False
+        worker.metal_config.memory_fraction = memory_fraction
+        worker.get_cache_block_size_bytes = MagicMock(return_value=per_block_bytes)
+        return WorkerCachePlanner(worker)
+
+    def test_hybrid_oom_error_reports_gdn_reservation(self, monkeypatch) -> None:
+        runner = SimpleNamespace(
+            is_hybrid=True,
+            scheduler_memory_reporting_mode=MagicMock(
+                return_value="paged_attention_capacity"
+            ),
+            profile_run=MagicMock(return_value=500_000_000),
+            validate_paged_attention_support=MagicMock(),
+            scheduler_config=SimpleNamespace(max_num_seqs=256),
+            linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
+        )
+        worker = _make_worker(runner, use_paged_attention=True)
+        worker.metal_config.is_auto_memory = False
+        worker.metal_config.memory_fraction = 0.5
+        worker.get_cache_block_size_bytes = MagicMock(return_value=1)
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "_metal_limit_bytes",
+            lambda self: 10_000_000_000,
+        )
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "get_model_memory_usage",
+            lambda self: 1_000_000_000,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            MetalWorker.determine_available_memory(worker)
+
+        message = str(exc_info.value)
+        assert "kv_budget_before_hybrid=3.50GB" in message
+        assert "hybrid_gdn_state=16.49GB" in message
+        assert "(64.4MB/seq * max_num_seqs=256)" in message
+        assert "kv_budget=-12.99GB" in message
+        assert (
+            "lower --max-num-seqs (for single-user serving, try --max-num-seqs 1)"
+            in message
+        )
+        assert "increase VLLM_METAL_MEMORY_FRACTION" in message
+        runner.scheduler_memory_reporting_mode.assert_called_once_with(
+            paged_attention_enabled=True
+        )
+        runner.profile_run.assert_called_once_with()
+        runner.validate_paged_attention_support.assert_called_once_with()
+
+    def test_non_hybrid_oom_error_omits_gdn_reservation(self, monkeypatch) -> None:
+        runner = SimpleNamespace(is_hybrid=False)
+        planner = self._make_planner(runner, memory_fraction=0.1)
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "_metal_limit_bytes",
+            lambda self: 10_000_000_000,
+        )
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "get_model_memory_usage",
+            lambda self: 2_000_000_000,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            planner._paged_attention_plan(overhead=100_000_000)
+
+        message = str(exc_info.value)
+        assert "hybrid_gdn_state" not in message
+        assert "kv_budget_before_hybrid" not in message
+        assert "--max-num-seqs" not in message
+        assert "kv_budget=-1.10GB" in message

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -171,6 +171,20 @@ _register_turboquant_spec_manager()
 
 
 @dataclass(frozen=True)
+class _HybridGDNReservation:
+    bytes_per_slot: int = 0
+    max_num_seqs: int = 0
+
+    @property
+    def total_bytes(self) -> int:
+        return self.bytes_per_slot * self.max_num_seqs
+
+    @property
+    def enabled(self) -> bool:
+        return self.total_bytes > 0
+
+
+@dataclass(frozen=True)
 class _PagedAttentionPlan:
     block_size: int
     fraction: float
@@ -178,6 +192,8 @@ class _PagedAttentionPlan:
     usable_metal: int
     model_memory: int
     per_block_bytes: int
+    kv_budget_before_hybrid: int
+    hybrid_gdn_reservation: _HybridGDNReservation
     kv_budget: int
     num_blocks: int
 
@@ -564,22 +580,93 @@ class WorkerCachePlanner:
         """Return Metal-memory budget available for paged KV cache."""
         return int(metal_limit * fraction) - model_memory - overhead
 
+    def _hybrid_gdn_reservation(self) -> _HybridGDNReservation:
+        """Return startup GDN state reserved outside the paged KV pool."""
+        runner = self._worker.model_runner
+        if not runner.is_hybrid:
+            return _HybridGDNReservation()
+        return _HybridGDNReservation(
+            bytes_per_slot=runner.linear_cache_bytes_per_slot(),
+            max_num_seqs=runner.scheduler_config.max_num_seqs,
+        )
+
+    @staticmethod
+    def _hybrid_gdn_detail(reservation: _HybridGDNReservation) -> str:
+        if not reservation.enabled:
+            return ""
+        return (
+            f"hybrid_gdn_state={reservation.total_bytes / 1e9:.2f}GB "
+            f"({reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
+            f"max_num_seqs={reservation.max_num_seqs}), "
+        )
+
+    @staticmethod
+    def _paged_attention_mitigations(
+        reservation: _HybridGDNReservation,
+        *,
+        kv_budget_before_hybrid: int,
+    ) -> str:
+        mitigations = [
+            "increase VLLM_METAL_MEMORY_FRACTION",
+            "use a smaller or more quantized model",
+        ]
+        if reservation.enabled and reservation.max_num_seqs > 1:
+            seq_mitigation = (
+                "lower --max-num-seqs (for single-user serving, try --max-num-seqs 1)"
+            )
+            if kv_budget_before_hybrid > 0:
+                mitigations.insert(0, seq_mitigation)
+            else:
+                mitigations.append(seq_mitigation)
+        return "Mitigations: " + "; ".join(mitigations) + "."
+
+    @classmethod
+    def _memory_breakdown(
+        cls,
+        *,
+        metal_limit: int,
+        fraction: float,
+        usable_metal: int,
+        model_memory: int,
+        overhead: int,
+        kv_budget_before_hybrid: int,
+        reservation: _HybridGDNReservation,
+        kv_budget: int,
+    ) -> str:
+        before_hybrid = (
+            f"kv_budget_before_hybrid={kv_budget_before_hybrid / 1e9:.2f}GB, "
+            if reservation.enabled
+            else ""
+        )
+        return (
+            f"metal_limit={metal_limit / 1e9:.2f}GB, "
+            f"fraction={fraction}, "
+            f"usable_metal={usable_metal / 1e9:.2f}GB, "
+            f"model_memory={model_memory / 1e9:.2f}GB, "
+            f"overhead={overhead / 1e9:.2f}GB, "
+            f"{before_hybrid}"
+            f"{cls._hybrid_gdn_detail(reservation)}"
+            f"kv_budget={kv_budget / 1e9:.2f}GB"
+        )
+
     def setup_paged_attention(self, *, overhead: int) -> None:
         """Allocate paged KV cache and patch the loaded model."""
         self._worker.model_runner.validate_paged_attention_support()
         plan = self._paged_attention_plan(overhead=overhead)
         logger.info(
             "Paged attention memory breakdown: "
-            "metal_limit=%.2fGB, fraction=%.2f, usable_metal=%.2fGB, "
-            "model_memory=%.2fGB, overhead=%.2fGB, "
-            "kv_budget=%.2fGB, per_block_bytes=%d, "
+            "%s, per_block_bytes=%d, "
             "num_blocks=%d, max_tokens_cached=%d",
-            plan.metal_limit / 1e9,
-            plan.fraction,
-            plan.usable_metal / 1e9,
-            plan.model_memory / 1e9,
-            overhead / 1e9,
-            plan.kv_budget / 1e9,
+            self._memory_breakdown(
+                metal_limit=plan.metal_limit,
+                fraction=plan.fraction,
+                usable_metal=plan.usable_metal,
+                model_memory=plan.model_memory,
+                overhead=overhead,
+                kv_budget_before_hybrid=plan.kv_budget_before_hybrid,
+                reservation=plan.hybrid_gdn_reservation,
+                kv_budget=plan.kv_budget,
+            ),
             plan.per_block_bytes,
             plan.num_blocks,
             plan.num_blocks * plan.block_size,
@@ -669,30 +756,34 @@ class WorkerCachePlanner:
         model_memory = self.get_model_memory_usage()
         per_block_bytes = self._worker.get_cache_block_size_bytes()
         usable_metal = int(metal_limit * fraction)
-        kv_budget = self.kv_budget_bytes(
+        kv_budget_before_hybrid = self.kv_budget_bytes(
             metal_limit,
             model_memory,
             fraction,
             overhead,
         )
+        reservation = self._hybrid_gdn_reservation()
+        kv_budget = kv_budget_before_hybrid - reservation.total_bytes
 
-        if self._worker.model_runner.is_hybrid:
-            kv_budget -= (
-                self._worker.model_runner.linear_cache_bytes_per_slot()
-                * self._worker.model_runner.scheduler_config.max_num_seqs
-            )
+        breakdown = self._memory_breakdown(
+            metal_limit=metal_limit,
+            fraction=fraction,
+            usable_metal=usable_metal,
+            model_memory=model_memory,
+            overhead=overhead,
+            kv_budget_before_hybrid=kv_budget_before_hybrid,
+            reservation=reservation,
+            kv_budget=kv_budget,
+        )
+        mitigations = self._paged_attention_mitigations(
+            reservation,
+            kv_budget_before_hybrid=kv_budget_before_hybrid,
+        )
 
         if kv_budget <= 0:
             raise ValueError(
                 "Paged attention: not enough Metal memory for KV cache. "
-                f"metal_limit={metal_limit / 1e9:.2f}GB, "
-                f"fraction={fraction}, "
-                f"usable_metal={usable_metal / 1e9:.2f}GB, "
-                f"model_memory={model_memory / 1e9:.2f}GB, "
-                f"overhead={overhead / 1e9:.2f}GB, "
-                f"kv_budget={kv_budget / 1e9:.2f}GB. "
-                "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
-                "use a smaller or more quantized model."
+                f"{breakdown}. {mitigations}"
             )
 
         num_blocks = kv_budget // per_block_bytes
@@ -700,15 +791,7 @@ class WorkerCachePlanner:
             raise ValueError(
                 "Paged attention: computed num_blocks too low "
                 f"({num_blocks} < minimum {PAGED_ATTENTION_MIN_BLOCKS}). "
-                f"metal_limit={metal_limit / 1e9:.2f}GB, "
-                f"fraction={fraction}, "
-                f"usable_metal={usable_metal / 1e9:.2f}GB, "
-                f"model_memory={model_memory / 1e9:.2f}GB, "
-                f"overhead={overhead / 1e9:.2f}GB, "
-                f"kv_budget={kv_budget / 1e9:.2f}GB, "
-                f"per_block_bytes={per_block_bytes}. "
-                "Mitigations: increase VLLM_METAL_MEMORY_FRACTION, "
-                "use a smaller or more quantized model."
+                f"{breakdown}, per_block_bytes={per_block_bytes}. {mitigations}"
             )
 
         return _PagedAttentionPlan(
@@ -718,6 +801,8 @@ class WorkerCachePlanner:
             usable_metal=usable_metal,
             model_memory=model_memory,
             per_block_bytes=per_block_bytes,
+            kv_budget_before_hybrid=kv_budget_before_hybrid,
+            hybrid_gdn_reservation=reservation,
             kv_budget=kv_budget,
             num_blocks=num_blocks,
         )


### PR DESCRIPTION
Improve paged-attention OOM diagnostics for hybrid Qwen3.5/GDN models by reporting the hidden startup GDN state reservation separately from the remaining KV cache budget.

The error now includes:

  - `kv_budget_before_hybrid`
  - `hybrid_gdn_state`
  - per-sequence GDN state size
  - `max_num_seqs`
  - a targeted `--max-num-seqs 1` mitigation for single-user serving

This addresses the diagnostic gap from #398 without changing allocation behavior.

Fixes #398