### PR TITLE
Bump mlx-vlm and enable PaddleOCR-VL multi-image requests

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -44,7 +44,7 @@ Native multimodal support currently targets image-only vision-language requests 
 | Model | Support | Runner | Scope | Example checkpoint |
 | --- | --- | --- | --- | --- |
 | Qwen3-VL | 🔵 | native multimodal paged generation | image input, no video | `mlx-community/Qwen3-VL-4B-Instruct-4bit` |
-| PaddleOCR-VL | 🔵 | native multimodal paged generation | image input, one image per request | `PaddlePaddle/PaddleOCR-VL-1.6` |
+| PaddleOCR-VL | 🔵 | native multimodal paged generation | image input, no video | `PaddlePaddle/PaddleOCR-VL-1.6` |
 
 ## Text-Only Language Models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "mlx>=0.31.0,<0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
-    # mlx-vlm 0.5.x also requires llguidance>=1.7.0.
-    "mlx-vlm>=0.5.0,<0.6.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
+    "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
     # First allowed Transformers v5 release per vLLM 0.22.1's exclude list.
     "transformers>=5.5.1",

--- a/tests/multimodal/test_paddleocr_vl.py
+++ b/tests/multimodal/test_paddleocr_vl.py
@@ -18,6 +18,9 @@ _SPATIAL_MERGE_SIZE = 2
 _IMAGE_GRID_THW_2X2 = (1, 4, 4)
 _IMAGE_TOKEN_COUNT_2X2 = 4
 _RAW_PATCH_COUNT_2X2 = 16
+_TEXT_TOKEN_ID = 10
+_VISION_START_TOKEN_ID = 20
+_IMAGE_PLACEHOLDER_TOKEN_ID = 30
 
 
 class _RecordingLanguageModel:
@@ -176,16 +179,26 @@ class TestPaddleOCRVLMultimodalAdapterValidation:
         with pytest.raises(error_type, match=match):
             _adapter().get_mrope_input_positions([1, 2, 3], [feature])
 
-    def test_multiple_images_per_request_rejected(self) -> None:
-        # Guard against mlx-vlm < 0.6 multi-image position corruption; see
-        # mlx-vlm#1282.  Remove together with the adapter guard on bump.
+    def test_multiple_images_per_request_delegated_in_offset_order(self) -> None:
+        language_model = _RecordingLanguageModel()
+        adapter = _adapter(language_model=language_model)
         features = [
-            _feature(offset=1, grid_thw=(1, 4, 4), length=4, raw_patches=16),
             _feature(offset=8, grid_thw=(1, 6, 4), length=6, raw_patches=24),
+            _feature(offset=2, grid_thw=(1, 4, 4), length=4, raw_patches=16),
         ]
+        input_tokens = (
+            [_TEXT_TOKEN_ID, _VISION_START_TOKEN_ID]
+            + [_IMAGE_PLACEHOLDER_TOKEN_ID] * _IMAGE_TOKEN_COUNT_2X2
+            + [_TEXT_TOKEN_ID, _VISION_START_TOKEN_ID]
+            + [_IMAGE_PLACEHOLDER_TOKEN_ID] * 6
+            + [_TEXT_TOKEN_ID, _TEXT_TOKEN_ID]
+        )
 
-        with pytest.raises(NotImplementedError, match="mlx-vlm#1282"):
-            _adapter().get_mrope_input_positions([1] * 12, features)
+        adapter.get_mrope_input_positions(input_tokens, features)
+
+        call = language_model.rope_calls[0]
+        assert call["input_ids"].tolist() == [input_tokens]
+        assert call["image_grid_thw"].tolist() == [[1, 4, 4], [1, 6, 4]]
 
 
 class TestPaddleOCRVLMultimodalAdapterPositions:
@@ -237,6 +250,23 @@ class TestPaddleOCRVLMultimodalAdapterEncodeMultimodal:
         assert call["pixel_values"].shape == (1, _RAW_PATCH_COUNT_2X2, 3, 14, 14)
         assert call["image_grid_thw"].tolist() == [[1, 4, 4]]
         assert call["output_hidden_states"] is False
