### PR TITLE
Add opt-in native MLX random sampling for no-logprobs decode

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Metal sampling with vLLM Sampler integration."""
 
+from types import SimpleNamespace
+
 import mlx.core as mx
 import numpy as np
 import pytest
@@ -11,8 +13,9 @@ from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor
 from vllm.v1.outputs import LogprobsLists
-from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch
 from vllm.v1.sample.sampler import Sampler
 
 from tests.stub_runner import make_stub_runner
@@ -23,7 +26,15 @@ from vllm_metal.v1.model_runner import (
     _create_request_generator,
     _ExecutionBatch,
 )
-from vllm_metal.v1.sampling_batch import SamplingBatch, sample_from_logits
+from vllm_metal.v1.sampling_batch import (
+    SamplingBatch,
+    _mlx_apply_min_p,
+    _mlx_apply_top_k_top_p,
+    _mlx_top_k_subset_sample,
+    sample_decode_tokens,
+    sample_from_logits,
+    sample_prefill_tokens,
+)
 
 VOCAB_SIZE = 1024
 MAX_NUM_PROMPT_TOKENS = 64
@@ -304,14 +315,105 @@ class TestV1SeededSamplingGenerator:
 
 class TestV1SamplingBatch:
     @staticmethod
-    def _batch(params_list: list[SamplingParams]) -> SamplingBatch:
+    def _batch(
+        params_list: list[SamplingParams],
+        *,
+        enable_native_random_sampling: bool = False,
+        generators: dict[int, torch.Generator] | None = None,
+        logitsprocs: LogitsProcessors | None = None,
+    ) -> SamplingBatch:
         return SamplingBatch(
             params_list,
             [[1]] * len(params_list),
             [[]] * len(params_list),
             vocab_size=VOCAB_SIZE,
             device=torch.device("cpu"),
+            logitsprocs=logitsprocs,
+            generators=generators,
+            enable_native_random_sampling=enable_native_random_sampling,
         )
+
+    @staticmethod
+    def _default_logitsprocs() -> LogitsProcessors:
+        config = SimpleNamespace(
+            reasoning_config=None,
+            speculative_config=None,
+            scheduler_config=SimpleNamespace(max_num_seqs=8),
+        )
+        return build_logitsprocs(
+            config,
+            torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+        )
+
+    @staticmethod
+    def _forbid_torch_bridge(monkeypatch: pytest.MonkeyPatch) -> None:
+        def fail_bridge(*args, **kwargs):  # noqa: ANN002, ANN003
+            raise AssertionError("native MLX sampling should not call mlx_to_torch")
+
+        monkeypatch.setattr("vllm_metal.v1.sampling_batch.mlx_to_torch", fail_bridge)
+
+    @staticmethod
+    def _spy_torch_bridge(monkeypatch: pytest.MonkeyPatch) -> list[bool]:
+        calls = []
+
+        from vllm_metal.v1 import sampling_batch as sampling_batch_module
+
+        original_bridge = sampling_batch_module.mlx_to_torch
+
+        def wrapped_bridge(*args, **kwargs):  # noqa: ANN002, ANN003
+            calls.append(True)
+            return original_bridge(*args, **kwargs)
+
+        monkeypatch.setattr(sampling_batch_module, "mlx_to_torch", wrapped_bridge)
+        return calls
+
+    @staticmethod
+    def _finite_token_ids(row: np.ndarray) -> set[int]:
+        return {int(token_id) for token_id in np.flatnonzero(np.isfinite(row))}
+
+    @staticmethod
+    def _torch_reference_candidate_sets(
+        logits: torch.Tensor,
+        params_list: list[SamplingParams],
+    ) -> list[set[int]]:
+        vocab_size = logits.shape[-1]
+        filtered = logits.to(torch.float32).clone()
+        temperatures = torch.tensor(
+            [sp.temperature if sp.temperature >= 1e-5 else 1.0 for sp in params_list],
+            dtype=torch.float32,
+        )
+        filtered.div_(temperatures.unsqueeze(1))
+
+        min_p = torch.tensor(
+            [sp.min_p for sp in params_list],
+            dtype=torch.float32,
+        ).unsqueeze(1)
+        if torch.any(min_p > 1e-5):
+            probabilities = torch.nn.functional.softmax(filtered, dim=-1)
+            max_probabilities = torch.amax(probabilities, dim=-1, keepdim=True)
+            filtered.masked_fill_(
+                probabilities < max_probabilities * min_p, -float("inf")
+            )
+
+        top_k_values = [
+            vocab_size if sp.top_k <= 0 or sp.top_k >= vocab_size else sp.top_k
+            for sp in params_list
+        ]
+        top_p_values = [sp.top_p for sp in params_list]
+        top_k = None
+        top_p = None
+        if any(top_k != vocab_size for top_k in top_k_values):
+            top_k = torch.tensor(top_k_values, dtype=torch.int32)
+        if any(top_p_value != 1.0 for top_p_value in top_p_values):
+            top_p = torch.tensor(top_p_values, dtype=torch.float32)
+
+        filtered = apply_top_k_top_p_pytorch(filtered, top_k, top_p)
+        return [
+            {int(token_id) for token_id in torch.nonzero(torch.isfinite(row)).view(-1)}
+            for row in filtered
+        ]
 
     def test_can_use_native_greedy_requires_greedy_without_filters(self) -> None:
         assert self._batch([SamplingParams(temperature=0.0)]).can_use_native_greedy()
@@ -404,6 +506,368 @@ class TestV1SamplingBatch:
         assert not self._batch(
             [SamplingParams(temperature=0.0), SamplingParams(temperature=0.8, top_k=4)]
         ).can_use_native_greedy()
+
+    def test_native_random_requires_decode_flag_and_safe_params(self) -> None:
+        safe = [SamplingParams(temperature=0.8, top_p=0.9, top_k=4, min_p=0.05)]
+        assert not self._batch(safe).can_use_native_random()
+        assert self._batch(
+            safe, enable_native_random_sampling=True
+        ).can_use_native_random()
+
+        assert not self._batch(
+            [SamplingParams(temperature=0.8, logprobs=1)],
+            enable_native_random_sampling=True,
+        ).can_use_native_random()
+        assert not self._batch(
+            [SamplingParams(temperature=0.8, presence_penalty=0.5)],
+            enable_native_random_sampling=True,
+        ).can_use_native_random()
+        assert not self._batch(
+            [SamplingParams(temperature=0.8, allowed_token_ids=[1, 2])],
+            enable_native_random_sampling=True,
+        ).can_use_native_random()
+        assert not self._batch(
+            [SamplingParams(temperature=0.8, min_tokens=1)],
+            enable_native_random_sampling=True,
+            logitsprocs=self._default_logitsprocs(),
+        ).can_use_native_random()
+
+        bad_sp = SamplingParams(temperature=0.8)
+        bad_sp._bad_words_token_ids = [[99]]
+        assert not self._batch(
+            [bad_sp],
+            enable_native_random_sampling=True,
+        ).can_use_native_random()
+        assert not self._batch(
+            [SamplingParams(temperature=0.8, seed=1)],
+            enable_native_random_sampling=True,
+            generators={0: torch.Generator().manual_seed(1)},
+        ).can_use_native_random()
+
+    def test_native_random_rejects_custom_logits_processor(self) -> None:
+        class ArgmaxInvariantProcessor:
+            def is_argmax_invariant(self) -> bool:
+                return True
+
+            def apply(self, logits):  # noqa: ANN001
+                return logits
+
+        assert not self._batch(
+            [SamplingParams(temperature=0.8)],
+            enable_native_random_sampling=True,
+            logitsprocs=LogitsProcessors([ArgmaxInvariantProcessor()]),
+        ).can_use_native_random()
+
+    def test_native_random_filter_masks_match_torch_reference(self) -> None:
+        params_list = [
+            SamplingParams(temperature=0.8, top_k=4, top_p=0.9, min_p=0.03),
+            SamplingParams(temperature=1.2, top_k=3, top_p=0.75, min_p=0.1),
+            SamplingParams(temperature=0.7, top_k=0, top_p=0.8, min_p=0.05),
+        ]
+        torch_logits = torch.tensor(
+            [
+                [4.0, 3.0, 2.0, 1.0, 0.0, -1.0],
+                [0.0, 2.0, 4.0, 3.0, 1.0, -1.0],
+                [5.0, 4.0, 3.0, 2.0, 1.0, 0.0],
+            ],
+            dtype=torch.float32,
+        )
+        batch = SamplingBatch(
+            params_list,
+            [[1], [2], [3]],
+            [[], [], []],
+            vocab_size=6,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+        temperatures = mx.array(
+            [sp.temperature for sp in params_list],
+            dtype=mx.float32,
+        )[:, None]
+        mlx_logits = mx.array(torch_logits.numpy(), dtype=mx.float32) / temperatures
+        mlx_filtered = _mlx_apply_top_k_top_p(
+            _mlx_apply_min_p(mlx_logits, batch), batch
+        )
+
+        assert [
+            self._finite_token_ids(row) for row in np.array(mlx_filtered)
+        ] == self._torch_reference_candidate_sets(torch_logits, params_list)
+
+    def test_native_random_allows_inactive_builtin_logits_processors(self) -> None:
+        logitsprocs = self._default_logitsprocs()
+        processor_names = [type(p).__name__ for p in logitsprocs.non_argmax_invariant]
+        assert "MinTokensLogitsProcessor" in processor_names
+        assert "LogitBiasLogitsProcessor" in processor_names
+        assert self._batch(
+            [SamplingParams(temperature=0.8, top_p=0.9, top_k=4, min_p=0.05)],
+            enable_native_random_sampling=True,
+            logitsprocs=logitsprocs,
+        ).can_use_native_random()
+
+    def test_direct_sample_from_logits_keeps_random_torch_fallback_by_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = self._spy_torch_bridge(monkeypatch)
+
+        result = sample_from_logits(
+            mx.array([[4.0, 1.0, 0.0]], dtype=mx.float32),
+            self._batch([SamplingParams(temperature=0.8, top_k=1)]),
+            Sampler(),
+            torch.device("cpu"),
+        )
+
+        assert result.token_ids == [0]
+        assert calls
+
+    def test_all_greedy_but_processor_forces_torch_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = self._spy_torch_bridge(monkeypatch)
+
+        class NoOpNotArgmaxInvariantProcessor:
+            def is_argmax_invariant(self) -> bool:
+                return False
+
+            def apply(self, logits):  # noqa: ANN001
+                return logits
+
+        result = sample_from_logits(
+            mx.array([[4.0, 1.0, 0.0]], dtype=mx.float32),
+            self._batch(
+                [SamplingParams(temperature=0.0)],
+                logitsprocs=LogitsProcessors([NoOpNotArgmaxInvariantProcessor()]),
+            ),
+            Sampler(),
+            torch.device("cpu"),
+        )
+
+        assert result.token_ids == [0]
+        assert calls
+
+    def test_native_random_combined_filters_candidate_set_no_torch_bridge(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._forbid_torch_bridge(monkeypatch)
+        logits = mx.array(
+            [[5.0, 4.0, 0.0, -1.0], [0.0, -1.0, 5.0, 4.0]],
+            dtype=mx.float32,
+        )
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.8, top_k=3, top_p=0.9, min_p=0.05),
+                SamplingParams(temperature=0.8, top_k=2, top_p=0.8, min_p=0.05),
+            ],
+            [[1], [2]],
+            [[], []],
+            vocab_size=4,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+
+        for _ in range(10):
+            result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+            assert len(result.token_ids) == 2
+            assert all(isinstance(token_id, int) for token_id in result.token_ids)
+            assert result.token_ids[0] in {0, 1}
+            assert result.token_ids[1] in {2, 3}
+            assert result.logprobs is None
+
+    def test_native_random_top_k_subset_preserves_boundary_ties(self) -> None:
+        logits = mx.array([[0.0, 0.0, 0.0, -100.0]], dtype=mx.float32)
+
+        assert _mlx_top_k_subset_sample(logits, [2], [1.0]) is None
+
+        batch = SamplingBatch(
+            [SamplingParams(temperature=1.0, top_k=2)],
+            [[1]],
+            [[]],
+            vocab_size=4,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+        mlx_filtered = _mlx_apply_top_k_top_p(logits, batch)
+
+        assert self._finite_token_ids(np.array(mlx_filtered)[0]) == {0, 1, 2}
+
+    def test_native_random_keeps_mixed_greedy_rows_greedy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        self._forbid_torch_bridge(monkeypatch)
+        logits = mx.array(
+            [[0.0, 7.0, 6.0, 1.0], [10.0, 9.0, 0.0, -1.0]],
+            dtype=mx.float32,
+        )
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0),
+                SamplingParams(temperature=0.8, top_k=2),
+            ],
+            [[1], [2]],
+            [[], []],
+            vocab_size=4,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+
+        for _ in range(20):
+            result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+            assert result.token_ids[0] == 1
+            assert result.token_ids[1] in {0, 1}
+
+    def test_native_random_falls_back_for_logprobs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = self._spy_torch_bridge(monkeypatch)
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.8, top_k=1, logprobs=1)],
+            [[1]],
+            [[]],
+            vocab_size=4,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+
+        result = sample_from_logits(
+            mx.array([[5.0, 1.0, 0.0, -1.0]], dtype=mx.float32),
+            batch,
+            Sampler(),
+            torch.device("cpu"),
+        )
+
+        assert result.token_ids == [0]
+        assert result.logprobs is not None
+        assert calls
+
+    def test_native_random_falls_back_for_mixed_penalty_batch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = self._spy_torch_bridge(monkeypatch)
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.8, top_k=1, presence_penalty=1.0),
+                SamplingParams(temperature=0.8, top_k=1),
+            ],
+            [[1], [2]],
+            [[], []],
+            vocab_size=4,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+
+        result = sample_from_logits(
+            mx.array([[5.0, 1.0, 0.0, -1.0], [0.0, 1.0, 2.0, 5.0]], dtype=mx.float32),
+            batch,
+            Sampler(),
+            torch.device("cpu"),
+        )
+
+        assert result.token_ids == [0, 3]
+        assert calls
+
+    def test_native_random_falls_back_for_seeded_sampling_params(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = self._spy_torch_bridge(monkeypatch)
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.8, top_k=2, seed=123)],
+            [[1]],
+            [[]],
+            vocab_size=4,
+            device=torch.device("cpu"),
+            enable_native_random_sampling=True,
+        )
+
+        result = sample_from_logits(
+            mx.array([[5.0, 1.0, 0.0, -1.0]], dtype=mx.float32),
+            batch,
+            Sampler(),
+            torch.device("cpu"),
+        )
+
+        assert result.token_ids == [0]
+        assert calls
+
+    def test_sample_decode_tokens_enables_native_random_for_paged_decode(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_NATIVE_RANDOM_SAMPLING", "1")
+        self._forbid_torch_bridge(monkeypatch)
+        logits = mx.array(
+            [[[10.0, 9.0, 0.0, -1.0], [0.0, 1.0, 2.0, 3.0]]],
+            dtype=mx.float32,
+        )
+        decode_reqs = [
+            (
+                "r1",
+                SimpleNamespace(
+                    sampling_params=SamplingParams(temperature=0.8, top_k=2),
+                    token_ids=[11],
+                    prompt_len=1,
+                    generator=None,
+                ),
+            ),
+            (
+                "r2",
+                SimpleNamespace(
+                    sampling_params=SamplingParams(temperature=0.8, top_k=1),
+                    token_ids=[12],
+                    prompt_len=1,
+                    generator=None,
+                ),
+            ),
+        ]
+
+        result = sample_decode_tokens(
+            logits,
+            decode_reqs,
+            num_decode=2,
+            sampler=Sampler(),
+            device=torch.device("cpu"),
+            vocab_size=4,
+            logitsprocs=self._default_logitsprocs(),
+        )
+
+        assert result.token_ids[0] in {0, 1}
+        assert result.token_ids[1] == 3
+        assert result.logprobs is None
+
+    def test_sample_prefill_tokens_keeps_random_torch_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = self._spy_torch_bridge(monkeypatch)
+        logits = mx.array([[[10.0, 9.0, 0.0, -1.0]]], dtype=mx.float32)
+        prefill_reqs = [
+            SimpleNamespace(
+                sampling_params=SamplingParams(temperature=0.8, top_k=1),
+                token_ids=[11],
+                prompt_len=1,
+                full_prompt_token_ids=None,
+                generator=None,
+            )
+        ]
+
+        result = sample_prefill_tokens(
+            logits,
+            prefill_reqs,
+            cu_seqlens=[0, 1],
+            num_decode=0,
+            sampler=Sampler(),
+            device=torch.device("cpu"),
+            vocab_size=4,
+            logitsprocs=self._default_logitsprocs(),
+        )
+
+        assert result.token_ids == [0]
+        assert calls
 
     def test_sampling_metadata_skips_penalty_allocation_when_no_penalties(
         self,

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
     VLLM_METAL_GDN_LAZY_KERNELS: bool = True
     VLLM_METAL_MLA_KERNEL: bool = False
+    VLLM_METAL_NATIVE_RANDOM_SAMPLING: bool = False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
@@ -76,6 +77,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # qk_rope_head_dim=64, block_size ∈ {16, 32}, fp16/bf16,
     # decode-only).
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
+    # Native MLX no-logprobs random sampling for the paged decode path.
+    # Experimental opt-in until end-to-end throughput gains are stable.
+    "VLLM_METAL_NATIVE_RANDOM_SAMPLING": lambda: (
+        os.getenv("VLLM_METAL_NATIVE_RANDOM_SAMPLING", "0") == "1"
+    ),
 }
 
 

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -13,10 +13,16 @@ import torch
 from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.outputs import LogprobsLists
-from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor import (
+    LogitBiasLogitsProcessor,
+    LogitsProcessors,
+    MinPLogitsProcessor,
+    MinTokensLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
+import vllm_metal.envs as envs
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 
 GREEDY_TEMPERATURE_EPS = 1e-5
@@ -53,6 +59,7 @@ class SamplingBatch:
         device: torch.device,
         logitsprocs: LogitsProcessors | None = None,
         generators: dict[int, torch.Generator] | None = None,
+        enable_native_random_sampling: bool = False,
     ) -> None:
         batch_size = len(sampling_params_list)
         if len(prompt_token_id_lists) != batch_size:
@@ -75,6 +82,7 @@ class SamplingBatch:
         self.device = device
         self.logitsprocs = logitsprocs or LogitsProcessors()
         self.generators = {} if generators is None else generators
+        self.enable_native_random_sampling = enable_native_random_sampling
         self.all_greedy = all(
             sampling_params.temperature < GREEDY_TEMPERATURE_EPS
             for sampling_params in self.sampling_params_list
@@ -178,6 +186,44 @@ class SamplingBatch:
             and sampling_params.logprobs is None
             and not sampling_params.allowed_token_ids
             and not sampling_params.bad_words_token_ids
+            for sampling_params in self.sampling_params_list
+        )
+
+    def can_use_native_random(self) -> bool:
+        """Return whether MLX categorical sampling covers this batch exactly."""
+        if not self.enable_native_random_sampling:
+            return False
+        if self.needs_logprobs or self.generators:
+            return False
+        if any(
+            not isinstance(processor, MinPLogitsProcessor)
+            for processor in self.logitsprocs.argmax_invariant
+        ):
+            return False
+        for processor in self.logitsprocs.non_argmax_invariant:
+            if isinstance(processor, MinTokensLogitsProcessor):
+                if getattr(processor, "min_toks", None):
+                    return False
+                continue
+            if isinstance(processor, LogitBiasLogitsProcessor):
+                if getattr(processor, "biases", None):
+                    return False
+                continue
+            return False
+
+        return any(
+            sampling_params.temperature >= GREEDY_TEMPERATURE_EPS
+            for sampling_params in self.sampling_params_list
+        ) and all(
+            sampling_params.frequency_penalty == 0.0
+            and sampling_params.presence_penalty == 0.0
+            and sampling_params.repetition_penalty == 1.0
+            and sampling_params.logprobs is None
+            and sampling_params.seed is None
+            and not sampling_params.allowed_token_ids
+            and not sampling_params.bad_words_token_ids
+            and getattr(sampling_params, "min_tokens", 0) == 0
+            and not getattr(sampling_params, "logit_bias", None)
             for sampling_params in self.sampling_params_list
         )
 
@@ -333,6 +379,154 @@ def _mlx_greedy_sample(logits: mx.array) -> mx.array:
     return mx.argmax(logits, axis=-1)
 
 
+def _mlx_apply_min_p(logits: mx.array, batch: SamplingBatch) -> mx.array:
+    min_p_values = [
+        sampling_params.min_p for sampling_params in batch.sampling_params_list
+    ]
+    if all(min_p <= GREEDY_TEMPERATURE_EPS for min_p in min_p_values):
+        return logits
+
+    probabilities = mx.softmax(logits, axis=-1)
+    max_probabilities = mx.max(probabilities, axis=-1, keepdims=True)
+    adjusted_min_p = (
+        max_probabilities * mx.array(min_p_values, dtype=mx.float32)[:, None]
+    )
+    return mx.where(probabilities < adjusted_min_p, -float("inf"), logits)
+
+
+def _mlx_apply_top_p_to_logits(
+    logits: mx.array,
+    top_p_values: Sequence[float],
+) -> mx.array:
+    vocab_size = logits.shape[-1]
+    sorted_indices = mx.argsort(logits, axis=-1)
+    sorted_logits = mx.sort(logits, axis=-1)
+    sorted_probs = mx.softmax(sorted_logits, axis=-1)
+    sorted_probs_sum = mx.cumsum(sorted_probs, axis=-1)
+    top_p = mx.array(top_p_values, dtype=mx.float32)[:, None]
+    # Match vLLM's ascending-sort implementation: drop the low-probability
+    # tail whose cumulative mass is <= 1 - top_p, always keeping the max token.
+    top_p_mask = sorted_probs_sum <= (1.0 - top_p)
+    keep_highest_token = mx.arange(vocab_size)[None, :] == (vocab_size - 1)
+    sorted_logits = mx.where(
+        mx.logical_and(top_p_mask, mx.logical_not(keep_highest_token)),
+        -float("inf"),
+        sorted_logits,
+    )
+    return mx.put_along_axis(
+        mx.zeros_like(logits),
+        sorted_indices,
+        sorted_logits,
+        axis=-1,
+    )
+
+
+def _mlx_top_k_subset_sample(
+    logits: mx.array,
+    top_k_values: Sequence[int],
+    top_p_values: Sequence[float],
+) -> mx.array | None:
+    """Sample from the top-k subset when every row uses the same active k."""
+    vocab_size = logits.shape[-1]
+    first_top_k = top_k_values[0]
+    if first_top_k <= 0 or first_top_k >= vocab_size:
+        return None
+    if any(top_k != first_top_k for top_k in top_k_values):
+        return None
+
+    top_indices = mx.argpartition(-logits, kth=first_top_k - 1, axis=-1)[
+        :, :first_top_k
+    ]
+    top_logits = mx.take_along_axis(logits, top_indices, axis=-1)
+    # vLLM top-k keeps every token tied with the kth largest logit.
+    top_k_threshold = mx.min(top_logits, axis=-1, keepdims=True)
+    candidate_counts = mx.sum(logits >= top_k_threshold, axis=-1)
+    if bool(mx.any(candidate_counts > first_top_k).item()):
+        return None
+
+    if any(top_p != 1.0 for top_p in top_p_values):
+        top_logits = _mlx_apply_top_p_to_logits(top_logits, top_p_values)
+
+    sampled_offsets = mx.random.categorical(top_logits, axis=-1)
+    return mx.take_along_axis(top_indices, sampled_offsets[:, None], axis=-1)[:, 0]
+
+
+def _mlx_apply_top_k_top_p(logits: mx.array, batch: SamplingBatch) -> mx.array:
+    vocab_size = logits.shape[-1]
+    top_k_values = [
+        vocab_size
+        if sampling_params.top_k <= 0 or sampling_params.top_k >= vocab_size
+        else sampling_params.top_k
+        for sampling_params in batch.sampling_params_list
+    ]
+    top_p_values = [
+        sampling_params.top_p for sampling_params in batch.sampling_params_list
+    ]
+    if all(top_k == vocab_size for top_k in top_k_values) and all(
+        top_p == 1.0 for top_p in top_p_values
+    ):
+        return logits
+
+    sorted_indices = mx.argsort(logits, axis=-1)
+    sorted_logits = mx.sort(logits, axis=-1)
+
+    if any(top_k != vocab_size for top_k in top_k_values):
+        top_k = mx.array(top_k_values, dtype=mx.int32)
+        threshold_indices = (vocab_size - top_k)[:, None]
+        top_k_threshold = mx.take_along_axis(sorted_logits, threshold_indices, axis=-1)
+        sorted_logits = mx.where(
+            sorted_logits < top_k_threshold,
+            -float("inf"),
+            sorted_logits,
+        )
+
+    filtered_logits = mx.put_along_axis(
+        mx.zeros_like(logits),
+        sorted_indices,
+        sorted_logits,
+        axis=-1,
+    )
+    if any(top_p != 1.0 for top_p in top_p_values):
+        filtered_logits = _mlx_apply_top_p_to_logits(filtered_logits, top_p_values)
+    return filtered_logits
+
+
+def _mlx_random_sample(logits: mx.array, batch: SamplingBatch) -> mx.array:
+    logits = logits.astype(mx.float32)
+    greedy_tokens = _mlx_greedy_sample(logits)
+
+    temperatures = mx.array(
+        [sampling_params.temperature for sampling_params in batch.sampling_params_list],
+        dtype=mx.float32,
+    )
+    safe_temperatures = mx.where(
+        temperatures < GREEDY_TEMPERATURE_EPS, 1.0, temperatures
+    )
+    logits = logits / safe_temperatures[:, None]
+    logits = _mlx_apply_min_p(logits, batch)
+
+    top_k_values = [
+        sampling_params.top_k for sampling_params in batch.sampling_params_list
+    ]
+    top_p_values = [
+        sampling_params.top_p for sampling_params in batch.sampling_params_list
+    ]
+    random_tokens = _mlx_top_k_subset_sample(
+        logits,
+        top_k_values,
+        top_p_values,
+    )
+    if random_tokens is None:
+        logits = _mlx_apply_top_k_top_p(logits, batch)
+        random_tokens = mx.random.categorical(logits, axis=-1)
+
+    return mx.where(
+        temperatures < GREEDY_TEMPERATURE_EPS,
+        greedy_tokens,
+        random_tokens,
+    )
+
+
 def sample_from_logits(
     logits_2d: mx.array,
     batch: SamplingBatch,
@@ -348,6 +542,13 @@ def sample_from_logits(
     """
     if batch.can_use_native_greedy() and not batch.needs_logprobs:
         tokens = _mlx_greedy_sample(logits_2d)
