### PR TITLE
[Multimodal] Add PaddleOCR-VL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 ## Supported Models
 
-vllm-metal supports a growing set of text and multimodal models on Apple Silicon. See the full matrix in [docs/supported_models.md](docs/supported_models.md).
+vllm-metal supports a growing set of models on Apple Silicon. See the full matrix in [docs/supported_models.md](docs/supported_models.md).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 ## Supported Models
 
-vllm-metal supports a growing set of text-only language models on Apple Silicon. See the full matrix in [docs/supported_models.md](docs/supported_models.md).
+vllm-metal supports a growing set of text and multimodal models on Apple Silicon. See the full matrix in [docs/supported_models.md](docs/supported_models.md).
 
 ## Installation
 

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -1,6 +1,8 @@
 # Supported Models
 
-vllm-metal currently focuses on text-only language models on Apple Silicon. Multi-modal (vision / audio input) models are not yet supported.
+vllm-metal supports text language models and a small set of native multimodal
+models on Apple Silicon. Multimodal support is currently vision-only and runs on
+the paged backend.
 
 ## Legend
 
@@ -34,6 +36,18 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | --- | --- | --- | --- |
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
+
+## Multimodal Language Models
+
+Native multimodal support currently targets vision-language requests on the
+paged backend. The first supported family is PaddleOCR-VL; it uses the
+model-level M-RoPE position policy exposed by mlx-vlm and is limited to one image
+per request until the pinned mlx-vlm dependency includes multi-image
+`get_rope_index` fixes.
+
+| Model | Support | Runner | Scope | Example checkpoint |
+| --- | --- | --- | --- | --- |
+| PaddleOCR-VL | 🔵 | native multimodal paged generation | vision input, one image per request | `PaddlePaddle/PaddleOCR-VL-1.6` |
 
 ## Text-Only Language Models
 

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -39,15 +39,12 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 
 ## Multimodal Language Models
 
-Native multimodal support currently targets vision-language requests on the
-paged backend. The first supported family is PaddleOCR-VL; it uses the
-model-level M-RoPE position policy exposed by mlx-vlm and is limited to one image
-per request until the pinned mlx-vlm dependency includes multi-image
-`get_rope_index` fixes.
+Native multimodal support currently targets image-only vision-language requests on the paged backend.
 
 | Model | Support | Runner | Scope | Example checkpoint |
 | --- | --- | --- | --- | --- |
-| PaddleOCR-VL | 🔵 | native multimodal paged generation | vision input, one image per request | `PaddlePaddle/PaddleOCR-VL-1.6` |
+| Qwen3-VL | 🔵 | native multimodal paged generation | image input, no video | `mlx-community/Qwen3-VL-4B-Instruct-4bit` |
+| PaddleOCR-VL | 🔵 | native multimodal paged generation | image input, one image per request | `PaddlePaddle/PaddleOCR-VL-1.6` |
 
 ## Text-Only Language Models
 

