### PR TITLE
[Distributed] Support data parallelism for dense models across Macs

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -163,3 +163,40 @@ mlx.launch -n 2 --backend ring tools/pp_parity_check.py Qwen/Qwen3-0.6B
 - **Synchronous scheduling required.** Run with `--no-async-scheduling` (the engine fails loud otherwise).
 - **TP=1 only.** PP+TP is rejected; tensor parallelism (`--tensor-parallel-size > 1`) is not implemented.
 - **Model support.** YOCO / hybrid / MLA / pooling / VLM / non-paged / speculative decoding / LoRA are rejected; other shapes (sliding-window, MoE) are untested.
+
+## Data parallelism
+
+Data parallelism (DP) runs **N independent full-model replicas**, one per Mac, behind a single endpoint, and load-balances requests across them. Unlike pipeline parallelism it is a pure **throughput** scale-out: each replica holds the whole model, so DP does **not** serve a model larger than one Mac — use it only for a model that already fits one Mac. On a fixed cluster the two are mutually exclusive uses of the same nodes: **DP = more requests/sec for a model that fits; PP = one model split across nodes for longer context / a compute split.**
+
+Dense DP needs no cross-device collective — vLLM runs each replica as a fully independent engine placed on the `mlx` resource, and the request load balancer is upstream and platform-agnostic. Only the validated **dense + Ray DP backend + one replica per node + internal load balancer** shape is supported; everything else fails fast at config time (see the limitations below).
+
+**Serving (two Macs).** Bring up the Ray cluster exactly as for [pipeline parallelism](#pipeline-parallelism) — `ray start` on both Macs with `--resources='{"mlx":1}'`, the macOS cluster env vars, and a per-node `VLLM_HOST_IP` — then serve with DP instead of PP:
+
+```bash
+# Mac A (head): one full replica per Mac, Ray DP backend, internal LB.
+RAY_ADDRESS=auto VLLM_HOST_IP=10.0.0.1 VLLM_METAL_MEMORY_FRACTION=0.5 \
+  vllm serve mlx-community/Qwen3-8B-4bit \
+    --max-model-len 8192 \
+    --data-parallel-size 2 \
+    --data-parallel-backend ray \
+    --data-parallel-size-local 1 \
+    --data-parallel-address 10.0.0.1
+```
+
+- `--data-parallel-backend ray` is **required**: the default `mp` backend only spawns local subprocesses and cannot place a replica on a second Mac (it would silently overcommit one Mac).
+- `--data-parallel-size-local 1`: one Apple GPU per Mac means one replica per node.
+- `--data-parallel-address <head-ip>`: pin the DP master to the Ray head's IP so placement finds it. The Ray DP backend otherwise follows `get_ip()` / `VLLM_HOST_IP`, so set it explicitly to avoid a mismatch.
+
+On a healthy boot each Mac logs `patched Ray V2 worker get_node_and_gpu_ids ...` and an `EngineCore` actor is placed on each node IP.
+
+**Design.** vLLM owns the whole DP control plane (replica placement, the DP coordinator, the request load balancer); `MetalPlatform` only relaxes admission to the supported shape. One Metal-specific detail: Ray honours a `worker_process_setup_hook` only from the **job** runtime_env (`ray.init`), and the DP engine manager connects to Ray without forwarding it — so vllm-metal registers the Apple-GPU worker patch at the job level itself before the engine connects (`MetalPlatform._register_dp_ray_worker_setup_hook`); otherwise the per-replica `RayWorkerProc` would `KeyError` on the custom `mlx` resource.
+
+DP helps **under concurrency**, not single-stream latency, and stays below the 2× ideal because the head Mac also runs the API server, the DP coordinator, and the load balancer alongside its own replica; adding more replica nodes amortizes that head overhead. Measure your own throughput with `vllm bench serve`.
+
+**Limitations.**
+
+- **Capacity is unchanged.** Each replica loads the full model; DP does not serve a model larger than one Mac (that needs a sharded load, which is not yet available).
+- **Dense models only.** MoE DP (expert-parallel all-to-all) is rejected — MLX has no `all_to_all` collective.
+- **Requires a running Ray cluster.** DP registers the worker hook by initializing Ray itself; it fails loud if no cluster is reachable, or if Ray was already initialized by something else (do not pre-`ray.init` before serving).
+- **Validated at 2 Macs.** More nodes (one replica each) should work but are untested.
+- **Rejected combinations** (fail fast at config time): DP+PP, DP+TP, DP+MoE, DP+multimodal (the multimodal tensor-IPC path is DP=1 only), DP+speculative-decoding, DP+LoRA, DP+STT, `--data-parallel-external-lb` / `--data-parallel-hybrid-lb`, and any `--data-parallel-size-local` other than 1 (including the external-DP sentinel 0).

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -572,6 +572,24 @@ class TestMetalPlatform:
         with pytest.raises(RuntimeError, match="already initialized"):
             MetalPlatform._register_dp_ray_worker_setup_hook()
 
+    def test_register_dp_hook_rejects_foreign_worker_hook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A foreign worker_process_setup_hook in ray_runtime_env is rejected
+        (chaining unsupported), matching the single-stage Ray path — the DP job-level
+        registration must not silently replace a user-set hook."""
+        ray = pytest.importorskip("ray")
+        monkeypatch.setattr(MetalPlatform, "_dp_ray_hook_registered", False)
+        monkeypatch.setattr(ray, "is_initialized", lambda: False)
+        init_calls: list[dict] = []
+        monkeypatch.setattr(ray, "init", lambda **kwargs: init_calls.append(kwargs))
+        with pytest.raises(ValueError, match="chaining is not supported"):
+            MetalPlatform._register_dp_ray_worker_setup_hook(
+                {"worker_process_setup_hook": "some.other.hook"}
+            )
+        # Rejected before any ray.init side effect.
+        assert init_calls == []
+
     def test_dp_hook_registration_preserves_user_ray_runtime_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -530,13 +530,35 @@ class TestMetalPlatform:
     def test_register_dp_hook_is_idempotent(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Once this process has registered the DP hook, re-registering is a no-op."""
+        """With our hook already registered and the Ray session still live,
+        re-registering is a no-op."""
         ray = pytest.importorskip("ray")
         monkeypatch.setattr(MetalPlatform, "_dp_ray_hook_registered", True)
+        monkeypatch.setattr(ray, "is_initialized", lambda: True)
         init_calls: list[dict] = []
         monkeypatch.setattr(ray, "init", lambda **kwargs: init_calls.append(kwargs))
         MetalPlatform._register_dp_ray_worker_setup_hook()
         assert init_calls == []
+
+    def test_register_dp_hook_reregisters_after_ray_shutdown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A registered flag left True after ray.shutdown() is stale: if our Ray
+        session is gone, re-init with the hook so a second in-process DP engine still
+        gets the Metal worker patch — otherwise the DP manager rebuilds Ray with a
+        hook-less ray.init and the workers KeyError on the mlx resource."""
+        ray = pytest.importorskip("ray")
+        monkeypatch.setattr(MetalPlatform, "_dp_ray_hook_registered", True)
+        monkeypatch.setattr(ray, "is_initialized", lambda: False)
+        init_calls: list[dict] = []
+        monkeypatch.setattr(ray, "init", lambda **kwargs: init_calls.append(kwargs))
+        MetalPlatform._register_dp_ray_worker_setup_hook()
+        assert init_calls, "stale flag + shut-down Ray must trigger a re-init"
+        assert (
+            init_calls[0]["runtime_env"]["worker_process_setup_hook"]
+            == MetalPlatform._RAY_WORKER_SETUP_HOOK
+        )
+        assert MetalPlatform._dp_ray_hook_registered is True
 
     def test_register_dp_hook_rejects_foreign_ray_init(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Metal platform."""
 
+import importlib
 import platform
 import sys
 from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
+from vllm.config import ParallelConfig
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 
@@ -252,6 +254,376 @@ class TestMetalPlatform:
         )
         with pytest.raises(NotImplementedError, match="tensor parallelism"):
             MetalPlatform.check_and_update_config(vllm_config)
