### PR TITLE
[Multimodal] Batch runner encoder dispatch

### DIFF
--- a/tests/multimodal/test_paddleocr_vl.py
+++ b/tests/multimodal/test_paddleocr_vl.py
@@ -224,8 +224,9 @@ class TestPaddleOCRVLMultimodalAdapterValidation:
         error_type: type[Exception],
         match: str,
     ) -> None:
-        with pytest.raises(error_type, match=match):
+        with pytest.raises(error_type, match=match) as exc_info:
             _adapter().get_mrope_input_positions([1, 2, 3], [feature])
+        assert feature.identifier in str(exc_info.value)
 
     def test_multiple_images_per_request_delegated_in_offset_order(self) -> None:
         language_model = _RecordingLanguageModel()
@@ -356,8 +357,11 @@ class TestPaddleOCRVLMultimodalAdapterEncodeMultimodal:
     def test_rejects_patch_count_mismatch(self) -> None:
         adapter = _adapter(visual=_RecordingVisual())
 
-        with pytest.raises(ValueError, match="patch count does not match"):
-            adapter.encode_multimodal([_feature(raw_patches=15)])
+        feature = _feature(raw_patches=15)
+
+        with pytest.raises(ValueError, match="patch count does not match") as exc_info:
+            adapter.encode_multimodal([feature])
+        assert feature.identifier in str(exc_info.value)
 
     def test_requires_visual_for_encode(self) -> None:
         with pytest.raises(RuntimeError, match="visual tower not loaded"):

--- a/tests/multimodal/test_qwen3_vl.py
+++ b/tests/multimodal/test_qwen3_vl.py
@@ -124,8 +124,9 @@ class TestQwen3VLMultimodalAdapterValidation:
     ) -> None:
         tokens = [_IMAGE_PLACEHOLDER_TOKEN_ID] * _IMAGE_TOKEN_COUNT_2X2
 
-        with pytest.raises(error_type, match=match):
+        with pytest.raises(error_type, match=match) as exc_info:
             _adapter().get_mrope_input_positions(tokens, [feature])
+        assert feature.identifier in str(exc_info.value)
 
 
 class TestQwen3VLMultimodalAdapterPositions:
@@ -383,8 +384,9 @@ class TestQwen3VLMultimodalAdapterEncodeMultimodal:
             mm_position=feature.mm_position,
         )
 
-        with pytest.raises(ValueError, match="image features"):
+        with pytest.raises(ValueError, match="image features") as exc_info:
             adapter.encode_multimodal([feature])
+        assert feature.identifier in str(exc_info.value)
 
     def test_raises_when_vision_tower_is_none(self) -> None:
         adapter = Qwen3VLMultimodalAdapter(spatial_merge_size=_SPATIAL_MERGE_SIZE)
@@ -405,8 +407,9 @@ class TestQwen3VLMultimodalAdapterEncodeMultimodal:
             mm_position=PlaceholderRange(offset=0, length=4),
         )
 
-        with pytest.raises(ValueError, match="feature.data is required"):
+        with pytest.raises(ValueError, match="feature.data is required") as exc_info:
             adapter.encode_multimodal([feature])
+        assert feature.identifier in str(exc_info.value)
 
 
 class _RecordingLanguageModel:

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -383,35 +383,89 @@ def test_reject_scheduled_encoder_inputs_raises_when_no_adapter() -> None:
         runner._reject_scheduled_encoder_inputs({"req-0": [0]})
 
 
-def test_run_vision_encoders_calls_adapter_per_uncached_feature() -> None:
+def test_run_vision_encoders_batches_uncached_features() -> None:
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
-    features = [_feature("image-0")]
+    features = [_feature("image-0"), _feature("image-1")]
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", features)
-    expected = mx.array([[1.0, 2.0]])
+    expected0 = mx.array([[1.0, 2.0]])
+    expected1 = mx.array([[5.0, 6.0]])
     adapter.queue_outputs(
         [
             [
                 Qwen3VLVisionEncodeResult(
-                    hidden_states=expected,
+                    hidden_states=expected0,
                     deepstack_visual_embeds=[mx.array([[3.0, 4.0]])],
-                )
+                ),
+                Qwen3VLVisionEncodeResult(
+                    hidden_states=expected1,
+                    deepstack_visual_embeds=None,
+                ),
             ]
         ]
     )
 
