### PR TITLE
Pin fastapi<0.137 to fix serving crash (vLLM #45597)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ dependencies = [
     # Core utilities
     "numpy>=1.24.0",
     "psutil>=5.9.0",
+    # Temporary cap: fastapi>=0.137 adds a `_IncludedRouter` route type that
+    # crashes vLLM's prometheus middleware (vllm-project/vllm#45597).
+    # TODO: remove once we bump to a vLLM release that includes vllm#45629.
+    "fastapi[standard]>=0.115.0,<0.137",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This caps fastapi below 0.137 to fix the serving crash that's failing CI on main right now.

fastapi 0.137 added a `_IncludedRouter` route type that vLLM's `prometheus-fastapi-instrumentator` middleware doesn't
handle. It calls `route.path` on every route and hits `'_IncludedRouter' object has no attribute 'path'`, so every
request (even `/health`) returns 500 and the smoke test's `/v1/completions` call fails. This is vLLM bug
vllm-project/vllm#45597.

vLLM fixed it in their own code (vllm-project/vllm#45629, merged) by making the metrics middleware tolerate
`_IncludedRouter`, and they keep supporting fastapi>=0.137. But that fix isn't in any release yet. I checked: neither
v0.23.0 (which we build from) nor v0.23.1rc0 contains it, it's only on main. So capping fastapi is the only way to
unblock CI until vLLM ships #45629 in a release.

The pin is a stopgap: once vLLM cuts a 0.23.x release that includes #45629, we bump to it and drop the pin (fastapi
goes back to >=0.137). It uses the same `fastapi[standard]` form as vLLM's `requirements/common.txt`, and the comment records that removal condition.

Surfaced right after #443 (bump to vLLM 0.23.0).