+
+    @staticmethod
+    def _dp_parallel_config(**overrides: object) -> SimpleNamespace:
+        """A valid dense data-parallel-over-Ray parallel_config, with overrides.
+
+        Defaults to the one supported shape (dense + ray backend + local==1 +
+        internal LB); reject tests override the field they exercise. Executor
+        backend defaults to ``mp`` so the executor branch falls through without
+        importing Ray; the ALLOW test overrides it to ``ray``.
+        """
+        base: dict[str, object] = {
+            "worker_cls": "auto",
+            "distributed_executor_backend": "mp",
+            "pipeline_parallel_size": 1,
+            "tensor_parallel_size": 1,
+            "disable_custom_all_reduce": False,
+            "data_parallel_size": 2,
+            "data_parallel_backend": "ray",
+            "data_parallel_size_local": 1,
+            "data_parallel_external_lb": False,
+            "data_parallel_hybrid_lb": False,
+        }
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    @classmethod
+    def _dp_vllm_config(
+        cls,
+        *,
+        parallel: dict | None = None,
+        parallel_config: object = None,
+        model: dict | None = None,
+        speculative_config: object = None,
+        lora_config: object = None,
+    ) -> SimpleNamespace:
+        """A complete vllm_config for a dense-DP run, with field overrides.
+
+        Reject tests override only the field under test on top of the full scaffold
+        so a guard fires for the right reason (not a missing attribute). Pass
+        ``parallel_config`` to inject a prebuilt (e.g. real ``ParallelConfig``)
+        object instead of the SimpleNamespace stand-in.
+        """
+        model_fields: dict[str, object] = {
+            "model": "test-model",
+            "is_moe": False,
+            "multimodal_config": None,
+            "disable_cascade_attn": False,
+            "tokenizer": None,
+            "max_model_len": 32768,
+            "hf_config": SimpleNamespace(model_type="qwen3"),
+        }
+        model_fields.update(model or {})
+        return SimpleNamespace(
+            parallel_config=(
+                parallel_config
+                if parallel_config is not None
+                else cls._dp_parallel_config(**(parallel or {}))
+            ),
+            cache_config=SimpleNamespace(block_size=None),
+            model_config=SimpleNamespace(**model_fields),
+            scheduler_config=SimpleNamespace(
+                async_scheduling=False,
+                enable_chunked_prefill=True,
+                max_num_batched_tokens=2048,
+                max_num_scheduled_tokens=None,
+            ),
+            speculative_config=speculative_config,
+            lora_config=lora_config,
+        )
+
+    @staticmethod
+    def _stub_ray(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+        """Stub ray.init / is_initialized and reset the DP-hook flag so a unit test
+        exercising the DP admission never contacts a real cluster. Returns the list
+        that captures ray.init kwargs."""
+        ray = pytest.importorskip("ray")
+        monkeypatch.setattr(MetalPlatform, "_dp_ray_hook_registered", False)
+        init_calls: list[dict] = []
+        monkeypatch.setattr(ray, "is_initialized", lambda: False)
+        monkeypatch.setattr(ray, "init", lambda **kwargs: init_calls.append(kwargs))
+        return init_calls
+
+    def test_check_and_update_config_allows_dense_data_parallel_ray(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dense DP over the Ray backend (one replica/node, internal LB) is allowed.
+
+        Also pins the job-level hook registration: DP registers the
+        worker_process_setup_hook via ray.init (Ray does not honor it from the
+        per-actor runtime_env the DP engine manager uses), and the registered hook
+        string resolves to a real callable. ray.init is stubbed (no real cluster).
+        """
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        init_calls = self._stub_ray(monkeypatch)
+        reset_config()
+        try:
+            vllm_config = self._dp_vllm_config(
+                parallel={
+                    "distributed_executor_backend": "ray",
+                    "ray_runtime_env": None,
+                }
+            )
+            MetalPlatform.check_and_update_config(vllm_config)
+            assert vllm_config.parallel_config.distributed_executor_backend == "ray"
+            assert init_calls, "DP must register the worker hook via ray.init"
+            # Pin the full cluster-connect contract: the documented RAY_ADDRESS=auto
+            # launch only works if we connect to the existing cluster, not a private
+            # local Ray, so address must be "auto".
+            assert init_calls[0]["address"] == "auto"
+            hook = init_calls[0]["runtime_env"]["worker_process_setup_hook"]
+            assert hook == MetalPlatform._RAY_WORKER_SETUP_HOOK
+            # The registered hook string must resolve to a real callable so a
+            # rename of compat._patch_ray_distributed breaks this unit test, not
+            # only a live cluster run.
+            module_path, _, attr = hook.rpartition(".")
+            resolved = getattr(importlib.import_module(module_path), attr)
+            assert callable(resolved)
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_allows_dp_for_text_only_backbone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A model whose multimodal_config is cleared by normalize (served on the
+        text-only backbone) is NOT rejected under DP — the DP multimodal guard runs
+        AFTER normalize_model_config, not before."""
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        self._stub_ray(monkeypatch)
+        # normalize clears multimodal_config (text-only backbone).
+        monkeypatch.setattr(
+            "vllm_metal.v1.model_adapter.DefaultModelAdapter.normalize_model_config",
+            lambda _self, mc: setattr(mc, "multimodal_config", None),
+        )
+        reset_config()
+        try:
+            vllm_config = self._dp_vllm_config(
+                parallel={
+                    "distributed_executor_backend": "ray",
+                    "ray_runtime_env": None,
+                },
+                model={"multimodal_config": SimpleNamespace()},
+            )
+            # Does not raise: multimodal_config is None after normalize.
+            MetalPlatform.check_and_update_config(vllm_config)
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_rejects_dp_moe(self) -> None:
+        """MoE data parallelism (expert-parallel all-to-all) is unsupported."""
+        with pytest.raises(NotImplementedError, match="dense models only"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(model={"is_moe": True})
+            )
+
+    def test_check_and_update_config_rejects_dp_mp_backend(self) -> None:
+        """DP across Macs requires the Ray DP backend; mp cannot span nodes."""
+        with pytest.raises(NotImplementedError, match="Ray DP backend"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel={"data_parallel_backend": "mp"})
+            )
+
+    def test_check_and_update_config_rejects_dp_size_local(self) -> None:
+        """One Apple GPU per node: exactly one DP replica per node (reject > 1)."""
+        with pytest.raises(
+            NotImplementedError, match="exactly one data-parallel replica"
+        ):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel={"data_parallel_size_local": 2})
+            )
+
+    def test_check_and_update_config_rejects_dp_size_local_external_sentinel(
+        self,
+    ) -> None:
+        """data_parallel_size_local==0 is upstream's externally-specified-DP
+        sentinel (headless / front-end-only). Metal never validated that topology,
+        so the guard must reject 0 too, not only > 1."""
+        with pytest.raises(
+            NotImplementedError, match="exactly one data-parallel replica"
+        ):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel={"data_parallel_size_local": 0})
+            )
+
+    def test_check_and_update_config_rejects_dp_external_lb(self) -> None:
+        """Only the default internal LB is supported under DP."""
+        with pytest.raises(NotImplementedError, match="internal load balancer"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel={"data_parallel_external_lb": True})
+            )
+
+    def test_check_and_update_config_rejects_dp_hybrid_lb(self) -> None:
+        """The hybrid load balancer is also rejected under DP."""
+        with pytest.raises(NotImplementedError, match="internal load balancer"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel={"data_parallel_hybrid_lb": True})
+            )
+
+    def test_check_and_update_config_rejects_dp_with_pipeline_parallel(self) -> None:
+        """DP combined with PP is not validated (per-replica ring scoping/ports)."""
+        with pytest.raises(
+            NotImplementedError, match="combining data parallelism with"
+        ):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel={"pipeline_parallel_size": 2})
+            )
+
+    def test_check_and_update_config_rejects_dp_speculative_decoding(self) -> None:
+        """DP with speculative decoding is unvalidated; reject at config time."""
+        with pytest.raises(NotImplementedError, match="speculative decoding"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(speculative_config=SimpleNamespace(method="ngram"))
+            )
+
+    def test_check_and_update_config_rejects_dp_lora(self) -> None:
+        """DP with LoRA is unvalidated; reject at config time."""
+        with pytest.raises(NotImplementedError, match="data parallelism with LoRA"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(lora_config=SimpleNamespace(max_loras=1))
+            )
+
+    def test_check_and_update_config_rejects_dp_multimodal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A genuine multimodal model (multimodal_config survives normalize) is
+        rejected under DP — the tensor-IPC path is DP=1 only."""
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        init_calls = self._stub_ray(monkeypatch)
+        # normalize leaves multimodal_config in place (genuine multimodal model).
+        monkeypatch.setattr(
+            "vllm_metal.v1.model_adapter.DefaultModelAdapter.normalize_model_config",
+            lambda _self, _mc: None,
+        )
+        reset_config()
+        try:
+            vllm_config = self._dp_vllm_config(
+                parallel={
+                    "distributed_executor_backend": "ray",
+                    "ray_runtime_env": None,
+                },
+                model={"multimodal_config": SimpleNamespace()},
+            )
+            with pytest.raises(NotImplementedError, match="multimodal models"):
+                MetalPlatform.check_and_update_config(vllm_config)
+            # Fail fast before any ray.init side effect.
+            assert init_calls == []
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_rejects_dp_stt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """STT models use a dedicated runner with no DP path; reject DP."""
+        self._patch_stt_resolution(monkeypatch, is_stt=True)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        init_calls = self._stub_ray(monkeypatch)
+        reset_config()
+        try:
+            vllm_config = self._dp_vllm_config(
+                parallel={
+                    "distributed_executor_backend": "ray",
+                    "ray_runtime_env": None,
+                }
+            )
+            with pytest.raises(NotImplementedError, match="speech-to-text"):
+                MetalPlatform.check_and_update_config(vllm_config)
+            # Fail fast before any ray.init side effect.
+            assert init_calls == []
+        finally:
+            reset_config()
+
+    def test_register_dp_hook_is_idempotent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Once this process has registered the DP hook, re-registering is a no-op."""
+        ray = pytest.importorskip("ray")
+        monkeypatch.setattr(MetalPlatform, "_dp_ray_hook_registered", True)
+        init_calls: list[dict] = []
+        monkeypatch.setattr(ray, "init", lambda **kwargs: init_calls.append(kwargs))
+        MetalPlatform._register_dp_ray_worker_setup_hook()
+        assert init_calls == []
+
+    def test_register_dp_hook_rejects_foreign_ray_init(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If Ray was already initialized by something else (no setup hook), the
+        DP workers would miss the patch — fail loud instead of silently proceeding."""
+        ray = pytest.importorskip("ray")
+        monkeypatch.setattr(MetalPlatform, "_dp_ray_hook_registered", False)
+        monkeypatch.setattr(ray, "is_initialized", lambda: True)
+        monkeypatch.setattr(ray, "init", lambda **kwargs: None)
+        with pytest.raises(RuntimeError, match="already initialized"):
+            MetalPlatform._register_dp_ray_worker_setup_hook()
+
+    def test_dp_hook_registration_preserves_user_ray_runtime_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user-provided ray_runtime_env (env_vars / working_dir / py_modules the
+        remote Macs need) is merged with the worker hook, not replaced by a
+        hook-only env: the DP manager reuses this job session without re-applying
+        ray_runtime_env, so dropping the user's keys would start remote actors
+        without the requested environment."""
+        pytest.importorskip("ray")
+        from ray.runtime_env import RuntimeEnv
+
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        init_calls = self._stub_ray(monkeypatch)
+        reset_config()
+        try:
+            vllm_config = self._dp_vllm_config(
+                parallel={
+                    "distributed_executor_backend": "ray",
+                    "ray_runtime_env": RuntimeEnv(env_vars={"VLLM_METAL_DP": "1"}),
+                }
+            )
+            MetalPlatform.check_and_update_config(vllm_config)
+            assert init_calls, "DP must register the worker hook via ray.init"
+            runtime_env = init_calls[0]["runtime_env"]
+            # Both the user's env and our worker hook reach the Ray job.
+            assert runtime_env["env_vars"] == {"VLLM_METAL_DP": "1"}
+            assert (
+                runtime_env["worker_process_setup_hook"]
+                == MetalPlatform._RAY_WORKER_SETUP_HOOK
+            )
+        finally:
+            reset_config()
+
+    def test_check_and_update_config_dp_binds_real_parallel_config_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The DP admission reads real ``vllm.config.ParallelConfig`` fields, not
+        only SimpleNamespace stand-ins: a real DP-over-Ray config in the supported
+        shape is admitted (and registers the job-level hook), while a real config
+        with the external LB flag is rejected. Pins the field-name contract so an
+        upstream rename of the ``data_parallel_*`` fields fails this unit test, not
+        only a live cluster run."""
+        pytest.importorskip("ray")
+        # Reject path: a real config with external LB must fail fast at the guard.
+        reject_pc = ParallelConfig(
+            data_parallel_size=2,
+            data_parallel_backend="ray",
+            data_parallel_size_local=1,
+            data_parallel_external_lb=True,
+        )
+        with pytest.raises(NotImplementedError, match="internal load balancer"):
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel_config=reject_pc)
+            )
+
+        # Admit path: the supported shape on a real config is accepted and
+        # registers the job-level Ray worker hook.
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        init_calls = self._stub_ray(monkeypatch)
+        admit_pc = ParallelConfig(
+            data_parallel_size=2,
+            data_parallel_backend="ray",
+            data_parallel_size_local=1,
+        )
+        reset_config()
+        try:
+            MetalPlatform.check_and_update_config(
+                self._dp_vllm_config(parallel_config=admit_pc)
+            )
+            assert init_calls, "DP must register the worker hook via ray.init"
+        finally:
+            reset_config()
 
     def test_device_capability(self) -> None:
         """Test device capability."""

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -43,6 +43,15 @@ class MetalPlatform(Platform):
     # name that does not collide with CUDA_VISIBLE_DEVICES.
     device_control_env_var: str = "VLLM_METAL_VISIBLE_DEVICES"
 
+    # Dotted path of the worker setup hook that patches RayWorkerProc to read the
+    # custom "mlx" resource (see compat._patch_ray_distributed). Installed both via
+    # the executor ray_runtime_env (single-stage) and, for data parallelism, at the
+    # Ray job level (_register_dp_ray_worker_setup_hook).
+    _RAY_WORKER_SETUP_HOOK: str = "vllm_metal.compat._patch_ray_distributed"
+    # Set once this process has initialized Ray with the job-level worker hook, so
+    # the DP registration is idempotent across repeated check_and_update_config calls.
+    _dp_ray_hook_registered: bool = False
+
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
         """Get the name of the Metal device.
@@ -230,6 +239,63 @@ class MetalPlatform(Platform):
         return torch.device("cpu")
 
     @classmethod
+    def _register_dp_ray_worker_setup_hook(cls, ray_runtime_env: object = None) -> None:
+        """Register the Apple-GPU worker patch at the Ray JOB level for DP.
+
+        ``ray_runtime_env`` is the user's ``parallel_config.ray_runtime_env`` (or
+        ``None``): its keys are preserved and merged with the worker hook so a DP
+        serve that ships a ``working_dir`` / ``py_modules`` / ``env_vars`` still
+        reaches the remote Macs.
+
+        Ray only runs a ``worker_process_setup_hook`` from the JOB runtime_env
+        (``ray.init``), not from a per-actor runtime_env. The data-parallel engine
+        manager connects to Ray without forwarding ``parallel_config.ray_runtime_env``
+        to ``ray.init`` (see ``vllm/v1/engine/utils.py``), so the hook wired into
+        ``ray_runtime_env`` for the single-stage Ray executor never reaches the
+        per-replica ``RayWorkerProc`` workers, and ``get_node_and_gpu_ids`` would
+        ``KeyError`` on the custom "mlx" resource. We initialize Ray ourselves with
+        the hook in the job runtime_env before the engine connects; the engine's
+        later ``ray.init`` reuses this session.
+
+        Ordering contract: this must run before anything else initializes Ray in
+        this process. ``address="auto"`` connects to the cluster the documented
+        launch points at via ``RAY_ADDRESS=auto`` and fails loud (ConnectionError)
+        if no cluster is reachable — DP requires a running Ray cluster.
+
+        Fails loud if Ray was already initialized by something other than this hook
+        (its job runtime_env is then fixed without our setup hook, which would
+        silently re-break the DP workers). Idempotent across repeated calls within
+        this process.
+        """
+        # SCAFFOLDING: remove when upstream CoreEngineActorManager forwards
+        # parallel_config.ray_runtime_env into its ray.init (vllm/v1/engine/utils.py),
+        # mirroring the single-stage initialize_ray_cluster path; the executor-level
+        # hook set in check_and_update_config would then reach the DP RayWorkerProc
+        # workers and this job-level registration could be dropped.
+        import ray
+
+        if cls._dp_ray_hook_registered:
+            return
+        if ray.is_initialized():
+            raise RuntimeError(
+                "Ray is already initialized before vllm-metal could register the "
+                "Apple-GPU worker setup hook at the Ray job level, which data "
+                "parallelism requires (Ray honors worker_process_setup_hook only "
+                "from the job runtime_env). Do not initialize Ray before serving — "
+                "let vllm-metal own ray.init (remove any manual ray.init)."
+            )
+        # Preserve a user-provided ray_runtime_env (working_dir / py_modules /
+        # env_vars the remote Macs may need) and add our worker hook: the DP manager
+        # reuses this job session without re-applying ray_runtime_env, so replacing
+        # it with a hook-only env would drop the user's settings from remote actors.
+        runtime_env: dict[str, object] = (
+            dict(ray_runtime_env) if isinstance(ray_runtime_env, dict) else {}
+        )
+        runtime_env["worker_process_setup_hook"] = cls._RAY_WORKER_SETUP_HOOK
+        ray.init(address="auto", runtime_env=runtime_env)
+        cls._dp_ray_hook_registered = True
+
+    @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         """Check and update vLLM configuration for Metal compatibility.
 
@@ -295,7 +361,7 @@ class MetalPlatform(Platform):
             # loud rather than warn-and-continue: the user asked for Ray.
             from ray.runtime_env import RuntimeEnv
 
-            hook = "vllm_metal.compat._patch_ray_distributed"
+            hook = cls._RAY_WORKER_SETUP_HOOK
             runtime_env = parallel_config.ray_runtime_env
             if runtime_env is None:
                 parallel_config.ray_runtime_env = RuntimeEnv(
@@ -336,6 +402,87 @@ class MetalPlatform(Platform):
                 "(tensor_parallel_size > 1), alone or combined with pipeline "
                 "parallelism; only TP=1 is validated."
             )
+
+        # Data parallelism (dense models, one full replica per Mac via the Ray DP
+        # backend). DP replicas are independent engines, not part of a single
+        # engine's world_size, so the tensor-parallel guard above does not cover
+        # them. Dense DP needs NO cross-device collective: upstream runs each
+        # replica as an independent
+        # EngineCoreActor (data_parallel_size reset to 1, no dp_group — see
+        # vllm/v1/engine/core.py), placed on the "mlx" resource, and each replica
+        # spawns the same RayExecutorV2/RayWorkerProc, so the Ray worker hook
+        # installed above covers it unchanged. We only relax admission: allow that
+        # validated dense-DP-over-Ray shape and fail fast on every other DP
+        # combination this reachability newly admits (guard-widening audit).
+        if getattr(parallel_config, "data_parallel_size", 1) > 1:
+            # MoE DP routes to DPMoEEngineCoreActor + an expert-parallel all-to-all
+            # that mx.distributed has no equivalent for; only dense DP is validated.
+            if model_config is not None and model_config.is_moe:
+                raise NotImplementedError(
+                    "Metal supports data parallelism for dense models only; MoE "
+                    "data parallelism (expert-parallel all-to-all) is not supported."
+                )
+            # The 'mp' DP backend spawns local subprocesses only and cannot place a
+            # replica on a second Mac — it would silently overcommit one node.
+            # Cross-Mac DP requires the Ray DP backend.
+            if parallel_config.data_parallel_backend != "ray":
+                raise NotImplementedError(
+                    "Metal data parallelism across Macs requires the Ray DP "
+                    "backend; re-run with --data-parallel-backend ray (the default "
+                    "'mp' backend spawns local subprocesses and cannot place "
+                    "replicas on other nodes)."
+                )
+            # One Apple GPU per node: exactly one full-model replica per node.
+            # Reject != 1, not just > 1: upstream treats data_parallel_size_local==0
+            # as a sentinel for externally-specified (headless / front-end-only) DP
+            # (see ParallelConfig.data_parallel_size_local), a topology Metal never
+            # validated and which the > 1 check alone would silently admit.
+            if parallel_config.data_parallel_size_local != 1:
+                raise NotImplementedError(
+                    "Metal allows exactly one data-parallel replica per node (one "
+                    "Apple GPU per Mac); set --data-parallel-size-local 1 "
+                    "(the external-DP sentinel 0 and values > 1 are not supported)."
+                )
+            # External/hybrid LB change the front-end topology (a per-rank API
+            # server) and are documented for MoE / wide-EP serving; only the
+            # default internal load balancer is validated.
+            if (
+                parallel_config.data_parallel_external_lb
+                or parallel_config.data_parallel_hybrid_lb
+            ):
+                raise NotImplementedError(
+                    "Metal data parallelism supports only the default internal load "
+                    "balancer; --data-parallel-external-lb / --data-parallel-hybrid-lb "
+                    "are not supported."
+                )
+            # DP+PP (each replica its own PP group) needs the mx.distributed ring
+            # bootstrap scoped per-replica and per-replica ring ports; never
+            # validated. (DP+TP is already rejected by the tensor-parallel guard.)
+            if parallel_config.pipeline_parallel_size > 1:
+                raise NotImplementedError(
+                    "Metal does not support combining data parallelism with "
+                    "pipeline parallelism yet; use --data-parallel-size or "
+                    "--pipeline-parallel-size > 1, not both."
+                )
+            # DP + speculative decoding / LoRA were never validated under data
+            # parallelism (each replica is an independent dense engine); mirror the
+            # pipeline-parallel rejections below rather than run an untested path.
+            # (DP + multimodal and DP + STT are rejected later, after the model
+            # config is normalized / the STT model is detected.)
+            if vllm_config.speculative_config is not None:
+                raise NotImplementedError(
+                    "Metal does not support data parallelism with speculative "
+                    "decoding; remove --speculative-config or use "
+                    "--data-parallel-size 1."
+                )
+            if vllm_config.lora_config is not None:
+                raise NotImplementedError(
+                    "Metal does not support data parallelism with LoRA; remove "
+                    "--enable-lora or use --data-parallel-size 1."
+                )
+            # NB: the Ray job-level hook is registered only AFTER the remaining DP
+            # rejections (multimodal, STT) further below, so an unsupported DP
+            # config fails fast before any ray.init side effect.
 
         scheduler_config = vllm_config.scheduler_config
 
@@ -434,6 +581,19 @@ class MetalPlatform(Platform):
 
             DefaultModelAdapter().normalize_model_config(model_config)
 
+            # DP + multimodal: the multimodal tensor-IPC queue only supports DP=1
+            # (vllm/v1/engine/utils.py). Checked AFTER normalize_model_config so a
+            # model served on the text-only backbone (multimodal_config cleared by
+            # the adapter) is not wrongly rejected — only a genuine multimodal model.
+            if (
+                getattr(parallel_config, "data_parallel_size", 1) > 1
+                and model_config.multimodal_config is not None
+            ):
+                raise NotImplementedError(
+                    "Metal does not support data parallelism for multimodal models "
+                    "(the multimodal tensor-IPC path is DP=1 only)."
+                )
+
         # STT model detection — set tokenizer fallback if not already configured.
         # Lazy imports to avoid circular import: platform.py is loaded during
         # vllm.config init, and stt.detection imports from vllm.config.
@@ -455,11 +615,24 @@ class MetalPlatform(Platform):
                     "Pipeline parallelism (pipeline_parallel_size > 1) is not "
                     "supported for speech-to-text models."
                 )
+            if getattr(parallel_config, "data_parallel_size", 1) > 1:
+                raise NotImplementedError(
+                    "Data parallelism (data_parallel_size > 1) is not "
+                    "supported for speech-to-text models."
+                )
             was_async_scheduling = bool(scheduler_config.async_scheduling)
             apply_stt_scheduler_policy(model_config, scheduler_config)
             if was_async_scheduling and not scheduler_config.async_scheduling:
                 logger.info("STT: disabled async_scheduling")
             logger.info("STT model detected")
+
+        # Data parallelism passed every admission guard above (including the
+        # multimodal and STT rejections). Only now — after all fail-fasts, before
+        # the engine connects — register the Apple-GPU worker patch at the Ray job
+        # level so it reaches the per-replica RayWorkerProc workers (the
+        # executor-level ray_runtime_env hook does not propagate on the DP path).
+        if getattr(parallel_config, "data_parallel_size", 1) > 1:
+            cls._register_dp_ray_worker_setup_hook(parallel_config.ray_runtime_env)
 
         # Log memory configuration
         total_mem = cls.get_device_total_memory()

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -264,8 +264,9 @@ class MetalPlatform(Platform):
 
         Fails loud if Ray was already initialized by something other than this hook
         (its job runtime_env is then fixed without our setup hook, which would
-        silently re-break the DP workers). Idempotent across repeated calls within
-        this process.
+        silently re-break the DP workers). Idempotent while our Ray session is live;
+        if that session was shut down, the now-stale flag is cleared and the hook is
+        re-registered so a second in-process DP engine still gets the patch.
         """
         # SCAFFOLDING: remove when upstream CoreEngineActorManager forwards
         # parallel_config.ray_runtime_env into its ray.init (vllm/v1/engine/utils.py),
@@ -274,9 +275,10 @@ class MetalPlatform(Platform):
         # workers and this job-level registration could be dropped.
         import ray
 
-        if cls._dp_ray_hook_registered:
-            return
         if ray.is_initialized():
+            if cls._dp_ray_hook_registered:
+                # Our hook is already in the live Ray session — idempotent no-op.
+                return
             raise RuntimeError(
                 "Ray is already initialized before vllm-metal could register the "
                 "Apple-GPU worker setup hook at the Ray job level, which data "
@@ -284,6 +286,10 @@ class MetalPlatform(Platform):
                 "from the job runtime_env). Do not initialize Ray before serving — "
                 "let vllm-metal own ray.init (remove any manual ray.init)."
             )
+        # Ray is not initialized: a fresh start, or our previous session was shut
+        # down in this process (a now-stale registered flag). Clear the flag so a
+        # second in-process DP engine re-registers instead of skipping the hook.
+        cls._dp_ray_hook_registered = False
         # Preserve a user-provided ray_runtime_env (working_dir / py_modules /
         # env_vars the remote Macs may need) and add our worker hook: the DP manager
         # reuses this job session without re-applying ray_runtime_env, so replacing

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -239,6 +239,32 @@ class MetalPlatform(Platform):
         return torch.device("cpu")
 
     @classmethod
+    def _ray_runtime_env_with_metal_hook(
+        cls, ray_runtime_env: object = None
+    ) -> dict[str, object]:
+        """Return a runtime_env dict that installs the Apple-GPU worker setup hook.
+
+        The single source of the hook-install rule, shared by the single-stage Ray
+        executor and the DP job-level ``ray.init`` so the two cannot drift: it
+        preserves the caller's ``ray_runtime_env`` keys (``working_dir`` /
+        ``py_modules`` / ``env_vars``) and rejects a conflicting foreign
+        ``worker_process_setup_hook`` (chaining is unsupported) rather than silently
+        replacing it.
+        """
+        runtime_env: dict[str, object] = (
+            dict(ray_runtime_env) if isinstance(ray_runtime_env, dict) else {}
+        )
+        existing = runtime_env.get("worker_process_setup_hook")
+        if existing not in (None, cls._RAY_WORKER_SETUP_HOOK):
+            raise ValueError(
+                "Metal must install a Ray worker_process_setup_hook, but one is "
+                f"already set ({existing!r}); chaining is not supported. Unset "
+                "ray_runtime_env's worker_process_setup_hook."
+            )
+        runtime_env["worker_process_setup_hook"] = cls._RAY_WORKER_SETUP_HOOK
+        return runtime_env
+
+    @classmethod
     def _register_dp_ray_worker_setup_hook(cls, ray_runtime_env: object = None) -> None:
         """Register the Apple-GPU worker patch at the Ray JOB level for DP.
 
@@ -290,15 +316,16 @@ class MetalPlatform(Platform):
         # down in this process (a now-stale registered flag). Clear the flag so a
         # second in-process DP engine re-registers instead of skipping the hook.
         cls._dp_ray_hook_registered = False
-        # Preserve a user-provided ray_runtime_env (working_dir / py_modules /
-        # env_vars the remote Macs may need) and add our worker hook: the DP manager
-        # reuses this job session without re-applying ray_runtime_env, so replacing
-        # it with a hook-only env would drop the user's settings from remote actors.
-        runtime_env: dict[str, object] = (
-            dict(ray_runtime_env) if isinstance(ray_runtime_env, dict) else {}
+        # Install the worker hook by the same rule as the single-stage Ray path
+        # (_ray_runtime_env_with_metal_hook): preserve the user's ray_runtime_env
+        # (working_dir / py_modules / env_vars the remote Macs may need) and reject a
+        # conflicting foreign hook rather than silently replacing it. The DP manager
+        # reuses this job session without re-applying ray_runtime_env, so this is the
+        # one place the user's env reaches the remote actors.
+        ray.init(
+            address="auto",
+            runtime_env=cls._ray_runtime_env_with_metal_hook(ray_runtime_env),
         )
-        runtime_env["worker_process_setup_hook"] = cls._RAY_WORKER_SETUP_HOOK
-        ray.init(address="auto", runtime_env=runtime_env)
         cls._dp_ray_hook_registered = True
 
     @classmethod
@@ -367,22 +394,9 @@ class MetalPlatform(Platform):
             # loud rather than warn-and-continue: the user asked for Ray.
             from ray.runtime_env import RuntimeEnv
 
-            hook = cls._RAY_WORKER_SETUP_HOOK
-            runtime_env = parallel_config.ray_runtime_env
-            if runtime_env is None:
-                parallel_config.ray_runtime_env = RuntimeEnv(
-                    worker_process_setup_hook=hook
-                )
-            else:
-                existing_hook = runtime_env.get("worker_process_setup_hook")
-                if existing_hook not in (None, hook):
-                    raise ValueError(
-                        "Metal must install a Ray worker_process_setup_hook for "
-                        "the 'ray' executor, but one is already set "
-                        f"({existing_hook!r}); chaining is not supported. Unset "
-                        "ray_runtime_env's worker_process_setup_hook."
-                    )
-                runtime_env["worker_process_setup_hook"] = hook
+            parallel_config.ray_runtime_env = RuntimeEnv(
+                **cls._ray_runtime_env_with_metal_hook(parallel_config.ray_runtime_env)
+            )
 
         # Disable features not supported on Metal
         parallel_config.disable_custom_all_reduce = True


### PR DESCRIPTION
This PR is:
- To relax `MetalPlatform.check_and_update_config` admission for dense data parallelism across Macs — Ray DP backend, one full replica per node, internal load balancer — the one shape validated end to end on two Macs.
- To fail fast on every other DP combination that relaxation newly reaches: MoE, `mp` backend, `data_parallel_size_local != 1` (including the external-DP sentinel `0`), external/hybrid LB, pipeline parallelism, speculative decoding, LoRA, multimodal, STT.
- To register the Apple-GPU worker hook at the Ray **job** level (`_register_dp_ray_worker_setup_hook`), after all rejects, so an unsupported config fails before any `ray.init` side effect.
- To add DP tests (admit, every reject, a real `vllm.config.ParallelConfig` contract test, hook idempotency / foreign-init) and a `docs/distributed.md` Data parallelism section.


vLLM already owns the dense-DP control plane (replica placement, DP coordinator, request load balancer) and dense DP needs no cross-device collective, so this is pure admission + reuse — no new control-plane code, no runner/attention/cache changes. The one Metal-specific piece: Ray honours a `worker_process_setup_hook` only from the job `runtime_env`, and the DP engine manager's `ray.init` does not forward `parallel_config.ray_runtime_env`, so the per-replica `RayWorkerProc` would `KeyError` on the custom `mlx` resource without the job-level registration. Marked `# SCAFFOLDING`, removable once upstream forwards `ray_runtime_env` on the DP path.

Smoke test (two Macs, Ray cluster up — see `docs/distributed.md`):
```
RAY_ADDRESS=auto VLLM_HOST_IP=<head-ip> VLLM_METAL_USE_PAGED_ATTENTION=1 \
VLLM_METAL_MEMORY_FRACTION=0.5 vllm serve mlx-community/Qwen3-8B-4bit \
    --max-model-len 8192 --data-parallel-size 2 --data-parallel-backend ray \
    --data-parallel-size-local 1 --data-parallel-address <head-ip>
```

Benchmark (2× AWS EC2 M4 Mac mini 24 GB, VPC Ethernet; Qwen3-8B-4bit, `--max-model-len 8192`, paged attention, `MEMORY_FRACTION=0.5`; `vllm bench serve`, sonnet, 128 output tokens, warmed — output tok/s). `--max-concurrency` caps total in-flight requests, which DP=2's load balancer splits across the two replicas, so the fair comparison matches per-replica load (1 Mac @ C vs DP=2 @ 2C, each replica sees C):

| per-replica concurrency | 1 Mac | DP=2 | speedup |
| --- | --- | --- | --- |
| 8 | 35.5 | 63.9 | 1.80× |
| 16 | 54.5 | 94.6 | 1.73× |
| 32 | 64.1 | 96.6 | 1.51× |

DP=2 saturates ~96 tok/s vs ~64 single (~1.5× peak). Sub-linear because the head Mac's replica shares the host with the API server + DP coordinator + load balancer (efficiency ~90% at light load → ~75% at saturation). DP scales throughput, not capacity.