-    runner._run_vision_encoders({"req-0": [0]})
+    runner._run_vision_encoders({"req-0": [0, 1]})
 
     assert adapter.encode_calls == [features]
     stored = runner.encoder_cache.encoder_outputs["image-0"]
-    assert mx.allclose(stored.hidden_states, expected).item()
+    assert mx.allclose(stored.hidden_states, expected0).item()
     assert stored.deepstack_visual_embeds is not None
     assert mx.allclose(stored.deepstack_visual_embeds[0], mx.array([[3.0, 4.0]])).item()
+    assert mx.allclose(
+        runner.encoder_cache.encoder_outputs["image-1"].hidden_states,
+        expected1,
+    ).item()
+    assert (
+        runner.encoder_cache.encoder_outputs["image-1"].deepstack_visual_embeds is None
+    )
 
 
-def test_run_vision_encoders_skips_cached_features(fake_encode_result) -> None:
+def test_run_vision_encoders_iterates_multiple_requests_and_indices() -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    req0_features = [_feature("img-a"), _feature("img-b")]
+    req1_features = [_feature("img-c")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", req0_features)
+    runner.encoder_cache.add_request("req-1", req1_features)
+
+    runner._run_vision_encoders({"req-0": [0, 1], "req-1": [0]})
+
+    assert len(adapter.encode_calls) == 1
+    encoded_identifiers = [feature.identifier for feature in adapter.encode_calls[0]]
+    assert encoded_identifiers == ["img-a", "img-b", "img-c"]
+    assert set(runner.encoder_cache.encoder_outputs) == {"img-a", "img-b", "img-c"}
+
+
+def test_run_vision_encoders_skips_cached_and_batches_only_uncached_features(
+    fake_encode_result,
+) -> None:
+    runner = _runner_with_encoder_cache()
+    adapter = _RecordingAdapter()
+    runner._multimodal_adapter = adapter
+    features = [_feature("cached-image"), _feature("fresh-image")]
+    assert runner.encoder_cache is not None
+    runner.encoder_cache.add_request("req-0", features)
+    cached = fake_encode_result(mx.array([[7.0]]))
+    runner.encoder_cache.encoder_outputs["cached-image"] = cached
+
+    runner._run_vision_encoders({"req-0": [0, 1]})
+
+    assert len(adapter.encode_calls) == 1
+    assert [feature.identifier for feature in adapter.encode_calls[0]] == [
+        "fresh-image"
+    ]
+    assert runner.encoder_cache.encoder_outputs["cached-image"] is cached
+    assert "fresh-image" in runner.encoder_cache.encoder_outputs
+
+
+def test_run_vision_encoders_skips_adapter_call_when_all_features_cached(
+    fake_encode_result,
+) -> None:
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
@@ -427,22 +481,25 @@ def test_run_vision_encoders_skips_cached_features(fake_encode_result) -> None:
     assert runner.encoder_cache.encoder_outputs["image-0"] is cached
 
 
-def test_run_vision_encoders_iterates_multiple_requests_and_indices() -> None:
+def test_run_vision_encoders_deduplicates_repeated_feature_identifier_across_requests() -> (
+    None
+):
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
-    req0_features = [_feature("img-a"), _feature("img-b")]
-    req1_features = [_feature("img-c")]
+    req0_features = [_feature("shared-image")]
+    req1_features = [_feature("shared-image")]
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", req0_features)
     runner.encoder_cache.add_request("req-1", req1_features)
 
-    runner._run_vision_encoders({"req-0": [0, 1], "req-1": [0]})
+    runner._run_vision_encoders({"req-0": [0], "req-1": [0]})
 
-    assert len(adapter.encode_calls) == 3
-    encoded_identifiers = [call[0].identifier for call in adapter.encode_calls]
-    assert encoded_identifiers == ["img-a", "img-b", "img-c"]
-    assert set(runner.encoder_cache.encoder_outputs) == {"img-a", "img-b", "img-c"}
+    assert len(adapter.encode_calls) == 1
+    assert [feature.identifier for feature in adapter.encode_calls[0]] == [
+        "shared-image"
+    ]
+    assert set(runner.encoder_cache.encoder_outputs) == {"shared-image"}
 
 
 def test_run_vision_encoders_raises_for_unregistered_request() -> None:
@@ -463,11 +520,14 @@ def test_run_vision_encoders_raises_for_out_of_range_index() -> None:
         runner._run_vision_encoders({"req-0": [3]})
 
 
-def test_run_vision_encoders_raises_when_adapter_returns_wrong_count() -> None:
+@pytest.mark.parametrize("output_count", [1, 3])
+def test_run_vision_encoders_raises_when_adapter_returns_wrong_count(
+    output_count,
+) -> None:
     runner = _runner_with_encoder_cache()
     adapter = _RecordingAdapter()
     runner._multimodal_adapter = adapter
-    features = [_feature("image-0")]
+    features = [_feature("image-0"), _feature("image-1")]
     assert runner.encoder_cache is not None
     runner.encoder_cache.add_request("req-0", features)
     adapter.queue_outputs(
@@ -476,17 +536,17 @@ def test_run_vision_encoders_raises_when_adapter_returns_wrong_count() -> None:
                 Qwen3VLVisionEncodeResult(
                     hidden_states=mx.zeros((1,)),
                     deepstack_visual_embeds=None,
-                ),
-                Qwen3VLVisionEncodeResult(
-                    hidden_states=mx.zeros((1,)),
-                    deepstack_visual_embeds=None,
-                ),
+                )
+                for _ in range(output_count)
             ]
         ]
     )
 
