### PR TITLE
[CI] Fix two stale PP guard tests from #427

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -80,7 +80,7 @@ class TestMetalPlatform:
             model_config=None,
         )
         with pytest.raises(
-            NotImplementedError, match="pipeline and tensor parallelism"
+            NotImplementedError, match="alone or combined with pipeline"
         ):
             MetalPlatform.check_and_update_config(vllm_config)
 
@@ -180,6 +180,40 @@ class TestMetalPlatform:
             speculative_config=SimpleNamespace(method="ngram"),
         )
         with pytest.raises(NotImplementedError, match="speculative decoding"):
+            MetalPlatform.check_and_update_config(vllm_config)
+
+    def test_check_and_update_config_rejects_pipeline_with_stt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PP>1 with an STT model is rejected at config time.
+
+        STT checkpoints use a dedicated runner with no pipeline-split path, so
+        reject before any worker spawns rather than fail after startup.
+        """
+        self._patch_stt_resolution(monkeypatch, is_stt=True)
+        vllm_config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                worker_cls="auto",
+                distributed_executor_backend="auto",
+                pipeline_parallel_size=2,
+                tensor_parallel_size=1,
+                disable_custom_all_reduce=False,
+            ),
+            model_config=SimpleNamespace(
+                model="openai/whisper-tiny",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                multimodal_config=None,
+                hf_config=SimpleNamespace(model_type="whisper"),
+            ),
+            scheduler_config=SimpleNamespace(
+                async_scheduling=False,
+                enable_chunked_prefill=False,
+            ),
+            speculative_config=None,
+            lora_config=None,
+        )
+        with pytest.raises(NotImplementedError, match="speech-to-text"):
             MetalPlatform.check_and_update_config(vllm_config)
 
     def test_check_and_update_config_rejects_uni_executor_with_pipeline_parallel(

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -34,38 +34,6 @@ def _make_worker(model_runner: object, *, use_paged_attention: bool) -> MetalWor
 class TestWorkerRunnerBoundaryDelegation:
     """Worker should delegate STT capability decisions to model runner."""
 
-    def test_init_device_rejects_pipeline_parallel_for_stt(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """STT checkpoints use a dedicated runner with no pipeline-split path, so
-        PP>1 must be rejected in init_device — before the ring rendezvous blocks —
-        rather than AttributeError in load_model after startup."""
-        worker = MetalWorker.__new__(MetalWorker)
-        worker.metal_config = SimpleNamespace(use_mlx=False)
-        worker.vllm_config = SimpleNamespace()
-        worker.parallel_config = SimpleNamespace(pipeline_parallel_size=2, world_size=2)
-        worker.model_config = SimpleNamespace(model="stub-stt-model", seed=0)
-        worker.rank = 0
-        worker.local_rank = 0
-        worker.distributed_init_method = "tcp://127.0.0.1:12345"
-        worker.pp = None
-
-        monkeypatch.setattr(
-            "vllm_metal.v1.worker.MetalPlatform.get_torch_device",
-            staticmethod(lambda *a, **k: SimpleNamespace()),
-        )
-        monkeypatch.setattr(
-            "vllm_metal.v1.worker.init_worker_distributed_environment",
-            lambda *a, **k: None,
-        )
-        monkeypatch.setattr("vllm_metal.stt.detection.is_stt_model", lambda _p: True)
-        monkeypatch.setattr(
-            "vllm_metal.utils.get_model_download_path", lambda _m: "/tmp/stt"
-        )
-
-        with pytest.raises(NotImplementedError, match="speech-to-text"):
-            MetalWorker.init_device(worker)
-
     def test_reset_mm_cache_delegates_to_runner(self) -> None:
         model_runner = MagicMock()
         worker = _make_worker(model_runner, use_paged_attention=True)


### PR DESCRIPTION
Main CI is red after #427: its final push moved two PP guards but didn't update the tests pinning the old locations .

Test-only fix