### PR TITLE
[Bugfix] Lazy allocate hybrid GDN state slots

### DIFF
--- a/tests/test_gdn_lazy_wrapper.py
+++ b/tests/test_gdn_lazy_wrapper.py
@@ -95,6 +95,7 @@ def _make_state_cache(
     num_v_heads: int = 1,
     value_head_dim: int = 4,
     key_head_dim: int = 32,
+    initial_seqs: int | None = None,
 ) -> GDNPagedStateCache:
     return GDNPagedStateCache(
         num_layers=1,
@@ -104,6 +105,7 @@ def _make_state_cache(
         num_v_heads=num_v_heads,
         value_head_dim=value_head_dim,
         key_head_dim=key_head_dim,
+        initial_seqs=initial_seqs,
         dtype=mx.float32,
     )
 
@@ -1017,6 +1019,36 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         # Act / Assert
         try:
             with pytest.raises(RuntimeError, match="out-of-range slot"):
+                wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
+        finally:
+            clear_context()
+
+    def test_rejects_unallocated_gdn_slots(self) -> None:
+        # Arrange
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            max_seqs=3,
+            initial_seqs=1,
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        set_context(
+            PagedAttentionContext(
+                slot_mapping=[0, 1],
+                cu_seqlens=[0, 1, 2],
+                gdn_slot_mapping=[0, 1],
+            )
+        )
+
+        # Act / Assert
+        try:
+            with pytest.raises(RuntimeError, match="beyond allocated state cache"):
                 wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
         finally:
             clear_context()

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
+import pytest
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 
 from tests.stub_runner import make_stub_runner
@@ -166,12 +167,70 @@ class TestGDNSlotLifecycle:
             num_v_heads=4,
             value_head_dim=16,
             key_head_dim=16,
+            initial_seqs=0,
             dtype=mx.float16,
         )
         backend = _HybridBackendStub(sc)
 
         runner = make_stub_runner(_paged_attention_backend=backend)
         return runner, sc