+
+    def test_encodes_multiple_image_features(self) -> None:
+        visual = _RecordingVisual()
+        adapter = _adapter(visual=visual)
+        features = [
+            _feature(offset=1, grid_thw=(1, 4, 4), raw_patches=16),
+            _feature(offset=8, grid_thw=(1, 6, 4), raw_patches=24),
+        ]
+
+        outputs = adapter.encode_multimodal(features)
+
+        assert len(outputs) == 2
+        assert [call["image_grid_thw"].tolist() for call in visual.calls] == [
+            [[1, 4, 4]],
+            [[1, 6, 4]],
+        ]
+        assert visual.calls[1]["pixel_values"].shape == (1, 24, 3, 14, 14)
 
     @pytest.mark.parametrize("weight_dtype", [mx.float16, mx.bfloat16, mx.float32])
     def test_casts_pixel_values_to_visual_weight_dtype(

--- a/tests/multimodal/test_paddleocr_vl.py
+++ b/tests/multimodal/test_paddleocr_vl.py
@@ -95,6 +95,54 @@ class _RecordingVisual:
         return mx.ones((_IMAGE_TOKEN_COUNT_2X2, 8), dtype=mx.float32)
 
 
+class _RealPaddleOCRVLGetRopeIndexLanguageModel:
+    def __init__(self) -> None:
+        try:
+            from mlx_vlm.models.paddleocr_vl.config import (
+                ModelConfig,
+                TextConfig,
+                VisionConfig,
+            )
+            from mlx_vlm.models.paddleocr_vl.language import LanguageModel
+        except ModuleNotFoundError as exc:
+            if exc.name and exc.name.startswith("mlx_vlm"):
+                pytest.skip("mlx-vlm is only installed on Darwin/arm64")
+            raise
+        except RuntimeError as exc:
+            if "No Metal device available" in str(exc):
+                pytest.skip("mlx-vlm import requires a Metal device")
+            raise
+
+        self._language_model_cls = LanguageModel
+        self.config = ModelConfig(
+            text_config=TextConfig(), vision_config=VisionConfig()
+        )
+        self.model = SimpleNamespace(embed_tokens=lambda input_ids: input_ids + 1)
+
+    @property
+    def image_token_id(self) -> int:
+        return int(self.config.image_token_id)
+
+    @property
+    def vision_start_token_id(self) -> int:
+        return int(self.config.vision_start_token_id)
+
+    def get_rope_index(
+        self,
+        input_ids: mx.array,
+        image_grid_thw: mx.array | None = None,
+        video_grid_thw: mx.array | None = None,
+        attention_mask: mx.array | None = None,
+    ) -> tuple[mx.array, mx.array]:
+        return self._language_model_cls.get_rope_index(
+            self,
+            input_ids,
+            image_grid_thw,
+            video_grid_thw,
+            attention_mask,
+        )
+
+
 def _adapter(
     *,
     visual: Any | None = None,
@@ -199,6 +247,31 @@ class TestPaddleOCRVLMultimodalAdapterValidation:
         call = language_model.rope_calls[0]
         assert call["input_ids"].tolist() == [input_tokens]
         assert call["image_grid_thw"].tolist() == [[1, 4, 4], [1, 6, 4]]
+
+    def test_multiple_images_exercise_real_mlx_vlm_rope_index(self) -> None:
+        language_model = _RealPaddleOCRVLGetRopeIndexLanguageModel()
+        adapter = _adapter(language_model=language_model)
+        features = [
+            _feature(offset=8, grid_thw=(1, 6, 4), length=6, raw_patches=24),
+            _feature(offset=2, grid_thw=(1, 4, 4), length=4, raw_patches=16),
+        ]
+        input_tokens = (
+            [_TEXT_TOKEN_ID, language_model.vision_start_token_id]
+            + [language_model.image_token_id] * _IMAGE_TOKEN_COUNT_2X2
+            + [_TEXT_TOKEN_ID, language_model.vision_start_token_id]
+            + [language_model.image_token_id] * 6
+            + [_TEXT_TOKEN_ID, _TEXT_TOKEN_ID]
+        )
+
+        positions, delta = adapter.get_mrope_input_positions(input_tokens, features)
+
+        assert positions.shape == (3, 1, 16)
+        assert delta == -5
+        assert positions[:, 0, :].tolist() == [
+            [0, 1, 2, 2, 2, 2, 4, 5, 6, 6, 6, 6, 6, 6, 9, 10],
+            [0, 1, 2, 2, 3, 3, 4, 5, 6, 6, 7, 7, 8, 8, 9, 10],
+            [0, 1, 2, 3, 2, 3, 4, 5, 6, 7, 6, 7, 6, 7, 9, 10],
+        ]
 
 
 class TestPaddleOCRVLMultimodalAdapterPositions:

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -307,6 +307,56 @@ class TestPackedRoPE:
         assert mx.allclose(q_out, q + 1).item()
         assert mx.allclose(k_out, k + 2).item()
 
+    def test_attention_rope_uses_qwen35_precomputed_mrope_payload(self, monkeypatch):
+        """Qwen3.5 non-fused M-RoPE fallback uses the interleaved apply path."""
+        import sys
+        import types
+
+        import mlx.core as mx
+
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_attention_rope,
+        )
+
+        recorded: dict[str, object] = {}
+
+        def fake_apply(q, k, cos, sin):
+            recorded["q"] = q
+            recorded["k"] = k
+            recorded["cos"] = cos
+            recorded["sin"] = sin
+            return q + 3, k + 4
+
+        fake_mod = types.ModuleType("mlx_vlm.models.qwen3_5.language")
+        fake_mod.apply_multimodal_rotary_pos_emb = fake_apply
+        monkeypatch.setitem(sys.modules, "mlx_vlm.models.qwen3_5.language", fake_mod)
+
+        class FakeRotaryEmbedding:
+            style = "interleaved"
+
+        class FakeQwen35PrecomputedMRoPE:
+            rotary_emb = FakeRotaryEmbedding()
+
+        q = mx.zeros((1, 1, 3, 2), dtype=mx.float32)
+        k = mx.zeros((1, 1, 3, 2), dtype=mx.float32)
+        cos = mx.ones((3, 1, 3, 2), dtype=mx.float32)
+        sin = mx.zeros((3, 1, 3, 2), dtype=mx.float32)
+
+        q_out, k_out = apply_attention_rope(
+            FakeQwen35PrecomputedMRoPE(),
+            q,
+            k,
+            [0, 3],
+            position_embeddings=(cos, sin),
+        )
+
+        assert recorded["q"] is q
+        assert recorded["k"] is k
+        assert recorded["cos"] is cos
+        assert recorded["sin"] is sin
+        assert mx.allclose(q_out, q + 3).item()
+        assert mx.allclose(k_out, k + 4).item()
+
     def test_mrope_uses_caller_positions_when_provided(self, monkeypatch):
         """When ``positions[i]`` is an array, M-RoPE consumes it directly."""
         import sys

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -37,6 +37,23 @@ class TestSDPAPagedAttentionWrapper:
     def teardown_method(self):
         clear_context()
 
+    def test_exposes_inner_rope_attributes(self):
+        class _Inner:
+            def __init__(self):
+                self.rotary_emb = object()
+                self.rope = object()
+
+        inner = _Inner()
+        wrapper = SDPAPagedAttentionWrapper(
+            inner,
+            layer_idx=0,
+            kv_cache=object(),
+            block_size=16,
+        )
+
+        assert wrapper.rotary_emb is inner.rotary_emb
+        assert wrapper.rope is inner.rope
+
     def test_forwards_precomputed_rope_embeddings_without_context(self):
         class _Inner:
             def __init__(self):

--- a/tests/test_qwen35_smoke.py
+++ b/tests/test_qwen35_smoke.py
@@ -3,7 +3,7 @@
 
 Qwen3.5 uses the `qwen3_5` architecture which requires transformers>=5.0.0.
 This test verifies that the upgraded dependency stack (mlx-lm>=0.31.3,
-mlx-vlm>=0.5.0, llguidance>=1.7.0, transformers>=5.5.1) works correctly
+mlx-vlm>=0.6.2, llguidance>=1.7.0, transformers>=5.5.1) works correctly
 with vLLM on Metal.
 
 Golden token IDs were generated with greedy decoding (temperature=0) on