--- a/tests/multimodal/test_paddleocr_vl.py
+++ b/tests/multimodal/test_paddleocr_vl.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for PaddleOCR-VL multimodal helpers and adapter capabilities."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
+import pytest
+import torch
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargsItem
+
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+from vllm_metal.multimodal.paddleocr_vl import PaddleOCRVLMultimodalAdapter
+
+_SPATIAL_MERGE_SIZE = 2
+_IMAGE_GRID_THW_2X2 = (1, 4, 4)
+_IMAGE_TOKEN_COUNT_2X2 = 4
+_RAW_PATCH_COUNT_2X2 = 16
+
+
+class _RecordingLanguageModel:
+    def __init__(self, *, scalar_delta: bool = False) -> None:
+        self._scalar_delta = scalar_delta
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids + 1)
+        self.rope_calls: list[dict[str, Any]] = []
+        self.call_lm_calls: list[dict[str, Any]] = []
+
+    def get_rope_index(
+        self,
+        input_ids: mx.array,
+        image_grid_thw: mx.array | None = None,
+        video_grid_thw: mx.array | None = None,
+        attention_mask: mx.array | None = None,
+    ) -> tuple[mx.array, mx.array]:
+        self.rope_calls.append(
+            {
+                "input_ids": input_ids,
+                "image_grid_thw": image_grid_thw,
+                "video_grid_thw": video_grid_thw,
+                "attention_mask": attention_mask,
+            }
+        )
+        seq_len = input_ids.shape[1]
+        positions = mx.arange(seq_len, dtype=mx.int32)
+        positions = mx.broadcast_to(positions[None, None, :], (3, 1, seq_len))
+        if self._scalar_delta:
+            return positions, mx.array(-2, dtype=mx.int32)
+        return positions, mx.array([[-2]], dtype=mx.int32)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        *,
+        inputs_embeds: mx.array,
+        cache: list[Any],
+        position_ids: mx.array,
+    ) -> Any:
+        self.call_lm_calls.append(
+            {
+                "input_ids": input_ids,
+                "inputs_embeds": inputs_embeds,
+                "cache": cache,
+                "position_ids": position_ids,
+            }
+        )
+        return SimpleNamespace(logits=mx.zeros((1, input_ids.shape[1], 8)))
+
+
+class _RecordingVisual:
+    def __init__(self, *, weight_dtype: mx.Dtype = mx.float32) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.embeddings = SimpleNamespace(
+            patch_embedding=SimpleNamespace(weight=mx.zeros((1,), dtype=weight_dtype))
+        )
+
+    def __call__(
+        self,
+        pixel_values: mx.array,
+        image_grid_thw: mx.array,
+        *,
+        output_hidden_states: bool | None = None,
+    ) -> mx.array:
+        self.calls.append(
+            {
+                "pixel_values": pixel_values,
+                "image_grid_thw": image_grid_thw,
+                "output_hidden_states": output_hidden_states,
+            }
+        )
+        return mx.ones((_IMAGE_TOKEN_COUNT_2X2, 8), dtype=mx.float32)
+
+
+def _adapter(
+    *,
+    visual: Any | None = None,
+    language_model: Any | None = None,
+    spatial_merge_size: int = _SPATIAL_MERGE_SIZE,
+) -> PaddleOCRVLMultimodalAdapter:
+    if language_model is None:
+        language_model = _RecordingLanguageModel()
+    return PaddleOCRVLMultimodalAdapter(
+        spatial_merge_size=spatial_merge_size,
+        visual=visual,
+        language_model=language_model,
+        embed_tokens_fn=language_model.model.embed_tokens,
+    )
+
+
+def _feature(
+    *,
+    offset: int = 0,
+    length: int = _IMAGE_TOKEN_COUNT_2X2,
+    grid_thw: tuple[int, ...] = _IMAGE_GRID_THW_2X2,
+    raw_patches: int = _RAW_PATCH_COUNT_2X2,
+    modality: str = "image",
+) -> MultiModalFeatureSpec:
+    field_config = MultiModalFieldConfig.batched("image", keep_on_cpu=True)
+    grid_elem = field_config.build_elems("image_grid_thw", torch.tensor([grid_thw]))[0]
+    pixel_elem = field_config.build_elems(
+        "pixel_values",
+        torch.zeros((1, raw_patches, 3, 14, 14), dtype=torch.float32),
+    )[0]
+    data = MultiModalKwargsItem(
+        {"image_grid_thw": grid_elem, "pixel_values": pixel_elem}
+    )
+    return MultiModalFeatureSpec(
+        data=data,
+        modality=modality,
+        identifier=f"{modality}-{offset}",
+        mm_position=PlaceholderRange(offset=offset, length=length),
+    )
+
+
+class TestPaddleOCRVLMultimodalAdapterValidation:
+    def test_invalid_spatial_merge_size_raises(self) -> None:
+        with pytest.raises(ValueError, match="spatial_merge_size must be positive"):
+            PaddleOCRVLMultimodalAdapter(spatial_merge_size=0)
+
+    @pytest.mark.parametrize(
+        ("feature", "error_type", "match"),
+        [
+            pytest.param(
+                _feature(grid_thw=(1, 4), raw_patches=4),
+                ValueError,
+                "image_grid_thw must contain exactly 3",
+                id="bad-grid-shape",
+            ),
+            pytest.param(
+                _feature(length=_IMAGE_TOKEN_COUNT_2X2 - 1),
+                ValueError,
+                "image_grid_thw implies 4",
+                id="embed-count-mismatch",
+            ),
+            pytest.param(
+                _feature(modality="video"),
+                NotImplementedError,
+                "Video multimodal features",
+                id="video-out-of-scope",
+            ),
+            pytest.param(
+                _feature(modality="image_embeds"),
+                ValueError,
+                "Unsupported modality: image_embeds",
+                id="unsupported-modality",
+            ),
+        ],
+    )
+    def test_invalid_image_features_raise(
+        self,
+        feature: MultiModalFeatureSpec,
+        error_type: type[Exception],
+        match: str,
+    ) -> None:
+        with pytest.raises(error_type, match=match):
+            _adapter().get_mrope_input_positions([1, 2, 3], [feature])
+
+    def test_multiple_images_per_request_rejected(self) -> None:
+        # Guard against mlx-vlm < 0.6 multi-image position corruption; see
+        # mlx-vlm#1282.  Remove together with the adapter guard on bump.
+        features = [
+            _feature(offset=1, grid_thw=(1, 4, 4), length=4, raw_patches=16),
+            _feature(offset=8, grid_thw=(1, 6, 4), length=6, raw_patches=24),
+        ]
+
+        with pytest.raises(NotImplementedError, match="mlx-vlm#1282"):
+            _adapter().get_mrope_input_positions([1] * 12, features)
+
+
+class TestPaddleOCRVLMultimodalAdapterPositions:
+    def test_empty_positions_carry_batch_axis(self) -> None:
+        positions, delta = _adapter().get_mrope_input_positions([], [])
+
+        assert positions.shape == (3, 1, 0)
+        assert delta == 0
+
+    def test_delegates_rope_index_to_language_model(self) -> None:
+        language_model = _RecordingLanguageModel()
+        adapter = _adapter(language_model=language_model)
+        features = [_feature(offset=1, grid_thw=(1, 4, 4), length=4, raw_patches=16)]
+
+        positions, delta = adapter.get_mrope_input_positions([1] * 12, features)
+
+        assert positions.shape == (3, 1, 12)
+        assert delta == -2
+        call = language_model.rope_calls[0]
+        assert call["input_ids"].tolist() == [[1] * 12]
+        assert call["image_grid_thw"].tolist() == [[1, 4, 4]]
+        assert call["video_grid_thw"] is None
+        assert call["attention_mask"] is None
+
+    def test_accepts_scalar_rope_delta_from_real_mlx_vlm(self) -> None:
+        language_model = _RecordingLanguageModel(scalar_delta=True)
+        adapter = _adapter(language_model=language_model)
+
+        _positions, delta = adapter.get_mrope_input_positions(
+            [1] * 8,
+            [_feature(offset=1)],
+        )
+
+        assert delta == -2
+
+
+class TestPaddleOCRVLMultimodalAdapterEncodeMultimodal:
+    def test_calls_visual_tower_with_batched_pixel_values_and_grid(self) -> None:
+        visual = _RecordingVisual()
+        adapter = _adapter(visual=visual)
+        feature = _feature()
+
+        outputs = adapter.encode_multimodal([feature])
+
+        assert len(outputs) == 1
+        assert outputs[0].hidden_states.shape == (_IMAGE_TOKEN_COUNT_2X2, 8)
+        assert outputs[0].deepstack_visual_embeds is None
+        call = visual.calls[0]
+        assert call["pixel_values"].shape == (1, _RAW_PATCH_COUNT_2X2, 3, 14, 14)
+        assert call["image_grid_thw"].tolist() == [[1, 4, 4]]
+        assert call["output_hidden_states"] is False
+
+    @pytest.mark.parametrize("weight_dtype", [mx.float16, mx.bfloat16, mx.float32])
+    def test_casts_pixel_values_to_visual_weight_dtype(
+        self,
+        weight_dtype: mx.Dtype,
+    ) -> None:
+        visual = _RecordingVisual(weight_dtype=weight_dtype)
+        adapter = _adapter(visual=visual)
+
+        adapter.encode_multimodal([_feature()])
+
+        assert visual.calls[0]["pixel_values"].dtype == weight_dtype
+
+    def test_rejects_patch_count_mismatch(self) -> None:
+        adapter = _adapter(visual=_RecordingVisual())
+
+        with pytest.raises(ValueError, match="patch count does not match"):
+            adapter.encode_multimodal([_feature(raw_patches=15)])
+
+    def test_requires_visual_for_encode(self) -> None:
+        with pytest.raises(RuntimeError, match="visual tower not loaded"):
+            _adapter(visual=None).encode_multimodal([_feature()])
+
+
+class TestPaddleOCRVLMultimodalAdapterCallLm:
+    def test_call_lm_forwards_inputs_embeds_and_positions(self) -> None:
+        language_model = _RecordingLanguageModel()
+        adapter = _adapter(language_model=language_model)
+        input_ids = mx.array([[1, 2]], dtype=mx.int32)
+        inputs_embeds = mx.ones((1, 2, 8), dtype=mx.float32)
+        position_ids = mx.zeros((3, 1, 2), dtype=mx.int32)
+        cache = [object()]
+
+        output = adapter.call_lm(input_ids, inputs_embeds, cache, position_ids)
+
+        assert output.logits.shape == (1, 2, 8)
+        call = language_model.call_lm_calls[0]
+        assert call["input_ids"] is input_ids
+        assert call["inputs_embeds"] is inputs_embeds
+        assert call["cache"] is cache
+        assert call["position_ids"] is position_ids
+
+    def test_rejects_unexpected_deepstack(self) -> None:
+        adapter = _adapter()
+
+        with pytest.raises(RuntimeError, match="does not expose deepstack"):
+            adapter.call_lm(
+                mx.array([[1]], dtype=mx.int32),
+                mx.ones((1, 1, 8), dtype=mx.float32),
+                [None],
+                mx.zeros((3, 1, 1), dtype=mx.int32),
+                deepstack_visual_embeds=[mx.ones((1, 8))],
+            )
+
+
+class TestPaddleOCRVLMultimodalAdapterFromLoadedModel:
+    def test_from_loaded_model_resolves_components(self) -> None:
+        language_model = _RecordingLanguageModel()
+        visual = _RecordingVisual()
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vision_config=SimpleNamespace(spatial_merge_size=2),
+            ),
+            visual=visual,
+            language_model=language_model,
+        )
+
+        adapter = PaddleOCRVLMultimodalAdapter.from_loaded_model(model)
+
+        assert adapter.text_model() is language_model
+        input_ids = mx.array([[1]], dtype=mx.int32)
+        assert adapter.embed_tokens(input_ids).tolist() == [[2]]
+
+    def test_requires_explicit_positions(self) -> None:
+        # PaddleOCR-VL's LM derives positions from model-level state, so
+        # the runner must route text-only batches through the mm forward.
+        assert PaddleOCRVLMultimodalAdapter.requires_explicit_positions is True

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -873,3 +873,11 @@ class TestQwen3VLMultimodalAdapterEmbedTokens:
 
         with pytest.raises(RuntimeError, match="embed_tokens_fn not resolved"):
             adapter.embed_tokens(mx.array([[1]], dtype=mx.int32))
+
+
+class TestAdapterCapabilities:
+    def test_requires_explicit_positions_defaults_false(self) -> None:
+        # Qwen3-VL applies RoPE inside attention from the paged context
+        # (apply_packed_rope + ctx.offsets), so text-only batches stay on
+        # the plain text path.
+        assert Qwen3VLMultimodalAdapter.requires_explicit_positions is False

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -481,6 +481,40 @@ class TestPrepareSDPAQKV:
                 shared_kv=(shared_k, shared_v),
             )
 
