### PR TITLE
[Performance] Batch Qwen3-VL vision encoder inputs

### DIFF
--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -302,26 +302,90 @@ class TestQwen3VLMultimodalAdapterEncodeMultimodal:
         assert len(outputs) == 1
         assert outputs[0].hidden_states.shape == (4, 8)
         assert outputs[0].hidden_states.tolist() == [[0.0] * 8] * 4
-        assert outputs[0].deepstack_visual_embeds is deepstack
+        assert outputs[0].deepstack_visual_embeds is not None
+        assert outputs[0].deepstack_visual_embeds[0].tolist() == deepstack[0].tolist()
         assert len(tower.calls) == 1
 
-    def test_returns_one_output_per_feature(self) -> None:
+    def test_batches_inputs_and_slices_outputs_per_feature(self) -> None:
+        hidden = mx.concatenate(
+            [
+                mx.full((4, 8), 1.0, dtype=mx.float32),
+                mx.full((4, 8), 2.0, dtype=mx.float32),
+            ],
+            axis=0,
+        )
+        deepstack = [
+            mx.concatenate(
+                [
+                    mx.full((4, 8), 3.0, dtype=mx.float32),
+                    mx.full((4, 8), 4.0, dtype=mx.float32),
+                ],
+                axis=0,
+            )
+        ]
+        tower = _RecordingVisionTower(
+            hidden_factory=lambda _: hidden,
+            deepstack_factory=lambda _: deepstack,
+        )
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+
+        outputs = adapter.encode_multimodal(
+            [
+                _vision_feature(offset=0, pixel_rows=4),
+                _vision_feature(offset=10, pixel_rows=4),
+            ]
+        )
+
+        assert len(outputs) == 2
+        assert outputs[0].hidden_states.tolist() == [[1.0] * 8] * 4
+        assert outputs[1].hidden_states.tolist() == [[2.0] * 8] * 4
+        assert outputs[0].deepstack_visual_embeds is not None
+        assert outputs[1].deepstack_visual_embeds is not None
+        assert outputs[0].deepstack_visual_embeds[0].tolist() == [[3.0] * 8] * 4
+        assert outputs[1].deepstack_visual_embeds[0].tolist() == [[4.0] * 8] * 4
+        assert len(tower.calls) == 1
+        pixel_values, grid_thw = tower.calls[0]
+        assert pixel_values.shape == (8, 8)
+        assert grid_thw.shape == (2, 3)
+        assert grid_thw.tolist() == [
+            list(_IMAGE_GRID_THW_2X2),
+            list(_IMAGE_GRID_THW_2X2),
+        ]
+
+    def test_raises_when_batched_hidden_rows_do_not_match_features(self) -> None:
+        tower = _RecordingVisionTower(
+            hidden_factory=lambda _: mx.zeros((7, 8), dtype=mx.float32)
+        )
+        adapter = Qwen3VLMultimodalAdapter(
+            spatial_merge_size=_SPATIAL_MERGE_SIZE,
+            vision_tower=tower,
+        )
+
+        with pytest.raises(ValueError, match="expected 8"):
+            adapter.encode_multimodal(
+                [
+                    _vision_feature(offset=0),
+                    _vision_feature(offset=10),
+                ]
+            )
+
+    def test_raises_when_grid_tokens_do_not_match_placeholder_length(self) -> None:
         tower = _RecordingVisionTower()
         adapter = Qwen3VLMultimodalAdapter(
             spatial_merge_size=_SPATIAL_MERGE_SIZE,
             vision_tower=tower,
         )
-        features = [
-            _vision_feature(offset=0),
-            _vision_feature(offset=10),
-        ]
 
