### PR TITLE
[CI] make the release more informative

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vllm-metal"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "High-performance Rust extension for vLLM Metal"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 - macOS on Apple Silicon
 - Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
+- Up-to-date Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM from source and builds the Metal extension on first run, both via `clang++`; an outdated toolchain fails to compile.
 
 ## Supported Models
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,6 +4,9 @@
 
 - macOS on Apple Silicon
 - Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
+- Up-to-date Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM from source and builds the Metal extension on first run, both via `clang++`; an outdated toolchain fails to compile. If a build fails on an existing install, update to the latest.
+
+`uv` is bootstrapped automatically; the Rust toolchain is only needed for the optional [Rust frontend](rust_frontend.md).
 
 Verify the Python architecture before installing:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "vllm-metal"
-version = "0.2.0"
+version = "0.3.0"
 description = "vLLM hardware plugin for Apple Silicon - unifies MLX and PyTorch under a single lowering path"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,24 +11,28 @@ main() {
 
   setup_dev_env
 
-  local version
-  version=$(get_version)
+  local base_version version
+  base_version=$(get_version)
+  # Per-commit dev version, e.g. 0.3.0.dev20260603184500 — unique and PEP 440.
+  version="${base_version}.dev$(date -u +%Y%m%d%H%M%S)"
   echo "Building version: $version"
+
+  # Stamp the build version into pyproject.toml so the wheel carries it. maturin
+  # reads [project].version and does not consult Cargo.toml when version is not
+  # dynamic. The runner checkout is ephemeral, so the committed file is untouched.
+  sed -i '' -E "s/^version = .*/version = \"${version}\"/" pyproject.toml
 
   section "Building wheel"
   uv build
 
   local tag
-  tag="v${version}-$(date +%Y%m%d-%H%M%S)"
+  tag="v${version}"
   echo "Generated tag: $tag"
-
-  local commit_sha
-  commit_sha="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 
   section "Creating GitHub release"
   gh release create "$tag" \
-    --title "Release $tag" \
-    --notes "Automated release for commit $commit_sha" \
+    --title "$tag" \
+    --generate-notes \
     dist/*.whl
 }
 

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -8,8 +8,12 @@ primary compute backend, with PyTorch for model loading and interoperability.
 import logging
 import os
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = "0.2.0"
+try:
+    __version__ = version("vllm-metal")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION

## Problem
Every release builds as `0.2.0` (static in pyproject), so builds are indistinguishable — `pip show`/`pip -U` can't compare them, and bug reports can't pin a build (#413's reporter identified theirs by release date). Notes are a static "Automated release for commit <sha>" string.

## Changes
- `release.sh`: derive a unique `X.Y.Z.dev<UTC-ts>` from the pyproject base,   stamp it into pyproject in the runner checkout only (committed file untouched;   maturin reads `[project].version` and ignores Cargo.toml when version isn't   dynamic), tag = version, switch to `--generate-notes`. Drop unused `commit_sha`. 
- `pyproject.toml`: bump base `0.2.0 → 0.3.0` (0.2.0 shipped; dev builds lead   toward the next version).
- docs: add up-to-date **Xcode Command Line Tools** to Requirements — the   installer compiles vLLM from source and the Metal extension JIT-builds on   first run, both via `clang++` (follow-up to #413/#414).

## Result
Each push → `vllm_metal-0.3.0.dev<ts>-…whl`, release `v0.3.0.dev<ts>` with auto notes. Installer unchanged (still serves newest release).

## Not in this PR (manual milestone notes)
`gh release create v0.3.0 --generate-notes --notes-start-tag <prev-milestone>`, then bump the pyproject base so nightlies resume above it.

