### PR TITLE
[GGUF] Add MLX-native Q8_0/Q4_0 runtime boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+gguf = [
+    # Local GGUF model loading. Keep aligned with upstream vLLM's lower bound
+    # unless a Metal-specific path needs a newer API.
+    "gguf>=0.17.0",
+]
 stt = [
     # Speech-to-text audio processing (Whisper models)
     "librosa>=0.10.2",
@@ -61,9 +66,10 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "ruff>=0.1.0",
     "mypy>=1.19.1",
+    "gguf>=0.17.0",
 ]
 all = [
-    "vllm-metal[stt,dev]",
+    "vllm-metal[gguf,stt,dev]",
 ]
 
 [project.urls]

--- a/tests/test_gguf_mlx_native.py
+++ b/tests/test_gguf_mlx_native.py
@@ -1,0 +1,504 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MLX-native GGUF representation and primitives.
+
+Fixtures are written with the upstream ``gguf`` package and read back through
+``mx.load`` so the tests exercise MLX's real GGUF repack, and parity is checked
+against ``gguf.quants.dequantize`` (the upstream reference), never a local
+re-implementation of the packing.
+"""
+
+from __future__ import annotations
+
+import os
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+gguf = pytest.importorskip("gguf")
+
+from vllm_metal.gguf.mlx_native import (  # noqa: E402
+    MLX_NATIVE_GGUF_TYPES,
+    GGUFMLXQuantizedTensor,
+    embedding_lookup,
+    qmatmul,
+)
+
+GGMLQuantizationType = gguf.GGMLQuantizationType
+
+NATIVE_QTYPES = [GGMLQuantizationType.Q8_0, GGMLQuantizationType.Q4_0]
+
+
+def _write_quantized_gguf(path, weight: np.ndarray, qtype) -> dict[str, mx.array]:
+    """Quantize ``weight`` to ``qtype``, write a 1-tensor GGUF, return mx.load()."""
+    raw = gguf.quants.quantize(weight, qtype)
+    writer = gguf.GGUFWriter(str(path), "llama")
+    writer.add_tensor("w.weight", raw, raw_shape=raw.shape, raw_dtype=qtype)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return mx.load(str(path))
+
+
+def _make_tensor(tmp_path, qtype, shape=(64, 128)) -> tuple:
+    weight = np.random.default_rng(0).standard_normal(shape).astype(np.float32)
+    arrays = _write_quantized_gguf(tmp_path / f"{qtype.name}.gguf", weight, qtype)
+    qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, "w.weight", qtype)
+    oracle = gguf.quants.dequantize(gguf.quants.quantize(weight, qtype), qtype).astype(
+        np.float32
+    )
+    return qt, oracle
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_contract_matches_logical_shape(tmp_path, qtype):
+    qt, _ = _make_tensor(tmp_path, qtype, shape=(64, 128))
+
+    assert qt.qweight_type == qtype
+    assert qt.bits == (8 if qtype == GGMLQuantizationType.Q8_0 else 4)
+    assert qt.group_size == 32
+    assert qt.logical_shape == (64, 128)
+    assert qt.out_features == 64
+    assert qt.in_features == 128
+    assert qt.packed_shape == tuple(qt.qweight.shape)
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_qmatmul_matches_dense_oracle_f32(tmp_path, qtype):
+    qt, oracle = _make_tensor(tmp_path, qtype)
+    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
+
+    out = qmatmul(x, qt)
+    expected = x @ mx.array(oracle).T
+    mx.eval(out, expected)
+
+    # f32 path has no f16 accumulation noise, so hold it tight: the only error
+    # is quantization rounding shared with the oracle. Measured headroom is
+    # ~4e-7 relative, so 4e-6 catches a quant-math regression with ~10x margin.
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_qmatmul_output_dtype_follows_x(tmp_path, qtype, dtype):
+    qt, _ = _make_tensor(tmp_path, qtype)
+    x = mx.random.normal((4, qt.in_features)).astype(dtype)
+
+    out = qmatmul(x, qt)
+
+    assert out.dtype == dtype
+    assert out.shape == (4, qt.out_features)
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_qmatmul_preserves_leading_shape(tmp_path, qtype):
+    qt, _ = _make_tensor(tmp_path, qtype)
+    x = mx.random.normal((2, 3, qt.in_features)).astype(mx.float16)
+
+    out = qmatmul(x, qt)
+    flat = qmatmul(x.reshape(-1, qt.in_features), qt)
+    mx.eval(out, flat)
+
+    assert out.shape == (2, 3, qt.out_features)
+    assert mx.array_equal(out.reshape(-1, qt.out_features), flat)
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_qmatmul_empty_batch(tmp_path, qtype):
+    qt, _ = _make_tensor(tmp_path, qtype)
+
+    out = qmatmul(mx.zeros((0, qt.in_features), dtype=mx.float16), qt)
+
+    assert out.shape == (0, qt.out_features)
+    assert out.dtype == mx.float16
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_embedding_lookup_matches_oracle_rows(tmp_path, qtype):
+    qt, oracle = _make_tensor(tmp_path, qtype)
+    ids = mx.array([[0, 5], [63, 0]], dtype=mx.int32)
+
+    out = embedding_lookup(ids, qt, output_dtype=mx.float32)
+    expected = mx.array(oracle)[ids]
+    mx.eval(out, expected)
+
+    assert out.shape == (2, 2, qt.in_features)
+    # dequant runs in float16 (the stored scale dtype); the oracle is float32,
+    # so allow float16 rounding.
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 5e-3
+    )
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_embedding_as_linear_matches_qmatmul(tmp_path, qtype):
+    # A tied lm_head reuses the embedding table as a linear weight; the same
+    # quantized tensor must work through qmatmul (the PR-2 tied-head path).
+    qt, oracle = _make_tensor(tmp_path, qtype, shape=(100, 64))
+    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
+
+    out = qmatmul(x, qt)
+    expected = x @ mx.array(oracle).T
+    mx.eval(out, expected)
+
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
+    )
+
+
+def test_accepts_int_qweight_type(tmp_path):
+    # A loader may pass the raw GGML type id; it must normalize to the enum.
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+    rebuilt = GGUFMLXQuantizedTensor(
+        qweight=qt.qweight,
+        scales=qt.scales,
+        biases=qt.biases,
+        qweight_type=int(GGMLQuantizationType.Q8_0),
+    )
+    assert rebuilt.qweight_type is GGMLQuantizationType.Q8_0
+
+
+def test_rejects_q4_1_with_mlx_bug_reference(tmp_path):
+    weight = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
+    arrays = _write_quantized_gguf(
+        tmp_path / "q4_1.gguf", weight, GGMLQuantizationType.Q4_1
+    )
+    with pytest.raises(ValueError, match="ml-explore/mlx#3664"):
+        GGUFMLXQuantizedTensor.from_mx_load(
+            arrays, "w.weight", GGMLQuantizationType.Q4_1
+        )
+    assert GGMLQuantizationType.Q4_1 not in MLX_NATIVE_GGUF_TYPES
+
+
+def test_rejects_unsupported_qtype():
+    with pytest.raises(ValueError, match="Unsupported GGUF quantization type"):
+        GGUFMLXQuantizedTensor(
+            qweight=mx.zeros((4, 8), dtype=mx.uint32),
+            scales=mx.zeros((4, 1), dtype=mx.float16),
+            biases=mx.zeros((4, 1), dtype=mx.float16),
+            qweight_type=GGMLQuantizationType.Q4_K,
+        )
+
+
+def test_rejects_wrong_qweight_dtype():
+    with pytest.raises(ValueError, match="qweight must be uint32"):
+        GGUFMLXQuantizedTensor(
+            qweight=mx.zeros((4, 8), dtype=mx.int32),
+            scales=mx.zeros((4, 1), dtype=mx.float16),
+            biases=mx.zeros((4, 1), dtype=mx.float16),
+            qweight_type=GGMLQuantizationType.Q8_0,
+        )
+
+
+def test_rejects_inconsistent_packed_dim():
+    # Q8_0 with 1 group needs packed inner dim 8 (1 * 8); give it 4.
+    with pytest.raises(ValueError, match="inconsistent"):
+        GGUFMLXQuantizedTensor(
+            qweight=mx.zeros((4, 4), dtype=mx.uint32),
+            scales=mx.zeros((4, 1), dtype=mx.float16),
+            biases=mx.zeros((4, 1), dtype=mx.float16),
+            qweight_type=GGMLQuantizationType.Q8_0,
+        )
+
+
+def test_from_mx_load_rejects_missing_companions(tmp_path):
+    weight = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
+    arrays = _write_quantized_gguf(
+        tmp_path / "q8.gguf", weight, GGMLQuantizationType.Q8_0
+    )
+    del arrays["w.scales"]
+    with pytest.raises(ValueError, match="missing MLX repack arrays"):
+        GGUFMLXQuantizedTensor.from_mx_load(
+            arrays, "w.weight", GGMLQuantizationType.Q8_0
+        )
+
+
+def test_rejects_non_float16_scales():
+    with pytest.raises(ValueError, match="scales must be float16"):
+        GGUFMLXQuantizedTensor(
+            qweight=mx.zeros((4, 8), dtype=mx.uint32),
+            scales=mx.zeros((4, 1), dtype=mx.float32),
+            biases=mx.zeros((4, 1), dtype=mx.float16),
+            qweight_type=GGMLQuantizationType.Q8_0,
+        )
+
+
+def test_rejects_scales_biases_shape_mismatch():
+    with pytest.raises(ValueError, match="must have the same shape"):
+        GGUFMLXQuantizedTensor(
+            qweight=mx.zeros((4, 8), dtype=mx.uint32),
+            scales=mx.zeros((4, 1), dtype=mx.float16),
+            biases=mx.zeros((4, 2), dtype=mx.float16),
+            qweight_type=GGMLQuantizationType.Q8_0,
+        )
+
+
+def test_rejects_scales_rows_mismatch():
+    with pytest.raises(ValueError, match="scales rows .* must match qweight rows"):
+        GGUFMLXQuantizedTensor(
+            qweight=mx.zeros((4, 8), dtype=mx.uint32),
+            scales=mx.zeros((2, 1), dtype=mx.float16),
+            biases=mx.zeros((2, 1), dtype=mx.float16),
+            qweight_type=GGMLQuantizationType.Q8_0,
+        )
+
+
+def test_from_mx_load_rejects_non_weight_name(tmp_path):
+    weight = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
+    arrays = _write_quantized_gguf(
+        tmp_path / "q8.gguf", weight, GGMLQuantizationType.Q8_0
+    )
+    with pytest.raises(ValueError, match="must end with '.weight'"):
+        GGUFMLXQuantizedTensor.from_mx_load(arrays, "w", GGMLQuantizationType.Q8_0)
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_mx_load_layout_is_affine_group32(tmp_path, qtype):
+    # Canary: assert mx.load's raw repack output directly (not via the
+    # constructor) so a future MLX layout/dtype drift surfaces here.
+    weight = np.random.default_rng(0).standard_normal((64, 128)).astype(np.float32)
+    arrays = _write_quantized_gguf(tmp_path / f"{qtype.name}.gguf", weight, qtype)
+    bits = 8 if qtype == GGMLQuantizationType.Q8_0 else 4
+
+    assert arrays["w.weight"].dtype == mx.uint32
+    assert arrays["w.scales"].dtype == mx.float16
+    assert arrays["w.biases"].dtype == mx.float16
+    assert arrays["w.scales"].shape == arrays["w.biases"].shape
+    num_groups = arrays["w.scales"].shape[1]
+    assert num_groups == 128 // 32
+    assert arrays["w.weight"].shape[1] == num_groups * bits
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_embedding_lookup_empty_ids(tmp_path, qtype):
+    qt, _ = _make_tensor(tmp_path, qtype)
+
+    out = embedding_lookup(mx.zeros((0,), dtype=mx.int32), qt, output_dtype=mx.float16)
+    assert out.shape == (0, qt.in_features)
+    assert out.dtype == mx.float16
+
+
+# --- Real-file parity (opt-in: needs local GGUF files) ------------------------
+#
+# Set VLLM_METAL_TEST_GGUF_PATHS to a comma-separated list of real .gguf files
+# (e.g. a Q8_0 and a Q4_0 model) to run these. They prove the representation and
+# primitives hold on real checkpoints — every MLX-native tensor constructs, with
+# qmatmul/embedding parity vs the gguf-py dequantize oracle and a quantized-vs-
+# dense memory comparison. Each file is checked for whichever native qtypes it
+# contains, so pointing at a Q4_0 file gives real Q4_0 coverage.
+
+_REAL_GGUF_PATHS = [
+    p.strip()
+    for p in os.environ.get("VLLM_METAL_TEST_GGUF_PATHS", "").split(",")
+    if p.strip()
+]
+_real_gguf = pytest.mark.skipif(
+    not _REAL_GGUF_PATHS,
+    reason="set VLLM_METAL_TEST_GGUF_PATHS to comma-separated .gguf paths",
+)
+_real_param = pytest.mark.parametrize("path", _REAL_GGUF_PATHS)
+
+
+def _native_tensors(path):
+    """Return (mx.load arrays, {name: GGUFReader tensor}) for MLX-native qtypes."""
+    reader = gguf.GGUFReader(path)
+    arrays = mx.load(path)
+    native = {
+        t.name: t for t in reader.tensors if t.tensor_type in MLX_NATIVE_GGUF_TYPES
+    }
+    return arrays, native
+
+
+@pytest.mark.slow
+@_real_gguf
+@_real_param
+def test_real_file_all_native_tensors_construct(path):
+    arrays, native = _native_tensors(path)
+    assert native, "expected MLX-native quantized tensors in the test GGUF"
+    for name, tensor in native.items():
+        qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, name, tensor.tensor_type)
+        # GGUF stores dims in reverse (ne[0] = in_features); logical is (out, in).
+        in_features, out_features = (int(d) for d in tensor.shape)
+        assert qt.logical_shape == (out_features, in_features)
+
+
+@pytest.mark.slow
+@_real_gguf
+@_real_param
+def test_real_file_linear_parity_vs_oracle(path):
+    arrays, native = _native_tensors(path)
+    # Any internal projection (not the embedding/output table) is a linear.
+    name = next(
+        n for n in native if not n.endswith(("token_embd.weight", "output.weight"))
+    )
+    tensor = native[name]
+    qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, name, tensor.tensor_type)
+    oracle = gguf.quants.dequantize(tensor.data, tensor.tensor_type).astype(np.float32)
+
+    x = mx.random.normal((4, qt.in_features)).astype(mx.float32)
+    out = qmatmul(x, qt)
+    expected = x @ mx.array(oracle).T
+    mx.eval(out, expected)
+
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
+    )
+
+
+@pytest.mark.slow
+@_real_gguf
+@_real_param
+def test_real_file_embedding_parity_vs_oracle(path):
+    arrays, native = _native_tensors(path)
+    name = next(n for n in native if n.endswith("token_embd.weight"))
+    tensor = native[name]
+    qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, name, tensor.tensor_type)
+    oracle = gguf.quants.dequantize(tensor.data, tensor.tensor_type).astype(np.float32)
+
+    ids = mx.array([0, 100, qt.out_features - 1], dtype=mx.int32)
+    out = embedding_lookup(ids, qt, output_dtype=mx.float32)
+    expected = mx.array(oracle)[ids]
+    mx.eval(out, expected)
+
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 5e-3
+    )
+
+
+@pytest.mark.slow
+@_real_gguf
+@_real_param
+def test_real_file_memory_below_dense(path):
+    arrays, native = _native_tensors(path)
+    quantized = dense_f16 = 0
+    for name, tensor in native.items():
+        qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, name, tensor.tensor_type)
+        quantized += qt.qweight.nbytes + qt.scales.nbytes + qt.biases.nbytes
+        dense_f16 += qt.out_features * qt.in_features * 2
+
+    # Per weight: Q8_0 ~1.125 bytes, Q4_0 ~0.625 (packed + f16 scale/bias) vs 2
+    # for dense f16, so any native mix stays well under 0.6x dense.
+    assert quantized < dense_f16 * 0.6
+
+
+# --- Real generate smoke (opt-in: needs a local dense Qwen3.5 checkpoint) ------
+#
+# Set VLLM_METAL_TEST_QWEN35_PATH to a dense Qwen3.5-0.8B to run this. It quantizes
+# every Linear/Embedding to Q8_0 (the same affine triple the GGUF path produces),
+# swaps in shims that route through qmatmul/embedding_lookup, and checks greedy
+# generation matches the dense model token-for-token. The real-file parity tests
+# above cover the other half — that a real GGUF Q8_0 file loads into the same
+# representation. The GGUF->module name mapping that joins the two is PR 3.
+
+_QWEN35_DENSE = os.environ.get("VLLM_METAL_TEST_QWEN35_PATH")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _QWEN35_DENSE, reason="set VLLM_METAL_TEST_QWEN35_PATH to a dense Qwen3.5"
+)
+def test_real_generate_matches_dense():
+    # mlx.nn and the swap harness are imported/defined here, not at module top,
+    # so the fast tests still collect on a machine without a Metal device.
+    import mlx.nn as nn
+    from mlx_lm import load
+    from mlx_lm.generate import generate_step
+    from mlx_lm.sample_utils import make_sampler
+
+    calls = {"linear": 0, "embedding": 0}
+
+    def to_q8(weight):
+        qweight, scales, biases = mx.quantize(
+            weight, group_size=32, bits=8, mode="affine"
+        )
+        return GGUFMLXQuantizedTensor(
+            qweight,
+            scales.astype(mx.float16),
+            biases.astype(mx.float16),
+            GGMLQuantizationType.Q8_0,
+        )
+
+    class QuantLinear(nn.Module):
+        def __init__(self, qt, bias):
+            super().__init__()
+            self.qt = qt
+            self.bias = bias
+
+        def __call__(self, x):
+            calls["linear"] += 1
+            out = qmatmul(x, self.qt)
+            return out if self.bias is None else out + self.bias
+
+    class QuantEmbedding(nn.Module):
+        def __init__(self, qt, output_dtype):
+            super().__init__()
+            self.qt = qt
+            self.output_dtype = output_dtype
+
+        def __call__(self, ids):
+            calls["embedding"] += 1
+            return embedding_lookup(ids, self.qt, self.output_dtype)
+
+        def as_linear(self, x):
+            calls["embedding"] += 1
+            return qmatmul(x, self.qt)
+
+    def swap_to_q8(module):
+        swapped = 0
+        for name, child in module.children().items():
+            leaves = child if isinstance(child, list) else [child]
+            for index, leaf in enumerate(leaves):
+                if not isinstance(leaf, nn.Module):
+                    continue
+                replacement = None
+                if (
+                    isinstance(leaf, nn.Linear)
+                    and leaf.weight.ndim == 2
+                    and leaf.weight.shape[1] % 32 == 0
+                ):
+                    bias = getattr(leaf, "bias", None)
+                    replacement = QuantLinear(to_q8(leaf.weight), bias)
+                elif isinstance(leaf, nn.Embedding) and leaf.weight.shape[1] % 32 == 0:
+                    replacement = QuantEmbedding(to_q8(leaf.weight), leaf.weight.dtype)
+                if replacement is None:
+                    swapped += swap_to_q8(leaf)
+                elif isinstance(child, list):
+                    child[index] = replacement
+                    swapped += 1
+                else:
+                    setattr(module, name, replacement)
+                    swapped += 1
+        return swapped
+
+    model, tokenizer = load(_QWEN35_DENSE)
+    prompt = mx.array(tokenizer.encode("The capital of France is"))
+    sampler = make_sampler(temp=0.0)
+
+    def greedy(num_tokens=20):
+        tokens = []
+        for (token, _), _ in zip(
+            generate_step(prompt, model, sampler=sampler),
+            range(num_tokens),
+            strict=False,
+        ):
+            tokens.append(int(token))
+        return tokens
+
+    reference = greedy()
+    assert swap_to_q8(model) > 0
+    calls["linear"] = calls["embedding"] = 0
+    candidate = greedy()
+
+    # Token parity AND proof the quantized primitives actually ran (a silent
+    # dense fallback would still match to greedy precision otherwise).
+    assert candidate == reference
+    assert calls["linear"] > 0
+    assert calls["embedding"] > 0

--- a/tests/test_gguf_mlx_native.py
+++ b/tests/test_gguf_mlx_native.py
@@ -20,8 +20,6 @@ gguf = pytest.importorskip("gguf")
 from vllm_metal.gguf.mlx_native import (  # noqa: E402
     MLX_NATIVE_GGUF_TYPES,
     GGUFMLXQuantizedTensor,
-    embedding_lookup,
-    qmatmul,
 )
 
 GGMLQuantizationType = gguf.GGMLQuantizationType
@@ -65,11 +63,11 @@ def test_contract_matches_logical_shape(tmp_path, qtype):
 
 
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_qmatmul_matches_dense_oracle_f32(tmp_path, qtype):
+def test_matmul_matches_dense_oracle_f32(tmp_path, qtype):
     qt, oracle = _make_tensor(tmp_path, qtype)
     x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
 
-    out = qmatmul(x, qt)
+    out = qt.matmul(x)
     expected = x @ mx.array(oracle).T
     mx.eval(out, expected)
 
@@ -84,23 +82,23 @@ def test_qmatmul_matches_dense_oracle_f32(tmp_path, qtype):
 
 @pytest.mark.parametrize("dtype", [mx.float32, mx.float16, mx.bfloat16])
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_qmatmul_output_dtype_follows_x(tmp_path, qtype, dtype):
+def test_matmul_output_dtype_follows_x(tmp_path, qtype, dtype):
     qt, _ = _make_tensor(tmp_path, qtype)
     x = mx.random.normal((4, qt.in_features)).astype(dtype)
 
-    out = qmatmul(x, qt)
+    out = qt.matmul(x)
 
     assert out.dtype == dtype
     assert out.shape == (4, qt.out_features)
 
 
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_qmatmul_preserves_leading_shape(tmp_path, qtype):
+def test_matmul_preserves_leading_shape(tmp_path, qtype):
     qt, _ = _make_tensor(tmp_path, qtype)
     x = mx.random.normal((2, 3, qt.in_features)).astype(mx.float16)
 
-    out = qmatmul(x, qt)
-    flat = qmatmul(x.reshape(-1, qt.in_features), qt)
+    out = qt.matmul(x)
+    flat = qt.matmul(x.reshape(-1, qt.in_features))
     mx.eval(out, flat)
 
     assert out.shape == (2, 3, qt.out_features)
@@ -108,21 +106,21 @@ def test_qmatmul_preserves_leading_shape(tmp_path, qtype):
 
 
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_qmatmul_empty_batch(tmp_path, qtype):
+def test_matmul_empty_batch(tmp_path, qtype):
     qt, _ = _make_tensor(tmp_path, qtype)
 
-    out = qmatmul(mx.zeros((0, qt.in_features), dtype=mx.float16), qt)
+    out = qt.matmul(mx.zeros((0, qt.in_features), dtype=mx.float16))
 
     assert out.shape == (0, qt.out_features)
     assert out.dtype == mx.float16
 
 
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_embedding_lookup_matches_oracle_rows(tmp_path, qtype):
+def test_embedding_matches_oracle_rows(tmp_path, qtype):
     qt, oracle = _make_tensor(tmp_path, qtype)
     ids = mx.array([[0, 5], [63, 0]], dtype=mx.int32)
 
-    out = embedding_lookup(ids, qt, output_dtype=mx.float32)
+    out = qt.embedding(ids, output_dtype=mx.float32)
     expected = mx.array(oracle)[ids]
     mx.eval(out, expected)
 
@@ -136,13 +134,13 @@ def test_embedding_lookup_matches_oracle_rows(tmp_path, qtype):
 
 
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_embedding_as_linear_matches_qmatmul(tmp_path, qtype):
+def test_embedding_as_linear_matches_matmul(tmp_path, qtype):
     # A tied lm_head reuses the embedding table as a linear weight; the same
-    # quantized tensor must work through qmatmul (the PR-2 tied-head path).
+    # quantized tensor must work through matmul (the PR-2 tied-head path).
     qt, oracle = _make_tensor(tmp_path, qtype, shape=(100, 64))
     x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
 
-    out = qmatmul(x, qt)
+    out = qt.matmul(x)
     expected = x @ mx.array(oracle).T
     mx.eval(out, expected)
 
@@ -276,10 +274,10 @@ def test_mx_load_layout_is_affine_group32(tmp_path, qtype):
 
 
 @pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_embedding_lookup_empty_ids(tmp_path, qtype):
+def test_embedding_empty_ids(tmp_path, qtype):
     qt, _ = _make_tensor(tmp_path, qtype)
 
-    out = embedding_lookup(mx.zeros((0,), dtype=mx.int32), qt, output_dtype=mx.float16)
+    out = qt.embedding(mx.zeros((0,), dtype=mx.int32), output_dtype=mx.float16)
     assert out.shape == (0, qt.in_features)
     assert out.dtype == mx.float16
 
@@ -289,7 +287,7 @@ def test_embedding_lookup_empty_ids(tmp_path, qtype):
 # Set VLLM_METAL_TEST_GGUF_PATHS to a comma-separated list of real .gguf files
 # (e.g. a Q8_0 and a Q4_0 model) to run these. They prove the representation and
 # primitives hold on real checkpoints — every MLX-native tensor constructs, with
-# qmatmul/embedding parity vs the gguf-py dequantize oracle and a quantized-vs-
+# matmul/embedding parity vs the gguf-py dequantize oracle and a quantized-vs-
 # dense memory comparison. Each file is checked for whichever native qtypes it
 # contains, so pointing at a Q4_0 file gives real Q4_0 coverage.
 
@@ -342,7 +340,7 @@ def test_real_file_linear_parity_vs_oracle(path):
     oracle = gguf.quants.dequantize(tensor.data, tensor.tensor_type).astype(np.float32)
 
     x = mx.random.normal((4, qt.in_features)).astype(mx.float32)
-    out = qmatmul(x, qt)
+    out = qt.matmul(x)
     expected = x @ mx.array(oracle).T
     mx.eval(out, expected)
 
@@ -363,7 +361,7 @@ def test_real_file_embedding_parity_vs_oracle(path):
     oracle = gguf.quants.dequantize(tensor.data, tensor.tensor_type).astype(np.float32)
 
     ids = mx.array([0, 100, qt.out_features - 1], dtype=mx.int32)
-    out = embedding_lookup(ids, qt, output_dtype=mx.float32)
+    out = qt.embedding(ids, output_dtype=mx.float32)
     expected = mx.array(oracle)[ids]
     mx.eval(out, expected)
 
@@ -393,7 +391,7 @@ def test_real_file_memory_below_dense(path):
 #
 # Set VLLM_METAL_TEST_QWEN35_PATH to a dense Qwen3.5-0.8B to run this. It quantizes
 # every Linear/Embedding to Q8_0 (the same affine triple the GGUF path produces),
-# swaps in shims that route through qmatmul/embedding_lookup, and checks greedy
+# swaps in shims that route through matmul/embedding, and checks greedy
 # generation matches the dense model token-for-token. The real-file parity tests
 # above cover the other half — that a real GGUF Q8_0 file loads into the same
 # representation. The GGUF->module name mapping that joins the two is PR 3.
@@ -434,7 +432,7 @@ def test_real_generate_matches_dense():
 
         def __call__(self, x):
             calls["linear"] += 1
-            out = qmatmul(x, self.qt)
+            out = self.qt.matmul(x)
             return out if self.bias is None else out + self.bias
 
     class QuantEmbedding(nn.Module):
@@ -445,11 +443,11 @@ def test_real_generate_matches_dense():
 
         def __call__(self, ids):
             calls["embedding"] += 1
-            return embedding_lookup(ids, self.qt, self.output_dtype)
+            return self.qt.embedding(ids, self.output_dtype)
 
         def as_linear(self, x):
             calls["embedding"] += 1
-            return qmatmul(x, self.qt)
+            return self.qt.matmul(x)
 
     def swap_to_q8(module):
         swapped = 0

--- a/vllm_metal/gguf/__init__.py
+++ b/vllm_metal/gguf/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Experimental GGUF support for vllm-metal (MLX-native quantized execution)."""