-        outputs = adapter.encode_multimodal(features)
-
-        assert len(outputs) == 2
-        assert outputs[0].hidden_states.tolist()[0][0] == 0.0
-        assert outputs[1].hidden_states.tolist()[0][0] == 1.0
-        assert len(tower.calls) == 2
+        with pytest.raises(ValueError, match="mm_position.get_num_embeds"):
+            adapter.encode_multimodal(
+                [
+                    _vision_feature(length=_IMAGE_TOKEN_COUNT_2X2 - 1),
+                ]
+            )
+        assert tower.calls == []
 
     def test_passes_mlx_arrays_to_vision_tower(self) -> None:
         tower = _RecordingVisionTower()

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -383,7 +383,7 @@ def test_reject_scheduled_encoder_inputs_raises_when_no_adapter() -> None:
         runner._reject_scheduled_encoder_inputs({"req-0": [0]})
 
 
-def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
+def test_run_vision_encoders_batches_uncached_features() -> None:
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
@@ -411,22 +411,6 @@ def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
     assert mx.allclose(stored.deepstack_visual_embeds[0], mx.array([[3.0, 4.0]])).item()
 
 
-def test_run_vision_encoders_skips_cached_features(fake_encode_result) -> None:
-    runner = _runner_with_encoder_cache()
-    adapter = _RecordingAdapter()
-    runner._multimodal_adapter = adapter
-    features = [_feature("image-0")]
-    assert runner.encoder_cache is not None
-    runner.encoder_cache.add_request("req-0", features)
-    cached = fake_encode_result(mx.array([[7.0]]))
-    runner.encoder_cache.encoder_outputs["image-0"] = cached
-
-    runner._run_vision_encoders({"req-0": [0]})
-
-    assert adapter.encode_calls == []
-    assert runner.encoder_cache.encoder_outputs["image-0"] is cached
-
-
 def test_run_vision_encoders_iterates_multiple_requests_and_indices() -> None:
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
@@ -439,10 +423,49 @@ def test_run_vision_encoders_iterates_multiple_requests_and_indices() -> None:
 
     runner._run_vision_encoders({"req-0": [0, 1], "req-1": [0]})
 
-    assert len(adapter.encode_calls) == 3
-    encoded_identifiers = [call[0].identifier for call in adapter.encode_calls]
+    assert len(adapter.encode_calls) == 1
+    encoded_identifiers = [feature.identifier for feature in adapter.encode_calls[0]]
     assert encoded_identifiers == ["img-a", "img-b", "img-c"]
     assert set(runner.encoder_cache.encoder_outputs) == {"img-a", "img-b", "img-c"}
+
+
+def test_run_vision_encoders_skips_cached_and_batches_only_uncached_features(
+    fake_encode_result,
+) -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("cached-image"), _feature("fresh-image")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+    cached = fake_encode_result(mx.array([[7.0]]))
+    runner.encoder_cache.encoder_outputs["cached-image"] = cached
+
+    runner._run_vision_encoders({"req-0": [0, 1]})
+
+    assert len(adapter.encode_calls) == 1
+    assert [feature.identifier for feature in adapter.encode_calls[0]] == [
+        "fresh-image"
+    ]
+    assert runner.encoder_cache.encoder_outputs["cached-image"] is cached
+    assert "fresh-image" in runner.encoder_cache.encoder_outputs
+
+
+def test_run_vision_encoders_deduplicates_repeated_feature_identifier() -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("shared-image"), _feature("shared-image")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+
+    runner._run_vision_encoders({"req-0": [0, 1]})
+
+    assert len(adapter.encode_calls) == 1
+    assert [feature.identifier for feature in adapter.encode_calls[0]] == [
+        "shared-image"
+    ]
+    assert set(runner.encoder_cache.encoder_outputs) == {"shared-image"}
 
 
 def test_run_vision_encoders_raises_for_unregistered_request() -> None:

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -174,7 +174,7 @@ class Qwen3VLMultimodalAdapter:
         self,
         features: list[MultiModalFeatureSpec],
     ) -> list[Qwen3VLVisionEncodeResult]:
-        """Run the vision tower per feature; return one result per feature.
+        """Run the vision tower for a feature batch; return one result per feature.
 
         Calls ``vision_tower`` directly rather than ``mlx_vlm.Model.__call__``
         so the LM is not re-entered through the top-level VLM dispatch.
