### PR TITLE
Optimize PaddleOCR-VL single-segment attention

### DIFF
--- a/tests/multimodal/test_paddleocr_vl.py
+++ b/tests/multimodal/test_paddleocr_vl.py
@@ -92,7 +92,12 @@ class _RecordingVisual:
                 "output_hidden_states": output_hidden_states,
             }
         )
-        return mx.ones((_IMAGE_TOKEN_COUNT_2X2, 8), dtype=mx.float32)
+        parts = []
+        for idx, grid in enumerate(image_grid_thw.tolist()):
+            t, h, w = (int(item) for item in grid)
+            tokens = t * (h // _SPATIAL_MERGE_SIZE) * (w // _SPATIAL_MERGE_SIZE)
+            parts.append(mx.full((tokens, 8), idx + 1, dtype=mx.float32))
+        return mx.concatenate(parts, axis=0)
 
 
 class _RealPaddleOCRVLGetRopeIndexLanguageModel:

--- a/vllm_metal/multimodal/paddleocr_vl/adapter.py
+++ b/vllm_metal/multimodal/paddleocr_vl/adapter.py
@@ -57,6 +57,7 @@ class PaddleOCRVLMultimodalAdapter:
         language_model = model.language_model
         spatial_merge_size = int(model.config.vision_config.spatial_merge_size)
         embed_tokens_fn = cls._resolve_embed_tokens(language_model)
+        cls._install_single_segment_attention_fast_path(visual)
         return cls(
             spatial_merge_size=spatial_merge_size,
             visual=visual,
@@ -80,6 +81,78 @@ class PaddleOCRVLMultimodalAdapter:
             )
         return embed_tokens
 
+    @staticmethod
+    def _install_single_segment_attention_fast_path(visual: Any) -> None:
+        """Skip PaddleOCR-VL's dense vision mask for single-image attention."""
+        try:
+            from mlx_vlm.models.paddleocr_vl import vision as paddleocr_vision
+        except (ImportError, RuntimeError):
+            return
+
+        attention_cls = getattr(paddleocr_vision, "Attention", None)
+        apply_rotary_pos_emb_vision = getattr(
+            paddleocr_vision,
+            "apply_rotary_pos_emb_vision",
+            None,
+        )
+        if attention_cls is None or apply_rotary_pos_emb_vision is None:
+            return
+
+        layers = getattr(visual, "layers", ())
+        if not any(
+            isinstance(getattr(layer, "self_attn", None), attention_cls)
+            for layer in layers
+        ):
+            return
+        if getattr(attention_cls, "_vllm_metal_single_segment_fast_path", False):
+            return
+
+        original_call = attention_cls.__call__
+
+        def fast_call(
+            self: Any,
+            x: mx.array,
+            cu_seqlens: mx.array,
+            rotary_pos_emb: mx.array | None = None,
+        ) -> mx.array:
+            seq_length = int(x.shape[0])
+            is_single_segment = (
+                int(cu_seqlens.shape[0]) == 2
+                and int(cu_seqlens[0]) == 0
+                and int(cu_seqlens[1]) == seq_length
+            )
+            if not is_single_segment:
+                return original_call(self, x, cu_seqlens, rotary_pos_emb)
+
+            qkv = (
+                self.qkv(x)
+                .reshape(seq_length, 3, self.num_heads, -1)
+                .transpose(1, 0, 2, 3)
+            )
+            q, k, v = mx.split(qkv, 3)
+
+            q = apply_rotary_pos_emb_vision(mx.expand_dims(q, 0), rotary_pos_emb)[0]
+            k = apply_rotary_pos_emb_vision(mx.expand_dims(k, 0), rotary_pos_emb)[0]
+
+            q = q.transpose(0, 2, 1, 3)
+            k = k.transpose(0, 2, 1, 3)
+            v = v.transpose(0, 2, 1, 3)
+
+            output = mx.fast.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                scale=self.scale,
+                mask=None,
+            )
+            output = output.transpose(0, 2, 1, 3)
+            output = output.reshape(seq_length, -1)
+            return self.out_proj(output)
+
+        attention_cls._vllm_metal_original_call = original_call
+        attention_cls.__call__ = fast_call
+        attention_cls._vllm_metal_single_segment_fast_path = True
+
     def text_model(self) -> Any:
         return self._language_model
 
@@ -101,6 +174,8 @@ class PaddleOCRVLMultimodalAdapter:
                 "visual tower not loaded; encode_multimodal unavailable. "
                 "Construct via PaddleOCRVLMultimodalAdapter.from_loaded_model."
             )