--- a/vllm_metal/gguf/mlx_native.py
+++ b/vllm_metal/gguf/mlx_native.py
@@ -1,18 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX-native quantized GGUF tensors and the primitives that compute with them.
+"""MLX-native quantized GGUF tensors that compute with their packed weights.
 
 MLX's GGUF loader (``mx.load``) repacks Q8_0 and Q4_0 weights into the affine,
 group-32 representation that ``mx.quantized_matmul`` already consumes: a
 ``uint32`` packed ``qweight`` alongside ``float16`` ``scales`` and ``biases``.
-``GGUFMLXQuantizedTensor`` wraps that triple in an explicit, validated contract,
-and :func:`qmatmul` / :func:`embedding_lookup` run on it directly so supported
-weights never get expanded into a dense copy.
+``GGUFMLXQuantizedTensor`` wraps that triple in an explicit, validated contract
+and exposes :meth:`~GGUFMLXQuantizedTensor.matmul` /
+:meth:`~GGUFMLXQuantizedTensor.embedding`, which run on the packed weights so
+supported weights never get expanded into a dense copy.
 
 Q4_1 is deliberately not supported here. MLX's repack mis-decodes Q4_1 blocks
 (it skips a 2-byte block header where Q4_1 uses 4), so ``mx.load`` returns
 corrupted Q4_1 weights. Fix tracked upstream at ml-explore/mlx#3664; Q4_1 can
 join once a fixed MLX release is in our supported range. K-quants and other
-qtypes MLX does not repack natively are left for the raw-block Metal path.
+qtypes MLX does not repack natively are out of scope for this path.
 """
 
 from __future__ import annotations