-    with pytest.raises(RuntimeError, match="encode_multimodal returned 2"):
-        runner._run_vision_encoders({"req-0": [0]})
+    with pytest.raises(
+        RuntimeError,
+        match=f"encode_multimodal returned {output_count}",
+    ):
+        runner._run_vision_encoders({"req-0": [0, 1]})
 
 
 def test_run_vision_encoders_no_op_when_no_adapter() -> None:

--- a/vllm_metal/multimodal/paddleocr_vl/adapter.py
+++ b/vllm_metal/multimodal/paddleocr_vl/adapter.py
@@ -107,11 +107,15 @@ class PaddleOCRVLMultimodalAdapter:
         for feature in features:
             if feature.modality != "image":
                 raise ValueError(
-                    "encode_multimodal only supports image features; got "
-                    f"modality={feature.modality!r}"
+                    f"Feature {feature.identifier!r}: encode_multimodal only "
+                    "supports image features; got "
+                    f"modality={feature.modality!r}."
                 )
             if feature.data is None:
-                raise ValueError("feature.data is required for vision encoding")
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: feature.data is required "
+                    "for vision encoding."
+                )
 
             pixel_values = self._as_mlx(
                 self._feature_value(feature.data, "pixel_values")
@@ -120,16 +124,21 @@ class PaddleOCRVLMultimodalAdapter:
                 pixel_values = mx.expand_dims(pixel_values, axis=0)
             if len(pixel_values.shape) != 5:
                 raise ValueError(
-                    "pixel_values must have shape (patches, 3, patch, patch) "
+                    f"Feature {feature.identifier!r}: pixel_values must have "
+                    "shape (patches, 3, patch, patch) "
                     "or (1, patches, 3, patch, patch); got "
                     f"{pixel_values.shape}"
                 )
 
-            grid_thw = self._grid_thw(feature.data, "image_grid_thw")
+            try:
+                grid_thw = self._grid_thw(feature.data, "image_grid_thw")
+            except ValueError as exc:
+                raise ValueError(f"Feature {feature.identifier!r}: {exc}") from exc
             raw_patches = grid_thw[0] * grid_thw[1] * grid_thw[2]
             if int(pixel_values.shape[1]) != raw_patches:
                 raise ValueError(
-                    "pixel_values patch count does not match image_grid_thw: "
+                    f"Feature {feature.identifier!r}: pixel_values patch "
+                    "count does not match image_grid_thw: "
                     f"got {pixel_values.shape[1]}, expected {raw_patches}"
                 )
             image_grid_thw = mx.array([grid_thw], dtype=mx.int32)
@@ -212,25 +221,35 @@ class PaddleOCRVLMultimodalAdapter:
             modality = feature.modality
             if modality == "video":
                 raise NotImplementedError(
-                    "Video multimodal features are not yet supported."
+                    f"Feature {feature.identifier!r}: Video multimodal "
+                    "features are not yet supported."
                 )
             if modality != "image":
-                raise ValueError(f"Unsupported modality: {modality}")
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: Unsupported modality: {modality}"
+                )
             if feature.data is None:
                 raise ValueError(
-                    "Image feature data is required to read image_grid_thw."
+                    f"Feature {feature.identifier!r}: Image feature data is "
+                    "required to read image_grid_thw."
                 )
 
