### PR TITLE
feat: dense encoder varlen attention primitive (RFC #333 PR1)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,10 @@ EOF
 
   uv pip install -r requirements/cpu.txt --index-strategy unsafe-best-match
   CXXFLAGS="-Wno-parentheses" uv pip install .
+  # FastAPI 0.137+ stores included routers as _IncludedRouter without .path,
+  # which breaks prometheus-fastapi-instrumentator route naming and vLLM /health.
+  # See https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370
+  uv pip install 'fastapi>=0.115.0,<0.137'
   cd -
 
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then

--- a/tests/test_encoder_varlen_attention.py
+++ b/tests/test_encoder_varlen_attention.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for dense non-causal varlen encoder attention (RFC #333 PR1)."""
+
+from __future__ import annotations
+
+import platform
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin",
+    reason="Metal encoder kernels require Apple Silicon",
+)
+
+from vllm_metal.metal import encoder_varlen_attention  # noqa: E402
+
+_HEAD_DIMS = [64, 80, 96, 128]
+_DTYPES = [mx.float16, mx.bfloat16, mx.float32]
+_SEGMENT_CONFIGS = [
+    [32, 48],
+    [16, 16, 16],
+    [7, 13, 21, 5],
+]
+
+
+def _tolerance(dtype: mx.Dtype) -> tuple[float, float]:
+    if dtype == mx.bfloat16:
+        return 1e-2, 2e-2
+    if dtype == mx.float16:
+        return 1e-2, 1.5e-2
+    return 1e-4, 1e-4
+
+
+def _ref_encoder_varlen_attention(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    cu_seqlens: mx.array,
+    *,
+    scale: float,
+) -> mx.array:
+    """Pure-MLX split-loop bidirectional attention reference."""
+    import mlx.core as mx
+
+    q_np = np.array(q.astype(mx.float32))
+    k_np = np.array(k.astype(mx.float32))
+    v_np = np.array(v.astype(mx.float32))
+    bounds = [int(x) for x in np.asarray(cu_seqlens)]
+    out = np.zeros_like(q_np, dtype=np.float32)
+
+    for seg in range(len(bounds) - 1):
+        lo, hi = bounds[seg], bounds[seg + 1]
+        q_seg = q_np[lo:hi]
+        k_seg = k_np[lo:hi]
+        v_seg = v_np[lo:hi]
+        scores = scale * np.einsum("ihd,jhd->hij", q_seg, k_seg)
+        scores = scores - np.max(scores, axis=-1, keepdims=True)
+        weights = np.exp(scores)
+        weights /= np.sum(weights, axis=-1, keepdims=True)
+        out[lo:hi] = np.einsum("hij,jhd->ihd", weights, v_seg)
+
+    return mx.array(out).astype(q.dtype)
+
+
+def _make_inputs(
+    segment_lens: list[int],
+    *,
+    num_heads: int,
+    head_dim: int,
+    dtype: mx.Dtype,
+    seed: int = 0,
+):
+    mx.random.seed(seed)
+    total_tokens = sum(segment_lens)
+    cu = mx.array([0, *np.cumsum(segment_lens).tolist()], dtype=mx.int32)
+    q = mx.random.normal(shape=(total_tokens, num_heads, head_dim)).astype(dtype)
+    k = mx.random.normal(shape=(total_tokens, num_heads, head_dim)).astype(dtype)
+    v = mx.random.normal(shape=(total_tokens, num_heads, head_dim)).astype(dtype)
+    max_seqlen = max(segment_lens)
+    scale = head_dim**-0.5
+    return q, k, v, cu, max_seqlen, scale
+
+
+@pytest.mark.parametrize("head_dim", _HEAD_DIMS)
+@pytest.mark.parametrize("dtype", _DTYPES)
+@pytest.mark.parametrize("segment_lens", _SEGMENT_CONFIGS)
+def test_encoder_varlen_matches_mlx_reference(
+    head_dim: int,
+    dtype: mx.Dtype,
+    segment_lens: list[int],
+) -> None:
+    num_heads = 4
+    q, k, v, cu, max_seqlen, scale = _make_inputs(
+        segment_lens,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        dtype=dtype,
+    )
+
+    out = encoder_varlen_attention(
+        q,
+        k,
+        v,
+        cu,
+        max_seqlen=max_seqlen,
+        softmax_scale=scale,
+    )
+    ref = _ref_encoder_varlen_attention(q, k, v, cu, scale=scale)
+
+    mx.eval(out, ref)
+    rtol, atol = _tolerance(dtype)
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def test_encoder_varlen_lazy_graph_self_chain() -> None:
+    segment_lens = [24, 40]
+    q, k, v, cu, max_seqlen, scale = _make_inputs(
+        segment_lens,
+        num_heads=2,
+        head_dim=64,
+        dtype=mx.float16,
+        seed=1,
+    )
+
+    first = encoder_varlen_attention(
+        q, k, v, cu, max_seqlen=max_seqlen, softmax_scale=scale
+    )
+    second = encoder_varlen_attention(
+        first, k, v, cu, max_seqlen=max_seqlen, softmax_scale=scale
+    )
+    mx.eval(second)
+    assert np.array(second).shape == (sum(segment_lens), 2, 64)
+
+
+def test_encoder_varlen_rejects_bad_cu_seqlens() -> None:
+    q, k, v, cu, max_seqlen, scale = _make_inputs(
+        [16, 16],
+        num_heads=2,
+        head_dim=64,
+        dtype=mx.float16,
+    )
+    bad = mx.array([0, 10, 31], dtype=mx.int32)
+    with pytest.raises(ValueError, match="cu_seqlens\\[-1\\]"):
+        encoder_varlen_attention(
+            q, k, v, bad, max_seqlen=max_seqlen, softmax_scale=scale
+        )
+
+
+def test_encoder_varlen_rejects_unsupported_head_dim() -> None:
+    q, k, v, cu, max_seqlen, scale = _make_inputs(
+        [16],
+        num_heads=2,
+        head_dim=72,
+        dtype=mx.float16,
+    )
+    with pytest.raises(ValueError, match="unsupported head_dim"):
+        encoder_varlen_attention(
+            q, k, v, cu, max_seqlen=max_seqlen, softmax_scale=scale
+        )
+
+
+def test_encoder_varlen_rejects_max_seqlen_too_small() -> None:
+    q, k, v, cu, _max_seqlen, scale = _make_inputs(
+        [32, 48],
+        num_heads=2,
+        head_dim=64,
+        dtype=mx.float16,
+    )
+    with pytest.raises(ValueError, match="max_seqlen must be >="):
+        encoder_varlen_attention(q, k, v, cu, max_seqlen=16, softmax_scale=scale)

--- a/tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
+++ b/tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
@@ -8,6 +8,7 @@ Compares mlx_vlm's per-segment ``ensure_fused_sdpa`` loop against the Metal
 Run:
     .venv-vllm-metal/bin/python tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
     .venv-vllm-metal/bin/python tools/benchmark/qwen3_vl_vision_varlen_benchmark.py --iters 30
+    .venv-vllm-metal/bin/python tools/benchmark/qwen3_vl_vision_varlen_benchmark.py --attention-only
 """
 
 from __future__ import annotations
@@ -27,7 +28,13 @@ except ImportError:  # pragma: no cover
     print("mlx_vlm unavailable; cannot run.")
     sys.exit(0)
 
-from vllm_metal.multimodal.fused_vit_attention import qwen3_vl_vision_attention_forward
+from vllm_metal.multimodal.fused_vit_attention import (
+    _baseline_segment_attention,
+    _fused_rope_varlen_core,
+    _qkv_to_shd,
+    _shd_to_bhsd,
+    qwen3_vl_vision_attention_forward,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,6 +51,9 @@ DEFAULT_CONFIGS: tuple[BenchConfig, ...] = (
     BenchConfig("8x1024", [1024] * 8),
     BenchConfig("4x4096", [4096] * 4),
     BenchConfig("varied (Qwen3-VL-ish)", [768, 256, 512, 1024, 384, 896]),
+    BenchConfig("16x256", [256] * 16),
+    BenchConfig("32x128", [128] * 32),
+    BenchConfig("64x64", [64] * 64),
     BenchConfig("4x1024 hd128", [1024] * 4, hidden_size=2048, num_heads=16),
     BenchConfig("8x512 hd64", [512] * 8, hidden_size=512, num_heads=8),
     BenchConfig("8x768 hd96", [768] * 8, hidden_size=1536, num_heads=16),
@@ -70,9 +80,12 @@ def _p50_p95(fn, *, warmup: int, iters: int) -> tuple[float, float]:
     return p50, p95
 
 
-def _run_config(cfg: BenchConfig, *, warmup: int, iters: int) -> None:
+def _run_config(
+    cfg: BenchConfig, *, warmup: int, iters: int, attention_only: bool
+) -> None:
     head_dim = cfg.hidden_size // cfg.num_heads
     cu, total = _build_cu_seqlens(cfg.segment_lens)
+    max_seqlen = max(cfg.segment_lens)
     rope_dim = head_dim // 2
 
     mx.random.seed(0)
@@ -81,19 +94,57 @@ def _run_config(cfg: BenchConfig, *, warmup: int, iters: int) -> None:
     rope = mx.random.normal((total, rope_dim)).astype(cfg.dtype)
     mx.eval(attn.parameters(), x, cu, rope)
 
-    def baseline() -> mx.array:
-        return qwen3_vl_vision_attention_forward(
-            attn, x, cu, rope, use_fused_varlen=False
-        )
+    if attention_only:
+        from mlx_vlm.models.qwen3_vl.vision import apply_rotary_pos_emb_vision
 
-    def fused() -> mx.array:
-        return qwen3_vl_vision_attention_forward(
-            attn, x, cu, rope, use_fused_varlen=True, use_fused_rope_varlen=True
-        )
+        qkv = attn.qkv(x).reshape(total, 3, attn.num_heads, -1)
+        q, k, v = _qkv_to_shd(qkv)
+        mx.eval(q, k, v)
+
+        def baseline() -> mx.array:
+            q_r = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rope)[0]
+            k_r = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rope)[0]
+            q_b, k_b, v_b = _shd_to_bhsd(q_r, k_r, v)
+            return _baseline_segment_attention(q_b, k_b, v_b, cu, attn.scale)
+
+        def fused() -> mx.array:
+            return _fused_rope_varlen_core(
+                q,
+                k,
+                v,
+                rope,
+                cu,
+                attn.scale,
+                max_seqlen=max_seqlen,
+            )
+    else:
+
+        def baseline() -> mx.array:
+            return qwen3_vl_vision_attention_forward(
+                attn,
+                x,
+                cu,
+                rope,
+                use_fused_varlen=False,
+                max_seqlen=max_seqlen,
+            )
+
+        def fused() -> mx.array:
+            return qwen3_vl_vision_attention_forward(
+                attn,
+                x,
+                cu,
+                rope,
+                use_fused_varlen=True,
+                use_fused_rope_varlen=True,
+                max_seqlen=max_seqlen,
+            )
 
     out_a = baseline()
     out_b = fused()
     mx.eval(out_a, out_b)
+    if attention_only:
+        out_a = out_a.transpose(0, 2, 1, 3).reshape(total, attn.num_heads, head_dim)
     diff = mx.abs(out_a - out_b)
     max_err = float(mx.max(diff).item())
     mean_err = float(mx.mean(diff).item())
@@ -115,9 +166,15 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--warmup", type=int, default=3)
     parser.add_argument("--iters", type=int, default=20)
+    parser.add_argument(
+        "--attention-only",
+        action="store_true",
+        help="Time RoPE + attention core only (exclude qkv/proj).",
+    )
     args = parser.parse_args()
 
-    print("Qwen3-VL vision Attention A/B (baseline segment SDPA vs encoder_varlen)")
+    mode = "attention core only" if args.attention_only else "full forward"
+    print(f"Qwen3-VL vision Attention A/B ({mode})")
     print(
         f"host={platform.machine()} mlx={mx.__version__} "
         f"warmup={args.warmup} iters={args.iters}"
@@ -132,7 +189,12 @@ def main() -> None:
     failures = 0
     for cfg in DEFAULT_CONFIGS:
         try:
-            _run_config(cfg, warmup=args.warmup, iters=args.iters)
+            _run_config(
+                cfg,
+                warmup=args.warmup,
+                iters=args.iters,
+                attention_only=args.attention_only,
+            )
         except ValueError as exc:
             failures += 1
             print(f"{cfg.label:24} SKIPPED: {exc}")

--- a/tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
+++ b/tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A/B benchmark: Qwen3-VL vision Attention baseline vs encoder_varlen_attention.
+
+Compares mlx_vlm's per-segment ``ensure_fused_sdpa`` loop against the Metal
+``encoder_varlen_attention`` primitive wired through
+``qwen3_vl_vision_attention_forward(use_fused_varlen=True)``.
+
+Run:
+    .venv-vllm-metal/bin/python tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
+    .venv-vllm-metal/bin/python tools/benchmark/qwen3_vl_vision_varlen_benchmark.py --iters 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import sys
+import time
+from dataclasses import dataclass
+
+import mlx.core as mx
+import numpy as np
+
+try:
+    from mlx_vlm.models.qwen3_vl.vision import Attention
+except ImportError:  # pragma: no cover
+    print("mlx_vlm unavailable; cannot run.")
+    sys.exit(0)
+
+from vllm_metal.multimodal.fused_vit_attention import qwen3_vl_vision_attention_forward
+
+
+@dataclass(frozen=True, slots=True)
+class BenchConfig:
+    label: str
+    segment_lens: list[int]
+    hidden_size: int = 1024
+    num_heads: int = 16
+    dtype: mx.Dtype = mx.bfloat16
+
+
+DEFAULT_CONFIGS: tuple[BenchConfig, ...] = (
+    BenchConfig("4x256", [256, 256, 256, 256]),
+    BenchConfig("8x1024", [1024] * 8),
+    BenchConfig("4x4096", [4096] * 4),
+    BenchConfig("varied (Qwen3-VL-ish)", [768, 256, 512, 1024, 384, 896]),
+    BenchConfig("4x1024 hd128", [1024] * 4, hidden_size=2048, num_heads=16),
+    BenchConfig("8x512 hd64", [512] * 8, hidden_size=512, num_heads=8),
+    BenchConfig("8x768 hd96", [768] * 8, hidden_size=1536, num_heads=16),
+)
+
+
+def _build_cu_seqlens(segment_lens: list[int]) -> mx.array:
+    total = sum(segment_lens)
+    bounds = [0, *np.cumsum(segment_lens).tolist()]
+    return mx.array(bounds, dtype=mx.int32), total
+
+
+def _p50_p95(fn, *, warmup: int, iters: int) -> tuple[float, float]:
+    for _ in range(warmup):
+        mx.eval(fn())
+    times_ms: list[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        mx.eval(fn())
+        times_ms.append((time.perf_counter() - t0) * 1e3)
+    times_ms.sort()
+    p50 = times_ms[len(times_ms) // 2]
+    p95 = times_ms[int(len(times_ms) * 0.95) - 1]
+    return p50, p95
+
+
+def _run_config(cfg: BenchConfig, *, warmup: int, iters: int) -> None:
+    head_dim = cfg.hidden_size // cfg.num_heads
+    cu, total = _build_cu_seqlens(cfg.segment_lens)
+    rope_dim = head_dim // 2
+
+    mx.random.seed(0)
+    attn = Attention(dim=cfg.hidden_size, num_heads=cfg.num_heads)
+    x = mx.random.normal((total, cfg.hidden_size)).astype(cfg.dtype)
+    rope = mx.random.normal((total, rope_dim)).astype(cfg.dtype)
+    mx.eval(attn.parameters(), x, cu, rope)
+
+    def baseline() -> mx.array:
+        return qwen3_vl_vision_attention_forward(
+            attn, x, cu, rope, use_fused_varlen=False
+        )
+
+    def fused() -> mx.array:
+        return qwen3_vl_vision_attention_forward(
+            attn, x, cu, rope, use_fused_varlen=True
+        )
+
+    out_a = baseline()
+    out_b = fused()
+    mx.eval(out_a, out_b)
+    diff = mx.abs(out_a - out_b)
+    max_err = float(mx.max(diff).item())
+    mean_err = float(mx.mean(diff).item())
+
+    base_p50, base_p95 = _p50_p95(baseline, warmup=warmup, iters=iters)
+    fused_p50, fused_p95 = _p50_p95(fused, warmup=warmup, iters=iters)
+    speedup = base_p50 / fused_p50 if fused_p50 > 0 else float("inf")
+
+    print(
+        f"{cfg.label:24} tokens={total:6d} "
+        f"max_err={max_err:.3e} mean_err={mean_err:.3e} "
+        f"baseline_p50={base_p50:8.3f}ms fused_p50={fused_p50:8.3f}ms "
+        f"baseline_p95={base_p95:8.3f}ms fused_p95={fused_p95:8.3f}ms "
+        f"speedup={speedup:.2f}x"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iters", type=int, default=20)
+    args = parser.parse_args()
+
+    print("Qwen3-VL vision Attention A/B (baseline segment SDPA vs encoder_varlen)")
+    print(
+        f"host={platform.machine()} mlx={mx.__version__} "
+        f"warmup={args.warmup} iters={args.iters}"
+    )
+    print(
+        f"{'config':24} {'tokens':>6} {'max_err':>10} {'mean_err':>10} "
+        f"{'base_p50':>10} {'fused_p50':>10} {'base_p95':>10} "
+        f"{'fused_p95':>10} {'speedup':>8}"
+    )
+    print("-" * 120)
+
+    failures = 0
+    for cfg in DEFAULT_CONFIGS:
+        try:
+            _run_config(cfg, warmup=args.warmup, iters=args.iters)
+        except ValueError as exc:
+            failures += 1
+            print(f"{cfg.label:24} SKIPPED: {exc}")
+
+    if failures:
+        print(f"\n{failures} config(s) skipped due to unsupported head_dim.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
+++ b/tools/benchmark/qwen3_vl_vision_varlen_benchmark.py
@@ -88,7 +88,7 @@ def _run_config(cfg: BenchConfig, *, warmup: int, iters: int) -> None:
 
     def fused() -> mx.array:
         return qwen3_vl_vision_attention_forward(
-            attn, x, cu, rope, use_fused_varlen=True
+            attn, x, cu, rope, use_fused_varlen=True, use_fused_rope_varlen=True
         )
 
     out_a = baseline()

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -31,6 +31,22 @@ def apply_compat_patches() -> None:
     _patch_vllm_bytelevel_tokenizer_loading()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_mlx_lm_gemma4_kv_shared_sanitize()
+    _maybe_patch_fused_vit_attention()
+
+
+def _maybe_patch_fused_vit_attention() -> None:
+    from vllm_metal import envs
+
+    if not envs.VLLM_METAL_USE_FUSED_VIT_ATTENTION:
+        return
+    try:
+        from vllm_metal.multimodal.fused_vit_attention import (
+            patch_qwen3_vl_vision_attention,
+        )
+
+        patch_qwen3_vl_vision_attention()
+    except ImportError as exc:
+        logger.warning("Fused ViT attention patch skipped: %s", exc)
 
 
 def _metal_ray_local_gpu_ids(

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
     VLLM_METAL_GDN_LAZY_KERNELS: bool = True
     VLLM_METAL_MLA_KERNEL: bool = False
+    VLLM_METAL_USE_FUSED_VIT_ATTENTION: bool = False
     VLLM_METAL_BUILD_FROM_SOURCE: bool = False
     VLLM_METAL_VISIBLE_DEVICES: str | None = None
     VLLM_METAL_RING_BASE_PORT: int = 32323
@@ -73,6 +74,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # qk_rope_head_dim=64, block_size ∈ {16, 32}, fp16/bf16,
     # decode-only).
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
+    # Route mlx_vlm Qwen3-VL vision-tower attention through the Metal
+    # encoder_varlen_attention primitive instead of the per-segment SDPA loop.
+    "VLLM_METAL_USE_FUSED_VIT_ATTENTION": lambda: (
+        os.getenv("VLLM_METAL_USE_FUSED_VIT_ATTENTION", "0") == "1"
+    ),
     # When set, compile the native _paged_ops extension from source at runtime
     # instead of loading the prebuilt artifact shipped in the wheel. Intended
     # for kernel developers / source installs; requires Xcode command-line

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -87,6 +87,167 @@ def _build_mla_paged_attention_source() -> str:
     return "\n".join(parts)
 
 
+def _build_encoder_varlen_source() -> str:
+    """Concatenate utils + encoder_varlen_attention into a single source."""
+    parts = [
+        _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "encoder_varlen_attention.metal"),
+    ]
+    return "\n".join(parts)
+
+
+_ENCODER_VARLEN_HEAD_DIMS = frozenset({64, 80, 96, 128})
+_encoder_varlen_loaded = False
+
+
+def _validate_encoder_cu_seqlens(cu_seqlens, *, total_tokens: int) -> None:
+    import mlx.core as mx
+    import numpy as np
+
+    if cu_seqlens.dtype != mx.int32:
+        raise ValueError(
+            "encoder_varlen_attention: cu_seqlens must have dtype int32 "
+            f"(got {cu_seqlens.dtype})."
+        )
+    if cu_seqlens.ndim != 1:
+        raise ValueError(
+            "encoder_varlen_attention: cu_seqlens must be 1-D "
+            f"(got ndim={cu_seqlens.ndim})."
+        )
+    if int(cu_seqlens.shape[0]) < 2:
+        raise ValueError(
+            "encoder_varlen_attention: cu_seqlens must have at least 2 entries "
+            f"(got shape={cu_seqlens.shape})."
+        )
+
+    bounds = [int(x) for x in np.asarray(cu_seqlens)]
+    if bounds[0] != 0:
+        raise ValueError(
+            f"encoder_varlen_attention: cu_seqlens[0] must be 0 (got {bounds[0]})."
+        )
+    for prev, cur in zip(bounds, bounds[1:], strict=False):
+        if cur < prev:
+            raise ValueError(
+                "encoder_varlen_attention: cu_seqlens must be non-decreasing "
+                f"(saw {prev} followed by {cur})."
+            )
+    if bounds[-1] != total_tokens:
+        raise ValueError(
+            "encoder_varlen_attention: cu_seqlens[-1] must equal total_tokens "
+            f"(got {bounds[-1]}, expected {total_tokens})."
+        )
+
+
+def _ensure_encoder_varlen_library() -> ModuleType:
+    """Return ops with the encoder-varlen Metal library compiled (lazy)."""
+    global _encoder_varlen_loaded
+    ops = get_ops()
+    if not _encoder_varlen_loaded:
+        ops.init_encoder_varlen_library(_build_encoder_varlen_source())
+        _encoder_varlen_loaded = True
+    return ops
+
+
+def encoder_varlen_attention(
+    query,
+    key,
+    value,
+    cu_seqlens,
+    *,
+    max_seqlen: int,
+    softmax_scale: float | None = None,
+    sequence_lengths=None,
+):
+    """Dense non-causal varlen encoder attention on packed Q/K/V.
+
+    Each ``cu_seqlens`` segment ``[start, end)`` attends bidirectionally
+    within itself.  RoPE and flatten/repack are the caller's responsibility.
+
+    Args:
+        query: ``[total_tokens, num_heads, head_dim]``
+        key: same shape as ``query`` (v1 requires equal Q/KV head count)
+        value: same shape as ``query``
+        cu_seqlens: ``[num_segments + 1]`` int32 prefix sums, starting at 0
+        max_seqlen: launch hint; must be >= the longest segment length
+        softmax_scale: defaults to ``head_dim ** -0.5``
+        sequence_lengths: accepted for MMEncoderAttention API parity; ignored
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    del sequence_lengths  # API parity only for the Metal path.
+
+    for name, arr in (("query", query), ("key", key), ("value", value)):
+        if arr.ndim != 3:
+            raise ValueError(
+                f"encoder_varlen_attention: {name} must be 3-D "
+                f"[total_tokens, num_heads, head_dim] (got shape={arr.shape})."
+            )
+
+    if query.shape != key.shape or query.shape != value.shape:
+        raise ValueError(
+            "encoder_varlen_attention: query, key, value must share shape "
+            f"(got query={query.shape}, key={key.shape}, value={value.shape})."
+        )
+
+    supported_dtypes = (mx.float16, mx.bfloat16, mx.float32)
+    if query.dtype not in supported_dtypes:
+        raise ValueError(
+            "encoder_varlen_attention: unsupported dtype "
+            f"{query.dtype} (supported: float16, bfloat16, float32)."
+        )
+    if key.dtype != query.dtype or value.dtype != query.dtype:
+        raise ValueError(
+            "encoder_varlen_attention: query, key, value must share dtype."
+        )
+
+    total_tokens = int(query.shape[0])
+    num_heads = int(query.shape[1])
+    head_dim = int(query.shape[2])
+    if head_dim not in _ENCODER_VARLEN_HEAD_DIMS:
+        raise ValueError(
+            "encoder_varlen_attention: unsupported head_dim "
+            f"{head_dim} (supported: {sorted(_ENCODER_VARLEN_HEAD_DIMS)})."
+        )
+
+    _validate_encoder_cu_seqlens(cu_seqlens, total_tokens=total_tokens)
+
+    if max_seqlen < 1:
+        raise ValueError(
+            f"encoder_varlen_attention: max_seqlen must be >= 1 (got {max_seqlen})."
+        )
+    bounds = [int(x) for x in np.asarray(cu_seqlens)]
+    segment_lens = [bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1)]
+    observed_max = max(segment_lens) if segment_lens else 0
+    if max_seqlen < observed_max:
+        raise ValueError(
+            "encoder_varlen_attention: max_seqlen must be >= the longest "
+            f"segment length (got max_seqlen={max_seqlen}, "
+            f"longest_segment={observed_max})."
+        )
+
+    scale = float(head_dim**-0.5 if softmax_scale is None else softmax_scale)
+
+    q = mx.contiguous(query)
+    k = mx.contiguous(key)
+    v = mx.contiguous(value)
+    seqlens = mx.contiguous(cu_seqlens)
+
+    out = mx.array(0)
+    ops = _ensure_encoder_varlen_library()
+    ops._encoder_varlen_attention_primitive(
+        q,
+        k,
+        v,
+        seqlens,
+        num_heads,
+        scale,
+        int(max_seqlen),
+        out,
+    )
+    return out
+
+
 def metal_mla_paged_attention(
     q_nope,  # [total_q_tokens, num_heads, kv_lora_rank]
     q_pe,  # [total_q_tokens, num_heads, qk_rope_head_dim]

--- a/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
+++ b/vllm_metal/metal/kernels_v2/encoder_varlen_attention.metal
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Portions of this file are adapted from Apple's MLX framework
+// (https://github.com/ml-explore/mlx)
+// Licensed under the Apache License 2.0
+// Copyright © 2023 Apple Inc.
+
+// ========================================== Encoder varlen attention kernel
+//
+// Dense non-causal attention over a packed batch of variable-length
+// segments — the attention shape used by vision-tower models (Qwen2.5-VL
+// et al.), where each segment is one image's patch grid.
+//
+// Inputs are shaped [total_tokens, num_heads, head_dim], with cu_seqlens
+// recording segment boundaries.  Each threadgroup is bound to one
+// (segment, q_tile, head) triple via the launch grid; cross-segment
+// attention is skipped by construction.
+//
+// Implementation mirrors Apple's MLX `steel_attention` kernel structure
+// (BQ=32, BK=32, WM=4, WN=1).  All MMA tiles (Q, K, S, V, O) live as
+// per-lane `vec<float, 2>` fragments using simdgroup_matrix<float, 8, 8>'s
+// BaseMMAFrag lane layout — each lane owns 1 row × 2 cols of every 8×8
+// frag it participates in.  Softmax row reductions run in registers via
+// the simd_shuffle_xor(1) + simd_shuffle_xor(8) butterfly that traverses
+// the four lanes that share a row in the simdgroup_matrix layout.
+// α-rescale of the running O accumulator is a per-lane scalar
+// `o_frags[d] *= factor`, not a `diag(α) @ O` 8×8 MMA.
+//
+// Per-lane register state.
+//   q_frag        vec<float, 2>      reloaded each `dd` (Q is dim-tiled)
+//   s_frags[TK]   vec<float, 2>[TK]  S = Q @ K^T accumulated across dd
+//   v_frag        vec<float, 2>      reloaded each (id, ik) MMA
+//   o_frags[TD]   vec<float, 2>[TD]  running unnormalised output (fp32)
+//   max_score     float              online softmax row max
+//   sum_score     float              online softmax row sum (= l)
+//
+// MMA dispatch identity.
+//   simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat) requires
+//   simdgroup_matrix operands.  We marshal `vec<float, 2>` ↔
+//   `simdgroup_float8x8::thread_elements()` via reinterpret_cast.  Apple's
+//   simdgroup_matrix<float, 8, 8> stores exactly two fp32 elements per
+//   lane in a `vec<float, 2>` thread_elements slot, so the cast is a
+//   bitwise no-op.
+//
+// Lane coord (MLX BaseMMAFrag::get_coord).
+//   const ushort qid = simd_lane_id / 4;
+//   const ushort fm  = (qid & 4) + ((simd_lane_id / 2) % 4);   // 0..7 row
+//   const ushort fn  = (qid & 2) * 2 + (simd_lane_id % 2) * 2; // 0/2/4/6 col
+// Lane owns frag[fm, fn..fn+1].  The four lanes per row are { l, l^1,
+// l^8, l^9 } — confirming xor-1 + xor-8 as the 4-way row reduction.
+//
+// f32 path (`encoder_varlen_attention_manual_kernel`) uses smaller tiles
+// (Q_TILE=8, K_TILE=16) on a manual-SIMD fallback: fp32 doubles
+// tg-memory pressure and a 32×32 MMA tile blows the 32 KB cap at
+// HEAD_DIM=128, so the MMA path stays bf16/f16 only.
+//
+// NOTE: utils.metal is concatenated ahead of this file by the source
+// builder in vllm_metal.metal.__init__, so bfloat16_t is available.
+
+#include <metal_stdlib>
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+
+using namespace metal;
+
+// Hand-mirrored on the C++ side at paged_ops.cpp.  Field order is part of
+// the ABI; do not reorder without updating the C++ struct in lockstep.
+struct EncoderVarlenParams {
+    int   num_q_heads;
+    int   num_kv_heads;
+    int   total_tokens;
+    int   num_segments;   // == cu_seqlens.shape[0] - 1; binary-search bound.
+    int   max_seqlen;     // Drives launch-grid pitch (tiles_per_segment).
+    float softmax_scale;
+};
+
+// Metal-side ABI tripwire mirroring the C++ static_asserts in paged_ops.cpp.
+// needs_rebuild() in build.py only stats the .cpp, so a .metal-only struct
+// edit would JIT-compile cleanly and silently misdecode the C++ bytes;
+// this size check fires at JIT time when the .metal struct drifts from
+// the C++ side.
+static_assert(sizeof(EncoderVarlenParams) == 24,
+              "EncoderVarlenParams ABI drift: size diverges from "
+              "paged_ops.cpp; update both files in lockstep.");
+
+// ========================================== MMA kernel — bf16 / f16
+
+template <typename T, uint HEAD_DIM>
+[[kernel]] void encoder_varlen_attention_mma_kernel(
+    device const T*       q           [[buffer(0)]],
+    device const T*       k           [[buffer(1)]],
+    device const T*       v           [[buffer(2)]],
+    device const int*     cu_seqlens  [[buffer(3)]],
+    device       T*       out         [[buffer(4)]],
+    constant     EncoderVarlenParams& params [[buffer(5)]],
+    uint3 tg_id        [[threadgroup_position_in_grid]],
+    uint  lid          [[thread_index_in_threadgroup]],
+    uint  simd_lane_id [[thread_index_in_simdgroup]],
+    uint  simd_id      [[simdgroup_index_in_threadgroup]])
+{
+    constexpr uint THREADS    = 256;
+    constexpr uint NUM_SIMDS  = 8;
+    constexpr uint Q_TILE     = 64;
+    constexpr uint K_TILE     = 32;
+    constexpr uint kFragSize  = 8;
+    constexpr uint TQ         = 1;                       // Each simdgroup owns 1×8=8 query rows
+    constexpr uint TK         = K_TILE / kFragSize;       // 4
+    constexpr uint TD         = HEAD_DIM / kFragSize;     // 8 / 10 / 12 / 16
+    static_assert(HEAD_DIM % kFragSize == 0,
+                  "HEAD_DIM must be a multiple of 8 for the 8x8 MMA path");
+
+    // Padding in tg memory to avoid bank conflicts on Apple GPU.
+    // pad = 16/sizeof(T) matches MLX steel_attention's padQ/padK/padV
+    // and helps hd64/80/128 by 2–5%.  At HEAD_DIM=96 the padded inner
+    // stride (104 elements / 208 bytes for bf16) is empirically worse
+    // than the unpadded (96 / 192 bytes), losing ~8%: 96 is exactly 1.5
+    // bank cycles wide so the unpadded layout already distributes lanes
+    // across banks evenly, and the extra 8 elements both inflate tg
+    // pressure and shift the bank pattern in a way that re-introduces
+    // conflicts.  Disabling padding for hd96 recovers that loss.
+    constexpr uint pad_default = 16 / sizeof(T);
+    constexpr uint padQ    = (HEAD_DIM == 96) ? 0 : pad_default;
+    constexpr uint padK    = pad_default;                  // K_TILE=32 always
+    constexpr uint padV    = (HEAD_DIM == 96) ? 0 : pad_default;
+    constexpr uint LDQ_tgp = HEAD_DIM + padQ;             // Q row stride
+    constexpr uint LDK_tgp = K_TILE  + padK;              // K col stride (K is transposed)
+    constexpr uint LDV_tgp = HEAD_DIM + padV;             // V row stride
+
+    // ---- Threadgroup memory ------------------------------------------------
+    // Q_smem  row-major  [Q_TILE, LDQ_tgp]   — Q[q, d]
+    // KV_smem aliases    K_smem and V_smem (max of the two; non-overlapping
+    //                    in time — V is loaded after the Q@K^T MMAs done).
+    //   K_smem  transposed [HEAD_DIM, LDK_tgp]  — K[d, k] (logically K^T)
+    //   V_smem  row-major  [K_TILE,   LDV_tgp]  — V[k, d]
+    threadgroup T Q_smem[Q_TILE * LDQ_tgp];
+    constexpr uint tgp_mem_K  = HEAD_DIM * LDK_tgp;
+    constexpr uint tgp_mem_V  = K_TILE   * LDV_tgp;
+    constexpr uint tgp_mem_KV = (tgp_mem_K > tgp_mem_V) ? tgp_mem_K : tgp_mem_V;
+    threadgroup T KV_smem[tgp_mem_KV];
+    threadgroup T* Ks = KV_smem;
+    threadgroup T* Vs = KV_smem;
+
+    const int   head_idx = int(tg_id.y);
+    const int   num_q    = params.num_q_heads;
+    const int   num_kv   = params.num_kv_heads;
+    const float scale    = params.softmax_scale * M_LOG2E_F;
+
+    // Decode (segment, q_base) from tg_id.x.  tiles_per_segment uses
+    // params.max_seqlen as the launch-grid pitch (matches C++ launcher).
+    const int tiles_per_segment =
+        (params.max_seqlen + int(Q_TILE) - 1) / int(Q_TILE);
+    const int seg         = int(tg_id.x) / tiles_per_segment;
+    const int tile_in_seg = int(tg_id.x) % tiles_per_segment;
+    if (seg >= params.num_segments) return;
+
+    const int seg_lo = cu_seqlens[seg];
+    const int seg_hi = cu_seqlens[seg + 1];
+    const int q_base = seg_lo + tile_in_seg * int(Q_TILE);
+    if (q_base >= seg_hi) return;
+    const int q_end   = min(q_base + int(Q_TILE), seg_hi);
+    const int q_count = q_end - q_base;
+
+    // ---- Lane coords within an 8×8 simdgroup_matrix frag ------------------
+    // (MLX BaseMMAFrag::get_coord, the canonical Apple simdgroup_matrix
+    //  layout on Apple GPU 7+.)  Lane owns 1 row × 2 cols at (fm, fn..fn+1).
+    const ushort qid = simd_lane_id / 4;
+    const ushort fm  = (qid & 4) + ((simd_lane_id / 2) % 4);   // 0..7
+    const ushort fn  = (qid & 2) * 2 + (simd_lane_id % 2) * 2; // 0,2,4,6
+
+    // Per-simdgroup row offset.  Each simdgroup owns rows [tm, tm+8).
+    const ushort tm = simd_id * kFragSize;
+
+    // ---- Cooperative load of Q-tile (vectorized, 16-byte) ----------------
+    // Q_smem[q, d] = q[q_base + q, head_idx, d].  HEAD_DIM is a multiple
+    // of VEC_T (=16/sizeof(T)) for every supported head dim, so the
+    // vec read+write are exact-aligned.  Padded rows zero-filled.
+    constexpr uint VEC_T = 16 / sizeof(T);     // 8 (bf16/f16), 4 (f32)
+    static_assert(HEAD_DIM % VEC_T == 0,
+                  "HEAD_DIM must be a multiple of 16/sizeof(T) for vec loads");
+    constexpr uint Q_VECS = (Q_TILE * HEAD_DIM) / VEC_T;
+    for (uint vi = lid; vi < Q_VECS; vi += THREADS) {
+        const uint base = vi * VEC_T;
+        const uint qrow = base / HEAD_DIM;
+        const uint d    = base % HEAD_DIM;
+        threadgroup vec<T, VEC_T>* qdst =
+            reinterpret_cast<threadgroup vec<T, VEC_T>*>(
+                &Q_smem[qrow * LDQ_tgp + d]);
+        if (qrow < uint(q_count)) {
+            const int qi = q_base + int(qrow);
+            *qdst = *reinterpret_cast<const device vec<T, VEC_T>*>(
+                &q[(qi * num_q + head_idx) * HEAD_DIM + d]);
+        } else {
+            *qdst = vec<T, VEC_T>(T(0));
+        }
+    }
+
+    // ---- Per-lane register state ------------------------------------------
+    // Each lane "owns" query row (tm + fm) for the duration of the kernel.
+    // The four lanes that share that row (l, l^1, l^8, l^9) all maintain
+    // the same max_score / sum_score (after the 2-shuffle butterfly).
+    using FragF = vec<float, 2>;
+    float max_score = -INFINITY;
+    float sum_score = 0.0f;
+    FragF o_frags[TD];
+    for (uint dt = 0; dt < TD; ++dt) o_frags[dt] = FragF(0.0f);
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // ---- Tg-memory offsets for fragment loads -----------------------------
+    // Q_smem[(tm + fm) * LDQ_tgp + fn + dd*kFragSize + {0,1}]
+    const uint Qs_offset    = uint(tm + fm) * LDQ_tgp + uint(fn);
+    constexpr uint Qs_d_stride = kFragSize;          // dd advances along d cols
+    // K_smem[(fm + dd*kFragSize) * LDK_tgp + fn + kt*kFragSize + {0,1}]
+    const uint Ks_base      = uint(fm) * LDK_tgp + uint(fn);
+    constexpr uint Ks_d_stride = kFragSize * LDK_tgp; // dd advances along d rows
+    constexpr uint Ks_k_stride = kFragSize;           // kt advances along k cols
+    // V_smem[(fm + ik*kFragSize) * LDV_tgp + fn + id*kFragSize + {0,1}]
+    const uint Vs_base      = uint(fm) * LDV_tgp + uint(fn);
+    constexpr uint Vs_k_stride = kFragSize * LDV_tgp; // ik advances along k rows
+    constexpr uint Vs_d_stride = kFragSize;           // id advances along d cols
+
+    // ========================================== K-tile loop
+    for (int tile_lo = seg_lo; tile_lo < seg_hi; tile_lo += int(K_TILE)) {
+        const int tile_hi = min(tile_lo + int(K_TILE), seg_hi);
+        const int k_count = tile_hi - tile_lo;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- Cooperative load K (transposed; vec read + scatter write) ---
+        // K_smem[d, krow] = K[ki, d].  Reads are vectorized (8 contiguous
+        // d's per device load); writes are scattered into the LDK_tgp-
+        // stride layout and stay scalar.  Net effect: 1/VEC_T fewer
+        // device-mem transactions.
+        constexpr uint K_VECS = (K_TILE * HEAD_DIM) / VEC_T;
+        for (uint vi = lid; vi < K_VECS; vi += THREADS) {
+            const uint base    = vi * VEC_T;
+            const uint krow    = base / HEAD_DIM;
+            const uint d_start = base % HEAD_DIM;
+            vec<T, VEC_T> k_vec;
+            if (krow < uint(k_count)) {
+                const int ki = tile_lo + int(krow);
+                k_vec = *reinterpret_cast<const device vec<T, VEC_T>*>(
+                    &k[(ki * num_kv + head_idx) * HEAD_DIM + d_start]);
+            } else {
+                k_vec = vec<T, VEC_T>(T(0));
+            }
+            for (uint i = 0; i < VEC_T; ++i) {
+                Ks[(d_start + i) * LDK_tgp + krow] = k_vec[i];
+            }
+        }
+
+        // S accumulator (one frag per K-axis 8-block; accumulated across dd)
+        FragF s_frags[TK];
+        for (uint kt = 0; kt < TK; ++kt) s_frags[kt] = FragF(0.0f);
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- S = Q @ K^T via TD × TK MMAs --------------------------------
+        // Outer: dd iterates the shared dim.  Q frag is reused across kt.
+        // simdgroup_barrier(mem_none) bracket every dd for instruction-
+        // ordering hint; inside the kt loop the loads are independent of
+        // the previous MMA and don't need extra barriers.
+        for (uint dd = 0; dd < TD; ++dd) {
+            simdgroup_barrier(mem_flags::mem_none);
+
+            // Load this lane's 1×2 slice of the Q frag at d offset dd*8.
+            FragF q_frag;
+            q_frag.x = float(Q_smem[Qs_offset + dd * Qs_d_stride + 0]);
+            q_frag.y = float(Q_smem[Qs_offset + dd * Qs_d_stride + 1]);
+
+            for (uint kt = 0; kt < TK; ++kt) {
+                FragF k_frag;
+                k_frag.x = float(Ks[Ks_base + dd * Ks_d_stride
+                                            + kt * Ks_k_stride + 0]);
+                k_frag.y = float(Ks[Ks_base + dd * Ks_d_stride
+                                            + kt * Ks_k_stride + 1]);
+
+                simdgroup_float8x8 D_mat, A_mat, B_mat, C_mat;
+                reinterpret_cast<thread FragF&>(A_mat.thread_elements()) = q_frag;
+                reinterpret_cast<thread FragF&>(B_mat.thread_elements()) = k_frag;
+                reinterpret_cast<thread FragF&>(C_mat.thread_elements()) = s_frags[kt];
+                simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat);
+                s_frags[kt] = reinterpret_cast<thread FragF&>(D_mat.thread_elements());
+            }
+        }
+
+        // ---- Apply softmax scale (fold-of-log2e already in `scale`) ------
+        for (uint kt = 0; kt < TK; ++kt) {
+            s_frags[kt] *= scale;
+        }
+
+        // ---- Mask out keys past tile_hi ----------------------------------
+        // Lane owns cols (fn, fn+1) of frag kt at global K positions
+        // (kt*8 + fn, kt*8 + fn + 1).  Set to -INF so exp2 → 0.
+        if (k_count < int(K_TILE)) {
+            for (uint kt = 0; kt < TK; ++kt) {
+                const int col0 = int(kt * kFragSize) + int(fn);
+                if (col0     >= k_count) s_frags[kt].x = -INFINITY;
+                if (col0 + 1 >= k_count) s_frags[kt].y = -INFINITY;
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- Cooperative load V (row-major, vectorized 16-byte) ----------
+        // V_smem[krow, d] = V[ki, d]; row-major writes are vectorizable.
+        constexpr uint V_VECS = (K_TILE * HEAD_DIM) / VEC_T;
+        for (uint vi = lid; vi < V_VECS; vi += THREADS) {
+            const uint base = vi * VEC_T;
+            const uint krow = base / HEAD_DIM;
+            const uint d    = base % HEAD_DIM;
+            threadgroup vec<T, VEC_T>* vdst =
+                reinterpret_cast<threadgroup vec<T, VEC_T>*>(
+                    &Vs[krow * LDV_tgp + d]);
+            if (krow < uint(k_count)) {
+                const int ki = tile_lo + int(krow);
+                *vdst = *reinterpret_cast<const device vec<T, VEC_T>*>(
+                    &v[(ki * num_kv + head_idx) * HEAD_DIM + d]);
+            } else {
+                *vdst = vec<T, VEC_T>(T(0));
+            }
+        }
+
+        // ---- Online softmax (in registers) -------------------------------
+        // Row max: per-frag (xor 1, xor 8) butterfly across the 4 lanes
+        // that share this row, accumulated into `new_max` across all TK
+        // frags.  Final per-row max is identical on all 4 lanes.
+        float new_max = max_score;
+        for (uint kt = 0; kt < TK; ++kt) {
+            float v = max(s_frags[kt].x, s_frags[kt].y);
+            v = max(v, simd_shuffle_xor(v, ushort(1)));
+            v = max(v, simd_shuffle_xor(v, ushort(8)));
+            new_max = max(new_max, v);
+        }
+        // NaN-safe: if every key in this and all prior tiles was masked,
+        // pin new_max to 0 so exp2(s - 0) is well-defined (s == -INF → 0).
+        if (new_max == -INFINITY) new_max = 0.0f;
+
+        const float factor =
+            (max_score == -INFINITY) ? 0.0f : exp2(max_score - new_max);
+        max_score = new_max;
+
+        // P = exp2(S - new_max), in place; lane-local row sum.
+        float sum_score_tmp = 0.0f;
+        for (uint kt = 0; kt < TK; ++kt) {
+            s_frags[kt].x = exp2(s_frags[kt].x - new_max);
+            s_frags[kt].y = exp2(s_frags[kt].y - new_max);
+            sum_score_tmp += s_frags[kt].x + s_frags[kt].y;
+        }
+        sum_score_tmp += simd_shuffle_xor(sum_score_tmp, ushort(1));
+        sum_score_tmp += simd_shuffle_xor(sum_score_tmp, ushort(8));
+
+        sum_score = sum_score * factor + sum_score_tmp;
+
+        // ---- Rescale O by factor (per-lane scalar; no diag-α MMA) -------
+        for (uint dt = 0; dt < TD; ++dt) {
+            o_frags[dt] *= factor;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // ---- O += P @ V via TD × TK MMAs ---------------------------------
+        // O[iq][id] += S[iq][ik] @ V[ik][id], iq fixed at 0 (TQ=1).
+        // ik OUTER / id INNER: within an ik iteration, all TD MMAs hit
+        // distinct o_frags[id] outputs and are independent — gives the
+        // compiler TD parallel MMAs to schedule before the next ik.
+        for (uint ik = 0; ik < TK; ++ik) {
+            for (uint id = 0; id < TD; ++id) {
+                FragF v_frag;
+                v_frag.x = float(Vs[Vs_base + ik * Vs_k_stride
+                                            + id * Vs_d_stride + 0]);
+                v_frag.y = float(Vs[Vs_base + ik * Vs_k_stride
+                                            + id * Vs_d_stride + 1]);
+
+                simdgroup_float8x8 D_mat, A_mat, B_mat, C_mat;
+                reinterpret_cast<thread FragF&>(A_mat.thread_elements()) = s_frags[ik];
+                reinterpret_cast<thread FragF&>(B_mat.thread_elements()) = v_frag;
+                reinterpret_cast<thread FragF&>(C_mat.thread_elements()) = o_frags[id];
+                simdgroup_multiply_accumulate(D_mat, A_mat, B_mat, C_mat);
+                o_frags[id] = reinterpret_cast<thread FragF&>(D_mat.thread_elements());
+            }
+        }
+    }
+
+    // ========================================== Final write
+    // O / l → out, valid query rows only.  Lane (fm, fn) owns query row
+    // (tm + fm) and d cols (id*8 + fn, id*8 + fn + 1) for each id frag.
+    const float inv_l = (sum_score > 0.0f) ? (1.0f / sum_score) : 0.0f;
+    const int q_row_local = int(tm) + int(fm);
+    if (q_row_local < q_count) {
+        const int qi = q_base + q_row_local;
+        device T* out_row = out + (qi * num_q + head_idx) * HEAD_DIM;
+        for (uint id = 0; id < TD; ++id) {
+            out_row[id * kFragSize + fn + 0] = T(o_frags[id].x * inv_l);
+            out_row[id * kFragSize + fn + 1] = T(o_frags[id].y * inv_l);
+        }
+    }
+}
+
+// ========================================== Manual SIMD kernel — f32 fallback
+//
+// f32 elements double tg-memory pressure and a 32×32 MMA tile would blow
+// the 32 KB cap at HEAD_DIM=128, so the f32 path drops to manual SIMD
+// reductions on a smaller (Q_TILE=8, K_TILE=16) tile.  Same online-softmax
+// math as the MMA path, expressed without simdgroup_matrix.
+
+template <typename T, uint HEAD_DIM, uint Q_TILE, uint K_TILE>
+[[kernel]] void encoder_varlen_attention_manual_kernel(
+    device const T*       q           [[buffer(0)]],
+    device const T*       k           [[buffer(1)]],
+    device const T*       v           [[buffer(2)]],
+    device const int*     cu_seqlens  [[buffer(3)]],
+    device       T*       out         [[buffer(4)]],
+    constant     EncoderVarlenParams& params [[buffer(5)]],
+    uint3 tg_id        [[threadgroup_position_in_grid]],
+    uint  lid          [[thread_index_in_threadgroup]],
+    uint  simd_lane_id [[thread_index_in_simdgroup]],
+    uint  simd_id      [[simdgroup_index_in_threadgroup]])
+{
+    constexpr uint THREADS    = 128;
+    constexpr uint NUM_SIMDS  = 4;
+    constexpr uint Q_PER_SIMD = Q_TILE / NUM_SIMDS;
+    static_assert(Q_TILE % NUM_SIMDS == 0,
+                  "Q_TILE must be a multiple of NUM_SIMDS (4)");
+    static_assert(K_TILE <= 32,
+                  "K_TILE > 32 unsupported in v1 (lane = 1 key)");
+
+    threadgroup T     Q_buf[Q_TILE * HEAD_DIM];
+    threadgroup T     K_buf[HEAD_DIM * K_TILE];
+    threadgroup T     V_buf[HEAD_DIM * K_TILE];
+    threadgroup float O_buf[Q_TILE * HEAD_DIM];
+    threadgroup float m_buf[Q_TILE];
+    threadgroup float l_buf[Q_TILE];
+
+    const int head_idx = int(tg_id.y);
+    const int num_q    = params.num_q_heads;
+    const int num_kv   = params.num_kv_heads;
+    const float scale  = params.softmax_scale * M_LOG2E_F;
+
+    const int tiles_per_segment =
+        (params.max_seqlen + int(Q_TILE) - 1) / int(Q_TILE);
+    const int seg         = int(tg_id.x) / tiles_per_segment;
+    const int tile_in_seg = int(tg_id.x) % tiles_per_segment;
+    if (seg >= params.num_segments) return;
+
+    const int seg_lo = cu_seqlens[seg];
+    const int seg_hi = cu_seqlens[seg + 1];
+    const int q_base = seg_lo + tile_in_seg * int(Q_TILE);
+    if (q_base >= seg_hi) return;
+    const int q_end   = min(q_base + int(Q_TILE), seg_hi);
+    const int q_count = q_end - q_base;
+
+    for (uint e = lid; e < Q_TILE * HEAD_DIM; e += THREADS) {
+        const uint qrow = e / HEAD_DIM;
+        const uint d    = e % HEAD_DIM;
+        if (qrow < uint(q_count)) {
+            const int qi = q_base + int(qrow);
+            Q_buf[e] = q[(qi * num_q + head_idx) * HEAD_DIM + d];
+        } else {
+            Q_buf[e] = T(0);
+        }
+    }
+
+    if (lid < Q_TILE) {
+        m_buf[lid] = -INFINITY;
+        l_buf[lid] = 0.0f;
+    }
+    for (uint e = lid; e < Q_TILE * HEAD_DIM; e += THREADS) {
+        O_buf[e] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (int tile_lo = seg_lo; tile_lo < seg_hi; tile_lo += int(K_TILE)) {
+        const int tile_hi = min(tile_lo + int(K_TILE), seg_hi);
+        const int k_count = tile_hi - tile_lo;
+
+        for (uint e = lid; e < K_TILE * HEAD_DIM; e += THREADS) {
+            const uint krow = e / HEAD_DIM;
+            const uint d    = e % HEAD_DIM;
+            const uint dst  = d * K_TILE + krow;
+            if (krow < uint(k_count)) {
+                const int ki = tile_lo + int(krow);
+                K_buf[dst] = k[(ki * num_kv + head_idx) * HEAD_DIM + d];
+                V_buf[dst] = v[(ki * num_kv + head_idx) * HEAD_DIM + d];
+            } else {
+                K_buf[dst] = T(0);
+                V_buf[dst] = T(0);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint local_q = 0; local_q < Q_PER_SIMD; ++local_q) {
+            const uint q_idx = simd_id * Q_PER_SIMD + local_q;
+
+            float s_l;
+            if (simd_lane_id < uint(K_TILE) && simd_lane_id < uint(k_count)) {
+                float dot = 0.0f;
+                for (uint d = 0; d < HEAD_DIM; ++d) {
+                    dot += float(Q_buf[q_idx * HEAD_DIM + d]) *
+                           float(K_buf[d * K_TILE + simd_lane_id]);
+                }
+                s_l = dot * scale;
+            } else {
+                s_l = -INFINITY;
+            }
+
+            const float tile_row_max = simd_max(s_l);
+            const float m_old        = m_buf[q_idx];
+            const float m_new        = max(m_old, tile_row_max);
+            const float alpha        = exp2(m_old - m_new);
+
+            const float p_l    = exp2(s_l - m_new);
+            const float l_sum  = simd_sum(p_l);
+
+            if (simd_lane_id == 0) {
+                m_buf[q_idx] = m_new;
+                l_buf[q_idx] = alpha * l_buf[q_idx] + l_sum;
+            }
+
+            const bool lane_has_key = simd_lane_id < uint(K_TILE);
+            for (uint d = 0; d < HEAD_DIM; ++d) {
+                const float v_ld =
+                    lane_has_key
+                        ? float(V_buf[d * K_TILE + simd_lane_id])
+                        : 0.0f;
+                const float pv_local = p_l * v_ld;
+                const float pv_sum   = simd_sum(pv_local);
+                if (simd_lane_id == 0) {
+                    O_buf[q_idx * HEAD_DIM + d] =
+                        alpha * O_buf[q_idx * HEAD_DIM + d] + pv_sum;
+                }
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (uint e = lid; e < Q_TILE * HEAD_DIM; e += THREADS) {
+        const uint qrow = e / HEAD_DIM;
+        const uint d    = e % HEAD_DIM;
+        if (qrow < uint(q_count)) {
+            const int qi  = q_base + int(qrow);
+            const float o = O_buf[e] / l_buf[qrow];
+            out[(qi * num_q + head_idx) * HEAD_DIM + d] = T(o);
+        }
+    }
+}
+
+// ========================================== Specialization macros
+//
+// bf16/f16 dispatch to the MMA kernel; f32 dispatches to the manual
+// kernel.  All twelve [[host_name]] strings stay in the
+// `encoder_varlen_attention_<dtype>_<head_dim>` format that the C++
+// dispatcher in paged_ops.cpp builds.  The C++ launcher chooses the
+// appropriate (Q_TILE, threadgroup) per dtype:
+//   bf16/f16 → Q_TILE=32, threadgroup=128
+//   f32      → Q_TILE=8,  threadgroup=128
+
+#define instantiate_encoder_varlen_mma(type, type_tag, head_dim) \
+    template [[host_name("encoder_varlen_attention_" #type_tag "_" #head_dim)]] \
+    [[kernel]] void encoder_varlen_attention_mma_kernel<type, head_dim>( \
+        device const type*       q           [[buffer(0)]], \
+        device const type*       k           [[buffer(1)]], \
+        device const type*       v           [[buffer(2)]], \
+        device const int*        cu_seqlens  [[buffer(3)]], \
+        device       type*       out         [[buffer(4)]], \
+        constant     EncoderVarlenParams& params [[buffer(5)]], \
+        uint3 tg_id        [[threadgroup_position_in_grid]], \
+        uint  lid          [[thread_index_in_threadgroup]], \
+        uint  simd_lane_id [[thread_index_in_simdgroup]], \
+        uint  simd_id      [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_encoder_varlen_manual(type, type_tag, head_dim, q_tile, k_tile) \
+    template [[host_name("encoder_varlen_attention_" #type_tag "_" #head_dim)]] \
+    [[kernel]] void encoder_varlen_attention_manual_kernel<type, head_dim, q_tile, k_tile>( \
+        device const type*       q           [[buffer(0)]], \
+        device const type*       k           [[buffer(1)]], \
+        device const type*       v           [[buffer(2)]], \
+        device const int*        cu_seqlens  [[buffer(3)]], \
+        device       type*       out         [[buffer(4)]], \
+        constant     EncoderVarlenParams& params [[buffer(5)]], \
+        uint3 tg_id        [[threadgroup_position_in_grid]], \
+        uint  lid          [[thread_index_in_threadgroup]], \
+        uint  simd_lane_id [[thread_index_in_simdgroup]], \
+        uint  simd_id      [[simdgroup_index_in_threadgroup]]);
+
+#define instantiate_encoder_varlen_mma_set(type, type_tag) \
+    instantiate_encoder_varlen_mma(type, type_tag,  64) \
+    instantiate_encoder_varlen_mma(type, type_tag,  80) \
+    instantiate_encoder_varlen_mma(type, type_tag,  96) \
+    instantiate_encoder_varlen_mma(type, type_tag, 128)
+
+#define instantiate_encoder_varlen_manual_set(type, type_tag) \
+    instantiate_encoder_varlen_manual(type, type_tag,  64, 8, 16) \
+    instantiate_encoder_varlen_manual(type, type_tag,  80, 8, 16) \
+    instantiate_encoder_varlen_manual(type, type_tag,  96, 8, 16) \
+    instantiate_encoder_varlen_manual(type, type_tag, 128, 8, 16)
+
+instantiate_encoder_varlen_mma_set(half,       f16)
+instantiate_encoder_varlen_mma_set(bfloat16_t, bf16)
+instantiate_encoder_varlen_manual_set(float,   f32)

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -9,6 +9,7 @@
 // RTTI matching which fails due to hidden symbol visibility in libmlx.
 
 #include <algorithm>
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -1131,6 +1132,358 @@ void gdn_linear_attention_impl(
   add_temporary_compat(enc, y, d, s);
 }
 // ---------------------------------------------------------------------------
+// Encoder varlen attention — dense non-causal varlen attention.
+// ---------------------------------------------------------------------------
+
+// Encoder varlen attention — dense non-causal varlen attention.
+//
+// Wrapped as a real MLX UnaryPrimitive so the kernel dispatch carries graph
+// provenance through the lazy graph (mirroring the PagedAttentionPrimitive
+// class above).  The primitive is read-only: Q/K/V/cu_seqlens go in, a fresh
+// output array comes out.  Validation lives in two layers: the Python
+// helper at vllm_metal.metal.encoder_varlen_attention rejects bad shapes /
+// dtypes / cu_seqlens before launch; eval_gpu enforces row-contiguity on
+// every input array (the only layer that can — the Python mx.array surface
+// does not expose flags().row_contiguous).
+// ---------------------------------------------------------------------------
+
+static std::string encoder_varlen_source_;
+static bool encoder_varlen_library_initialized_ = false;
+
+void init_encoder_varlen_library(const std::string& src) {
+  // The MLX library cache (Device::library_map_) is name-keyed: a second
+  // get_library("encoder_varlen_kern", ...) call hits the cache and never
+  // re-reads the source.  The Python layer's _encoder_varlen_loaded flag
+  // gates Python callers, but this binding is part of the public C++ API
+  // and a direct caller bypasses that gate.  Guard explicitly here so the
+  // actual behavior is visible at the call site.
+  if (encoder_varlen_library_initialized_) {
+    if (src != encoder_varlen_source_) {
+      throw std::runtime_error(
+          "init_encoder_varlen_library called twice with different source; "
+          "MLX library cache is name-keyed and will not pick up the new "
+          "source. Restart the interpreter to recompile.");
+    }
+    return;
+  }
+  encoder_varlen_source_ = src;
+  auto& d = metal::device(Device::gpu);
+  d.get_library(
+      "encoder_varlen_kern",
+      [&]() { return encoder_varlen_source_; });
+  // Set the flag only after get_library returns successfully so a Metal
+  // compile failure leaves the slot retryable rather than wedged.
+  encoder_varlen_library_initialized_ = true;
+}
+
+// Hand-mirrored on the .metal side at
+// kernels_v2/encoder_varlen_attention.metal.  Field order is part of the
+// ABI; do not reorder without updating both files in lockstep.  We do not
+// stuff this into a project-local header because needs_rebuild() in
+// build.py only stats paged_ops.cpp / build.py / constants.py — header-only
+// edits would silently fail to trigger an .so rebuild.
+struct EncoderVarlenParams {
+  int   num_q_heads;
+  int   num_kv_heads;
+  int   total_tokens;
+  int   num_segments;   // == cu_seqlens.shape[0] - 1; binary-search bound.
+  // Reserved ABI: launch hint only; not used to bound indexing in the
+  // current kernel.  Intentionally excluded from is_equivalent (see below).
+  // If a future kernel reads this in a way that affects output, dispatch
+  // shape, or scratch sizing, it MUST be added to is_equivalent — otherwise
+  // two calls with different max_seqlen values will alias in the lazy graph.
+  int   max_seqlen;
+  float softmax_scale;
+};
+
+// ABI tripwires for the .metal-side struct mirror.  Per-field offsetof is
+// stronger than size-only: a same-size reorder (e.g. swapping two int fields)
+// would slip past sizeof but break field decoding in-kernel.  needs_rebuild()
+// in build.py only stats the .cpp, so a struct edit here is the only way to
+// force an .so rebuild and surface this check at compile time.
+static_assert(offsetof(EncoderVarlenParams, num_q_heads)   ==  0,
+              "EncoderVarlenParams ABI drift: num_q_heads offset changed");
+static_assert(offsetof(EncoderVarlenParams, num_kv_heads)  ==  4,
+              "EncoderVarlenParams ABI drift: num_kv_heads offset changed");
+static_assert(offsetof(EncoderVarlenParams, total_tokens)  ==  8,
+              "EncoderVarlenParams ABI drift: total_tokens offset changed");
+static_assert(offsetof(EncoderVarlenParams, num_segments)  == 12,
+              "EncoderVarlenParams ABI drift: num_segments offset changed");
+static_assert(offsetof(EncoderVarlenParams, max_seqlen)    == 16,
+              "EncoderVarlenParams ABI drift: max_seqlen offset changed");
+static_assert(offsetof(EncoderVarlenParams, softmax_scale) == 20,
+              "EncoderVarlenParams ABI drift: softmax_scale offset changed");
+static_assert(sizeof(EncoderVarlenParams) == 24,
+              "EncoderVarlenParams ABI drift: struct size changed; "
+              "update kernels_v2/encoder_varlen_attention.metal in lockstep");
+
+class EncoderVarlenAttentionPrimitive : public UnaryPrimitive {
+ public:
+  EncoderVarlenAttentionPrimitive(
+      Stream stream,
+      int num_kv_heads,
+      float softmax_scale,
+      int dtype_tag,
+      int head_dim,
+      int max_seqlen)
+      : UnaryPrimitive(stream),
+        num_kv_heads_(num_kv_heads),
+        softmax_scale_(softmax_scale),
+        dtype_tag_(dtype_tag),
+        head_dim_(head_dim),
+        max_seqlen_(max_seqlen) {}
+
+  void eval_cpu(const std::vector<array>&, array&) override {
+    throw std::runtime_error(
+        "EncoderVarlenAttentionPrimitive only supports GPU");
+  }
+
+  void eval_gpu(const std::vector<array>& inputs, array& out) override {
+    const auto& q          = inputs[0];
+    const auto& k          = inputs[1];
+    const auto& v          = inputs[2];
+    const auto& cu_seqlens = inputs[3];
+
+    // Defense-in-depth: the Python helper does not (and cannot) check
+    // contiguity, so this is the only layer that catches non-row-contiguous
+    // inputs.  Run before set_data so a rejected call does not leak a
+    // freshly-allocated output buffer.
+    if (!q.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q must be row-contiguous "
+          "(wrap upstream in mx.contiguous(...) before calling).");
+    }
+    if (!k.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: k must be row-contiguous.");
+    }
+    if (!v.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: v must be row-contiguous.");
+    }
+    if (!cu_seqlens.flags().row_contiguous) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must be row-contiguous.");
+    }
+
+    // Defense-in-depth: the Python helper validates shape / dtype /
+    // num_kv_heads, but a caller that drives the underscore-prefixed
+    // _encoder_varlen_attention_primitive binding directly bypasses that.
+    // Re-check the structural invariants the kernel relies on so a
+    // bypass surfaces as a clean throw rather than silent K/V misindexing
+    // in-kernel.  Value-level checks (cu_seqlens monotonicity /
+    // final-token-count) are intentionally not re-checked here — those
+    // belong in the helper, and the binding's docstring marks it internal.
+    // cu_seqlens dtype / ndim / shape and q/k/v dtype-match ARE re-checked
+    // below: all of them are load-fatal failure modes through the kernel's
+    // typed bindings (int* for cu_seqlens; a single template parameter T
+    // for q/k/v, selected from q.dtype() only — a mismatched k/v would
+    // mis-stride the load against the resource binding).
+    if (q.ndim() != 3 || k.ndim() != 3 || v.ndim() != 3) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q, k, v must each be 3-D "
+          "[total_tokens, num_heads, head_dim].");
+    }
+    if (k.shape(0) != q.shape(0) || v.shape(0) != q.shape(0) ||
+        k.shape(2) != q.shape(2) || v.shape(2) != q.shape(2) ||
+        k.shape(1) != q.shape(1) || v.shape(1) != q.shape(1)) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q, k, v must share the same shape "
+          "(v1 requires num_q_heads == num_kv_heads).");
+    }
+    if (k.dtype() != q.dtype() || v.dtype() != q.dtype()) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: q, k, v must share dtype "
+          "(kernel template binds all three to the same T, selected from "
+          "q.dtype() only; a mismatched k/v dtype mis-strides the load "
+          "against the resource binding and may read past the K/V buffer).");
+    }
+    if (static_cast<int>(k.shape(1)) != num_kv_heads_) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: num_kv_heads parameter does not "
+          "match k.shape(1); kernel would silently misindex K/V.");
+    }
+    if (static_cast<int>(q.shape(2)) != head_dim_) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: head_dim parameter does not "
+          "match q.shape(2).");
+    }
+    // cu_seqlens dtype / shape / rank: the kernel binding is
+    // `device const int*`, and find_segment dereferences cu_seqlens[seg + 1]
+    // up through cu_seqlens[num_segments].  A non-int32 dtype mis-strides
+    // the load (4-byte stride read as 8 / 2 bytes); ndim != 1 silently
+    // mis-strides the load; shape(0) < 2 → num_segments <= 0 and the very
+    // first dereference is out-of-bounds.  The Python helper enforces all
+    // three on the raw and ValidatedSeqlens paths; these guards catch
+    // direct callers of the underscore binding that bypass those layers.
+    if (cu_seqlens.dtype() != int32) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must have dtype int32 "
+          "(kernel binding is device const int*; any other element width "
+          "would mis-stride the load).");
+    }
+    if (cu_seqlens.ndim() != 1) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must be 1-D "
+          "(kernel binding is device const int*; any other rank "
+          "would mis-stride the load).");
+    }
+    if (cu_seqlens.shape(0) < 2) {
+      throw std::invalid_argument(
+          "encoder_varlen_attention: cu_seqlens must have at least 2 "
+          "entries (num_segments + 1); the kernel reads cu_seqlens[seg + 1] "
+          "in find_segment and would dereference out of bounds.");
+    }
+
+    // Allocate output via the MLX allocator (mirroring
+    // PagedAttentionPrimitive::eval_gpu's set_data + allocator::malloc
+    // pattern).  This is the array whose descriptor the
+    // _encoder_varlen_attention_primitive binding's overwrite_descriptor
+    // call publishes back to Python — the cross-module RTTI bypass path
+    // documented at the top of this file.
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const int total_tokens = static_cast<int>(q.shape(0));
+    const int num_q_heads  = static_cast<int>(q.shape(1));
+    const int num_segments = static_cast<int>(cu_seqlens.shape(0)) - 1;
+
+    EncoderVarlenParams params{};
+    params.num_q_heads   = num_q_heads;
+    params.num_kv_heads  = num_kv_heads_;
+    params.total_tokens  = total_tokens;
+    params.num_segments  = num_segments;
+    params.max_seqlen    = max_seqlen_;
+    params.softmax_scale = softmax_scale_;
+
+    const char* dtype_tag = nullptr;
+    switch (dtype_tag_) {
+      case 0: dtype_tag = "f16";  break;
+      case 1: dtype_tag = "bf16"; break;
+      case 2: dtype_tag = "f32";  break;
+      default:
+        throw std::runtime_error(
+            "Unknown dtype_tag in EncoderVarlenAttentionPrimitive");
+    }
+    const std::string kname =
+        "encoder_varlen_attention_" + std::string(dtype_tag) + "_" +
+        std::to_string(head_dim_);
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+    auto* lib = d.get_library("encoder_varlen_kern");
+    auto* kernel = d.get_kernel(kname, lib, kname, {});
+
+    auto& enc = get_command_encoder_compat(d, s);
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_input_array(q, 0);
+    enc.set_input_array(k, 1);
+    enc.set_input_array(v, 2);
+    enc.set_input_array(cu_seqlens, 3);
+    enc.set_output_array(out, 4);
+    enc.set_bytes(params, 5);
+
+    // Grid: segment-pitched Q-tile grid.  Each threadgroup owns one
+    // Q-tile (Q_TILE consecutive queries from a single segment, same
+    // q_head).  Tiles past seg_hi are over-launched and early-exit in
+    // the kernel — the pitch is `tiles_per_segment = ceil(max_seqlen /
+    // Q_TILE)` so every active threadgroup stays on exactly one segment
+    // and the kernel can decode (seg, tile_in_seg) from tg_id.x by
+    // simple division.  Per-dtype Q_TILE:
+    //   bf16/f16 → 32 (MMA path; 4 simdgroups × 8 queries = 8x8 MMA tile)
+    //   f32      →  8 (manual-SIMD fallback; smaller because fp32 elements
+    //                 double tg-memory pressure → 32×32 doesn't fit at hd128).
+    // Threadgroup width:
+    //   bf16/f16 (M3 MMA path) → 256 = 8 simdgroups, each owning 8 query
+    //                             rows; doubled Q_TILE amortises K-tile
+    //                             cooperative loads over twice the queries.
+    //   f32 (manual fallback) → 128 = 4 simdgroups, smaller tile.
+    const int q_tile             = (dtype_tag_ == 2) ? 8 : 64;
+    const int threadgroup_width  = (dtype_tag_ == 2) ? 128 : 256;
+    const int tiles_per_segment  = (max_seqlen_ + q_tile - 1) / q_tile;
+    const int x_dim              = num_segments * tiles_per_segment;
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(x_dim, num_q_heads, 1),
+        MTL::Size::Make(threadgroup_width, 1, 1));
+
+    // No add_temporary calls: inside a primitive, MLX's evaluator manages
+    // array lifetimes via the completion handler, and add_temporary would
+    // strip buffer pointers from the encoder's input/output tracking and
+    // silently defeat the fence for downstream primitives.
+  }
+
+  const char* name() const override { return "EncoderVarlenAttention"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    auto* rhs = dynamic_cast<const EncoderVarlenAttentionPrimitive*>(&other);
+    return rhs
+        && rhs->num_kv_heads_  == num_kv_heads_
+        && rhs->softmax_scale_ == softmax_scale_
+        && rhs->dtype_tag_     == dtype_tag_
+        && rhs->head_dim_      == head_dim_
+        && rhs->max_seqlen_    == max_seqlen_;
+    // max_seqlen_ IS part of the equivalence: the tiled kernel uses it
+    // as the segment-pitched grid pitch (tiles_per_segment =
+    // ceil(max_seqlen / Q_TILE)).  Two primitives with different
+    // max_seqlen_ would over-launch by different amounts and decode
+    // (seg, tile_in_seg) from tg_id.x differently, so they are NOT
+    // interchangeable for caching purposes.
+  }
+
+ private:
+  int   num_kv_heads_;
+  float softmax_scale_;
+  int   dtype_tag_;
+  int   head_dim_;
+  int   max_seqlen_;
+};
+
+static int encoder_varlen_dtype_to_tag(Dtype dt) {
+  switch (dt) {
+    case float16:  return 0;
+    case bfloat16: return 1;
+    case float32:  return 2;
+    default:
+      throw std::runtime_error(
+          "Unsupported dtype for encoder_varlen_attention "
+          "(supported: float16, bfloat16, float32)");
+  }
+}
+
+static array encoder_varlen_attention_primitive_fn(
+    const array& q,
+    const array& k,
+    const array& v,
+    const array& cu_seqlens,
+    int num_kv_heads,
+    float softmax_scale,
+    int max_seqlen) {
+  // Rank guard before q.shape(2): a direct underscore-binding caller with
+  // ndim < 3 would otherwise hit MLX's low-level out-of-range from shape()
+  // here, before eval_gpu's "must each be 3-D" check could fire.  Same
+  // message as eval_gpu so callers see one consistent error regardless of
+  // path.  k/v rank stays in eval_gpu since they aren't accessed here.
+  if (q.ndim() != 3) {
+    throw std::invalid_argument(
+        "encoder_varlen_attention: q, k, v must each be 3-D "
+        "[total_tokens, num_heads, head_dim].");
+  }
+  const int dtype_tag = encoder_varlen_dtype_to_tag(q.dtype());
+  const int head_dim  = static_cast<int>(q.shape(2));
+  auto prim = std::make_shared<EncoderVarlenAttentionPrimitive>(
+      default_stream(Device::gpu),
+      num_kv_heads,
+      softmax_scale,
+      dtype_tag,
+      head_dim,
+      max_seqlen);
+  return array(
+      q.shape(),
+      q.dtype(),
+      std::move(prim),
+      {q, k, v, cu_seqlens});
+}
+
+// ---------------------------------------------------------------------------
 // nanobind module
 // ---------------------------------------------------------------------------
 