@@ -46,33 +47,9 @@ _QUANT_MODE = "affine"
 _WEIGHT_SUFFIX = ".weight"
 
 
-def _as_supported_qtype(value: GGMLQuantizationType | int) -> GGMLQuantizationType:
-    """Normalize to a ``GGMLQuantizationType`` and require it to be MLX-native."""
-    try:
-        qweight_type = GGMLQuantizationType(value)
-    except ValueError as exc:
-        raise ValueError(f"Unknown GGUF quantization type: {value!r}") from exc
-    if qweight_type in MLX_NATIVE_GGUF_TYPES:
-        return qweight_type
-    supported = ", ".join(t.name for t in _BITS)
-    if qweight_type == GGMLQuantizationType.Q4_1:
-        # Remove this special case once a fixed MLX release (ml-explore/mlx#3664)
-        # is our lower bound and Q4_1 can be added to _BITS.
-        raise ValueError(
-            "GGUF Q4_1 is not supported on the MLX-native path: MLX's GGUF "
-            "repack mis-decodes Q4_1 blocks and returns corrupted weights "
-            "(ml-explore/mlx#3664). "
-            f"Supported MLX-native qtypes: {supported}."
-        )
-    raise ValueError(
-        f"Unsupported GGUF quantization type for the MLX-native path: "
-        f"{qweight_type.name}. Supported MLX-native qtypes: {supported}."
-    )
-
-
 @dataclass(frozen=True, eq=False)
 class GGUFMLXQuantizedTensor:
-    """An MLX-native quantized GGUF weight plus its originating quant type.
+    """An MLX-native quantized GGUF weight that computes with its packed data.
 
     The contract consumers can rely on:
 
@@ -83,9 +60,8 @@ class GGUFMLXQuantizedTensor:
       :data:`MLX_NATIVE_GGUF_TYPES`.
     * logical weight is ``(out_features, in_features)``; :attr:`group_size` is 32;
       :attr:`bits` is 8 for Q8_0, 4 for Q4_0.
-    * activations: :func:`qmatmul` accepts float16/bfloat16/float32 ``x`` and
-      returns ``x``'s dtype; :func:`embedding_lookup` returns an explicit
-      ``output_dtype``.
+    * activations: :meth:`matmul` accepts float16/bfloat16/float32 ``x`` and
+      returns ``x``'s dtype; :meth:`embedding` returns an explicit ``output_dtype``.
 
     Construct directly when you already hold the affine arrays (e.g. a row slice
     of another tensor), or via :meth:`from_mx_load` from an ``mx.load`` result.
@@ -97,11 +73,40 @@ class GGUFMLXQuantizedTensor:
     qweight_type: GGMLQuantizationType
 
     def __post_init__(self) -> None:
-        # Coerce ints to the enum (and reject non-native qtypes) so every error
-        # message and downstream consumer can rely on a real GGMLQuantizationType.
-        object.__setattr__(self, "qweight_type", _as_supported_qtype(self.qweight_type))
-        bits = _BITS[self.qweight_type]
+        # Coerce ints to the enum (rejecting non-native qtypes), then validate the
+        # arrays, since this is built straight from mx.load() / GGUF file data.
+        object.__setattr__(
+            self, "qweight_type", self._normalize_qtype(self.qweight_type)
+        )
+        self._validate_contract()
 