+        mx.eval(tokens)
+        if tokens.ndim == 0:
+            return _SamplingResult([int(tokens.item())])
+        return _SamplingResult(tokens.tolist())  # type: ignore[arg-type]
+
+    if batch.can_use_native_random():
+        tokens = _mlx_random_sample(logits_2d, batch)
         mx.eval(tokens)
         if tokens.ndim == 0:
             return _SamplingResult([int(tokens.item())])
@@ -415,6 +616,7 @@ def sample_decode_tokens(
         device=device,
         logitsprocs=logitsprocs,
         generators=generators,
+        enable_native_random_sampling=envs.VLLM_METAL_NATIVE_RANDOM_SAMPLING,
     )
     return sample_from_logits(decode_logits, batch, sampler, device)
 
@@ -465,6 +667,8 @@ def sample_prefill_tokens(
         )
         generators = {} if pr.generator is None else {0: pr.generator}
 
+        # This first native random slice is decode-only; prefill keeps the
+        # vLLM torch sampler until its semantics and e2e value are proven.
         batch = SamplingBatch(
             [pr.sampling_params],
             [prompt_for_meta[:prompt_len]],


### PR DESCRIPTION
Refs #343

## Summary

This PR adds a first, opt-in native MLX random sampling path for paged decode requests that do not request logprobs.

Supported in this first slice:

- temperature
- top_k
- top_p
- min_p
- categorical sampling

The existing greedy `mx.argmax` fast path is unchanged. `sample_from_logits()` remains the single sampling entry point.

## Scope

Native MLX random sampling is enabled only when `VLLM_METAL_NATIVE_RANDOM_SAMPLING=1`.

The new path conservatively falls back to the existing vLLM Torch sampler for:

- logprobs
- seeded generators / `SamplingParams.seed`
- frequency / presence / repetition penalties
- `allowed_token_ids`
- bad words
- active `min_tokens`
- active `logit_bias`
- unknown or unsupported logits processors
- prefill sampling

The env flag defaults to off because the current end-to-end benchmark does not show a stable throughput improvement.

## Correctness Notes

The MLX path applies filters in the same order as the existing sampler path:

1. temperature
2. min_p
3. top_k / top_p
4. categorical sampling

The top-k subset fast path preserves vLLM's boundary-tie semantics: if tokens are tied at the kth threshold, it falls back to the full filtering path so tied candidates are not dropped.

## Validation

Commands were run from the repository root with the project virtualenv.

```bash
.venv-vllm-metal/bin/python -m pytest tests/test_sampling.py -q
# 51 passed, 16 warnings

.venv-vllm-metal/bin/python -m pytest tests/test_sampling.py tests/test_v1_model_runner_generate.py -q
# 86 passed, 16 warnings

.venv-vllm-metal/bin/python -m pytest tests/test_paged_attention.py tests/test_grammar_bitmask.py -q
# 38 passed, 16 warnings

.venv-vllm-metal/bin/python -m pytest tests/test_register.py tests/test_config.py -q
# 21 passed, 2 warnings

.venv-vllm-metal/bin/python -m ruff check tests/test_sampling.py vllm_metal/v1/sampling_batch.py vllm_metal/envs.py
# All checks passed!

.venv-vllm-metal/bin/python -m ruff format --check tests/test_sampling.py vllm_metal/v1/sampling_batch.py vllm_metal/envs.py
# 3 files already formatted
```

## End-to-End Benchmark

This is not claimed as a performance win.

Benchmark setup:

- model: `Qwen/Qwen3-0.6B`
- revision: `c1899de289a04d12100db370d81485cdf75e47ca`
- path: paged attention
- env: `VLLM_METAL_USE_PAGED_ATTENTION=1`
- branch native env: `VLLM_METAL_NATIVE_RANDOM_SAMPLING=1`
- workload: random input 32 / output 128, 16 prompts, max concurrency 4
- sampling: `temperature=0.8`, `top_p=0.9`, `top_k=50`, `min_p=0.05`
- hardware: Apple M5, 16GB, macOS 26.4

3-run mean branch vs main:

| Metric | Result |
| --- | ---: |
| output throughput | -8.80% |
| total token throughput | -8.80% |
| mean TPOT | +16.87% |
| mean ITL | +34.95% |
| mean TTFT | +38.07% |

Given these results, the new path stays experimental and opt-in.

## Follow-up Work

Before this can be advertised as a performance improvement, the next steps are:

- profile the native path against the Torch bridge to identify whether the current cost comes from full-vocab sorting, extra MLX ops, or categorical sampling itself
- revisit the top-p pre-filter idea only if the candidate-set semantics can be kept exact
- evaluate larger-vocab and higher-concurrency decode-heavy workloads where sampler overhead is more visible
- add penalties and seeded RNG in separate PRs after their vLLM semantics are matched
- consider enabling the path by default only after a main-vs-branch end-to-end benchmark shows a stable win