@@ -1315,5 +1668,39 @@ NB_MODULE(_paged_ops, m) {
         "in the wrapper's lazy graph and avoids the per-call mx.eval "
         "boundary the eager binding requires. Saves ~200 μs at B=1 "
         "small-H cells where dispatch overhead dominates.");
+
+
+  m.def("init_encoder_varlen_library", &init_encoder_varlen_library,
+        nb::arg("src"),
+        "JIT-compile the dense non-causal varlen encoder attention shader.");
+
+  m.def("_encoder_varlen_attention_primitive",
+        [](nb::handle q_h,
+           nb::handle k_h,
+           nb::handle v_h,
+           nb::handle cu_seqlens_h,
+           int num_kv_heads,
+           float softmax_scale,
+           int max_seqlen,
+           nb::handle out_h) {
+          auto result = encoder_varlen_attention_primitive_fn(
+              *nb::inst_ptr<array>(q_h),
+              *nb::inst_ptr<array>(k_h),
+              *nb::inst_ptr<array>(v_h),
+              *nb::inst_ptr<array>(cu_seqlens_h),
+              num_kv_heads,
+              softmax_scale,
+              max_seqlen);
+          nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
+        },
+        nb::arg("q"),
+        nb::arg("k"),
+        nb::arg("v"),
+        nb::arg("cu_seqlens"),
+        nb::arg("num_kv_heads"),
+        nb::arg("softmax_scale"),
+        nb::arg("max_seqlen"),
+        nb::arg("out"),
+        "Internal: call via vllm_metal.metal.encoder_varlen_attention.");
 
 }