+    def test_position_embeddings_path_does_not_require_rope_attribute(self) -> None:
+        # Arrange — PaddleOCR-VL precomputes ``(cos, sin)`` at the model level
+        # and passes those embeddings into ``self_attn`` positionally.
+        inner = _make_inner(with_v_proj=True)
+        del inner.rope
+        inner.rope_parameters = {"mrope_section": [1, 1, 1]}
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        cos = mx.ones((3, _BATCH, _SEQ_LEN, _HEAD_DIM), dtype=mx.float32)
+        sin = mx.zeros((3, _BATCH, _SEQ_LEN, _HEAD_DIM), dtype=mx.float32)
+        expected_q = mx.full((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM), 5.0)
+        expected_k = mx.full((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM), 7.0)
+
+        with patch.object(
+            sdpa_mod,
+            "_apply_paddleocr_position_embeddings",
+            return_value=(expected_q, expected_k),
+        ) as apply_position_embeddings:
+            queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
+                inner,
+                x,
+                ctx,
+                _N_HEADS,
+                _N_KV_HEADS,
+                position_embeddings=(cos, sin),
+            )
+
+        assert apply_position_embeddings.call_count == 1
+        assert queries is expected_q
+        assert keys is expected_k
+        assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert gate is None
+        assert kv_for_sharing == (expected_k, values)
+
 
 class TestSDPAForward:
     """Tests for ``sdpa_forward`` runtime argument propagation."""

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -481,9 +481,9 @@ class TestPrepareSDPAQKV:
                 shared_kv=(shared_k, shared_v),
             )
 
-    def test_position_embeddings_path_does_not_require_rope_attribute(self) -> None:
-        # Arrange — PaddleOCR-VL precomputes ``(cos, sin)`` at the model level
-        # and passes those embeddings into ``self_attn`` positionally.
+    def test_precomputed_rope_path_does_not_require_rope_attribute(self) -> None:
+        # Arrange — some VLMs precompute ``(cos, sin)`` at the model level
+        # and pass those embeddings into ``self_attn`` positionally.
         inner = _make_inner(with_v_proj=True)
         del inner.rope
         inner.rope_parameters = {"mrope_section": [1, 1, 1]}
@@ -496,9 +496,9 @@ class TestPrepareSDPAQKV:
 
         with patch.object(
             sdpa_mod,
-            "_apply_paddleocr_position_embeddings",
+            "apply_attention_rope",
             return_value=(expected_q, expected_k),
-        ) as apply_position_embeddings:
+        ) as apply_rope:
             queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
                 inner,
                 x,
@@ -508,7 +508,10 @@ class TestPrepareSDPAQKV:
                 position_embeddings=(cos, sin),
             )
 
-        assert apply_position_embeddings.call_count == 1
+        assert apply_rope.call_count == 1
+        position_embeddings_arg = apply_rope.call_args.kwargs["position_embeddings"]
+        assert position_embeddings_arg[0] is cos
+        assert position_embeddings_arg[1] is sin
         assert queries is expected_q
         assert keys is expected_k
         assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -8,6 +8,7 @@ import pytest
 
 import vllm_metal.envs as envs
 from vllm_metal.config import reset_config
+from vllm_metal.multimodal.paddleocr_vl import PaddleOCRVLMultimodalAdapter
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1.model_adapter import (
     DefaultModelAdapter,
@@ -460,6 +461,21 @@ class _Qwen35LanguageModelStub:
         return None
 
 
+class _PaddleOCRLanguageModelStub:
+    def __init__(self) -> None:
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids)
+
+    def __call__(
+        self,
+        inputs: object,
+        inputs_embeds: object | None = None,
+        cache: object | None = None,
+        position_ids: object | None = None,
+        mask: object | None = None,
+    ) -> None:
+        return None
+
+
 class TestBuildMultimodalAdapter:
     def test_builds_qwen35_adapter_from_loaded_vlm(self) -> None:
         vision_tower = object()
@@ -494,6 +510,39 @@ class TestBuildMultimodalAdapter:
         adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
 
         assert isinstance(adapter, Qwen3VLMultimodalAdapter)
+
+    def test_builds_paddleocr_vl_adapter_from_model_type(self) -> None:
+        language_model = _PaddleOCRLanguageModelStub()
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vision_config=SimpleNamespace(spatial_merge_size=2),
+            ),
+            visual=object(),
+            language_model=language_model,
+        )
+        hf_config = SimpleNamespace(model_type="paddleocr_vl")
+
+        adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
+
+        assert isinstance(adapter, PaddleOCRVLMultimodalAdapter)
+        assert adapter.text_model() is language_model
+
+    def test_builds_paddleocr_vl_adapter_from_architecture(self) -> None:
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                vision_config=SimpleNamespace(spatial_merge_size=2),
+            ),
+            visual=object(),
+            language_model=_PaddleOCRLanguageModelStub(),
+        )
+        hf_config = SimpleNamespace(
+            model_type="custom",
+            architectures=["PaddleOCRVLForConditionalGeneration"],
+        )
+
+        adapter = DefaultModelAdapter().build_multimodal_adapter(model, hf_config)
+
+        assert isinstance(adapter, PaddleOCRVLMultimodalAdapter)
 
     def test_generic_vlm_has_no_model_owned_adapter(self) -> None:
         model = SimpleNamespace()

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -7,6 +7,7 @@ Run with:
 
 from __future__ import annotations
 
+import mlx.core as mx
 import pytest
 
 from vllm_metal.attention.context import (
@@ -15,6 +16,7 @@ from vllm_metal.attention.context import (
     get_context,
     prepare_unified,
 )
+from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
 
 
 class TestOffsetCache:
@@ -29,6 +31,54 @@ class TestOffsetCache:
     def test_make_mask_multi_token(self):
         c = OffsetCache(0)
         assert c.make_mask(5) == "causal"
+
+
+class TestSDPAPagedAttentionWrapper:
+    def teardown_method(self):
+        clear_context()
+
+    def test_forwards_paddleocr_position_embeddings_without_context(self):
+        class _Inner:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(
+                self,
+                x,
+                mask=None,
+                cache=None,
+                position_embeddings=None,
+                **kwargs,
+            ):
+                self.calls.append(
+                    {
+                        "x": x,
+                        "mask": mask,
+                        "cache": cache,
+                        "position_embeddings": position_embeddings,
+                        "kwargs": kwargs,
+                    }
+                )
+                return x
+
+        inner = _Inner()
+        wrapper = SDPAPagedAttentionWrapper(
+            inner,
+            layer_idx=0,
+            kv_cache=object(),
+            block_size=16,
+        )
+        x = mx.ones((1, 2, 4), dtype=mx.float32)
+        position_embeddings = (
+            mx.ones((3, 1, 2, 4), dtype=mx.float32),
+            mx.zeros((3, 1, 2, 4), dtype=mx.float32),
+        )
+
+        out = wrapper(x, None, None, position_embeddings)
+
+        assert out is x
+        assert inner.calls[0]["position_embeddings"] is position_embeddings
+        assert inner.calls[0]["kwargs"] == {}
 
 
 class TestPrepare:

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -37,7 +37,7 @@ class TestSDPAPagedAttentionWrapper:
     def teardown_method(self):
         clear_context()
 
-    def test_forwards_paddleocr_position_embeddings_without_context(self):
+    def test_forwards_precomputed_rope_embeddings_without_context(self):
         class _Inner:
             def __init__(self):
                 self.calls = []
@@ -238,6 +238,57 @@ class TestPackedRoPE:
                 [0, 3],
                 positions=[mx.zeros((3, 1, 3), dtype=mx.int32)],
             )
+
+    def test_attention_rope_uses_precomputed_mrope_payload(self, monkeypatch):
+        """Precomputed M-RoPE apply policy lives in the compat layer."""
+        import sys
+        import types
+
+        import mlx.core as mx
+
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_attention_rope,
+        )
+
+        recorded: dict[str, object] = {}
+
+        def fake_apply(q, k, cos, sin, mrope_section):
+            recorded["q"] = q
+            recorded["k"] = k
+            recorded["cos"] = cos
+            recorded["sin"] = sin
+            recorded["mrope_section"] = mrope_section
+            return q + 1, k + 2
+
+        fake_mod = types.ModuleType("mlx_vlm.models.paddleocr_vl.language")
+        fake_mod.apply_multimodal_rotary_pos_emb = fake_apply
+        monkeypatch.setitem(
+            sys.modules, "mlx_vlm.models.paddleocr_vl.language", fake_mod
+        )
+
+        class FakePrecomputedMRoPE:
+            rope_parameters = {"mrope_section": [1, 1, 1]}
+
+        q = mx.zeros((1, 1, 3, 2), dtype=mx.float32)
+        k = mx.zeros((1, 1, 3, 2), dtype=mx.float32)
+        cos = mx.ones((3, 1, 3, 2), dtype=mx.float32)
+        sin = mx.zeros((3, 1, 3, 2), dtype=mx.float32)
+
+        q_out, k_out = apply_attention_rope(
+            FakePrecomputedMRoPE(),
+            q,
+            k,
+            [0, 3],
+            position_embeddings=(cos, sin),
+        )
+
+        assert recorded["q"] is q
+        assert recorded["k"] is k
+        assert recorded["cos"] is cos
+        assert recorded["sin"] is sin
+        assert recorded["mrope_section"] == [1, 1, 1]
+        assert mx.allclose(q_out, q + 1).item()
+        assert mx.allclose(k_out, k + 2).item()
 
     def test_mrope_uses_caller_positions_when_provided(self, monkeypatch):
         """When ``positions[i]`` is an array, M-RoPE consumes it directly."""

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -32,6 +32,7 @@ class _MmAdapter:
     """Fake adapter that records call_lm + supplies stable positions."""
 
     forward_ready = True