@@ -193,7 +193,9 @@ class Qwen3VLMultimodalAdapter:
         # fp16/bf16 weights, so we align dtypes once per encode batch.
         target_dtype = self._vision_tower.patch_embed.proj.weight.dtype
 
-        outputs: list[Qwen3VLVisionEncodeResult] = []
+        pixel_values_parts: list[mx.array] = []
+        grid_thw_parts: list[mx.array] = []
+        feature_lengths: list[int] = []
         for feature in features:
             if feature.modality != "image":
                 raise ValueError(
@@ -206,23 +208,65 @@ class Qwen3VLMultimodalAdapter:
             pixel_values = self._as_mlx(
                 self._feature_value(feature.data, "pixel_values")
             ).astype(target_dtype)
-            # vLLM delivers per-feature grid_thw as a 1D ``(3,)`` row, but
-            # the mlx_vlm vision tower indexes ``grid_thw[i, 1:]`` and reads
-            # ``grid_thw.shape[0]``; reshape back to ``(1, 3)``.
             image_grid_thw = self._as_mlx(
                 self._feature_value(feature.data, "image_grid_thw")
             ).reshape(1, 3)
+            t, h, w = self._grid_thw(feature.data, "image_grid_thw")
+            feature_length = t * h * w // (self._spatial_merge_size**2)
+            num_embeds = feature.mm_position.get_num_embeds()
+            if num_embeds != feature_length:
+                raise ValueError(
+                    "image_grid_thw implies "
+                    f"{feature_length} multimodal embeddings, got "
+                    f"mm_position.get_num_embeds()={num_embeds}"
+                )
+            feature_lengths.append(feature_length)
+            pixel_values_parts.append(pixel_values)
+            grid_thw_parts.append(image_grid_thw)
 
-            hidden_states, deepstack_visual_embeds = self._vision_tower(
-                pixel_values,
-                image_grid_thw,
+        if not pixel_values_parts:
+            return []
+
+        pixel_values_batch = mx.concatenate(pixel_values_parts, axis=0)
+        image_grid_thw_batch = mx.concatenate(grid_thw_parts, axis=0)
+
+        hidden_states, deepstack_visual_embeds = self._vision_tower(
+            pixel_values_batch,
+            image_grid_thw_batch,
+        )
+
+        expected_rows = sum(feature_lengths)
+        if int(hidden_states.shape[0]) != expected_rows:
+            raise ValueError(
+                "vision_tower returned hidden states with "
+                f"{hidden_states.shape[0]} rows, expected {expected_rows} "
+                "from image_grid_thw and spatial_merge_size."
             )
+        if deepstack_visual_embeds is not None:
+            for layer in deepstack_visual_embeds:
+                if int(layer.shape[0]) != expected_rows:
+                    raise ValueError(
+                        "vision_tower returned deepstack layer with "
+                        f"{layer.shape[0]} rows, expected {expected_rows}."
+                    )
+
+        outputs: list[Qwen3VLVisionEncodeResult] = []
+        start = 0
+        for feature_length in feature_lengths:
+            end = start + feature_length
+            feature_deepstack: Sequence[mx.array] | None = None
+            if deepstack_visual_embeds is not None:
+                feature_deepstack = tuple(
+                    layer[start:end] for layer in deepstack_visual_embeds
+                )
+
             outputs.append(
                 Qwen3VLVisionEncodeResult(
-                    hidden_states=hidden_states,
-                    deepstack_visual_embeds=deepstack_visual_embeds,
+                    hidden_states=hidden_states[start:end],
+                    deepstack_visual_embeds=feature_deepstack,
                 )
             )
+            start = end
 
         return outputs
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1460,27 +1460,21 @@ class MetalModelRunner:
         self,
         scheduled_encoder_inputs: dict[str, list[int]],
     ) -> None:
-        """Run the vision encoder for each scheduled feature, stash by identifier.
+        """Run the vision encoder for scheduled features, stash by identifier.
 
         Skips features whose ``identifier`` already lives in
         ``encoder_cache.encoder_outputs`` (cache hit; the scheduler may
-        re-list a feature across chunks).  Calls
-        ``adapter.encode_multimodal`` one feature at a time so a single bad
-        feature is reported with a precise req_id+idx rather than poisoning
-        a whole request batch.
-
-        TODO(multimodal-batching): batch scheduled features into a single
-        ``adapter.encode_multimodal`` call.  Upstream vLLM stacks pixel_values
-        and image_grid_thw across requests so the vision tower runs once per
-        step; we serialize, which inflates TTFT under concurrency (e.g.,
-        conc=8 + 384x384 measured ~3.5s p50 TTFT).  Requires per-feature
-        slicing of returned hidden_states + deepstack residuals by
-        ``grid_thw.prod()``.
+        re-list a feature across chunks).  Uncached features are batched into
+        one ``adapter.encode_multimodal`` call so the vision tower runs once per
+        scheduler step instead of once per feature.
         """
         adapter = self._multimodal_adapter
         cache = self.encoder_cache
         if adapter is None or cache is None:
             return
+
+        features_to_encode: list[MultiModalFeatureSpec] = []
+        feature_ids_to_encode: set[str] = set()
         for req_id, feature_indices in scheduled_encoder_inputs.items():
             mm_features = cache.mm_features.get(req_id)
             if mm_features is None:
@@ -1495,16 +1489,26 @@ class MetalModelRunner:
                         f"request {req_id!r} with {len(mm_features)} features."
                     )
                 feature = mm_features[idx]
-                if feature.identifier in cache.encoder_outputs:
+                if (
+                    feature.identifier in cache.encoder_outputs
+                    or feature.identifier in feature_ids_to_encode
+                ):
                     continue
-                outputs = adapter.encode_multimodal([feature])
-                if len(outputs) != 1:
-                    raise RuntimeError(
-                        f"encode_multimodal returned {len(outputs)} outputs "
-                        "for 1 feature; adapter must return one result per "
-                        "feature."
-                    )
-                cache.encoder_outputs[feature.identifier] = outputs[0]
+                features_to_encode.append(feature)
+                feature_ids_to_encode.add(feature.identifier)
+
+        if not features_to_encode:
+            return
+
+        outputs = adapter.encode_multimodal(features_to_encode)
+        if len(outputs) != len(features_to_encode):
+            raise RuntimeError(
+                f"encode_multimodal returned {len(outputs)} outputs for "
+                f"{len(features_to_encode)} features; adapter must return one "
+                "result per feature."
+            )
+        for feature, output in zip(features_to_encode, outputs, strict=True):
+            cache.encoder_outputs[feature.identifier] = output
 
     def _run_mm_paged_forward(
         self,


### PR DESCRIPTION
## Summary

Batch scheduled Qwen3-VL image features before calling the vision tower on Metal.

Before this change, `_run_vision_encoders` called `adapter.encode_multimodal(...)` once per uncached feature. Under concurrent multimodal prefill, that serialized Qwen3-VL vision encoder work across requests.

This PR batches uncached scheduled Qwen3-VL image features into one adapter call per scheduler step, then slices the hidden states and deepstack outputs back per feature.

## Changes

- Batch Qwen3-VL `pixel_values` and `image_grid_thw` in `Qwen3VLMultimodalAdapter.encode_multimodal`.
- Slice `hidden_states` and `deepstack_visual_embeds` back to one result per feature.
- Validate that `image_grid_thw` matches placeholder length before calling the vision tower.
- Validate returned hidden/deepstack row counts before caching outputs.
- Deduplicate repeated scheduled feature identifiers.
- Keep existing multimodal cache hits untouched.
- Add focused tests for batching, slicing, cache-skip behavior, repeated identifiers, and fail-fast shape checks.

## Local Benchmark

Paired A/B/A/B against `upstream/main` with `vllm serve` + `vllm bench serve`.

Environment:

- Hardware: Apple M5 MacBook Air, 16 GB unified memory
- vLLM: `0.22.0`
- mlx-vlm: `0.5.0`
- Model: `mlx-community/Qwen3-VL-4B-Instruct-4bit`
- Workload: `random-mm`, 4 prompts, max concurrency 2
- Image bucket: `{(128, 128, 1): 1.0}`
- Input/output: 32 input tokens, 1 output token
- `VLLM_METAL_MEMORY_FRACTION=0.70`
- `--max-model-len 1024`
- `--max-num-seqs 2`
- `--max-num-batched-tokens 1024`

Results:

| group | mean TTFT | TTFT std | total tok/s | tok/s std | duration |
| --- | ---: | ---: | ---: | ---: | ---: |
| main | 22.32s | 2.29s | 9.59 | 0.97 | 44.88s |
| this PR | 14.65s | 6.14s | 15.84 | 6.53 | 29.54s |
| change | -34.36% |  | +65.18% |  | -34.18% |

Per-run results:

| run | completed | total input tokens | total output tokens | duration | total tok/s | mean TTFT |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| main-a1 | 4/4 | 424 | 4 | 48.10s | 8.90 | 23.94s |
| pr-b1 | 4/4 | 424 | 4 | 38.14s | 11.22 | 18.99s |
| main-a2 | 4/4 | 424 | 4 | 41.65s | 10.28 | 20.70s |
| pr-b2 | 4/4 | 424 | 4 | 20.93s | 20.45 | 10.31s |

Because this benchmark uses `--random-output-len 1`, I am treating it as evidence for multimodal prefill / TTFT, not as a decode throughput claim. The sample is also small and has visible run-to-run variance, so broader device/workload claims should wait for maintainer cross-check.

## Benchmark Command Shape

Server:

```bash
VLLM_ENABLE_V1_MULTIPROCESSING=0 \
VLLM_METAL_USE_PAGED_ATTENTION=1 \
VLLM_METAL_MEMORY_FRACTION=0.70 \
GLOO_SOCKET_IFNAME=lo0 \
vllm serve mlx-community/Qwen3-VL-4B-Instruct-4bit \
  --host 127.0.0.1 \
  --port 8000 \
  --max-model-len 1024 \
  --max-num-seqs 2 \
  --max-num-batched-tokens 1024 \
  --generation-config vllm \
  --limit-mm-per-prompt '{"image": 1}'
```

Benchmark:

```bash
vllm bench serve \
  --backend openai-chat \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/chat/completions \
  --model mlx-community/Qwen3-VL-4B-Instruct-4bit \
  --dataset-name random-mm \
  --num-prompts 4 \
  --max-concurrency 2 \
  --request-rate inf \
  --random-input-len 32 \
  --random-output-len 1 \
  --random-mm-bucket-config '{(128, 128, 1): 1.0}' \
  --ignore-eos \
  --temperature 0 \
  --metric-percentiles 50,90,99 \
  --percentile-metrics ttft,tpot,itl,e2el \
  --save-result \
  --save-detailed
```

## Validation

```bash
python -m pytest \
  tests/multimodal/test_qwen3_vl.py \
  tests/v1/mm/test_model_runner_multimodal_cache.py \
  -q
```

Result: `72 passed`

```bash
python -m ruff check \
  vllm_metal/multimodal/qwen3_vl/adapter.py \
  vllm_metal/v1/model_runner.py \
  tests/multimodal/test_qwen3_vl.py \
  tests/v1/mm/test_model_runner_multimodal_cache.py
```

Result: passed

```bash
python -m ruff format --check \
  vllm_metal/multimodal/qwen3_vl/adapter.py \
  vllm_metal/v1/model_runner.py \
  tests/multimodal/test_qwen3_vl.py \
  tests/v1/mm/test_model_runner_multimodal_cache.py
```

Result: passed

```bash
git diff --check
```

Result: passed