+        if not features:
+            return []
 
         target_dtype = self._visual.embeddings.patch_embedding.weight.dtype
         outputs: list[PaddleOCRVLVisionEncodeResult] = []
@@ -135,6 +210,12 @@ class PaddleOCRVLMultimodalAdapter:
             except ValueError as exc:
                 raise ValueError(f"Feature {feature.identifier!r}: {exc}") from exc
             raw_patches = grid_thw[0] * grid_thw[1] * grid_thw[2]
+            if int(pixel_values.shape[0]) != 1:
+                raise ValueError(
+                    f"Feature {feature.identifier!r}: pixel_values batch "
+                    f"dimension must be 1 for image features; got "
+                    f"{pixel_values.shape[0]}"
+                )
             if int(pixel_values.shape[1]) != raw_patches:
                 raise ValueError(
                     f"Feature {feature.identifier!r}: pixel_values patch "
@@ -142,7 +223,6 @@ class PaddleOCRVLMultimodalAdapter:
                     f"got {pixel_values.shape[1]}, expected {raw_patches}"
                 )
             image_grid_thw = mx.array([grid_thw], dtype=mx.int32)
-
             hidden_states = self._visual(
                 pixel_values.astype(target_dtype),
                 image_grid_thw,


### PR DESCRIPTION
## Summary

- Add a PaddleOCR-VL vision attention fast path for the common single-image segment case where `cu_seqlens == [0, seq_len]`.
- Skip construction and use of the dense block-diagonal vision attention mask for that case, and call MLX scaled dot product attention with `mask=None`.
- Preserve the upstream `mlx-vlm` attention implementation for all non-single-segment cases.
- Update the PaddleOCR-VL multimodal adapter test fixture so per-image vision encoding behavior remains explicit.

## Motivation

PaddleOCR-VL requests in vLLM Metal usually encode one page/image at a time before the language model consumes the resulting visual embeddings. In that path, the visual attention sequence has exactly one contiguous segment, so the dense attention mask contains one all-zero block and does not change the result. Avoiding that mask reduces vision tower work without changing behavior for multi-segment inputs.

## Implementation Notes

- The patch is installed from `PaddleOCRVLMultimodalAdapter.from_loaded_model`.
- It only applies when the loaded visual tower actually uses `mlx_vlm.models.paddleocr_vl.vision.Attention`.
- It is class-level and idempotent via `_vllm_metal_single_segment_fast_path`.
- Runtime guard:
  - fast path: `cu_seqlens.shape == (2,)`, `cu_seqlens[0] == 0`, and `cu_seqlens[1] == seq_len`
  - fallback: call the original `Attention.__call__`

## Benchmark

Local benchmark machine: Apple Silicon, MLX/Metal backend.

Baseline commit: `377d3322dee65b027e92eb02e1613b0f44d136c6`
Current commit: `d51ffa528e2556a9e5ac254e469268ca0c3a43b9`

### Isolated PaddleOCR-VL Vision Tower

This directly measures the changed path, after one warmup run, with 5 measured runs.


| input             | baseline mean | current mean | speedup | latency reduction |
| ----------------- | ------------- | ------------ | ------- | ----------------- |
| page 1, edge 768  | 1.3884s       | 1.3319s      | 1.04x   | 4.1%              |
| page 1, edge 1280 | 5.1287s       | 4.8111s      | 1.07x   | 6.2%              |


Median latency also improved:


| input             | baseline median | current median | speedup | latency reduction |
| ----------------- | --------------- | -------------- | ------- | ----------------- |
| page 1, edge 768  | 1.3946s         | 1.3070s        | 1.07x   | 6.3%              |
| page 1, edge 1280 | 5.1315s         | 4.7886s        | 1.07x   | 6.7%              |


### End-to-End vLLM Metal Sanity Check

HTTP E2E includes request handling, VLM preprocessing, generation, prefix cache, and MM cache effects, so it is noisier than the isolated vision benchmark.


| input             | baseline mean | current mean | change |
| ----------------- | ------------- | ------------ | ------ |
| 1 page, edge 768  | 1.970s        | 2.024s       | -2.7%  |
| 2 pages, edge 768 | 2.905s        | 2.940s       | -1.2%  |
| 4 pages, edge 768 | 4.035s        | 3.949s       | +2.1%  |
| 1 page, edge 1280 | 5.206s        | 4.960s       | +4.7%  |


The isolated benchmark is the primary signal for this PR because it directly targets the patched visual attention path.
