### PR TITLE
[Multimodal] Enable Qwen3-VL forward path

### DIFF
--- a/tests/multimodal/test_qwen3_vl_parity.py
+++ b/tests/multimodal/test_qwen3_vl_parity.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end parity: ``adapter.call_lm`` vs ``mlx_vlm.Model.__call__``.
+
+Marked ``slow`` — opt in with ``pytest -m slow`` (matches the existing
+real-model convention in ``tests/test_qwen35_smoke.py``).  Skips when
+the model is not pre-pulled into the HF cache; pre-pull locally with::
+
+    hf download mlx-community/Qwen3-VL-4B-Instruct-4bit
+
+Override via ``QWEN3_VL_PARITY_MODEL`` env var.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItem
+
+from vllm_metal.multimodal import (
+    MultiModalFeatureSpec,
+    PlaceholderRange,
+    merge_multimodal_embeddings,
+)
+from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
+
+MODEL_ID = os.environ.get(
+    "QWEN3_VL_PARITY_MODEL", "mlx-community/Qwen3-VL-4B-Instruct-4bit"
+)
+
+
+def _model_in_cache(model_id: str) -> bool:
+    from huggingface_hub import scan_cache_dir
+    from huggingface_hub.errors import CacheNotFound
+
+    try:
+        info = scan_cache_dir()
+    except CacheNotFound:
+        return False
+    for repo in info.repos:
+        if repo.repo_id != model_id:
+            continue
+        for rev in repo.revisions:
+            if rev.size_on_disk > 100 * 1024 * 1024:
+                return True
+    return False
+
+
+if not _model_in_cache(MODEL_ID):
+    pytest.skip(
+        f"{MODEL_ID} not in HF cache; pre-pull with `hf download {MODEL_ID}`",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def loaded():
+    from mlx_vlm import load
+
+    model, processor = load(MODEL_ID)
+    return model, processor
+
+
+def _build_image_inputs(model, processor):
+    """Encode 'describe the image' + one deterministic dummy image."""
+    from mlx_vlm.prompt_utils import apply_chat_template
+
+    rng = np.random.default_rng(0)
+    image = Image.fromarray((rng.random((128, 128, 3)) * 255).astype(np.uint8))
+    prompt = apply_chat_template(
+        processor, model.config, "describe the image", num_images=1
+    )
+    proc = processor(text=[prompt], images=[image], return_tensors="np")
+    input_ids = mx.array(np.asarray(proc["input_ids"]))
+    pixel_values = mx.array(np.asarray(proc["pixel_values"]))
+    image_grid_thw = mx.array(np.asarray(proc["image_grid_thw"]))
+    return input_ids, pixel_values, image_grid_thw
+
+
+def _build_feature(
+    pixel_values: mx.array,
+    image_grid_thw: mx.array,
+    offset: int,
+    length: int,
+) -> MultiModalFeatureSpec:
+    """Wrap mlx-vlm processor output into the MultiModalKwargsItem the adapter expects.
+
+    Mirrors vLLM's Qwen2-VL field factory: pixel_values uses ``flat_from_sizes``
+    (the leading axis is patch count, not batch); image_grid_thw uses ``batched``.
+    """
+    pixels_t = torch.from_numpy(np.asarray(pixel_values))
+    grid_t = torch.from_numpy(np.asarray(image_grid_thw))  # (1, 3)
+    pixel_grid_sizes = grid_t.prod(-1)  # (1,) — patches per image
+    pixel_cfg = MultiModalFieldConfig.flat_from_sizes("image", pixel_grid_sizes)
+    grid_cfg = MultiModalFieldConfig.batched("image", keep_on_cpu=True)
+    pixel_elem = pixel_cfg.build_elems("pixel_values", pixels_t)[0]
+    grid_elem = grid_cfg.build_elems("image_grid_thw", grid_t)[0]
+    return MultiModalFeatureSpec(
+        data=MultiModalKwargsItem(
+            {"pixel_values": pixel_elem, "image_grid_thw": grid_elem}
+        ),
+        modality="image",
+        identifier="img-0",
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+def _reference_logits(model, input_ids, pixel_values, image_grid_thw) -> mx.array:
+    out: Any = model(
+        input_ids, pixel_values=pixel_values, image_grid_thw=image_grid_thw
+    )
+    logits = getattr(out, "logits", out)
+    mx.eval(logits)
+    return logits
+
+
+def _adapter_logits(model, input_ids, pixel_values, image_grid_thw) -> mx.array:
+    adapter = Qwen3VLMultimodalAdapter.from_loaded_model(model)
+    image_token_id = int(model.config.image_token_index)
+
+    ids_np = np.asarray(input_ids)[0]
+    is_image_np = ids_np == image_token_id
+    placeholder_positions = np.where(is_image_np)[0]
+    assert placeholder_positions.size > 0, "processor produced no image placeholders"
+    placeholder_offset = int(placeholder_positions[0])
+    placeholder_len = int(placeholder_positions.size)
+
+    feature = _build_feature(
+        pixel_values, image_grid_thw, placeholder_offset, placeholder_len
+    )
+    encode_result = adapter.encode_multimodal([feature])[0]
+
+    inputs_embeds = adapter.embed_tokens(input_ids)
+    is_image_mx = mx.array(is_image_np)
+    spliced = merge_multimodal_embeddings(
+        inputs_embeds, [encode_result.hidden_states], is_image_mx
+    )
+
+    positions, _delta = adapter.get_mrope_input_positions(ids_np.tolist(), [feature])
+
+    n_layers = len(model.language_model.model.layers)
+    out: Any = adapter.call_lm(
+        input_ids,
+        inputs_embeds=spliced,
+        cache=[None] * n_layers,
+        position_ids=positions,
+        visual_pos_masks=is_image_mx[None, :],
+        deepstack_visual_embeds=encode_result.deepstack_visual_embeds,
+    )
+    logits = getattr(out, "logits", out)
+    mx.eval(logits)
+    return logits
+
+
+@pytest.mark.slow
+def test_call_lm_logits_match_reference(loaded):
+    model, processor = loaded
+    input_ids, pixel_values, image_grid_thw = _build_image_inputs(model, processor)
+
+    ref = _reference_logits(model, input_ids, pixel_values, image_grid_thw)
+    got = _adapter_logits(model, input_ids, pixel_values, image_grid_thw)
+
+    assert got.shape == ref.shape, (
+        f"adapter logits shape {got.shape} differs from reference {ref.shape}"
+    )
+
+    diff = mx.abs(got - ref)
+    abs_max = float(mx.max(diff).item())
+    rel = diff / (mx.abs(ref) + 1e-6)
+    rel_max = float(mx.max(rel).item())
+
+    # Compare next-token argmax (deterministic check, looser than logits parity)
+    ref_argmax = int(mx.argmax(ref[0, -1]).item())
+    got_argmax = int(mx.argmax(got[0, -1]).item())
+
+    assert got_argmax == ref_argmax, (
+        f"next-token argmax mismatch: adapter={got_argmax} ref={ref_argmax} "
+        f"(abs_max={abs_max:.4g}, rel_max={rel_max:.4g})"
+    )
+
+    # Logits parity: 4-bit quant + accumulation order leaves ~1e-2 absolute noise.
+    assert abs_max < 5e-2, (
+        f"logits abs_max {abs_max:.4g} exceeds 5e-2 (rel_max={rel_max:.4g})"
+    )

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -203,7 +203,7 @@ def test_execute_model_frees_encoder_outputs_before_encoder_fail_fast(
     assert runner.encoder_cache is not None
     runner.encoder_cache.encoder_outputs["drop"] = fake_encode_result(mx.array([[1.0]]))
 
-    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+    with pytest.raises(RuntimeError, match="not forward_ready"):
         runner.execute_model(
             _scheduler_output(
                 scheduled_encoder_inputs={"req-0": [0]},
@@ -226,7 +226,7 @@ def test_execute_model_cleans_finished_requests_before_encoder_fail_fast() -> No
         sampling_params=SamplingParams(),
     )
 
-    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+    with pytest.raises(RuntimeError, match="not forward_ready"):
         runner.execute_model(
             _scheduler_output(
                 finished_req_ids={"done"},
@@ -238,14 +238,16 @@ def test_execute_model_cleans_finished_requests_before_encoder_fail_fast() -> No
     assert "done" not in runner._request_states
 
 
-def test_execute_model_rejects_encoder_inputs_until_forward_is_wired() -> None:
+def test_execute_model_rejects_encoder_inputs_when_adapter_not_forward_ready() -> None:
     runner = _runner_with_encoder_cache()
-    runner._multimodal_adapter = Qwen3VLMultimodalAdapter(
+    adapter = Qwen3VLMultimodalAdapter(
         spatial_merge_size=2,
         language_model=object(),
     )
+    adapter.forward_ready = False
+    runner._multimodal_adapter = adapter
 
-    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+    with pytest.raises(RuntimeError, match="not forward_ready"):
         runner.execute_model(_scheduler_output(scheduled_encoder_inputs={"req-0": [0]}))
 
 
@@ -328,7 +330,8 @@ class _RecordingAdapter:
 def test_reject_scheduled_encoder_inputs_dispatches_when_adapter_is_forward_ready() -> (
     None
 ):
-    runner = _runner_with_encoder_cache()
+    # Dispatch only happens on the paged backend; mm is paged-only (RFC #319).
+    runner = _paged_runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
     features = [_feature("image-0")]
@@ -342,11 +345,33 @@ def test_reject_scheduled_encoder_inputs_dispatches_when_adapter_is_forward_read
     assert "image-0" in runner.encoder_cache.encoder_outputs
 
 
+def test_reject_scheduled_encoder_inputs_raises_on_non_paged_backend() -> None:
+    """forward_ready=True but no paged backend must fail fast.
+
+    The non-paged legacy path never splices encoded image embeddings, so
+    running the encoder and falling through to _prefill_single would silently
+    drop image conditioning (or feed raw placeholder IDs to the LM).
+    """
+    runner = _runner_with_encoder_cache()  # _paged_attention_backend is None
+    adapter = _RecordingAdapter()  # forward_ready = True
+    runner._multimodal_adapter = adapter
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", [_feature("image-0")])
+
+    with pytest.raises(NotImplementedError, match="paged attention backend"):
+        runner._reject_scheduled_encoder_inputs({"req-0": [0]})
+
+    # The encoder must not run when the request is going to be rejected.
+    assert adapter.encode_calls == []
+
+
 def test_reject_scheduled_encoder_inputs_raises_when_adapter_not_ready() -> None:
     runner = _runner_with_encoder_cache()
-    runner._multimodal_adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=2)
+    adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=2)
+    adapter.forward_ready = False
+    runner._multimodal_adapter = adapter
 
-    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+    with pytest.raises(RuntimeError, match="not forward_ready"):
         runner._reject_scheduled_encoder_inputs({"req-0": [0]})
 
 
@@ -354,7 +379,7 @@ def test_reject_scheduled_encoder_inputs_raises_when_no_adapter() -> None:
     runner = _runner_with_encoder_cache()
     runner._multimodal_adapter = None
 
-    with pytest.raises(NotImplementedError, match="Multimodal encoder execution"):
+    with pytest.raises(RuntimeError, match="not forward_ready"):
         runner._reject_scheduled_encoder_inputs({"req-0": [0]})
 
 

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -29,8 +29,9 @@ class Qwen3VLVisionEncodeResult:
 class Qwen3VLMultimodalAdapter:
     """Model-owned multimodal helpers for the Qwen3-VL execution path."""
 
-    forward_ready: bool = False
-    """Closed until parity against ``mlx_vlm.Model.__call__`` passes."""
+    forward_ready: bool = True
+    """Runner gate for the multimodal forward path; False forces the runner
+    to reject mm requests rather than invoke an incomplete adapter."""
 
     _SUPPORTED_EMBEDS_KWARGS: tuple[str, ...] = (
         "inputs_embeds",

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -187,11 +187,6 @@ class ModelLifecycle:
         }
         if is_vlm:
             logger.info("Using mlx-vlm for vision-language model")
-            logger.warning(
-                "VLM loaded via mlx-vlm; Metal multimodal encoder execution "
-                "is not wired yet. Text-only requests continue through the "
-                "language model."
-            )
             model, tokenizer = mlx_vlm_load(model_name)
         elif awq_loader is not None:
             with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1370,24 +1370,32 @@ class MetalModelRunner:
     ) -> None:
         """Dispatch to vision encoders or fail fast based on adapter state.
 
-        When the active adapter signals ``forward_ready``, scheduled encoder
-        inputs are routed to :meth:`_run_vision_encoders`.  Until Phase 4
-        flips that flag for the parity-tested model, the gate raises so
-        partial work on a new model never disturbs models already in
-        production.  Phase 5+ adapters land at ``False`` and route through
-        this guard until each one's parity test passes.
+        When the active adapter signals ``forward_ready`` *and* the paged
+        attention backend is active, scheduled encoder inputs are routed to
+        :meth:`_run_vision_encoders`.  Otherwise the gate raises so that mm
+        requests never reach a misconfigured adapter or the non-paged path —
+        only the paged path splices encoded image embeddings, so the legacy
+        path would run the language model on raw image placeholder tokens.
         """
         if not scheduled_encoder_inputs:
             return
         adapter = self._multimodal_adapter
-        if adapter is not None and adapter.forward_ready:
-            self._run_vision_encoders(scheduled_encoder_inputs)
-            return
-        raise NotImplementedError(
-            "Multimodal encoder execution is not wired on Metal yet. "
-            "Metal currently registers multimodal runtime state, but image "
-            "encoding and embedding splice are not connected to the runner."
-        )
+        if adapter is None or not adapter.forward_ready:
+            raise RuntimeError(
+                "Multimodal encoder dispatch requested but adapter is missing "
+                "or not forward_ready; mm requests cannot run on this "
+                "configuration."
+            )
+        if self._paged_attention_backend is None:
+            raise NotImplementedError(
+                "Multimodal requests require the paged attention backend. "
+                "Set VLLM_METAL_USE_PAGED_ATTENTION=1: only the paged path "
+                "splices encoded image embeddings via _run_mm_paged_forward; "
+                "the non-paged legacy path would run the language model on raw "
+                "image placeholder tokens (RFC #319 hard rule 4: multimodal "
+                "is paged-only)."
+            )
+        self._run_vision_encoders(scheduled_encoder_inputs)
 
     def _spec_decode_preflight_reqs(
         self,
@@ -1430,6 +1438,14 @@ class MetalModelRunner:
         ``adapter.encode_multimodal`` one feature at a time so a single bad
         feature is reported with a precise req_id+idx rather than poisoning
         a whole request batch.
+
+        TODO(multimodal-batching): batch scheduled features into a single
+        ``adapter.encode_multimodal`` call.  Upstream vLLM stacks pixel_values
+        and image_grid_thw across requests so the vision tower runs once per
+        step; we serialize, which inflates TTFT under concurrency (e.g.,
+        conc=8 + 384x384 measured ~3.5s p50 TTFT).  Requires per-feature
+        slicing of returned hidden_states + deepstack residuals by
+        ``grid_thw.prod()``.
         """
         adapter = self._multimodal_adapter
         cache = self.encoder_cache


### PR DESCRIPTION
## Summary

Flip `Qwen3VLMultimodalAdapter.forward_ready` to `True` so the Qwen3-VL multimodal path goes live: scheduled encoder inputs route through `_run_vision_encoders` and the paged mm forward runs end-to-end via `adapter.call_lm`, instead of failing fast at the encoder-dispatch gate.

This is **follow-up 3** from #350 (paged-core) — the user-visible gate flip plus the end-to-end parity test. The dependency blocker is cleared: #404 bumped vLLM to 0.22.0, which carries `llguidance >=1.7` (vllm [#42150](https://github.com/vllm-project/vllm/pull/42150)) and pins `mlx-vlm >=0.5.0`.

## What changes

- **`forward_ready: False → True`** on the adapter. 
- **`_reject_scheduled_encoder_inputs`: `NotImplementedError` → `RuntimeError`** describing the real gate condition (adapter missing / not `forward_ready`), now that the path is wired rather than "not connected yet".
- **Non-paged fail-fast**: when `VLLM_METAL_USE_PAGED_ATTENTION=0`, the gate now raises `NotImplementedError` for mm requests instead of running the encoder and falling through to the legacy `_prefill_single` path (which would feed raw image placeholder tokens to the LM without splicing image embeddings). Only the paged `_run_mm_paged_forward` splices.
- Drop the now-stale "encoder not connected" warning in `model_lifecycle`.
- Add **`tests/multimodal/test_qwen3_vl_parity.py`** (`slow`): end-to-end logits parity of `adapter.call_lm` vs `mlx_vlm.Model.__call__`; module-skips unless the model is in the HF cache.
- Sync encoder-dispatch gate tests (forward_ready=False → `RuntimeError`; dispatch now requires the paged backend) and add a non-paged mm fail-fast test.

## Scope

- **Paged-only** (RFC #319 hard rule 4). Non-paged prefill + decode is deferred; mm requests on the non-paged path now fail fast with a clear error.
- The #350 spec-decode reject in `_run_mm_paged_forward` **stays in place**. Correct per-query-token `segment_positions` is a separate change; mm + spec-decode is not triggerable today (the only spec-decode method, Gemma4 MTP, is text-only — no Qwen3-VL draft exists), so the reject is inert on the normal forward path.

## Validation

Re-validated this session under **vLLM 0.22.0 / mlx-vlm 0.5.0**:

**Logits parity** (`test_qwen3_vl_parity.py` — next-token argmax matches reference, `abs_max(diff) < 5e-2`):

| checkpoint | result |
| --- | --- |
| `Qwen3-VL-4B-Instruct-4bit` | ✅ pass |
| `Qwen3-VL-4B-Instruct-8bit` | ✅ pass |

**End-to-end greedy alignment vs `mlx_vlm.generate`** (`temperature=0`; re-run this session under vLLM 0.22.0 / mlx-vlm 0.5.0 — vllm-metal `LLM.generate` vs `mlx_vlm.stream_generate` on the same deterministic 128×128 image):

- **8-bit: 32/32 generated tokens match exactly** (vllm-metal capped at `max_tokens=32`; the mlx-vlm reference is token-identical over the shared length). The entire pipeline (vision encode → splice → M-RoPE → paged attention → call_lm → sampler) is numerically equivalent to `mlx_vlm.generate` up to bf16/quant noise.
- 4-bit: 8/33 prefix match, diverges at pos 8 — 4-bit quant logit precision flips a close-call argmax; the two continuations are the *same* content reordered ("abstract, pixelated, noisy" vs "pixelated, abstract, chaotic"), **not** a pipeline correctness issue.

Bisection confirmed M-RoPE positions are bit-exact vs `LanguageModel.get_rope_index`, per-feature vision output matches the batched reference, and the splice matches `Model.merge_input_ids_with_image_features`.

**Throughput** (`vllm bench serve --dataset-name random-mm`, re-run this session under vLLM 0.22.0 on the Metal server, `--ignore-eos`):

| run | total tok/s | output tok/s | TTFT med | TPOT med | ITL med |
| --- | ---: | ---: | ---: | ---: | ---: |
| MM 32p, conc 4, 256×256, 128/128 | 401.6 | 155.8 | 292 ms | 19.6 ms | 19.5 ms |
| Text 32p, conc 4, 128/128 | 380.1 | 184.3 | 68 ms | 19.6 ms | 19.6 ms |
| MM 50p, conc 8, 384×384, 256/128 | 669.6 | 159.3 | 875 ms | 39.3 ms | 38.8 ms |

- Decode is **identical between MM and text** at conc 4 — TPOT 19.6 ms / ITL ~19.5 ms either way. The vision tower runs once in prefill; no per-token multimodal cost.
- MM prefill overhead is **+224 ms** median TTFT for one 256×256 image (292 vs 68 ms) at equal prompt length.
- At conc 8 / 384×384, median TTFT is 875 ms (TPOT ~39 ms under 8-way batched decode). Per-feature vision encoding is still serialized — batching scheduled encoder inputs into a single tower call is a documented `_run_vision_encoders` TODO (`adapter.encode_multimodal([all_features])` with `grid_thw.prod()`-based per-feature output slicing).

