### PR TITLE
[GGUF] Add native GGUF Q8_0 primitive boundary

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -126,7 +126,7 @@ build_native_artifacts() {
 }
 
 # Fail unless the freshly built wheel actually bundles the prebuilt native
-# artifacts: the _paged_ops*.so extension and the three .metallib shader
+# artifacts: the _paged_ops*.so extension and all .metallib shader
 # libraries. maturin's `include` directive is what pulls these (gitignored)
 # files in; if that ever regresses, the wheel would install fine but fail at
 # first run with "Prebuilt native extension not found". The expected filenames

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,7 +11,7 @@ main() {
 
   setup_dev_env
 
-  # Build the prebuilt native extension (.so) and the three precompiled
+  # Build the prebuilt native extension (.so) and all precompiled
   # .metallib shader libraries into vllm_metal/metal/ before `uv build`, so the
   # wheel ships them (via the maturin `include` directive) and end users never
   # invoke clang++ or `xcrun metal` at runtime.

--- a/tests/test_gguf_q8.py
+++ b/tests/test_gguf_q8.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for native GGUF Q8_0 tensor primitives."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from vllm_metal.gguf import (
+    GGUF_QTYPE_Q8_0,
+    GGUFQuantizedTensor,
+    q8_0_matmul,
+)
+
+
+def _pack_q8_0_raw(qweight: np.ndarray, scales: np.ndarray) -> mx.array:
+    rows, blocks, _ = qweight.shape
+    raw = np.zeros((rows, blocks, 34), dtype=np.uint8)
+    raw[:, :, :2] = scales.astype(np.float16).reshape(rows, blocks, 1).view(np.uint8)
+    raw[:, :, 2:] = qweight.astype(np.int8).view(np.uint8)
+    return mx.array(raw.reshape(rows, blocks * 34))
+
+
+def _quantize_q8_1_np(x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    tokens, cols = x.shape
+    padded_cols = ((cols + 511) // 512) * 512
+    blocks = padded_cols // 32
+    qx = np.zeros((tokens, blocks, 32), dtype=np.int8)
+    x_scales = np.zeros((tokens, blocks), dtype=np.float32)
+
+    for token in range(tokens):
+        for block in range(blocks):
+            start = block * 32
+            vals = np.zeros(32, dtype=np.float32)
+            valid = max(0, min(32, cols - start))
+            if valid:
+                vals[:valid] = x[token, start : start + valid]
+            amax = np.max(np.abs(vals))
+            if amax == 0.0:
+                continue
+            d = float(amax / 127.0)
+            qx[token, block] = np.clip(np.round(vals / d), -127, 127).astype(np.int8)
+            x_scales[token, block] = np.float16(d).astype(np.float32)
+
+    return qx, x_scales
+
+
+def _q8_0_q8_1_matmul_np(
+    x: np.ndarray,
+    qweight: np.ndarray,
+    scales: np.ndarray,
+) -> np.ndarray:
+    qx, x_scales = _quantize_q8_1_np(x)
+    rows, blocks, _ = qweight.shape
+    out = np.zeros((x.shape[0], rows), dtype=np.float32)
+    for token in range(x.shape[0]):
+        for row in range(rows):
+            acc = 0.0
+            for block in range(blocks):
+                dot = np.dot(
+                    qweight[row, block].astype(np.int32),
+                    qx[token, block].astype(np.int32),
+                )
+                acc += dot * float(scales[row, block]) * x_scales[token, block]
+            out[token, row] = acc
+    return out
+
+
+def _q8_0_dense_matmul_np(
+    x: np.ndarray,
+    qweight: np.ndarray,
+    scales: np.ndarray,
+) -> np.ndarray:
+    dense_weight = qweight.astype(np.float32) * scales.astype(np.float32)[..., None]
+    return x @ dense_weight.reshape(dense_weight.shape[0], -1).T
+
+
+def _require_metal() -> None:
+    if not hasattr(mx, "metal") or not mx.metal.is_available():
+        pytest.skip("MLX Metal device is not available")
+
+
+def test_q8_0_tensor_contract_keeps_raw_blocks() -> None:
+    qweight_np = np.arange(-32, 32, dtype=np.int8).reshape(2, 1, 32)
+    scales_np = np.array([[0.25], [0.5]], dtype=np.float16)
+    qweight = _pack_q8_0_raw(qweight_np, scales_np)
+
+    tensor = GGUFQuantizedTensor(
+        qweight=qweight,
+        qweight_type=GGUF_QTYPE_Q8_0,
+        logical_shape=(2, 32),
+    )
+
+    assert tensor.qtype_id == GGUF_QTYPE_Q8_0
+    assert tensor.qtype_name == "Q8_0"
+    assert tensor.logical_shape == (2, 32)
+    assert tensor.raw_block_shape == (2, 1, 34)
+    assert tensor.raw_bytes_per_row == 34
+    assert tensor.matmul_transpose is True
+
+
+def test_q8_0_tensor_rejects_shape_that_would_need_dense_interpretation() -> None:
+    qweight = mx.zeros((2, 34), dtype=mx.uint8)
+
+    with pytest.raises(ValueError, match="does not match logical shape"):
+        GGUFQuantizedTensor(
+            qweight=qweight,
+            qweight_type=GGUF_QTYPE_Q8_0,
+            logical_shape=(2, 64),
+        )
+
+
+def test_q8_0_tensor_rejects_unsupported_qtype() -> None:
+    qweight = mx.zeros((2, 34), dtype=mx.uint8)
+
+    with pytest.raises(ValueError, match="Unsupported native GGUF qtype id"):
+        GGUFQuantizedTensor(
+            qweight=qweight,
+            qweight_type=2,
+            logical_shape=(2, 32),
+        )
+
+
+@pytest.mark.parametrize(
+    ("output_dtype", "rtol", "atol"),
+    [
+        (mx.float32, 2e-4, 2e-4),
+        (mx.float16, 2e-2, 2e-2),
+        (mx.bfloat16, 6e-2, 6e-2),
+    ],
+)
+def test_q8_0_matmul_matches_activation_quantized_reference(
+    monkeypatch,
+    output_dtype: mx.Dtype,
+    rtol: float,
+    atol: float,
+) -> None:
+    _require_metal()
+    monkeypatch.setenv("VLLM_METAL_BUILD_FROM_SOURCE", "1")
+    qweight_np = ((np.arange(3 * 2 * 32) % 63) - 31).astype(np.int8).reshape(3, 2, 32)
+    scales_np = np.array(
+        [[0.5, 0.125], [0.25, 0.75], [2.0, 0.0625]],
+        dtype=np.float16,
+    )
+    tensor = GGUFQuantizedTensor(
+        qweight=_pack_q8_0_raw(qweight_np, scales_np),
+        qweight_type=GGUF_QTYPE_Q8_0,
+        logical_shape=(3, 64),
+    )
+    x_np = np.array(
+        [
+            np.linspace(-0.7, 0.7, 64, dtype=np.float32),
+            np.linspace(0.3, -0.4, 64, dtype=np.float32),
+        ]
+    )
+    x = mx.array(x_np, dtype=mx.float32)
+
+    out = q8_0_matmul(x, tensor, output_dtype=output_dtype)
+    expected = _q8_0_q8_1_matmul_np(x_np, qweight_np, scales_np)
+    mx.eval(out)
+
+    assert out.dtype == output_dtype
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        expected,
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def test_q8_0_matmul_matches_dense_reference_for_exact_q8_1_inputs(
+    monkeypatch,
+) -> None:
+    _require_metal()
+    monkeypatch.setenv("VLLM_METAL_BUILD_FROM_SOURCE", "1")
+    qweight_np = np.stack(
+        [
+            np.arange(-16, 16, dtype=np.int8),
+            np.arange(15, -17, -1, dtype=np.int8),
+        ]
+    ).reshape(2, 1, 32)
+    scales_np = np.array([[0.5], [0.25]], dtype=np.float16)
+    tensor = GGUFQuantizedTensor(
+        qweight=_pack_q8_0_raw(qweight_np, scales_np),
+        qweight_type=GGUF_QTYPE_Q8_0,
+        logical_shape=(2, 32),
+    )
+    x_q = np.array(
+        [
+            [
+                -127,
+                -64,
+                -32,
+                -16,
+                -8,
+                -4,
+                -2,
+                -1,
+                0,
+                1,
+                2,
+                4,
+                8,
+                16,
+                32,
+                64,
+                127,
+                96,
+                80,
+                48,
+                24,
+                12,
+                6,
+                3,
+                -3,
+                -6,
+                -12,
+                -24,
+                -48,
+                -80,
+                -96,
+                112,
+            ],
+        ],
+        dtype=np.float32,
+    )
+    x_np = x_q / 127.0
+
+    out = q8_0_matmul(mx.array(x_np, dtype=mx.float32), tensor)
+    expected = _q8_0_dense_matmul_np(x_np, qweight_np, scales_np)
+    mx.eval(out)
+
+    np.testing.assert_allclose(np.array(out), expected, rtol=2e-4, atol=2e-4)

--- a/tests/test_metal_build_cache.py
+++ b/tests/test_metal_build_cache.py
@@ -16,6 +16,8 @@ from vllm_metal.metal import build
 @dataclass
 class _Paths:
     src: Path
+    gguf_src: Path
+    gguf_header: Path
     bld: Path
     consts: Path
     nb_src: Path
@@ -27,6 +29,8 @@ class _Paths:
 @pytest.fixture
 def patched(tmp_path, monkeypatch) -> _Paths:
     src = tmp_path / "paged_ops.cpp"
+    gguf_src = tmp_path / "gguf_ops.cpp"
+    gguf_header = tmp_path / "gguf_ops.h"
     bld = tmp_path / "build.py"
     consts = tmp_path / "constants.py"
     nb_src = tmp_path / "nb_combined.cpp"
@@ -34,11 +38,14 @@ def patched(tmp_path, monkeypatch) -> _Paths:
     hsh = tmp_path / "_paged_ops.so.sha256"
 
     src.write_bytes(b"// source v1")
+    gguf_src.write_bytes(b"// gguf source v1")
+    gguf_header.write_bytes(b"// gguf header v1")
     bld.write_bytes(b"# build v1")
     consts.write_bytes(b"PARTITION_SIZE = 256")
     nb_src.write_bytes(b"// nanobind combined v1")
 
-    monkeypatch.setattr(build, "_SRC", src)
+    monkeypatch.setattr(build, "_SOURCES", (src, gguf_src))
+    monkeypatch.setattr(build, "_HEADERS", (gguf_header,))
     monkeypatch.setattr(build, "_BUILD", bld)
     monkeypatch.setattr(build, "_CONSTANTS", consts)
     monkeypatch.setattr(build, "_OUT", out)
@@ -55,7 +62,7 @@ def patched(tmp_path, monkeypatch) -> _Paths:
     )
     monkeypatch.setattr(build, "_build_spec", lambda: spec)
 
-    return _Paths(src, bld, consts, nb_src, out, hsh, spec)
+    return _Paths(src, gguf_src, gguf_header, bld, consts, nb_src, out, hsh, spec)
 
 
 def test_needs_rebuild_when_so_missing(patched):
@@ -86,7 +93,14 @@ def test_old_content_with_newer_so_mtime_still_rebuilds(patched):
     patched.out.write_bytes(b"compiled-from-prev-branch")
     patched.hsh.write_text("hash-from-prev-branch")
     older = patched.out.stat().st_mtime - 86400
-    for p in (patched.src, patched.bld, patched.consts, patched.nb_src):
+    for p in (
+        patched.src,
+        patched.gguf_src,
+        patched.gguf_header,
+        patched.bld,
+        patched.consts,
+        patched.nb_src,
+    ):
         os.utime(p, (older, older))
     assert build.needs_rebuild() is True
 
@@ -94,6 +108,18 @@ def test_old_content_with_newer_so_mtime_still_rebuilds(patched):
 def test_hash_changes_with_source_bytes(patched):
     h1 = build._input_hash(patched.spec)
     patched.src.write_bytes(b"// source v2")
+    assert build._input_hash(patched.spec) != h1
+
+
+def test_hash_changes_with_gguf_source_bytes(patched):
+    h1 = build._input_hash(patched.spec)
+    patched.gguf_src.write_bytes(b"// gguf source v2")
+    assert build._input_hash(patched.spec) != h1
+
+
+def test_hash_changes_with_header_bytes(patched):
+    h1 = build._input_hash(patched.spec)
+    patched.gguf_header.write_bytes(b"// gguf header v2")
     assert build._input_hash(patched.spec) != h1
 
 
@@ -161,6 +187,11 @@ def test_metallib_path_named_in_package(tmp_path, monkeypatch):
     assert build.metallib_path("gdn_kern") == tmp_path / "gdn_kern.metallib"
 
 
+def test_gguf_metallib_is_packaged_but_loaded_lazily():
+    assert build.GGUF_METALLIB_NAME in build.METALLIB_NAMES
+    assert build.GGUF_METALLIB_NAME not in build.CORE_METALLIB_NAMES
+
+
 def test_metallib_digest_changes_with_source():
     # The metallib staleness stamp is keyed on the assembled shader source, so a
     # one-byte shader edit must change the digest (else an edited kernel loads
@@ -209,7 +240,7 @@ def test_is_stale_false_when_stamp_unreadable(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# stale_artifacts: aggregates is_stale over the .so + the three .metallibs,
+# stale_artifacts: aggregates is_stale over the .so + the .metallibs,
 # with digests stubbed so no real mlx/nanobind/shader sources are touched.
 # --------------------------------------------------------------------------
 

--- a/vllm_metal/gguf/__init__.py
+++ b/vllm_metal/gguf/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native GGUF tensor primitives for vllm-metal."""
+
+from vllm_metal.gguf.q8 import q8_0_matmul
+from vllm_metal.gguf.tensor import (
+    GGUF_QTYPE_Q8_0,
+    GGUFQTypeSpec,
+    GGUFQuantizedTensor,
+    qtype_spec,
+)
+
+__all__ = [
+    "GGUF_QTYPE_Q8_0",
+    "GGUFQTypeSpec",
+    "GGUFQuantizedTensor",
+    "q8_0_matmul",
+    "qtype_spec",
+]

--- a/vllm_metal/gguf/q8.py
+++ b/vllm_metal/gguf/q8.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Q8_0 GGUF Metal primitive wrappers."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from vllm_metal.gguf.tensor import (
+    GGUF_QTYPE_Q8_0,
+    GGUFQuantizedTensor,
+)
+
+
+def q8_0_matmul(
+    x: mx.array,
+    weight: GGUFQuantizedTensor,
+    *,
+    output_dtype: mx.Dtype | None = None,
+) -> mx.array:
+    """Multiply activations by a raw GGUF Q8_0 weight.
+
+    ``weight`` stores the logical matrix as ``(output_dims, input_dims)`` and
+    this primitive computes ``x @ weight.T``. Inputs must be fp16, bf16, or
+    fp32; the output dtype is the input dtype unless ``output_dtype`` requests a
+    cast before dispatch.
+    """
+    if weight.qtype_id != GGUF_QTYPE_Q8_0:
+        raise ValueError(f"q8_0_matmul requires Q8_0, got {weight.qtype_name}")
+    if len(x.shape) == 0:
+        raise ValueError("q8_0_matmul input must have at least one dimension")
+    if x.shape[-1] != weight.input_dims:
+        raise ValueError(
+            f"Input dimension {x.shape[-1]} does not match GGUF weight "
+            f"input dimension {weight.input_dims}"
+        )
+
+    x_2d = x.reshape(-1, weight.input_dims)
+    if output_dtype is not None:
+        if not mx.issubdtype(output_dtype, mx.floating):
+            raise ValueError(f"output_dtype must be floating, got {output_dtype}")
+        x_2d = x_2d.astype(output_dtype)
+    elif not mx.issubdtype(x_2d.dtype, mx.floating):
+        raise ValueError(f"q8_0_matmul input must be floating, got {x_2d.dtype}")
+
+    x_2d = mx.contiguous(x_2d)
+    qweight = mx.contiguous(weight.qweight)
+    out = mx.zeros((x_2d.shape[0], weight.output_dims), dtype=x_2d.dtype)
+
+    from vllm_metal.metal import ensure_gguf_ops
+
+    ensure_gguf_ops().gguf_q8_0_mul_mat(
+        x_2d,
+        qweight,
+        weight.qtype_id,
+        out,
+    )
+    return out.reshape(*x.shape[:-1], weight.output_dims)

--- a/vllm_metal/gguf/tensor.py
+++ b/vllm_metal/gguf/tensor.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Raw GGUF quantized tensor representation.
+
+This module intentionally does not load GGUF files. It only defines the
+in-memory contract consumed by native Metal primitives.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+
+GGUF_QTYPE_Q8_0 = 8
+
+
+@dataclass(frozen=True)
+class GGUFQTypeSpec:
+    """Layout for one GGUF quantized block type."""
+
+    qtype: int
+    name: str
+    block_size: int
+    type_size: int
+
+
+_QTYPE_SPECS = {
+    GGUF_QTYPE_Q8_0: GGUFQTypeSpec(
+        qtype=GGUF_QTYPE_Q8_0,
+        name="Q8_0",
+        block_size=32,
+        type_size=34,
+    ),
+}
+
+
+def qtype_spec(qweight_type: int) -> GGUFQTypeSpec:
+    """Return the supported GGUF qtype spec for *qweight_type*."""
+    qtype = int(qweight_type)
+    try:
+        return _QTYPE_SPECS[qtype]
+    except KeyError as exc:
+        supported = ", ".join(spec.name for spec in _QTYPE_SPECS.values())
+        raise ValueError(
+            f"Unsupported native GGUF qtype id: {qtype}. Supported qtypes: {supported}"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class GGUFQuantizedTensor:
+    """Raw GGUF qweight plus explicit qtype metadata.
+
+    Contract for Q8_0 in this PR:
+    - ``qweight`` is raw GGUF block bytes with shape
+      ``(output_dims, blocks_per_row * 34)`` and dtype ``uint8``.
+    - Raw block bytes are interpreted as contiguous row-major storage.
+    - ``qweight_type`` is an explicit integer tag, currently only Q8_0.
+    - ``logical_shape`` is ``(output_dims, input_dims)``.
+    - Matmul computes ``x @ weight.T``; the raw weight rows are output rows.
+    """
+
+    qweight: mx.array
+    qweight_type: int
+    logical_shape: tuple[int, int]
+
+    def __post_init__(self) -> None:
+        if self.qweight.dtype != mx.uint8:
+            raise ValueError(
+                f"GGUF qweight must be raw uint8 block bytes, got {self.qweight.dtype}"
+            )
+        if len(self.qweight.shape) != 2:
+            raise ValueError(
+                f"GGUF qweight must be 2D [output_dims, raw_bytes], "
+                f"got {self.qweight.shape}"
+            )
+
+        spec = qtype_spec(self.qweight_type)
+        output_dims, input_dims = _validate_logical_shape(self.logical_shape)
+        if input_dims % spec.block_size != 0:
+            raise ValueError(
+                f"{spec.name} input dimension must be divisible by "
+                f"{spec.block_size}, got {input_dims}"
+            )
+
+        expected_raw_bytes = (input_dims // spec.block_size) * spec.type_size
+        if self.qweight.shape != (output_dims, expected_raw_bytes):
+            raise ValueError(
+                f"{spec.name} raw qweight shape {self.qweight.shape} does not "
+                f"match logical shape {self.logical_shape}; expected "
+                f"({output_dims}, {expected_raw_bytes})"
+            )
+
+    @property
+    def qtype_id(self) -> int:
+        return qtype_spec(self.qweight_type).qtype
+
+    @property
+    def qtype_name(self) -> str:
+        return qtype_spec(self.qweight_type).name
+
+    @property
+    def output_dims(self) -> int:
+        return self.logical_shape[0]
+
+    @property
+    def input_dims(self) -> int:
+        return self.logical_shape[1]
+
+    @property
+    def raw_block_shape(self) -> tuple[int, int, int]:
+        spec = qtype_spec(self.qweight_type)
+        return (
+            self.output_dims,
+            self.input_dims // spec.block_size,
+            spec.type_size,
+        )
+
+    @property
+    def raw_bytes_per_row(self) -> int:
+        return self.qweight.shape[1]
+
+    @property
+    def matmul_transpose(self) -> bool:
+        """Whether matmul uses the logical weight transposed."""
+        return True
+
+
+def _validate_logical_shape(shape: tuple[int, int] | Any) -> tuple[int, int]:
+    if len(shape) != 2:
+        raise ValueError(f"GGUF logical shape must be 2D, got {shape}")
+    output_dims = int(shape[0])
+    input_dims = int(shape[1])
+    if output_dims <= 0 or input_dims <= 0:
+        raise ValueError(f"GGUF logical shape must be positive, got {shape}")
+    return output_dims, input_dims

--- a/vllm_metal/metal/README.md
+++ b/vllm_metal/metal/README.md
@@ -19,19 +19,21 @@ vLLM-project Apache-2.0 sources.
 The shader set is defined explicitly in Python — the `.metal` files are
 concatenated by name, never globbed, so source order matters (e.g.
 `float8.metal` must precede `utils.metal`, which `#include`s it; the loader
-strips local `#include "…"` directives). There are **four** library outputs
+strips local `#include "…"` directives). There are **five** library outputs
 across **two** compile mechanisms:
 
 ### 1. C++ `_paged_ops` extension — `__init__.py`
 
-`get_ops()` builds the nanobind extension, then initializes three JIT
-Metal libraries from concatenated source:
+`get_ops()` builds the nanobind extension, then initializes three core JIT
+Metal libraries from concatenated source. GGUF Q8_0 kernels are initialized
+lazily through `ensure_gguf_ops()` when the raw GGUF primitive is used:
 
 | Library | Builder → init | Concatenated sources (in order) |
 |---------|----------------|----------------------------------|
 | **v2 paged attention** | `_build_v2_paged_attention_source` → `init_v2_library` | `#define VLLM_METAL_PARTITION_SIZE` · `float8.metal` · `utils.metal` · `turboquant.metal` · `pagedattention.metal` · `pagedattention_tiled.metal` |
 | **GDN linear attention** | `_build_gdn_source` → `init_gdn_library` | `utils.metal` · `gdn_linear_attention.metal` |
 | **MLA** | `_build_mla_paged_attention_source` → `init_mla_library` | `utils.metal` · `mla.metal` |
+| **GGUF Q8_0** | `_build_gguf_source` → `init_gguf_library` via `ensure_gguf_ops()` | `utils.metal` · `gguf_quant.metal` |
 
 ### 2. `mx.fast.metal_kernel` snippets — `attention/impls/gdn_lazy.py`
 
@@ -53,6 +55,7 @@ The lazy GDN decode fast path compiles two shaders directly through MLX
 | `pagedattention_tiled.metal` | Tiled Flash-Attention-style kernel using simdgroup 8×8 MMA; independent of the per-token kernel, same library. |
 | `turboquant.metal` | TurboQuant KV-cache compression (K: asymmetric uniform int8 / sub-8-bit; V: 3-bit Lloyd-Max + FWHT). Must be concatenated **after** `pagedattention.metal` declares `Vec<>`. |
 | `mla.metal` | Paged Multi-head Latent Attention kernel (RFC #360). Single-pass mode is wired today; partitioned 2-pass mode is scaffolded but inactive. |
+| `gguf_quant.metal` | Raw GGUF Q8_0 matmul primitive. Activations are internally quantized to Q8_1 blocks before multiplying against raw Q8_0 weight blocks. |
 | `gdn_linear_attention.metal` | GDN (gated delta-net) linear-attention kernel for hybrid models (prefill / chunked path). |
 | `gdn_conv1d_silu_decode.metal` | Lazy GDN decode: causal conv1d + SiLU. Compiled via `mx.fast.metal_kernel`. |
 | `gdn_recurrent_decode.metal` | Lazy GDN decode: recurrent state update. Compiled via `mx.fast.metal_kernel`. |
@@ -60,7 +63,7 @@ The lazy GDN decode fast path compiles two shaders directly through MLX
 ## Unwired leftover shaders
 
 These files exist in `kernels_v2/` but are **not referenced** by any build
-or dispatch path (`__init__.py`, `paged_ops.cpp`, `build.py`,
+or dispatch path (`__init__.py`, `paged_ops.cpp`, `gguf_ops.cpp`, `build.py`,
 `gdn_lazy.py`, or any shader `#include`). They are v2-directory
 copies of old v1 kernels whose functionality is now handled MLX-natively.
 PR #378 only removed `kernels_v1/`, so it does not touch these:

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -27,14 +27,15 @@ _THIS_DIR = Path(__file__).resolve().parent
 _KERNELS_V2_DIR = _THIS_DIR / "kernels_v2"
 
 # Cached after first get_ops() call.  By default both the .cpp extension and
-# the three Metal shader libraries are loaded prebuilt from the package (the
+# the core Metal shader libraries are loaded prebuilt from the package (the
 # .so plus precompiled .metallib files), so there is no first-request shader
-# compile.  Set VLLM_METAL_BUILD_FROM_SOURCE=1 to recompile the .so from source
-# AND compile the shaders in-process from .metal (for kernel developers
-# iterating on paged_ops.cpp or the .metal sources); editing .metal then
-# requires restarting the interpreter to pick up changes.  Either way the
+# compile for normal serving. Set VLLM_METAL_BUILD_FROM_SOURCE=1 to recompile
+# the .so from source AND compile the shaders in-process from .metal (for
+# kernel developers iterating on C++ or .metal sources); editing .metal then
+# requires restarting the interpreter to pick up changes. Either way the
 # libraries are held in MLX's cache for the lifetime of the process.
 _ops_module: ModuleType | None = None
+_gguf_ops_ready = False
 
 
 @functools.cache
@@ -85,6 +86,43 @@ def _build_mla_paged_attention_source() -> str:
         _read_metal_source(_KERNELS_V2_DIR / "mla.metal"),
     ]
     return "\n".join(parts)
+
+
+def _build_gguf_source() -> str:
+    """Concatenate utils + GGUF quant kernels into a single source."""
+    parts = [
+        _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "gguf_quant.metal"),
+    ]
+    return "\n".join(parts)
+
+
+def ensure_gguf_ops() -> ModuleType:
+    """Return ``_paged_ops`` after lazily loading GGUF Metal kernels."""
+    global _gguf_ops_ready
+    mod = get_ops()
+    if _gguf_ops_ready:
+        return mod
+
+    from vllm_metal import envs
+    from vllm_metal.metal.build import GGUF_METALLIB_NAME, metallib_path
+
+    if envs.VLLM_METAL_BUILD_FROM_SOURCE:
+        mod.init_gguf_library(_build_gguf_source())
+    else:
+        path = metallib_path(GGUF_METALLIB_NAME)
+        if not path.exists():
+            raise RuntimeError(
+                f"Prebuilt GGUF Metal library missing: {path.name} "
+                f"(expected in {_THIS_DIR}). Install a vllm-metal release "
+                f"wheel, or set VLLM_METAL_BUILD_FROM_SOURCE=1 to compile "
+                f"shaders from source."
+            )
+        mod.init_library_path(GGUF_METALLIB_NAME, str(path))
+
+    _gguf_ops_ready = True
+    logger.info("Native GGUF Metal kernels loaded")
+    return mod
 
 
 def metal_mla_paged_attention(
@@ -150,7 +188,7 @@ def metal_mla_paged_attention(
 def get_ops() -> ModuleType:
     """Import the native paged_ops extension and initialise its Metal libraries.
 
-    By default the prebuilt ``.so`` is loaded and the three precompiled
+    By default the prebuilt ``.so`` is loaded and the core precompiled
     ``.metallib`` shader libraries are loaded by path via MLX
     (``Device::get_library(name, path)``). When ``VLLM_METAL_BUILD_FROM_SOURCE``
     is set, the ``.so`` is rebuilt and the shader sources are read, pre-processed
@@ -211,8 +249,8 @@ def get_ops() -> ModuleType:
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
 
-    # 3. Initialise the three Metal shader libraries (v2 online-softmax, GDN
-    #    linear attention, MLA paged attention).  By default we load the
+    # 3. Initialise the core Metal shader libraries (v2 online-softmax, GDN
+    #    linear attention, MLA paged attention). By default we load the
     #    precompiled .metallib files shipped in the wheel (no first-request
     #    shader compile); only compile the shaders in-process when the developer
     #    opts in via VLLM_METAL_BUILD_FROM_SOURCE (no silent fallback).
@@ -221,16 +259,16 @@ def get_ops() -> ModuleType:
         mod.init_gdn_library(_build_gdn_source())
         mod.init_mla_library(_build_mla_paged_attention_source())
     else:
-        from vllm_metal.metal.build import METALLIB_NAMES, metallib_path
+        from vllm_metal.metal.build import CORE_METALLIB_NAMES, metallib_path
 
-        missing = [n for n in METALLIB_NAMES if not metallib_path(n).exists()]
+        missing = [n for n in CORE_METALLIB_NAMES if not metallib_path(n).exists()]
         if missing:
             raise RuntimeError(
                 f"Prebuilt Metal libraries missing: {missing} (expected in "
                 f"{_THIS_DIR}). Install a vllm-metal release wheel, or set "
                 f"VLLM_METAL_BUILD_FROM_SOURCE=1 to compile shaders from source."
             )
-        for name in METALLIB_NAMES:
+        for name in CORE_METALLIB_NAMES:
             mod.init_library_path(name, str(metallib_path(name)))
 
     _ops_module = mod

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""JIT build script for the native paged-attention Metal extension.
+"""JIT build script for the native Metal extension.
 
-Compiles ``paged_ops.cpp`` + nanobind into a shared library that dispatches
-Metal shaders through MLX's own command encoder.
+Compiles nanobind plus owner-specific C++ sources into a shared library that
+dispatches Metal shaders through MLX's own command encoder.
 """
 
 from __future__ import annotations
@@ -20,7 +20,11 @@ from vllm_metal.metal.constants import PARTITION_SIZE
 logger = logging.getLogger(__name__)
 
 _THIS_DIR = Path(__file__).resolve().parent
-_SRC = _THIS_DIR / "paged_ops.cpp"
+_SOURCES = (
+    _THIS_DIR / "paged_ops.cpp",
+    _THIS_DIR / "gguf_ops.cpp",
+)
+_HEADERS = (_THIS_DIR / "gguf_ops.h",)
 _BUILD = _THIS_DIR / "build.py"
 _CONSTANTS = _THIS_DIR / "constants.py"
 _EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
@@ -38,11 +42,13 @@ def _stamp_path(artifact: Path) -> Path:
 # The .so's stamp; identical mechanism to each .metallib's (see is_stale).
 _HASH = _stamp_path(_OUT)
 
-# Names of the three precompiled Metal shader libraries.  Each is the cache-key
+# Names of the precompiled Metal shader libraries.  Each is the cache-key
 # name the C++ extension registers the library under (passed to
 # ``init_library_path(name, path)`` in paged_ops.cpp), so a later dispatch's
 # ``get_library(name)`` returns the .metallib loaded at startup.
-METALLIB_NAMES = ("paged_attention_v2_kern", "gdn_kern", "paged_mla_kern")
+CORE_METALLIB_NAMES = ("paged_attention_v2_kern", "gdn_kern", "paged_mla_kern")
+GGUF_METALLIB_NAME = "gguf_kern"
+METALLIB_NAMES = (*CORE_METALLIB_NAMES, GGUF_METALLIB_NAME)
 
 
 def output_path() -> Path:
@@ -76,6 +82,7 @@ def _metallib_source(name: str) -> str:
     coupling with :mod:`vllm_metal.metal`."""
     from vllm_metal.metal import (
         _build_gdn_source,
+        _build_gguf_source,
         _build_mla_paged_attention_source,
         _build_v2_paged_attention_source,
     )
@@ -84,6 +91,7 @@ def _metallib_source(name: str) -> str:
         "paged_attention_v2_kern": _build_v2_paged_attention_source,
         "gdn_kern": _build_gdn_source,
         "paged_mla_kern": _build_mla_paged_attention_source,
+        "gguf_kern": _build_gguf_source,
     }
     return builders[name]()
 
@@ -129,7 +137,7 @@ def _compile_metallib(name: str, source: str) -> Path:
 
 
 def build_metallibs() -> list[Path]:
-    """Precompile the three Metal shader libraries to ``.metallib`` files.
+    """Precompile the Metal shader libraries to ``.metallib`` files.
 
     PACKAGING-only (CI + release.sh): the default runtime path loads these
     prebuilt libraries, but source mode (``VLLM_METAL_BUILD_FROM_SOURCE=1``)
@@ -216,7 +224,7 @@ def _build_spec() -> _BuildSpec:
         "-undefined",
         "dynamic_lookup",
         str(nb_src),
-        str(_SRC),
+        *(str(src) for src in _SOURCES),
         "-o",
         str(_OUT),
     ]
@@ -243,7 +251,7 @@ def _input_hash(spec: _BuildSpec) -> str:
     # so editing a flag still busts the hash.
     # Versions catch in-place upgrades where the install path is reused.
     h.update(f"mlx={spec.mlx_version}\0nb={spec.nb_version}\0".encode())
-    for p in (_SRC, _BUILD, _CONSTANTS, spec.nb_src):
+    for p in (*_SOURCES, *_HEADERS, _BUILD, _CONSTANTS, spec.nb_src):
         h.update(p.name.encode())
         h.update(b"\0")
         h.update(p.read_bytes())
@@ -314,7 +322,7 @@ def build() -> Path:
 
     spec = _build_spec()
     expected_hash = _input_hash(spec)
-    logger.info("Building native paged-attention extension ...")
+    logger.info("Building native Metal extension ...")
 
     for p, label in [
         (spec.py_include, "Python include"),
@@ -325,7 +333,7 @@ def build() -> Path:
         if not Path(p).exists():
             raise FileNotFoundError(f"{label} not found: {p}")
 
-    _run_or_raise(spec.cmd, "build paged_ops extension")
+    _run_or_raise(spec.cmd, "build native Metal extension")
 
     _HASH.write_text(expected_hash)
     logger.info("Built %s", _OUT)

--- a/vllm_metal/metal/gguf_ops.cpp
+++ b/vllm_metal/metal/gguf_ops.cpp
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+// C++ nanobind bridge for raw GGUF quantized-weight Metal primitives.
+
+#include "gguf_ops.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+
+#include "mlx/backend/metal/device.h"
+#include "mlx/mlx.h"
+#include "mlx/primitives.h"
+
+namespace nb = nanobind;
+using namespace mlx::core;
+
+namespace {
+
+#if MLX_VERSION_NUMERIC >= 31002
+static metal::CommandEncoder& get_command_encoder_compat(
+    metal::Device& d,
+    Stream s) {
+  (void)d;
+  return metal::get_command_encoder(s);
+}
+
+static void add_temporary_compat(
+    metal::CommandEncoder& enc,
+    const array& arr,
+    metal::Device& d,
+    Stream s) {
+  (void)d;
+  (void)s;
+  enc.add_temporary(arr);
+}
+#else
+static metal::CommandEncoder& get_command_encoder_compat(
+    metal::Device& d,
+    Stream s) {
+  return d.get_command_encoder(s.index);
+}
+
+static void add_temporary_compat(
+    metal::CommandEncoder& enc,
+    const array& arr,
+    metal::Device& d,
+    Stream s) {
+  (void)enc;
+  d.add_temporary(arr, s.index);
+}
+#endif
+
+static std::string dtype_to_metal(Dtype dt) {
+  switch (dt) {
+    case float16: return "half";
+    case bfloat16: return "bfloat16_t";
+    case float32: return "float";
+    case uint8: return "uchar";
+    default:
+      throw std::runtime_error("Unsupported dtype for GGUF Metal kernel");
+  }
+}
+
+static std::string gguf_source_;
+constexpr int kGGUFQK8_0 = 32;
+constexpr int kGGUFQ8_0BlockBytes = 34;
+constexpr int kGGUFQ8_1BlockBytes = 36;
+constexpr int kGGUFQTypeQ8_0 = 8;
+
+void init_gguf_library(const std::string& src) {
+  gguf_source_ = src;
+  auto& d = metal::device(Device::gpu);
+  d.get_library("gguf_kern", [&]() { return gguf_source_; });
+}
+
+static void validate_gguf_q8_0_weight(
+    const char* op_name,
+    const array& qweight) {
+  if (qweight.dtype() != uint8) {
+    throw std::runtime_error(
+        std::string(op_name) + ": qweight must be uint8 raw GGUF bytes");
+  }
+  if (qweight.ndim() != 2) {
+    throw std::runtime_error(
+        std::string(op_name) + ": qweight must be 2D [rows, raw_bytes]");
+  }
+  int bytes_per_row = static_cast<int>(qweight.shape(1));
+  if (bytes_per_row <= 0 || bytes_per_row % kGGUFQ8_0BlockBytes != 0) {
+    throw std::runtime_error(
+        std::string(op_name) +
+        ": qweight raw-byte dimension must be a positive multiple of 34");
+  }
+}
+
+class GGUFQ8_0MulMatPrimitive : public UnaryPrimitive {
+ public:
+  GGUFQ8_0MulMatPrimitive(
+      Stream stream,
+      int input_dims,
+      int rows,
+      int blocks_per_row,
+      int bytes_per_row,
+      int padded_blocks)
+      : UnaryPrimitive(stream),
+        input_dims_(input_dims),
+        rows_(rows),
+        blocks_per_row_(blocks_per_row),
+        bytes_per_row_(bytes_per_row),
+        padded_blocks_(padded_blocks) {}
+
+  void eval_cpu(const std::vector<array>&, array&) override {
+    throw std::runtime_error("GGUFQ8_0MulMatPrimitive only supports GPU");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, array& out) override {
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const array& x = inputs[0];
+    const array& qweight = inputs[1];
+    int num_tokens = static_cast<int>(x.shape(0));
+
+    Shape qx_shape{
+        static_cast<ShapeElem>(num_tokens),
+        static_cast<ShapeElem>(padded_blocks_ * kGGUFQ8_1BlockBytes)};
+    array qx(
+        allocator::malloc(
+            static_cast<size_t>(num_tokens) * padded_blocks_ *
+            kGGUFQ8_1BlockBytes),
+        qx_shape,
+        uint8);
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+    auto& enc = get_command_encoder_compat(d, s);
+    auto* lib = d.get_library("gguf_kern");
+    auto dt = dtype_to_metal(x.dtype());
+
+    std::string qname = "gguf_q8_1_quantize_" + dt;
+    auto* qkernel = d.get_kernel(qname, lib, qname, {});
+    enc.set_compute_pipeline_state(qkernel);
+    enc.set_input_array(x, 0);
+    enc.set_output_array(qx, 1);
+    enc.set_bytes(input_dims_, 2);
+    enc.set_bytes(padded_blocks_, 3);
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(padded_blocks_, num_tokens, 1),
+        MTL::Size::Make(kGGUFQK8_0, 1, 1));
+    enc.barrier();
+
+    std::string mname = "gguf_q8_0_matvec_" + dt;
+    auto* mkernel = d.get_kernel(mname, lib, mname, {});
+    enc.set_compute_pipeline_state(mkernel);
+    enc.set_input_array(qweight, 0);
+    enc.set_input_array(qx, 1);
+    enc.set_output_array(out, 2);
+    enc.set_bytes(rows_, 3);
+    enc.set_bytes(blocks_per_row_, 4);
+    enc.set_bytes(bytes_per_row_, 5);
+    enc.set_bytes(padded_blocks_, 6);
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(rows_, num_tokens, 1),
+        MTL::Size::Make(kGGUFQK8_0, 1, 1));
+
+    add_temporary_compat(enc, x, d, s);
+    add_temporary_compat(enc, qweight, d, s);
+    add_temporary_compat(enc, out, d, s);
+    add_temporary_compat(enc, qx, d, s);
+  }
+
+  const char* name() const override { return "GGUFQ8_0MulMat"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* rhs = dynamic_cast<const GGUFQ8_0MulMatPrimitive*>(&other);
+    return rhs && rhs->input_dims_ == input_dims_ &&
+        rhs->rows_ == rows_ &&
+        rhs->blocks_per_row_ == blocks_per_row_ &&
+        rhs->bytes_per_row_ == bytes_per_row_ &&
+        rhs->padded_blocks_ == padded_blocks_;
+  }
+
+ private:
+  int input_dims_;
+  int rows_;
+  int blocks_per_row_;
+  int bytes_per_row_;
+  int padded_blocks_;
+};
+
+static array gguf_q8_0_mul_mat_primitive_fn(
+    const array& x,
+    const array& qweight,
+    int qweight_type) {
+  if (qweight_type != kGGUFQTypeQ8_0) {
+    throw std::runtime_error(
+        "gguf_q8_0_mul_mat: qweight_type must be GGUF Q8_0");
+  }
+  if (x.ndim() != 2) {
+    throw std::runtime_error("gguf_q8_0_mul_mat: x must be 2D");
+  }
+  if (x.dtype() != float16 && x.dtype() != bfloat16 && x.dtype() != float32) {
+    throw std::runtime_error(
+        "gguf_q8_0_mul_mat: x must be fp16, bf16, or fp32");
+  }
+  validate_gguf_q8_0_weight("gguf_q8_0_mul_mat", qweight);
+
+  int input_dims = static_cast<int>(x.shape(1));
+  if (input_dims <= 0 || input_dims % kGGUFQK8_0 != 0) {
+    throw std::runtime_error(
+        "gguf_q8_0_mul_mat: input dimension must be a positive multiple of 32");
+  }
+  int rows = static_cast<int>(qweight.shape(0));
+  int bytes_per_row = static_cast<int>(qweight.shape(1));
+  int blocks_per_row = bytes_per_row / kGGUFQ8_0BlockBytes;
+  if (blocks_per_row * kGGUFQK8_0 != input_dims) {
+    throw std::runtime_error(
+        "gguf_q8_0_mul_mat: qweight shape does not match x input dimension");
+  }
+  int padded_cols = ((input_dims + 511) / 512) * 512;
+  int padded_blocks = padded_cols / kGGUFQK8_0;
+
+  auto prim = std::make_shared<GGUFQ8_0MulMatPrimitive>(
+      default_stream(Device::gpu),
+      input_dims,
+      rows,
+      blocks_per_row,
+      bytes_per_row,
+      padded_blocks);
+  return array(
+      Shape{static_cast<ShapeElem>(x.shape(0)), static_cast<ShapeElem>(rows)},
+      x.dtype(),
+      std::move(prim),
+      {x, qweight});
+}
+
+}  // namespace
+
+void register_gguf_ops(nb::module_& m) {
+  m.def("init_gguf_library", &init_gguf_library,
+        nb::arg("src"),
+        "JIT-compile the GGUF raw-weight Metal shaders.");
+
+  m.def("gguf_q8_0_mul_mat",
+        [](nb::handle x_h,
+           nb::handle qweight_h,
+           int qweight_type,
+           nb::handle out_h) {
+          auto result = gguf_q8_0_mul_mat_primitive_fn(
+              *nb::inst_ptr<array>(x_h),
+              *nb::inst_ptr<array>(qweight_h),
+              qweight_type);
+          nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
+        },
+        nb::arg("x"),
+        nb::arg("qweight"),
+        nb::arg("qweight_type"),
+        nb::arg("out"),
+        "Raw GGUF Q8_0 linear matvec/matmul. Wraps an MLX Primitive that "
+        "internally quantizes activations to Q8_1 and multiplies against raw "
+        "Q8_0 GGUF blocks.");
+}

--- a/vllm_metal/metal/gguf_ops.h
+++ b/vllm_metal/metal/gguf_ops.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+void register_gguf_ops(nanobind::module_& m);

--- a/vllm_metal/metal/kernels_v2/gguf_quant.metal
+++ b/vllm_metal/metal/kernels_v2/gguf_quant.metal
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Raw GGUF Q8_0 quantized-weight kernels.
+
+constant int GGUF_QK8_0 = 32;
+constant int GGUF_Q8_0_BLOCK_BYTES = 34;  // half d + int8 qs[32]
+constant int GGUF_Q8_1_BLOCK_BYTES = 36;  // half2(d, sum) + int8 qs[32]
+
+template <typename T>
+[[kernel]] void gguf_q8_1_quantize(
+    const device T* __restrict__ x [[buffer(0)]],
+    device uchar* __restrict__ qx [[buffer(1)]],
+    constant int& input_dims [[buffer(2)]],
+    constant int& padded_blocks [[buffer(3)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]]) {
+  const int block = int(tgid.x);
+  const int token = int(tgid.y);
+  const int col = block * GGUF_QK8_0 + int(lane);
+
+  const float xi = (col < input_dims)
+      ? static_cast<float>(x[token * input_dims + col])
+      : 0.0f;
+  const float amax = simd_max(fabs(xi));
+  const float sum = simd_sum(xi);
+  const float d = amax / 127.0f;
+  const float qf = (amax == 0.0f) ? 0.0f : round(xi / d);
+  const int qi = int(clamp(qf, -127.0f, 127.0f));
+
+  const int base = (token * padded_blocks + block) * GGUF_Q8_1_BLOCK_BYTES;
+  if (lane == 0) {
+    device half* ds = reinterpret_cast<device half*>(qx + base);
+    ds[0] = half(d);
+    ds[1] = half(sum);
+  }
+  qx[base + 4 + int(lane)] = as_type<uchar>(char(qi));
+}
+
+template <typename T>
+[[kernel]] void gguf_q8_0_matvec(
+    const device uchar* __restrict__ qweight [[buffer(0)]],
+    const device uchar* __restrict__ qx [[buffer(1)]],
+    device T* __restrict__ out [[buffer(2)]],
+    constant int& rows [[buffer(3)]],
+    constant int& blocks_per_row [[buffer(4)]],
+    constant int& bytes_per_row [[buffer(5)]],
+    constant int& padded_blocks [[buffer(6)]],
+    uint3 tgid [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]]) {
+  const int row = int(tgid.x);
+  const int token = int(tgid.y);
+  if (row >= rows) {
+    return;
+  }
+
+  float acc = 0.0f;
+  for (int block = 0; block < blocks_per_row; ++block) {
+    const int w_base = row * bytes_per_row
+        + block * GGUF_Q8_0_BLOCK_BYTES;
+    const int x_base = (token * padded_blocks + block)
+        * GGUF_Q8_1_BLOCK_BYTES;
+
+    const device half* wd_ptr =
+        reinterpret_cast<const device half*>(qweight + w_base);
+    const device half* xd_ptr =
+        reinterpret_cast<const device half*>(qx + x_base);
+    const float wd = static_cast<float>(wd_ptr[0]);
+    const float xd = static_cast<float>(xd_ptr[0]);
+
+    const char wq = as_type<char>(qweight[w_base + 2 + int(lane)]);
+    const char xq = as_type<char>(qx[x_base + 4 + int(lane)]);
+    const float partial = static_cast<float>(int(wq) * int(xq));
+    acc += simd_sum(partial) * wd * xd;
+  }
+
+  if (lane == 0) {
+    out[token * rows + row] = static_cast<T>(acc);
+  }
+}
+
+#define instantiate_gguf_q8_1_quantize(type)                         \
+  template [[host_name("gguf_q8_1_quantize_" #type)]]                \
+  [[kernel]] void gguf_q8_1_quantize<type>(                          \
+      const device type*, device uchar*, constant int&,               \
+      constant int&, uint3, uint);
+
+#define instantiate_gguf_q8_0_matvec(type)                            \
+  template [[host_name("gguf_q8_0_matvec_" #type)]]                  \
+  [[kernel]] void gguf_q8_0_matvec<type>(                             \
+      const device uchar*, const device uchar*, device type*,         \
+      constant int&, constant int&, constant int&, constant int&,      \
+      uint3, uint);
+
+instantiate_gguf_q8_1_quantize(float);
+instantiate_gguf_q8_1_quantize(half);
+instantiate_gguf_q8_1_quantize(bfloat16_t);
+
+instantiate_gguf_q8_0_matvec(float);
+instantiate_gguf_q8_0_matvec(half);
+instantiate_gguf_q8_0_matvec(bfloat16_t);

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -16,6 +16,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/string.h>
 
+#include "gguf_ops.h"
+
 #include "mlx/mlx.h"
 #include "mlx/backend/metal/device.h"
 #include "mlx/primitives.h"
@@ -993,6 +995,8 @@ NB_MODULE(_paged_ops, m) {
   m.def("init_library_path", &init_library_path,
         nb::arg("name"), nb::arg("path"),
         "Load a precompiled .metallib from disk, cached under `name`.");
+
+  register_gguf_ops(m);
 
   m.def("init_gdn_library", &init_gdn_library,
         nb::arg("gdn_src"),


### PR DESCRIPTION
Add the first native GGUF boundary for vllm-metal: a raw GGUF tensor representation plus a Q8_0 Metal primitive.

This PR intentionally does not add the GGUF loader, model wrappers, lifecycle wiring, compatibility shims, non-Q8 kernels, MoE, or model-level enablement. Those depend on this primitive boundary and should be reviewed separately.


* Keep `qweight` as raw GGUF `uint8` block bytes.
* Keep `qweight_type` explicit.
* Define the Q8_0 layout contract: logical shape, raw block shape, row-major contiguous raw bytes, transpose convention, input dtype, and output dtype.
* Add a lazy GGUF Metal library init path so existing core Metal kernels still load as before.
* Add Q8_0 Metal kernels that quantize activations to Q8_1 internally and multiply against raw Q8_0 blocks.
* Add focused correctness tests through public seams only.