-            t, h, w = self._grid_thw(feature.data, "image_grid_thw")
+            try:
+                t, h, w = self._grid_thw(feature.data, "image_grid_thw")
+            except ValueError as exc:
+                raise ValueError(f"Feature {feature.identifier!r}: {exc}") from exc
             if t != 1:
-                raise ValueError(f"Multi-frame images are not yet supported, got t={t}")
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: Multi-frame images are "
+                    f"not yet supported, got t={t}"
+                )
             num_grid_tokens = (
                 t * (h // self._spatial_merge_size) * (w // self._spatial_merge_size)
             )
             num_embeds = feature.mm_position.get_num_embeds()
             if num_embeds != num_grid_tokens:
                 raise ValueError(
-                    "image_grid_thw implies "
+                    f"Feature {feature.identifier!r}: image_grid_thw implies "
                     f"{num_grid_tokens} multimodal embeddings, got "
                     f"mm_position.get_num_embeds()={num_embeds}"
                 )

--- a/vllm_metal/multimodal/qwen3_vl/adapter.py
+++ b/vllm_metal/multimodal/qwen3_vl/adapter.py
@@ -202,11 +202,15 @@ class Qwen3VLMultimodalAdapter:
         for feature in features:
             if feature.modality != "image":
                 raise ValueError(
-                    "encode_multimodal only supports image features; got "
-                    f"modality={feature.modality!r}"
+                    f"Feature {feature.identifier!r}: encode_multimodal only "
+                    "supports image features; got "
+                    f"modality={feature.modality!r}."
                 )
             if feature.data is None:
-                raise ValueError("feature.data is required for vision encoding")
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: feature.data is required "
+                    "for vision encoding."
+                )
 
             pixel_values = self._as_mlx(
                 self._feature_value(feature.data, "pixel_values")
@@ -327,18 +331,28 @@ class Qwen3VLMultimodalAdapter:
             modality = feature.modality
             if modality == "video":
                 raise NotImplementedError(
-                    "Video multimodal features are not yet supported."
+                    f"Feature {feature.identifier!r}: Video multimodal "
+                    "features are not yet supported."
                 )
             if modality != "image":
-                raise ValueError(f"Unsupported modality: {modality}")
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: Unsupported modality: {modality}"
+                )
             if feature.data is None:
                 raise ValueError(
-                    "Image feature data is required to read image_grid_thw."
+                    f"Feature {feature.identifier!r}: Image feature data is "
+                    "required to read image_grid_thw."
                 )
 
-            t, h, w = self._grid_thw(feature.data, "image_grid_thw")
+            try:
+                t, h, w = self._grid_thw(feature.data, "image_grid_thw")
+            except ValueError as exc:
+                raise ValueError(f"Feature {feature.identifier!r}: {exc}") from exc
             if t != 1:
-                raise ValueError(f"Multi-frame images are not yet supported, got t={t}")
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: Multi-frame images are "
+                    f"not yet supported, got t={t}"
+                )
 
             llm_grid_h = h // self._spatial_merge_size
             llm_grid_w = w // self._spatial_merge_size
@@ -346,7 +360,7 @@ class Qwen3VLMultimodalAdapter:
             num_embeds = feature.mm_position.get_num_embeds()
             if num_embeds != num_grid_tokens:
                 raise ValueError(
-                    "image_grid_thw implies "
+                    f"Feature {feature.identifier!r}: image_grid_thw implies "
                     f"{num_grid_tokens} multimodal embeddings, got "
                     f"mm_position.get_num_embeds()={num_embeds}"
                 )

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -78,7 +78,7 @@ class MultimodalRuntimeAdapter(Protocol):
         self,
         features: list[MultiModalFeatureSpec],
     ) -> Sequence[MultimodalEncodeResult]:
-        """Run the model's vision tower; return one result per feature.
+        """Run the model's vision tower; return one result per feature in order.
 
         Results may carry optional deepstack visual embeds for models whose
         language model injects vision residuals in intermediate layers.

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1469,27 +1469,21 @@ class MetalModelRunner:
         self,
         scheduled_encoder_inputs: dict[str, list[int]],
     ) -> None:
