### PR TITLE
Remove YOCO fast prefill env flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,6 @@
 | `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute (1=yes, 0=no) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
-| `VLLM_METAL_KV_SHARING_FAST_PREFILL` | `1` | Enable Gemma4 YOCO fast prefill for eligible Gemma4 models on the paged KV path |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
 | `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` / `text-only-compat` use the compatibility allowlist; `multimodal-native` disables overrides |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
@@ -22,12 +21,6 @@
 - `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
 - `text-only-compat`: use the same compatibility allowlist as `auto`.
 - `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
-
-## Gemma4 YOCO Fast Prefill
-
-Gemma4 YOCO fast prefill is enabled by default for eligible Gemma4 text models on the paged KV path. It runs the YOCO KV-shared decoder layers only on the selected logits positions during prefill, then scatters those hidden states back before the final norm and LM head. Set `VLLM_METAL_KV_SHARING_FAST_PREFILL=0` to disable it.
-
-This path requires `VLLM_METAL_USE_PAGED_ATTENTION=1` and is currently limited to Gemma4/Gemma4 text models with KV-shared layers. Ineligible models continue without fast prefill; if `VLLM_METAL_KV_SHARING_FAST_PREFILL=1` was explicitly set, vllm-metal logs a warning for the skipped enablement.
 
 ## Paged KV vs MLX KV Memory Settings
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,6 @@ class TestMetalConfig:
         assert config.mlx_device == "gpu"
         assert config.debug is False
         assert config.use_paged_attention is True
-        assert config.kv_sharing_fast_prefill is True
         assert config.multimodal_mode == "auto"
 
     def test_custom_config_from_env(self, monkeypatch) -> None:
@@ -44,7 +43,6 @@ class TestMetalConfig:
         monkeypatch.setenv("VLLM_MLX_DEVICE", "cpu")
         monkeypatch.setenv("VLLM_METAL_DEBUG", "1")
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
-        monkeypatch.setenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "1")
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
 
         config = MetalConfig.from_env()
@@ -53,37 +51,14 @@ class TestMetalConfig:
         assert config.use_mlx is False
         assert config.mlx_device == "cpu"
         assert config.debug is True
-        assert config.kv_sharing_fast_prefill is True
         assert config.multimodal_mode == "multimodal-native"
 
-    def test_kv_sharing_fast_prefill_can_be_disabled(self, monkeypatch) -> None:
-        monkeypatch.setenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "0")
-
-        config = MetalConfig.from_env()
-
-        assert config.kv_sharing_fast_prefill is False
-
-    def test_kv_sharing_fast_prefill_default_off_without_paged_attention(
-        self, monkeypatch
-    ) -> None:
+    def test_paged_attention_can_be_disabled(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
 
         config = MetalConfig.from_env()
 
         assert config.use_paged_attention is False
-        assert config.kv_sharing_fast_prefill is False
-
-    def test_explicit_kv_sharing_fast_prefill_requires_paged_attention_env(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
-        monkeypatch.setenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "1")
-
-        with pytest.raises(
-            ValueError,
-            match="VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention",
-        ):
-            MetalConfig.from_env()
 
     def test_get_config_singleton(self) -> None:
         """Test that get_config returns a singleton."""
@@ -169,20 +144,6 @@ class TestMetalConfig:
         assert config.turboquant is False
         assert config.k_quant == "q8_0"
         assert config.v_quant == "q3_0"
-
-    def test_kv_sharing_fast_prefill_requires_paged_attention(self) -> None:
-        with pytest.raises(
-            ValueError,
-            match="VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention",
-        ):
-            MetalConfig(
-                memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=True,
-                mlx_device="gpu",
-                debug=False,
-                use_paged_attention=False,
-                kv_sharing_fast_prefill=True,
-            )
 
     def test_text_only_compat_mode_is_accepted(self) -> None:
         config = MetalConfig(

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -174,7 +174,6 @@ def test_try_enable_skips_ineligible_gemma4_yoco_shape(
     assert not try_enable_gemma4_yoco_fast_prefill(
         object(),
         model_args,
-        use_paged_attention=True,
     )
     assert "Gemma4 YOCO fast prefill skipped" in _logged_call_text(debug)
 
@@ -192,28 +191,9 @@ def test_try_enable_logs_skip_at_debug(
             "num_hidden_layers": 32,
             "num_kv_shared_layers": 8,
         },
-        use_paged_attention=True,
     )
     debug.assert_called_once()
     assert "model_type='qwen3' is not Gemma4" in _logged_call_text(debug)
-
-
-def test_try_enable_logs_without_paged_attention(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    debug = Mock()
-    monkeypatch.setattr("vllm_metal.attention.yoco.logger.debug", debug)
-
-    assert not try_enable_gemma4_yoco_fast_prefill(
-        object(),
-        {
-            "model_type": "gemma4",
-            "num_hidden_layers": 42,
-            "num_kv_shared_layers": 18,
-        },
-        use_paged_attention=False,
-    )
-    assert "paged attention is disabled" in _logged_call_text(debug)
 
 
 def test_try_enable_logs_missing_num_hidden_layers(
@@ -228,7 +208,6 @@ def test_try_enable_logs_missing_num_hidden_layers(
             "model_type": "gemma4",
             "num_kv_shared_layers": 18,
         },
-        use_paged_attention=True,
     )
     assert "num_hidden_layers is missing or not an int" in _logged_call_text(debug)
 
@@ -246,7 +225,6 @@ def test_try_enable_logs_when_not_all_layers_are_paged(
             "num_hidden_layers": 4,
             "num_kv_shared_layers": 2,
         },
-        use_paged_attention=True,
         num_paged_layers=3,
     )
     assert "only 3/4 layers use paged attention" in _logged_call_text(debug)
@@ -396,7 +374,6 @@ def test_try_enable_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> N
             "num_hidden_layers": 4,
             "num_kv_shared_layers": 2,
         },
-        use_paged_attention=True,
         num_paged_layers=4,
     )
 

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -29,9 +29,9 @@ _FAST_PREFILL_ENABLED_ATTR = "_vllm_metal_yoco_fast_prefill_enabled"
 _REAL_RESULT_MARKER = "VLLM_METAL_YOCO_FAST_PREFILL_RESULT="
 
 
-def _logged_warning_text(warning: Mock) -> str:
+def _logged_call_text(log_method: Mock) -> str:
     rendered = []
-    for call in warning.call_args_list:
+    for call in log_method.call_args_list:
         if not call.args:
             continue
         fmt = str(call.args[0])
@@ -42,7 +42,7 @@ def _logged_warning_text(warning: Mock) -> str:
 def _run_real_gemma4_paged_path(
     model_path: str,
     *,
-    fast_prefill: bool,
+    skip_fast_prefill_hook: bool = False,
 ) -> tuple[dict[str, list[int]], bool]:
     memory_fraction = os.environ.get(
         "GEMMA4_FAST_PREFILL_MEMORY_FRACTION",
@@ -53,26 +53,35 @@ def _run_real_gemma4_paged_path(
         {
             "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
             "VLLM_METAL_USE_PAGED_ATTENTION": "1",
-            "VLLM_METAL_KV_SHARING_FAST_PREFILL": "1" if fast_prefill else "0",
             "VLLM_METAL_MEMORY_FRACTION": memory_fraction,
         }
     )
 
     script = f"""
 import json
-from contextlib import suppress
+from contextlib import nullcontext, suppress
+from unittest.mock import patch
 
 from vllm import LLM, SamplingParams
 
 model_path = {model_path!r}
 prompts = {json.dumps(_REAL_GEMMA4_PROMPTS)}
 enabled_attr = {_FAST_PREFILL_ENABLED_ATTR!r}
-llm = LLM(
-    model=model_path,
-    max_model_len={_REAL_GEMMA4_MAX_MODEL_LEN},
-    max_num_seqs={len(_REAL_GEMMA4_PROMPTS)},
-    enable_prefix_caching=False,
+fast_prefill_hook = (
+    patch(
+        "vllm_metal.v1.cache_policy.try_enable_gemma4_yoco_fast_prefill",
+        return_value=False,
+    )
+    if {skip_fast_prefill_hook!r}
+    else nullcontext()
 )
+with fast_prefill_hook:
+    llm = LLM(
+        model=model_path,
+        max_model_len={_REAL_GEMMA4_MAX_MODEL_LEN},
+        max_num_seqs={len(_REAL_GEMMA4_PROMPTS)},
+        enable_prefix_caching=False,
+    )
 runner = llm.llm_engine.model_executor.driver_worker.model_runner
 model = runner.model
 language_model = getattr(model, "language_model", None)
@@ -119,7 +128,8 @@ if callable(shutdown):
     if result.returncode != 0:
         raise AssertionError(
             "real Gemma4 paged-path subprocess failed "
-            f"(fast_prefill={fast_prefill}, code={result.returncode})\n"
+            f"(skip_fast_prefill_hook={skip_fast_prefill_hook}, "
+            f"code={result.returncode})\n"
             f"{output[-8000:]}"
         )
     for line in output.splitlines():
@@ -158,26 +168,21 @@ def test_try_enable_skips_ineligible_gemma4_yoco_shape(
     model_args,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    warning = Mock()
-    monkeypatch.setattr("vllm_metal.attention.yoco.logger.warning", warning)
+    debug = Mock()
+    monkeypatch.setattr("vllm_metal.attention.yoco.logger.debug", debug)
 
     assert not try_enable_gemma4_yoco_fast_prefill(
         object(),
         model_args,
         use_paged_attention=True,
-        warn_on_skip=True,
     )
-    warning_text = _logged_warning_text(warning)
-    assert "Gemma4 YOCO fast prefill is enabled" in warning_text
-    assert "continuing without fast prefill" in warning_text
+    assert "Gemma4 YOCO fast prefill skipped" in _logged_call_text(debug)
 
 
-def test_try_enable_can_skip_ineligible_model_without_warning(
+def test_try_enable_logs_skip_at_debug(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    warning = Mock()
     debug = Mock()
-    monkeypatch.setattr("vllm_metal.attention.yoco.logger.warning", warning)
     monkeypatch.setattr("vllm_metal.attention.yoco.logger.debug", debug)
 
     assert not try_enable_gemma4_yoco_fast_prefill(
@@ -188,17 +193,16 @@ def test_try_enable_can_skip_ineligible_model_without_warning(
             "num_kv_shared_layers": 8,
         },
         use_paged_attention=True,
-        warn_on_skip=False,
     )
-    warning.assert_not_called()
     debug.assert_called_once()
+    assert "model_type='qwen3' is not Gemma4" in _logged_call_text(debug)
 
 
 def test_try_enable_logs_without_paged_attention(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    warning = Mock()
-    monkeypatch.setattr("vllm_metal.attention.yoco.logger.warning", warning)
+    debug = Mock()
+    monkeypatch.setattr("vllm_metal.attention.yoco.logger.debug", debug)
 
     assert not try_enable_gemma4_yoco_fast_prefill(
         object(),
@@ -208,19 +212,15 @@ def test_try_enable_logs_without_paged_attention(
             "num_kv_shared_layers": 18,
         },
         use_paged_attention=False,
-        warn_on_skip=True,
     )
-    warning_text = _logged_warning_text(warning)
-    assert "Gemma4 YOCO fast prefill is enabled" in warning_text
-    assert "paged attention is disabled" in warning_text
-    assert "continuing without fast prefill" in warning_text
+    assert "paged attention is disabled" in _logged_call_text(debug)
 
 
 def test_try_enable_logs_missing_num_hidden_layers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    warning = Mock()
-    monkeypatch.setattr("vllm_metal.attention.yoco.logger.warning", warning)
+    debug = Mock()
+    monkeypatch.setattr("vllm_metal.attention.yoco.logger.debug", debug)
 
     assert not try_enable_gemma4_yoco_fast_prefill(
         object(),
@@ -229,16 +229,15 @@ def test_try_enable_logs_missing_num_hidden_layers(
             "num_kv_shared_layers": 18,
         },
         use_paged_attention=True,
-        warn_on_skip=True,
     )
-    assert "num_hidden_layers is missing or not an int" in _logged_warning_text(warning)
+    assert "num_hidden_layers is missing or not an int" in _logged_call_text(debug)
 
 
 def test_try_enable_logs_when_not_all_layers_are_paged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    warning = Mock()
-    monkeypatch.setattr("vllm_metal.attention.yoco.logger.warning", warning)
+    debug = Mock()
+    monkeypatch.setattr("vllm_metal.attention.yoco.logger.debug", debug)
 
     assert not try_enable_gemma4_yoco_fast_prefill(
         object(),
@@ -249,9 +248,8 @@ def test_try_enable_logs_when_not_all_layers_are_paged(
         },
         use_paged_attention=True,
         num_paged_layers=3,
-        warn_on_skip=True,
     )
-    assert "only 3/4 layers use paged attention" in _logged_warning_text(warning)
+    assert "only 3/4 layers use paged attention" in _logged_call_text(debug)
 
 
 def test_reduced_context_from_full_paged_metadata() -> None:
@@ -434,7 +432,7 @@ def test_try_enable_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> N
 
 
 @pytest.mark.slow
-def test_real_gemma4_paged_path_matches_with_fast_prefill_off_on() -> None:
+def test_real_gemma4_paged_path_default_fast_prefill_matches_original() -> None:
     model_path = os.environ.get(_REAL_GEMMA4_MODEL_ENV) or os.environ.get(
         _REAL_GEMMA4_FALLBACK_MODEL_ENV
     )
@@ -446,19 +444,17 @@ def test_real_gemma4_paged_path_matches_with_fast_prefill_off_on() -> None:
     if not os.path.isdir(model_path):
         pytest.skip(f"{model_path} is not a directory")
 
-    off_tokens, off_enabled = _run_real_gemma4_paged_path(
+    original_tokens, original_enabled = _run_real_gemma4_paged_path(
         model_path,
-        fast_prefill=False,
+        skip_fast_prefill_hook=True,
     )
-    assert not off_enabled
+    assert not original_enabled
 
-    on_tokens, on_enabled = _run_real_gemma4_paged_path(
+    fast_tokens, fast_enabled = _run_real_gemma4_paged_path(
         model_path,
-        fast_prefill=True,
     )
-
-    assert on_enabled
-    assert on_tokens == off_tokens
+    assert fast_enabled
+    assert fast_tokens == original_tokens
 
 
 @pytest.mark.parametrize(

--- a/tools/benchmark/gemma4_mtp_benchmark.py
+++ b/tools/benchmark/gemma4_mtp_benchmark.py
@@ -106,7 +106,6 @@ def environment_metadata() -> dict[str, Any]:
             for name in (
                 "VLLM_METAL_MEMORY_FRACTION",
                 "VLLM_METAL_USE_PAGED_ATTENTION",
-                "VLLM_METAL_KV_SHARING_FAST_PREFILL",
                 "VLLM_ENABLE_V1_MULTIPROCESSING",
             )
             if os.environ.get(name) is not None

--- a/vllm_metal/attention/yoco.py
+++ b/vllm_metal/attention/yoco.py
@@ -33,13 +33,11 @@ def try_enable_gemma4_yoco_fast_prefill(
     model: Any,
     model_args: Mapping[str, object],
     *,
-    use_paged_attention: bool,
     num_paged_layers: int | None = None,
 ) -> bool:
     """Enable Gemma4 YOCO fast prefill when the loaded model is eligible."""
     reason = _yoco_fast_prefill_skip_reason(
         model_args,
-        use_paged_attention=use_paged_attention,
         num_paged_layers=num_paged_layers,
     )
     if reason is not None:
@@ -57,12 +55,8 @@ def try_enable_gemma4_yoco_fast_prefill(
 def _yoco_fast_prefill_skip_reason(
     model_args: Mapping[str, object],
     *,
-    use_paged_attention: bool,
     num_paged_layers: int | None,
 ) -> str | None:
-    if not use_paged_attention:
-        return "paged attention is disabled"
-
     model_type = model_args.get("model_type")
     if model_type not in _GEMMA4_MODEL_TYPES:
         return f"model_type={model_type!r} is not Gemma4"

--- a/vllm_metal/attention/yoco.py
+++ b/vllm_metal/attention/yoco.py
@@ -35,7 +35,6 @@ def try_enable_gemma4_yoco_fast_prefill(
     *,
     use_paged_attention: bool,
     num_paged_layers: int | None = None,
-    warn_on_skip: bool = True,
 ) -> bool:
     """Enable Gemma4 YOCO fast prefill when the loaded model is eligible."""
     reason = _yoco_fast_prefill_skip_reason(
@@ -44,20 +43,14 @@ def try_enable_gemma4_yoco_fast_prefill(
         num_paged_layers=num_paged_layers,
     )
     if reason is not None:
-        _log_fast_prefill_skip(
-            reason,
-            warn_on_skip=warn_on_skip,
-        )
+        _log_fast_prefill_skip(reason)
         return False
 
     if _install_gemma4_yoco_fast_prefill_patch(model):
         logger.info("Gemma4 YOCO fast prefill enabled")
         return True
 
-    _log_fast_prefill_skip(
-        "the Gemma4 text-model patch could not be installed",
-        warn_on_skip=warn_on_skip,
-    )
+    _log_fast_prefill_skip("the Gemma4 text-model patch could not be installed")
     return False
 
 
@@ -94,15 +87,8 @@ def _yoco_fast_prefill_skip_reason(
     return None
 
 
-def _log_fast_prefill_skip(reason: str, *, warn_on_skip: bool) -> None:
-    if warn_on_skip:
-        logger.warning(
-            "Gemma4 YOCO fast prefill is enabled, but %s; "
-            "continuing without fast prefill",
-            reason,
-        )
-    else:
-        logger.debug("Gemma4 YOCO fast prefill skipped: %s", reason)
+def _log_fast_prefill_skip(reason: str) -> None:
+    logger.debug("Gemma4 YOCO fast prefill skipped: %s", reason)
 
 
 @dataclass(frozen=True)

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Configuration for vLLM Metal plugin via environment variables."""
 
-import os
 from dataclasses import dataclass
 from typing import Literal
 
@@ -44,7 +43,6 @@ class MetalConfig:
     mlx_device: Literal["gpu", "cpu"]
     debug: bool
     use_paged_attention: bool = True
-    kv_sharing_fast_prefill: bool = False
     multimodal_mode: MultimodalMode = "auto"
     turboquant: bool = False  # Enable TurboQuant KV cache compression
     k_quant: str = "q8_0"  # Key quantization type: q8_0, q4_0, int8, uint8, etc.
@@ -57,13 +55,6 @@ class MetalConfig:
                 "supported with paged attention (the default). "
                 "The MLX KV cache path (VLLM_METAL_USE_PAGED_ATTENTION=0) "
                 "requires VLLM_METAL_MEMORY_FRACTION=auto."
-            )
-
-        if self.kv_sharing_fast_prefill and not self.use_paged_attention:
-            raise ValueError(
-                "VLLM_METAL_KV_SHARING_FAST_PREFILL requires paged attention. "
-                "Enable VLLM_METAL_USE_PAGED_ATTENTION=1 or set "
-                "VLLM_METAL_KV_SHARING_FAST_PREFILL=0."
             )
 
         if self.use_paged_attention and not self.is_auto_memory:
@@ -123,14 +114,6 @@ class MetalConfig:
                     "Must be 'auto' or a numeric value in (0, 1]."
                 ) from e
 
-        use_paged_attention = envs.VLLM_METAL_USE_PAGED_ATTENTION
-        kv_sharing_fast_prefill = envs.VLLM_METAL_KV_SHARING_FAST_PREFILL
-        if (
-            not use_paged_attention
-            and "VLLM_METAL_KV_SHARING_FAST_PREFILL" not in os.environ
-        ):
-            kv_sharing_fast_prefill = False
-
         # TurboQuant config is set via --additional-config, not env vars.
         # See MetalPlatform.check_and_update_config() for how it's applied.
         return cls(
@@ -138,8 +121,7 @@ class MetalConfig:
             use_mlx=envs.VLLM_METAL_USE_MLX,
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
             debug=envs.VLLM_METAL_DEBUG,
-            use_paged_attention=use_paged_attention,
-            kv_sharing_fast_prefill=kv_sharing_fast_prefill,
+            use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
             multimodal_mode=envs.VLLM_METAL_MULTIMODAL_MODE,  # type: ignore[arg-type]
         )
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     VLLM_MLX_DEVICE: str = "gpu"
     VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
-    VLLM_METAL_KV_SHARING_FAST_PREFILL: bool = True
     VLLM_METAL_MULTIMODAL_MODE: str = "auto"
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
     VLLM_METAL_GDN_LAZY_KERNELS: bool = True
@@ -47,11 +46,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use native Metal paged attention (default True).
     "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
         os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
-    ),
-    # Experimental YOCO/KV-sharing fast prefill. Default on for eligible
-    # paged-attention models.
-    "VLLM_METAL_KV_SHARING_FAST_PREFILL": lambda: (
-        os.getenv("VLLM_METAL_KV_SHARING_FAST_PREFILL", "1") == "1"
     ),
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -629,7 +629,6 @@ class WorkerCachePlanner:
         try_enable_gemma4_yoco_fast_prefill(
             self._worker.model_runner.model,
             self._worker.model_runner.model_args,
-            use_paged_attention=config.use_paged_attention,
             num_paged_layers=n_patched,
         )
         logger.info(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
@@ -28,6 +27,7 @@ from vllm_metal.attention.runtime.hybrid import (
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.attention.runtime.mla import MLAPagedAttentionRuntime
 from vllm_metal.attention.runtime.protocol import PagedAttentionRuntime
+from vllm_metal.attention.yoco import try_enable_gemma4_yoco_fast_prefill
 from vllm_metal.config import (
     PAGED_ATTENTION_DEFAULT_MEMORY_FRACTION,
     PAGED_ATTENTION_MIN_BLOCKS,
@@ -625,16 +625,13 @@ class WorkerCachePlanner:
         )
         n_patched = backend.patch_model(self._worker.model_runner.model)
         config = get_config()
-        if config.kv_sharing_fast_prefill:
-            from vllm_metal.attention.yoco import try_enable_gemma4_yoco_fast_prefill
 
-            try_enable_gemma4_yoco_fast_prefill(
-                self._worker.model_runner.model,
-                self._worker.model_runner.model_args,
-                use_paged_attention=config.use_paged_attention,
-                num_paged_layers=n_patched,
-                warn_on_skip="VLLM_METAL_KV_SHARING_FAST_PREFILL" in os.environ,
-            )
+        try_enable_gemma4_yoco_fast_prefill(
+            self._worker.model_runner.model,
+            self._worker.model_runner.model_args,
+            use_paged_attention=config.use_paged_attention,
+            num_paged_layers=n_patched,
+        )
         logger.info(
             "Paged attention enabled: %d layers patched, "
             "%d blocks allocated (block_size=%d, mla=%s, turboquant=%s, k_quant=%s)",


### PR DESCRIPTION
This PR is:

- To remove the user-visible YOCO fast prefill env/config flag now that Gemma4 YOCO fast prefill is the default eligible path.
- To enable Gemma4 YOCO fast prefill directly from paged-attention setup when the loaded model matches the supported Gemma4 text contract.
- To remove stale docs and benchmark references to disabling YOCO fast prefill.