### PR TITLE
[kernel] Occupancy-gated split-KV decode (Flash-Decoding)

### DIFF
--- a/tests/test_split_kv_decode.py
+++ b/tests/test_split_kv_decode.py
@@ -10,10 +10,13 @@ Every split case engages on any hardware: base_grid <= 32, while the gate
 threshold is >= 56 (8 x 7 cores on the smallest Apple GPU) and 112 on the
 IORegistry fallback used in VMs — and each test asserts that premise via the
 exported ``min_decode_grid()`` so a gate regression fails loudly instead of
-silently degrading every cell to single-pass-vs-reference.  TurboQuant and
-sliding-window batches are excluded from the split until their interaction is
-validated; their single-pass coverage lives in test_turboquant.py and
-test_primitive_and_donation.py.
+silently degrading every cell to single-pass-vs-reference.
+
+Sliding-window and TurboQuant batches take the split too: windowed cells
+cover window starts on and off partition boundaries (fully- and
+partially-masked partitions), and TQ cells cover both packing families
+(8-bit direct, 4-bit packed) with the inverse FWHT deferred to the reduce
+pass.
 
 Run with:
     python -m pytest tests/test_split_kv_decode.py -v
@@ -26,6 +29,12 @@ import numpy as np
 import pytest
 
 from tools.attention_bench_utils import ref_paged_attn
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.attention.caches.turboquant import (
+    get_v_centroids,
+    turbo_quant_decode,
+    turbo_quant_encode,
+)
 from vllm_metal.metal import get_ops
 
 NUM_QUERY_HEADS = 16  # Qwen3-0.6B GQA shape: 16 query / 8 KV heads
@@ -81,7 +90,7 @@ def _run_paged_decode(
         cu_seqlens_q,
         BLOCK_SIZE,
         max_kv_len,
-        -1,  # sliding_window (disabled; windowed batches skip the split)
+        -1,  # sliding_window (disabled here; windowed cells below)
         out,
     )
     mx.eval(out)
@@ -144,3 +153,189 @@ def test_high_occupancy_stays_single_pass() -> None:
 
     out, ref = _run_paged_decode(kv_lens, mx.float16, seed=1)
     _assert_close(out, ref, mx.float16)
