### PR TITLE
[GGUF] Add GGUF-aware Linear/Embedding wrappers

### DIFF
--- a/tests/test_gguf_wrappers.py
+++ b/tests/test_gguf_wrappers.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the GGUF-aware Linear/Embedding wrappers.
+
+Wrappers are exercised around the REAL tensor (built from a gguf/mx.load fixture
+like the PR-1 tests), with parity checked against ``gguf.quants.dequantize`` — no
+SimpleNamespace/MagicMock tensor fakes. The wrapper modules are nn.Modules, so
+this suite needs MLX (it won't collect on a machine without a Metal device).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_flatten
+
+gguf = pytest.importorskip("gguf")
+
+from vllm_metal.gguf.mlx_native import GGUFMLXQuantizedTensor  # noqa: E402
+from vllm_metal.gguf.wrappers import GGUFEmbedding, GGUFLinear  # noqa: E402
+
+GGMLQuantizationType = gguf.GGMLQuantizationType
+
+NATIVE_QTYPES = [GGMLQuantizationType.Q8_0, GGMLQuantizationType.Q4_0]
+
+
+def _write_quantized_gguf(path, weight: np.ndarray, qtype) -> dict[str, mx.array]:
+    raw = gguf.quants.quantize(weight, qtype)
+    writer = gguf.GGUFWriter(str(path), "llama")
+    writer.add_tensor("w.weight", raw, raw_shape=raw.shape, raw_dtype=qtype)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+    return mx.load(str(path))
+
+
+def _make_tensor(tmp_path, qtype, shape=(64, 128)):
+    weight = np.random.default_rng(0).standard_normal(shape).astype(np.float32)
+    arrays = _write_quantized_gguf(tmp_path / f"{qtype.name}.gguf", weight, qtype)
+    qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, "w.weight", qtype)
+    oracle = gguf.quants.dequantize(gguf.quants.quantize(weight, qtype), qtype).astype(
+        np.float32
+    )
+    return qt, oracle
+
+
+def test_quant_arrays_are_not_module_parameters(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+    bias = mx.zeros((qt.out_features,), dtype=mx.float32)
+
+    # The packed quant arrays are owned by the tensor, not the Module, so a dtype
+    # cast / parameter sweep can't touch them.
+    assert dict(tree_flatten(GGUFLinear(qt).parameters())) == {}
+    emb = GGUFEmbedding(qt, output_dtype=mx.float16)
+    assert dict(tree_flatten(emb.parameters())) == {}
+    # Only the dense bias is a parameter, and freeze() leaves it non-trainable.
+    biased = GGUFLinear(qt, bias=bias)
+    assert [k for k, _ in tree_flatten(biased.parameters())] == ["bias"]
+    assert dict(tree_flatten(biased.trainable_parameters())) == {}
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_linear_matches_dense_oracle(tmp_path, qtype):
+    qt, oracle = _make_tensor(tmp_path, qtype)
+    layer = GGUFLinear(qt)
+    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
+
+    out = layer(x)
+    expected = x @ mx.array(oracle).T
+    mx.eval(out, expected)
+
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
+    )
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_linear_bias_is_a_real_post_matmul_add(tmp_path, qtype):
+    qt, _ = _make_tensor(tmp_path, qtype)
+    bias = mx.random.normal((qt.out_features,)).astype(mx.float32)
+    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
+
+    biased = GGUFLinear(qt, bias=bias)
+    plain = GGUFLinear(qt)
+    no_bias = plain(x)
+    with_bias = biased(x)
+    mx.eval(no_bias, with_bias)
+
+    assert "bias" in biased
+    assert "bias" not in plain
+    np.testing.assert_allclose(
+        np.array(with_bias), np.array(no_bias + bias), rtol=0, atol=1e-6
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_linear_output_dtype_follows_x(tmp_path, dtype, with_bias):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+    # GGUF bias is float32; the wrapper must cast it so a bf16/f16 x stays bf16/f16.
+    bias = mx.zeros((qt.out_features,), dtype=mx.float32) if with_bias else None
+    layer = GGUFLinear(qt, bias=bias)
+    x = mx.random.normal((4, qt.in_features)).astype(dtype)
+
+    out = layer(x)
+
+    assert out.dtype == dtype
+    assert out.shape == (4, qt.out_features)
+
+
+def test_linear_rejects_bad_bias(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+    for bad in (
+        mx.zeros((1,), dtype=mx.float32),  # would broadcast
+        mx.zeros((), dtype=mx.float32),  # scalar
+        mx.zeros((qt.out_features - 1,), dtype=mx.float32),  # wrong length
+        mx.zeros((qt.out_features,), dtype=mx.int32),  # non-floating
+    ):
+        with pytest.raises(ValueError, match="bias must be a floating mx.array"):
+            GGUFLinear(qt, bias=bad)
+
+
+def test_linear_extra_repr_shows_dims(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0, shape=(64, 128))
+    repr_str = repr(GGUFLinear(qt))
+    assert "input_dims=128" in repr_str
+    assert "output_dims=64" in repr_str
+    assert "bias=False" in repr_str
+
+
+def test_embedding_extra_repr_shows_dims(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0, shape=(64, 128))
+    # "out_features, in_features" in order, mirroring QuantizedEmbedding's repr.
+    assert "64, 128" in repr(GGUFEmbedding(qt, output_dtype=mx.float16))
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_embedding_matches_dense_oracle(tmp_path, qtype):
+    qt, oracle = _make_tensor(tmp_path, qtype)
+    layer = GGUFEmbedding(qt, output_dtype=mx.float32)
+    ids = mx.array([[0, 5], [63, 0]], dtype=mx.int32)
+
+    out = layer(ids)
+    expected = mx.array(oracle)[ids]
+    mx.eval(out, expected)
+
+    assert out.shape == (2, 2, qt.in_features)
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 5e-3
+    )
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_embedding_as_linear_matches_oracle(tmp_path, qtype):
+    # Tied lm_head: the embedding table is reused as the output projection.
+    qt, oracle = _make_tensor(tmp_path, qtype, shape=(100, 64))
+    layer = GGUFEmbedding(qt, output_dtype=mx.float32)
+    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
+
+    out = layer.as_linear(x)
+    expected = x @ mx.array(oracle).T
+    mx.eval(out, expected)
+
+    ref_max = float(mx.max(mx.abs(expected)))
+    np.testing.assert_allclose(
+        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
+    )
+
+
+def test_embedding_output_dtype(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+    out = GGUFEmbedding(qt, output_dtype=mx.bfloat16)(mx.array([0, 1], dtype=mx.int32))
+    assert out.dtype == mx.bfloat16
+
+
+def test_embedding_rejects_non_floating_output_dtype(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+    # A non-floating output_dtype would silently truncate dequantized rows.
+    for bad in (mx.int32, mx.uint8, mx.int8):
+        with pytest.raises(ValueError, match="output_dtype must be a floating"):
+            GGUFEmbedding(qt, output_dtype=bad)
+
+
+def test_wrapper_never_sees_invalid_tensor(tmp_path):
+    # Q4_1 is rejected when the tensor is built — before any wrapper can exist.
+    weight = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
+    arrays = _write_quantized_gguf(
+        tmp_path / "q4_1.gguf", weight, GGMLQuantizationType.Q4_1
+    )
+    with pytest.raises(ValueError, match="ml-explore/mlx#3664"):
+        GGUFMLXQuantizedTensor.from_mx_load(
+            arrays, "w.weight", GGMLQuantizationType.Q4_1
+        )

--- a/vllm_metal/gguf/tensor.py
+++ b/vllm_metal/gguf/tensor.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The runtime contract the GGUF-aware wrappers depend on.
+
+A small, format-neutral protocol so an MLX-native quantized tensor (the only
+implementer today, ``GGUFMLXQuantizedTensor``) and a future raw-block/K-quant
+tensor can be consumed by the same Linear/Embedding wrappers without
+backend-specific dispatch branches. Introduced at the reviewer's request in the
+PR 1 review.
+
+This module imports no ``gguf`` and no MLX at runtime — the ``mx`` annotations
+are only evaluated under ``TYPE_CHECKING`` — so it stays dependency-light.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import mlx.core as mx
+
+
+@runtime_checkable
+class GGUFTensor(Protocol):
+    """A GGUF weight that knows how to matmul and gather embedding rows.
+
+    ``GGUFMLXQuantizedTensor`` satisfies this structurally (no inheritance);
+    ``isinstance(tensor, GGUFTensor)`` only checks the members below are present.
+    """
+
+    @property
+    def out_features(self) -> int:
+        """Logical output dim — rows of the logical ``(out, in)`` weight."""
+        ...
+
+    @property
+    def in_features(self) -> int:
+        """Logical input dim — cols of the logical ``(out, in)`` weight."""
+        ...
+
+    def matmul(self, x: mx.array) -> mx.array:
+        """``x @ W.T`` without dequantizing; preserves leading dims, returns x.dtype."""
+        ...
+
+    def embedding(self, ids: mx.array, output_dtype: mx.Dtype) -> mx.array:
+        """Gather and dequantize the rows selected by ``ids``; returns output_dtype."""
+        ...

--- a/vllm_metal/gguf/wrappers.py
+++ b/vllm_metal/gguf/wrappers.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GGUF-aware Linear and Embedding modules backed by a GGUFTensor.
+
+Thin ``nn.Module`` drop-ins that delegate all quantized math to the tensor's
+``matmul`` / ``embedding``. They add only the ``nn.Module`` surface, an optional
+dense bias, and the tied-lm_head ``as_linear`` hook — no quant logic and no
+re-validation of what the tensor already guarantees. Unsupported qtypes are
+rejected when the tensor is built (PR 1's ``GGUFMLXQuantizedTensor``), so a
+wrapper never sees an invalid one.
+
+The quantized arrays are owned by the tensor, not by these modules, so they are
+intentionally invisible to ``Module.parameters()`` (a feature: a dtype cast or
+parameter sweep won't touch packed uint32). The forward path runs through MLX's
+lazy evaluation of the output, which does not need the arrays to be parameters.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from vllm_metal.gguf.tensor import GGUFTensor
+
+
+class GGUFLinear(nn.Module):
+    """A quantized linear layer: ``x @ W.T`` (plus an optional bias).
+
+    Mirrors ``mlx.nn.QuantizedLinear`` — the bias is a dense array added after
+    the matmul. It is cast to the activation dtype so the output follows ``x``'s
+    dtype (GGUF biases are stored as float32, which would otherwise promote a
+    float16/bfloat16 result).
+    """
+
+    def __init__(self, tensor: GGUFTensor, bias: mx.array | None = None) -> None:
+        super().__init__()
+        self.tensor = tensor
+        if bias is not None:
+            self.bias = self._validate_bias(tensor, bias)
+        self.freeze()
+
+    @staticmethod
+    def _validate_bias(tensor: GGUFTensor, bias: mx.array) -> mx.array:
+        expected = (tensor.out_features,)
+        if (
+            not isinstance(bias, mx.array)
+            or bias.shape != expected
+            or not mx.issubdtype(bias.dtype, mx.floating)
+        ):
+            got = (
+                f"{bias.dtype} {bias.shape}"
+                if isinstance(bias, mx.array)
+                else type(bias)
+            )
+            raise ValueError(
+                f"GGUFLinear bias must be a floating mx.array of shape "
+                f"{expected}, got {got}"
+            )
+        return bias
+
+    def __call__(self, x: mx.array) -> mx.array:
+        out = self.tensor.matmul(x)
+        if "bias" in self:
+            out = out + self["bias"].astype(out.dtype)
+        return out
+
+    def _extra_repr(self) -> str:
+        return (
+            f"input_dims={self.tensor.in_features}, "
+            f"output_dims={self.tensor.out_features}, bias={'bias' in self}"
+        )
+
+
+class GGUFEmbedding(nn.Module):
+    """A quantized embedding table; ``as_linear`` reuses it for a tied lm_head.
+
+    Mirrors ``mlx.nn.QuantizedEmbedding``: ``__call__`` gathers and dequantizes
+    rows, ``as_linear`` runs the table as the output projection.
+    """
+
+    def __init__(self, tensor: GGUFTensor, output_dtype: mx.Dtype) -> None:
+        super().__init__()
+        self.tensor = tensor
+        self.output_dtype = self._validate_output_dtype(output_dtype)
+        self.freeze()
+
+    @staticmethod
+    def _validate_output_dtype(output_dtype: mx.Dtype) -> mx.Dtype:
+        # A non-floating output_dtype would silently truncate dequantized rows to
+        # integers; reject it at this public wrapper boundary.
+        if not isinstance(output_dtype, mx.Dtype) or not mx.issubdtype(
+            output_dtype, mx.floating
+        ):
+            raise ValueError(
+                "GGUFEmbedding output_dtype must be a floating mx.Dtype, got "
+                f"{output_dtype!r}"
+            )
+        return output_dtype
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        return self.tensor.embedding(ids, self.output_dtype)
+
+    def as_linear(self, x: mx.array) -> mx.array:
+        return self.tensor.matmul(x)
+
+    def _extra_repr(self) -> str:
+        # Bare "num_embeddings, dims" mirrors mlx.nn.QuantizedEmbedding's repr.
+        return f"{self.tensor.out_features}, {self.tensor.in_features}"


### PR DESCRIPTION
This PR adds the GGUF-aware Linear and Embedding modules and the small `GGUFTensor` protocol requested in the PR 1 review. This is the second PR of the #415 stack.

`GGUFTensor` (`tensor.py`) is the seam the wrappers depend on: `matmul`, `embedding`, `out_features`, and `in_features`. PR 1's `GGUFMLXQuantizedTensor` satisfies it structurally, unchanged here, and a future raw-block tensor can satisfy the same interface.

One deviation from the original sketch: I added `out_features` and `in_features` next to the two methods, since both wrappers' `_extra_repr` need the logical shape. Reading it through the protocol keeps the wrappers independent from the concrete tensor type. Happy to trim this back to just the two methods if preferred — that would be a one-line change.

`GGUFLinear` and `GGUFEmbedding` (`wrappers.py`) are thin `nn.Module` drop-ins that delegate all quant math to the tensor. The bias is dense, added after the matmul, and cast to the activation dtype. GGUF biases are f32, which would otherwise promote a bf16/f16 result. Shape and floating dtype are validated at construction.

`GGUFEmbedding.as_linear` covers the tied `lm_head` case. The packed quant arrays stay owned by the tensor, so they are intentionally not exposed as `Module.parameters()`; this prevents dtype sweeps from touching packed `uint32` data. The forward path runs through lazy eval.

Unsupported qtypes are rejected when the tensor is built, before any wrapper exists.