--- a/vllm_metal/attention/impls/sdpa_wrapper.py
+++ b/vllm_metal/attention/impls/sdpa_wrapper.py
@@ -78,6 +78,16 @@ class SDPAPagedAttentionWrapper(nn.Module):
             self, "_mk_cache_idx", cache_idx if cache_idx is not None else layer_idx
         )
 
+    @property
+    def rotary_emb(self) -> Any:
+        """Expose the wrapped attention's M-RoPE module."""
+        return self._inner.rotary_emb
+
+    @property
+    def rope(self) -> Any:
+        """Expose the wrapped attention's RoPE module."""
+        return self._inner.rope
+
     def rebind_cache(
         self,
         kv_cache: MetalPagedKVCache,

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -65,25 +65,38 @@ def apply_precomputed_mrope(
     the attention layer itself.  Keep that model-specific apply policy in this
     compat module so SDPA projection/cache code can stay model-agnostic.
     """
-    from mlx_vlm.models.paddleocr_vl.language import (
-        apply_multimodal_rotary_pos_emb,
-    )
+    cos, sin = position_embeddings
+
+    rotary_emb = getattr(attn_module, "rotary_emb", None)
+    if rotary_emb is not None and getattr(rotary_emb, "style", None) == "interleaved":
+        from mlx_vlm.models.qwen3_5.language import apply_multimodal_rotary_pos_emb
+
+        return apply_multimodal_rotary_pos_emb(queries, keys, cos, sin)
 
     rope_parameters = getattr(attn_module, "rope_parameters", None)
-    if rope_parameters is None or "mrope_section" not in rope_parameters:
-        raise NotImplementedError(
-            f"Attention module {type(attn_module).__name__} received "
-            "precomputed M-RoPE embeddings but does not expose "
-            "rope_parameters['mrope_section']."
+    if rope_parameters is not None and "mrope_section" in rope_parameters:
+        from mlx_vlm.models.paddleocr_vl.language import (
+            apply_multimodal_rotary_pos_emb,
         )
 
-    cos, sin = position_embeddings
-    return apply_multimodal_rotary_pos_emb(
-        queries,
-        keys,
-        cos,
-        sin,
-        rope_parameters["mrope_section"],
+        return apply_multimodal_rotary_pos_emb(
+            queries,
+            keys,
+            cos,
+            sin,
+            rope_parameters["mrope_section"],
+        )
+
+    if rotary_emb is not None:
+        raise NotImplementedError(
+            f"Attention module {type(attn_module).__name__} received "
+            "precomputed M-RoPE embeddings but its rotary_emb style "
+            f"{getattr(rotary_emb, 'style', None)!r} is not supported."
+        )
+    raise NotImplementedError(
+        f"Attention module {type(attn_module).__name__} received precomputed "
+        "M-RoPE embeddings but does not expose a supported `rotary_emb` or "
+        "rope_parameters['mrope_section']."
     )
 
 

--- a/vllm_metal/multimodal/paddleocr_vl/adapter.py
+++ b/vllm_metal/multimodal/paddleocr_vl/adapter.py
@@ -157,18 +157,13 @@ class PaddleOCRVLMultimodalAdapter:
                 "Construct via PaddleOCRVLMultimodalAdapter.from_loaded_model."
             )
 
-        self._validate_image_features(mm_features)
+        sorted_features = sorted(mm_features, key=lambda f: f.mm_position.offset)
+        image_grid_thw_values = self._validate_image_features_and_collect_grids(
+            sorted_features
+        )
         image_grid_thw = (
-            mx.array(
-                [
-                    self._grid_thw(feature.data, "image_grid_thw")
-                    for feature in sorted(
-                        mm_features, key=lambda f: f.mm_position.offset
-                    )
-                ],
-                dtype=mx.int32,
-            )
-            if mm_features
+            mx.array(image_grid_thw_values, dtype=mx.int32)
+            if image_grid_thw_values
             else None
         )
         input_ids = mx.array([input_tokens], dtype=mx.int32)
@@ -208,21 +203,12 @@ class PaddleOCRVLMultimodalAdapter:
             position_ids=position_ids,
         )
 
-    def _validate_image_features(
+    def _validate_image_features_and_collect_grids(
         self,
         features: list[MultiModalFeatureSpec],
-    ) -> None:
-        # mlx-vlm < 0.6 mis-counts vision blocks for prompts with more than
-        # one image (mx.sum collapse of vision-start indices), silently
-        # corrupting M-RoPE positions.  Fixed upstream in mlx-vlm#1282; drop
-        # this guard once the pinned mlx-vlm includes that fix.
-        if len(features) > 1:
-            raise NotImplementedError(
-                "Multiple images per request are not yet supported: the "
-                "installed mlx-vlm get_rope_index mis-counts multi-image "
-                "prompts (fixed upstream in mlx-vlm#1282)."
-            )
-        for feature in sorted(features, key=lambda feature: feature.mm_position.offset):
+    ) -> list[tuple[int, int, int]]:
+        image_grid_thw_values: list[tuple[int, int, int]] = []
+        for feature in features:
             modality = feature.modality
             if modality == "video":
                 raise NotImplementedError(
@@ -248,6 +234,9 @@ class PaddleOCRVLMultimodalAdapter:
                     f"{num_grid_tokens} multimodal embeddings, got "
                     f"mm_position.get_num_embeds()={num_embeds}"
                 )
+            image_grid_thw_values.append((t, h, w))
+
+        return image_grid_thw_values
 
     @classmethod
     def _grid_thw(cls, data: MultiModalKwargsItem, key: str) -> tuple[int, int, int]:


### PR DESCRIPTION
## Summary

Enable PaddleOCR-VL requests with multiple image features now that the pinned `mlx-vlm` version includes the multi-image M-RoPE fix, and keep Qwen3.5 paged-attention smoke compatible with the new `mlx-vlm` language forward.

- Bump Darwin/arm64 `mlx-vlm` from `>=0.5.0,<0.6.0` to `>=0.6.2,<0.7.0`.
- Remove the PaddleOCR-VL adapter guard that rejected more than one image per request.
- Keep the adapter-level offset-ordering contract for `image_grid_thw`, while avoiding a redundant sort and duplicate `image_grid_thw` extraction during validation.
- Expose the wrapped SDPA attention RoPE attributes (`rotary_emb` and `rope`) so `mlx-vlm` 0.6.2 Qwen3.5 can precompute position embeddings after paged-attention patching.
- Add unit coverage for multi-image feature delegation, multi-feature vision encoding, and wrapper RoPE attribute forwarding.

## Motivation

The initial PaddleOCR-VL adapter intentionally rejected multi-image requests because `mlx-vlm <0.6` mis-counted multiple vision blocks in `get_rope_index`, corrupting M-RoPE positions for prompts with more than one image. `mlx-vlm` v0.6.2 includes the upstream fix for that path, so the adapter can accept multiple image features.

The same `mlx-vlm` PR ports the fix to `glm4v`, `glm4v_moe`, `paddleocr_vl`, `qwen2_5_vl`, `qwen2_vl`, `qwen3_omni_moe`, and `qwen3_vl_moe`; its regression test also checks those seven plus `qwen3_vl` and `qwen3_5`. This vllm-metal PR only enables and tests PaddleOCR-VL, but the dependency bump makes the broader upstream fixes available.

The dependency bump also exposes a Qwen3.5 compatibility requirement: `mlx-vlm` 0.6.2 reads `layer.self_attn.rotary_emb` before calling the attention module, while vllm-metal replaces `self_attn` with `SDPAPagedAttentionWrapper` for paged attention. The wrapper now forwards the narrow RoPE attribute surface from the wrapped attention module instead of hiding it.

## Implementation Notes

- `get_mrope_input_positions()` now sorts features once by placeholder offset, validates them in that order, and reuses the collected `image_grid_thw` values for the `mlx-vlm` language-model call.
- `_validate_image_features_and_collect_grids()` validates modality, frame count, and placeholder length while returning the already-read grids. This avoids re-running `_grid_thw()` for the same features.
- Multi-image tests use representative placeholder offsets: offsets point at the first image placeholder token, not the preceding vision-start token.
- `SDPAPagedAttentionWrapper` exposes `rotary_emb` and `rope` properties that point at the wrapped attention module, preserving the RoPE contract expected by Qwen3.5 model-level forward code.

## Testing

- `.venv-vllm-metal/bin/python -m pytest -q tests/multimodal/test_paddleocr_vl.py`
- `.venv-vllm-metal/bin/python -m pytest -q tests/multimodal/test_paddleocr_vl.py tests/v1/mm/test_paged_forward_mm.py::TestDeepstackPerChunkSlice`
- `.venv-vllm-metal/bin/python -m pytest -q tests/test_paged_attention.py::TestSDPAPagedAttentionWrapper`
- `.venv-vllm-metal/bin/ruff check vllm_metal/attention/impls/sdpa_wrapper.py tests/test_paged_attention.py`
- `.venv-vllm-metal/bin/ruff format --check vllm_metal/attention/impls/sdpa_wrapper.py tests/test_paged_attention.py`
- `.venv-vllm-metal/bin/mypy vllm_metal/attention/impls/sdpa_wrapper.py`
- Manual PaddleOCR-VL smoke with all 10 pages from `2603.24373v1.pdf` using `limit_mm_per_prompt={"image": 10}`.
- Manual Qwen3.5 paged-attention smoke reached generation without the previous `rotary_emb` wrapper crash, and the CI smoke prompt `The capital of France is` matched the expected output.