-        """Run the vision encoder for each scheduled feature, stash by identifier.
+        """Run the vision encoder for scheduled features, stash by identifier.
 
         Skips features whose ``identifier`` already lives in
         ``encoder_cache.encoder_outputs`` (cache hit; the scheduler may
-        re-list a feature across chunks).  Calls
-        ``adapter.encode_multimodal`` one feature at a time so a single bad
-        feature is reported with a precise req_id+idx rather than poisoning
-        a whole request batch.
-
-        TODO(multimodal-batching): batch scheduled features into a single
-        ``adapter.encode_multimodal`` call.  Upstream vLLM stacks pixel_values
-        and image_grid_thw across requests so the vision tower runs once per
-        step; we serialize, which inflates TTFT under concurrency (e.g.,
-        conc=8 + 384x384 measured ~3.5s p50 TTFT).  Requires per-feature
-        slicing of returned hidden_states + deepstack residuals by
-        ``grid_thw.prod()``.
+        re-list a feature across chunks).  Uncached features are batched into
+        one ``adapter.encode_multimodal`` call so adapters can handle the
+        scheduled encoder work for the whole step.
         """
         adapter = self._multimodal_adapter
         cache = self.encoder_cache
         if adapter is None or cache is None:
             return
+
+        features_to_encode: list[MultiModalFeatureSpec] = []
+        identifiers_to_encode: set[str] = set()
         for req_id, feature_indices in scheduled_encoder_inputs.items():
             mm_features = cache.mm_features.get(req_id)
             if mm_features is None:
@@ -1504,16 +1498,26 @@ class MetalModelRunner:
                         f"request {req_id!r} with {len(mm_features)} features."
                     )
                 feature = mm_features[idx]
-                if feature.identifier in cache.encoder_outputs:
+                if (
+                    feature.identifier in cache.encoder_outputs
+                    or feature.identifier in identifiers_to_encode
+                ):
                     continue
-                outputs = adapter.encode_multimodal([feature])
-                if len(outputs) != 1:
-                    raise RuntimeError(
-                        f"encode_multimodal returned {len(outputs)} outputs "
-                        "for 1 feature; adapter must return one result per "
-                        "feature."
-                    )
-                cache.encoder_outputs[feature.identifier] = outputs[0]
+                features_to_encode.append(feature)
+                identifiers_to_encode.add(feature.identifier)
+
+        if not features_to_encode:
+            return
+
+        outputs = adapter.encode_multimodal(features_to_encode)
+        if len(outputs) != len(features_to_encode):
+            raise RuntimeError(
+                f"encode_multimodal returned {len(outputs)} outputs for "
+                f"{len(features_to_encode)} features; adapter must return one "
+                "result per feature."
+            )
+        for feature, output in zip(features_to_encode, outputs, strict=True):
+            cache.encoder_outputs[feature.identifier] = output
 
     def _run_mm_paged_forward(
         self,


### PR DESCRIPTION
## Summary
- Batch uncached scheduled multimodal encoder features into one `adapter.encode_multimodal(...)` call per runner step.
- Store encoder outputs by feature identifier while skipping cache hits and duplicate identifiers in the same step.
- Clarify the adapter contract that multimodal encode outputs preserve input feature order.

## Notes
This PR is only the generic runner-level dispatch hook. Adapter-specific vision-tower batching and benchmark evidence can follow separately.

## Tests
- `pytest tests/v1/mm/test_model_runner_multimodal_cache.py -q`
- `pytest tests/v1/mm -q`
- `pytest tests/multimodal/test_paddleocr_vl.py::TestPaddleOCRVLMultimodalAdapterEncodeMultimodal tests/multimodal/test_qwen3_vl.py::TestQwen3VLMultimodalAdapterEncodeMultimodal -q`
- `ruff check vllm_metal/v1/model_runner.py vllm_metal/v1/model_adapter.py tests/v1/mm/test_model_runner_multimodal_cache.py`
- `ruff format --check vllm_metal/v1/model_runner.py vllm_metal/v1/model_adapter.py tests/v1/mm/test_model_runner_multimodal_cache.py`
- `mypy vllm_metal/v1/model_runner.py vllm_metal/v1/model_adapter.py --pretty`
- `git diff --check`
