### PR TITLE
[Installation] Add strict=False when parsing GitHub release JSON

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,7 @@ extract_wheel_url() {
 import sys
 import json
 try:
-    data = json.loads('''$release_data''')
+    data = json.loads('''$release_data''', strict=False)
     assets = data.get('assets', [])
     for asset in assets:
         name = asset.get('name', '')


### PR DESCRIPTION
## Motivation

GitHub release metadata may contain control characters in the release body.
When parsing the release metadata, json.loads() can raise:

    JSONDecodeError: Invalid control character

As a result, the installer fails to extract the wheel URL and exits with:

    Error: No wheel file found in the latest release.

## Change

Add strict=False to json.loads() when parsing release metadata so the installer
can tolerate control characters and continue extracting the wheel URL.