+    @staticmethod
+    def _normalize_qtype(value: GGMLQuantizationType | int) -> GGMLQuantizationType:
+        """Coerce to a ``GGMLQuantizationType`` and require it to be MLX-native."""
+        try:
+            qweight_type = GGMLQuantizationType(value)
+        except ValueError as exc:
+            raise ValueError(f"Unknown GGUF quantization type: {value!r}") from exc
+        if qweight_type in MLX_NATIVE_GGUF_TYPES:
+            return qweight_type
+        supported = ", ".join(t.name for t in _BITS)
+        if qweight_type == GGMLQuantizationType.Q4_1:
+            # Remove this special case once a fixed MLX release (ml-explore/mlx#3664)
+            # is our lower bound and Q4_1 can be added to _BITS.
+            raise ValueError(
+                "GGUF Q4_1 is not supported on the MLX-native path: MLX's GGUF "
+                "repack mis-decodes Q4_1 blocks and returns corrupted weights "
+                "(ml-explore/mlx#3664). "
+                f"Supported MLX-native qtypes: {supported}."
+            )
+        raise ValueError(
+            f"Unsupported GGUF quantization type for the MLX-native path: "
+            f"{qweight_type.name}. Supported MLX-native qtypes: {supported}."
+        )
+
+    def _validate_contract(self) -> None:
+        """Validate dtypes and the affine packing shapes against the contract."""
+        bits = _BITS[self.qweight_type]
         if self.qweight.dtype != mx.uint32:
             raise ValueError(
                 f"{self.qweight_type.name} qweight must be uint32, "
@@ -153,12 +158,12 @@ class GGUFMLXQuantizedTensor:
     ) -> GGUFMLXQuantizedTensor:
         """Build from an ``mx.load`` result.
 
-        ``weight_name`` is the original GGUF tensor name (``...​.weight``); MLX
+        ``weight_name`` is the original GGUF tensor name (``....weight``); MLX
         stores the companion scales/biases under the same prefix. ``qweight_type``
         is supplied by the caller because ``mx.load`` does not expose per-tensor
         quant types — a loader reads it from ``gguf.GGUFReader``.
         """