+
+    def test_new_slots_grow_state_cache_lazily(self):
+        runner, sc = self._make_runner_stub(max_seqs=2)
+
+        assert sc.allocated_seqs == 0
+        slot_a = runner._gdn_alloc_slot("req-A")
+        slot_b = runner._gdn_alloc_slot("req-B")
+
+        assert slot_a == 0
+        assert slot_b == 1
+        assert sc.allocated_seqs == 2
+        assert sc.conv_states[0].shape == (2, 3, 64)
+        assert sc.recurrent_states[0].shape == (2, 4, 16, 16)
+
+    def test_capacity_failure_does_not_record_request_mapping(self):
+        runner, sc = self._make_runner_stub(max_seqs=1)
+
+        assert runner._gdn_alloc_slot("req-A") == 0
+        with pytest.raises(RuntimeError, match="more slots than max_num_seqs"):
+            runner._gdn_alloc_slot("req-B")
+
+        assert sc.allocated_seqs == 1
+        assert runner._gdn_req_to_slot == {"req-A": 0}
+        assert runner._gdn_free_slots == []
+
+    def test_grow_materializes_pending_state_before_replacing_arrays(self):
+        sc = GDNPagedStateCache(
+            num_layers=1,
+            max_seqs=2,
+            conv_kernel_dim=4,
+            conv_dim=64,
+            num_v_heads=4,
+            value_head_dim=16,
+            key_head_dim=16,
+            initial_seqs=1,
+            dtype=mx.float16,
+        )
+        sc.set_pending_conv_state(0, [0], mx.full((1, 3, 64), 7, dtype=mx.float16))
+        sc.set_pending_recurrent_state(
+            0, [0], mx.full((1, 4, 16, 16), 9, dtype=mx.float32)
+        )
+
+        sc.ensure_capacity(2)
+
+        assert sc.allocated_seqs == 2
+        assert not sc.has_pending_conv_state(0)
+        assert not sc.has_pending_recurrent_state(0)
+        mx.eval(sc.conv_states[0], sc.recurrent_states[0])
+        assert mx.allclose(sc.conv_states[0][0], mx.full((3, 64), 7, dtype=mx.float16))
+        assert mx.allclose(
+            sc.recurrent_states[0][0],
+            mx.full((4, 16, 16), 9, dtype=mx.float32),
+        )
+        assert mx.array_equal(sc.conv_states[0][1], mx.zeros((3, 64), dtype=mx.float16))
+        assert mx.array_equal(
+            sc.recurrent_states[0][1], mx.zeros((4, 16, 16), dtype=mx.float32)
+        )
 
     def test_reused_slot_is_zeroed(self):
         """A slot returned to the free list and re-allocated must have

--- a/tests/test_qwen3_next_gdn.py
+++ b/tests/test_qwen3_next_gdn.py
@@ -188,6 +188,27 @@ class TestGDNSlotLifecycle:
         assert sc.conv_states[0].shape == (2, 3, 64)
         assert sc.recurrent_states[0].shape == (2, 4, 16, 16)
 
+    def test_step_slot_assignment_grows_once_for_multiple_requests(self):
+        runner, sc = self._make_runner_stub(max_seqs=3)
+
+        with patch.object(sc, "ensure_capacity", wraps=sc.ensure_capacity) as grow:
+            slots = runner._gdn_assign_slots_for_step(["req-A", "req-B"])
+
+        assert slots == [0, 1]
+        assert sc.allocated_seqs == 2
+        grow.assert_called_once_with(2)
+        assert runner._gdn_req_to_slot == {"req-A": 0, "req-B": 1}
+
+    def test_step_slot_assignment_failure_is_atomic(self):
+        runner, sc = self._make_runner_stub(max_seqs=1)
+
+        with pytest.raises(RuntimeError, match="more slots than max_num_seqs"):
+            runner._gdn_assign_slots_for_step(["req-A", "req-B"])
+
+        assert sc.allocated_seqs == 0
+        assert runner._gdn_req_to_slot == {}
+        assert runner._gdn_free_slots == []
+
     def test_capacity_failure_does_not_record_request_mapping(self):
         runner, sc = self._make_runner_stub(max_seqs=1)
 

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -402,8 +402,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             )
 
         assert mr.get_context() is None
-        assert runner._gdn_req_to_slot == {"p0": 0}
-        assert "p1" not in runner._gdn_req_to_slot
+        assert runner._gdn_req_to_slot == {}
 
     def test_start_paged_forward_collects_hidden_states_for_gemma4_mtp(
         self, monkeypatch

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -347,6 +347,64 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         assert runner._execute_model_state.target_hidden_states is None
         assert runner._execute_model_state.cu_seqlens == [0, 1]
 
+    def test_start_paged_forward_clears_context_on_gdn_slot_error(self) -> None:
+        state_cache = GDNPagedStateCache(
+            num_layers=1,
+            max_seqs=1,
+            conv_kernel_dim=2,
+            conv_dim=4,
+            num_v_heads=1,
+            value_head_dim=4,
+            key_head_dim=32,
+            initial_seqs=0,
+            dtype=mx.float32,
+        )
+        backend = _HybridBackendStub.__new__(_HybridBackendStub)
+        backend._state_cache = state_cache
+        runner = make_stub_runner(
+            tokenizer=object(),
+            model_args={"full_attention_interval": 2},
+            _paged_attention_backend=backend,
+        )
+        runner.num_layers = 0
+        runner._paged_block_size = 4
+        scheduler_output = self._make_scheduler_output({"p0": 1, "p1": 1}, {})
+        prefill_reqs = [
+            mr.PrefillRequest(
+                req_id="p0",
+                token_ids=[5],
+                sampling_params=SamplingParams(),
+                block_ids=[0],
+                generator=None,
+                prompt_len=1,
+                start_pos=0,
+                full_prompt_token_ids=None,
+            ),
+            mr.PrefillRequest(
+                req_id="p1",
+                token_ids=[6],
+                sampling_params=SamplingParams(),
+                block_ids=[1],
+                generator=None,
+                prompt_len=1,
+                start_pos=0,
+                full_prompt_token_ids=None,
+            ),
+        ]
+
+        mr.clear_context()
+        with pytest.raises(RuntimeError, match="more slots than max_num_seqs"):
+            runner._start_paged_forward(
+                mr._ExecutionBatch(),
+                prefill_reqs=prefill_reqs,
+                decode_reqs=[],
+                scheduler_output=scheduler_output,
+            )
+
+        assert mr.get_context() is None
+        assert runner._gdn_req_to_slot == {"p0": 0}
+        assert "p1" not in runner._gdn_req_to_slot
+
     def test_start_paged_forward_collects_hidden_states_for_gemma4_mtp(
         self, monkeypatch
     ) -> None:

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -329,14 +329,14 @@ class TestPagedAttentionPlanDiagnostics:
             scheduler_memory_reporting_mode=MagicMock(
                 return_value="paged_attention_capacity"
             ),
-            profile_run=MagicMock(return_value=100_000_000),
+            profile_run=MagicMock(return_value=3_900_000_000),
             validate_paged_attention_support=MagicMock(),
-            scheduler_config=SimpleNamespace(max_num_seqs=256),
+            scheduler_config=SimpleNamespace(max_num_seqs=2),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
         )
         worker = _make_worker(runner, use_paged_attention=True)
         worker.metal_config.is_auto_memory = False
-        worker.metal_config.memory_fraction = 0.1
+        worker.metal_config.memory_fraction = 0.5
         worker.get_cache_block_size_bytes = MagicMock(return_value=1)
         monkeypatch.setattr(
             WorkerCachePlanner,
@@ -346,20 +346,20 @@ class TestPagedAttentionPlanDiagnostics:
         monkeypatch.setattr(
             WorkerCachePlanner,
             "get_model_memory_usage",
-            lambda self: 1_200_000_000,
+            lambda self: 1_000_000_000,
         )
 
         with pytest.raises(ValueError) as exc_info:
             MetalWorker.determine_available_memory(worker)
 
         message = str(exc_info.value)
-        assert "kv_budget_before_hybrid=-0.30GB" in message
+        assert "kv_budget_before_hybrid=0.10GB" in message
         assert "hybrid_gdn_state=lazy" in message
         assert (
-            "first_slot_reserve=0.06GB, 64.4MB/seq * reserved_slots=1/max_num_seqs=256"
+            "growth_peak_reserve=0.19GB, 64.4MB/seq * peak_slots=3/max_num_seqs=2"
         ) in message
-        assert "kv_budget=-0.36GB" in message
-        assert "--max-num-seqs" not in message
+        assert "kv_budget=-0.09GB" in message
+        assert "lower --max-num-seqs" in message
         assert "increase VLLM_METAL_MEMORY_FRACTION" in message
         runner.scheduler_memory_reporting_mode.assert_called_once_with(
             paged_attention_enabled=True
@@ -367,12 +367,10 @@ class TestPagedAttentionPlanDiagnostics:
         runner.profile_run.assert_called_once_with()
         runner.validate_paged_attention_support.assert_called_once_with()
 
-    def test_hybrid_plan_reserves_one_gdn_slot_not_max_at_startup(
-        self, monkeypatch
-    ) -> None:
+    def test_hybrid_plan_reserves_transient_gdn_growth_peak(self, monkeypatch) -> None:
         runner = SimpleNamespace(
             is_hybrid=True,
-            scheduler_config=SimpleNamespace(max_num_seqs=256),
+            scheduler_config=SimpleNamespace(max_num_seqs=2),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
         )
         planner = self._make_planner(
@@ -395,16 +393,16 @@ class TestPagedAttentionPlanDiagnostics:
 
         assert plan.base_kv_budget == 3_500_000_000
         assert plan.hybrid_gdn_reservation.bytes_per_slot == 64_400_000
-        assert plan.hybrid_gdn_reservation.reserved_slots == 1
-        assert plan.hybrid_gdn_reservation.max_num_seqs == 256
-        assert plan.hybrid_gdn_reservation.total_bytes == 64_400_000
-        assert plan.kv_budget == 3_435_600_000
-        assert plan.num_blocks == 34
+        assert plan.hybrid_gdn_reservation.reserved_slots == 3
+        assert plan.hybrid_gdn_reservation.max_num_seqs == 2
+        assert plan.hybrid_gdn_reservation.total_bytes == 193_200_000
+        assert plan.kv_budget == 3_306_800_000
+        assert plan.num_blocks == 33
         breakdown = plan.format_breakdown()
         assert "hybrid_gdn_state=lazy" in breakdown
         assert "kv_budget_before_hybrid=3.50GB" in breakdown
         assert (
-            "first_slot_reserve=0.06GB, 64.4MB/seq * reserved_slots=1/max_num_seqs=256"
+            "growth_peak_reserve=0.19GB, 64.4MB/seq * peak_slots=3/max_num_seqs=2"
         ) in breakdown
 
     def test_non_hybrid_oom_error_omits_gdn_reservation(self, monkeypatch) -> None:

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -353,10 +353,12 @@ class TestPagedAttentionPlanDiagnostics:
             MetalWorker.determine_available_memory(worker)
 
         message = str(exc_info.value)
-        assert "kv_budget_before_hybrid" not in message
+        assert "kv_budget_before_hybrid=-0.30GB" in message
         assert "hybrid_gdn_state=lazy" in message
-        assert "startup=0.00GB, 64.4MB/seq, max_num_seqs=256" in message
-        assert "kv_budget=-0.30GB" in message
+        assert (
+            "first_slot_reserve=0.06GB, 64.4MB/seq * reserved_slots=1/max_num_seqs=256"
+        ) in message
+        assert "kv_budget=-0.36GB" in message
         assert "--max-num-seqs" not in message
         assert "increase VLLM_METAL_MEMORY_FRACTION" in message
         runner.scheduler_memory_reporting_mode.assert_called_once_with(
@@ -365,7 +367,7 @@ class TestPagedAttentionPlanDiagnostics:
         runner.profile_run.assert_called_once_with()
         runner.validate_paged_attention_support.assert_called_once_with()
 
-    def test_hybrid_plan_does_not_reserve_max_gdn_slots_at_startup(
+    def test_hybrid_plan_reserves_one_gdn_slot_not_max_at_startup(
         self, monkeypatch
     ) -> None:
         runner = SimpleNamespace(
@@ -393,13 +395,17 @@ class TestPagedAttentionPlanDiagnostics:
 
         assert plan.base_kv_budget == 3_500_000_000
         assert plan.hybrid_gdn_reservation.bytes_per_slot == 64_400_000
+        assert plan.hybrid_gdn_reservation.reserved_slots == 1
         assert plan.hybrid_gdn_reservation.max_num_seqs == 256
-        assert plan.hybrid_gdn_reservation.total_bytes == 0
-        assert plan.kv_budget == plan.base_kv_budget
-        assert plan.num_blocks == 35
+        assert plan.hybrid_gdn_reservation.total_bytes == 64_400_000
+        assert plan.kv_budget == 3_435_600_000
+        assert plan.num_blocks == 34
         breakdown = plan.format_breakdown()
         assert "hybrid_gdn_state=lazy" in breakdown
-        assert "kv_budget_before_hybrid" not in breakdown
+        assert "kv_budget_before_hybrid=3.50GB" in breakdown
+        assert (
+            "first_slot_reserve=0.06GB, 64.4MB/seq * reserved_slots=1/max_num_seqs=256"
+        ) in breakdown
 
     def test_non_hybrid_oom_error_omits_gdn_reservation(self, monkeypatch) -> None:
         runner = SimpleNamespace(is_hybrid=False)

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -367,10 +367,10 @@ class TestPagedAttentionPlanDiagnostics:
         runner.profile_run.assert_called_once_with()
         runner.validate_paged_attention_support.assert_called_once_with()
 
-    def test_hybrid_plan_reserves_transient_gdn_growth_peak(self, monkeypatch) -> None:
+    def test_hybrid_plan_reserves_bounded_gdn_growth_cushion(self, monkeypatch) -> None:
         runner = SimpleNamespace(
             is_hybrid=True,
-            scheduler_config=SimpleNamespace(max_num_seqs=2),
+            scheduler_config=SimpleNamespace(max_num_seqs=256),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
         )
         planner = self._make_planner(
@@ -394,7 +394,7 @@ class TestPagedAttentionPlanDiagnostics:
         assert plan.base_kv_budget == 3_500_000_000
         assert plan.hybrid_gdn_reservation.bytes_per_slot == 64_400_000
         assert plan.hybrid_gdn_reservation.reserved_slots == 3
-        assert plan.hybrid_gdn_reservation.max_num_seqs == 2
+        assert plan.hybrid_gdn_reservation.max_num_seqs == 256
         assert plan.hybrid_gdn_reservation.total_bytes == 193_200_000
         assert plan.kv_budget == 3_306_800_000
         assert plan.num_blocks == 33
@@ -402,8 +402,38 @@ class TestPagedAttentionPlanDiagnostics:
         assert "hybrid_gdn_state=lazy" in breakdown
         assert "kv_budget_before_hybrid=3.50GB" in breakdown
         assert (
-            "growth_peak_reserve=0.19GB, 64.4MB/seq * peak_slots=3/max_num_seqs=2"
+            "growth_peak_reserve=0.19GB, 64.4MB/seq * peak_slots=3/max_num_seqs=256"
         ) in breakdown
+
+    def test_hybrid_plan_reserves_one_peak_slot_for_single_sequence(
+        self, monkeypatch
+    ) -> None:
+        runner = SimpleNamespace(
+            is_hybrid=True,
+            scheduler_config=SimpleNamespace(max_num_seqs=1),
+            linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
+        )
+        planner = self._make_planner(
+            runner,
+            memory_fraction=0.5,
+            per_block_bytes=100_000_000,
+        )
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "_metal_limit_bytes",
+            lambda self: 10_000_000_000,
+        )
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "get_model_memory_usage",
+            lambda self: 1_000_000_000,
+        )
+
+        plan = planner._paged_attention_plan(overhead=500_000_000)
+
+        assert plan.hybrid_gdn_reservation.reserved_slots == 1
+        assert plan.hybrid_gdn_reservation.total_bytes == 64_400_000
+        assert plan.num_blocks == 34
 
     def test_non_hybrid_oom_error_omits_gdn_reservation(self, monkeypatch) -> None:
         runner = SimpleNamespace(is_hybrid=False)

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -323,21 +323,61 @@ class TestPagedAttentionPlanDiagnostics:
         worker.get_cache_block_size_bytes = MagicMock(return_value=per_block_bytes)
         return WorkerCachePlanner(worker)
 
-    def test_hybrid_oom_error_reports_gdn_reservation(self, monkeypatch) -> None:
+    def test_hybrid_oom_error_reports_lazy_gdn_state(self, monkeypatch) -> None:
         runner = SimpleNamespace(
             is_hybrid=True,
             scheduler_memory_reporting_mode=MagicMock(
                 return_value="paged_attention_capacity"
             ),
-            profile_run=MagicMock(return_value=500_000_000),
+            profile_run=MagicMock(return_value=100_000_000),
             validate_paged_attention_support=MagicMock(),
             scheduler_config=SimpleNamespace(max_num_seqs=256),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
         )
         worker = _make_worker(runner, use_paged_attention=True)
         worker.metal_config.is_auto_memory = False
-        worker.metal_config.memory_fraction = 0.5
+        worker.metal_config.memory_fraction = 0.1
         worker.get_cache_block_size_bytes = MagicMock(return_value=1)
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "_metal_limit_bytes",
+            lambda self: 10_000_000_000,
+        )
+        monkeypatch.setattr(
+            WorkerCachePlanner,
+            "get_model_memory_usage",
+            lambda self: 1_200_000_000,
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            MetalWorker.determine_available_memory(worker)
+
+        message = str(exc_info.value)
+        assert "kv_budget_before_hybrid" not in message
+        assert "hybrid_gdn_state=lazy" in message
+        assert "startup=0.00GB, 64.4MB/seq, max_num_seqs=256" in message
+        assert "kv_budget=-0.30GB" in message
+        assert "--max-num-seqs" not in message
+        assert "increase VLLM_METAL_MEMORY_FRACTION" in message
+        runner.scheduler_memory_reporting_mode.assert_called_once_with(
+            paged_attention_enabled=True
+        )
+        runner.profile_run.assert_called_once_with()
+        runner.validate_paged_attention_support.assert_called_once_with()
+
+    def test_hybrid_plan_does_not_reserve_max_gdn_slots_at_startup(
+        self, monkeypatch
+    ) -> None:
+        runner = SimpleNamespace(
+            is_hybrid=True,
+            scheduler_config=SimpleNamespace(max_num_seqs=256),
+            linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
+        )
+        planner = self._make_planner(
+            runner,
+            memory_fraction=0.5,
+            per_block_bytes=100_000_000,
+        )
         monkeypatch.setattr(
             WorkerCachePlanner,
             "_metal_limit_bytes",
@@ -349,24 +389,17 @@ class TestPagedAttentionPlanDiagnostics:
             lambda self: 1_000_000_000,
         )
 
-        with pytest.raises(ValueError) as exc_info:
-            MetalWorker.determine_available_memory(worker)
+        plan = planner._paged_attention_plan(overhead=500_000_000)
 
-        message = str(exc_info.value)
-        assert "kv_budget_before_hybrid=3.50GB" in message
-        assert "hybrid_gdn_state=16.49GB" in message
-        assert "(64.4MB/seq * max_num_seqs=256)" in message
-        assert "kv_budget=-12.99GB" in message
-        assert (
-            "lower --max-num-seqs (for single-user serving, try --max-num-seqs 1)"
-            in message
-        )
-        assert "increase VLLM_METAL_MEMORY_FRACTION" in message
-        runner.scheduler_memory_reporting_mode.assert_called_once_with(
-            paged_attention_enabled=True
-        )
-        runner.profile_run.assert_called_once_with()
-        runner.validate_paged_attention_support.assert_called_once_with()
+        assert plan.base_kv_budget == 3_500_000_000
+        assert plan.hybrid_gdn_reservation.bytes_per_slot == 64_400_000
+        assert plan.hybrid_gdn_reservation.max_num_seqs == 256
+        assert plan.hybrid_gdn_reservation.total_bytes == 0
+        assert plan.kv_budget == plan.base_kv_budget
+        assert plan.num_blocks == 35
+        breakdown = plan.format_breakdown()
+        assert "hybrid_gdn_state=lazy" in breakdown
+        assert "kv_budget_before_hybrid" not in breakdown
 
     def test_non_hybrid_oom_error_omits_gdn_reservation(self, monkeypatch) -> None:
         runner = SimpleNamespace(is_hybrid=False)

--- a/vllm_metal/metal_kernel_backend/attention_linear.py
+++ b/vllm_metal/metal_kernel_backend/attention_linear.py
@@ -164,8 +164,7 @@ class GDNPagedAttentionWrapper(nn.Module):
             raise RuntimeError("GDN wrapper requires one slot per request")
         if len(set(slot_ids)) != len(slot_ids):
             raise RuntimeError("GDN wrapper requires unique slots per request")
-        if any(slot < 0 or slot >= self._gdn_state_cache.max_seqs for slot in slot_ids):
-            raise RuntimeError("GDN wrapper received out-of-range slot mapping")
+        self._gdn_state_cache.require_allocated_slots(slot_ids)
 
         return _GDNForwardState(
             x=x,

--- a/vllm_metal/mlx_backend/gdn_cache.py
+++ b/vllm_metal/mlx_backend/gdn_cache.py
@@ -6,11 +6,13 @@ sequence length, GDN linear attention uses fixed-size recurrent state
 per request: a convolution buffer and a hidden state matrix.
 
 Layout per linear layer:
-  - conv_state:      [max_seqs, conv_kernel - 1, conv_dim]
-  - recurrent_state: [max_seqs, num_v_heads, value_head_dim, key_head_dim]
+  - conv_state:      [allocated_seqs, conv_kernel - 1, conv_dim]
+  - recurrent_state: [allocated_seqs, num_v_heads, value_head_dim, key_head_dim]
 
 Each request occupies one slot (indexed by request position in the batch).
 State is managed by the GDN wrapper, not by the scheduler's block system.
+``max_seqs`` remains the scheduler-visible hard cap; ``allocated_seqs`` grows
+on request admission and never exceeds that cap.
 
 Pending state handoff:
   - At most one compact pending conv or recurrent update may exist per linear
@@ -51,13 +53,24 @@ class GDNPagedStateCache:
         num_v_heads: int,
         value_head_dim: int,
         key_head_dim: int,
+        initial_seqs: int | None = None,
         dtype: mx.Dtype = mx.float16,
     ) -> None:
         if dtype not in (mx.float16, mx.bfloat16, mx.float32):
             raise ValueError(f"Unsupported dtype for GDN state cache: {dtype}")
+        if max_seqs < 0:
+            raise ValueError("max_seqs must be non-negative")
+        if initial_seqs is None:
+            initial_seqs = max_seqs
+        if initial_seqs < 0 or initial_seqs > max_seqs:
+            raise ValueError(
+                "initial_seqs must be between 0 and max_seqs "
+                f"(got {initial_seqs}, max_seqs={max_seqs})"
+            )
 
         self.num_layers = num_layers
         self.max_seqs = max_seqs
+        self.allocated_seqs = initial_seqs
         self.conv_kernel_dim = conv_kernel_dim
         self.conv_dim = conv_dim
         self.num_v_heads = num_v_heads
@@ -65,15 +78,14 @@ class GDNPagedStateCache:
         self.key_head_dim = key_head_dim
         self.dtype = dtype
 
-        conv_shape = (max_seqs, conv_kernel_dim - 1, conv_dim)
-        recurrent_shape = (max_seqs, num_v_heads, value_head_dim, key_head_dim)
-
         self.conv_states: list[mx.array] = [
-            mx.zeros(conv_shape, dtype=dtype) for _ in range(num_layers)
+            mx.zeros(self._conv_shape(initial_seqs), dtype=dtype)
+            for _ in range(num_layers)
         ]
         # Recurrent state uses float32 to avoid overflow in kernel accumulation.
         self.recurrent_states: list[mx.array] = [
-            mx.zeros(recurrent_shape, dtype=mx.float32) for _ in range(num_layers)
+            mx.zeros(self._recurrent_shape(initial_seqs), dtype=mx.float32)
+            for _ in range(num_layers)
         ]
         self.pending_conv_states: list[mx.array | None] = [
             None for _ in range(num_layers)
@@ -87,12 +99,86 @@ class GDNPagedStateCache:
         self.pending_recurrent_slot_ids: list[list[int] | None] = [
             None for _ in range(num_layers)
         ]
-        mx.eval(*self.conv_states, *self.recurrent_states)
+        self._eval_state_arrays()
+
+    def _conv_shape(self, num_seqs: int) -> tuple[int, int, int]:
+        return (num_seqs, self.conv_kernel_dim - 1, self.conv_dim)
+
+    def _recurrent_shape(self, num_seqs: int) -> tuple[int, int, int, int]:
+        return (
+            num_seqs,
+            self.num_v_heads,
+            self.value_head_dim,
+            self.key_head_dim,
+        )
+
+    def _eval_state_arrays(self) -> None:
+        arrays = [*self.conv_states, *self.recurrent_states]
+        if arrays:
+            mx.eval(*arrays)
+
+    def ensure_capacity(self, num_seqs: int) -> None:
+        """Grow stable state pools so slots ``[0, num_seqs)`` are valid."""
+        if num_seqs < 0:
+            raise ValueError("num_seqs must be non-negative")
+        if num_seqs > self.max_seqs:
+            raise RuntimeError(
+                "GDN state cache requested more slots than max_num_seqs "
+                f"({num_seqs} > {self.max_seqs})"
+            )
+        if num_seqs <= self.allocated_seqs:
+            return
+
+        self.apply_pending_states()
+        old_allocated = self.allocated_seqs
+
+        conv_states: list[mx.array] = []
+        recurrent_states: list[mx.array] = []
+        for layer_idx in range(self.num_layers):
+            old_conv = self.conv_states[layer_idx]
+            conv = mx.zeros(self._conv_shape(num_seqs), dtype=self.dtype)
+            if old_allocated:
+                conv[:old_allocated] = old_conv
+            conv_states.append(conv)
+
+            old_recurrent = self.recurrent_states[layer_idx]
+            recurrent = mx.zeros(self._recurrent_shape(num_seqs), dtype=mx.float32)
+            if old_allocated:
+                recurrent[:old_allocated] = old_recurrent
+            recurrent_states.append(recurrent)
+
+        self.conv_states = conv_states
+        self.recurrent_states = recurrent_states
+        self.allocated_seqs = num_seqs
+        self._eval_state_arrays()
+
+    def require_allocated_slots(self, slot_ids: list[int]) -> None:
+        """Validate slots against both the scheduler cap and allocated rows."""
+        if any(slot < 0 or slot >= self.max_seqs for slot in slot_ids):
+            raise RuntimeError("GDN wrapper received out-of-range slot mapping")
+        if any(slot >= self.allocated_seqs for slot in slot_ids):
+            raise RuntimeError(
+                "GDN wrapper received slot mapping beyond allocated state cache"
+            )
+
+    def reset_slot(self, slot: int) -> None:
+        """Clear state for one allocated slot before it is reused."""
+        self.require_allocated_slots([slot])
+        self.apply_pending_states()
+        for layer_idx in range(self.num_layers):
+            conv = self.conv_states[layer_idx]
+            conv[slot] = mx.zeros_like(conv[slot])
+            self.conv_states[layer_idx] = conv
+
+            recurrent = self.recurrent_states[layer_idx]
+            recurrent[slot] = mx.zeros_like(recurrent[slot])
+            self.recurrent_states[layer_idx] = recurrent
 
     def set_pending_conv_state(
         self, layer_idx: int, slot_ids: list[int], state_updates: mx.array
     ) -> None:
         """Store compact conv updates to be consumed by the next decode."""
+        self.require_allocated_slots(slot_ids)
         if self.has_pending_conv_state(layer_idx):
             self.apply_pending_conv_state(layer_idx)
         self.pending_conv_states[layer_idx] = state_updates
@@ -127,6 +213,7 @@ class GDNPagedStateCache:
         self, layer_idx: int, slot_ids: list[int]
     ) -> GDNDecodeStateView:
         """Return authoritative conv state and slot ids for a decode kernel."""
+        self.require_allocated_slots(slot_ids)
         if not self.has_pending_conv_state(layer_idx):
             return self._decode_state_view(
                 self.conv_states[layer_idx], slot_ids, uses_compact_state=False
@@ -145,6 +232,7 @@ class GDNPagedStateCache:
         self, layer_idx: int, slot_ids: list[int], state_updates: mx.array
     ) -> None:
         """Store compact recurrent updates to be consumed by the next decode."""
+        self.require_allocated_slots(slot_ids)
         if self.has_pending_recurrent_state(layer_idx):
             self.apply_pending_recurrent_state(layer_idx)
         self.pending_recurrent_states[layer_idx] = state_updates
@@ -163,6 +251,7 @@ class GDNPagedStateCache:
         self, layer_idx: int, slot_ids: list[int]
     ) -> GDNDecodeStateView:
         """Return authoritative recurrent state and slot ids for a decode kernel."""
+        self.require_allocated_slots(slot_ids)
         if not self.has_pending_recurrent_state(layer_idx):
             return self._decode_state_view(
                 self.recurrent_states[layer_idx], slot_ids, uses_compact_state=False
@@ -226,6 +315,7 @@ class GDNPagedStateCache:
         pending_slots = self.pending_conv_slot_ids[layer_idx]
         if pending_state is None or pending_slots is None:
             return
+        self.require_allocated_slots(pending_slots)
 
         slot_ids_arr = mx.array(pending_slots, dtype=mx.int32)
         conv_state = self.conv_states[layer_idx]
@@ -244,6 +334,7 @@ class GDNPagedStateCache:
         pending_slots = self.pending_recurrent_slot_ids[layer_idx]
         if pending_state is None or pending_slots is None:
             return
+        self.require_allocated_slots(pending_slots)
 
         slot_ids_arr = mx.array(pending_slots, dtype=mx.int32)
         recurrent_state = self.recurrent_states[layer_idx]

--- a/vllm_metal/paged_attention_backend/hybrid.py
+++ b/vllm_metal/paged_attention_backend/hybrid.py
@@ -152,15 +152,17 @@ class HybridPagedAttentionBackend:
             num_v_heads=self._linear_num_v_heads,
             value_head_dim=self._linear_value_head_dim,
             key_head_dim=self._linear_key_head_dim,
+            initial_seqs=0,
             dtype=self._dtype,
         )
 
         logger.info(
             "Hybrid cache initialized: %d SDPA layers (%d blocks), "
-            "%d linear layers (%d slots)",
+            "%d linear layers (%d/%d GDN slots allocated)",
             len(self._sdpa_indices),
             num_blocks,
             len(self._linear_indices),
+            self._state_cache.allocated_seqs,
             self._max_num_seqs,
         )
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+HYBRID_GDN_GROWTH_CUSHION_SLOTS = 2
+
 
 @dataclass(frozen=True, kw_only=True)
 class TurboQuantAttentionSpec(FullAttentionSpec):
@@ -757,13 +759,14 @@ class WorkerCachePlanner:
         max_num_seqs = runner.scheduler_config.max_num_seqs
         if max_num_seqs <= 0:
             return _HybridGDNReservation()
+        cushion_slots = min(max_num_seqs, HYBRID_GDN_GROWTH_CUSHION_SLOTS)
         return _HybridGDNReservation(
             bytes_per_slot=runner.linear_cache_bytes_per_slot(),
             # ``ensure_capacity`` grows by allocating a larger state pool and
-            # copying the old pool into it.  The worst exact-growth step is
-            # (max_num_seqs - 1) -> max_num_seqs, whose transient peak keeps
-            # both old and new GDN pools live.
-            reserved_slots=(2 * max_num_seqs) - 1,
+            # copying the old pool into it. Reserve a bounded growth cushion
+            # instead of the full scheduler cap so large max_num_seqs values
+            # still benefit from lazy GDN allocation.
+            reserved_slots=(2 * cushion_slots) - 1,
             max_num_seqs=max_num_seqs,
         )
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -235,11 +235,7 @@ class _PagedAttentionPlan:
             "use a smaller or more quantized model",
         ]
         reservation = self.hybrid_gdn_reservation
-        if (
-            reservation.enabled
-            and reservation.reserved_slots == reservation.max_num_seqs
-            and reservation.max_num_seqs > 1
-        ):
+        if reservation.enabled and reservation.max_num_seqs > 1:
             seq_mitigation = (
                 "lower --max-num-seqs (for single-user serving, try --max-num-seqs 1)"
             )
@@ -253,18 +249,11 @@ class _PagedAttentionPlan:
         reservation = self.hybrid_gdn_reservation
         if not reservation.is_hybrid:
             return ""
-        if reservation.enabled:
-            return (
-                f"hybrid_gdn_state=lazy "
-                f"(first_slot_reserve={reservation.total_bytes / 1e9:.2f}GB, "
-                f"{reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
-                f"reserved_slots={reservation.reserved_slots}/"
-                f"max_num_seqs={reservation.max_num_seqs})"
-            )
         return (
             "hybrid_gdn_state=lazy "
-            f"(first_slot_reserve=0.00GB, "
-            f"{reservation.bytes_per_slot / 1e6:.1f}MB/seq, "
+            f"(growth_peak_reserve={reservation.total_bytes / 1e9:.2f}GB, "
+            f"{reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
+            f"peak_slots={reservation.reserved_slots}/"
             f"max_num_seqs={reservation.max_num_seqs})"
         )
 
@@ -766,9 +755,15 @@ class WorkerCachePlanner:
         if not runner.is_hybrid:
             return _HybridGDNReservation()
         max_num_seqs = runner.scheduler_config.max_num_seqs
+        if max_num_seqs <= 0:
+            return _HybridGDNReservation()
         return _HybridGDNReservation(
             bytes_per_slot=runner.linear_cache_bytes_per_slot(),
-            reserved_slots=1 if max_num_seqs > 0 else 0,
+            # ``ensure_capacity`` grows by allocating a larger state pool and
+            # copying the old pool into it.  The worst exact-growth step is
+            # (max_num_seqs - 1) -> max_num_seqs, whose transient peak keeps
+            # both old and new GDN pools live.
+            reserved_slots=(2 * max_num_seqs) - 1,
             max_num_seqs=max_num_seqs,
         )
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -235,7 +235,11 @@ class _PagedAttentionPlan:
             "use a smaller or more quantized model",
         ]
         reservation = self.hybrid_gdn_reservation
-        if reservation.enabled and reservation.max_num_seqs > 1:
+        if (
+            reservation.enabled
+            and reservation.reserved_slots == reservation.max_num_seqs
+            and reservation.max_num_seqs > 1
+        ):
             seq_mitigation = (
                 "lower --max-num-seqs (for single-user serving, try --max-num-seqs 1)"
             )
@@ -251,14 +255,16 @@ class _PagedAttentionPlan:
             return ""
         if reservation.enabled:
             return (
-                f"hybrid_gdn_state={reservation.total_bytes / 1e9:.2f}GB "
-                f"({reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
+                f"hybrid_gdn_state=lazy "
+                f"(first_slot_reserve={reservation.total_bytes / 1e9:.2f}GB, "
+                f"{reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
                 f"reserved_slots={reservation.reserved_slots}/"
                 f"max_num_seqs={reservation.max_num_seqs})"
             )
         return (
             "hybrid_gdn_state=lazy "
-            f"(startup=0.00GB, {reservation.bytes_per_slot / 1e6:.1f}MB/seq, "
+            f"(first_slot_reserve=0.00GB, "
+            f"{reservation.bytes_per_slot / 1e6:.1f}MB/seq, "
             f"max_num_seqs={reservation.max_num_seqs})"
         )
 
@@ -755,14 +761,15 @@ class WorkerCachePlanner:
             )
 
     def _hybrid_gdn_reservation(self) -> _HybridGDNReservation:
-        """Return startup GDN state reserved outside the paged KV pool."""
+        """Return lazy GDN headroom reserved outside the paged KV pool."""
         runner = self._worker.model_runner
         if not runner.is_hybrid:
             return _HybridGDNReservation()
+        max_num_seqs = runner.scheduler_config.max_num_seqs
         return _HybridGDNReservation(
             bytes_per_slot=runner.linear_cache_bytes_per_slot(),
-            reserved_slots=0,
-            max_num_seqs=runner.scheduler_config.max_num_seqs,
+            reserved_slots=1 if max_num_seqs > 0 else 0,
+            max_num_seqs=max_num_seqs,
         )
 
     def _memory_fraction(self) -> float:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -184,15 +184,20 @@ _register_turboquant_spec_manager()
 @dataclass(frozen=True)
 class _HybridGDNReservation:
     bytes_per_slot: int = 0
+    reserved_slots: int = 0
     max_num_seqs: int = 0
 
     @property
     def total_bytes(self) -> int:
-        return self.bytes_per_slot * self.max_num_seqs
+        return self.bytes_per_slot * self.reserved_slots
 
     @property
     def enabled(self) -> bool:
         return self.total_bytes > 0
+
+    @property
+    def is_hybrid(self) -> bool:
+        return self.bytes_per_slot > 0 and self.max_num_seqs > 0
 
 
 @dataclass(frozen=True)
@@ -219,6 +224,7 @@ class _PagedAttentionPlan:
         ]
         if self.hybrid_gdn_reservation.enabled:
             parts.append(f"kv_budget_before_hybrid={self.base_kv_budget / 1e9:.2f}GB")
+        if self.hybrid_gdn_reservation.is_hybrid:
             parts.append(self._hybrid_gdn_detail())
         parts.append(f"kv_budget={self.kv_budget / 1e9:.2f}GB")
         return ", ".join(parts)
@@ -241,11 +247,18 @@ class _PagedAttentionPlan:
 
     def _hybrid_gdn_detail(self) -> str:
         reservation = self.hybrid_gdn_reservation
-        if not reservation.enabled:
+        if not reservation.is_hybrid:
             return ""
+        if reservation.enabled:
+            return (
+                f"hybrid_gdn_state={reservation.total_bytes / 1e9:.2f}GB "
+                f"({reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
+                f"reserved_slots={reservation.reserved_slots}/"
+                f"max_num_seqs={reservation.max_num_seqs})"
+            )
         return (
-            f"hybrid_gdn_state={reservation.total_bytes / 1e9:.2f}GB "
-            f"({reservation.bytes_per_slot / 1e6:.1f}MB/seq * "
+            "hybrid_gdn_state=lazy "
+            f"(startup=0.00GB, {reservation.bytes_per_slot / 1e6:.1f}MB/seq, "
             f"max_num_seqs={reservation.max_num_seqs})"
         )
 
@@ -748,6 +761,7 @@ class WorkerCachePlanner:
             return _HybridGDNReservation()
         return _HybridGDNReservation(
             bytes_per_slot=runner.linear_cache_bytes_per_slot(),
+            reserved_slots=0,
             max_num_seqs=runner.scheduler_config.max_num_seqs,
         )
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -405,30 +405,30 @@ class MetalModelRunner:
         """Allocate a stable GDN state pool slot for a request."""
         if req_id in self._gdn_req_to_slot:
             return self._gdn_req_to_slot[req_id]
-        reused = False
+
         if self._gdn_free_slots:
-            slot = self._gdn_free_slots.pop()
+            slot = self._gdn_free_slots[-1]
             reused = True
         else:
             slot = len(self._gdn_req_to_slot)
-        self._gdn_req_to_slot[req_id] = slot
+
+            reused = False
+        backend = self._paged_attention_backend
+        if not isinstance(backend, HybridPagedAttentionBackend):
+            raise RuntimeError("GDN slot allocation requires hybrid paged backend")
+        sc = backend._state_cache
+        if sc is None:
+            raise RuntimeError("GDN state cache is not initialized")
+
+        sc.ensure_capacity(slot + 1)
         # Zero state for reused slots so the new request starts clean.
         # Done at alloc time (inside the forward-pass graph) rather than
         # at free time to avoid mx.eval synchronisation issues.
         if reused:
-            backend = self._paged_attention_backend
-            if not isinstance(backend, HybridPagedAttentionBackend):
-                raise RuntimeError("GDN slot allocation requires hybrid paged backend")
-            sc = backend._state_cache
-            if sc is None:
-                raise RuntimeError("GDN state cache is not initialized")
-            for layer_idx in range(sc.num_layers):
-                conv = sc.conv_states[layer_idx]
-                conv[slot] = mx.zeros_like(conv[slot])
-                sc.conv_states[layer_idx] = conv
-                rec = sc.recurrent_states[layer_idx]
-                rec[slot] = mx.zeros_like(rec[slot])
-                sc.recurrent_states[layer_idx] = rec
+            sc.reset_slot(slot)
+            self._gdn_free_slots.pop()
+
+        self._gdn_req_to_slot[req_id] = slot
         return slot
 
     def _gdn_materialize_state_cache(self) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -931,28 +931,28 @@ class MetalModelRunner:
         for pr in prefill_reqs:
             prefill_info.append((pr.block_ids, len(pr.token_ids), pr.start_pos))
 
-        prepare_unified(decode_info, prefill_info, self._paged_block_size)
-
-        # ---- GDN slot mapping (hybrid models) ----
-        if self.is_hybrid:
-            ctx = get_context()
-            if ctx is not None:
-                gdn_slots = []
-                # Decode requests come first, then prefill
-                for req_id, _ in decode_reqs:
-                    gdn_slots.append(self._gdn_alloc_slot(req_id))
-                for pr in prefill_reqs:
-                    gdn_slots.append(self._gdn_alloc_slot(pr.req_id))
-                ctx.gdn_slot_mapping = gdn_slots
-
-        # ---- forward (lazy graph + async submit) ----
-        offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]
-        input_ids = mx.array([all_token_ids], dtype=mx.int32)
         logits: mx.array | None = None
         target_hidden_states: mx.array | None = None
         pooling_hidden_states: mx.array | None = None
         mm_prefill_deltas: dict[str, int] = {}
+
+        prepare_unified(decode_info, prefill_info, self._paged_block_size)
         try:
+            # ---- GDN slot mapping (hybrid models) ----
+            if self.is_hybrid:
+                ctx = get_context()
+                if ctx is not None:
+                    gdn_slots = []
+                    # Decode requests come first, then prefill
+                    for req_id, _ in decode_reqs:
+                        gdn_slots.append(self._gdn_alloc_slot(req_id))
+                    for pr in prefill_reqs:
+                        gdn_slots.append(self._gdn_alloc_slot(pr.req_id))
+                    ctx.gdn_slot_mapping = gdn_slots
+
+            # ---- forward (lazy graph + async submit) ----
+            offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]
+            input_ids = mx.array([all_token_ids], dtype=mx.int32)
             if has_pooling_work:
                 pooling_hidden_states = forward_sequence_hidden_states(
                     self._forward_model,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -403,16 +403,15 @@ class MetalModelRunner:
 
     def _gdn_alloc_slot(self, req_id: str) -> int:
         """Allocate a stable GDN state pool slot for a request."""
-        if req_id in self._gdn_req_to_slot:
-            return self._gdn_req_to_slot[req_id]
+        return self._gdn_assign_slots_for_step([req_id])[0]
 
-        if self._gdn_free_slots:
-            slot = self._gdn_free_slots[-1]
-            reused = True
-        else:
-            slot = len(self._gdn_req_to_slot)
+    def _gdn_assign_slots_for_step(self, req_ids: list[str]) -> list[int]:
+        """Assign all GDN state slots needed by one scheduler step.
 
