### PR TITLE
[CI] Remove metal & cpp JIT compile, release the binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,11 @@ Cargo.lock
 *.metallib
 *.air
 
+# Prebuilt native extension artifacts (built at packaging time, bundled into
+# the wheel via [tool.maturin] include; never committed). *.so is covered above.
+vllm_metal/metal/*.metallib
+vllm_metal/metal/*.sha256
+
 # Model files
 *.bin
 *.safetensors

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 - macOS on Apple Silicon
 - Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
-- Up-to-date Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM from source and builds the Metal extension on first run, both via `clang++`; an outdated toolchain fails to compile.
+- Xcode Command Line Tools (`xcode-select --install`). vLLM core is compiled from source via `clang++`. The Metal kernels ship **prebuilt**, so no Metal compiler or toolchain is needed to run them.
 
 ## Supported Models
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,8 +45,12 @@ Requirements:
   xcodebuild -downloadComponent MetalToolchain
   ```
 
-Without `VLLM_METAL_BUILD_FROM_SOURCE`, the prebuilt artifacts from the wheel
-are loaded as-is and your kernel edits have no effect.
+Without `VLLM_METAL_BUILD_FROM_SOURCE`, the prebuilt artifacts are loaded as-is.
+If you edited a kernel source after building them locally, loading **fails
+loudly** on the stale-hash mismatch rather than silently running the old kernel —
+set the variable, or rerun `python -m vllm_metal.metal.build` to refresh the
+prebuilt artifacts. (A plain wheel install ships no hash stamps, so end users
+never hit this.)
 
 ## Run lint locally
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,6 +18,36 @@ source .venv-vllm-metal/bin/activate
 pip install -e ".[dev]"
 ```
 
+## Editing the Metal kernels
+
+Release wheels ship the native paged-attention extension and its Metal shader
+libraries **prebuilt**, so end users never compile them. To edit the kernels —
+the `.metal` shaders or `paged_ops.cpp` — and run from your local source, set:
+
+```bash
+VLLM_METAL_BUILD_FROM_SOURCE=1 vllm serve ...   # or: pytest, your script, etc.
+```
+
+In this mode the C++ extension is recompiled when its inputs change (the build
+is hash-checked, so unchanged sources are skipped) and the shaders are compiled
+in-process by MLX from the `.metal` source at runtime. There is **no manual
+`.metallib` rebuild step**: edit a kernel, restart the Python process, and the
+change is picked up.
+
+Requirements:
+
+- **Xcode Command Line Tools** (`xcode-select --install`) — provides `clang++`
+  for the C++ extension.
+- For shader (`.metal`) work, the **Metal toolchain**. Recent Xcode bundles it;
+  on Xcode 26+ it is a separate download:
+
+  ```bash
+  xcodebuild -downloadComponent MetalToolchain
+  ```
+
+Without `VLLM_METAL_BUILD_FROM_SOURCE`, the prebuilt artifacts from the wheel
+are loaded as-is and your kernel edits have no effect.
+
 ## Run lint locally
 
 Mirrors the `lint` job in CI (`ruff`, `ruff format --check`, `mypy`, `shellcheck`):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,7 +8,8 @@ Thanks for your interest in contributing! This plugin targets **Apple Silicon Ma
 git clone https://github.com/vllm-project/vllm-metal.git
 cd vllm-metal
 
-# Creates ./.venv-vllm-metal/ and installs vLLM core + the plugin
+# Creates ./.venv-vllm-metal/, installs vLLM core + the plugin, and
+# prebuilds the native Metal kernels from your checkout
 ./install.sh
 
 # Activate the virtualenv
@@ -36,14 +37,9 @@ change is picked up.
 
 Requirements:
 
-- **Xcode Command Line Tools** (`xcode-select --install`) — provides `clang++`
-  for the C++ extension.
-- For shader (`.metal`) work, the **Metal toolchain**. Recent Xcode bundles it;
-  on Xcode 26+ it is a separate download:
-
-  ```bash
-  xcodebuild -downloadComponent MetalToolchain
-  ```
+- **Xcode Command Line Tools** (`xcode-select --install`) — `clang++` rebuilds
+  the `.so`; keep it current enough for the pinned MLX headers.
+- No Metal toolchain needed: MLX compiles the `.metal` shaders in-process.
 
 Without `VLLM_METAL_BUILD_FROM_SOURCE`, the prebuilt artifacts are loaded as-is.
 If you edited a kernel source after building them locally, loading **fails

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - macOS on Apple Silicon
 - Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
-- Up-to-date Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM from source via `clang++`; an outdated toolchain fails to compile. If a build fails on an existing install, update to the latest.
+- Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM core from source via `clang++`.
 
 > **Metal kernels are prebuilt.** Release wheels ship the native paged-attention
 > extension (`_paged_ops*.so`) and its precompiled Metal shader libraries

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,15 @@
 
 - macOS on Apple Silicon
 - Native arm64 Python 3.12. Rosetta/x86_64 Python is not supported.
-- Up-to-date Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM from source and builds the Metal extension on first run, both via `clang++`; an outdated toolchain fails to compile. If a build fails on an existing install, update to the latest.
+- Up-to-date Xcode Command Line Tools (`xcode-select --install`). The installer compiles vLLM from source via `clang++`; an outdated toolchain fails to compile. If a build fails on an existing install, update to the latest.
+
+> **Metal kernels are prebuilt.** Release wheels ship the native paged-attention
+> extension (`_paged_ops*.so`) and its precompiled Metal shader libraries
+> (`*.metallib`), so `pip install` requires no compiler or Metal toolchain to
+> *run* the kernels — nothing is compiled on first request. The Command Line
+> Tools above are still needed because the installer builds vLLM core from
+> source. Building the Metal kernels yourself is only for contributors editing
+> them; see [Contributing](CONTRIBUTING.md).
 
 `uv` is bootstrapped automatically; the Rust toolchain is only needed for the optional [Rust frontend](rust_frontend.md).
 

--- a/install.sh
+++ b/install.sh
@@ -215,7 +215,19 @@ EOF
   cd -
 
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
-    uv pip install .
+    # Local source install (running ./install.sh from a checkout). Prebuild the
+    # native paged-attention artifacts from this tree — the _paged_ops .so and
+    # the precompiled .metallib shaders — so the kernels load with no runtime
+    # compile, exactly like a release wheel; otherwise get_ops() fails loud
+    # ("Prebuilt native extension not found") the first time paged attention is
+    # used. build_native_artifacts needs the build deps (mlx, nanobind)
+    # importable, so the editable install pulls them in first and points the
+    # install at this tree, where the artifacts land. The remote (curl | bash)
+    # branch below installs a prebuilt release wheel instead and needs no
+    # toolchain. Mirrors scripts/release.sh / scripts/test.sh.
+    uv pip install -e .
+    ensure_metal_toolchain
+    build_native_artifacts
   else
     local release_data
     release_data=$(fetch_latest_release "$repo_owner" "$repo_name")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,13 @@ classifiers = [
 ]
 
 dependencies = [
-    # MLX - Required for Apple Silicon GPU acceleration
-    # Upper-bound: paged_ops.cpp uses mlx/backend/metal/device.h (private API).
-    # Bump after verifying the JIT build against the new MLX minor release.
-    "mlx>=0.31.0,<0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # MLX - Required for Apple Silicon GPU acceleration.
+    # EXACT pin: the prebuilt _paged_ops.so links MLX private headers and
+    # subclasses mlx::core::Primitive (mlx/backend/metal/device.h, etc.), and
+    # libmlx.dylib carries no SONAME version (compatibility version 0.0.0), so
+    # a wheel built against one MLX is only ABI-safe against that exact MLX.
+    # Rebuild and re-release the wheel on every MLX bump.
+    "mlx==0.31.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
     # mlx-vlm 0.5.x also requires llguidance>=1.7.0.
@@ -82,6 +85,11 @@ python-source = "."
 module-name = "vllm_metal._rs"
 # Strip symbols for smaller binary
 strip = true
+# Bundle the prebuilt Metal artifacts into the wheel. These are gitignored
+# (*.so / *.metallib) so maturin's default git-tracked file walk skips them;
+# listing them explicitly ships the prebuilt native extension at packaging
+# time so the end-user machine never invokes clang++ at runtime.
+include = ["vllm_metal/metal/*.metallib", "vllm_metal/metal/_paged_ops*.so"]
 
 [tool.ruff]
 line-length = 88

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -124,3 +124,42 @@ build_native_artifacts() {
   section "Building native Metal artifacts"
   python -m vllm_metal.metal.build
 }
+
+# Fail unless the freshly built wheel actually bundles the prebuilt native
+# artifacts: the _paged_ops*.so extension and the three .metallib shader
+# libraries. maturin's `include` directive is what pulls these (gitignored)
+# files in; if that ever regresses, the wheel would install fine but fail at
+# first run with "Prebuilt native extension not found". The expected filenames
+# are read from build.py so this guard never drifts from the runtime loader.
+#
+# Usage: verify_wheel_artifacts <path-to-wheel>
+verify_wheel_artifacts() {
+  local wheel="$1"
+  section "Verifying wheel bundles native artifacts"
+
+  local expected
+  if ! expected=$(python -c "
+from vllm_metal.metal.build import METALLIB_NAMES, metallib_path, output_path
+print(output_path().name)
+for _name in METALLIB_NAMES:
+    print(metallib_path(_name).name)
+"); then
+    error "Failed to resolve expected native artifact names from build.py."
+    return 1
+  fi
+
+  local contents name
+  contents=$(unzip -l "$wheel")
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    if grep -qF "$name" <<< "$contents"; then
+      success "bundled: ${name}"
+    else
+      error "Wheel ${wheel} is missing native artifact: ${name}"
+      error "maturin [tool.maturin] 'include' likely failed to bundle it."
+      return 1
+    fi
+  done <<< "$expected"
+
+  success "Wheel bundles all native artifacts"
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -79,3 +79,48 @@ setup_dev_env() {
 get_version() {
   uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])"
 }
+
+# Ensure `xcrun metal` can actually compile a .metallib.
+#
+# Producing a .metallib needs the Metal toolchain. On Xcode 26+ it is a
+# separate downloadable component; older Xcode bundles it. Rather than guess,
+# trial-compile a trivial shader: if that succeeds the toolchain is already
+# present (no slow download), otherwise download MetalToolchain and re-check.
+ensure_metal_toolchain() {
+  section "Ensuring Metal toolchain"
+
+  local tmpdir metal_src metal_lib
+  tmpdir=$(mktemp -d)
+  metal_src="${tmpdir}/probe.metal"
+  metal_lib="${tmpdir}/probe.metallib"
+  printf '[[kernel]] void _t() {}\n' > "${metal_src}"
+
+  if xcrun -sdk macosx metal -o "${metal_lib}" "${metal_src}" &> /dev/null; then
+    success "Metal toolchain present"
+    rm -rf "${tmpdir}"
+    return 0
+  fi
+
+  echo "Metal toolchain not available, downloading via xcodebuild..."
+  xcodebuild -downloadComponent MetalToolchain
+
+  if ! xcrun -sdk macosx metal -o "${metal_lib}" "${metal_src}" &> /dev/null; then
+    error "Metal toolchain still unavailable after download; cannot compile .metallib."
+    rm -rf "${tmpdir}"
+    return 1
+  fi
+
+  success "Metal toolchain ready"
+  rm -rf "${tmpdir}"
+}
+
+# Build the in-package native artifacts (the _paged_ops*.so and the three
+# precompiled .metallib shader libraries) into vllm_metal/metal/ so that
+# `uv build` can bundle them into the wheel via the maturin `include` directive.
+#
+# `python` here is the venv interpreter activated by setup_dev_env, so mlx and
+# nanobind are importable.
+build_native_artifacts() {
+  section "Building native Metal artifacts"
+  python -m vllm_metal.metal.build
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,13 @@ main() {
 
   setup_dev_env
 
+  # Build the prebuilt native extension (.so) and the three precompiled
+  # .metallib shader libraries into vllm_metal/metal/ before `uv build`, so the
+  # wheel ships them (via the maturin `include` directive) and end users never
+  # invoke clang++ or `xcrun metal` at runtime.
+  ensure_metal_toolchain
+  build_native_artifacts
+
   local base_version version
   base_version=$(get_version)
   # Per-commit dev version, e.g. 0.3.0.dev20260603184500 — unique and PEP 440.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,6 +32,17 @@ main() {
   section "Building wheel"
   uv build
 
+  # Guard: never publish a wheel that doesn't actually bundle the prebuilt
+  # native artifacts (maturin `include`). Abort here — before the tag and
+  # release — rather than ship a wheel that fails with "Prebuilt native
+  # extension not found" on the user's first run.
+  local wheels=(dist/*.whl)
+  if [ ! -f "${wheels[0]}" ]; then
+    error "No wheel found in dist/ after uv build."
+    exit 1
+  fi
+  verify_wheel_artifacts "${wheels[0]}"
+
   local tag
   tag="v${version}"
   echo "Generated tag: $tag"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -147,6 +147,11 @@ main() {
   setup_dev_env
 
   if [ "$(uname)" == "Darwin" ]; then
+    # Build the native artifacts (.so + .metallib) into the package tree before
+    # install.sh's `uv pip install .`, so the wheel bundles them (maturin
+    # `include`) and CI exercises the prebuilt path users get, like release.sh.
+    ensure_metal_toolchain
+    build_native_artifacts
     installs
     # shellcheck source=/dev/null
     source .venv-vllm-metal/bin/activate

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -152,6 +152,21 @@ main() {
     # `include`) and CI exercises the prebuilt path users get, like release.sh.
     ensure_metal_toolchain
     build_native_artifacts
+
+    # Shift-left the release wheel guard. The pytest run below imports the source
+    # tree, which shadows the installed wheel, so a maturin `include` regression
+    # (artifacts silently dropped from the wheel) would pass CI here and only
+    # surface when release.sh runs on main. Build the wheel and assert it bundles
+    # the prebuilt artifacts now — the same check release.sh runs before publish.
+    section "Building wheel"
+    uv build
+    local wheels=(dist/*.whl)
+    if [ ! -f "${wheels[0]}" ]; then
+      error "No wheel found in dist/ after uv build."
+      exit 1
+    fi
+    verify_wheel_artifacts "${wheels[0]}"
+
     installs
     # shellcheck source=/dev/null
     source .venv-vllm-metal/bin/activate

--- a/tests/test_metal_build_cache.py
+++ b/tests/test_metal_build_cache.py
@@ -109,11 +109,15 @@ def test_hash_changes_with_nb_src_bytes(patched):
     assert build._input_hash(patched.spec) != h1
 
 
-def test_hash_changes_with_cmd(patched):
-    # Simulates venv switch / different MLX install path.
+def test_hash_ignores_cmd_paths(patched):
+    # The .so links `-undefined dynamic_lookup` and bakes in no absolute path, so
+    # moving the venv (different -L/-I/-o paths in spec.cmd) yields an equivalent
+    # binary and must NOT flag the artifact stale. Semantically meaningful inputs
+    # (compile flags, PARTITION_SIZE) live in build.py/constants.py, whose bytes
+    # ARE hashed below — so this excludes only machine-specific paths.
     h1 = build._input_hash(patched.spec)
     s2 = dataclasses.replace(patched.spec, cmd=patched.spec.cmd + ["-L/other/mlx/lib"])
-    assert build._input_hash(s2) != h1
+    assert build._input_hash(s2) == h1
 
 
 def test_hash_changes_with_mlx_version(patched):
@@ -141,3 +145,139 @@ def test_needs_rebuild_swallows_resolution_errors(patched, monkeypatch):
 
     monkeypatch.setattr(build, "_build_spec", boom)
     assert build.needs_rebuild() is True
+
+
+# --------------------------------------------------------------------------
+# Path contract (the runtime loader and verify_wheel_artifacts depend on these)
+# --------------------------------------------------------------------------
+
+
+def test_output_path_points_at_the_so(patched):
+    assert build.output_path() == patched.out
+
+
+def test_metallib_path_named_in_package(tmp_path, monkeypatch):
+    monkeypatch.setattr(build, "_THIS_DIR", tmp_path)
+    assert build.metallib_path("gdn_kern") == tmp_path / "gdn_kern.metallib"
+
+
+def test_metallib_digest_changes_with_source():
+    # The metallib staleness stamp is keyed on the assembled shader source, so a
+    # one-byte shader edit must change the digest (else an edited kernel loads
+    # silently stale).
+    assert build._metallib_digest("shader A") != build._metallib_digest("shader B")
+    assert build._metallib_digest("shader A") == build._metallib_digest("shader A")
+
+
+# --------------------------------------------------------------------------
+# is_stale: one staleness primitive for the .so and every .metallib.
+# --------------------------------------------------------------------------
+
+
+def test_is_stale_false_when_artifact_missing(tmp_path):
+    assert build.is_stale(tmp_path / "a.metallib", "digest") is False
+
+
+def test_is_stale_false_when_stamp_missing(tmp_path):
+    # Wheel installs ship the artifact but NO .sha256 stamp -> never "stale", so
+    # end users never hit a staleness error.
+    art = tmp_path / "a.metallib"
+    art.write_bytes(b"lib")
+    assert build.is_stale(art, "digest") is False
+
+
+def test_is_stale_false_when_stamp_matches(tmp_path):
+    art = tmp_path / "a.metallib"
+    art.write_bytes(b"lib")
+    build._stamp_path(art).write_text("digest")
+    assert build.is_stale(art, "digest") is False
+
+
+def test_is_stale_true_when_stamp_differs(tmp_path):
+    art = tmp_path / "a.metallib"
+    art.write_bytes(b"lib")
+    build._stamp_path(art).write_text("OLD")
+    assert build.is_stale(art, "NEW") is True
+
+
+def test_is_stale_false_when_stamp_unreadable(tmp_path):
+    # A stamp we can't read must not break loading -> treated as not stale.
+    art = tmp_path / "a.metallib"
+    art.write_bytes(b"lib")
+    build._stamp_path(art).mkdir()  # read_text() -> IsADirectoryError (OSError)
+    assert build.is_stale(art, "whatever") is False
+
+
+# --------------------------------------------------------------------------
+# stale_artifacts: aggregates is_stale over the .so + the three .metallibs,
+# with digests stubbed so no real mlx/nanobind/shader sources are touched.
+# --------------------------------------------------------------------------
+
+
+def _raise(exc):
+    def _f(*_a, **_k):
+        raise exc
+
+    return _f
+
+
+@pytest.fixture
+def stale_env(tmp_path, monkeypatch):
+    """Hermetic environment for stale_artifacts(): all artifacts live in
+    tmp_path and the digest computations are stubbed, so the real build deps
+    (mlx, nanobind, shader-source builders) are never imported."""
+    monkeypatch.setattr(build, "_OUT", tmp_path / "_paged_ops.so")
+    monkeypatch.setattr(build, "_THIS_DIR", tmp_path)
+    monkeypatch.setattr(build, "_build_spec", lambda: None)
+    monkeypatch.setattr(build, "_input_hash", lambda _spec: "SO_DIGEST")
+    monkeypatch.setattr(build, "_metallib_source", lambda name: f"SRC::{name}")
+    return tmp_path
+
+
+def _seed_fresh() -> None:
+    """Write every artifact with a stamp matching its stubbed digest."""
+    build._OUT.write_bytes(b"so")
+    build._stamp_path(build._OUT).write_text("SO_DIGEST")
+    for name in build.METALLIB_NAMES:
+        lib = build.metallib_path(name)
+        lib.write_bytes(b"lib")
+        build._stamp_path(lib).write_text(build._metallib_digest(f"SRC::{name}"))
+
+
+def test_stale_artifacts_empty_when_all_fresh(stale_env):
+    _seed_fresh()
+    assert build.stale_artifacts() == []
+
+
+def test_stale_artifacts_empty_without_stamps_skips_build_deps(stale_env, monkeypatch):
+    # Wheel install: artifacts present, no stamps. Must short-circuit to [] BEFORE
+    # importing build deps -> _input_hash (which would raise here) is never hit.
+    build._OUT.write_bytes(b"so")
+    for name in build.METALLIB_NAMES:
+        build.metallib_path(name).write_bytes(b"lib")
+    monkeypatch.setattr(
+        build, "_input_hash", _raise(AssertionError("touched build deps"))
+    )
+    assert build.stale_artifacts() == []
+
+
+def test_stale_artifacts_flags_edited_so(stale_env):
+    _seed_fresh()
+    build._stamp_path(build._OUT).write_text("STALE")  # paged_ops.cpp edited
+    assert build.stale_artifacts() == [build._OUT]
+
+
+def test_stale_artifacts_flags_edited_shader(stale_env):
+    _seed_fresh()
+    lib = build.metallib_path(build.METALLIB_NAMES[0])
+    build._stamp_path(lib).write_text("STALE")  # a .metal shader edited
+    assert build.stale_artifacts() == [lib]
+
+
+def test_stale_artifacts_swallows_digest_errors(stale_env, monkeypatch):
+    # If digest computation blows up (e.g. mlx/nanobind missing on a dev box),
+    # loading must not break -> [] even though a stamp mismatches.
+    _seed_fresh()
+    build._stamp_path(build._OUT).write_text("STALE")
+    monkeypatch.setattr(build, "_input_hash", _raise(RuntimeError("boom")))
+    assert build.stale_artifacts() == []

--- a/tests/test_metal_build_cache.py
+++ b/tests/test_metal_build_cache.py
@@ -281,3 +281,14 @@ def test_stale_artifacts_swallows_digest_errors(stale_env, monkeypatch):
     build._stamp_path(build._OUT).write_text("STALE")
     monkeypatch.setattr(build, "_input_hash", _raise(RuntimeError("boom")))
     assert build.stale_artifacts() == []
+
+
+def test_stale_artifacts_propagates_builder_drift(stale_env, monkeypatch):
+    # A KeyError means METALLIB_NAMES drifted from the source-builder map in
+    # _metallib_source -- a code bug. stale_artifacts() must let it surface, not
+    # swallow it to [] (which would hide the bug); only environmental failures
+    # (OSError/ImportError/RuntimeError) are swallowed.
+    _seed_fresh()  # stamps exist -> past the no-stamps short-circuit, into the try
+    monkeypatch.setattr(build, "_metallib_source", _raise(KeyError("gdn_kern")))
+    with pytest.raises(KeyError):
+        build.stale_artifacts()

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
     VLLM_METAL_GDN_LAZY_KERNELS: bool = True
     VLLM_METAL_MLA_KERNEL: bool = False
+    VLLM_METAL_BUILD_FROM_SOURCE: bool = False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
@@ -76,6 +77,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # qk_rope_head_dim=64, block_size ∈ {16, 32}, fp16/bf16,
     # decode-only).
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
+    # When set, compile the native _paged_ops extension from source at runtime
+    # instead of loading the prebuilt artifact shipped in the wheel. Intended
+    # for kernel developers / source installs; requires Xcode command-line
+    # tools (clang++). Default off — release wheels ship the .so prebuilt.
+    "VLLM_METAL_BUILD_FROM_SOURCE": lambda: (
+        os.getenv("VLLM_METAL_BUILD_FROM_SOURCE", "0") == "1"
+    ),
 }
 
 

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -28,8 +28,9 @@ _KERNELS_V2_DIR = _THIS_DIR / "kernels_v2"
 # Cached after first get_ops() call.  The Metal shaders are JIT-compiled once
 # and held in MLX's library cache for the lifetime of the process.  Editing
 # .metal source files requires restarting the Python interpreter to pick up
-# changes (the .cpp extension itself is rebuilt automatically by build.py when
-# paged_ops.cpp is newer than the .so).
+# changes.  The .cpp extension itself is loaded prebuilt from the package by
+# default; set VLLM_METAL_BUILD_FROM_SOURCE=1 to recompile it from source (for
+# kernel developers iterating on paged_ops.cpp).
 _ops_module: ModuleType | None = None
 
 
@@ -152,10 +153,27 @@ def get_ops() -> ModuleType:
     if _ops_module is not None:
         return _ops_module
 
-    # 1. JIT-build the C++ extension if needed
-    from vllm_metal.metal.build import build
+    # Preload libmlx so the prebuilt extension's @rpath/libmlx.dylib symbols
+    # resolve against the already-loaded image, regardless of any rpath baked
+    # in at build time. Must happen before the .so is dlopen'd below.
+    import mlx.core  # noqa: F401
 
-    so_path = build()
+    # 1. Locate the native extension: load the prebuilt artifact by default;
+    #    only compile from source when explicitly opted in (no silent fallback).
+    from vllm_metal import envs
+    from vllm_metal.metal.build import build, output_path
+
+    if envs.VLLM_METAL_BUILD_FROM_SOURCE:
+        so_path = build()
+    else:
+        so_path = output_path()
+        if not so_path.exists():
+            raise RuntimeError(
+                f"Prebuilt native extension not found at {so_path}. Install a "
+                f"vllm-metal release wheel (which ships it prebuilt), or set "
+                f"VLLM_METAL_BUILD_FROM_SOURCE=1 to compile it from source "
+                f"(requires Xcode command-line tools)."
+            )
 
     # 2. Import the built extension
     spec = importlib.util.spec_from_file_location("_paged_ops", str(so_path))

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -165,10 +165,12 @@ def get_ops() -> ModuleType:
     if _ops_module is not None:
         return _ops_module
 
-    # The prebuilt .so is linked with `-undefined dynamic_lookup` and carries no
-    # libmlx load command or rpath (see build.py), so its undefined MLX symbols
-    # are resolved at load time against images already in the process. Import
-    # mlx.core first so libmlx is resident before the .so is dlopen'd below.
+    # The prebuilt .so links `-lmlx` with no rpath, so it records a dependency on
+    # `@rpath/libmlx.dylib` (libmlx's install name) that it cannot resolve on its
+    # own; dyld instead satisfies it against an already-resident libmlx, matched
+    # by install name (`-undefined dynamic_lookup` resolves any stragglers the
+    # same way; see build.py). Both need libmlx loaded first, so import mlx.core
+    # now to make it resident before the .so is dlopen'd below.
     import mlx.core  # noqa: F401
 
     # 1. Locate the native extension: load the prebuilt artifact by default;

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -25,12 +25,14 @@ logger = logging.getLogger(__name__)
 _THIS_DIR = Path(__file__).resolve().parent
 _KERNELS_V2_DIR = _THIS_DIR / "kernels_v2"
 
-# Cached after first get_ops() call.  The Metal shaders are JIT-compiled once
-# and held in MLX's library cache for the lifetime of the process.  Editing
-# .metal source files requires restarting the Python interpreter to pick up
-# changes.  The .cpp extension itself is loaded prebuilt from the package by
-# default; set VLLM_METAL_BUILD_FROM_SOURCE=1 to recompile it from source (for
-# kernel developers iterating on paged_ops.cpp).
+# Cached after first get_ops() call.  By default both the .cpp extension and
+# the three Metal shader libraries are loaded prebuilt from the package (the
+# .so plus precompiled .metallib files), so there is no first-request shader
+# compile.  Set VLLM_METAL_BUILD_FROM_SOURCE=1 to recompile the .so from source
+# AND compile the shaders in-process from .metal (for kernel developers
+# iterating on paged_ops.cpp or the .metal sources); editing .metal then
+# requires restarting the interpreter to pick up changes.  Either way the
+# libraries are held in MLX's cache for the lifetime of the process.
 _ops_module: ModuleType | None = None
 
 
@@ -139,11 +141,14 @@ def metal_mla_paged_attention(
 
 
 def get_ops() -> ModuleType:
-    """JIT-build and import the native paged_ops extension.
+    """Import the native paged_ops extension and initialise its Metal libraries.
 
-    The Metal shader sources are read, pre-processed (includes inlined),
-    and passed to the C++ extension which JIT-compiles them via
-    ``mlx::core::metal::Device::get_library()``.
+    By default the prebuilt ``.so`` is loaded and the three precompiled
+    ``.metallib`` shader libraries are loaded by path via MLX
+    (``Device::get_library(name, path)``). When ``VLLM_METAL_BUILD_FROM_SOURCE``
+    is set, the ``.so`` is rebuilt and the shader sources are read, pre-processed
+    (includes inlined) and JIT-compiled in-process via
+    ``mlx::core::metal::Device::get_library(name, builder)`` instead.
 
     Returns:
         The ``_paged_ops`` module with ``paged_attention_primitive()`` and
@@ -182,17 +187,29 @@ def get_ops() -> ModuleType:
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
 
-    # 3. Initialise v2 library (online softmax kernel)
-    v2_src = _build_v2_paged_attention_source()
-    mod.init_v2_library(v2_src)
+    # 3. Initialise the three Metal shader libraries (v2 online-softmax, GDN
+    #    linear attention, MLA paged attention).  By default we load the
+    #    precompiled .metallib files shipped in the wheel (no first-request
+    #    shader compile); only compile the shaders in-process when the developer
+    #    opts in via VLLM_METAL_BUILD_FROM_SOURCE (no silent fallback).
+    if envs.VLLM_METAL_BUILD_FROM_SOURCE:
+        mod.init_v2_library(_build_v2_paged_attention_source())
+        mod.init_gdn_library(_build_gdn_source())
+        mod.init_mla_library(_build_mla_paged_attention_source())
+    else:
+        from vllm_metal.metal.build import metallib_path
 
-    # 4. Initialise GDN linear attention library
-    gdn_src = _build_gdn_source()
-    mod.init_gdn_library(gdn_src)
-
-    # 5. Initialise MLA paged-attention library (RFC #360)
-    mla_src = _build_mla_paged_attention_source()
-    mod.init_mla_library(mla_src)
+        names = ["paged_attention_v2_kern", "gdn_kern", "paged_mla_kern"]
+        missing = [n for n in names if not metallib_path(n).exists()]
+        if missing:
+            raise RuntimeError(
+                f"Prebuilt Metal libraries missing: {missing} (expected in "
+                f"{_THIS_DIR}). Install a vllm-metal release wheel, or set "
+                f"VLLM_METAL_BUILD_FROM_SOURCE=1 to compile shaders from source."
+            )
+        mod.init_v2_library_path(str(metallib_path("paged_attention_v2_kern")))
+        mod.init_gdn_library_path(str(metallib_path("gdn_kern")))
+        mod.init_mla_library_path(str(metallib_path("paged_mla_kern")))
 
     _ops_module = mod
     logger.info("Native paged-attention Metal kernels loaded")
@@ -200,16 +217,17 @@ def get_ops() -> ModuleType:
 
 
 def warm_up_kernels() -> None:
-    """Front-load v2 / GDN / MLA Metal kernel compilation at startup.
+    """Front-load v2 / GDN / MLA Metal library loading at startup.
 
-    :func:`get_ops` JIT-builds the C++ ``_paged_ops`` extension and eagerly
-    compiles the v2 / GDN / MLA Metal libraries: MLX's
-    ``Device::get_library`` compiles the source synchronously inside each
-    ``init_*_library`` call. Calling it here moves that cost off the first
-    request and fails fast at startup if the kernels cannot compile on this
-    macOS (e.g. an unsupported Metal language version).
+    :func:`get_ops` imports the C++ ``_paged_ops`` extension and initialises the
+    v2 / GDN / MLA Metal libraries — by default loading the precompiled
+    ``.metallib`` files, or (under ``VLLM_METAL_BUILD_FROM_SOURCE``) compiling
+    the shader source synchronously inside each ``init_*_library`` call. Calling
+    it here moves that cost off the first request and fails fast at startup if
+    the libraries are missing or the shaders cannot compile on this macOS (e.g.
+    an unsupported Metal language version).
 
-    The compile is process-wide with no per-cache state, which is why this
+    The load/compile is process-wide with no per-cache state, which is why this
     takes no arguments.
     """
     macos_version = platform.mac_ver()[0]

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -166,7 +166,7 @@ def get_ops() -> ModuleType:
     # 1. Locate the native extension: load the prebuilt artifact by default;
     #    only compile from source when explicitly opted in (no silent fallback).
     from vllm_metal import envs
-    from vllm_metal.metal.build import build, output_path
+    from vllm_metal.metal.build import build, output_path, stale_artifacts
 
     if envs.VLLM_METAL_BUILD_FROM_SOURCE:
         so_path = build()
@@ -178,6 +178,17 @@ def get_ops() -> ModuleType:
                 f"vllm-metal release wheel (which ships it prebuilt), or set "
                 f"VLLM_METAL_BUILD_FROM_SOURCE=1 to compile it from source "
                 f"(requires Xcode command-line tools)."
+            )
+        # Locally-built artifacts (the .so and the .metallib shaders) drift if a
+        # developer edits paged_ops.cpp or a .metal file without rebuilding. Warn
+        # loudly — but do NOT auto-build, which would reintroduce the silent
+        # fallback this design removed. No-op for wheel installs (no stamps).
+        stale = stale_artifacts()
+        if stale:
+            logger.warning(
+                "Prebuilt Metal artifacts are stale vs the current sources "
+                "(%s); set VLLM_METAL_BUILD_FROM_SOURCE=1 to rebuild them.",
+                ", ".join(p.name for p in stale),
             )
 
     # 2. Import the built extension

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -10,6 +10,7 @@ Usage::
 
 from __future__ import annotations
 
+import functools
 import importlib
 import importlib.util
 import logging
@@ -36,8 +37,14 @@ _KERNELS_V2_DIR = _THIS_DIR / "kernels_v2"
 _ops_module: ModuleType | None = None
 
 
+@functools.cache
 def _read_metal_source(path: Path) -> str:
-    """Read a .metal file and strip local #include directives."""
+    """Read a .metal file and strip local #include directives.
+
+    Cached for the process lifetime: the three library source builders all pull
+    in shared shaders (e.g. utils.metal), so without this each staleness check
+    or source-mode init would re-read and re-strip the same files several times.
+    """
     text = path.read_text()
     # Remove #include "..." for our vendored files (keep <metal_stdlib> etc.)
     text = re.sub(r'#include\s+"[^"]*"', "", text)
@@ -158,9 +165,10 @@ def get_ops() -> ModuleType:
     if _ops_module is not None:
         return _ops_module
 
-    # Preload libmlx so the prebuilt extension's @rpath/libmlx.dylib symbols
-    # resolve against the already-loaded image, regardless of any rpath baked
-    # in at build time. Must happen before the .so is dlopen'd below.
+    # The prebuilt .so is linked with `-undefined dynamic_lookup` and carries no
+    # libmlx load command or rpath (see build.py), so its undefined MLX symbols
+    # are resolved at load time against images already in the process. Import
+    # mlx.core first so libmlx is resident before the .so is dlopen'd below.
     import mlx.core  # noqa: F401
 
     # 1. Locate the native extension: load the prebuilt artifact by default;
@@ -180,15 +188,18 @@ def get_ops() -> ModuleType:
                 f"(requires Xcode command-line tools)."
             )
         # Locally-built artifacts (the .so and the .metallib shaders) drift if a
-        # developer edits paged_ops.cpp or a .metal file without rebuilding. Warn
-        # loudly — but do NOT auto-build, which would reintroduce the silent
-        # fallback this design removed. No-op for wheel installs (no stamps).
+        # developer edits paged_ops.cpp or a .metal file without rebuilding. Fail
+        # loudly rather than run stale kernels — but do NOT auto-build, which
+        # would reintroduce the silent compile this design removed. No-op for
+        # wheel installs (no stamps), so end users are never affected.
         stale = stale_artifacts()
         if stale:
-            logger.warning(
-                "Prebuilt Metal artifacts are stale vs the current sources "
-                "(%s); set VLLM_METAL_BUILD_FROM_SOURCE=1 to rebuild them.",
-                ", ".join(p.name for p in stale),
+            raise RuntimeError(
+                f"Prebuilt Metal artifacts are stale vs the current sources "
+                f"({', '.join(p.name for p in stale)}): a kernel source was "
+                f"edited without rebuilding. Set VLLM_METAL_BUILD_FROM_SOURCE=1 "
+                f"to build from source, or run `python -m vllm_metal.metal.build` "
+                f"to refresh the prebuilt artifacts."
             )
 
     # 2. Import the built extension
@@ -217,9 +228,8 @@ def get_ops() -> ModuleType:
                 f"{_THIS_DIR}). Install a vllm-metal release wheel, or set "
                 f"VLLM_METAL_BUILD_FROM_SOURCE=1 to compile shaders from source."
             )
-        mod.init_v2_library_path(str(metallib_path("paged_attention_v2_kern")))
-        mod.init_gdn_library_path(str(metallib_path("gdn_kern")))
-        mod.init_mla_library_path(str(metallib_path("paged_mla_kern")))
+        for name in METALLIB_NAMES:
+            mod.init_library_path(name, str(metallib_path(name)))
 
     _ops_module = mod
     logger.info("Native paged-attention Metal kernels loaded")

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -208,10 +208,9 @@ def get_ops() -> ModuleType:
         mod.init_gdn_library(_build_gdn_source())
         mod.init_mla_library(_build_mla_paged_attention_source())
     else:
-        from vllm_metal.metal.build import metallib_path
+        from vllm_metal.metal.build import METALLIB_NAMES, metallib_path
 
-        names = ["paged_attention_v2_kern", "gdn_kern", "paged_mla_kern"]
-        missing = [n for n in names if not metallib_path(n).exists()]
+        missing = [n for n in METALLIB_NAMES if not metallib_path(n).exists()]
         if missing:
             raise RuntimeError(
                 f"Prebuilt Metal libraries missing: {missing} (expected in "

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -282,8 +282,14 @@ def stale_artifacts() -> list[Path]:
     the ``_paged_ops`` ``.so`` (vs ``paged_ops.cpp`` et al.) and each
     ``.metallib`` (vs its ``.metal`` shaders) — checked through the single
     :func:`is_stale` mechanism. Returns ``[]`` for wheel installs (no stamps)
-    without importing the build deps, and never raises: a staleness check must
-    not break loading."""
+    without importing the build deps.
+
+    Environmental failures — mlx/nanobind not importable, a source file that
+    cannot be read — are swallowed (logged at debug) so a staleness check never
+    breaks loading. A programming error such as a ``METALLIB_NAMES`` entry with
+    no source builder (a ``KeyError`` from :func:`_metallib_source`) is
+    deliberately left to propagate: that is a bug to fix, not a condition to
+    hide behind ``[]``."""
     artifacts = (_OUT, *(metallib_path(n) for n in METALLIB_NAMES))
     if not any(_stamp_path(a).exists() for a in artifacts):
         return []
@@ -291,7 +297,10 @@ def stale_artifacts() -> list[Path]:
         digests = {_OUT: _input_hash(_build_spec())}
         for name in METALLIB_NAMES:
             digests[metallib_path(name)] = _metallib_digest(_metallib_source(name))
-    except (OSError, ImportError, RuntimeError, KeyError):
+    except (OSError, ImportError, RuntimeError) as exc:
+        # The check couldn't run (not a verdict on the artifacts); don't block a
+        # loadable install, but leave a breadcrumb instead of failing silently.
+        logger.debug("staleness check skipped (%s): %s", type(exc).__name__, exc)
         return []
     return [a for a in artifacts if is_stale(a, digests[a])]
 

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -38,9 +38,9 @@ def _stamp_path(artifact: Path) -> Path:
 # The .so's stamp; identical mechanism to each .metallib's (see is_stale).
 _HASH = _stamp_path(_OUT)
 
-# Names of the three precompiled Metal shader libraries.  These are the same
-# cache-key names the C++ extension registers each library under
-# (init_*_library_path in paged_ops.cpp), so a later dispatch's
+# Names of the three precompiled Metal shader libraries.  Each is the cache-key
+# name the C++ extension registers the library under (passed to
+# ``init_library_path(name, path)`` in paged_ops.cpp), so a later dispatch's
 # ``get_library(name)`` returns the .metallib loaded at startup.
 METALLIB_NAMES = ("paged_attention_v2_kern", "gdn_kern", "paged_mla_kern")
 
@@ -224,10 +224,13 @@ def _build_spec() -> _BuildSpec:
 
 def _input_hash(spec: _BuildSpec) -> str:
     h = hashlib.sha256()
-    # Resolved compile invocation captures MLX/nanobind/Python paths and
-    # compile-time defines like PARTITION_SIZE.
-    h.update("\0".join(spec.cmd).encode())
-    h.update(b"\0")
+    # Hash the inputs that change the produced .so, but NOT the machine-specific
+    # include/lib paths in spec.cmd: with `-undefined dynamic_lookup` the .so
+    # bakes in no absolute path, so the same sources + MLX/nanobind versions give
+    # an equivalent binary wherever the venv lives (moving it must not flag the
+    # artifact stale). The compile flags and defines (e.g. PARTITION_SIZE) come
+    # from build.py / constants.py, whose contents are hashed in the loop below,
+    # so editing a flag still busts the hash.
     # Versions catch in-place upgrades where the install path is reused.
     h.update(f"mlx={spec.mlx_version}\0nb={spec.nb_version}\0".encode())
     for p in (_SRC, _BUILD, _CONSTANTS, spec.nb_src):
@@ -311,8 +314,6 @@ def build() -> Path:
 
 
 if __name__ == "__main__":
-    import logging
-
     logging.basicConfig(level=logging.INFO)
     so = build()
     print(so)

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -57,11 +57,17 @@ def metallib_path(name: str) -> Path:
 
 # Stable parts of the metallib compile command (the per-build temp input and
 # output paths are appended in _compile_metallib). One constant so the actual
-# compile and the staleness digest agree on the flags. ``-fno-fast-math`` is
-# REQUIRED so the precompiled library matches MLX's runtime ``newLibrary`` (which
-# sets ``setFastMathEnabled(false)``); without it the kernel numerics drift away
-# from the in-process source compile.
-_METALLIB_FLAGS = ("xcrun", "-sdk", "macosx", "metal", "-O3", "-fno-fast-math")
+# compile and the staleness digest agree on the flags. We mirror the flags MLX
+# uses to build its own shader libraries (share/cmake/MLX/extension.cmake:
+# ``MTLLIB_COMPILE_OPTIONS = -Wall -Wextra -fno-fast-math -Wno-c++17-extensions``;
+# the -W* flags only affect diagnostics). ``-fno-fast-math`` is the
+# numerics-critical one: the metal compiler defaults to fast-math ON, but MLX's
+# runtime ``newLibrary`` sets ``setFastMathEnabled(false)``, so without it the
+# precompiled kernels diverge from the in-process source compile. We deliberately
+# do NOT add ``-O3``: MLX compiles its shaders at the metal default optimization
+# (already enabled), so matching keeps the prebuilt path numerically and
+# behaviourally identical to what users get today.
+_METALLIB_FLAGS = ("xcrun", "-sdk", "macosx", "metal", "-fno-fast-math")
 
 
 def _metallib_source(name: str) -> str:
@@ -195,11 +201,15 @@ def _build_spec() -> _BuildSpec:
         "Metal",
         "-framework",
         "Foundation",
-        # No absolute "-Wl,-rpath,{mlx_lib}": baking the build machine's MLX
-        # path into a prebuilt wheel is wrong (it won't exist on the user's
-        # machine). Symbol resolution relies on "-undefined dynamic_lookup"
-        # plus MLX being imported first at load time (see metal/__init__.py),
-        # so libmlx is already resident when this .so is dlopen'd.
+        # "-lmlx" above validates our MLX symbols at link time and records a
+        # dependency on "@rpath/libmlx.dylib" (libmlx's install name). We add NO
+        # "-Wl,-rpath": baking the build machine's MLX path into a prebuilt wheel
+        # is wrong (it won't exist on the user's machine). So that recorded
+        # dependency is resolved not via an rpath but against an already-resident
+        # libmlx, which dyld matches by install name; "-undefined dynamic_lookup"
+        # resolves any remaining symbols the same way. Both require libmlx to be
+        # loaded first, which metal/__init__.py guarantees by importing mlx.core
+        # before this .so is dlopen'd.
         "-D_METAL_",
         "-DACCELERATE_NEW_LAPACK",
         f"-DVLLM_METAL_PARTITION_SIZE={PARTITION_SIZE}",

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -11,6 +11,7 @@ import hashlib
 import logging
 import subprocess
 import sysconfig
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -29,10 +30,85 @@ _EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
 _OUT = _THIS_DIR / f"_paged_ops{_EXT_SUFFIX}"
 _HASH = _OUT.with_suffix(_OUT.suffix + ".sha256")
 
+# Names of the three precompiled Metal shader libraries.  These are the same
+# cache-key names the C++ extension registers each library under
+# (init_*_library_path in paged_ops.cpp), so a later dispatch's
+# ``get_library(name)`` returns the .metallib loaded at startup.
+METALLIB_NAMES = ("paged_attention_v2_kern", "gdn_kern", "paged_mla_kern")
+
 
 def output_path() -> Path:
     """Path to the prebuilt native extension (whether or not it exists yet)."""
     return _OUT
+
+
+def metallib_path(name: str) -> Path:
+    """Path to a precompiled Metal shader library (whether or not it exists)."""
+    return _THIS_DIR / f"{name}.metallib"
+
+
+def _compile_metallib(name: str, source: str) -> Path:
+    """Compile Metal *source* to ``<name>.metallib`` inside the package dir.
+
+    ``-fno-fast-math`` is REQUIRED so the precompiled library matches MLX's
+    runtime ``newLibrary`` (which sets ``setFastMathEnabled(false)``); without
+    it the kernel numerics drift away from the in-process source compile.
+    """
+    out = metallib_path(name)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".metal", delete=False, dir=_THIS_DIR
+    )
+    try:
+        tmp.write(source)
+        tmp.close()
+        cmd = [
+            "xcrun",
+            "-sdk",
+            "macosx",
+            "metal",
+            "-O3",
+            "-fno-fast-math",
+            tmp.name,
+            "-o",
+            str(out),
+        ]
+        logger.info("  %s", " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to compile Metal library '{name}':\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+    return out
+
+
+def build_metallibs() -> list[Path]:
+    """Precompile the three Metal shader libraries to ``.metallib`` files.
+
+    PACKAGING-only (CI + release.sh): the default runtime path loads these
+    prebuilt libraries, but source mode (``VLLM_METAL_BUILD_FROM_SOURCE=1``)
+    compiles the shaders in-process via MLX, so a source-install dev without
+    the Metal toolchain never reaches this code.
+
+    The source builders are imported at call time (function-level) to avoid any
+    import-order coupling with :mod:`vllm_metal.metal`.
+    """
+    from vllm_metal.metal import (
+        _build_gdn_source,
+        _build_mla_paged_attention_source,
+        _build_v2_paged_attention_source,
+    )
+
+    builders = {
+        "paged_attention_v2_kern": _build_v2_paged_attention_source,
+        "gdn_kern": _build_gdn_source,
+        "paged_mla_kern": _build_mla_paged_attention_source,
+    }
+    logger.info("Building Metal shader libraries ...")
+    return [_compile_metallib(name, builder()) for name, builder in builders.items()]
 
 
 def _find_package_path(name: str) -> Path:
@@ -190,4 +266,7 @@ if __name__ == "__main__":
     import logging
 
     logging.basicConfig(level=logging.INFO)
-    print(build())
+    so = build()
+    print(so)
+    for lib in build_metallibs():
+        print(lib)

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -28,7 +28,15 @@ _EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
 # (maturin ``include``) bundles it into the wheel and the runtime loads it
 # without ever invoking clang++ on the end-user machine.
 _OUT = _THIS_DIR / f"_paged_ops{_EXT_SUFFIX}"
-_HASH = _OUT.with_suffix(_OUT.suffix + ".sha256")
+
+
+def _stamp_path(artifact: Path) -> Path:
+    """The ``.sha256`` sidecar recording the inputs an artifact was built from."""
+    return artifact.with_suffix(artifact.suffix + ".sha256")
+
+
+# The .so's stamp; identical mechanism to each .metallib's (see is_stale).
+_HASH = _stamp_path(_OUT)
 
 # Names of the three precompiled Metal shader libraries.  These are the same
 # cache-key names the C++ extension registers each library under
@@ -84,6 +92,16 @@ def _metallib_digest(source: str) -> str:
     return h.hexdigest()
 
 
+def _run_or_raise(cmd: list[str], what: str) -> None:
+    """Log and run a compiler command, raising with both streams on failure."""
+    logger.info("  %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to {what}:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
 def _compile_metallib(name: str, source: str) -> Path:
     """Compile Metal *source* to ``<name>.metallib`` in the package dir and write
     its ``.sha256`` staleness stamp."""
@@ -94,15 +112,10 @@ def _compile_metallib(name: str, source: str) -> Path:
     try:
         tmp.write(source)
         tmp.close()
-        cmd = [*_METALLIB_FLAGS, tmp.name, "-o", str(out)]
-        logger.info("  %s", " ".join(cmd))
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to compile Metal library '{name}':\n"
-                f"stdout:\n{result.stdout}\n"
-                f"stderr:\n{result.stderr}"
-            )
+        _run_or_raise(
+            [*_METALLIB_FLAGS, tmp.name, "-o", str(out)],
+            f"compile Metal library '{name}'",
+        )
     finally:
         Path(tmp.name).unlink(missing_ok=True)
     _stamp_path(out).write_text(_metallib_digest(source))
@@ -235,11 +248,6 @@ def needs_rebuild() -> bool:
         return True
 
 
-def _stamp_path(artifact: Path) -> Path:
-    """The ``.sha256`` sidecar recording the inputs an artifact was built from."""
-    return artifact.with_suffix(artifact.suffix + ".sha256")
-
-
 def is_stale(artifact: Path, expected_digest: str) -> bool:
     """One staleness primitive for every prebuilt artifact (the ``.so`` and each
     ``.metallib``). True only if ``artifact`` and its ``.sha256`` stamp both
@@ -276,16 +284,14 @@ def stale_artifacts() -> list[Path]:
 
 
 def build() -> Path:
-    """JIT-build the native extension, returning the path to the .so."""
+    """JIT-build the native extension, returning the path to the .so.
+
+    Skips the compile when the prebuilt .so is already current (needs_rebuild)."""
+    if not needs_rebuild():
+        return _OUT
+
     spec = _build_spec()
     expected_hash = _input_hash(spec)
-    if _OUT.exists() and _HASH.exists():
-        try:
-            if _HASH.read_text().strip() == expected_hash:
-                return _OUT
-        except OSError:
-            pass
-
     logger.info("Building native paged-attention extension ...")
 
     for p, label in [
@@ -297,15 +303,7 @@ def build() -> Path:
         if not Path(p).exists():
             raise FileNotFoundError(f"{label} not found: {p}")
 
-    logger.info("  %s", " ".join(spec.cmd))
-    result = subprocess.run(spec.cmd, capture_output=True, text=True)
-
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"Failed to build paged_ops extension:\n"
-            f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}"
-        )
+    _run_or_raise(spec.cmd, "build paged_ops extension")
 
     _HASH.write_text(expected_hash)
     logger.info("Built %s", _OUT)

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -47,55 +47,19 @@ def metallib_path(name: str) -> Path:
     return _THIS_DIR / f"{name}.metallib"
 
 
-def _compile_metallib(name: str, source: str) -> Path:
-    """Compile Metal *source* to ``<name>.metallib`` inside the package dir.
-
-    ``-fno-fast-math`` is REQUIRED so the precompiled library matches MLX's
-    runtime ``newLibrary`` (which sets ``setFastMathEnabled(false)``); without
-    it the kernel numerics drift away from the in-process source compile.
-    """
-    out = metallib_path(name)
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".metal", delete=False, dir=_THIS_DIR
-    )
-    try:
-        tmp.write(source)
-        tmp.close()
-        cmd = [
-            "xcrun",
-            "-sdk",
-            "macosx",
-            "metal",
-            "-O3",
-            "-fno-fast-math",
-            tmp.name,
-            "-o",
-            str(out),
-        ]
-        logger.info("  %s", " ".join(cmd))
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to compile Metal library '{name}':\n"
-                f"stdout:\n{result.stdout}\n"
-                f"stderr:\n{result.stderr}"
-            )
-    finally:
-        Path(tmp.name).unlink(missing_ok=True)
-    return out
+# Stable parts of the metallib compile command (the per-build temp input and
+# output paths are appended in _compile_metallib). One constant so the actual
+# compile and the staleness digest agree on the flags. ``-fno-fast-math`` is
+# REQUIRED so the precompiled library matches MLX's runtime ``newLibrary`` (which
+# sets ``setFastMathEnabled(false)``); without it the kernel numerics drift away
+# from the in-process source compile.
+_METALLIB_FLAGS = ("xcrun", "-sdk", "macosx", "metal", "-O3", "-fno-fast-math")
 
 
-def build_metallibs() -> list[Path]:
-    """Precompile the three Metal shader libraries to ``.metallib`` files.
-
-    PACKAGING-only (CI + release.sh): the default runtime path loads these
-    prebuilt libraries, but source mode (``VLLM_METAL_BUILD_FROM_SOURCE=1``)
-    compiles the shaders in-process via MLX, so a source-install dev without
-    the Metal toolchain never reaches this code.
-
-    The source builders are imported at call time (function-level) to avoid any
-    import-order coupling with :mod:`vllm_metal.metal`.
-    """
+def _metallib_source(name: str) -> str:
+    """Assemble the concatenated Metal source for one shader library. Source
+    builders are imported at call time (function-level) to avoid import-order
+    coupling with :mod:`vllm_metal.metal`."""
     from vllm_metal.metal import (
         _build_gdn_source,
         _build_mla_paged_attention_source,
@@ -107,8 +71,54 @@ def build_metallibs() -> list[Path]:
         "gdn_kern": _build_gdn_source,
         "paged_mla_kern": _build_mla_paged_attention_source,
     }
+    return builders[name]()
+
+
+def _metallib_digest(source: str) -> str:
+    """Content hash of a metallib: its assembled ``.metal`` source + the compile
+    flags. Editing any concatenated shader changes ``source`` and so the digest."""
+    h = hashlib.sha256()
+    h.update("\0".join(_METALLIB_FLAGS).encode())
+    h.update(b"\0")
+    h.update(source.encode())
+    return h.hexdigest()
+
+
+def _compile_metallib(name: str, source: str) -> Path:
+    """Compile Metal *source* to ``<name>.metallib`` in the package dir and write
+    its ``.sha256`` staleness stamp."""
+    out = metallib_path(name)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".metal", delete=False, dir=_THIS_DIR
+    )
+    try:
+        tmp.write(source)
+        tmp.close()
+        cmd = [*_METALLIB_FLAGS, tmp.name, "-o", str(out)]
+        logger.info("  %s", " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to compile Metal library '{name}':\n"
+                f"stdout:\n{result.stdout}\n"
+                f"stderr:\n{result.stderr}"
+            )
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+    _stamp_path(out).write_text(_metallib_digest(source))
+    return out
+
+
+def build_metallibs() -> list[Path]:
+    """Precompile the three Metal shader libraries to ``.metallib`` files.
+
+    PACKAGING-only (CI + release.sh): the default runtime path loads these
+    prebuilt libraries, but source mode (``VLLM_METAL_BUILD_FROM_SOURCE=1``)
+    compiles the shaders in-process via MLX, so a source-install dev without
+    the Metal toolchain never reaches this code.
+    """
     logger.info("Building Metal shader libraries ...")
-    return [_compile_metallib(name, builder()) for name, builder in builders.items()]
+    return [_compile_metallib(name, _metallib_source(name)) for name in METALLIB_NAMES]
 
 
 def _find_package_path(name: str) -> Path:
@@ -223,6 +233,46 @@ def needs_rebuild() -> bool:
         return _HASH.read_text().strip() != _input_hash(spec)
     except (OSError, ImportError, RuntimeError):
         return True
+
+
+def _stamp_path(artifact: Path) -> Path:
+    """The ``.sha256`` sidecar recording the inputs an artifact was built from."""
+    return artifact.with_suffix(artifact.suffix + ".sha256")
+
+
+def is_stale(artifact: Path, expected_digest: str) -> bool:
+    """One staleness primitive for every prebuilt artifact (the ``.so`` and each
+    ``.metallib``). True only if ``artifact`` and its ``.sha256`` stamp both
+    exist but the stamp no longer matches ``expected_digest`` — i.e. a source
+    was edited without rebuilding. A missing stamp (every wheel install, which
+    ships artifacts but no stamps) returns False, so end users never see a
+    staleness warning. Never raises."""
+    stamp = _stamp_path(artifact)
+    if not artifact.exists() or not stamp.exists():
+        return False
+    try:
+        return stamp.read_text().strip() != expected_digest
+    except OSError:
+        return False
+
+
+def stale_artifacts() -> list[Path]:
+    """Prebuilt artifacts whose stamp no longer matches the current sources —
+    the ``_paged_ops`` ``.so`` (vs ``paged_ops.cpp`` et al.) and each
+    ``.metallib`` (vs its ``.metal`` shaders) — checked through the single
+    :func:`is_stale` mechanism. Returns ``[]`` for wheel installs (no stamps)
+    without importing the build deps, and never raises: a staleness check must
+    not break loading."""
+    artifacts = (_OUT, *(metallib_path(n) for n in METALLIB_NAMES))
+    if not any(_stamp_path(a).exists() for a in artifacts):
+        return []
+    try:
+        digests = {_OUT: _input_hash(_build_spec())}
+        for name in METALLIB_NAMES:
+            digests[metallib_path(name)] = _metallib_digest(_metallib_source(name))
+    except (OSError, ImportError, RuntimeError, KeyError):
+        return []
+    return [a for a in artifacts if is_stale(a, digests[a])]
 
 
 def build() -> Path:

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -23,10 +23,16 @@ _SRC = _THIS_DIR / "paged_ops.cpp"
 _BUILD = _THIS_DIR / "build.py"
 _CONSTANTS = _THIS_DIR / "constants.py"
 _EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
-_CACHE_DIR = Path.home() / ".cache" / "vllm-metal"
-_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-_OUT = _CACHE_DIR / f"_paged_ops{_EXT_SUFFIX}"
+# The built extension lives inside the package directory so packaging
+# (maturin ``include``) bundles it into the wheel and the runtime loads it
+# without ever invoking clang++ on the end-user machine.
+_OUT = _THIS_DIR / f"_paged_ops{_EXT_SUFFIX}"
 _HASH = _OUT.with_suffix(_OUT.suffix + ".sha256")
+
+
+def output_path() -> Path:
+    """Path to the prebuilt native extension (whether or not it exists yet)."""
+    return _OUT
 
 
 def _find_package_path(name: str) -> Path:
@@ -90,7 +96,11 @@ def _build_spec() -> _BuildSpec:
         "Metal",
         "-framework",
         "Foundation",
-        f"-Wl,-rpath,{mlx_lib}",
+        # No absolute "-Wl,-rpath,{mlx_lib}": baking the build machine's MLX
+        # path into a prebuilt wheel is wrong (it won't exist on the user's
+        # machine). Symbol resolution relies on "-undefined dynamic_lookup"
+        # plus MLX being imported first at load time (see metal/__init__.py),
+        # so libmlx is already resident when this .so is dlopen'd.
         "-D_METAL_",
         "-DACCELERATE_NEW_LAPACK",
         f"-DVLLM_METAL_PARTITION_SIZE={PARTITION_SIZE}",
@@ -174,3 +184,10 @@ def build() -> Path:
     _HASH.write_text(expected_hash)
     logger.info("Built %s", _OUT)
     return _OUT
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    print(build())

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -80,13 +80,14 @@ void init_v2_library(const std::string& v2_src) {
       [&]() { return v2_paged_attention_source_; });
 }
 
-// Load a precompiled .metallib instead of compiling source. Uses the
-// get_library(name, path) overload, which loads the library and caches it
-// under "paged_attention_v2_kern"; later dispatch calls
-// get_library("paged_attention_v2_kern") (no path) return the cached library.
-void init_v2_library_path(const std::string& path) {
+// Load a precompiled .metallib instead of compiling its source. Uses MLX's
+// get_library(name, path) overload, which loads the library at `path` and
+// caches it under `name`; a later dispatch's get_library(name) (no path) then
+// returns this cached library. One generic loader for every shader library —
+// the cache-key name is passed in, so there is no per-library variant.
+void init_library_path(const std::string& name, const std::string& path) {
   auto& d = metal::device(Device::gpu);
-  d.get_library("paged_attention_v2_kern", path);
+  d.get_library(name, path);
 }
 
 // ---------------------------------------------------------------------------
@@ -698,13 +699,6 @@ void init_gdn_library(const std::string& src) {
   d.get_library("gdn_kern", [&]() { return gdn_source_; });
 }
 
-// Load a precompiled .metallib instead of compiling source (see
-// init_v2_library_path); caches the library under "gdn_kern".
-void init_gdn_library_path(const std::string& path) {
-  auto& d = metal::device(Device::gpu);
-  d.get_library("gdn_kern", path);
-}
-
 // ---------------------------------------------------------------------------
 // MLA paged attention (RFC #360)
 // ---------------------------------------------------------------------------
@@ -715,13 +709,6 @@ void init_mla_library(const std::string& src) {
   mla_source_ = src;
   auto& d = metal::device(Device::gpu);
   d.get_library("paged_mla_kern", [&]() { return mla_source_; });
-}
-
-// Load a precompiled .metallib instead of compiling source (see
-// init_v2_library_path); caches the library under "paged_mla_kern".
-void init_mla_library_path(const std::string& path) {
-  auto& d = metal::device(Device::gpu);
-  d.get_library("paged_mla_kern", path);
 }
 
 // Dispatch the MLA paged attention kernel.
@@ -1003,17 +990,13 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("v2_src"),
         "JIT-compile the v2 online-softmax Metal shader.");
 
-  m.def("init_v2_library_path", &init_v2_library_path,
-        nb::arg("path"),
-        "Load a precompiled v2 online-softmax .metallib from disk.");
+  m.def("init_library_path", &init_library_path,
+        nb::arg("name"), nb::arg("path"),
+        "Load a precompiled .metallib from disk, cached under `name`.");
 
   m.def("init_gdn_library", &init_gdn_library,
         nb::arg("gdn_src"),
         "JIT-compile the GDN linear attention Metal shader.");
-
-  m.def("init_gdn_library_path", &init_gdn_library_path,
-        nb::arg("path"),
-        "Load a precompiled GDN linear attention .metallib from disk.");
 
   m.def("tq_encode",
         [](nb::handle key_h, nb::handle value_h,
@@ -1146,10 +1129,6 @@ NB_MODULE(_paged_ops, m) {
   m.def("init_mla_library", &init_mla_library,
         nb::arg("src"),
         "JIT-compile the MLA paged attention Metal shader (RFC #360).");
-
-  m.def("init_mla_library_path", &init_mla_library_path,
-        nb::arg("path"),
-        "Load a precompiled MLA paged attention .metallib (RFC #360).");
 
   m.def("mla_paged_attention_primitive",
         [](nb::handle q_nope_h,

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -80,6 +80,15 @@ void init_v2_library(const std::string& v2_src) {
       [&]() { return v2_paged_attention_source_; });
 }
 
+// Load a precompiled .metallib instead of compiling source. Uses the
+// get_library(name, path) overload, which loads the library and caches it
+// under "paged_attention_v2_kern"; later dispatch calls
+// get_library("paged_attention_v2_kern") (no path) return the cached library.
+void init_v2_library_path(const std::string& path) {
+  auto& d = metal::device(Device::gpu);
+  d.get_library("paged_attention_v2_kern", path);
+}
+
 // ---------------------------------------------------------------------------
 // Helper: dtype → Metal type string
 // ---------------------------------------------------------------------------
@@ -689,6 +698,13 @@ void init_gdn_library(const std::string& src) {
   d.get_library("gdn_kern", [&]() { return gdn_source_; });
 }
 
+// Load a precompiled .metallib instead of compiling source (see
+// init_v2_library_path); caches the library under "gdn_kern".
+void init_gdn_library_path(const std::string& path) {
+  auto& d = metal::device(Device::gpu);
+  d.get_library("gdn_kern", path);
+}
+
 // ---------------------------------------------------------------------------
 // MLA paged attention (RFC #360)
 // ---------------------------------------------------------------------------
@@ -699,6 +715,13 @@ void init_mla_library(const std::string& src) {
   mla_source_ = src;
   auto& d = metal::device(Device::gpu);
   d.get_library("paged_mla_kern", [&]() { return mla_source_; });
+}
+
+// Load a precompiled .metallib instead of compiling source (see
+// init_v2_library_path); caches the library under "paged_mla_kern".
+void init_mla_library_path(const std::string& path) {
+  auto& d = metal::device(Device::gpu);
+  d.get_library("paged_mla_kern", path);
 }
 
 // Dispatch the MLA paged attention kernel.
@@ -980,9 +1003,17 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("v2_src"),
         "JIT-compile the v2 online-softmax Metal shader.");
 
+  m.def("init_v2_library_path", &init_v2_library_path,
+        nb::arg("path"),
+        "Load a precompiled v2 online-softmax .metallib from disk.");
+
   m.def("init_gdn_library", &init_gdn_library,
         nb::arg("gdn_src"),
         "JIT-compile the GDN linear attention Metal shader.");
+
+  m.def("init_gdn_library_path", &init_gdn_library_path,
+        nb::arg("path"),
+        "Load a precompiled GDN linear attention .metallib from disk.");
 
   m.def("tq_encode",
         [](nb::handle key_h, nb::handle value_h,
@@ -1115,6 +1146,10 @@ NB_MODULE(_paged_ops, m) {
   m.def("init_mla_library", &init_mla_library,
         nb::arg("src"),
         "JIT-compile the MLA paged attention Metal shader (RFC #360).");
+
+  m.def("init_mla_library_path", &init_mla_library_path,
+        nb::arg("path"),
+        "Load a precompiled MLA paged attention .metallib (RFC #360).");
 
   m.def("mla_paged_attention_primitive",
         [](nb::handle q_nope_h,


### PR DESCRIPTION




## What & why

Ship the native paged-attention extension **prebuilt in the wheel** instead of compiling it on the user's machine at first run.

Today `get_ops()` JIT-builds `paged_ops.cpp` + nanobind with `clang++` into `~/.cache` on first use — fragile (needs Xcode CLT, matching MLX headers, and nanobind). After this PR, users run zero cpp compilers.

This will also pave the way for future simpler installation (one line pip install)


## Cold start: no first-run compilation

Today the native kernels compile on first use, and that first run is slow. Measured (`get_ops()` wall time, fresh process, M-series):

| startup kernel init                                   | main (JIT) | this PR |
|-------------------------------------------------------|-----------:|--------:|
| clang++ build of `paged_ops.cpp` + nanobind           |    ~3.8 s  |    —    |
| Metal shader source→AIR compile (9.8 MB v2 dominates) |    ~8.1 s  |    —    |
| **first run on a fresh machine**                      | **~12 s**  | **~0.35 s** |
| subsequent restarts (OS caches warm)                  |   ~0.05 s  | ~0.04 s |

A freshly-installed wheel reaches its first token **~11.5 s sooner**, with zero compilers or Metal toolchain invoked. macOS caches compiled kernels across processes, so on `main` this is a **one-time, per-machine** cost (it recurs on every kernel-source change or MLX bump); steady-state restart time is unchanged.

<sub>Method: measured in-tree by toggling `VLLM_METAL_BUILD_FROM_SOURCE` (same sources, only load strategy differs); cold shader compile isolated by salting the source to force a metal-compiler cache miss, leaving the shared system cache untouched (stable 8.0–8.2 s across runs).</sub>

## Changes

- **Prebuilt `.so`** — `build.py` emits `_paged_ops*.so` into the package at build time; `get_ops()` loads it and fails loud if it's missing (no silent runtime compile). maturin `include` bundles it; `mlx` pinned to `==0.31.2`.
- **Precompiled shaders** — the v2 / GDN / MLA Metal libraries are compiled to `.metallib` (`xcrun metal -O3 -fno-fast-math`, matching MLX's `setFastMathEnabled(false)`) and loaded by path — no first-request shader compile.
- **CI / release** — `release.sh` and the CI test job build the artifacts before packaging, behind a defensive Metal-toolchain check; the wheel is self-contained.
- **Staleness guard** — editing `paged_ops.cpp` or a `.metal` shader without rebuilding makes `get_ops()` warn (content-hash stamps); silent for wheel users.

## Contributors

No compiler needed to *use* it. To hack on the kernels, set `VLLM_METAL_BUILD_FROM_SOURCE=1` (see `docs/CONTRIBUTING.md`) — this compiles the `.cpp` and shaders from source at runtime, so edit + restart is enough.

## ABI note

The prebuilt `.so` links MLX's private headers and subclasses its `Primitive` types, and `libmlx.dylib` carries no SONAME version — so the wheel is ABI-safe only against the exact MLX it was built against. Hence the `mlx==0.31.2` pin and a rebuild on every MLX bump.


