### PR TITLE
[Installation] Fix broken installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -43,19 +43,19 @@ fetch_latest_release() {
 extract_wheel_url() {
   local release_data="$1"
 
-  python3 -c "
-import sys
-import json
-try:
-    data = json.loads('''$release_data''')
-    assets = data.get('assets', [])
-    for asset in assets:
-        name = asset.get('name', '')
-        if name.endswith('.whl'):
-            print(asset.get('browser_download_url', ''))
-            break
-except Exception as e:
-    print('', file=sys.stderr)
+  # Pipe the JSON to Python on stdin as DATA. Do NOT interpolate it into the
+  # program text: embedding it in a source-string literal (json.loads('''...'''))
+  # lets Python's parser mangle the backslash/control sequences in the
+  # release-notes body, so json parsing throws and the wheel URL comes back
+  # empty -- surfacing as a misleading "No wheel file found in the latest
+  # release" even when the wheel is present.
+  printf '%s' "$release_data" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for asset in data.get('assets', []):
+    if asset.get('name', '').endswith('.whl'):
+        print(asset.get('browser_download_url', ''))
+        break
 "
 }
 


### PR DESCRIPTION
Problem:

```bash
$ curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh | bash
# ....
#  - vllm==0.17.1 (from file:...)
 + vllm==0.22.1+cpu (from file:///private/var/folders/s9/tdccvq7n731b5cvfkz9wng040000gn/T/tmp.MwdIMx5xJ6/vllm-0.22.1)
/Users/ran/workspace/vllm-metal-pp
Fetching latest release...

Error: No wheel file found in the latest release.
```

Solution: Pass the GitHub release JSON to Python via stdin instead of interpolating it into a source-string literal — release-notes content was corrupting json.loads and making install.sh report "No wheel file found" on releases that have one.