### PR TITLE
Close prefill/decode asymmetry in hybrid GDN state submission

### DIFF
--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1182,26 +1182,6 @@ class TestV1MetalModelRunnerGDNSubmit:
         )
         return backend
 
-    def test_prefill_hybrid_submits_logits_and_updated_gdn_states(
-        self, monkeypatch
-    ) -> None:
-        # Arrange
-        submitted: list[tuple[object, ...]] = []
-        runner = make_stub_runner(_paged_attention_runtime=self._make_hybrid_backend())
-        logits = mx.array([0], dtype=mx.float32)
-        expected_states = runner._gdn_updated_state_arrays()
-        monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
-
-        # Act
-        runner._submit_paged_forward_outputs(logits, has_prefill=True)
-
-        # Assert
-        assert len(submitted) == 1
-        assert submitted[0][0] is logits
-        assert len(submitted[0][1:]) == len(expected_states)
-        for actual, expected in zip(submitted[0][1:], expected_states, strict=True):
-            assert actual is expected
-
     def test_prefill_hybrid_submits_pending_compact_gdn_states(
         self, monkeypatch
     ) -> None:
@@ -1228,7 +1208,7 @@ class TestV1MetalModelRunnerGDNSubmit:
         monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
 
         # Act
-        runner._submit_paged_forward_outputs(logits, has_prefill=True)
+        runner._submit_paged_forward_outputs(logits)
 
         # Assert
         assert len(submitted) == 1
@@ -1237,18 +1217,25 @@ class TestV1MetalModelRunnerGDNSubmit:
         assert cache.has_pending_conv_state(0)
         assert cache.has_pending_recurrent_state(0)
 
-    def test_decode_only_hybrid_submits_logits_only(self, monkeypatch) -> None:
+    def test_decode_only_hybrid_submits_logits_and_updated_gdn_states(
+        self, monkeypatch
+    ) -> None:
         # Arrange
         submitted: list[tuple[object, ...]] = []
         runner = make_stub_runner(_paged_attention_runtime=self._make_hybrid_backend())
         logits = mx.array([0], dtype=mx.float32)
+        expected_states = runner._gdn_updated_state_arrays()
         monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
 
         # Act
-        runner._submit_paged_forward_outputs(logits, has_prefill=False)
+        runner._submit_paged_forward_outputs(logits)
 
         # Assert
-        assert submitted == [(logits,)]
+        assert len(submitted) == 1
+        assert submitted[0][0] is logits
+        assert len(submitted[0][1:]) == len(expected_states)
+        for actual, expected in zip(submitted[0][1:], expected_states, strict=True):
+            assert actual is expected
 
     def test_prefill_non_hybrid_submits_logits_only(self, monkeypatch) -> None:
         # Arrange
@@ -1258,7 +1245,7 @@ class TestV1MetalModelRunnerGDNSubmit:
         monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
 
         # Act
-        runner._submit_paged_forward_outputs(logits, has_prefill=True)
+        runner._submit_paged_forward_outputs(logits)
 
         # Assert
         assert submitted == [(logits,)]

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1217,9 +1217,7 @@ class TestV1MetalModelRunnerGDNSubmit:
         assert cache.has_pending_conv_state(0)
         assert cache.has_pending_recurrent_state(0)
 
-    def test_decode_only_hybrid_submits_logits_and_updated_gdn_states(
-        self, monkeypatch
-    ) -> None:
+    def test_hybrid_submits_logits_and_updated_gdn_states(self, monkeypatch) -> None:
         # Arrange
         submitted: list[tuple[object, ...]] = []
         runner = make_stub_runner(_paged_attention_runtime=self._make_hybrid_backend())

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -616,16 +616,13 @@ class MetalModelRunner:
         self,
         logits: mx.array,
         *,
-        has_prefill: bool,
         target_hidden_states: mx.array | None = None,
     ) -> None:
         """Submit logits, hidden states, and GDN state side effects."""
         outputs = [logits]
         if target_hidden_states is not None:
             outputs.append(target_hidden_states)
-        if has_prefill and isinstance(
-            self._paged_attention_runtime, HybridPagedAttentionRuntime
-        ):
+        if isinstance(self._paged_attention_runtime, HybridPagedAttentionRuntime):
             outputs.extend(self._gdn_updated_state_arrays())
         mx.async_eval(*outputs)
 
@@ -1173,13 +1170,9 @@ class MetalModelRunner:
             mx.async_eval(pp_send_handle)
         else:
             assert logits is not None
-            # For GDN prefill, state-cache updates are side effects that the
-            # logits graph does not necessarily force. Submit them with logits
-            # and any target hidden states retained for assistant decoding.
             self._submit_paged_forward_outputs(
                 logits,
                 target_hidden_states=target_hidden_states,
-                has_prefill=bool(prefill_reqs),
             )
 
         # ---- build cu_seqlens for logit extraction ----

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1170,6 +1170,8 @@ class MetalModelRunner:
             mx.async_eval(pp_send_handle)
         else:
             assert logits is not None
+            # Hybrid GDN state writes are forward side effects and are not
+            # guaranteed to be forced by `mx.eval(logits)` alone.
             self._submit_paged_forward_outputs(
                 logits,
                 target_hidden_states=target_hidden_states,


### PR DESCRIPTION
This PR is:
- To close the prefill/decode asymmetry in hybrid GDN state submission
- To add focused coverage for the hybrid submission path

Hybrid GDN decode updates mutate the conv/recurrent state-cache arrays as side effects of the forward, and those writes are not transitively forced by `mx.eval(logits)`. Previously the paged runner only submitted those state arrays to `mx.async_eval` when a batch contained prefill work. This change removes that prefill-only gate and always submits the authoritative GDN state arrays for hybrid paged runtimes.
