### PR TITLE
Bump vLLM to 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,10 @@ https://docs.vllm.ai/en/latest/cli/
 
 ### Optional: Rust frontend (experimental)
 
-Pass `--with-vllm-rs` to also install [`vllm-frontend-rs`](https://github.com/Inferact/vllm-frontend-rs), an experimental Rust drop-in for vLLM's serving layer. Requires the Rust toolchain (https://rustup.rs):
+Pass `--with-vllm-rs` to also install `vllm-rs`, the experimental Rust frontend vendored in the bundled vLLM release. Requires the Rust toolchain (https://rustup.rs):
 
 ```bash
 ./install.sh --with-vllm-rs
 ```
 
 See [docs/rust_frontend.md](docs/rust_frontend.md) for usage and architecture.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,6 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 - **vLLM compatibility**: Full integration with vLLM's engine, scheduler, and OpenAI-compatible API
 - **Paged attention** *(experimental)*: Efficient KV cache management for long sequences
 - **GQA support**: Grouped-Query Attention for efficient inference
-- **Rust frontend** *(experimental)*: Optional drop-in [`vllm-frontend-rs`](rust_frontend.md) replaces the Python serving layer while keeping vllm-metal's MLX/Metal engine
+- **Rust frontend** *(experimental)*: Optional `vllm-rs` frontend replaces the Python serving layer while keeping vllm-metal's MLX/Metal engine
 
 Check the sidebar for guides on installation, configuration, and supported features.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/instal
 
 ### Optional: Rust frontend
 
-Pass `--with-vllm-rs` to also install [`vllm-frontend-rs`](rust_frontend.md), an experimental Rust drop-in for vLLM's serving layer. Requires the Rust toolchain on `PATH` (install from <https://rustup.rs>):
+Pass `--with-vllm-rs` to also install `vllm-rs`, the experimental Rust frontend vendored in the bundled vLLM release. Requires the Rust toolchain on `PATH` (install from <https://rustup.rs>):
 
 ```bash
 ./install.sh --with-vllm-rs

--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -20,7 +20,9 @@ Activate the venv first so the spawned headless Python engine inherits vllm-meta
 
 ```bash
 source ~/.venv-vllm-metal/bin/activate
-VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B
+VLLM_USE_RUST_FRONTEND=1 \
+  VLLM_RUST_FRONTEND_PATH="$HOME/.cargo/bin/vllm-rs" \
+  vllm serve Qwen/Qwen3-0.6B
 ```
 
 ## Standalone frontend

--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -1,8 +1,10 @@
 # Rust Frontend (experimental)
 
-vllm-metal supports the optional [`vllm-frontend-rs`](https://github.com/Inferact/vllm-frontend-rs) Rust frontend as a drop-in replacement for vLLM's Python serving layer. The Rust frontend is hardware-agnostic; vllm-metal continues to run the engine on Metal/MLX inside the spawned Python subprocess.
+vllm-metal supports the optional `vllm-rs` Rust frontend as a drop-in replacement for vLLM's Python serving layer. The Rust frontend is hardware-agnostic; vllm-metal continues to run the engine on Metal/MLX inside the spawned Python subprocess.
 
-For architecture, flag reference, and usage, see the [upstream README](https://github.com/Inferact/vllm-frontend-rs#readme).
+As of vLLM 0.22.0, the Rust frontend source is vendored in the main vLLM repository under `rust/`. The former `Inferact/vllm-frontend-rs` repository is kept only as a historical archive.
+
+For architecture, flag reference, and usage, see the [upstream README](https://github.com/vllm-project/vllm/tree/main/rust#readme).
 
 ## Install
 
@@ -18,9 +20,9 @@ Activate the venv first so the spawned headless Python engine inherits vllm-meta
 
 ```bash
 source ~/.venv-vllm-metal/bin/activate
-vllm-rs serve Qwen/Qwen3-0.6B
+VLLM_USE_RUST_FRONTEND=1 vllm serve Qwen/Qwen3-0.6B
 ```
 
-## Caveat: integration direction
+## Standalone frontend
 
-Use `vllm-rs serve` (Rust binary spawns Python engine) on bundled vllm 0.21.0. The reverse direction `VLLM_USE_RUST_FRONTEND=1 vllm serve` requires an upstream vLLM hook that has not landed yet.
+The `vllm-rs` binary is also installed to `~/.cargo/bin`. It can be used directly for advanced frontend-only or externally managed engine flows documented upstream.

--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ install_vllm_rs() {
   echo "Installing vllm-rs from vLLM source: $vllm_src_dir/rust"
 
   # Run cargo from the vLLM repository root so rustup honors rust-toolchain.toml.
-  if ! ( cd "$vllm_src_dir" && cargo install --path rust/src/cmd --bin vllm-rs ); then
+  if ! ( cd "$vllm_src_dir" && cargo install --locked --path rust/src/cmd --bin vllm-rs ); then
     error "Failed to install vllm-rs."
     exit 1
   fi

--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,8 @@ download_and_install_wheel() {
 }
 
 install_vllm_rs() {
+  local vllm_src_dir="$1"
+
   section "Installing vllm-rs (experimental Rust frontend)"
 
   if ! command -v cargo &> /dev/null || ! command -v rustup &> /dev/null; then
@@ -85,21 +87,15 @@ install_vllm_rs() {
     exit 1
   fi
 
-  local repo_url="https://github.com/inferact/vllm-frontend-rs"
-  local tmp_dir
-  tmp_dir=$(mktemp -d)
-  # shellcheck disable=SC2064
-  trap "rm -rf '$tmp_dir'" RETURN
-
-  echo "Cloning $repo_url ..."
-  if ! git clone --depth 1 "$repo_url" "$tmp_dir/vllm-frontend-rs"; then
-    error "Failed to clone vllm-frontend-rs."
+  if [[ ! -d "$vllm_src_dir/rust/src/cmd" ]]; then
+    error "Rust frontend source not found under $vllm_src_dir/rust."
     exit 1
   fi
 
-  # Run cargo from inside the tree so rustup honors rust-toolchain.toml;
-  # `cargo install --git` would ignore it and use the system default toolchain.
-  if ! ( cd "$tmp_dir/vllm-frontend-rs" && cargo install --path src/cmd --bin vllm-rs ); then
+  echo "Installing vllm-rs from vLLM source: $vllm_src_dir/rust"
+
+  # Run cargo from the vLLM repository root so rustup honors rust-toolchain.toml.
+  if ! ( cd "$vllm_src_dir" && cargo install --path rust/src/cmd --bin vllm-rs ); then
     error "Failed to install vllm-rs."
     exit 1
   fi
@@ -125,8 +121,8 @@ main() {
 Usage: install.sh [--with-vllm-rs]
 
 Options:
-  --with-vllm-rs    Also install vllm-rs (experimental Rust frontend) via
-                    cargo from https://github.com/inferact/vllm-frontend-rs.
+  --with-vllm-rs    Also install vllm-rs (experimental Rust frontend) from
+                    the bundled vLLM release source.
                     Requires the Rust toolchain on PATH (https://rustup.rs).
   -h, --help        Show this help.
 EOF
@@ -186,17 +182,17 @@ EOF
     exit 1
   fi
 
-  local vllm_v="0.21.0"
+  local vllm_v="0.22.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
+  local vllm_src_dir="vllm-$vllm_v"
   curl -OL $url_base/v$vllm_v/$filename
   tar xf $filename
-  cd vllm-$vllm_v
+  cd "$vllm_src_dir"
 
   uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
   CXXFLAGS="-Wno-parentheses" uv pip install .
   cd -
-  rm -rf vllm-$vllm_v*
 
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
     uv pip install .
@@ -216,8 +212,10 @@ EOF
   fi
 
   if [[ "$with_vllm_rs" == "1" ]]; then
-    install_vllm_rs
+    install_vllm_rs "$vllm_src_dir"
   fi
+
+  rm -rf vllm-$vllm_v*
 
   echo ""
   success "Installation complete!"
@@ -231,7 +229,7 @@ EOF
   if [[ "$with_vllm_rs" == "1" ]]; then
     echo ""
     echo "vllm-rs is installed to ~/.cargo/bin. Make sure that directory is on your PATH."
-    echo "Activate the venv, then run: vllm-rs serve <MODEL>"
+    echo "Activate the venv, then run: VLLM_USE_RUST_FRONTEND=1 vllm serve <MODEL>"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -229,7 +229,8 @@ EOF
   if [[ "$with_vllm_rs" == "1" ]]; then
     echo ""
     echo "vllm-rs is installed to ~/.cargo/bin. Make sure that directory is on your PATH."
-    echo "Activate the venv, then run: VLLM_USE_RUST_FRONTEND=1 vllm serve <MODEL>"
+    echo "Activate the venv, then run:"
+    echo "  VLLM_USE_RUST_FRONTEND=1 VLLM_RUST_FRONTEND_PATH=\"$HOME/.cargo/bin/vllm-rs\" vllm serve <MODEL>"
   fi
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,10 @@ dependencies = [
     # Bump after verifying the JIT build against the new MLX minor release.
     "mlx>=0.31.0,<0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    # Keep below 0.5.0 while vLLM 0.20.1 requires llguidance<1.4.0.
-    # mlx-vlm 0.5.0 requires llguidance>=1.7.0.
-    "mlx-vlm>=0.4.0,<0.5.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # vLLM 0.22.0 requires llguidance>=1.7.0,<1.8.0.
+    "mlx-vlm>=0.5.0,<0.6.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
-    # Lower bound aligned with vllm 0.21.0's exclude list in requirements/common.txt
+    # First allowed Transformers v5 release per vLLM 0.22.0's exclude list.
     "transformers>=5.5.1",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",


### PR DESCRIPTION
Bump vLLM to 0.22.0

Also update the optional `vllm-rs` install/docs path to use the Rust frontend vendored in upstream vLLM 0.22.0 instead of the archived external repo.