+
+
+def _ref_attention_np(
+    query: mx.array, k_rows: np.ndarray, v_rows: np.ndarray
+) -> np.ndarray:
+    """float32 GQA attention over the given K/V rows (T, KV_HEADS, HEAD)."""
+    q = np.array(query.astype(mx.float32))[0]
+    rep = NUM_QUERY_HEADS // NUM_KV_HEADS
+    k = np.repeat(k_rows, rep, axis=1)
+    v = np.repeat(v_rows, rep, axis=1)
+    scores = np.einsum("hd,thd->ht", q, k) * HEAD_SIZE**-0.5
+    p = np.exp(scores - scores.max(axis=1, keepdims=True))
+    p /= p.sum(axis=1, keepdims=True)
+    return np.einsum("ht,thd->hd", p, v)
+
+
+@pytest.mark.parametrize(
+    "kv_len,window",
+    [
+        (2048, 512),  # window start ON a partition boundary: 3 of 4 fully masked
+        (2048, 700),  # window start mid-partition: partially masked partition
+        (8192, 1300),  # long context: 13 fully-masked partitions
+    ],
+)
+def test_split_decode_sliding_window(kv_len: int, window: int) -> None:
+    """Partitioned decode with a sliding window matches a windowed reference.
+
+    Fully-masked partitions must contribute exact zeros (epsilon-normalized
+    partial, zero merge weight), never NaN."""
+    mx.random.seed(2)
+    ops = get_ops()
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    assert kv_len > ops.PARTITION_SIZE
+
+    nblocks = kv_len // BLOCK_SIZE
+    key_cache = mx.random.normal(
+        shape=(nblocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(mx.float16)
+    value_cache = mx.random.normal(
+        shape=(nblocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(mx.float16)
+    query = mx.random.normal(shape=(1, NUM_QUERY_HEADS, HEAD_SIZE)).astype(mx.float16)
+    # identity block table: flat cache row t == token t, so the reference can
+    # slice the window directly
+    block_tables = mx.arange(nblocks, dtype=mx.int32).reshape(1, nblocks)
+    seq_lens = mx.array([kv_len], dtype=mx.int32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    mx.eval(key_cache, value_cache, query, block_tables, seq_lens, cu_seqlens_q)
+
+    out = mx.array(0)
+    ops.paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        NUM_KV_HEADS,
+        HEAD_SIZE**-0.5,
+        0.0,
+        block_tables,
+        seq_lens,
+        cu_seqlens_q,
+        BLOCK_SIZE,
+        kv_len,
+        window,
+        out,
+    )
+    mx.eval(out)
+    o = np.array(out.astype(mx.float32))[0]
+    assert np.isfinite(o).all()
+
+    start = kv_len - window
+    k_rows = np.array(
+        key_cache.reshape(-1, NUM_KV_HEADS, HEAD_SIZE)[start:kv_len].astype(mx.float32)
+    )
+    v_rows = np.array(
+        value_cache.reshape(-1, NUM_KV_HEADS, HEAD_SIZE)[start:kv_len].astype(
+            mx.float32
+        )
+    )
+    ref = _ref_attention_np(query, k_rows, v_rows)
+    np.testing.assert_allclose(o, ref, atol=1.5e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "quant,window",
+    [
+        ("q8_0", -1),
+        ("q4_0", -1),
+        ("q8_0", 700),  # TQ x sliding window: both gate-admitted features at once
+    ],
+)
+def test_split_decode_turboquant(quant: str, window: int) -> None:
+    """Partitioned TurboQuant decode matches the dequantized reference.
+
+    kv_len=1300 also covers an odd partition count on the TQ reduce path
+    (single inverse FWHT applied after the fp32 partition merge).  The
+    windowed cell combines TQ with sliding-window masking — one fully and
+    one partially masked partition over rotated-domain partials."""
+    kv_len = 1300
+    mx.random.seed(3)
+    ops = get_ops()
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    assert kv_len > ops.PARTITION_SIZE
+
+    nblocks = (kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    cache = MetalPagedKVCache(
+        num_layers=1,
+        num_blocks=nblocks,
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_SIZE,
+        dtype=mx.float16,
+        turboquant=True,
+        k_quant=quant,
+    )
+    k = mx.random.normal(shape=(kv_len, NUM_KV_HEADS, HEAD_SIZE)).astype(mx.float16)
+    v = mx.random.normal(shape=(kv_len, NUM_KV_HEADS, HEAD_SIZE)).astype(mx.float16)
+    query = mx.random.normal(shape=(1, NUM_QUERY_HEADS, HEAD_SIZE)).astype(mx.float16)
+    mx.eval(k, v, query)
+
+    (k_packed, k_scale, k_zero), (v_packed, v_scale) = turbo_quant_encode(k, v, quant)
+    slot = mx.arange(kv_len, dtype=mx.int64)
+    layer = 0
+    flat_k = cache.key_caches[layer].reshape(-1, NUM_KV_HEADS, cache.k_packed_dim)
+    flat_k[slot] = k_packed
+    cache.key_caches[layer] = flat_k.reshape(cache.key_caches[layer].shape)
+    flat_v = cache.value_caches[layer].reshape(-1, NUM_KV_HEADS, cache.v_packed_dim)
+    flat_v[slot] = v_packed
+    cache.value_caches[layer] = flat_v.reshape(cache.value_caches[layer].shape)
+    scale_groups = k_scale.shape[-1]
+    for attr, data in [
+        ("key_scale_caches", k_scale),
+        ("value_scale_caches", v_scale),
+        ("key_zero_caches", k_zero),
+    ]:
+        arr = getattr(cache, attr)[layer]
+        flat = arr.reshape(-1, NUM_KV_HEADS, scale_groups)
+        flat[slot] = data
+        getattr(cache, attr)[layer] = flat.reshape(arr.shape)
+    mx.eval(cache.key_caches[layer], cache.value_caches[layer])
+
+    block_tables = mx.arange(nblocks, dtype=mx.int32).reshape(1, nblocks)
+    seq_lens = mx.array([kv_len], dtype=mx.int32)
+    cu_seqlens_q = mx.array([0, 1], dtype=mx.int32)
+    out = mx.zeros((1, NUM_QUERY_HEADS, HEAD_SIZE), dtype=mx.float16)
+    mx.eval(block_tables, seq_lens, cu_seqlens_q, out)
+
+    ops.paged_attention_primitive(
+        query,
+        cache.key_caches[layer],
+        cache.value_caches[layer],
+        NUM_KV_HEADS,
+        HEAD_SIZE**-0.5,
+        0.0,
+        block_tables,
+        seq_lens,
+        cu_seqlens_q,
+        BLOCK_SIZE,
+        kv_len,
+        window,
+        out,
+        key_scale_cache=cache.key_scale_caches[layer],
+        value_scale_cache=cache.value_scale_caches[layer],
+        key_zero_cache=cache.key_zero_caches[layer],
+        v_centroids=get_v_centroids(cache.v_bits),
+        use_turboquant=True,
+        quant_type=quant,
+        v_bits=cache.v_bits,
+    )
+    mx.eval(out)
+    o = np.array(out.astype(mx.float32))[0]
+    assert np.isfinite(o).all()
+
+    k_ref, v_ref = turbo_quant_decode(
+        (k_packed, k_scale, k_zero),
+        (v_packed, v_scale),
+        output_dtype=mx.float16,
+        key_quant_type=quant,
+    )
+    mx.eval(k_ref, v_ref)
+    start = max(0, kv_len - window) if window > 0 else 0
+    ref = _ref_attention_np(
+        query,
+        np.array(k_ref.astype(mx.float32))[start:kv_len],
+        np.array(v_ref.astype(mx.float32))[start:kv_len],
+    )
+    np.testing.assert_allclose(o, ref, atol=1.5e-2, rtol=2e-2)

--- a/tests/test_split_kv_decode.py
+++ b/tests/test_split_kv_decode.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Split-KV (flash-decoding) decode correctness.
+
+``dispatch_paged_attention_v2_online`` routes pure-decode batches to the
+partitioned kernel (``_ps512`` + ``paged_attention_v2_reduce``) when the base
+grid (num_q_heads * num_seqs) underfills the GPU — fewer than 8 threadgroups
+per core — and the longest context spans >= 2 partitions (> 512 tokens).
+
+Every split case engages on any hardware: base_grid <= 32, while the gate
+threshold is >= 56 (8 x 7 cores on the smallest Apple GPU) and 112 on the
+IORegistry fallback used in VMs — and each test asserts that premise via the
+exported ``min_decode_grid()`` so a gate regression fails loudly instead of
+silently degrading every cell to single-pass-vs-reference.  TurboQuant and
+sliding-window batches are excluded from the split until their interaction is
+validated; their single-pass coverage lives in test_turboquant.py and
+test_primitive_and_donation.py.
+
+Run with:
+    python -m pytest tests/test_split_kv_decode.py -v
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from tools.attention_bench_utils import ref_paged_attn
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16  # Qwen3-0.6B GQA shape: 16 query / 8 KV heads
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+NUM_BLOCKS = 256
+
+# atol/rtol per dtype.  float32: both paths compute in fp32, only
+# kernel-order error is left.
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+    mx.float32: (1e-3, 1e-3),
+}
+
+
+def _run_paged_decode(
+    kv_lens: list[int], dtype: mx.Dtype, seed: int
+) -> tuple[mx.array, mx.array]:
+    """Run one decode step through the primitive; return (out, reference)."""
+    mx.random.seed(seed)
+    num_seqs = len(kv_lens)
+    max_kv_len = max(kv_lens)
+    scale = HEAD_SIZE**-0.5
+
+    key_cache = mx.random.normal(
+        shape=(NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    value_cache = mx.random.normal(
+        shape=(NUM_BLOCKS, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    query = mx.random.normal(shape=(num_seqs, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+
+    max_blocks_per_seq = (max_kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    block_tables = mx.random.randint(
+        0, NUM_BLOCKS, shape=(num_seqs, max_blocks_per_seq)
+    ).astype(mx.int32)
+    kv_lens_arr = mx.array(kv_lens, dtype=mx.int32)
+    cu_seqlens_q = mx.arange(num_seqs + 1, dtype=mx.int32)
+    mx.eval(key_cache, value_cache, query, block_tables, kv_lens_arr, cu_seqlens_q)
+
+    out = mx.array(0)
+    get_ops().paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        NUM_KV_HEADS,
+        scale,
+        0.0,  # softcap
+        block_tables,
+        kv_lens_arr,
+        cu_seqlens_q,
+        BLOCK_SIZE,
+        max_kv_len,
+        -1,  # sliding_window (disabled; windowed batches skip the split)
+        out,
+    )
+    mx.eval(out)
+
+    ref = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=[1] * num_seqs,
+        kv_lens=kv_lens,
+        block_tables=np.array(block_tables),
+        scale=scale,
+    )
+    mx.eval(ref)
+    return out, ref
+
+
+def _assert_close(out: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+@pytest.mark.parametrize(
+    "kv_lens",
+    [
+        [8192],  # headline single-stream regime: 16 partitions
+        [100, 2048],  # 1 valid partition inside a 4-partition grid
+        [700, 4096],  # non-block-aligned lengths: 2 vs 8 valid partitions
+        [1300],  # ODD partition count (3): reduce shmem 16-byte alignment
+    ],
+)
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+def test_split_decode_vs_reference(kv_lens: list[int], dtype: mx.Dtype) -> None:
+    """Partitioned decode matches the pure-MLX reference."""
+    ops = get_ops()
+    # Engagement premise: the gate is invisible from Python, so assert the
+    # inputs that make it take the split path — otherwise a gate regression
+    # would silently turn every cell into single-pass-vs-reference.
+    assert NUM_QUERY_HEADS * len(kv_lens) < ops.min_decode_grid()
+    assert max(kv_lens) > ops.PARTITION_SIZE
+
+    out, ref = _run_paged_decode(kv_lens, dtype, seed=0)
+    _assert_close(out, ref, dtype)
+
+
+def test_high_occupancy_stays_single_pass() -> None:
+    """The gate's OFF side: a batch whose base grid meets this machine's
+    threshold must stay on the single-pass path and still match the reference.
+    num_seqs is derived from the exported threshold, so the construction is
+    machine-robust (engages nowhere)."""
+    ops = get_ops()
+    num_seqs = -(-ops.min_decode_grid() // NUM_QUERY_HEADS)  # ceil division
+    kv_lens = [1024] * num_seqs  # > PARTITION_SIZE: only the grid term gates
+    assert NUM_QUERY_HEADS * num_seqs >= ops.min_decode_grid()
+
+    out, ref = _run_paged_decode(kv_lens, mx.float16, seed=1)
+    _assert_close(out, ref, mx.float16)

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -201,6 +201,14 @@ def _build_spec() -> _BuildSpec:
         "Metal",
         "-framework",
         "Foundation",
+        # IOKit + CoreFoundation: gpu_core_count() in paged_ops.cpp queries the
+        # IORegistry. Explicit -framework is load-bearing — "-undefined
+        # dynamic_lookup" below resolves only against already-loaded images,
+        # and nothing else loads IOKit.
+        "-framework",
+        "IOKit",
+        "-framework",
+        "CoreFoundation",
         # "-lmlx" above validates our MLX symbols at link time and records a
         # dependency on "@rpath/libmlx.dylib" (libmlx's install name). We add NO
         # "-Wl,-rpath": baking the build machine's MLX path into a prebuilt wheel

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -13,6 +13,9 @@
 #include <string>
 #include <unordered_map>
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
+
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
@@ -33,6 +36,63 @@ using namespace mlx::core;
 
 static std::string v2_paged_attention_source_;
 constexpr int kPartitionSize = VLLM_METAL_PARTITION_SIZE;
+
+// ---------------------------------------------------------------------------
+// Split-KV (flash-decoding) decode gate
+// ---------------------------------------------------------------------------
+// Decode runs one threadgroup per (q-head, query-token).  At low concurrency
+// with a long context the base grid (num_q_heads * num_decode_tokens) leaves
+// GPU cores idle while each threadgroup serially crawls the whole KV.  The
+// (already-compiled) paged_attention_v2 split path partitions the KV across
+// grid.z + a reduce pass to manufacture the missing parallelism.  Engages only
+// when the base grid underfills the GPU, so saturated high-concurrency serving
+// is untouched.
+
+// GPU core count via IORegistry.  Metal/MLX expose no core-count API, but the
+// split-KV gate needs to scale per machine — a small laptop GPU and a large
+// desktop one saturate at very different grid sizes.  Read once; falls back to
+// a modest default if the query ever fails (future macOS / service tree).
+static int gpu_core_count() {
+  static const int v = []() {
+    int cores = 0;
+    io_iterator_t it;
+    if (IOServiceGetMatchingServices(kIOMainPortDefault,
+                                     IOServiceMatching("AGXAccelerator"),
+                                     &it) == KERN_SUCCESS) {
+      io_object_t obj;
+      while ((obj = IOIteratorNext(it))) {
+        CFTypeRef p = IORegistryEntrySearchCFProperty(
+            obj, kIOServicePlane, CFSTR("gpu-core-count"),
+            kCFAllocatorDefault, kIORegistryIterateRecursively);
+        if (p) {
+          if (CFGetTypeID(p) == CFNumberGetTypeID())
+            CFNumberGetValue((CFNumberRef)p, kCFNumberIntType, &cores);
+          CFRelease(p);
+        }
+        IOObjectRelease(obj);
+        if (cores > 0) break;
+      }
+      IOObjectRelease(it);
+    }
+    return cores > 0 ? cores : 14;
+  }();
+  return v;
+}
+
+// Engage the split while the base decode grid (num_q_heads * num_seqs) stays
+// below ~8 threadgroups per GPU core.  On a 14-core M1 Pro that is 112.  At 8K
+// context with the fixed 512-token (16-way) split, this regime measured:
+// conc=1 -33%, conc=2 -6.7%, conc=4 -5.3%, fading to ~-1.6% (noise) by conc=8 —
+// so the split stays on through ~conc 6 and disengages beyond, where it stops
+// paying.  Scales with core count.
+// (An adaptive runtime split count was tried and reverted: this kernel is
+// memory-bound, so it likes oversubscription — fewer splits hurt, and ~512-token
+// partitions are the sweet spot, so a fixed size + a wider gate is simpler and
+// just as fast.)
+static int min_decode_grid() {
+  static const int v = gpu_core_count() * 8;
+  return v;
+}
 
 // MLX 0.31.2 moved stream-scoped encoder/temporary management from
 // ``metal::Device`` onto ``metal::CommandEncoder`` plus a free
@@ -334,13 +394,23 @@ static void dispatch_paged_attention_v2_online(
   auto dt        = dtype_to_metal(query.dtype());
   auto k_cache_dt = dtype_to_metal(key_cache.dtype());
   auto v_cache_dt = dtype_to_metal(value_cache.dtype());
+  // ----- Split-KV (flash-decoding) occupancy gate ------------------------
+  const bool pure_decode = !has_prefill;  // every seq has exactly 1 query token
+  const int base_grid = num_heads * total_q_tokens;  // grid.z = 1 occupancy
+  const int max_num_partitions =
+      (max_seq_len + kPartitionSize - 1) / kPartitionSize;
+  // TurboQuant and sliding-window batches stay on the single-pass path until
+  // their interaction with the split is validated (deferred to a follow-up).
+  const bool partition = pure_decode && !use_turboquant && sliding_window < 0
+      && base_grid < min_decode_grid() && max_num_partitions >= 2;
+
   std::string kname =
       "paged_attention_" + dt + "_cache_" + k_cache_dt + "_" + v_cache_dt +
       "_hs" + std::to_string(head_size) +
       "_bs" + std::to_string(block_size) +
-      "_nt256_nsl32_ps0";
+      "_nt256_nsl32_ps" + std::to_string(partition ? kPartitionSize : 0);
 
-  bool use_partitioning  = false;
+  bool use_partitioning  = partition;
   bool use_alibi         = false;
   bool use_fp8           = false;
   bool use_sinks         = false;
@@ -349,8 +419,8 @@ static void dispatch_paged_attention_v2_online(
   int  v_bits_i          = v_bits;
 
   // The hash name is MLX's cache key.  It MUST encode every function-constant
-  // value that varies across calls — otherwise the first compilation wins and
-  // subsequent calls with different constants silently reuse the wrong kernel.
+  // value that varies across calls.  ``kname`` already encodes the partition
+  // suffix (_ps0 vs _ps512), which is 1:1 with use_partitioning.
   std::string hash_name = kname + "_v2"
       + "_tq" + (use_tq_fc ? "1" : "0")
       + "_kb" + std::to_string(k_bits_i)
@@ -374,20 +444,13 @@ static void dispatch_paged_attention_v2_online(
                           * static_cast<int>(sizeof(float));
   int merge_bytes = (2 * NUM_WARPS + NUM_WARPS * head_size)
                     * static_cast<int>(sizeof(float));
-  // TurboQuant V uses register-only FWHT (no threadgroup workspace needed).
-  (void)use_turboquant;
   size_t shmem = static_cast<size_t>(std::max(warp_scores_bytes, merge_bytes));
 
   auto& enc = get_command_encoder_compat(d, s);
-  enc.set_compute_pipeline_state(kernel);
-  enc.set_threadgroup_memory_length(shmem, 0);
 
-  bind_paged_attn_buffers(enc, out, query, key_cache, value_cache,
-                          num_kv_heads, softcap, block_tables, seq_lens,
-                          cu_seqlens_q, sliding_window);
-  enc.set_bytes(scale, 9);
-
-  if (use_turboquant) {
+  // TurboQuant scale/zero/centroid buffers (slots 22-27); shared by both paths.
+  auto bind_turboquant = [&]() {
+    if (!use_turboquant) return;
     enc.set_input_array(*key_scale_cache,   22);
     enc.set_input_array(*value_scale_cache, 23);
     int32_t v_block_stride_i = static_cast<int32_t>(value_cache.strides()[0]);
@@ -396,8 +459,92 @@ static void dispatch_paged_attention_v2_online(
     enc.set_bytes(v_head_stride_i,  25);
     enc.set_input_array(*key_zero_cache, 26);
     enc.set_input_array(*v_centroids, 27);
+  };
+
+  if (!partition) {
+    // Single-pass path (grid.z = 1): the original decode/per-token kernel.
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_threadgroup_memory_length(shmem, 0);
+    bind_paged_attn_buffers(enc, out, query, key_cache, value_cache,
+                            num_kv_heads, softcap, block_tables, seq_lens,
+                            cu_seqlens_q, sliding_window);
+    enc.set_bytes(scale, 9);
+    bind_turboquant();
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(num_heads, total_q_tokens, 1),
+        MTL::Size::Make(NUM_THREADS, 1, 1));
+    return;
   }
 
+  // ----- Split-KV path: paged_attention(_ps512) -> paged_attention_v2_reduce.
+  // Per-partition scratch: partial output + softmax (max, exp-sum) stats.
+  // Tiny (~64 KB tmp_out @ conc=1/8K).  add_temporary keeps them alive until
+  // the command buffer completes; MLX auto-inserts a barrier between the two
+  // dispatches via input/output dependency tracking (set_output here ->
+  // set_input below), mirroring MLX's own sdpa_vector_2pass.
+  auto make_temp = [&](Shape shape, Dtype dtype) {
+    array a(std::move(shape), dtype, nullptr, {});
+    a.set_data(allocator::malloc(a.nbytes()));
+    add_temporary_compat(enc, a, d, s);
+    return a;
+  };
+  array tmp_out = make_temp(
+      Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
+      query.dtype());
+  array exp_sums =
+      make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+  array max_logits =
+      make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+
+  // Pass 1: partitioned kernel writes partials.  Out slot (2) = tmp_out scratch.
+  enc.set_compute_pipeline_state(kernel);
+  enc.set_threadgroup_memory_length(shmem, 0);
+  bind_paged_attn_buffers(enc, tmp_out, query, key_cache, value_cache,
+                          num_kv_heads, softcap, block_tables, seq_lens,
+                          cu_seqlens_q, sliding_window);
+  enc.set_bytes(scale, 9);
+  enc.set_output_array(exp_sums, 0);
+  enc.set_output_array(max_logits, 1);
+  bind_turboquant();
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, max_num_partitions),
+      MTL::Size::Make(NUM_THREADS, 1, 1));
+
+  // Pass 2: reduce per-partition partials -> out (log-sum-exp combine).
+  std::string rname =
+      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
+      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
+  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
+  // other function constants are inert for it.  Both are pinned false on this
+  // path today (the gate excludes TurboQuant, sinks are unsupported), but the
+  // cache key MUST encode every constant the pipeline is specialized on —
+  // otherwise the first compile wins and a later caller with different
+  // constants silently reuses the wrong pipeline.
+  std::string rhash = rname + "_v2reduce"
+      + "_tq" + (use_tq_fc ? "1" : "0")
+      + "_sk" + (use_sinks ? "1" : "0");
+  auto* rkernel = d.get_kernel(
+      rname, lib, rhash,
+      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
+  enc.set_compute_pipeline_state(rkernel);
+  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
+  // (odd partition counts would yield 8 mod 16 and trip the API-validation
+  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
+  // is never touched.
+  size_t reduce_shmem =
+      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
+  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(seq_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+  enc.set_input_array(cu_seqlens_q, 7);
+  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
+  enc.set_bytes(num_seqs_i, 8);
   enc.dispatch_threadgroups(
       MTL::Size::Make(num_heads, total_q_tokens, 1),
       MTL::Size::Make(NUM_THREADS, 1, 1));
@@ -985,6 +1132,9 @@ void gdn_linear_attention_impl(
 
 NB_MODULE(_paged_ops, m) {
   m.attr("PARTITION_SIZE") = nb::int_(kPartitionSize);
+  m.def("min_decode_grid", &min_decode_grid,
+        "Decode-grid threshold (threadgroups) below which split-KV decode "
+        "engages on this machine.");
 
   m.def("init_v2_library", &init_v2_library,
         nb::arg("v2_src"),

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -399,9 +399,12 @@ static void dispatch_paged_attention_v2_online(
   const int base_grid = num_heads * total_q_tokens;  // grid.z = 1 occupancy
   const int max_num_partitions =
       (max_seq_len + kPartitionSize - 1) / kPartitionSize;
-  // TurboQuant and sliding-window batches stay on the single-pass path until
-  // their interaction with the split is validated (deferred to a follow-up).
-  const bool partition = pure_decode && !use_turboquant && sliding_window < 0
+  // TurboQuant and sliding-window batches take the split too.  TQ partials
+  // stay in the rotated domain with one inverse FWHT in the reduce (measured
+  // -23% TPOT at conc=1/8K); windowed batches mask per partition, and a
+  // fully-masked partition contributes exact zeros — epsilon-normalized
+  // partial, zero merge weight (Gemma-4 E2B measured -35% TPOT at conc=1).
+  const bool partition = pure_decode
       && base_grid < min_decode_grid() && max_num_partitions >= 2;
 
   std::string kname =
@@ -515,11 +518,12 @@ static void dispatch_paged_attention_v2_online(
       "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
       "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
   // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
-  // other function constants are inert for it.  Both are pinned false on this
-  // path today (the gate excludes TurboQuant, sinks are unsupported), but the
-  // cache key MUST encode every constant the pipeline is specialized on —
-  // otherwise the first compile wins and a later caller with different
-  // constants silently reuses the wrong pipeline.
+  // other function constants are inert for it.  TurboQuant batches take this
+  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
+  // sinks are unsupported and stay false.  The cache key MUST encode every
+  // constant the pipeline is specialized on — otherwise the first compile
+  // wins and a later caller with different constants silently reuses the
+  // wrong pipeline.
   std::string rhash = rname + "_v2reduce"
       + "_tq" + (use_tq_fc ? "1" : "0")
       + "_sk" + (use_sinks ? "1" : "0");


### PR DESCRIPTION
## TLDR
* Partition kernel was already there. just not wired in. This PR wired it in, also including SWA & Turboquant. 
* verified speedup on benchmark. 

## What & Why
Decode runs one threadgroup per (q-head, token). At low concurrency with a long context the base grid (`num_q_heads x num_decode_tokens`) leaves most GPU cores idle while each threadgroup serially crawls the whole KV. 

This PR engages the **already-compiled** partitioned kernel path (`_ps512` + `paged_attention_v2_reduce`, shipped in every metallib but never requested until now) to split the KV across `grid.z` and merge with a log-sum-exp reduce
pass, recovering the missing parallelism exactly where it exists.

## Correctness

- `test_paged_deterministic` 6/6,
- all unit tests passed. 

## Benchmarks (M1 Pro 14-core, random dataset, ignore_eos, seed 42, prefix caching off)

**Qwen3-0.6B fp16** — 8000-token prompts / 128 output (conc 1–8); 1000-token
prompts / 128 output (conc 32):

| Regime | Mean TPOT main → PR | Output tok/s main → PR | Mean TTFT main → PR |
|---|---:|---:|---:|
| conc=1, 8K  | 54.0 → **35.3 ms (−34.6%)** | 7.66 → **9.00 (+17.5%)** | 9.9 → 9.7 s |
| conc=4, 8K  | 313.4 → 290.8 ms (−7.2%) | 9.27 → 9.85 (+6.3%) | 15.4 → 15.0 s |
| conc=8, 8K  | 409.5 → 487.3 ms (+19.0%)* | 9.60 → 9.81 (+2.2%) | 50.5 → **40.0 s (−20.9%)** |
| conc=32, 1K | 222.2 → 219.1 ms (−1.4%) | 117.8 → 119.7 (+1.6%) | 6.3 → 6.1 s |

\* conc=8 is queue-saturated (32 x 8K prompts vs `max_num_batched_tokens=2048`): faster decode steps admit queued prefills ~10 s sooner, so decode tokens overlap more traffic and per-token latency books higher — but per-request e2e is equal (~102 s both sides) and the whole run finishes 2.1% faster. The gate is off in steady state here (128 TGs >= 112); aggregate is neutral-to-positive.

**TurboQuant & sliding window** — single-pass vs split, conc=1:

| Config | Mean TPOT single-pass → split | Mean TTFT |
|---|---:|---:|
| Qwen3-0.6B + TQ (q8_0/q3_0), 8000+128, np=20 | 46.81 → **35.98 ms (−23.1%)** | 73.8 → 73.6 s (unchanged†) |
| Gemma-4 E2B 8-bit (28/35 layers windowed, W=512), 4000+128, np=8 | 66.73 → **43.48 ms (−34.8%)** | 9.0 → 8.9 s |

† TQ prefill is slow on main independently of this PR; the split touches only
decode, and the unchanged TTFT confirms it.


<img width="2678" height="945" alt="bench_comparison" src="https://github.com/user-attachments/assets/cdebcaac-8002-49fa-9a2e-97c6479127bf" />

<details>
<summary>Benchmark config</summary>

- Server: `vllm serve <model> --max-model-len 8448 --no-enable-prefix-caching`,
  `VLLM_METAL_USE_PAGED_ATTENTION=1`, `VLLM_METAL_MEMORY_FRACTION=0.3`;
  TurboQuant via `--additional-config '{"turboquant": true}'`
- Client: `vllm bench serve --dataset-name random --random-output-len 128
  --request-rate inf --ignore-eos --seed 42`
- Hardware: M1 Pro 14-core GPU, 32 GB

</details>

## Scope notes

- Mixed prefill+decode steps stay single-pass (prefill threadgroups already  fill the GPU). MLA decode is untouched
- Upstream mlx_lm bug during gemma4 loading. https://github.com/ml-explore/mlx-lm/pull/1240 I use monkey patch locally. Not worth a PR, because it has been fixed in the upstream, just not released yet. 