### PR TITLE
Clean up dead private helper code

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_KV_SHARING_FAST_PREFILL` | `1` | Enable Gemma4 YOCO fast prefill for eligible Gemma4 models on the paged KV path |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
-| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto`, `text-only-compat`, or `multimodal-native` |
+| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` / `text-only-compat` use the compatibility allowlist; `multimodal-native` disables overrides |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |
 | `VLLM_METAL_GDN_LAZY_KERNELS` | `1` | Enable lazy GDN kernels for eligible hybrid batches. Set to `0` to force the eager conv / C++ recurrent fallback path. |
@@ -18,8 +18,8 @@
 
 ## Multimodal Serve Modes
 
-- `auto`: use native multimodal loading by default, but fall back to the text-only compatibility path for known-incompatible checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
-- `text-only-compat`: force the text-only compatibility path only for known-safe checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers. Other multimodal checkpoints stay on the native multimodal loader.
+- `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
+- `text-only-compat`: use the same compatibility allowlist as `auto`.
 - `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
 
 ## Gemma4 YOCO Fast Prefill

--- a/tests/test_mla_materialized_prefill.py
+++ b/tests/test_mla_materialized_prefill.py
@@ -120,11 +120,10 @@ def test_materialized_prefill_matches_absorbed_loop(
 def test_materialized_prefill_gate() -> None:
     """The gate engages for an absorbed model on pure prefill (past=0) and falls
     back to the absorbed loop for chunked prefill (past>0)."""
-    inner, cache, wrapper = _make()
+    inner, _, wrapper = _make()
     # pure prefill (past=0): ctx_len == num_new → engage
     assert wrapper._materialized_prefill_ok(
         inner,
-        cache,
         pac.PagedAttentionContext(
             slot_mapping=[0, 1],
             block_tables=[[0]],
@@ -136,7 +135,6 @@ def test_materialized_prefill_gate() -> None:
     # past>0 (ctx_len 4 > num_new 2): chunked prefill → fall back
     assert not wrapper._materialized_prefill_ok(
         inner,
-        cache,
         pac.PagedAttentionContext(
             slot_mapping=[0, 1],
             block_tables=[[0]],

--- a/vllm_metal/attention/impls/mla.py
+++ b/vllm_metal/attention/impls/mla.py
@@ -194,9 +194,7 @@ class MLAPagedAttentionWrapper(nn.Module):
         out_unembedded = inner.unembed_out(out_for_unembed)
         return out_unembedded.transpose(0, 2, 1, 3).reshape(1, seq_len, -1)
 
-    def _materialized_prefill_ok(
-        self, inner: nn.Module, latent_cache: MLAPagedLatentCache, ctx: Any
-    ) -> bool:
+    def _materialized_prefill_ok(self, inner: nn.Module, ctx: Any) -> bool:
         """Gate for the materialized-prefill fast path (RFC #360 Phase 2): an
         absorbed model with MultiLinear ``embed_q``/``unembed_out`` and pure
         prefill (past=0). On by default — bitwise-equal to the absorbed
@@ -402,7 +400,7 @@ class MLAPagedAttentionWrapper(nn.Module):
         # Materialized-prefill fast path (opt-in; absorbed model, past=0).
         # Materializes full K/V and runs standard MHA via MLX SDPA instead of the
         # absorbed 512-wide MQA loop (RFC #360 Phase 2). Falls through otherwise.
-        if self._materialized_prefill_ok(inner, latent_cache, ctx):
+        if self._materialized_prefill_ok(inner, ctx):
             final = self._materialized_prefill(
                 inner, q_nope, q_pe, kv_norm, k_pe, ctx, seq_len
             )

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -227,19 +227,12 @@ class DefaultModelAdapter(ModelAdapter):
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether the current serve mode should use the text-only path.
 
-        Modes:
-        - ``multimodal-native``: never force compatibility; keep native VLM
-          loading active so multimodal support can be developed/tested.
-        - ``text-only-compat``: force the text-only path only for the
-          known-safe compatibility allowlist.
-        - ``auto``: apply the compatibility path only for known-incompatible
-          checkpoints such as Gemma4 and Qwen3.5/Qwen3.6 FP8 wrappers.
+        ``multimodal-native`` disables compatibility overrides. ``auto`` and
+        ``text-only-compat`` share the same compatibility allowlist.
         """
         multimodal_mode = self._multimodal_mode()
         if multimodal_mode == "multimodal-native":
             return False
-        if multimodal_mode == "text-only-compat":
-            return self._matches_auto_text_backbone_override(hf_config)
         return self._matches_auto_text_backbone_override(hf_config)
 
     def normalize_model_config(self, model_config: ModelConfig) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -722,7 +722,6 @@ class MetalModelRunner:
 
     def _prefill_single(
         self,
-        req_id: str,
         token_ids: list[int],
         sampling_params: SamplingParams,
         generator: torch.Generator | None = None,
@@ -730,7 +729,6 @@ class MetalModelRunner:
         """Process a single prefill request.
 
         Args:
-            req_id: Request ID
             token_ids: Prompt token IDs
             sampling_params: Sampling parameters for this request
 
@@ -1801,7 +1799,6 @@ class MetalModelRunner:
                 continue
 
             next_token, cache, logprobs = self._prefill_single(
-                req_id,
                 token_ids,
                 sampling_params,
                 generator=generator,


### PR DESCRIPTION
This PR is:
- To remove a redundant multimodal mode branch where `auto` and `text-only-compat` intentionally share the same compatibility allowlist.
- To drop unused private helper arguments from the prefill and MLA materialized-prefill paths.
- To keep private helper signatures aligned with the data they actually consume after the attention refactor.