+    requires_explicit_positions = False
 
     def __init__(self, *, hidden_size: int = 4, vocab_size: int = 8) -> None:
         self.hidden_size = hidden_size
@@ -257,6 +258,110 @@ class TestMmPrefillChunkedFeatureSlicing:
                 embeds[0, chunk_local],
                 mx.full((adapter.hidden_size,), value, dtype=mx.float32),
             ).item()
+
+
+class TestTextOnlyRoutingForExplicitPositionsAdapter:
+    """``requires_explicit_positions`` adapters (PaddleOCR-VL) route
+    text-only batches through the mm forward so the LM always receives
+    runner-built position_ids instead of re-deriving them from the
+    zero-offset paged caches."""
+
+    def test_text_only_prefill_routes_through_call_lm_with_positions(self) -> None:
+        adapter = _MmAdapter()
+        adapter.requires_explicit_positions = True
+        runner = _runner(adapter)
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+        prefill = _mm_prefill(
+            "req-text",
+            token_ids=[7, 8, 9],
+            prompt_len=3,
+            start_pos=0,
+            full_prompt=[7, 8, 9],
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        assert len(adapter.call_lm_calls) == 1
+        call = adapter.call_lm_calls[0]
+        # Explicit absolute arange — not model-derived positions.
+        assert call["position_ids"].tolist() == [[[0, 1, 2]]] * 3
+        assert call["visual_pos_masks"].tolist() == [[False, False, False]]
+        assert call["deepstack_visual_embeds"] is None
+
+    def test_text_only_decode_positions_use_cache_start_pos(self) -> None:
+        adapter = _MmAdapter()
+        adapter.requires_explicit_positions = True
+        runner = _runner(adapter)
+        # Text-only request: no mrope delta stashed.
+        state = RequestState(
+            token_ids=[1, 2, 3, 4, 5, 6],
+            prompt_len=5,
+            cache=[],
+            sampling_params=SamplingParams(),
+            mrope_position_delta=None,
+        )
+        runner._request_states["req-text"] = state
+        segment = PagedDecodeSegment(
+            req_id="req-text",
+            input_token_ids=(6,),
+            start_row=0,
+            num_query_tokens=1,
+            draft_token_ids=(),
+            cache_start_pos=5,
+            block_ids=(0,),
+        )
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=(segment,)
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[],
+            decode_reqs=[("req-text", state)],
+            scheduler_output=_scheduler_output(),
+        )
+
+        call = adapter.call_lm_calls[0]
+        # Decode position = absolute cache_start_pos — exactly what the
+        # model-level re-derivation would have gotten wrong (position 0).
+        assert call["position_ids"].tolist() == [[[5]]] * 3
+
+    def test_text_only_batch_stays_on_text_path_without_flag(self) -> None:
+        adapter = _MmAdapter()  # requires_explicit_positions = False
+        runner = _runner(adapter)
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+        runner._target_forward = MagicMock(
+            return_value=MagicMock(
+                logits=mx.zeros((1, 3, adapter.vocab_size), dtype=mx.float32),
+                hidden_states=None,
+            )
+        )
+        prefill = _mm_prefill(
+            "req-text",
+            token_ids=[7, 8, 9],
+            prompt_len=3,
+            start_pos=0,
+            full_prompt=[7, 8, 9],
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        assert adapter.call_lm_calls == []
+        runner._target_forward.assert_called_once()
 
 
 class TestMmDecodeSegmentPositions:

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -8,8 +8,8 @@ transparently by the Metal paged attention kernel.
 Handles models whose attention module exposes:
 - ``q_proj``, ``k_proj``, ``o_proj`` linear projections (``v_proj`` optional —
   see K-eq-V variant below)
-- ``rope`` / ``rotary_emb`` for rotary position embeddings, or caller-provided
-  ``position_embeddings`` for PaddleOCR-VL
+- ``rope`` / ``rotary_emb`` for rotary position embeddings, or precomputed
+  ``position_embeddings`` supplied by the caller
 - ``n_heads``, ``n_kv_heads`` head counts
 - Optionally ``q_norm``, ``k_norm``, ``v_norm`` per-head RMSNorms
 
@@ -34,7 +34,7 @@ import mlx.nn as nn
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.context import PagedAttentionContext
 from vllm_metal.attention.impls.varlen_rope_compat import (
-    apply_packed_rope,
+    apply_attention_rope,
 )
 from vllm_metal.metal import get_ops
 
@@ -43,34 +43,6 @@ from vllm_metal.metal import get_ops
 # sizes only.  Sorted descending so _pick_kernel_block_size selects the
 # largest valid divisor first, minimising the block-table expansion ratio.
 _KERNEL_BLOCK_SIZES = (32, 16, 8)
-
-
-def _apply_paddleocr_position_embeddings(
-    attn_module: nn.Module,
-    queries: mx.array,
-    keys: mx.array,
-    position_embeddings: tuple[mx.array, mx.array],
-) -> tuple[mx.array, mx.array]:
-    """Apply PaddleOCR-VL's precomputed M-RoPE position embeddings."""
-    from mlx_vlm.models.paddleocr_vl.language import (
-        apply_multimodal_rotary_pos_emb,
-    )
-
-    rope_parameters = getattr(attn_module, "rope_parameters", None)
-    if rope_parameters is None or "mrope_section" not in rope_parameters:
-        raise NotImplementedError(
-            f"Attention module {type(attn_module).__name__} received "
-            "position_embeddings but does not expose rope_parameters"
-            "['mrope_section']."
-        )
-    cos, sin = position_embeddings
-    return apply_multimodal_rotary_pos_emb(
-        queries,
-        keys,
-        cos,
-        sin,
-        rope_parameters["mrope_section"],
-    )
 
 
 def _has_packed_qkv_sdpa_contract(module: nn.Module) -> bool:
@@ -283,25 +255,16 @@ def prepare_sdpa_qkv(
         if hasattr(inner, "q_norm"):
             queries = inner.q_norm(queries)
         queries = queries.transpose(0, 2, 1, 3)
-        if position_embeddings is not None:
-            queries, _ = _apply_paddleocr_position_embeddings(
-                inner, queries, keys, position_embeddings
-            )
-        else:
-            if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
-                raise NotImplementedError(
-                    f"Attention module {type(inner).__name__} does not have a "
-                    "'rope' or 'rotary_emb' attribute."
-                )
-            queries, _ = apply_packed_rope(
-                inner,
-                queries,
-                keys,
-                ctx.cu_seqlens,
-                offsets=ctx.offsets if ctx.offsets else None,
-                apply_keys=False,
-                positions=ctx.segment_positions,
-            )
+        queries, _ = apply_attention_rope(
+            inner,
+            queries,
+            keys,
+            ctx.cu_seqlens,
+            offsets=ctx.offsets if ctx.offsets else None,
+            apply_keys=False,
+            positions=ctx.segment_positions,
+            position_embeddings=position_embeddings,
+        )
     else:
         if not packed_qkv:
             keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
@@ -324,24 +287,15 @@ def prepare_sdpa_qkv(
         keys = keys.transpose(0, 2, 1, 3)
         values = values.transpose(0, 2, 1, 3)
 
-        if position_embeddings is not None:
-            queries, keys = _apply_paddleocr_position_embeddings(
-                inner, queries, keys, position_embeddings
-            )
-        elif not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
-            raise NotImplementedError(
-                f"Attention module {type(inner).__name__} does not have a "
-                "'rope' or 'rotary_emb' attribute."
-            )
-        else:
-            queries, keys = apply_packed_rope(
-                inner,
-                queries,
-                keys,
-                ctx.cu_seqlens,
-                offsets=ctx.offsets if ctx.offsets else None,
-                positions=ctx.segment_positions,
-            )
+        queries, keys = apply_attention_rope(
+            inner,
+            queries,
+            keys,
+            ctx.cu_seqlens,
+            offsets=ctx.offsets if ctx.offsets else None,
+            positions=ctx.segment_positions,
+            position_embeddings=position_embeddings,
+        )
 
     kv_for_sharing = (keys, values)
     return queries, keys, values, gate, kv_for_sharing

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -8,7 +8,8 @@ transparently by the Metal paged attention kernel.
 Handles models whose attention module exposes:
 - ``q_proj``, ``k_proj``, ``o_proj`` linear projections (``v_proj`` optional —
   see K-eq-V variant below)
-- ``rope`` or ``rotary_emb`` for rotary position embeddings
+- ``rope`` / ``rotary_emb`` for rotary position embeddings, or caller-provided
+  ``position_embeddings`` for PaddleOCR-VL
 - ``n_heads``, ``n_kv_heads`` head counts
 - Optionally ``q_norm``, ``k_norm``, ``v_norm`` per-head RMSNorms
 
@@ -42,6 +43,34 @@ from vllm_metal.metal import get_ops
 # sizes only.  Sorted descending so _pick_kernel_block_size selects the
 # largest valid divisor first, minimising the block-table expansion ratio.
 _KERNEL_BLOCK_SIZES = (32, 16, 8)
+
+
+def _apply_paddleocr_position_embeddings(
+    attn_module: nn.Module,
+    queries: mx.array,
+    keys: mx.array,
+    position_embeddings: tuple[mx.array, mx.array],
+) -> tuple[mx.array, mx.array]:
+    """Apply PaddleOCR-VL's precomputed M-RoPE position embeddings."""
+    from mlx_vlm.models.paddleocr_vl.language import (
+        apply_multimodal_rotary_pos_emb,
+    )
+
+    rope_parameters = getattr(attn_module, "rope_parameters", None)
+    if rope_parameters is None or "mrope_section" not in rope_parameters:
+        raise NotImplementedError(
+            f"Attention module {type(attn_module).__name__} received "
+            "position_embeddings but does not expose rope_parameters"
+            "['mrope_section']."
+        )
+    cos, sin = position_embeddings
+    return apply_multimodal_rotary_pos_emb(
+        queries,
+        keys,
+        cos,
+        sin,
+        rope_parameters["mrope_section"],
+    )
 
 
 def _has_packed_qkv_sdpa_contract(module: nn.Module) -> bool:
@@ -154,6 +183,7 @@ def prepare_sdpa_qkv(
     shared_kv: tuple[mx.array, mx.array] | None = None,
     *,
     read_existing_kv: bool = False,
+    position_embeddings: tuple[mx.array, mx.array] | None = None,
 ) -> tuple[mx.array, mx.array, mx.array, mx.array | None, tuple[mx.array, mx.array]]:
     """Project ``x`` into Q/K/V with norms, RoPE and Gemma4 variants.
 
@@ -253,20 +283,25 @@ def prepare_sdpa_qkv(
         if hasattr(inner, "q_norm"):
             queries = inner.q_norm(queries)
         queries = queries.transpose(0, 2, 1, 3)
-        if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
-            raise NotImplementedError(
-                f"Attention module {type(inner).__name__} does not have a "
-                "'rope' or 'rotary_emb' attribute."
+        if position_embeddings is not None:
+            queries, _ = _apply_paddleocr_position_embeddings(
+                inner, queries, keys, position_embeddings
             )
-        queries, _ = apply_packed_rope(
-            inner,
-            queries,
-            keys,
-            ctx.cu_seqlens,
-            offsets=ctx.offsets if ctx.offsets else None,
-            apply_keys=False,
-            positions=ctx.segment_positions,
-        )
+        else:
+            if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
+                raise NotImplementedError(
+                    f"Attention module {type(inner).__name__} does not have a "
+                    "'rope' or 'rotary_emb' attribute."
+                )
+            queries, _ = apply_packed_rope(
+                inner,
+                queries,
+                keys,
+                ctx.cu_seqlens,
+                offsets=ctx.offsets if ctx.offsets else None,
+                apply_keys=False,
+                positions=ctx.segment_positions,
+            )
     else:
         if not packed_qkv:
             keys = inner.k_proj(x).reshape(B, L, n_kv_heads, -1)
@@ -289,19 +324,24 @@ def prepare_sdpa_qkv(
         keys = keys.transpose(0, 2, 1, 3)
         values = values.transpose(0, 2, 1, 3)
 
-        if not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
+        if position_embeddings is not None:
+            queries, keys = _apply_paddleocr_position_embeddings(
+                inner, queries, keys, position_embeddings
+            )
+        elif not hasattr(inner, "rope") and not hasattr(inner, "rotary_emb"):
             raise NotImplementedError(
                 f"Attention module {type(inner).__name__} does not have a "
                 "'rope' or 'rotary_emb' attribute."
             )
-        queries, keys = apply_packed_rope(
-            inner,
-            queries,
-            keys,
-            ctx.cu_seqlens,
-            offsets=ctx.offsets if ctx.offsets else None,
-            positions=ctx.segment_positions,
-        )
+        else:
+            queries, keys = apply_packed_rope(
+                inner,
+                queries,
+                keys,
+                ctx.cu_seqlens,
+                offsets=ctx.offsets if ctx.offsets else None,
+                positions=ctx.segment_positions,
+            )
 
     kv_for_sharing = (keys, values)
     return queries, keys, values, gate, kv_for_sharing
@@ -405,6 +445,7 @@ def sdpa_forward(
     shared_kv: tuple[mx.array, mx.array] | None = None,
     *,
     read_existing_kv: bool = False,
+    position_embeddings: tuple[mx.array, mx.array] | None = None,
 ) -> tuple[mx.array, tuple[mx.array, mx.array]]:
     """Full SDPA forward pass: project → norm → RoPE → Metal kernel.
 
@@ -432,6 +473,7 @@ def sdpa_forward(
         n_kv_heads,
         shared_kv,
         read_existing_kv=read_existing_kv,
+        position_embeddings=position_embeddings,
     )
 
     # --- Metal kernel dispatch ---

--- a/vllm_metal/attention/impls/sdpa_wrapper.py
+++ b/vllm_metal/attention/impls/sdpa_wrapper.py
@@ -33,8 +33,8 @@ from vllm_metal.attention.patching import walk_and_wrap
 # ---------------------------------------------------------------------------
 
 
-def _is_position_embeddings(value: Any) -> bool:
-    """Return True for PaddleOCR-VL ``(cos, sin)`` position embeddings."""
+def _is_rope_embedding_pair(value: Any) -> bool:
+    """Return True for caller-precomputed RoPE ``(cos, sin)`` embeddings."""
     return (
         isinstance(value, (tuple, list))
         and len(value) == 2
@@ -103,11 +103,10 @@ class SDPAPagedAttentionWrapper(nn.Module):
         **kwargs: Any,
     ) -> Any:
         position_embeddings = kwargs.pop("position_embeddings", None)
-        if _is_position_embeddings(position_ids):
-            # PaddleOCRDecoderLayer calls
-            # ``self_attn(x, mask, cache, position_embeddings)`` positionally.
-            # Preserve that fourth argument instead of treating it as
-            # Qwen-style ``position_ids``.
+        if _is_rope_embedding_pair(position_ids):
+            # Some attention contracts pass precomputed ``(cos, sin)`` RoPE
+            # embeddings positionally as the fourth argument. Preserve that
+            # payload instead of treating it as Qwen-style ``position_ids``.
             position_embeddings = position_ids
             position_ids = None
 

--- a/vllm_metal/attention/impls/sdpa_wrapper.py
+++ b/vllm_metal/attention/impls/sdpa_wrapper.py
@@ -33,6 +33,15 @@ from vllm_metal.attention.patching import walk_and_wrap
 # ---------------------------------------------------------------------------
 
 
+def _is_position_embeddings(value: Any) -> bool:
+    """Return True for PaddleOCR-VL ``(cos, sin)`` position embeddings."""
+    return (
+        isinstance(value, (tuple, list))
+        and len(value) == 2
+        and all(isinstance(item, mx.array) for item in value)
+    )
+
+
 class SDPAPagedAttentionWrapper(nn.Module):
     """Wraps an mlx_lm Attention module to use native Metal paged KV.
 
@@ -93,9 +102,26 @@ class SDPAPagedAttentionWrapper(nn.Module):
         position_ids: mx.array | None = None,
         **kwargs: Any,
     ) -> Any:
+        position_embeddings = kwargs.pop("position_embeddings", None)
+        if _is_position_embeddings(position_ids):
+            # PaddleOCRDecoderLayer calls
+            # ``self_attn(x, mask, cache, position_embeddings)`` positionally.
+            # Preserve that fourth argument instead of treating it as
+            # Qwen-style ``position_ids``.
+            position_embeddings = position_ids
+            position_ids = None
+
         ctx = get_context()
         if ctx is None:
             # No paged context → delegate to original attention.
+            if position_embeddings is not None:
+                return self._inner(
+                    x,
+                    mask=mask,
+                    cache=cache,
+                    position_embeddings=position_embeddings,
+                    **kwargs,
+                )
             # Only pass position_ids when provided (mlx_vlm models);
             # mlx_lm models (e.g. Gemma4) use offset via **kwargs instead.
             if position_ids is not None:
@@ -119,6 +145,7 @@ class SDPAPagedAttentionWrapper(nn.Module):
             self._mk_kv_cache,
             self._mk_cache_idx,
             shared_kv=shared_kv,
+            position_embeddings=position_embeddings,
         )
 
         # YOCO models (Gemma4) expect (output, shared_kv, offset) return.

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -52,6 +52,76 @@ def _apply_mrope_segment_with_positions(
     return apply_multimodal_rotary_pos_emb(q_seg, k_seg, cos, sin)
 
 
+def apply_precomputed_mrope(
+    attn_module: object,
+    queries: mx.array,
+    keys: mx.array,
+    position_embeddings: tuple[mx.array, mx.array],
+) -> tuple[mx.array, mx.array]:
+    """Apply caller-precomputed M-RoPE ``(cos, sin)`` embeddings to Q/K.
+
+    Some VLM attention modules receive the rotary embeddings from their parent
+    language model instead of exposing a ``rope`` or ``rotary_emb`` callable on
+    the attention layer itself.  Keep that model-specific apply policy in this
+    compat module so SDPA projection/cache code can stay model-agnostic.
+    """
+    from mlx_vlm.models.paddleocr_vl.language import (
+        apply_multimodal_rotary_pos_emb,
+    )
+
+    rope_parameters = getattr(attn_module, "rope_parameters", None)
+    if rope_parameters is None or "mrope_section" not in rope_parameters:
+        raise NotImplementedError(
+            f"Attention module {type(attn_module).__name__} received "
+            "precomputed M-RoPE embeddings but does not expose "
+            "rope_parameters['mrope_section']."
+        )
+
+    cos, sin = position_embeddings
+    return apply_multimodal_rotary_pos_emb(
+        queries,
+        keys,
+        cos,
+        sin,
+        rope_parameters["mrope_section"],
+    )
+
+
+def apply_attention_rope(
+    attn_module: object,
+    queries: mx.array,
+    keys: mx.array,
+    cu_seqlens: list[int],
+    offsets: list[int] | None = None,
+    apply_keys: bool = True,
+    *,
+    positions: list[mx.array | None] | None = None,
+    position_embeddings: tuple[mx.array, mx.array] | None = None,
+) -> tuple[mx.array, mx.array]:
+    """Apply the attention module's RoPE contract to packed Q/K tensors."""
+    if position_embeddings is not None:
+        rotated_q, rotated_k = apply_precomputed_mrope(
+            attn_module, queries, keys, position_embeddings
+        )
+        return rotated_q, (rotated_k if apply_keys else keys)
+
+    if not hasattr(attn_module, "rope") and not hasattr(attn_module, "rotary_emb"):
+        raise NotImplementedError(
+            f"Attention module {type(attn_module).__name__} does not have a "
+            "'rope' or 'rotary_emb' attribute."
+        )
+
+    return apply_packed_rope(
+        attn_module,
+        queries,
+        keys,
+        cu_seqlens,
+        offsets=offsets,
+        apply_keys=apply_keys,
+        positions=positions,
+    )
+
+
 def apply_packed_rope(
     attn_module: object,
     queries: mx.array,

--- a/vllm_metal/multimodal/paddleocr_vl/__init__.py
+++ b/vllm_metal/multimodal/paddleocr_vl/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PaddleOCR-VL multimodal adapter exports."""
+
+from __future__ import annotations
+
+from vllm_metal.multimodal.paddleocr_vl.adapter import (
+    PaddleOCRVLMultimodalAdapter,
+    PaddleOCRVLVisionEncodeResult,
+)
+
+__all__ = ["PaddleOCRVLMultimodalAdapter", "PaddleOCRVLVisionEncodeResult"]

--- a/vllm_metal/multimodal/paddleocr_vl/adapter.py
+++ b/vllm_metal/multimodal/paddleocr_vl/adapter.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PaddleOCR-VL multimodal adapter for vLLM Metal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import torch
+from vllm.multimodal.inputs import MultiModalKwargsItem
+
+from vllm_metal.multimodal.feature_spec import MultiModalFeatureSpec
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
+
+
+@dataclass(frozen=True)
+class PaddleOCRVLVisionEncodeResult:
+    """Vision tower output for one PaddleOCR-VL multimodal feature."""
+
+    hidden_states: mx.array
+    deepstack_visual_embeds: None = None
+
+
+class PaddleOCRVLMultimodalAdapter:
+    """Model-owned multimodal helpers for PaddleOCR-VL execution."""
+
+    forward_ready: bool = True
+
+    requires_explicit_positions: bool = True
+    """The LM precomputes (cos, sin) from model-level position state; the
+    paged text path would re-derive positions from zero-offset caches
+    (arange from 0), so every batch — text-only included — must carry
+    runner-built ``position_ids`` via the multimodal forward."""
+
+    def __init__(
+        self,
+        *,
+        spatial_merge_size: int,
+        visual: Any | None = None,
+        language_model: Any | None = None,
+        embed_tokens_fn: Any | None = None,
+    ) -> None:
+        if spatial_merge_size <= 0:
+            raise ValueError(
+                f"spatial_merge_size must be positive, got {spatial_merge_size}"
+            )
+        self._spatial_merge_size = spatial_merge_size
+        self._visual = visual
+        self._language_model = language_model
+        self._embed_tokens_fn = embed_tokens_fn
+
+    @classmethod
+    def from_loaded_model(cls, model: Any) -> PaddleOCRVLMultimodalAdapter:
+        """Create an adapter from an mlx-vlm PaddleOCR-VL composite."""
+        visual = model.visual
+        language_model = model.language_model
+        spatial_merge_size = int(model.config.vision_config.spatial_merge_size)
+        embed_tokens_fn = cls._resolve_embed_tokens(language_model)
+        return cls(
+            spatial_merge_size=spatial_merge_size,
+            visual=visual,
+            language_model=language_model,
+            embed_tokens_fn=embed_tokens_fn,
+        )
+
+    @staticmethod
+    def _resolve_embed_tokens(language_model: Any) -> Any:
+        inner = getattr(language_model, "model", None)
+        if inner is None:
+            raise RuntimeError(
+                "language_model.model attribute missing; mlx_vlm version "
+                "drift detected. Expected the PaddleOCR text backbone."
+            )
+        embed_tokens = getattr(inner, "embed_tokens", None)
+        if embed_tokens is None or not callable(embed_tokens):
+            raise RuntimeError(
+                "language_model.model.embed_tokens missing or not callable; "
+                "mlx_vlm version drift detected."
+            )
+        return embed_tokens
+
+    def text_model(self) -> Any:
+        return self._language_model
+
+    def embed_tokens(self, input_ids: mx.array) -> mx.array:
+        if self._embed_tokens_fn is None:
+            raise RuntimeError(
+                "embed_tokens_fn not resolved; construct via "
+                "PaddleOCRVLMultimodalAdapter.from_loaded_model."
+            )
+        return self._embed_tokens_fn(input_ids)
+
+    def encode_multimodal(
+        self,
+        features: list[MultiModalFeatureSpec],
+    ) -> list[PaddleOCRVLVisionEncodeResult]:
+        """Run PaddleOCR-VL's vision tower for each image feature."""
+        if self._visual is None:
+            raise RuntimeError(
+                "visual tower not loaded; encode_multimodal unavailable. "
+                "Construct via PaddleOCRVLMultimodalAdapter.from_loaded_model."
+            )
+
+        target_dtype = self._visual.embeddings.patch_embedding.weight.dtype
+        outputs: list[PaddleOCRVLVisionEncodeResult] = []
+        for feature in features:
+            if feature.modality != "image":
+                raise ValueError(
+                    "encode_multimodal only supports image features; got "
+                    f"modality={feature.modality!r}"
+                )
+            if feature.data is None:
+                raise ValueError("feature.data is required for vision encoding")
+
+            pixel_values = self._as_mlx(
+                self._feature_value(feature.data, "pixel_values")
+            )
+            if len(pixel_values.shape) == 4:
+                pixel_values = mx.expand_dims(pixel_values, axis=0)
+            if len(pixel_values.shape) != 5:
+                raise ValueError(
+                    "pixel_values must have shape (patches, 3, patch, patch) "
+                    "or (1, patches, 3, patch, patch); got "
+                    f"{pixel_values.shape}"
+                )
+
+            grid_thw = self._grid_thw(feature.data, "image_grid_thw")
+            raw_patches = grid_thw[0] * grid_thw[1] * grid_thw[2]
+            if int(pixel_values.shape[1]) != raw_patches:
+                raise ValueError(
+                    "pixel_values patch count does not match image_grid_thw: "
+                    f"got {pixel_values.shape[1]}, expected {raw_patches}"
+                )
+            image_grid_thw = mx.array([grid_thw], dtype=mx.int32)
+
+            hidden_states = self._visual(
+                pixel_values.astype(target_dtype),
+                image_grid_thw,
+                output_hidden_states=False,
+            )
+            outputs.append(PaddleOCRVLVisionEncodeResult(hidden_states=hidden_states))
+
+        return outputs
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[mx.array, int]:
+        """Return ``((3, 1, seq_len) int32 positions, mrope_position_delta)``."""
+        if not input_tokens:
+            return mx.zeros((3, 1, 0), dtype=mx.int32), 0
+        if self._language_model is None:
+            raise RuntimeError(
+                "language_model not loaded; get_mrope_input_positions unavailable. "
+                "Construct via PaddleOCRVLMultimodalAdapter.from_loaded_model."
+            )
+
+        self._validate_image_features(mm_features)
+        image_grid_thw = (
+            mx.array(
+                [
+                    self._grid_thw(feature.data, "image_grid_thw")
+                    for feature in sorted(
+                        mm_features, key=lambda f: f.mm_position.offset
+                    )
+                ],
+                dtype=mx.int32,
+            )
+            if mm_features
+            else None
+        )
+        input_ids = mx.array([input_tokens], dtype=mx.int32)
+        position_ids, rope_deltas = self._language_model.get_rope_index(
+            input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=None,
+            attention_mask=None,
+        )
+        return position_ids.astype(mx.int32), self._first_scalar_int(rope_deltas)
+
+    def call_lm(
+        self,
+        input_ids: mx.array,
+        inputs_embeds: mx.array,
+        cache: list[Any],
+        position_ids: mx.array,
+        *,
+        visual_pos_masks: Any | None = None,
+        deepstack_visual_embeds: Any | None = None,
+    ) -> Any:
+        """Invoke the PaddleOCR-VL language model with runner-built embeds."""
+        del visual_pos_masks
+        if self._language_model is None:
+            raise RuntimeError(
+                "language_model not loaded; call_lm unavailable. "
+                "Construct via PaddleOCRVLMultimodalAdapter.from_loaded_model."
+            )
+        if deepstack_visual_embeds is not None:
+            raise RuntimeError(
+                "PaddleOCR-VL does not expose deepstack visual residuals."
+            )
+        return self._language_model(
+            input_ids,
+            inputs_embeds=inputs_embeds,
+            cache=cache,
+            position_ids=position_ids,
+        )
+
+    def _validate_image_features(
+        self,
+        features: list[MultiModalFeatureSpec],
+    ) -> None:
+        # mlx-vlm < 0.6 mis-counts vision blocks for prompts with more than
+        # one image (mx.sum collapse of vision-start indices), silently
+        # corrupting M-RoPE positions.  Fixed upstream in mlx-vlm#1282; drop
+        # this guard once the pinned mlx-vlm includes that fix.
+        if len(features) > 1:
+            raise NotImplementedError(
+                "Multiple images per request are not yet supported: the "
+                "installed mlx-vlm get_rope_index mis-counts multi-image "
+                "prompts (fixed upstream in mlx-vlm#1282)."
+            )
+        for feature in sorted(features, key=lambda feature: feature.mm_position.offset):
+            modality = feature.modality
+            if modality == "video":
+                raise NotImplementedError(
+                    "Video multimodal features are not yet supported."
+                )
+            if modality != "image":
+                raise ValueError(f"Unsupported modality: {modality}")
+            if feature.data is None:
+                raise ValueError(
+                    "Image feature data is required to read image_grid_thw."
+                )
+
+            t, h, w = self._grid_thw(feature.data, "image_grid_thw")
+            if t != 1:
+                raise ValueError(f"Multi-frame images are not yet supported, got t={t}")
+            num_grid_tokens = (
+                t * (h // self._spatial_merge_size) * (w // self._spatial_merge_size)
+            )
+            num_embeds = feature.mm_position.get_num_embeds()
+            if num_embeds != num_grid_tokens:
+                raise ValueError(
+                    "image_grid_thw implies "
+                    f"{num_grid_tokens} multimodal embeddings, got "
+                    f"mm_position.get_num_embeds()={num_embeds}"
+                )
+
+    @classmethod
+    def _grid_thw(cls, data: MultiModalKwargsItem, key: str) -> tuple[int, int, int]:
+        value = cls._as_mlx(cls._feature_value(data, key))
+        if len(value.shape) == 2 and value.shape[0] == 1:
+            value = value[0]
+        values = value.tolist()
+        if len(values) != 3:
+            raise ValueError(f"{key} must contain exactly 3 values, got {values}.")
+        t, h, w = values
+        return int(t), int(h), int(w)
+
+    @staticmethod
+    def _as_mlx(value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return torch_to_mlx(value)
+        return value
+
+    @staticmethod
+    def _feature_value(data: MultiModalKwargsItem, key: str) -> Any:
+        return data[key].data
+
+    @staticmethod
+    def _first_scalar_int(value: mx.array) -> int:
+        if value.ndim == 0:
+            return int(value.item())
+        return int(value.reshape(-1)[0].item())

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -33,6 +33,11 @@ class Qwen3VLMultimodalAdapter:
     """Runner gate for the multimodal forward path; False forces the runner
     to reject mm requests rather than invoke an incomplete adapter."""
 
+    requires_explicit_positions: bool = False
+    """Qwen3-VL attention applies RoPE from the paged context
+    (``apply_packed_rope`` + ``ctx.offsets``), so text-only batches are
+    safe on the plain text path."""
+
     _SUPPORTED_EMBEDS_KWARGS: tuple[str, ...] = (
         "inputs_embeds",
         "input_embeddings",

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -44,6 +44,16 @@ class MultimodalRuntimeAdapter(Protocol):
     model already in production.
     """
 
+    requires_explicit_positions: bool
+    """Whether text-only batches must also run the multimodal forward.
+
+    True for models whose language model derives rotary embeddings from
+    model-level position state (PaddleOCR-VL): on the paged text path the
+    runner supplies zero-offset caches and no ``position_ids``, so the LM
+    would re-derive every position from 0.  Routing through ``call_lm``
+    keeps positions explicit on every batch.
+    """
+
     def text_model(self) -> Any:
         """Return the callable language model for text-only VLM execution."""
 
@@ -182,6 +192,10 @@ _QWEN3_VL_ARCHITECTURES: frozenset[str] = frozenset(
         "Qwen3_5ForConditionalGeneration",
         "Qwen3VLForConditionalGeneration",
     }
+)
+_PADDLEOCR_VL_MODEL_TYPES: frozenset[str] = frozenset({"paddleocr_vl"})
+_PADDLEOCR_VL_ARCHITECTURES: frozenset[str] = frozenset(
+    {"PaddleOCRVLForConditionalGeneration"}
 )
 
 
@@ -445,17 +459,29 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
 
         model_type = getattr(hf_config, "model_type", "")
         architectures = getattr(hf_config, "architectures", ()) or ()
-        if model_type not in _QWEN3_VL_MODEL_TYPES and not any(
+        if model_type in _QWEN3_VL_MODEL_TYPES or any(
             arch in _QWEN3_VL_ARCHITECTURES for arch in architectures
         ):
-            return None
+            from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 
-        from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
+            return cast(
+                MultimodalRuntimeAdapter,
+                Qwen3VLMultimodalAdapter.from_loaded_model(model),
+            )
 
-        return cast(
-            MultimodalRuntimeAdapter,
-            Qwen3VLMultimodalAdapter.from_loaded_model(model),
-        )
+        if model_type in _PADDLEOCR_VL_MODEL_TYPES or any(
+            arch in _PADDLEOCR_VL_ARCHITECTURES for arch in architectures
+        ):
+            from vllm_metal.multimodal.paddleocr_vl import (
+                PaddleOCRVLMultimodalAdapter,
+            )
+
+            return cast(
+                MultimodalRuntimeAdapter,
+                PaddleOCRVLMultimodalAdapter.from_loaded_model(model),
+            )
+
+        return None
 
     def build_yoco_cache_mapping(
         self, args: dict[str, Any]

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -48,10 +48,10 @@ class MultimodalRuntimeAdapter(Protocol):
     """Whether text-only batches must also run the multimodal forward.
 
     True for models whose language model derives rotary embeddings from
-    model-level position state (PaddleOCR-VL): on the paged text path the
-    runner supplies zero-offset caches and no ``position_ids``, so the LM
-    would re-derive every position from 0.  Routing through ``call_lm``
-    keeps positions explicit on every batch.
+    model-level position state: on the paged text path the runner supplies
+    zero-offset caches and no ``position_ids``, so the LM would re-derive
+    every position from 0.  Routing through ``call_lm`` keeps positions
+    explicit on every batch.
     """
 
     def text_model(self) -> Any:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -938,6 +938,17 @@ class MetalModelRunner:
                 "let mm requests reach paged forward."
             )
 
+        # PaddleOCR-VL derives RoPE from model-level position state: on the
+        # text path the LM would re-derive positions against the zero-offset
+        # paged caches (arange from 0), corrupting decode/packed/chunked text
+        # batches.  Adapters flag ``requires_explicit_positions`` so text-only
+        # batches also run the mm forward, which always passes position_ids.
+        use_mm_forward = has_mm or (
+            adapter is not None
+            and adapter.forward_ready
+            and adapter.requires_explicit_positions
+        )
+
         # ---- build unified token sequence: decode first, then prefill ----
         all_token_ids: list[int] = []
 
@@ -990,7 +1001,7 @@ class MetalModelRunner:
                     cache=offset_caches,
                     model_config=self.model_config,
                 )
-            elif has_mm:
+            elif use_mm_forward:
                 model_output, mm_prefill_deltas = self._run_mm_paged_forward(
                     input_ids,
                     offset_caches,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -938,11 +938,11 @@ class MetalModelRunner:
                 "let mm requests reach paged forward."
             )
 
-        # PaddleOCR-VL derives RoPE from model-level position state: on the
-        # text path the LM would re-derive positions against the zero-offset
-        # paged caches (arange from 0), corrupting decode/packed/chunked text
-        # batches.  Adapters flag ``requires_explicit_positions`` so text-only
-        # batches also run the mm forward, which always passes position_ids.
+        # Some VLM LMs derive RoPE from model-level position state.  On the
+        # text path they would re-derive positions against zero-offset paged
+        # caches, corrupting decode/packed/chunked text batches.  Adapters flag
+        # ``requires_explicit_positions`` so text-only batches also run the mm
+        # forward, which always passes position_ids.
         use_mm_forward = has_mm or (
             adapter is not None
             and adapter.forward_ready


### PR DESCRIPTION
## Summary

Add native PaddleOCR-VL (`model_type: paddleocr_vl`) support on the Metal paged multimodal path.

The main difference from Qwen3-VL is RoPE ownership: PaddleOCR-VL attention layers do not own a `rope` / `rotary_emb` module. Instead, the language model computes M-RoPE `(cos, sin)` embeddings at the model level and passes them into each `self_attn` call. This PR teaches the Metal attention wrapper to consume those caller-provided position embeddings and teaches the runner to provide explicit positions whenever this model needs them.

## What changes

- New `vllm_metal/multimodal/paddleocr_vl/` adapter:
  - resolves the PaddleOCR-VL vision tower, language model, patch merge size, and token embeddings at load time;
  - encodes image features with patch-count validation and dtype alignment to the patch embedding weights;
  - delegates M-RoPE position construction to `language_model.get_rope_index`;
  - forwards `inputs_embeds`, `cache`, and `position_ids` through `call_lm`.
- Metal attention now accepts PaddleOCR-VL's model-level `(cos, sin)` position embeddings, including the mlx-vlm convention where they arrive in the fourth positional argument slot.
- SDPA preparation applies PaddleOCR-VL M-RoPE with `rope_parameters["mrope_section"]`, bypassing the normal per-layer `apply_packed_rope` path for this architecture.
- Add `MultimodalRuntimeAdapter.requires_explicit_positions`. PaddleOCR-VL sets it to `True`, so text-only batches still route through the multimodal paged path and receive correct absolute prefill/decode positions. Qwen3-VL keeps the existing text path.
- Dispatch recognizes `model_type: paddleocr_vl` and `PaddleOCRVLForConditionalGeneration`.

## Scope

- **One image per request** for now. The pinned mlx-vlm 0.5.x `get_rope_index` collapses multiple vision-start indices; this is fixed upstream in [Blaizzy/mlx-vlm#1282](https://github.com/Blaizzy/mlx-vlm/pull/1282), but not in the current pin.
- **Spec-decode fails fast** on PaddleOCR-VL through the existing multimodal-path reject. That is preferable to the previous behavior, where text-only PaddleOCR-VL spec-decode could silently use position-0 RoPE. The `feat/multimodal-spec-decode-paged` branch has the per-query-token `segment_positions` split needed to lift the reject later.
- **Paged-only**, as in #408: multimodal requests on the non-paged path keep failing fast at the encoder-dispatch chokepoint.

## Validation

**Unit tests**: 348 passed across `tests/v1/mm`, `tests/multimodal`, attention, paged-attention, model-adapter, runner-generate, and Gemma4-MTP suites.

New coverage includes:

- adapter validation, encode, `call_lm`, position construction, multi-image guard, and `requires_explicit_positions`;
- `position_embeddings` SDPA path without a per-layer `rope` attribute;
- wrapper fallback forwarding of `(cos, sin)` when no paged context is active;
- text-only prefill/decode routing for explicit-position adapters;
- dispatch by `model_type` and architecture.

**Real model** (`PaddlePaddle/PaddleOCR-VL-1.6`, paged backend):

- Full-page OCR on a 1275×1650 arXiv page (~2610 image tokens) produced coherent markdown for title, authors, abstract, and two-column body in 7.0 s.
- Text-only greedy output is byte-identical to native `mlx_vlm generate --temperature 0` on the same snapshot. The explicit-position path avoids reusing position-0 RoPE during decode.

## Notes for reviewers

- mlx-vlm contracts were checked against the pinned 0.5.0 source: `apply_multimodal_rotary_pos_emb`, `Attention.rope_parameters["mrope_section"]`, `visual.embeddings.patch_embedding`, `get_rope_index`, and `LanguageModel.__call__`.
- The `(cos, sin)` detection is structural (`2-sequence of mx.array`). Current callers are unambiguous: Qwen3-VL passes one `(3, 1, L)` array in that slot; PaddleOCR-VL passes a two-array tuple.