### PR TITLE
[Installation] Install release wheel on local runs and parse release JSON via stdin

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,15 +8,19 @@ Thanks for your interest in contributing! This plugin targets **Apple Silicon Ma
 git clone https://github.com/vllm-project/vllm-metal.git
 cd vllm-metal
 
-# Creates ./.venv-vllm-metal/, installs vLLM core + the plugin, and
-# prebuilds the native Metal kernels from your checkout
+# Creates ./.venv-vllm-metal/ and installs vLLM core + the latest release wheel
 ./install.sh
 
 # Activate the virtualenv
 source .venv-vllm-metal/bin/activate
 
-# Install dev dependencies (pytest, ruff, mypy, ...)
+# Replace the release wheel with an editable install from your checkout
+# and pull in dev dependencies (pytest, ruff, mypy, ...)
 pip install -e ".[dev]"
+
+# Build the native kernels from your checkout (the editable install
+# removes the wheel's prebuilt ones)
+python -m vllm_metal.metal.build
 ```
 
 ## Editing the Metal kernels

--- a/install.sh
+++ b/install.sh
@@ -43,11 +43,13 @@ fetch_latest_release() {
 extract_wheel_url() {
   local release_data="$1"
 
-  python3 -c "
+  printf '%s' "$release_data" | python3 -c "
 import sys
 import json
+
 try:
-    data = json.loads('''$release_data''', strict=False)
+    data = json.load(sys.stdin)
+
     assets = data.get('assets', [])
     for asset in assets:
         name = asset.get('name', '')
@@ -55,7 +57,7 @@ try:
             print(asset.get('browser_download_url', ''))
             break
 except Exception as e:
-    print('', file=sys.stderr)
+    print(f'Failed to parse release JSON: {e}', file=sys.stderr)
 "
 }
 
@@ -108,7 +110,6 @@ install_vllm_rs() {
   fi
 
   echo "Installing vllm-rs from vLLM source: $vllm_src_dir/rust"
-
   # Run cargo from the vLLM repository root so rustup honors rust-toolchain.toml.
   if ! ( cd "$vllm_src_dir" && cargo install --locked --path rust/src/cmd --bin vllm-rs ); then
     error "Failed to install vllm-rs."
@@ -214,34 +215,18 @@ EOF
   CXXFLAGS="-Wno-parentheses" uv pip install .
   cd -
 
-  if [[ -n "$local_lib" && -f "$local_lib" ]]; then
-    # Local source install (running ./install.sh from a checkout). Prebuild the
-    # native paged-attention artifacts from this tree — the _paged_ops .so and
-    # the precompiled .metallib shaders — so the kernels load with no runtime
-    # compile, exactly like a release wheel; otherwise get_ops() fails loud
-    # ("Prebuilt native extension not found") the first time paged attention is
-    # used. build_native_artifacts needs the build deps (mlx, nanobind)
-    # importable, so the editable install pulls them in first and points the
-    # install at this tree, where the artifacts land. The remote (curl | bash)
-    # branch below installs a prebuilt release wheel instead and needs no
-    # toolchain. Mirrors scripts/release.sh / scripts/test.sh.
-    uv pip install -e .
-    ensure_metal_toolchain
-    build_native_artifacts
-  else
-    local release_data
-    release_data=$(fetch_latest_release "$repo_owner" "$repo_name")
+  local release_data
+  release_data=$(fetch_latest_release "$repo_owner" "$repo_name")
 
-    local wheel_url
-    wheel_url=$(extract_wheel_url "$release_data")
+  local wheel_url
+  wheel_url=$(extract_wheel_url "$release_data")
 
-    if [[ -z "$wheel_url" ]]; then
-      error "No wheel file found in the latest release."
-      exit 1
-    fi
-
-    download_and_install_wheel "$wheel_url" "$package_name"
+  if [[ -z "$wheel_url" ]]; then
+    error "No wheel file found in the latest release."
+    exit 1
   fi
+
+  download_and_install_wheel "$wheel_url" "$package_name"
 
   if [[ "$with_vllm_rs" == "1" ]]; then
     install_vllm_rs "$vllm_src_dir"


### PR DESCRIPTION
## Summary
- Remove the local editable-install branch so `./install.sh` always installs the latest release wheel.
- Parse GitHub release JSON from stdin to avoid bash quoting/interpolation issues.
- Update contributor docs to match the new install flow.

## Verification
- `bash -n install.sh`
- `git diff --check origin/main...HEAD`
- Full uninstall/reinstall via `rm -rf .venv-vllm-metal && ./install.sh`
- Confirmed the installed wheel and artifacts are present in `.venv-vllm-metal`