-            reused = False
+        Capacity growth happens once for the whole step before request mappings
+        are mutated, so a later allocation failure cannot leave a partial
+        request-to-slot assignment behind.
+        """
         backend = self._paged_attention_backend
         if not isinstance(backend, HybridPagedAttentionBackend):
             raise RuntimeError("GDN slot allocation requires hybrid paged backend")
@@ -420,16 +419,50 @@ class MetalModelRunner:
         if sc is None:
             raise RuntimeError("GDN state cache is not initialized")
 
-        sc.ensure_capacity(slot + 1)
+        assigned_slots: list[int] = []
+        planned_by_req: dict[str, int] = {}
+        planned_new: list[tuple[str, int, bool]] = []
+        free_slots = list(self._gdn_free_slots)
+        next_new_slot = sc.allocated_seqs
+
+        for req_id in req_ids:
+            existing = self._gdn_req_to_slot.get(req_id)
+            if existing is not None:
+                assigned_slots.append(existing)
+                continue
+            planned = planned_by_req.get(req_id)
+            if planned is not None:
+                assigned_slots.append(planned)
+                continue
+
+            if free_slots:
+                slot = free_slots.pop()
+                reused = True
+            else:
+                slot = next_new_slot
+                next_new_slot += 1
+                reused = False
+            planned_by_req[req_id] = slot
+            planned_new.append((req_id, slot, reused))
+            assigned_slots.append(slot)
+
+        if not planned_new:
+            return assigned_slots
+
+        target_capacity = max(slot for _, slot, _ in planned_new) + 1
+        sc.ensure_capacity(target_capacity)
+
         # Zero state for reused slots so the new request starts clean.
         # Done at alloc time (inside the forward-pass graph) rather than
         # at free time to avoid mx.eval synchronisation issues.
-        if reused:
-            sc.reset_slot(slot)
-            self._gdn_free_slots.pop()
+        for _, slot, reused in planned_new:
+            if reused:
+                sc.reset_slot(slot)
 
-        self._gdn_req_to_slot[req_id] = slot
-        return slot
+        for req_id, slot, _ in planned_new:
+            self._gdn_req_to_slot[req_id] = slot
+        self._gdn_free_slots = free_slots
+        return assigned_slots
 
     def _gdn_materialize_state_cache(self) -> None:
         """Detach GDN state arrays from the lazy graph to prevent growth."""
@@ -942,13 +975,10 @@ class MetalModelRunner:
             if self.is_hybrid:
                 ctx = get_context()
                 if ctx is not None:
-                    gdn_slots = []
-                    # Decode requests come first, then prefill
-                    for req_id, _ in decode_reqs:
-                        gdn_slots.append(self._gdn_alloc_slot(req_id))
-                    for pr in prefill_reqs:
-                        gdn_slots.append(self._gdn_alloc_slot(pr.req_id))
-                    ctx.gdn_slot_mapping = gdn_slots
+                    # Decode requests come first, then prefill.
+                    gdn_req_ids = [req_id for req_id, _ in decode_reqs]
+                    gdn_req_ids.extend(pr.req_id for pr in prefill_reqs)
+                    ctx.gdn_slot_mapping = self._gdn_assign_slots_for_step(gdn_req_ids)
 
             # ---- forward (lazy graph + async submit) ----
             offset_caches = [OffsetCache(0) for _ in range(self.num_layers)]


### PR DESCRIPTION
Hybrid Qwen3.5 models eagerly allocate GDN recurrent state for `max_num_seqs` during paged-attention startup. On memory-constrained Apple Silicon, this can consume several GB before serving any request.

`HybridPagedAttentionBackend.initialize()` created `GDNPagedStateCache` with full `max_num_seqs` rows, and the paged cache planner treated that full GDN state as startup-reserved memory.
Fixes #400