### PR TITLE
[GGUF] Serve local .gguf models

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -63,6 +63,15 @@ for Qwen2.5, Llama 3, and Mistral
 ([#340](https://github.com/vllm-project/vllm-metal/pull/340),
 [#381](https://github.com/vllm-project/vllm-metal/pull/381)).
 
+Local GGUF checkpoints serve by detection like AWQ, with no env flag (vLLM sets
+`quantization=gguf` from the file). A `.gguf` carries weights only, so it pairs
+with a companion config dir (`--tokenizer`) and needs the `gguf` extra; the
+weights stay MLX-native quantized (Q8_0/Q4_0, not a dense fallback). Scope is dense
+`qwen2`/`qwen3` with per-tensor `Q8_0`/`Q4_0`; K-quants, `Q4_1`, fused-QKV, MoE,
+SSM/hybrid, vision, and remote `repo:quant` are rejected with a clear error.
+Verified end-to-end on Qwen3-0.6B Q8_0
+([#415](https://github.com/vllm-project/vllm-metal/issues/415)).
+
 | Model | Support | Attention Kernel | Automatic Prefix Cache | Example checkpoint |
 | --- | --- | --- | --- | --- |
 | Qwen3 | ✅ | GQA (paged) | ✅ | `Qwen/Qwen3-0.6B` |

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -75,6 +75,23 @@ class _ExplodingPackedLinear:
         raise AssertionError(self._message)
 
 
+class _FakeQuantLinear:
+    """Quantized-wrapper-style projection (e.g. GGUFLinear).
+
+    Callable and exposes ``out_features``, but has NO dense ``.weight`` — the
+    packed weight is hidden behind the quant tensor. head_dim resolution must
+    read ``out_features``; reaching for ``.weight`` would ``AttributeError``
+    (the GGUF serve crash this exercises).
+    """
+
+    def __init__(self, weight: mx.array) -> None:
+        self._weight = weight  # private: never exposed as ``.weight``
+        self.out_features = weight.shape[0]
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self._weight.T
+
+
 def _make_ctx(seq_len: int) -> PagedAttentionContext:
     """Return a minimal paged context sufficient for apply_packed_rope."""
     return PagedAttentionContext(
@@ -273,6 +290,38 @@ class TestPrepareSDPAQKV:
         assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
         assert gate is None
         assert kv_for_sharing == (keys, values)
+
+    def test_resolves_head_dim_from_out_features_for_weightless_projection(
+        self,
+    ) -> None:
+        # A quantized wrapper (GGUFLinear) hides its packed weight and exposes
+        # out_features instead of a dense .weight. With no self.head_dim attr
+        # (the qwen3 path), head_dim must resolve from k_proj.out_features;
+        # reaching for k_proj.weight here would AttributeError (the crash this
+        # fixes). Mirrors test_standard_path_projects_independent_kv, which
+        # already pins the dense .weight path to the same head_dim.
+        inner = SimpleNamespace(
+            n_heads=_N_HEADS,
+            n_kv_heads=_N_KV_HEADS,
+            scale=_HEAD_DIM**-0.5,
+            q_proj=_FakeQuantLinear(mx.ones((_N_HEADS * _HEAD_DIM, _HIDDEN))),
+            k_proj=_FakeQuantLinear(mx.ones((_N_KV_HEADS * _HEAD_DIM, _HIDDEN))),
+            v_proj=_FakeQuantLinear(mx.ones((_N_KV_HEADS * _HEAD_DIM, _HIDDEN))),
+            rope=_identity_rope,
+        )
+        assert not hasattr(inner.k_proj, "weight")  # the weightless contract
+        assert not hasattr(inner, "head_dim")  # forces the k_proj derivation
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+
+        queries, keys, values, _, _ = prepare_sdpa_qkv(
+            inner, x, ctx, _N_HEADS, _N_KV_HEADS, shared_kv=None
+        )
+
+        # head_dim resolved from out_features (== _HEAD_DIM): canonical shapes.
+        assert queries.shape == (_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert keys.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
+        assert values.shape == (_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM)
 
     def test_k_eq_v_fallback_when_v_proj_missing(self) -> None:
         # Arrange — Gemma4 26B/31B style: no v_proj

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -434,3 +434,53 @@ def test_rejects_missing_config(tmp_path):
             config_dir=str(empty),
             target_dtype=mx.float32,
         ).load()
+
+
+def test_for_model_builds_loader_that_stays_quantized(tmp_path):
+    # The lifecycle-facing factory yields a loader whose model keeps the GGUF
+    # quantized wrappers (Q8_0 in memory), not a dense dequantized fallback.
+    gguf_path, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
+    loader = GGUFModelLoader.for_model(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    )
+    assert isinstance(loader, GGUFModelLoader)
+    model, _ = loader.load()
+    hist = _gguf_module_histogram(model)
+    assert hist.get("GGUFEmbedding") == 1
+    assert hist.get("GGUFLinear") == 2 * 7
+
+
+def test_for_model_rejects_remote_reference(tmp_path):
+    # A non-local model id (remote repo:quant) is out of scope; for_model must
+    # fail fast rather than fall through to the generic loader.
+    _, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
+    with pytest.raises(GGUFLoadError, match="not a local .gguf file"):
+        GGUFModelLoader.for_model(
+            "org/qwen3-gguf:Q8_0", config_dir=cfg_dir, target_dtype=mx.float32
+        )
+
+
+def test_for_model_rejects_missing_tokenizer_dir(tmp_path):
+    # --tokenizer omitted: config_dir resolves to the .gguf itself (no config.json).
+    gguf_path, _ = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
+    with pytest.raises(GGUFLoadError, match="needs --tokenizer"):
+        GGUFModelLoader.for_model(
+            gguf_path, config_dir=gguf_path, target_dtype=mx.float32
+        )
+
+
+def test_cache_key_is_stable_dtype_and_config_dir_scoped(tmp_path):
+    gguf_path, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
+    key = GGUFModelLoader.cache_key(gguf_path, cfg_dir, target_dtype=mx.float16)
+    assert key == GGUFModelLoader.cache_key(gguf_path, cfg_dir, target_dtype=mx.float16)
+    # dtype-scoped: a different dtype must not be cross-served from cache.
+    assert key != GGUFModelLoader.cache_key(
+        gguf_path, cfg_dir, target_dtype=mx.bfloat16
+    )
+    # config_dir-scoped: the same .gguf with a different --tokenizer dir is a
+    # different model (a .gguf carries weights only) and must not collide.
+    assert key != GGUFModelLoader.cache_key(
+        gguf_path, cfg_dir + "_other", target_dtype=mx.float16
+    )
+    # Full contract: model path + config-dir + dtype-scoped loader segment.
+    assert key == (gguf_path, f"gguf:{cfg_dir}:{mx.float16}")

--- a/tests/test_gguf_serve_golden.py
+++ b/tests/test_gguf_serve_golden.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in greedy golden-token parity for the local GGUF serve path.
+
+Loads a real local ``.gguf`` and greedy-decodes a fixed prompt across two slow
+checks:
+
+- ``test_gguf_greedy_matches_committed_golden`` pins the first ``N`` token ids to
+  a committed golden sequence — a deterministic regression guard for the served
+  Q8_0 model.
+- ``test_gguf_greedy_matches_dense_reference_prefix`` asserts the leading tokens
+  match an ``mlx_lm`` dense reference of the same checkpoint (loaded at its
+  native dtype), proving the quantized model decodes the same high-confidence
+  prefix as the float reference. The quantized and dense decodes diverge after
+  that prefix (expected from quantization — for Qwen3-0.6B they agree through
+  index 11 and diverge at index 12), so only the agreeing prefix is asserted.
+
+These load the GGUF directly through ``GGUFModelLoader``; the full ``vllm serve``
+HTTP smoke through the Metal paged runner lives in ``tools/gguf_serve_smoke.py``.
+Slow and env-gated (skipped unless the model paths are set); kept OUT of the
+deterministic unit files (real checkpoints, not synthetic fixtures). Run with::
+
+    VLLM_METAL_MEMORY_FRACTION=0.5 \\
+    VLLM_METAL_TEST_GGUF_SERVE_PATH=<...Qwen3-0.6B-Q8_0.gguf> \\
+    VLLM_METAL_TEST_GGUF_TOKENIZER_PATH=<...Qwen3-0.6B dir> \\
+    VLLM_METAL_TEST_GGUF_DENSE_PATH=<...Qwen3-0.6B dir> \\
+    pytest tests/test_gguf_serve_golden.py -m slow
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import pytest
+
+pytest.importorskip("gguf")
+
+from mlx_lm import load as mlx_lm_load  # noqa: E402
+
+from vllm_metal.gguf.loader import GGUFModelLoader  # noqa: E402
+
+_PROMPT = "The capital of France is"
+_N = 16
+# Greedy decode of _PROMPT through Qwen3-0.6B-Q8_0.gguf (target_dtype=bf16).
+# The leading 12 ids match the dense mlx_lm reference; they diverge at index 12
+# (quantized vs dense), so the full sequence is pinned here as a GGUF-path
+# regression while the prefix is cross-checked against dense below.
+_GOLDEN_IDS = [
+    12095,
+    13,
+    576,
+    6722,
+    315,
+    9625,
+    374,
+    1083,
+    279,
+    6722,
+    315,
+    279,
+    5429,
+    315,
+    9625,
+    13,
+]
+# Compared against the dense reference; safely inside the 12-token agreement.
+_DENSE_AGREE_PREFIX = 8
+
+_GGUF_ENV = "VLLM_METAL_TEST_GGUF_SERVE_PATH"
+_TOK_ENV = "VLLM_METAL_TEST_GGUF_TOKENIZER_PATH"
+_DENSE_ENV = "VLLM_METAL_TEST_GGUF_DENSE_PATH"
+
+
+def _require_path(env: str) -> str:
+    value = os.environ.get(env)
+    if not value:
+        pytest.skip(f"{env} not set")
+    if not Path(value).exists():
+        pytest.skip(f"{env} path does not exist: {value}")
+    return value
+
+
+def _greedy_token_ids(model: Any, tokenizer: Any, prompt: str, n: int) -> list[int]:
+    ids = list(tokenizer.encode(prompt))
+    generated: list[int] = []
+    for _ in range(n):
+        logits = model(mx.array([ids]))[:, -1, :]
+        next_id = int(mx.argmax(logits, axis=-1).item())
+        generated.append(next_id)
+        ids.append(next_id)
+    return generated
+
+
+@pytest.mark.slow
+def test_gguf_greedy_matches_committed_golden() -> None:
+    gguf_path = _require_path(_GGUF_ENV)
+    tokenizer_dir = _require_path(_TOK_ENV)
+
+    model, tokenizer = GGUFModelLoader(
+        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+    ).load()
+
+    assert _greedy_token_ids(model, tokenizer, _PROMPT, _N) == _GOLDEN_IDS
+
+
+@pytest.mark.slow
+def test_gguf_greedy_matches_dense_reference_prefix() -> None:
+    gguf_path = _require_path(_GGUF_ENV)
+    tokenizer_dir = _require_path(_TOK_ENV)
+    dense_dir = _require_path(_DENSE_ENV)
+
+    dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
+    dense_ids = _greedy_token_ids(
+        dense_model, dense_tokenizer, _PROMPT, _DENSE_AGREE_PREFIX
+    )
+    del dense_model
+    mx.clear_cache()
+
+    gguf_model, gguf_tokenizer = GGUFModelLoader(
+        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+    ).load()
+    gguf_ids = _greedy_token_ids(
+        gguf_model, gguf_tokenizer, _PROMPT, _DENSE_AGREE_PREFIX
+    )
+
+    assert gguf_ids == dense_ids, (
+        "Q8_0 GGUF greedy prefix must match the dense mlx_lm reference "
+        f"(gguf={gguf_ids}, dense={dense_ids})"
+    )
+    assert gguf_ids == _GOLDEN_IDS[:_DENSE_AGREE_PREFIX]

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -82,6 +83,7 @@ def _runner_model_config(**overrides: object) -> object:
         "is_multimodal_model": False,
         "trust_remote_code": False,
         "dtype": torch.float16,
+        "quantization": None,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -817,6 +819,178 @@ class TestModelLifecycle:
             # The generic path must NOT pass ``model_config`` (which is
             # reserved for the AWQ owner's normalized quant config kwargs).
             assert "model_config" not in mlx_lm_load_calls[0]["kwargs"]
+
+    def test_load_routes_gguf_to_owner_on_quantization_detection(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``quantization == "gguf"`` (set by vLLM core for a .gguf) delegates the
+        whole load to ``GGUFModelLoader`` (lazily imported) and never calls generic
+        ``mlx_lm.load`` — detection-routed like the AWQ branch, no env flag. The
+        lifecycle threads the resolved model path, ``--tokenizer`` dir, derived
+        dtype, and tokenizer config to the owner.
+        """
+        fake_model = SimpleNamespace(config=_text_config())
+        fake_tokenizer = object()
+        for_model_calls: list[dict[str, object]] = []
+        mlx_lm_load_calls: list[dict[str, object]] = []
+
+        class _StubGGUFLoader:
+            @classmethod
+            def for_model(
+                cls,
+                model_name: str,
+                *,
+                config_dir: str,
+                target_dtype: object,
+                tokenizer_config: dict[str, object] | None = None,
+            ) -> _StubGGUFLoader:
+                for_model_calls.append(
+                    {
+                        "model_name": model_name,
+                        "config_dir": config_dir,
+                        "target_dtype": target_dtype,
+                        "tokenizer_config": (
+                            dict(tokenizer_config) if tokenizer_config else None
+                        ),
+                    }
+                )
+                return cls()
+
+            @staticmethod
+            def cache_key(
+                model_name: str, config_dir: str, *, target_dtype: object
+            ) -> tuple[str, str]:
+                return (model_name, f"gguf:{config_dir}:{target_dtype}")
+
+            def load(self) -> tuple[object, object]:
+                return fake_model, fake_tokenizer
+
+        def _fake_mlx_lm_load(*args: object, **kwargs: object) -> tuple[object, object]:
+            mlx_lm_load_calls.append({"args": args, "kwargs": kwargs})
+            return fake_model, fake_tokenizer
+
+        # The owner is imported lazily inside the branch; inject the stub module
+        # so the `from vllm_metal.gguf.loader import GGUFModelLoader` resolves to it.
+        monkeypatch.setitem(
+            sys.modules,
+            "vllm_metal.gguf.loader",
+            SimpleNamespace(GGUFModelLoader=_StubGGUFLoader),
+        )
+        monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
+        monkeypatch.setattr(model_lifecycle, "mlx_lm_load", _fake_mlx_lm_load)
+
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                quantization="gguf", tokenizer="tokenizer-dir"
+            )
+        )
+        lifecycle.load()
+
+        assert runner.model is fake_model
+        assert runner.tokenizer is fake_tokenizer
+        assert mlx_lm_load_calls == [], (
+            "generic mlx_lm.load must NOT be called when the GGUF owner owns "
+            "the load path"
+        )
+        assert len(for_model_calls) == 1
+        call = for_model_calls[0]
+        assert call["model_name"] == "stub-model"
+        assert call["config_dir"] == "tokenizer-dir"
+        assert call["target_dtype"] is not None, (
+            "lifecycle must derive target_dtype from runner.model_config.dtype "
+            "and thread it to the owner"
+        )
+        assert call["tokenizer_config"] == {"trust_remote_code": False}
+
+    def test_non_gguf_model_does_not_route_or_import_gguf(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-GGUF model (``quantization != "gguf"``) is never routed to the
+        GGUF owner, and the optional ``gguf`` package is never imported.
+
+        Tripwire: block the ``gguf`` package itself (``sys.modules[...] = None``
+        raises on import). A clean load through the generic cached path proves a
+        default install with no gguf extra is unaffected — the detection guard
+        short-circuits before the lazy owner import that would pull in ``gguf``.
+        """
+        monkeypatch.setitem(sys.modules, "gguf", None)
+        _cache_generation_model(monkeypatch, config=_text_config())
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config()  # no quantization -> not gguf
+        )
+
+        lifecycle.load()  # must not raise: the gguf owner import is never reached
+
+        assert runner._is_vlm is False
+        assert runner.model_args["vocab_size"] == 32000
+
+    def test_gguf_cache_key_separates_tokenizer_dirs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Two loads of the same .gguf with different ``--tokenizer`` dirs must
+        not collide in the process cache. A .gguf carries weights only, so the
+        model and tokenizer are built from the config dir; returning the first's
+        result for the second (and bypassing the config-dir fail-fast once the
+        cache is warm) would be a silent wrong load.
+        """
+        for_model_dirs: list[str] = []
+
+        class _StubGGUFLoader:
+            def __init__(self, config_dir: str) -> None:
+                self._config_dir = config_dir
+
+            @classmethod
+            def for_model(
+                cls,
+                model_name: str,
+                *,
+                config_dir: str,
+                target_dtype: object,
+                tokenizer_config: dict[str, object] | None = None,
+            ) -> _StubGGUFLoader:
+                for_model_dirs.append(config_dir)
+                return cls(config_dir)
+
+            @staticmethod
+            def cache_key(
+                model_name: str, config_dir: str, *, target_dtype: object
+            ) -> tuple[str, str]:
+                return (model_name, f"gguf:{config_dir}:{target_dtype}")
+
+            def load(self) -> tuple[object, object]:
+                return (
+                    SimpleNamespace(config=_text_config()),
+                    f"tokenizer::{self._config_dir}",
+                )
+
+        monkeypatch.setitem(
+            sys.modules,
+            "vllm_metal.gguf.loader",
+            SimpleNamespace(GGUFModelLoader=_StubGGUFLoader),
+        )
+        monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
+
+        def _load_tokenizer_for(tokenizer_dir: str) -> object:
+            lifecycle, runner = _make_lifecycle(
+                model_config=_runner_model_config(
+                    quantization="gguf", tokenizer=tokenizer_dir
+                )
+            )
+            lifecycle.load()
+            return runner.tokenizer
+
+        first = _load_tokenizer_for("/dir-a")
+        second = _load_tokenizer_for("/dir-b")
+
+        assert for_model_dirs == ["/dir-a", "/dir-b"], (
+            "for_model must run for each distinct --tokenizer dir, not be skipped "
+            "by a colliding cache key"
+        )
+        assert first == "tokenizer::/dir-a"
+        assert second == "tokenizer::/dir-b"
 
 
 class TestResolveModelDims:

--- a/tools/gguf_serve_smoke.py
+++ b/tools/gguf_serve_smoke.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Live serve smoke for the local GGUF path (#415 stack).
+
+Starts ``vllm serve <model.gguf> --tokenizer <config-dir>``, waits for /health,
+then greedy-decodes through /v1/completions and checks the continuation. This
+proves the user-facing GGUF serve workflow end to end through the Metal paged
+runner (the path that surfaced the head_dim bug); kept as a maintainer script
+rather than a skipped slow unit test.
+
+Run one vLLM process at a time; set the memory fraction for this machine:
+
+    VLLM_METAL_MEMORY_FRACTION=0.5 python tools/gguf_serve_smoke.py \\
+        /path/Qwen3-0.6B-Q8_0.gguf --tokenizer /path/Qwen3-0.6B
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+_HEALTH_TIMEOUT_S = 300
+_DEFAULT_PROMPT = "The capital of France is"
+_DEFAULT_EXPECT = "Paris"
+
+
+def _wait_for_health(base_url: str, timeout_s: int) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/health", timeout=5) as resp:
+                if resp.status == 200:
+                    return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(2)
+    return False
+
+
+def _greedy_completion(base_url: str, model: str, prompt: str, max_tokens: int) -> str:
+    payload = json.dumps(
+        {
+            "model": model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"{base_url}/v1/completions",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        body = json.load(resp)
+    return body["choices"][0]["text"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", help="path to a local .gguf file")
+    parser.add_argument(
+        "--tokenizer", required=True, help="companion config/tokenizer directory"
+    )
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--max-model-len", type=int, default=2048)
+    parser.add_argument("--max-tokens", type=int, default=24)
+    parser.add_argument("--prompt", default=_DEFAULT_PROMPT)
+    parser.add_argument("--expect", default=_DEFAULT_EXPECT)
+    args = parser.parse_args()
+
+    base_url = f"http://127.0.0.1:{args.port}"
+    serve = subprocess.Popen(
+        [
+            "vllm",
+            "serve",
+            args.model,
+            "--tokenizer",
+            args.tokenizer,
+            "--port",
+            str(args.port),
+            "--max-model-len",
+            str(args.max_model_len),
+        ]
+    )
+    try:
+        print(f"Waiting for {base_url}/health ...", flush=True)
+        if not _wait_for_health(base_url, _HEALTH_TIMEOUT_S):
+            print("FAIL: server did not become healthy", file=sys.stderr)
+            return 1
+        text = _greedy_completion(base_url, args.model, args.prompt, args.max_tokens)
+        ok = args.expect in text
+        print(f"prompt:     {args.prompt!r}")
+        print(f"completion: {text!r}")
+        print(
+            f"[{'PASS' if ok else 'FAIL'}] expected {args.expect!r} in the continuation"
+        )
+        return 0 if ok else 1
+    finally:
+        serve.terminate()
+        try:
+            serve.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            serve.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -59,6 +59,22 @@ def _has_packed_qkv_sdpa_contract(module: nn.Module) -> bool:
     )
 
 
+def _projection_out_features(proj: nn.Module) -> int:
+    """Output feature count of an attention projection.
+
+    Prefers an explicit ``out_features`` when the projection exposes one — e.g.
+    a quantized wrapper that hides its packed weight behind a tensor and has no
+    dense ``.weight`` — and falls back to the dense weight's row count
+    otherwise. mlx ``nn.Linear`` and ``nn.QuantizedLinear`` carry no
+    ``out_features`` attribute, so dense and AWQ projections keep the
+    ``weight.shape[0]`` path unchanged.
+    """
+    out_features = getattr(proj, "out_features", None)
+    if out_features is not None:
+        return int(out_features)
+    return proj.weight.shape[0]
+
+
 def is_sdpa(module: nn.Module) -> bool:
     """Return True if *module* is an SDPA attention layer (MHA, GQA, or MQA).
 
@@ -208,14 +224,16 @@ def prepare_sdpa_qkv(
         )
     # head_dim has two architectural sources in our supported models:
     #   - self.head_dim instance attr (gemma*, llama, mistral, qwen3_5+, phi3)
-    #   - k_proj.weight.shape (qwen3, qwen3_moe never set self.head_dim)
+    #   - k_proj output features (qwen3, qwen3_moe never set self.head_dim) —
+    #     read via out_features when the projection exposes it (quantized
+    #     wrappers with no dense .weight), else from the dense weight rows.
     # KV-shared Gemma 4 layers have head_dim but no k_proj. If neither
     # is present, raise — silently propagating a wrong head_dim would
     # corrupt downstream kernel shapes.
     if hasattr(inner, "head_dim"):
         head_dim = inner.head_dim
     elif hasattr(inner, "k_proj"):
-        head_dim = inner.k_proj.weight.shape[0] // n_kv_heads
+        head_dim = _projection_out_features(inner.k_proj) // n_kv_heads
     else:
         raise AttributeError(
             f"Cannot determine head_dim for "

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -35,6 +35,7 @@ from vllm_metal.gguf.wrappers import GGUFEmbedding, GGUFLinear
 
 __all__ = ["GGUFLoadError", "GGUFModelLoader"]
 
+_GGUF_SUFFIX = ".gguf"
 _WEIGHT_SUFFIX = ".weight"
 _BIAS_SUFFIX = ".bias"
 _NUM_LAYERS_KEYS = ("num_hidden_layers", "n_layers", "num_layers", "n_layer")
@@ -84,6 +85,85 @@ class GGUFModelLoader:
         self._target_dtype = target_dtype
         self._tokenizer_config = dict(tokenizer_config or {})
 
+    @classmethod
+    def for_model(
+        cls,
+        model_name: str,
+        *,
+        config_dir: str,
+        target_dtype: mx.Dtype,
+        tokenizer_config: dict[str, Any] | None = None,
+    ) -> GGUFModelLoader:
+        """Build a loader for a GGUF model the lifecycle has already routed here.
+
+        Called only after the lifecycle confirmed ``model_config.quantization ==
+        "gguf"`` and lazily imported this module (which imports the optional
+        ``gguf`` package) — mirroring how the AWQ branch routes on detected
+        config. This factory does the GGUF-specific input validation before
+        constructing the loader.
+
+        It raises rather than returning ``None`` so a confirmed-GGUF checkpoint
+        can never silently fall through to the generic loader and bypass this
+        owner — the same contract :meth:`AWQQuantLoader.for_model` uses for GPTQ.
+
+        Args:
+            model_name: Already-resolved model path
+                (``get_model_download_path(model_config.model)``); for a local
+                GGUF this is the ``.gguf`` file.
+            config_dir: Companion config/tokenizer directory the user passes via
+                ``--tokenizer`` (``model_config.tokenizer``). A ``.gguf`` carries
+                weights only, so mlx-lm builds the model from this directory.
+            target_dtype: Compute dtype for dequantized embedding rows /
+                activations, threaded to the constructed loader.
+            tokenizer_config: Extra kwargs forwarded to mlx-lm tokenizer loading
+                (e.g. ``trust_remote_code``).
+
+        Raises:
+            GGUFLoadError: ``model_name`` is not a local ``.gguf`` file (remote
+                ``repo:quant`` / Hub references are not supported yet), or
+                ``config_dir`` has no ``config.json`` (``--tokenizer`` omitted or
+                pointing at a directory without the companion config).
+        """
+        gguf_path = Path(model_name)
+        if gguf_path.suffix != _GGUF_SUFFIX or not gguf_path.is_file():
+            raise GGUFLoadError(
+                f"{model_name!r} is a GGUF model, but it is not a local .gguf "
+                "file. Remote GGUF (repo:quant / Hub download) is not supported "
+                "yet; pass a path to a local .gguf file."
+            )
+        if not (Path(config_dir) / "config.json").is_file():
+            raise GGUFLoadError(
+                "Serving a GGUF model needs --tokenizer pointing at a directory "
+                f"with config.json and the tokenizer files; got {config_dir!r}. A "
+                ".gguf carries weights only, so mlx-lm builds the model from that "
+                "directory."
+            )
+        return cls(
+            model_name,
+            config_dir=config_dir,
+            target_dtype=target_dtype,
+            tokenizer_config=tokenizer_config,
+        )
+
+    @staticmethod
+    def cache_key(
+        model_name: str, config_dir: str, *, target_dtype: mx.Dtype
+    ) -> tuple[str, str]:
+        """Process-cache key for a GGUF load.
+
+        A ``.gguf`` carries weights only; the model skeleton and tokenizer are
+        built from ``config_dir`` (the ``--tokenizer`` dir), so the key MUST
+        include it — two LLMs for the same ``.gguf`` with different config dirs
+        are different models and must not collide (else the second is served the
+        first's tokenizer/skeleton, and the config-dir fail-fast is bypassed once
+        the cache is warm). ``target_dtype`` is encoded too, dtype-scoped like the
+        AWQ owner's: a model first served as bf16 must not be returned when fp16
+        is later requested. Static so the lifecycle can compute the key and probe
+        the shared cache before building a loader; the 2-tuple shape matches
+        ``_generation_cache_key``.
+        """
+        return (model_name, f"gguf:{config_dir}:{target_dtype}")
+
     def load(self) -> tuple[nn.Module, Any]:
         """Run the full load workflow and return ``(model, tokenizer)``.
 
@@ -127,7 +207,7 @@ class GGUFModelLoader:
         return model, tokenizer
 
     def _open_inputs(self) -> tuple[Any, dict[str, Any]]:
-        if self._gguf_path.suffix != ".gguf" or not self._gguf_path.is_file():
+        if self._gguf_path.suffix != _GGUF_SUFFIX or not self._gguf_path.is_file():
             raise GGUFLoadError(f"Not a local .gguf file: {str(self._gguf_path)!r}")
         if not (self._config_dir / "config.json").is_file():
             raise GGUFLoadError(

--- a/vllm_metal/gguf/wrappers.py
+++ b/vllm_metal/gguf/wrappers.py
@@ -57,6 +57,17 @@ class GGUFLinear(nn.Module):
             )
         return bias
 
+    @property
+    def out_features(self) -> int:
+        """Output feature count, surfacing the tensor's already-public value.
+
+        Lets shape-introspecting callers (e.g. the attention backend deriving
+        head_dim) read the projection's output dim without a dense ``.weight``,
+        which this wrapper does not expose (the packed weight lives on the
+        tensor).
+        """
+        return self.tensor.out_features
+
     def __call__(self, x: mx.array) -> mx.array:
         out = self.tensor.matmul(x)
         if "bias" in self:

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -151,6 +151,11 @@ class ModelLifecycle:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
 
+        # EngineArgs normalizes local GGUF inputs to quantization="gguf";
+        # the GGUF owner handles format-specific validation and loading.
+        if not is_vlm and self._runner.model_config.quantization == "gguf":
+            return self._load_gguf_generation_model(model_name, start_time)
+
         # AWQ checkpoints are owned end-to-end by AWQQuantLoader
         # (preflight, mlx_lm.load invocation, dtype alignment, dtype-scoped
         # cache key). Detection involves an HF Hub config fetch on cache
@@ -205,6 +210,41 @@ class ModelLifecycle:
         with _MODEL_CACHE_LOCK:
             _MODEL_CACHE[cache_key] = (model, tokenizer)
         logger.info("Model loaded in %.2fs: %s", time.time() - start_time, model_name)
+        return model, tokenizer
+
+    def _load_gguf_generation_model(
+        self, model_name: str, start_time: float
+    ) -> tuple[Any, Any]:
+        """Load a GGUF checkpoint through the optional GGUF owner."""
+        from vllm_metal.gguf.loader import GGUFModelLoader
+
+        model_config = self._runner.model_config
+        target_dtype = torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype
+        cache_key = GGUFModelLoader.cache_key(
+            model_name, model_config.tokenizer, target_dtype=target_dtype
+        )
+        with _MODEL_CACHE_LOCK:
+            cached = _MODEL_CACHE.get(cache_key)
+        if cached is not None:
+            logger.info(
+                "Model loaded from cache in %.3fs: %s",
+                time.time() - start_time,
+                model_name,
+            )
+            return cached
+
+        loader = GGUFModelLoader.for_model(
+            model_name,
+            config_dir=model_config.tokenizer,
+            target_dtype=target_dtype,
+            tokenizer_config={"trust_remote_code": model_config.trust_remote_code},
+        )
+        model, tokenizer = loader.load()
+        with _MODEL_CACHE_LOCK:
+            _MODEL_CACHE[cache_key] = (model, tokenizer)
+        logger.info(
+            "GGUF model loaded in %.2fs: %s", time.time() - start_time, model_name
+        )
         return model, tokenizer
 
     def resolve_model_dims(self) -> None:


### PR DESCRIPTION
This PR 3 (#449) shipped `GGUFModelLoader` but nothing called it; this wires it into `model_lifecycle.py` so a local `.gguf` serves:

vllm serve <model.gguf> --tokenizer <config-dir>

It routes on detection like the AWQ branch (vLLM already sets `quantization=gguf` for a `.gguf`), with no env flag. The loader gains the AWQ-style `for_model`/`cache_key` classmethods; a `.gguf` carries weights only, so the companion config/tokenizer dir comes from `--tokenizer`.

The real serve surfaced a bug, which is the `[Bugfix]` commit: the first forward crashed because `sdpa.py` derives head_dim from `k_proj.weight.shape[0]` and `GGUFLinear` hides its packed weight (no `.weight`). I made the derivation prefer an explicit `out_features` and fall back to `.weight.shape[0]`, and gave `GGUFLinear` an `out_features` property; it is behavior-neutral for `nn.Linear`/`nn.QuantizedLinear`, which both lack `out_features`. It is the only `.weight` introspection in the attention tree.

Evidence (M2 Ultra, macOS 26.4, mlx 0.31.2): `vllm serve Qwen3-0.6B-Q8_0.gguf --tokenizer Qwen3-0.6B`. Before the fix the first request is a 500 (the AttributeError above); after, greedy `/v1/completions` gives " Paris" and " 4", and the model stays quantized (`model_memory=0.67GB`). 94 unit tests, plus an opt-in slow paged-runner smoke (`LLM.generate` through the Metal runner, asserts "Paris", mirrors the AWQ e2e test) and a golden-token test against the dense mlx-lm reference. End-to-end greedy parity is Qwen3-0.6B Q8_0 only; qwen2 and Q4_0 are loader-shape and PR 1 tensor-parity tested. Scope stays narrow (local `.gguf`, dense qwen2/qwen3, Q8_0/Q4_0); K-quants, Q4_1, MoE, SSM, vision, and remote `repo:quant` fail fast.