### PR TITLE
Bump vLLM to 0.23.0

### DIFF
--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -2,7 +2,7 @@
 
 vllm-metal supports the optional `vllm-rs` Rust frontend as a drop-in replacement for vLLM's Python serving layer. The Rust frontend is hardware-agnostic; vllm-metal continues to run the engine on Metal/MLX inside the spawned Python subprocess.
 
-As of vLLM 0.22.1, the Rust frontend source is vendored in the main vLLM repository under `rust/`. The former `Inferact/vllm-frontend-rs` repository is kept only as a historical archive.
+As of vLLM 0.23.0, the Rust frontend source is vendored in the main vLLM repository under `rust/`. The former `Inferact/vllm-frontend-rs` repository is kept only as a historical archive.
 
 For architecture, flag reference, and usage, see the [upstream README](https://github.com/vllm-project/vllm/tree/main/rust#readme).
 

--- a/install.sh
+++ b/install.sh
@@ -198,7 +198,7 @@ EOF
     exit 1
   fi
 
-  local vllm_v="0.22.1"
+  local vllm_v="0.23.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   local vllm_tmp_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
-    # First allowed Transformers v5 release per vLLM 0.22.1's exclude list.
+    # First allowed Transformers v5 release per vLLM 0.23.0's exclude list.
     "transformers>=5.5.1",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -2724,24 +2724,26 @@ def test_tq_spec_merge_uniform_specs():
     assert merged.page_size_bytes == specs[0].page_size_bytes
 
 
-def test_tq_spec_registered_in_vllm_spec_manager_map():
-    """Importing ``cache_policy`` must register our subclass with vLLM.
+def test_tq_spec_resolves_to_full_attention_manager():
+    """TurboQuant specs must resolve to vLLM's full-attention manager.
 
-    vLLM's ``get_manager_for_kv_cache_spec`` uses strict-type lookup
-    (``spec_manager_map[type(spec)]``), not isinstance. If this assertion
-    fails the engine-core will crash at startup with ``KeyError:
-    TurboQuantAttentionSpec`` the moment TurboQuant is enabled.
+    vLLM 0.23 resolves ``FullAttentionSpec`` subclasses through
+    ``KVCacheSpecRegistry`` MRO fallback.
     """
-    from vllm.v1.core.single_type_kv_cache_manager import (
-        FullAttentionManager,
-        spec_manager_map,
+    spec = _build_turboquant_attention_spec(
+        block_size=16,
+        num_kv_heads=4,
+        head_dim=128,
+        k_quant="q8_0",
+        v_quant="q3_0",
     )
 
-    assert TurboQuantAttentionSpec in spec_manager_map, (
-        "TurboQuantAttentionSpec missing from vLLM's spec_manager_map — "
-        "engine-core will KeyError at startup."
-    )
-    assert spec_manager_map[TurboQuantAttentionSpec] is FullAttentionManager
+    from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+    from vllm.v1.kv_cache_interface import FullAttentionSpec
+    from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+    assert KVCacheSpecRegistry.get_manager_class(spec) is FullAttentionManager
+    assert KVCacheSpecRegistry.get_uniform_type_base_spec(spec) is FullAttentionSpec
 
 
 def test_tq_spec_merge_rejects_mixed_quant():

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -155,34 +155,6 @@ def _build_turboquant_attention_spec(
     )
 
 
-def _register_turboquant_spec_manager() -> None:
-    """Register ``TurboQuantAttentionSpec`` in vLLM's spec→manager map.
-
-    vLLM's ``get_manager_for_kv_cache_spec`` uses strict-type lookup
-    (``spec_manager_map[type(spec)]``), not ``isinstance``, so the
-    ``FullAttentionSpec`` entry does not cover subclasses.  We reuse
-    ``FullAttentionManager`` because a TurboQuant cache is accessed
-    like a regular KV page from the scheduler's POV — block indexing,
-    no special slot math (per-element byte layout is handled entirely
-    inside the Metal kernel).
-
-    Mirrors the upstream registration for ``MLAAttentionSpec`` (which
-    vLLM also maps to ``FullAttentionManager``).
-    """
-    try:
-        from vllm.v1.core.single_type_kv_cache_manager import (
-            FullAttentionManager,
-            spec_manager_map,
-        )
-    except ImportError:
-        # vLLM shape changed; let the scheduler raise its own clearer error.
-        return
-    spec_manager_map.setdefault(TurboQuantAttentionSpec, FullAttentionManager)
-
-
-_register_turboquant_spec_manager()
-
-
 @dataclass(frozen=True)
 class _HybridGDNReservation:
     bytes_per_slot: int = 0


### PR DESCRIPTION
This keeps vllm-metal aligned with upstream vLLM 0.23.0.

The TurboQuant test is updated because vLLM 0.23 resolves KV cache specs through `KVCacheSpecRegistry` instead of the old `spec_manager_map`.