--- a/vllm_metal/multimodal/fused_vit_attention.py
+++ b/vllm_metal/multimodal/fused_vit_attention.py
@@ -101,6 +101,20 @@ def _fused_varlen_attention(
     return out
 
 
+def _apply_rotary_pos_emb_vision_shd(
+    tensor: mx.array,
+    freqs: mx.array,
+) -> mx.array:
+    """RoPE for ``[total_tokens, num_heads, head_dim]`` without batch dim churn."""
+    from mlx_vlm.models.qwen3_vl.vision import rotate_half
+
+    orig_dtype = tensor.dtype
+    cos = mx.tile(mx.expand_dims(mx.cos(freqs), axis=1), (1, 1, 2))
+    sin = mx.tile(mx.expand_dims(mx.sin(freqs), axis=1), (1, 1, 2))
+    output = (tensor * cos) + (rotate_half(tensor) * sin)
+    return output.astype(orig_dtype)
+
+
 def _qkv_to_shd(qkv: mx.array) -> tuple[mx.array, mx.array, mx.array]:
     """``[S, 3, H, D]`` linear output -> Q/K/V in ``[S, H, D]``."""
     return qkv[:, 0], qkv[:, 1], qkv[:, 2]
@@ -115,6 +129,20 @@ def _shd_to_bhsd(
     return q.transpose(1, 0, 2)[None], k.transpose(1, 0, 2)[None], v.transpose(1, 0, 2)[None]
 
 
+def _fused_rope_varlen_core(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    freqs: mx.array,
+    cu_seqlens: mx.array,
+    scale: float,
+) -> mx.array:
+    """RoPE + varlen attention on ``[S, H, D]`` tensors."""
+    q = _apply_rotary_pos_emb_vision_shd(q, freqs)
+    k = _apply_rotary_pos_emb_vision_shd(k, freqs)
+    return _fused_varlen_attention(q, k, v, cu_seqlens, scale)
+
+
 def qwen3_vl_vision_attention_forward(
     attn,
     x: mx.array,
@@ -122,6 +150,7 @@ def qwen3_vl_vision_attention_forward(
     rotary_pos_emb: mx.array | None = None,
     *,
     use_fused_varlen: bool = False,
+    use_fused_rope_varlen: bool = False,
 ) -> mx.array:
     """Qwen3-VL vision ``Attention`` forward with selectable attention core."""
     from mlx_vlm.models.qwen3_vl.vision import apply_rotary_pos_emb_vision
@@ -130,13 +159,19 @@ def qwen3_vl_vision_attention_forward(
     qkv = attn.qkv(x).reshape(seq_length, 3, attn.num_heads, -1)
     q, k, v = _qkv_to_shd(qkv)
 
-    q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
-    k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
-
-    if use_fused_varlen:
+    if use_fused_varlen and use_fused_rope_varlen:
+        core = _fused_rope_varlen_core(
+            q, k, v, rotary_pos_emb, cu_seqlens, attn.scale
+        )
+        output = core.reshape(seq_length, -1)
+    elif use_fused_varlen:
+        q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
+        k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
         core = _fused_varlen_attention(q, k, v, cu_seqlens, attn.scale)
         output = core.reshape(seq_length, -1)
     else:
+        q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
+        k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
         q, k, v = _shd_to_bhsd(q, k, v)
         core = _baseline_segment_attention(q, k, v, cu_seqlens, attn.scale)
         output = core.transpose(0, 2, 1, 3).reshape(seq_length, -1)
@@ -164,6 +199,7 @@ def patch_qwen3_vl_vision_attention() -> None:
             cu_seqlens,
             rotary_pos_emb,
             use_fused_varlen=True,
+            use_fused_rope_varlen=True,
         )
 
     vision.Attention.__call__ = _patched_call

--- a/vllm_metal/multimodal/fused_vit_attention.py
+++ b/vllm_metal/multimodal/fused_vit_attention.py
@@ -62,7 +62,10 @@ def _fused_varlen_attention(
     cu_seqlens: mx.array,
     scale: float,
 ) -> mx.array:
-    """Single-call dense varlen encoder attention (Metal primitive)."""
+    """Single-call dense varlen encoder attention (Metal primitive).
+
+    Expects Q/K/V in kernel-native ``[total_tokens, num_heads, head_dim]`` layout.
+    """
     import numpy as np
 
     from vllm_metal.metal import encoder_varlen_attention
@@ -70,26 +73,22 @@ def _fused_varlen_attention(
     head_dim = int(q.shape[-1])
     q, k, v, head_dim, orig_head_dim = _pad_head_dim_if_needed(q, k, v, head_dim)
 
-    q_pack = q[0].transpose(1, 0, 2)
-    k_pack = k[0].transpose(1, 0, 2)
-    v_pack = v[0].transpose(1, 0, 2)
-
     orig_dtype = q.dtype
     kernel_dtype = (
         orig_dtype if orig_dtype in (mx.float16, mx.bfloat16) else mx.bfloat16
     )
-    if q_pack.dtype != kernel_dtype:
-        q_pack = q_pack.astype(kernel_dtype)
-        k_pack = k_pack.astype(kernel_dtype)
-        v_pack = v_pack.astype(kernel_dtype)
+    if q.dtype != kernel_dtype:
+        q = q.astype(kernel_dtype)
+        k = k.astype(kernel_dtype)
+        v = v.astype(kernel_dtype)
 
     bounds = [int(x) for x in np.asarray(cu_seqlens)]
     max_seqlen = max(bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1))
 
     out = encoder_varlen_attention(
-        q_pack,
-        k_pack,
-        v_pack,
+        q,
+        k,
+        v,
         cu_seqlens,
         max_seqlen=max_seqlen,
         softmax_scale=scale,
@@ -99,7 +98,21 @@ def _fused_varlen_attention(
     if out.dtype != orig_dtype:
         out = out.astype(orig_dtype)
 
-    return out.transpose(1, 0, 2)[None]
+    return out
+
+
+def _qkv_to_shd(qkv: mx.array) -> tuple[mx.array, mx.array, mx.array]:
+    """``[S, 3, H, D]`` linear output -> Q/K/V in ``[S, H, D]``."""
+    return qkv[:, 0], qkv[:, 1], qkv[:, 2]
+
+
+def _shd_to_bhsd(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+) -> tuple[mx.array, mx.array, mx.array]:
+    """``[S, H, D]`` -> ``[1, H, S, D]`` for baseline SDPA."""
+    return q.transpose(1, 0, 2)[None], k.transpose(1, 0, 2)[None], v.transpose(1, 0, 2)[None]
 
 
 def qwen3_vl_vision_attention_forward(
@@ -114,22 +127,20 @@ def qwen3_vl_vision_attention_forward(
     from mlx_vlm.models.qwen3_vl.vision import apply_rotary_pos_emb_vision
 
     seq_length = x.shape[0]
-    qkv = attn.qkv(x).reshape(seq_length, 3, attn.num_heads, -1).transpose(1, 0, 2, 3)
-    q, k, v = mx.split(qkv, 3)
+    qkv = attn.qkv(x).reshape(seq_length, 3, attn.num_heads, -1)
+    q, k, v = _qkv_to_shd(qkv)
 
     q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
     k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
 
-    q = q.transpose(0, 2, 1, 3)
-    k = k.transpose(0, 2, 1, 3)
-    v = v.transpose(0, 2, 1, 3)
-
     if use_fused_varlen:
         core = _fused_varlen_attention(q, k, v, cu_seqlens, attn.scale)
+        output = core.reshape(seq_length, -1)
     else:
+        q, k, v = _shd_to_bhsd(q, k, v)
         core = _baseline_segment_attention(q, k, v, cu_seqlens, attn.scale)
+        output = core.transpose(0, 2, 1, 3).reshape(seq_length, -1)
 
-    output = core.transpose(0, 2, 1, 3).reshape(seq_length, -1)
     return attn.proj(output)
 
 

--- a/vllm_metal/multimodal/fused_vit_attention.py
+++ b/vllm_metal/multimodal/fused_vit_attention.py
@@ -14,6 +14,18 @@ _FUSED_SDPA_PAD_TARGETS = (64, 80, 128)
 _PATCHED = False
 
 
+def _infer_max_segment_len(
+    cu_seqlens: mx.array,
+    *,
+    max_seqlen: int | None = None,
+) -> int:
+    """Longest segment length for kernel launch; one sync when not provided."""
+    if max_seqlen is not None:
+        return max_seqlen
+    diffs = cu_seqlens[1:] - cu_seqlens[:-1]
+    return int(mx.max(diffs).item())
+
+
 def _baseline_segment_attention(
     q: mx.array,
     k: mx.array,
@@ -61,13 +73,13 @@ def _fused_varlen_attention(
     v: mx.array,
     cu_seqlens: mx.array,
     scale: float,
+    *,
+    max_seqlen: int | None = None,
 ) -> mx.array:
     """Single-call dense varlen encoder attention (Metal primitive).
 
     Expects Q/K/V in kernel-native ``[total_tokens, num_heads, head_dim]`` layout.
     """
-    import numpy as np
-
     from vllm_metal.metal import encoder_varlen_attention
 
     head_dim = int(q.shape[-1])
@@ -82,15 +94,14 @@ def _fused_varlen_attention(
         k = k.astype(kernel_dtype)
         v = v.astype(kernel_dtype)
 
-    bounds = [int(x) for x in np.asarray(cu_seqlens)]
-    max_seqlen = max(bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1))
+    launch_max_seqlen = _infer_max_segment_len(cu_seqlens, max_seqlen=max_seqlen)
 
     out = encoder_varlen_attention(
         q,
         k,
         v,
         cu_seqlens,
-        max_seqlen=max_seqlen,
+        max_seqlen=launch_max_seqlen,
         softmax_scale=scale,
     )
     if orig_head_dim is not None:
@@ -140,11 +151,13 @@ def _fused_rope_varlen_core(
     freqs: mx.array,
     cu_seqlens: mx.array,
     scale: float,
+    *,
+    max_seqlen: int | None = None,
 ) -> mx.array:
     """RoPE + varlen attention on ``[S, H, D]`` tensors."""
     q = _apply_rotary_pos_emb_vision_shd(q, freqs)
     k = _apply_rotary_pos_emb_vision_shd(k, freqs)
-    return _fused_varlen_attention(q, k, v, cu_seqlens, scale)
+    return _fused_varlen_attention(q, k, v, cu_seqlens, scale, max_seqlen=max_seqlen)
 
 
 def qwen3_vl_vision_attention_forward(
@@ -155,6 +168,7 @@ def qwen3_vl_vision_attention_forward(
     *,
     use_fused_varlen: bool = False,
     use_fused_rope_varlen: bool = False,
+    max_seqlen: int | None = None,
 ) -> mx.array:
     """Qwen3-VL vision ``Attention`` forward with selectable attention core."""
     from mlx_vlm.models.qwen3_vl.vision import apply_rotary_pos_emb_vision
@@ -164,12 +178,22 @@ def qwen3_vl_vision_attention_forward(
     q, k, v = _qkv_to_shd(qkv)
 
     if use_fused_varlen and use_fused_rope_varlen:
-        core = _fused_rope_varlen_core(q, k, v, rotary_pos_emb, cu_seqlens, attn.scale)
+        core = _fused_rope_varlen_core(
+            q,
+            k,
+            v,
+            rotary_pos_emb,
+            cu_seqlens,
+            attn.scale,
+            max_seqlen=max_seqlen,
+        )
         output = core.reshape(seq_length, -1)
     elif use_fused_varlen:
         q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
         k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
-        core = _fused_varlen_attention(q, k, v, cu_seqlens, attn.scale)
+        core = _fused_varlen_attention(
+            q, k, v, cu_seqlens, attn.scale, max_seqlen=max_seqlen
+        )
         output = core.reshape(seq_length, -1)
     else:
         q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]

--- a/vllm_metal/multimodal/fused_vit_attention.py
+++ b/vllm_metal/multimodal/fused_vit_attention.py
@@ -126,7 +126,11 @@ def _shd_to_bhsd(
     v: mx.array,
 ) -> tuple[mx.array, mx.array, mx.array]:
     """``[S, H, D]`` -> ``[1, H, S, D]`` for baseline SDPA."""
-    return q.transpose(1, 0, 2)[None], k.transpose(1, 0, 2)[None], v.transpose(1, 0, 2)[None]
+    return (
+        q.transpose(1, 0, 2)[None],
+        k.transpose(1, 0, 2)[None],
+        v.transpose(1, 0, 2)[None],
+    )
 
 
 def _fused_rope_varlen_core(
@@ -160,9 +164,7 @@ def qwen3_vl_vision_attention_forward(
     q, k, v = _qkv_to_shd(qkv)
 
     if use_fused_varlen and use_fused_rope_varlen:
-        core = _fused_rope_varlen_core(
-            q, k, v, rotary_pos_emb, cu_seqlens, attn.scale
-        )
+        core = _fused_rope_varlen_core(q, k, v, rotary_pos_emb, cu_seqlens, attn.scale)
         output = core.reshape(seq_length, -1)
     elif use_fused_varlen:
         q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]

--- a/vllm_metal/multimodal/fused_vit_attention.py
+++ b/vllm_metal/multimodal/fused_vit_attention.py
@@ -74,6 +74,15 @@ def _fused_varlen_attention(
     k_pack = k[0].transpose(1, 0, 2)
     v_pack = v[0].transpose(1, 0, 2)
 
+    orig_dtype = q.dtype
+    kernel_dtype = (
+        orig_dtype if orig_dtype in (mx.float16, mx.bfloat16) else mx.bfloat16
+    )
+    if q_pack.dtype != kernel_dtype:
+        q_pack = q_pack.astype(kernel_dtype)
+        k_pack = k_pack.astype(kernel_dtype)
+        v_pack = v_pack.astype(kernel_dtype)
+
     bounds = [int(x) for x in np.asarray(cu_seqlens)]
     max_seqlen = max(bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1))
 
@@ -87,6 +96,8 @@ def _fused_varlen_attention(
     )
     if orig_head_dim is not None:
         out = out[..., :orig_head_dim]
+    if out.dtype != orig_dtype:
+        out = out.astype(orig_dtype)
 
     return out.transpose(1, 0, 2)[None]
 

--- a/vllm_metal/multimodal/fused_vit_attention.py
+++ b/vllm_metal/multimodal/fused_vit_attention.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3-VL vision-tower attention wiring for encoder varlen attention."""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_ENCODER_VARLEN_HEAD_DIMS = frozenset({64, 80, 96, 128})
+_FUSED_SDPA_PAD_TARGETS = (64, 80, 128)
+_PATCHED = False
+
+
+def _baseline_segment_attention(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    cu_seqlens: mx.array,
+    scale: float,
+) -> mx.array:
+    """Per-segment ``ensure_fused_sdpa`` loop (mlx_vlm baseline)."""
+    from mlx_vlm.models.base import ensure_fused_sdpa
+
+    splits = [
+        mx.split(tensor, cu_seqlens[1:-1].tolist(), axis=2) for tensor in (q, k, v)
+    ]
+    attn_outputs = [
+        ensure_fused_sdpa(q_seg, k_seg, v_seg, scale)
+        for q_seg, k_seg, v_seg in zip(*splits, strict=True)
+    ]
+    return mx.concatenate(attn_outputs, axis=2)
+
+
+def _pad_head_dim_if_needed(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    head_dim: int,
+) -> tuple[mx.array, mx.array, mx.array, int, int | None]:
+    """Pad Q/K/V head dim to a supported encoder-varlen specialization."""
+    if head_dim in _ENCODER_VARLEN_HEAD_DIMS:
+        return q, k, v, head_dim, None
+
+    target = next((t for t in _FUSED_SDPA_PAD_TARGETS if head_dim <= t), None)
+    if target is None:
+        raise ValueError(
+            "fused ViT attention: unsupported head_dim "
+            f"{head_dim} (supported: {sorted(_ENCODER_VARLEN_HEAD_DIMS)})."
+        )
+
+    pad = [(0, 0)] * (q.ndim - 1) + [(0, target - head_dim)]
+    return mx.pad(q, pad), mx.pad(k, pad), mx.pad(v, pad), target, head_dim
+
+
+def _fused_varlen_attention(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    cu_seqlens: mx.array,
+    scale: float,
+) -> mx.array:
+    """Single-call dense varlen encoder attention (Metal primitive)."""
+    import numpy as np
+
+    from vllm_metal.metal import encoder_varlen_attention
+
+    head_dim = int(q.shape[-1])
+    q, k, v, head_dim, orig_head_dim = _pad_head_dim_if_needed(q, k, v, head_dim)
+
+    q_pack = q[0].transpose(1, 0, 2)
+    k_pack = k[0].transpose(1, 0, 2)
+    v_pack = v[0].transpose(1, 0, 2)
+
+    bounds = [int(x) for x in np.asarray(cu_seqlens)]
+    max_seqlen = max(bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1))
+
+    out = encoder_varlen_attention(
+        q_pack,
+        k_pack,
+        v_pack,
+        cu_seqlens,
+        max_seqlen=max_seqlen,
+        softmax_scale=scale,
+    )
+    if orig_head_dim is not None:
+        out = out[..., :orig_head_dim]
+
+    return out.transpose(1, 0, 2)[None]
+
+
+def qwen3_vl_vision_attention_forward(
+    attn,
+    x: mx.array,
+    cu_seqlens: mx.array,
+    rotary_pos_emb: mx.array | None = None,
+    *,
+    use_fused_varlen: bool = False,
+) -> mx.array:
+    """Qwen3-VL vision ``Attention`` forward with selectable attention core."""
+    from mlx_vlm.models.qwen3_vl.vision import apply_rotary_pos_emb_vision
+
+    seq_length = x.shape[0]
+    qkv = attn.qkv(x).reshape(seq_length, 3, attn.num_heads, -1).transpose(1, 0, 2, 3)
+    q, k, v = mx.split(qkv, 3)
+
+    q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
+    k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
+
+    q = q.transpose(0, 2, 1, 3)
+    k = k.transpose(0, 2, 1, 3)
+    v = v.transpose(0, 2, 1, 3)
+
+    if use_fused_varlen:
+        core = _fused_varlen_attention(q, k, v, cu_seqlens, attn.scale)
+    else:
+        core = _baseline_segment_attention(q, k, v, cu_seqlens, attn.scale)
+
+    output = core.transpose(0, 2, 1, 3).reshape(seq_length, -1)
+    return attn.proj(output)
+
+
+def patch_qwen3_vl_vision_attention() -> None:
+    """Replace mlx_vlm Qwen3-VL vision ``Attention.__call__`` with varlen core."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    from mlx_vlm.models.qwen3_vl import vision
+
+    def _patched_call(
+        self,
+        x: mx.array,
+        cu_seqlens: mx.array,
+        rotary_pos_emb: mx.array | None = None,
+    ) -> mx.array:
+        return qwen3_vl_vision_attention_forward(
+            self,
+            x,
+            cu_seqlens,
+            rotary_pos_emb,
+            use_fused_varlen=True,
+        )
+
+    vision.Attention.__call__ = _patched_call
+    _PATCHED = True
+    logger.info(
+        "Patched mlx_vlm Qwen3-VL vision Attention to use encoder_varlen_attention"
+    )


### PR DESCRIPTION
## Summary

Implements **RFC #333 PR1**: a separate dense, non-causal varlen encoder attention primitive for ViT-style vision towers (Qwen2.5-VL / Qwen3-VL et al.).

**Primitive (commits `11a71a2` + `8958be8`):**

- Adds `encoder_varlen_attention.metal` (tiled FlashAttention-2-style kernel; bf16/f16 MMA + f32 fallback)
- Adds `EncoderVarlenAttentionPrimitive` + nanobind wiring in `paged_ops.cpp`
- Adds public `vllm_metal.metal.encoder_varlen_attention()` with shape/dtype/`cu_seqlens` validation
- Lazy-compiles `encoder_varlen_kern` on first call (paged-only paths pay no cold-start cost)
- Unit tests: MLX split-loop reference parity (36 cases), validation errors, lazy-graph self-chain

**Opt-in Qwen3-VL wiring + benchmark (`82bd183`, bf16 cast fix `fbff5cb`):**

- `VLLM_METAL_USE_FUSED_VIT_ATTENTION=1` toggles fused varlen vision attention (default off)
- `vllm_metal/multimodal/fused_vit_attention.py` — `qwen3_vl_vision_attention_forward` (casts Q/K/V to bf16 before varlen kernel)
- `vllm_metal/compat.py` — patches `mlx_vlm` Qwen3-VL vision `Attention` when env is set
- `vllm_metal/envs.py` — env flag definition
- Harness: `tools/benchmark/qwen3_vl_vision_varlen_benchmark.py` (baseline per-segment `ensure_fused_sdpa` vs fused path)

**Perf follow-ups (`ec0bc98`, `361f6eb`):**

- Keep Q/K/V in kernel-native **(S,H,D)** layout through the fused vision path (no pack/unpack transposes)
- Fuse **SHD-native RoPE** with the varlen attention core where `mx.compile` allows; fuller fusion still blocked by compile/graph limits

Built on kernel/C++ work from closed draft #335, ported to current `main` and completed with Python helper + tests.

## Correctness & performance (local A/B)

Run (Apple Silicon, `mlx=0.31.2`, warmup=5, iters=20):

```text
.venv-vllm-metal/bin/python tools/benchmark/qwen3_vl_vision_varlen_benchmark.py --warmup 5 --iters 20
```

Requires editable install with native build, e.g. `VLLM_METAL_BUILD_FROM_SOURCE=1 pip install -e .` (CI macOS job rebuilds `.so`; benchmark is not run in CI).

| config | tokens | max_err | speedup (fused/baseline p50) |
|--------|--------|---------|------------------------------|
| 4x256 | 1024 | ~2.85e-4 | **1.16x** |
| 8x1024 | 8192 | ~1.82e-4 | **1.05x** |
| 4x4096 | 16384 | ~1.28e-4 | **1.11x** |
| varied (Qwen3-VL-ish) | 3840 | ~2.55e-4 | **1.08x** |
| 4x1024 hd128 | 4096 | ~1.78e-4 | **1.08x** |
| 8x512 hd64 | 4096 | ~2.48e-4 | **1.17x** |
| 8x768 hd96 | 6144 | ~1.80e-4 | **1.20x** |

Max abs error ~1.3e-4–2.5e-4 vs per-segment SDPA baseline (bf16 compute on f32 activations; was ~8.6e-8–1.04e-7 before the bf16 cast). **Performance:** after kernel-native layout and SHD RoPE fused with the varlen core, fused path is **1.05–1.20×** baseline p50 on all rows in the harness (**>1.1×** on 4×256, 4×4096, 8×512 hd64, 8×768 hd96). Earlier **0.97–1.13×** parity came before those changes; **0.06–0.40×** regressions were f32 hitting the slow kernel (`fbff5cb`).

## Out of scope (follow-ups)

- Default-on vision wiring without maintainer sign-off
- Prebuilt 4th `.metallib` in release wheels (lazy JIT for now, same as #335)
- Kernel tuning to close the perf gap (#335 target)
- `perfgate` CI preflight (maintainer noted unnecessary on #333)

## Test plan

- [x] `VLLM_METAL_BUILD_FROM_SOURCE=1 pytest tests/test_encoder_varlen_attention.py -q` — 40/40 locally
- [x] CI macOS test job (rebuilds `.so`; encoder shader JITs on first test)
- [x] Local A/B benchmark harness (see above; manual, not in CI)

Refs: #333