-        qweight_type = _as_supported_qtype(qweight_type)
+        qweight_type = cls._normalize_qtype(qweight_type)
         if not weight_name.endswith(_WEIGHT_SUFFIX):
             raise ValueError(
                 f"GGUF weight name must end with '{_WEIGHT_SUFFIX}', got "
@@ -173,8 +178,9 @@ class GGUFMLXQuantizedTensor:
         if missing:
             raise ValueError(
                 f"{qweight_type.name} tensor {weight_name!r} is missing MLX repack "
-                f"arrays {missing}; MLX did not natively repack it (expected with "
-                f"this MLX version) — load it through the raw-block path instead"
+                f"arrays {missing}; MLX did not natively repack this tensor with the "
+                f"current MLX version, so this qtype is not supported by the "
+                f"MLX-native GGUF path"
             )
         return cls(
             qweight=arrays[weight_name],
@@ -207,46 +213,40 @@ class GGUFMLXQuantizedTensor:
     def packed_shape(self) -> tuple[int, ...]:
         return tuple(self.qweight.shape)
 
+    def matmul(self, x: mx.array) -> mx.array:
+        """Compute ``x @ dequantize(self).T`` without materializing the weight.
 
-def qmatmul(x: mx.array, qt: GGUFMLXQuantizedTensor) -> mx.array:
-    """Compute ``x @ dequantize(qt).T`` without materializing the dense weight.
+        ``x`` may be float16, bfloat16, or float32, and its last dim must be
+        :attr:`in_features`; any leading shape is preserved. The result has the
+        same dtype as ``x`` (``mx.quantized_matmul`` promotes a bfloat16 ``x``
+        against the float16 scales to float32, so it is cast back).
+        """
+        out = mx.quantized_matmul(
+            x,
+            self.qweight,
+            scales=self.scales,
+            biases=self.biases,
+            transpose=True,
+            group_size=_GROUP_SIZE,
+            bits=self.bits,
+            mode=_QUANT_MODE,
+        )
+        return out.astype(x.dtype)
 
-    ``x`` may be float16, bfloat16, or float32, and its last dim must be
-    ``qt.in_features``; any leading shape is preserved. The result has the same
-    dtype as ``x`` (``mx.quantized_matmul`` promotes a bfloat16 ``x`` against the
-    float16 scales to float32, so it is cast back).
-    """
-    out = mx.quantized_matmul(
-        x,
-        qt.qweight,
-        scales=qt.scales,
-        biases=qt.biases,
-        transpose=True,
-        group_size=_GROUP_SIZE,
-        bits=qt.bits,
-        mode=_QUANT_MODE,
-    )
-    return out.astype(x.dtype)
+    def embedding(self, ids: mx.array, output_dtype: mx.Dtype) -> mx.array:
+        """Gather and dequantize embedding rows for ``ids``.
 
-
-def embedding_lookup(
-    ids: mx.array,
-    qt: GGUFMLXQuantizedTensor,
-    output_dtype: mx.Dtype,
-) -> mx.array:
-    """Gather and dequantize embedding rows for ``ids``.
-
-    Only the selected rows are dequantized; the table stays quantized. ``ids`` of
-    any rank >= 1 are accepted and a trailing ``in_features`` axis is appended.
-    Ids must be in range; out-of-range ids gather garbage rows (MLX gather has no
-    bounds check), so callers own that validation.
-    """
-    rows = mx.dequantize(
-        qt.qweight[ids],
-        qt.scales[ids],
-        qt.biases[ids],
-        group_size=_GROUP_SIZE,
-        bits=qt.bits,
-        mode=_QUANT_MODE,
-    )
-    return rows.astype(output_dtype)
+        Only the selected rows are dequantized; the table stays quantized. ``ids``
+        of any rank >= 1 are accepted and a trailing :attr:`in_features` axis is
+        appended. Ids must be in range; out-of-range ids gather garbage rows (MLX
+        gather has no bounds check), so callers own that validation.
+        """
+        rows = mx.dequantize(
+            self.qweight[ids],
+            self.scales[ids],
+            self.biases[ids],
+            group_size=_GROUP_SIZE,
+            bits=self.bits,
+            mode=_QUANT_MODE,
+        )
+        return rows.astype(output_dtype)

--- a/vllm_metal/gguf/mlx_native.py
+++ b/vllm_metal/gguf/mlx_native.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX-native quantized GGUF tensors and the primitives that compute with them.
+
+MLX's GGUF loader (``mx.load``) repacks Q8_0 and Q4_0 weights into the affine,
+group-32 representation that ``mx.quantized_matmul`` already consumes: a
+``uint32`` packed ``qweight`` alongside ``float16`` ``scales`` and ``biases``.
+``GGUFMLXQuantizedTensor`` wraps that triple in an explicit, validated contract,
+and :func:`qmatmul` / :func:`embedding_lookup` run on it directly so supported
+weights never get expanded into a dense copy.
+
+Q4_1 is deliberately not supported here. MLX's repack mis-decodes Q4_1 blocks
+(it skips a 2-byte block header where Q4_1 uses 4), so ``mx.load`` returns
+corrupted Q4_1 weights. Fix tracked upstream at ml-explore/mlx#3664; Q4_1 can
+join once a fixed MLX release is in our supported range. K-quants and other
+qtypes MLX does not repack natively are left for the raw-block Metal path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+
+try:
+    import gguf
+except ImportError as exc:  # pragma: no cover - exercised only without the extra
+    raise ImportError(
+        "GGUF support requires the optional 'gguf' dependency. "
+        "Install it with: pip install 'vllm-metal[gguf]'"
+    ) from exc
+
+GGMLQuantizationType = gguf.GGMLQuantizationType
+
+# qtypes MLX repacks into its affine representation (see module docstring for
+# why Q4_1 is excluded despite being a 4-bit standard qtype).
+_BITS: dict[GGMLQuantizationType, int] = {
+    GGMLQuantizationType.Q8_0: 8,
+    GGMLQuantizationType.Q4_0: 4,
+}
+MLX_NATIVE_GGUF_TYPES = frozenset(_BITS)
+
+# MLX's GGUF repack always groups these qtypes by 32 in the affine quant mode.
+_GROUP_SIZE = 32
+_QUANT_MODE = "affine"
+
+_WEIGHT_SUFFIX = ".weight"
+
+
+def _as_supported_qtype(value: GGMLQuantizationType | int) -> GGMLQuantizationType:
+    """Normalize to a ``GGMLQuantizationType`` and require it to be MLX-native."""
+    try:
+        qweight_type = GGMLQuantizationType(value)
+    except ValueError as exc:
+        raise ValueError(f"Unknown GGUF quantization type: {value!r}") from exc
+    if qweight_type in MLX_NATIVE_GGUF_TYPES:
+        return qweight_type
+    supported = ", ".join(t.name for t in _BITS)
+    if qweight_type == GGMLQuantizationType.Q4_1:
+        # Remove this special case once a fixed MLX release (ml-explore/mlx#3664)
+        # is our lower bound and Q4_1 can be added to _BITS.
+        raise ValueError(
+            "GGUF Q4_1 is not supported on the MLX-native path: MLX's GGUF "
+            "repack mis-decodes Q4_1 blocks and returns corrupted weights "
+            "(ml-explore/mlx#3664). "
+            f"Supported MLX-native qtypes: {supported}."
+        )
+    raise ValueError(
+        f"Unsupported GGUF quantization type for the MLX-native path: "
+        f"{qweight_type.name}. Supported MLX-native qtypes: {supported}."
+    )
+
+
+@dataclass(frozen=True, eq=False)
+class GGUFMLXQuantizedTensor:
+    """An MLX-native quantized GGUF weight plus its originating quant type.
+
+    The contract consumers can rely on:
+
+    * ``qweight`` — ``uint32`` packed weights, 2-D, shape :attr:`packed_shape`.
+    * ``scales`` / ``biases`` — ``float16``, shape
+      ``(out_features, in_features // group_size)``.
+    * ``qweight_type`` — a ``gguf.GGMLQuantizationType`` in
+      :data:`MLX_NATIVE_GGUF_TYPES`.
+    * logical weight is ``(out_features, in_features)``; :attr:`group_size` is 32;
+      :attr:`bits` is 8 for Q8_0, 4 for Q4_0.
+    * activations: :func:`qmatmul` accepts float16/bfloat16/float32 ``x`` and
+      returns ``x``'s dtype; :func:`embedding_lookup` returns an explicit
+      ``output_dtype``.
+
+    Construct directly when you already hold the affine arrays (e.g. a row slice
+    of another tensor), or via :meth:`from_mx_load` from an ``mx.load`` result.
+    """
+
+    qweight: mx.array
+    scales: mx.array
+    biases: mx.array
+    qweight_type: GGMLQuantizationType
+
+    def __post_init__(self) -> None:
+        # Coerce ints to the enum (and reject non-native qtypes) so every error
+        # message and downstream consumer can rely on a real GGMLQuantizationType.
+        object.__setattr__(self, "qweight_type", _as_supported_qtype(self.qweight_type))
+        bits = _BITS[self.qweight_type]
+
+        if self.qweight.dtype != mx.uint32:
+            raise ValueError(
+                f"{self.qweight_type.name} qweight must be uint32, "
+                f"got {self.qweight.dtype}"
+            )
+        for name, arr in (("scales", self.scales), ("biases", self.biases)):
+            if arr.dtype != mx.float16:
+                raise ValueError(
+                    f"{self.qweight_type.name} {name} must be float16, got {arr.dtype}"
+                )
+        if self.qweight.ndim != 2 or self.scales.ndim != 2 or self.biases.ndim != 2:
+            raise ValueError(
+                f"{self.qweight_type.name} qweight/scales/biases must be 2-D, got "
+                f"{self.qweight.shape}, {self.scales.shape}, {self.biases.shape}"
+            )
+        if self.scales.shape != self.biases.shape:
+            raise ValueError(
+                f"{self.qweight_type.name} scales {self.scales.shape} and biases "
+                f"{self.biases.shape} must have the same shape"
+            )
+
+        out_features, packed_in = self.qweight.shape
+        scale_rows, num_groups = self.scales.shape
+        if scale_rows != out_features:
+            raise ValueError(
+                f"{self.qweight_type.name} scales rows {scale_rows} must match "
+                f"qweight rows {out_features}"
+            )
+        # affine packing: a group of 32 weights is 32 * bits bits, i.e. `bits`
+        # uint32 words (32 bits each), so the packed inner dim is num_groups * bits.
+        if packed_in != num_groups * bits:
+            raise ValueError(
+                f"{self.qweight_type.name} packed inner dim {packed_in} is "
+                f"inconsistent with {num_groups} groups at {bits} bits "
+                f"(expected {num_groups * bits})"
+            )
+        if num_groups < 1:
+            raise ValueError(
+                f"{self.qweight_type.name} must have at least one group, "
+                f"got scales shape {self.scales.shape}"
+            )
+
+    @classmethod
+    def from_mx_load(
+        cls,
+        arrays: dict[str, mx.array],
+        weight_name: str,
+        qweight_type: GGMLQuantizationType,
+    ) -> GGUFMLXQuantizedTensor:
+        """Build from an ``mx.load`` result.
+
+        ``weight_name`` is the original GGUF tensor name (``...​.weight``); MLX
+        stores the companion scales/biases under the same prefix. ``qweight_type``
+        is supplied by the caller because ``mx.load`` does not expose per-tensor
+        quant types — a loader reads it from ``gguf.GGUFReader``.
+        """
+        qweight_type = _as_supported_qtype(qweight_type)
+        if not weight_name.endswith(_WEIGHT_SUFFIX):
+            raise ValueError(
+                f"GGUF weight name must end with '{_WEIGHT_SUFFIX}', got "
+                f"{weight_name!r}"
+            )
+        prefix = weight_name[: -len(_WEIGHT_SUFFIX)]
+        scales_name = f"{prefix}.scales"
+        biases_name = f"{prefix}.biases"
+        missing = [
+            n for n in (weight_name, scales_name, biases_name) if n not in arrays
+        ]
+        if missing:
+            raise ValueError(
+                f"{qweight_type.name} tensor {weight_name!r} is missing MLX repack "
+                f"arrays {missing}; MLX did not natively repack it (expected with "
+                f"this MLX version) — load it through the raw-block path instead"
+            )
+        return cls(
+            qweight=arrays[weight_name],
+            scales=arrays[scales_name],
+            biases=arrays[biases_name],
+            qweight_type=qweight_type,
+        )
+
+    @property
+    def bits(self) -> int:
+        return _BITS[self.qweight_type]
+
+    @property
+    def group_size(self) -> int:
+        return _GROUP_SIZE
+
+    @property
+    def out_features(self) -> int:
+        return self.qweight.shape[0]
+
+    @property
+    def in_features(self) -> int:
+        return self.scales.shape[1] * _GROUP_SIZE
+
+    @property
+    def logical_shape(self) -> tuple[int, int]:
+        return (self.out_features, self.in_features)
+
+    @property
+    def packed_shape(self) -> tuple[int, ...]:
+        return tuple(self.qweight.shape)
+
+
+def qmatmul(x: mx.array, qt: GGUFMLXQuantizedTensor) -> mx.array:
+    """Compute ``x @ dequantize(qt).T`` without materializing the dense weight.
+
+    ``x`` may be float16, bfloat16, or float32, and its last dim must be
+    ``qt.in_features``; any leading shape is preserved. The result has the same
+    dtype as ``x`` (``mx.quantized_matmul`` promotes a bfloat16 ``x`` against the
+    float16 scales to float32, so it is cast back).
+    """
+    out = mx.quantized_matmul(
+        x,
+        qt.qweight,
+        scales=qt.scales,
+        biases=qt.biases,
+        transpose=True,
+        group_size=_GROUP_SIZE,
+        bits=qt.bits,
+        mode=_QUANT_MODE,
+    )
+    return out.astype(x.dtype)
+
+
+def embedding_lookup(
+    ids: mx.array,
+    qt: GGUFMLXQuantizedTensor,
+    output_dtype: mx.Dtype,
+) -> mx.array:
+    """Gather and dequantize embedding rows for ``ids``.
+
+    Only the selected rows are dequantized; the table stays quantized. ``ids`` of
+    any rank >= 1 are accepted and a trailing ``in_features`` axis is appended.
+    Ids must be in range; out-of-range ids gather garbage rows (MLX gather has no
+    bounds check), so callers own that validation.
+    """
+    rows = mx.dequantize(
+        qt.qweight[ids],
+        qt.scales[ids],
+        qt.biases[ids],
+        group_size=_GROUP_SIZE,
+        bits=qt.bits,
+        mode=_QUANT_MODE,
+    )
+    return rows.astype(output_dtype)


### PR DESCRIPTION
The original roadmap had this PR covering Q8_0, Q4_0, and Q4_1. While implementing it, I found that MLX's GGUF repack path currently mis-decodes Q4_1 weights.

Specifically, `mx.load()` appears to silently corrupt Q4_1 tensors because it skips a 2-byte block header, while Q4_1 uses a 4-byte block header. I checked this against the `gguf` package's `dequantize` implementation: Q4_1 shows a max absolute error of about `5.0`, while Q8_0 and Q4_0 are around `0.002`.

I filed the upstream fix here: ml-explore/mlx#3664.

Because of that, this PR ships **Q8_0 + Q4_0 only**. Q4_1 is rejected at construction time with a clear error pointing to ml-explore/mlx#3664. Re-enabling Q4_1 should be done as a follow-up once a fixed MLX release is within our pinned range. We currently pin `mlx==0.31.2`, so that follow-up will also need the usual MLX bump and JIT-build check.
