### PR TITLE
[GGUF] Add experimental dense GGUF loading for local models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "transformers>=5.5.1",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
+    "gguf>=0.17.0",
     # Native Metal extension JIT build
     "nanobind==2.10.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Core utilities

--- a/tests/test_gguf.py
+++ b/tests/test_gguf.py
@@ -113,18 +113,18 @@ def test_model_config_candidates_take_precedence(tmp_path: Path) -> None:
     assert reference.model_path == model_dir
 
 
-def test_cache_key_includes_all_local_shards(tmp_path: Path) -> None:
+def test_dense_cache_key_includes_all_local_shards_and_dtype(tmp_path: Path) -> None:
     shards = (
         tmp_path / "model-00001-of-00002.gguf",
         tmp_path / "model-00002-of-00002.gguf",
     )
     reference = GGUFReference(shards[0], tmp_path / "model", shards)
 
-    cache_key = reference.cache_key()
+    cache_key = reference.dense_cache_key(target_dtype=mx.float16)
 
     assert str(shards[0]) in cache_key[0]
     assert str(shards[1]) in cache_key[0]
-    assert cache_key[1] == f"gguf-dense:{tmp_path / 'model'}"
+    assert cache_key[1] == f"gguf-dense:{tmp_path / 'model'}:{mx.float16}"
 
 
 def test_load_gguf_generation_model_uses_cache_and_loader(
@@ -169,7 +169,10 @@ def test_load_gguf_generation_model_uses_cache_and_loader(
     assert captured["reference"].model_path == model_dir
     assert captured["target_dtype"] == mx.float16
     assert captured["tokenizer_config"] == {"trust_remote_code": True}
-    assert cache[captured["reference"].cache_key()] == (loaded_model, loaded_tokenizer)
+    assert cache[captured["reference"].dense_cache_key(target_dtype=mx.float16)] == (
+        loaded_model,
+        loaded_tokenizer,
+    )
 
     cached_model, cached_tokenizer = gguf_lifecycle.load_gguf_generation_model(
         str(gguf_path),
@@ -182,6 +185,50 @@ def test_load_gguf_generation_model_uses_cache_and_loader(
     assert cached_model is loaded_model
     assert cached_tokenizer is loaded_tokenizer
     assert captured["load_count"] == 1
+
+
+def test_load_gguf_generation_model_cache_is_scoped_by_dtype(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "model"
+    _write_config(model_dir)
+    gguf_path = tmp_path / "model-Q8_0.gguf"
+    _write_gguf_header(gguf_path)
+
+    loaded_dtypes: list[mx.Dtype] = []
+
+    class FakeGGUFLoader:
+        def __init__(self, _reference, *, target_dtype, tokenizer_config):
+            self.target_dtype = target_dtype
+
+        def load(self):
+            loaded_dtypes.append(self.target_dtype)
+            return object(), object()
+
+    monkeypatch.setattr(gguf_lifecycle, "GGUFMLXLoader", FakeGGUFLoader)
+    cache: dict[tuple[str, str], tuple[object, object]] = {}
+    cache_lock = Lock()
+
+    first_model, first_tokenizer = gguf_lifecycle.load_gguf_generation_model(
+        str(gguf_path),
+        model_config=SimpleNamespace(dtype=torch.float16, trust_remote_code=False),
+        model_cache=cache,
+        model_cache_lock=cache_lock,
+        start_time=0.0,
+    )
+    second_model, second_tokenizer = gguf_lifecycle.load_gguf_generation_model(
+        str(gguf_path),
+        model_config=SimpleNamespace(dtype=torch.bfloat16, trust_remote_code=False),
+        model_cache=cache,
+        model_cache_lock=cache_lock,
+        start_time=0.0,
+    )
+
+    assert first_model is not second_model
+    assert first_tokenizer is not second_tokenizer
+    assert loaded_dtypes == [mx.float16, mx.bfloat16]
+    assert len(cache) == 2
 
 
 def test_translate_prefers_upstream_name_map() -> None:

--- a/tests/test_gguf.py
+++ b/tests/test_gguf.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for experimental dense GGUF loading support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+
+from vllm_metal.gguf import lifecycle as gguf_lifecycle
+from vllm_metal.gguf.loader import (
+    GGUFLoadError,
+    _adjust_tensor_for_mlx_sanitize,
+    _decode_tensor,
+    _dequantize_q8_0,
+    _dequantize_q8_1,
+    translate_gguf_tensor_name,
+)
+from vllm_metal.gguf.refs import (
+    GGUFReference,
+    is_local_gguf,
+    resolve_gguf_reference,
+)
+
+
+def _write_gguf_header(path: Path) -> None:
+    path.write_bytes(b"GGUF" + b"\x00" * 32)
+
+
+def _write_config(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text("{}", encoding="utf-8")
+
+
+def _pack_q8_0_raw(qweight: np.ndarray, scales: np.ndarray) -> np.ndarray:
+    rows, blocks, _ = qweight.shape
+    raw = np.zeros((rows, blocks, 34), dtype=np.uint8)
+    raw[:, :, :2] = scales.astype(np.float16).reshape(rows, blocks, 1).view(np.uint8)
+    raw[:, :, 2:] = qweight.astype(np.int8).view(np.uint8)
+    return raw.reshape(rows, blocks * 34)
+
+
+def _pack_q8_1_raw(qweight: np.ndarray, scales: np.ndarray) -> np.ndarray:
+    rows, blocks, _ = qweight.shape
+    raw = np.zeros((rows, blocks, 40), dtype=np.uint8)
+    raw[:, :, :2] = scales.astype(np.float16).reshape(rows, blocks, 1).view(np.uint8)
+    raw[:, :, 4:36] = qweight.astype(np.int8).view(np.uint8)
+    return raw.reshape(rows, blocks * 40)
+
+
+def test_resolve_single_local_gguf_file(tmp_path: Path) -> None:
+    model_dir = tmp_path / "Qwen3.5-0.8B"
+    _write_config(model_dir)
+    gguf_path = tmp_path / "Qwen3.5-0.8B-Q8_0.gguf"
+    _write_gguf_header(gguf_path)
+
+    reference = resolve_gguf_reference(gguf_path)
+
+    assert reference.gguf_path == gguf_path
+    assert reference.all_gguf_paths == (gguf_path,)
+    assert reference.model_path == model_dir
+    assert is_local_gguf(gguf_path)
+
+
+def test_resolve_local_shard_group_from_any_shard(tmp_path: Path) -> None:
+    _write_config(tmp_path / "model")
+    shard_1 = tmp_path / "model-Q4_K-00001-of-00002.gguf"
+    shard_2 = tmp_path / "model-Q4_K-00002-of-00002.gguf"
+    _write_gguf_header(shard_2)
+    _write_gguf_header(shard_1)
+
+    reference = resolve_gguf_reference(shard_2)
+
+    assert reference.gguf_path == shard_1
+    assert reference.all_gguf_paths == (shard_1, shard_2)
+    assert reference.model_path == tmp_path / "model"
+    assert is_local_gguf(tmp_path)
+
+
+def test_incomplete_local_shard_group_is_not_local_gguf(tmp_path: Path) -> None:
+    _write_gguf_header(tmp_path / "model-00001-of-00002.gguf")
+
+    assert not is_local_gguf(tmp_path)
+    with pytest.raises(ValueError, match="Incomplete GGUF shard group"):
+        resolve_gguf_reference(tmp_path / "model-00001-of-00002.gguf")
+
+
+def test_directory_with_multiple_groups_requires_explicit_input(tmp_path: Path) -> None:
+    _write_gguf_header(tmp_path / "a.gguf")
+    _write_gguf_header(tmp_path / "b.gguf")
+
+    assert not is_local_gguf(tmp_path)
+    with pytest.raises(ValueError, match="multiple GGUF files"):
+        resolve_gguf_reference(tmp_path)
+
+
+def test_model_config_candidates_take_precedence(tmp_path: Path) -> None:
+    model_dir = tmp_path / "from-config"
+    _write_config(model_dir)
+    gguf_path = tmp_path / "other-name.gguf"
+    _write_gguf_header(gguf_path)
+
+    reference = resolve_gguf_reference(
+        gguf_path,
+        model_config=SimpleNamespace(hf_config_path=model_dir),
+    )
+
+    assert reference.model_path == model_dir
+
+
+def test_cache_key_includes_all_local_shards(tmp_path: Path) -> None:
+    shards = (
+        tmp_path / "model-00001-of-00002.gguf",
+        tmp_path / "model-00002-of-00002.gguf",
+    )
+    reference = GGUFReference(shards[0], tmp_path / "model", shards)
+
+    cache_key = reference.cache_key()
+
+    assert str(shards[0]) in cache_key[0]
+    assert str(shards[1]) in cache_key[0]
+    assert cache_key[1] == f"gguf-dense:{tmp_path / 'model'}"
+
+
+def test_load_gguf_generation_model_uses_cache_and_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    model_dir = tmp_path / "model"
+    _write_config(model_dir)
+    gguf_path = tmp_path / "model-Q8_0.gguf"
+    _write_gguf_header(gguf_path)
+
+    loaded_model = object()
+    loaded_tokenizer = object()
+    captured: dict[str, object] = {}
+
+    class FakeGGUFLoader:
+        def __init__(self, reference, *, target_dtype, tokenizer_config):
+            captured["reference"] = reference
+            captured["target_dtype"] = target_dtype
+            captured["tokenizer_config"] = tokenizer_config
+
+        def load(self):
+            captured["load_count"] = int(captured.get("load_count", 0)) + 1
+            return loaded_model, loaded_tokenizer
+
+    monkeypatch.setattr(gguf_lifecycle, "GGUFMLXLoader", FakeGGUFLoader)
+    cache: dict[tuple[str, str], tuple[object, object]] = {}
+    cache_lock = Lock()
+    model_config = SimpleNamespace(dtype=torch.float16, trust_remote_code=True)
+
+    model, tokenizer = gguf_lifecycle.load_gguf_generation_model(
+        str(gguf_path),
+        model_config=model_config,
+        model_cache=cache,
+        model_cache_lock=cache_lock,
+        start_time=0.0,
+    )
+
+    assert model is loaded_model
+    assert tokenizer is loaded_tokenizer
+    assert captured["reference"].gguf_path == gguf_path
+    assert captured["reference"].model_path == model_dir
+    assert captured["target_dtype"] == mx.float16
+    assert captured["tokenizer_config"] == {"trust_remote_code": True}
+    assert cache[captured["reference"].cache_key()] == (loaded_model, loaded_tokenizer)
+
+    cached_model, cached_tokenizer = gguf_lifecycle.load_gguf_generation_model(
+        str(gguf_path),
+        model_config=model_config,
+        model_cache=cache,
+        model_cache_lock=cache_lock,
+        start_time=0.0,
+    )
+
+    assert cached_model is loaded_model
+    assert cached_tokenizer is loaded_tokenizer
+    assert captured["load_count"] == 1
+
+
+def test_translate_prefers_upstream_name_map() -> None:
+    translated = translate_gguf_tensor_name(
+        "blk.0.attn_q.weight",
+        model_type="qwen3_5",
+        upstream_name_map={"blk.0.attn_q.weight": "model.layers.0.attn.q_proj.weight"},
+    )
+
+    assert translated == "model.layers.0.attn.q_proj.weight"
+
+
+def test_translate_uses_local_fallback_for_gemma4_language_model() -> None:
+    translated = translate_gguf_tensor_name(
+        "blk.3.ffn_gate.weight",
+        model_type="gemma4",
+    )
+
+    assert translated == "model.language_model.layers.3.mlp.gate_proj.weight"
+
+
+def test_qwen35_shifted_norm_is_adjusted_before_mlx_sanitize() -> None:
+    array = mx.array([2.0, 3.0], dtype=mx.float32)
+
+    adjusted = _adjust_tensor_for_mlx_sanitize(
+        "model.layers.0.input_layernorm.weight",
+        array,
+        model_type="qwen3_5",
+    )
+
+    np.testing.assert_allclose(np.asarray(adjusted), np.array([1.0, 2.0]))
+
+
+def test_dequantize_q8_0_raw_blocks() -> None:
+    qweight = np.arange(-16, 48, dtype=np.int8).reshape(2, 1, 32)
+    scales = np.array([[0.5], [0.25]], dtype=np.float16)
+    raw = _pack_q8_0_raw(qweight, scales)
+
+    decoded = _dequantize_q8_0(raw, (32, 2))
+
+    expected = qweight.astype(np.float32) * scales.astype(np.float32)[..., None]
+    np.testing.assert_allclose(decoded, expected.reshape(2, 32), rtol=0, atol=0)
+
+
+def test_dequantize_q8_1_raw_blocks() -> None:
+    qweight = np.arange(-16, 48, dtype=np.int8).reshape(2, 1, 32)
+    scales = np.array([[0.5], [0.25]], dtype=np.float16)
+    raw = _pack_q8_1_raw(qweight, scales)
+
+    decoded = _dequantize_q8_1(raw, (32, 2))
+
+    expected = qweight.astype(np.float32) * scales.astype(np.float32)[..., None]
+    np.testing.assert_allclose(decoded, expected.reshape(2, 32), rtol=0, atol=0)
+
+
+def test_decode_tensor_uses_gguf_dequantize_for_supported_quant_types() -> None:
+    import gguf
+
+    if not hasattr(gguf, "quantize"):
+        pytest.skip("gguf.quantize is unavailable")
+
+    dense = np.linspace(-1.0, 1.0, 64, dtype=np.float32).reshape(2, 32)
+    quant_type = gguf.GGMLQuantizationType.Q4_0
+    block_size, type_size = gguf.GGML_QUANT_SIZES[quant_type]
+    raw = gguf.quantize(dense.reshape(-1, block_size), quant_type)
+    tensor = SimpleNamespace(
+        name="blk.0.ffn_gate.weight",
+        data=raw.reshape(-1, type_size),
+        shape=(32, 2),
+        tensor_type=quant_type,
+    )
+
+    decoded = _decode_tensor(tensor, target_dtype=mx.float32)
+    expected = gguf.dequantize(raw.reshape(-1, type_size), quant_type).reshape(2, 32)
+
+    np.testing.assert_allclose(np.asarray(decoded), expected, rtol=0, atol=0)
+
+
+def test_decode_tensor_raises_for_unknown_quant_type() -> None:
+    tensor = SimpleNamespace(
+        name="unknown.weight",
+        data=np.zeros((1,), dtype=np.uint8),
+        shape=(1,),
+        tensor_type=9999,
+    )
+
+    with pytest.raises(GGUFLoadError, match="Unsupported GGUF tensor type 9999"):
+        _decode_tensor(tensor, target_dtype=mx.float32)

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -164,6 +164,53 @@ def _make_lifecycle(
 
 
 class TestModelLifecycle:
+    def test_load_generation_model_dispatches_local_gguf_loader(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        gguf_path = tmp_path / "model-Q8_0.gguf"
+        gguf_path.write_bytes(b"GGUF" + b"\x00" * 32)
+
+        loaded_model = SimpleNamespace(config=_text_config())
+        loaded_tokenizer = object()
+        captured: dict[str, object] = {}
+
+        def fake_load_gguf_generation_model(
+            model_name,
+            *,
+            model_config,
+            model_cache,
+            model_cache_lock,
+            start_time,
+        ):
+            captured["model_name"] = model_name
+            captured["model_config"] = model_config
+            captured["model_cache"] = model_cache
+            captured["model_cache_lock"] = model_cache_lock
+            captured["start_time"] = start_time
+            return loaded_model, loaded_tokenizer
+
+        monkeypatch.setattr(
+            model_lifecycle,
+            "load_gguf_generation_model",
+            fake_load_gguf_generation_model,
+        )
+        lifecycle, runner = _make_lifecycle(model_config=_runner_model_config())
+
+        model, tokenizer = lifecycle._load_generation_model(
+            str(gguf_path),
+            is_vlm=False,
+        )
+
+        assert model is loaded_model
+        assert tokenizer is loaded_tokenizer
+        assert captured["model_name"] == str(gguf_path)
+        assert captured["model_config"] is runner.model_config
+        assert captured["model_cache"] is model_lifecycle._MODEL_CACHE
+        assert captured["model_cache_lock"] is model_lifecycle._MODEL_CACHE_LOCK
+        assert isinstance(captured["start_time"], float)
+
     def test_private_mlx_lm_compatible_model_path_adapts_indexed_custom_shards(
         self, tmp_path: Path
     ) -> None:

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -512,9 +512,13 @@ def _patch_vllm_gguf_speculator_detection() -> None:
                 return model, tokenizer, vllm_speculative_config
             raise
 
-    config_utils.maybe_override_with_speculators = _patched_maybe_override_with_speculators
+    config_utils.maybe_override_with_speculators = (
+        _patched_maybe_override_with_speculators
+    )
     if arg_utils is not None:
-        arg_utils.maybe_override_with_speculators = _patched_maybe_override_with_speculators
+        arg_utils.maybe_override_with_speculators = (
+            _patched_maybe_override_with_speculators
+        )
     setattr(config_utils, sentinel, True)
 
 

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -8,6 +8,7 @@ diagnosable.
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import sys
@@ -462,17 +463,20 @@ def _patch_vllm_gguf_speculator_detection() -> None:
     a GGUF feature we support in vllm-metal's experimental path, so falling back
     to the original model/tokenizer/speculative config is the narrowest fix.
     """
-    config_utils = sys.modules.get("vllm.transformers_utils.config")
-    arg_utils = sys.modules.get("vllm.engine.arg_utils")
-    if config_utils is None:
+    config_utils_module: Any | None = sys.modules.get("vllm.transformers_utils.config")
+    arg_utils: Any | None = sys.modules.get("vllm.engine.arg_utils")
+    if config_utils_module is None:
         try:
-            import vllm.transformers_utils.config as config_utils
+            config_utils_module = importlib.import_module(
+                "vllm.transformers_utils.config"
+            )
         except ImportError as exc:
             logger.warning(
                 "Could not install local GGUF speculator compatibility patch: %s",
                 exc,
             )
             return
+    config_utils: Any = config_utils_module
 
     sentinel = "_vllm_metal_gguf_speculator_patch"
     if getattr(config_utils, sentinel, False):
@@ -524,7 +528,7 @@ def _patch_vllm_gguf_speculator_detection() -> None:
 
 def _patch_vllm_local_gguf_engine_args() -> None:
     """Infer config/tokenizer paths for local GGUF files before ModelConfig."""
-    arg_utils = sys.modules.get("vllm.engine.arg_utils")
+    arg_utils: Any | None = sys.modules.get("vllm.engine.arg_utils")
     if arg_utils is None:
         return
 

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from collections.abc import Callable, Mapping
 from functools import lru_cache
 from pathlib import Path
@@ -29,6 +30,8 @@ def apply_compat_patches() -> None:
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
     _patch_vllm_bytelevel_tokenizer_loading()
+    _patch_vllm_gguf_speculator_detection()
+    _patch_vllm_local_gguf_engine_args()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_mlx_lm_gemma4_kv_shared_sanitize()
 
@@ -447,6 +450,125 @@ def _patch_vllm_bytelevel_tokenizer_loading() -> None:
     tokenizer_registry.get_tokenizer = _patched_get_tokenizer
     tokenizer_registry.cached_get_tokenizer = lru_cache(_patched_get_tokenizer)
     setattr(tokenizer_registry, sentinel, True)
+
+
+def _patch_vllm_gguf_speculator_detection() -> None:
+    """Skip upstream speculator probing for local GGUF files it cannot parse.
+
+    vLLM probes configs for `speculators_config` before `ModelConfig` is built.
+    That probe does not receive `--hf-config-path`, so local GGUF files with
+    newer architecture strings (for example qwen35) can fail before the Metal
+    loader has a chance to use the paired HF config.  Speculator metadata is not
+    a GGUF feature we support in vllm-metal's experimental path, so falling back
+    to the original model/tokenizer/speculative config is the narrowest fix.
+    """
+    config_utils = sys.modules.get("vllm.transformers_utils.config")
+    arg_utils = sys.modules.get("vllm.engine.arg_utils")
+    if config_utils is None:
+        try:
+            import vllm.transformers_utils.config as config_utils
+        except ImportError as exc:
+            logger.warning(
+                "Could not install local GGUF speculator compatibility patch: %s",
+                exc,
+            )
+            return
+
+    sentinel = "_vllm_metal_gguf_speculator_patch"
+    if getattr(config_utils, sentinel, False):
+        return
+
+    original = config_utils.maybe_override_with_speculators
+
+    def _patched_maybe_override_with_speculators(
+        model,
+        tokenizer,
+        trust_remote_code,
+        revision=None,
+        vllm_speculative_config=None,
+        hf_token=None,
+        **kwargs,
+    ):
+        _patch_vllm_local_gguf_engine_args()
+        try:
+            return original(
+                model=model,
+                tokenizer=tokenizer,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                vllm_speculative_config=vllm_speculative_config,
+                hf_token=hf_token,
+                **kwargs,
+            )
+        except ValueError as exc:
+            from vllm_metal.gguf.refs import is_local_gguf
+
+            if is_local_gguf(model) and "GGUF model with architecture" in str(exc):
+                logger.info(
+                    "Skipping vLLM speculator config probe for local GGUF model "
+                    "that transformers cannot parse directly: %s",
+                    model,
+                )
+                return model, tokenizer, vllm_speculative_config
+            raise
+
+    config_utils.maybe_override_with_speculators = _patched_maybe_override_with_speculators
+    if arg_utils is not None:
+        arg_utils.maybe_override_with_speculators = _patched_maybe_override_with_speculators
+    setattr(config_utils, sentinel, True)
+
+
+def _patch_vllm_local_gguf_engine_args() -> None:
+    """Infer config/tokenizer paths for local GGUF files before ModelConfig."""
+    arg_utils = sys.modules.get("vllm.engine.arg_utils")
+    if arg_utils is None:
+        return
+
+    engine_args_cls = getattr(arg_utils, "EngineArgs", None)
+    if engine_args_cls is None:
+        return
+
+    sentinel = "_vllm_metal_local_gguf_engine_args_patch"
+    if getattr(engine_args_cls, sentinel, False):
+        return
+
+    original_create_model_config = engine_args_cls.create_model_config
+
+    def _patched_create_model_config(self, *args, **kwargs):
+        from vllm_metal.gguf.refs import is_local_gguf, resolve_gguf_reference
+
+        model = getattr(self, "model", None)
+        if model is not None and is_local_gguf(model):
+            try:
+                reference = resolve_gguf_reference(model, model_config=self)
+            except ValueError as exc:
+                logger.info(
+                    "Could not infer paired config/tokenizer path for local GGUF "
+                    "%s before ModelConfig creation: %s",
+                    model,
+                    exc,
+                )
+            else:
+                paired_path = str(reference.model_path)
+                if getattr(self, "hf_config_path", None) is None:
+                    self.hf_config_path = paired_path
+                    logger.info(
+                        "Using inferred local GGUF hf_config_path=%s for %s",
+                        paired_path,
+                        model,
+                    )
+                if getattr(self, "tokenizer", None) in (None, model):
+                    self.tokenizer = paired_path
+                    logger.info(
+                        "Using inferred local GGUF tokenizer=%s for %s",
+                        paired_path,
+                        model,
+                    )
+
+        return original_create_model_config(self, *args, **kwargs)
+
+    engine_args_cls.create_model_config = _patched_create_model_config
+    setattr(engine_args_cls, sentinel, True)
 
 
 def _ceildiv(value: int, divisor: int) -> int:

--- a/vllm_metal/gguf/__init__.py
+++ b/vllm_metal/gguf/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Experimental GGUF loading support for vllm-metal."""
+
+from vllm_metal.gguf.refs import GGUFReference, is_local_gguf, resolve_gguf_reference
+
+__all__ = [
+    "GGUFLoadError",
+    "GGUFMLXLoader",
+    "GGUFReference",
+    "is_local_gguf",
+    "resolve_gguf_reference",
+]
+
+
+def __getattr__(name: str):
+    if name in {"GGUFLoadError", "GGUFMLXLoader"}:
+        from vllm_metal.gguf.loader import GGUFLoadError, GGUFMLXLoader
+
+        return {
+            "GGUFLoadError": GGUFLoadError,
+            "GGUFMLXLoader": GGUFMLXLoader,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_metal/gguf/lifecycle.py
+++ b/vllm_metal/gguf/lifecycle.py
@@ -27,7 +27,7 @@ def load_gguf_generation_model(
 ) -> tuple[Any, Any]:
     target_dtype = torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype
     reference = resolve_gguf_reference(model_name, model_config=model_config)
-    cache_key = reference.cache_key()
+    cache_key = reference.dense_cache_key(target_dtype=target_dtype)
 
     with model_cache_lock:
         cached = model_cache.get(cache_key)

--- a/vllm_metal/gguf/lifecycle.py
+++ b/vllm_metal/gguf/lifecycle.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lifecycle glue for GGUF generation model loading."""
+
+from __future__ import annotations
+
+import time
+from threading import Lock
+from typing import Any
+
+import torch
+from vllm.logger import init_logger
+
+from vllm_metal.gguf.loader import GGUFMLXLoader
+from vllm_metal.gguf.refs import resolve_gguf_reference
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
+
+logger = init_logger(__name__)
+
+
+def load_gguf_generation_model(
+    model_name: str,
+    *,
+    model_config: Any,
+    model_cache: dict[tuple[str, str], tuple[Any, Any]],
+    model_cache_lock: Lock,
+    start_time: float,
+) -> tuple[Any, Any]:
+    target_dtype = torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype
+    reference = resolve_gguf_reference(model_name, model_config=model_config)
+    cache_key = reference.cache_key()
+
+    with model_cache_lock:
+        cached = model_cache.get(cache_key)
+    if cached is not None:
+        logger.info(
+            "GGUF model loaded from cache in %.3fs: %s",
+            time.time() - start_time,
+            reference.gguf_path,
+        )
+        return cached
+
+    tokenizer_config = {"trust_remote_code": model_config.trust_remote_code}
+    logger.info(
+        "Using experimental dense GGUF loader: weights=%s config=%s",
+        reference.gguf_path,
+        reference.model_path,
+    )
+    model, tokenizer = GGUFMLXLoader(
+        reference,
+        target_dtype=target_dtype,
+        tokenizer_config=tokenizer_config,
+    ).load()
+
+    with model_cache_lock:
+        model_cache[cache_key] = (model, tokenizer)
+    logger.info(
+        "GGUF model loaded in %.2fs: %s",
+        time.time() - start_time,
+        reference.gguf_path,
+    )
+    return model, tokenizer

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Dense fallback GGUF loader for MLX models."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from mlx.utils import tree_flatten
+from mlx_lm.utils import _get_classes as mlx_lm_get_classes
+from mlx_lm.utils import load_config as mlx_lm_load_config
+from mlx_lm.utils import load_tokenizer as mlx_lm_load_tokenizer
+from vllm.logger import init_logger
+
+from vllm_metal.gguf.refs import GGUFReference
+
+logger = init_logger(__name__)
+
+GGUF_QTYPE_Q8_1 = 9
+
+
+class GGUFLoadError(RuntimeError):
+    """Raised when a GGUF checkpoint cannot be loaded through MLX."""
+
+
+class GGUFMLXLoader:
+    """Load a local GGUF checkpoint into the corresponding MLX-LM model.
+
+    This is a compatibility loader: supported quantized GGUF tensors are
+    dequantized to dense MLX arrays before they are attached to the model.
+    Native raw-block execution is introduced in later PRs.
+    """
+
+    def __init__(
+        self,
+        reference: GGUFReference,
+        *,
+        target_dtype: mx.Dtype,
+        tokenizer_config: dict[str, Any] | None = None,
+    ) -> None:
+        self.reference = reference
+        self.target_dtype = target_dtype
+        self.tokenizer_config = tokenizer_config or {}
+
+    def load(self) -> tuple[Any, Any]:
+        config = mlx_lm_load_config(self.reference.model_path)
+        model_class, model_args_class = mlx_lm_get_classes(config=config)
+        model_args = model_args_class.from_dict(config)
+        model = model_class(model_args)
+
+        weights = self._load_weights(config, model=model)
+        if hasattr(model, "sanitize"):
+            weights = model.sanitize(weights)
+
+        model.eval()
+        model.load_weights(list(weights.items()), strict=True)
+        mx.eval(model.parameters())
+
+        tokenizer = mlx_lm_load_tokenizer(
+            self.reference.model_path,
+            self.tokenizer_config,
+            eos_token_ids=config.get("eos_token_id", None),
+        )
+        return model, tokenizer
+
+    def _load_weights(
+        self,
+        config: dict[str, Any],
+        *,
+        model: nn.Module | None = None,
+    ) -> dict[str, mx.array]:
+        try:
+            import gguf
+        except ImportError as exc:
+            raise GGUFLoadError(
+                "GGUF support requires the `gguf` Python package."
+            ) from exc
+
+        model_type = str(config.get("model_type", ""))
+        upstream_name_map = _build_upstream_gguf_to_mlx_map(model, config)
+        weights: dict[str, mx.array] = {}
+        skipped: list[str] = []
+
+        for gguf_path in self.reference.all_gguf_paths:
+            reader = gguf.GGUFReader(str(gguf_path))
+            for tensor in reader.tensors:
+                translated = translate_gguf_tensor_name(
+                    tensor.name,
+                    model_type=model_type,
+                    upstream_name_map=upstream_name_map,
+                )
+                if translated is None:
+                    skipped.append(tensor.name)
+                    continue
+                array = _decode_tensor(tensor, target_dtype=self.target_dtype)
+                array = _reshape_special_tensor(translated, array)
+                array = _adjust_tensor_for_mlx_sanitize(
+                    translated,
+                    array,
+                    model_type=model_type,
+                )
+                _add_weight(weights, translated, array)
+
+        if not weights:
+            gguf_paths = ", ".join(str(path) for path in self.reference.all_gguf_paths)
+            raise GGUFLoadError(f"No loadable tensors found in {gguf_paths}")
+
+        if skipped:
+            logger.info(
+                "Skipped %d GGUF tensors without MLX mapping from %s: %s",
+                len(skipped),
+                ", ".join(str(path) for path in self.reference.all_gguf_paths),
+                ", ".join(skipped[:8]),
+            )
+
+        return weights
+
+
+_BLOCK_RE = re.compile(r"^blk\.(\d+)\.(.+)$")
+
+_GLOBAL_NAME_MAP = {
+    "token_embd.weight": "model.embed_tokens.weight",
+    "output_norm.weight": "model.norm.weight",
+    "output.weight": "lm_head.weight",
+    "per_layer_token_embd.weight": "model.embed_tokens_per_layer.weight",
+    "per_layer_model_proj.weight": "model.per_layer_model_projection.weight",
+    "per_layer_proj_norm.weight": "model.per_layer_projection_norm.weight",
+}
+
+_BLOCK_NAME_MAP = {
+    "attn_norm.weight": "input_layernorm.weight",
+    "post_attention_norm.weight": "post_attention_layernorm.weight",
+    "ffn_norm.weight": "pre_feedforward_layernorm.weight",
+    "post_ffw_norm.weight": "post_feedforward_layernorm.weight",
+    "post_norm.weight": "post_per_layer_input_norm.weight",
+    "ffn_gate.weight": "mlp.gate_proj.weight",
+    "ffn_down.weight": "mlp.down_proj.weight",
+    "ffn_up.weight": "mlp.up_proj.weight",
+    "attn_q.weight": "self_attn.q_proj.weight",
+    "attn_k.weight": "self_attn.k_proj.weight",
+    "attn_v.weight": "self_attn.v_proj.weight",
+    "attn_output.weight": "self_attn.o_proj.weight",
+    "attn_q_norm.weight": "self_attn.q_norm.weight",
+    "attn_k_norm.weight": "self_attn.k_norm.weight",
+    "inp_gate.weight": "per_layer_input_gate.weight",
+    "proj.weight": "per_layer_projection.weight",
+    "layer_output_scale.weight": "layer_scalar",
+    "attn_qkv.weight": "linear_attn.in_proj_qkv.weight",
+    "attn_gate.weight": "linear_attn.in_proj_z.weight",
+    "ssm_alpha.weight": "linear_attn.in_proj_a.weight",
+    "ssm_beta.weight": "linear_attn.in_proj_b.weight",
+    "ssm_conv1d.weight": "linear_attn.conv1d.weight",
+    "ssm_dt.bias": "linear_attn.dt_bias",
+    "ssm_a": "linear_attn.A_log",
+    "ssm_norm.weight": "linear_attn.norm.weight",
+    "ssm_out.weight": "linear_attn.out_proj.weight",
+}
+
+_SKIPPED_GLOBAL_NAMES = {
+    "rope_freqs.weight",
+}
+
+
+_MLX_QWEN_SHIFTED_NORM_MODEL_TYPES = {
+    "qwen3_5",
+    "qwen3_5_moe",
+    "qwen3_next",
+}
+
+_MLX_QWEN_SHIFTED_NORM_SUFFIXES = (
+    ".input_layernorm.weight",
+    ".post_attention_layernorm.weight",
+    "model.norm.weight",
+    ".q_norm.weight",
+    ".k_norm.weight",
+)
+
+
+def translate_gguf_tensor_name(
+    name: str,
+    *,
+    model_type: str,
+    upstream_name_map: dict[str, str] | None = None,
+) -> str | None:
+    if name in _SKIPPED_GLOBAL_NAMES:
+        return None
+
+    if upstream_name_map is not None:
+        translated = upstream_name_map.get(name)
+        if translated is not None:
+            return translated
+
+    translated = _GLOBAL_NAME_MAP.get(name)
+    if translated is None:
+        block_match = _BLOCK_RE.match(name)
+        if block_match is None:
+            return None
+        layer, suffix = block_match.groups()
+        block_suffix = _BLOCK_NAME_MAP.get(suffix)
+        if block_suffix is None:
+            return None
+        translated = f"model.layers.{layer}.{block_suffix}"
+
+    if model_type == "gemma4" and translated.startswith("model."):
+        return "model.language_model." + translated.removeprefix("model.")
+    return translated
+
+
+_GGUF_MODEL_TYPE_ALIASES = {
+    "qwen3_5": "qwen35",
+    "qwen3_5_moe": "qwen35moe",
+    "qwen3_6_moe": "qwen35moe",
+    "qwen3_next": "qwen3next",
+    "qwen3next": "qwen3next",
+    "qwen2_moe": "qwen2moe",
+    "qwen3_moe": "qwen3moe",
+    "gemma3_text": "gemma3",
+}
+
+
+def _build_upstream_gguf_to_mlx_map(
+    model: nn.Module | None,
+    config: dict[str, Any],
+) -> dict[str, str]:
+    if model is None:
+        return {}
+
+    try:
+        import gguf
+    except ImportError:
+        return {}
+
+    arch = _gguf_arch_from_config(gguf, config)
+    if arch is None:
+        return {}
+
+    num_layers = _num_hidden_layers(config)
+    if num_layers <= 0:
+        return {}
+
+    try:
+        tensor_name_map = gguf.get_tensor_name_map(arch, num_layers)
+    except Exception as exc:  # pragma: no cover - gguf version compatibility
+        logger.debug("Unable to build upstream GGUF tensor map: %s", exc)
+        return {}
+
+    leaves = tree_flatten(model.leaf_modules(), is_leaf=nn.Module.is_module)
+    if not isinstance(leaves, list):
+        return {}
+
+    reverse: dict[str, str] = {}
+    for module_path, module in leaves:
+        for param_name in module.parameters():
+            mlx_name = f"{module_path}.{param_name}" if module_path else param_name
+            gguf_name = _gguf_name_for_mlx_param(tensor_name_map, mlx_name)
+            if gguf_name is not None:
+                reverse.setdefault(gguf_name, mlx_name)
+    return reverse
+
+
+def _gguf_arch_from_config(gguf: Any, config: dict[str, Any]) -> Any | None:
+    model_type = str(config.get("model_type", "")).lower().replace("-", "_")
+    arch_name = _GGUF_MODEL_TYPE_ALIASES.get(model_type, model_type)
+    for arch, name in getattr(gguf, "MODEL_ARCH_NAMES", {}).items():
+        if str(name).lower().replace("-", "_") == arch_name:
+            return arch
+    return None
+
+
+def _num_hidden_layers(config: dict[str, Any]) -> int:
+    for key in ("num_hidden_layers", "n_layers", "num_layers", "n_layer"):
+        value = config.get(key)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+def _gguf_name_for_mlx_param(tensor_name_map: Any, mlx_name: str) -> str | None:
+    translated = tensor_name_map.get_name(
+        mlx_name,
+        try_suffixes=(".weight", ".bias"),
+    )
+    if translated is not None:
+        return translated
+
+    if mlx_name.startswith("model.language_model."):
+        stripped_name = "model." + mlx_name.removeprefix("model.language_model.")
+        return tensor_name_map.get_name(
+            stripped_name,
+            try_suffixes=(".weight", ".bias"),
+        )
+    return None
+
+
+def _reshape_special_tensor(name: str, array: mx.array) -> mx.array:
+    if name.endswith(".linear_attn.conv1d.weight") and len(array.shape) == 2:
+        return mx.expand_dims(array, axis=1)
+    return array
+
+
+def _adjust_tensor_for_mlx_sanitize(
+    name: str,
+    array: mx.array,
+    *,
+    model_type: str,
+) -> mx.array:
+    if (
+        model_type in _MLX_QWEN_SHIFTED_NORM_MODEL_TYPES
+        and len(array.shape) == 1
+        and any(name.endswith(suffix) for suffix in _MLX_QWEN_SHIFTED_NORM_SUFFIXES)
+    ):
+        return array - 1.0
+    return array
+
+
+def _add_weight(weights: dict[str, mx.array], key: str, value: mx.array) -> None:
+    if key in weights:
+        raise GGUFLoadError(f"Duplicate GGUF tensor mapped to MLX weight: {key}")
+    weights[key] = value
+
+
+def _decode_tensor(tensor: Any, *, target_dtype: mx.Dtype) -> mx.array:
+    try:
+        import gguf
+    except ImportError as exc:
+        raise GGUFLoadError("GGUF support requires the `gguf` Python package.") from exc
+
+    try:
+        tensor_type = gguf.GGMLQuantizationType(tensor.tensor_type)
+    except ValueError as exc:
+        raise GGUFLoadError(
+            f"Unsupported GGUF tensor type {tensor.tensor_type} for tensor "
+            f"{tensor.name}."
+        ) from exc
+    final_shape = _final_shape(tensor.shape)
+
+    if tensor_type == gguf.GGMLQuantizationType.F32:
+        data = np.asarray(tensor.data, dtype=np.float32).reshape(final_shape)
+        return mx.array(data)
+    if tensor_type == gguf.GGMLQuantizationType.F16:
+        data = np.asarray(tensor.data, dtype=np.float16).reshape(final_shape)
+        return mx.array(data).astype(target_dtype)
+    if tensor_type == gguf.GGMLQuantizationType.BF16:
+        data = _decode_bf16(tensor.data).reshape(final_shape)
+        return mx.array(data).astype(target_dtype)
+    if tensor_type == gguf.GGMLQuantizationType.Q8_0:
+        data = _dequantize_q8_0(tensor.data, tensor.shape)
+        return mx.array(data).astype(target_dtype)
+    if int(tensor_type) == GGUF_QTYPE_Q8_1:
+        data = _dequantize_q8_1(tensor.data, tensor.shape)
+        return mx.array(data).astype(target_dtype)
+    if tensor_type in gguf.GGML_QUANT_SIZES:
+        try:
+            data = gguf.dequantize(
+                np.asarray(tensor.data, dtype=np.uint8),
+                tensor_type,
+            ).reshape(final_shape)
+        except NotImplementedError as exc:
+            raise GGUFLoadError(
+                f"Unsupported GGUF tensor type {tensor_type.name} for tensor "
+                f"{tensor.name}: gguf.dequantize does not implement this type."
+            ) from exc
+        return mx.array(data).astype(target_dtype)
+
+    raise GGUFLoadError(
+        f"Unsupported GGUF tensor type {tensor_type.name} for tensor {tensor.name}. "
+        "This experimental loader supports F32, F16, BF16, Q8_0/Q8_1, and "
+        "quantized tensor types implemented by gguf.dequantize."
+    )
+
+
+def _final_shape(shape: Iterable[int]) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in reversed(tuple(shape)))
+
+
+def _decode_bf16(data: Any) -> np.ndarray:
+    raw = np.asarray(data, dtype=np.uint16)
+    return (raw.astype(np.uint32) << 16).view(np.float32)
+
+
+def _dequantize_q8_0(data: Any, shape: Iterable[int]) -> np.ndarray:
+    dims = tuple(int(dim) for dim in shape)
+    if not dims:
+        raise GGUFLoadError("Q8_0 tensor has no shape.")
+
+    cols = dims[0]
+    if cols % 32 != 0:
+        raise GGUFLoadError(f"Q8_0 tensor column count must be divisible by 32: {dims}")
+
+    final_shape = _final_shape(dims)
+    rows = int(np.prod(final_shape[:-1], dtype=np.int64)) if len(final_shape) > 1 else 1
+    blocks = cols // 32
+    raw = np.asarray(data, dtype=np.uint8).reshape(rows, blocks, 34)
+    scales = raw[:, :, :2].copy().view(np.float16).astype(np.float32)
+    quants = raw[:, :, 2:].copy().view(np.int8).astype(np.float32)
+    dequantized = (quants * scales).reshape(rows, cols)
+    return dequantized.reshape(final_shape)
+
+
+def _dequantize_q8_1(data: Any, shape: Iterable[int]) -> np.ndarray:
+    dims = tuple(int(dim) for dim in shape)
+    if not dims:
+        raise GGUFLoadError("Q8_1 tensor has no shape.")
+
+    cols = dims[0]
+    if cols % 32 != 0:
+        raise GGUFLoadError(f"Q8_1 tensor column count must be divisible by 32: {dims}")
+
+    final_shape = _final_shape(dims)
+    rows = int(np.prod(final_shape[:-1], dtype=np.int64)) if len(final_shape) > 1 else 1
+    blocks = cols // 32
+    raw = np.asarray(data, dtype=np.uint8).reshape(rows, blocks, 40)
+    scales = raw[:, :, :2].copy().view(np.float16).astype(np.float32)
+    quants = raw[:, :, 4:36].copy().view(np.int8).astype(np.float32)
+    dequantized = (quants * scales).reshape(rows, cols)
+    return dequantized.reshape(final_shape)

--- a/vllm_metal/gguf/refs.py
+++ b/vllm_metal/gguf/refs.py
@@ -34,9 +34,15 @@ class GGUFReference:
     def all_gguf_paths(self) -> tuple[Path, ...]:
         return self.gguf_paths or (self.gguf_path,)
 
-    def cache_key(self) -> tuple[str, str]:
+    def dense_cache_key(self, *, target_dtype: Any) -> tuple[str, str]:
+        """Cache key for dense GGUF loads.
+
+        The dense loader casts decoded tensors to ``target_dtype`` before
+        caching the model. Keep dtype in the loader segment so a bf16 request
+        cannot reuse an earlier fp16 model for the same GGUF files.
+        """
         gguf_key = "\x1f".join(str(path) for path in self.all_gguf_paths)
-        return (gguf_key, f"gguf-dense:{self.model_path}")
+        return (gguf_key, f"gguf-dense:{self.model_path}:{target_dtype}")
 
 
 def is_local_gguf(model_name: str | Path) -> bool:

--- a/vllm_metal/gguf/refs.py
+++ b/vllm_metal/gguf/refs.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GGUF model reference resolution.
+
+The first supported mode is intentionally local-only. It accepts a single
+``.gguf`` file, a complete local ``*-NN-of-MM.gguf`` shard group, or a directory
+containing exactly one local GGUF file/group, then resolves a paired HF/MLX
+config/tokenizer directory.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_QUANT_SUFFIX_RE = re.compile(
+    r"(?i)(?:[-_.](?:UD-)?(?:IQ[1-4]_[A-Z0-9]+|Q[2-8](?:_[0-9A-Z]+)*|BF16|F16|F32))+$"
+)
+_SHARD_RE = re.compile(
+    r"^(?P<prefix>.*)-(?P<index>\d+)-of-(?P<count>\d+)\.gguf$",
+    re.IGNORECASE,
+)
+_SHARD_STEM_RE = re.compile(r"^(?P<prefix>.*)-\d+-of-\d+$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class GGUFReference:
+    gguf_path: Path
+    model_path: Path
+    gguf_paths: tuple[Path, ...] = ()
+
+    @property
+    def all_gguf_paths(self) -> tuple[Path, ...]:
+        return self.gguf_paths or (self.gguf_path,)
+
+    def cache_key(self) -> tuple[str, str]:
+        gguf_key = "\x1f".join(str(path) for path in self.all_gguf_paths)
+        return (gguf_key, f"gguf-dense:{self.model_path}")
+
+
+def is_local_gguf(model_name: str | Path) -> bool:
+    path = Path(model_name)
+    try:
+        return bool(_resolve_gguf_files(path))
+    except ValueError:
+        return False
+
+
+def resolve_gguf_reference(
+    model_name: str | Path,
+    *,
+    model_config: Any | None = None,
+) -> GGUFReference:
+    path = Path(model_name)
+    gguf_paths = _resolve_gguf_files(path)
+    gguf_path = gguf_paths[0]
+    model_path = _resolve_paired_model_path(gguf_path, model_config=model_config)
+    return GGUFReference(
+        gguf_path=gguf_path,
+        model_path=model_path,
+        gguf_paths=gguf_paths,
+    )
+
+
+def _resolve_gguf_files(path: Path) -> tuple[Path, ...]:
+    if path.is_file():
+        if not _has_gguf_header(path):
+            raise ValueError(f"Not a GGUF file: {path}")
+        return _resolve_file_with_shards(path)
+
+    if path.is_dir():
+        gguf_files = _gguf_files_in_dir(path)
+        if len(gguf_files) == 1:
+            return _resolve_file_with_shards(gguf_files[0])
+        if not gguf_files:
+            raise ValueError(f"No GGUF files found in directory: {path}")
+
+        resolved = _resolve_directory_gguf_group(gguf_files)
+        if resolved is not None:
+            return resolved
+        raise ValueError(
+            f"Directory contains multiple GGUF files or shard groups; "
+            f"pass one group explicitly: {path}"
+        )
+
+    raise ValueError(f"GGUF path does not exist: {path}")
+
+
+def _resolve_file_with_shards(path: Path) -> tuple[Path, ...]:
+    match = _SHARD_RE.match(path.name)
+    if match is None:
+        return (path,)
+
+    prefix = match.group("prefix")
+    count = int(match.group("count"))
+    shards = [
+        candidate
+        for candidate in path.parent.iterdir()
+        if candidate.is_file()
+        and candidate.name.startswith(f"{prefix}-")
+        and candidate.name.endswith(f"-of-{match.group('count')}.gguf")
+        and _has_gguf_header(candidate)
+    ]
+    return _validate_shard_group(shards, expected_count=count, source=path)
+
+
+def _resolve_directory_gguf_group(files: list[Path]) -> tuple[Path, ...] | None:
+    standalone: list[Path] = []
+    shard_groups: dict[tuple[str, str], list[Path]] = {}
+    expected_counts: dict[tuple[str, str], int] = {}
+
+    for file in files:
+        match = _SHARD_RE.match(file.name)
+        if match is None:
+            standalone.append(file)
+            continue
+        key = (match.group("prefix"), match.group("count"))
+        shard_groups.setdefault(key, []).append(file)
+        expected_counts[key] = int(match.group("count"))
+
+    candidates: list[tuple[Path, ...]] = []
+    if len(standalone) == 1:
+        candidates.append((standalone[0],))
+    elif len(standalone) > 1:
+        return None
+
+    for key, group in shard_groups.items():
+        try:
+            candidates.append(
+                _validate_shard_group(
+                    group,
+                    expected_count=expected_counts[key],
+                    source=group[0],
+                )
+            )
+        except ValueError:
+            return None
+
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _validate_shard_group(
+    shards: list[Path],
+    *,
+    expected_count: int,
+    source: Path,
+) -> tuple[Path, ...]:
+    indexed: dict[int, Path] = {}
+    for shard in shards:
+        match = _SHARD_RE.match(shard.name)
+        if match is None:
+            continue
+        index = int(match.group("index"))
+        count = int(match.group("count"))
+        if count != expected_count or index < 1 or index > expected_count:
+            continue
+        indexed[index] = shard
+
+    expected = set(range(1, expected_count + 1))
+    if set(indexed) != expected:
+        missing = ", ".join(str(i) for i in sorted(expected - set(indexed)))
+        raise ValueError(
+            f"Incomplete GGUF shard group for {source}; missing shard index: {missing}"
+        )
+    return tuple(indexed[index] for index in sorted(indexed))
+
+
+def _resolve_paired_model_path(
+    gguf_path: Path,
+    *,
+    model_config: Any | None,
+) -> Path:
+    for candidate in _paired_model_candidates(gguf_path, model_config):
+        if (candidate / "config.json").is_file():
+            return candidate
+
+    candidates = ", ".join(
+        str(p) for p in _paired_model_candidates(gguf_path, model_config)
+    )
+    raise ValueError(
+        "GGUF loading needs a paired HF/MLX config and tokenizer directory. "
+        f"Tried: {candidates}"
+    )
+
+
+def _paired_model_candidates(
+    gguf_path: Path,
+    model_config: Any | None,
+) -> list[Path]:
+    candidates: list[Path] = []
+
+    if model_config is not None:
+        for attr in ("hf_config_path", "tokenizer", "served_model_name"):
+            value = getattr(model_config, attr, None)
+            if isinstance(value, (str, Path)):
+                candidates.append(Path(value))
+
+    candidates.append(gguf_path.parent)
+
+    stem = _strip_quant_suffix(_strip_shard_suffix(gguf_path.stem))
+    for base in (gguf_path.parent, gguf_path.parent.parent):
+        if base:
+            candidates.append(base / stem)
+
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        expanded = candidate.expanduser()
+        if expanded not in seen:
+            seen.add(expanded)
+            deduped.append(expanded)
+    return deduped
+
+
+def _strip_quant_suffix(stem: str) -> str:
+    stripped = _QUANT_SUFFIX_RE.sub("", stem)
+    return stripped or stem
+
+
+def _strip_shard_suffix(stem: str) -> str:
+    match = _SHARD_STEM_RE.match(stem)
+    return match.group("prefix") if match is not None else stem
+
+
+def _gguf_files_in_dir(path: Path) -> list[Path]:
+    return sorted(p for p in path.glob("*.gguf") if _has_gguf_header(p))
+
+
+def _has_gguf_header(path: Path) -> bool:
+    if path.suffix.lower() != ".gguf":
+        return False
+    try:
+        with path.open("rb") as f:
+            return f.read(4) == b"GGUF"
+    except OSError:
+        return False

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -15,6 +15,8 @@ from vllm.logger import init_logger
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.compat import apply_compat_patches
+from vllm_metal.gguf import is_local_gguf
+from vllm_metal.gguf.lifecycle import load_gguf_generation_model
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
 from vllm_metal.utils import get_model_download_path
@@ -114,6 +116,8 @@ class ModelLifecycle:
         is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
         if self._model_adapter.should_force_text_backbone(hf_config):
             is_vlm = False
+        if is_local_gguf(model_name):
+            is_vlm = False
 
         model, tokenizer = self._load_generation_model(model_name, is_vlm)
 
@@ -150,6 +154,15 @@ class ModelLifecycle:
     def _load_generation_model(self, model_name: str, is_vlm: bool) -> tuple[Any, Any]:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
+
+        if not is_vlm and is_local_gguf(model_name):
+            return load_gguf_generation_model(
+                model_name,
+                model_config=self._runner.model_config,
+                model_cache=_MODEL_CACHE,
+                model_cache_lock=_MODEL_CACHE_LOCK,
+                start_time=start_time,
+            )
 
         # AWQ checkpoints are owned end-to-end by AWQQuantLoader
         # (preflight, mlx_lm.load invocation, dtype alignment, dtype-scoped


### PR DESCRIPTION
 Adds an experimental local GGUF load path for vllm-metal generation models.

This PR supports local `.gguf` files and complete local GGUF shard groups by resolving a paired HF/MLX config/tokenizer directory, translating GGUF tensor names to MLX-LM weights, and loading supported GGUF tensor types through a dense fallback path.