### PR TITLE
Close hybrid GDN runtime bypass paths

### DIFF
--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1374,6 +1374,50 @@ class TestV1MetalModelRunnerGDNSubmit:
 
         assert submitted == [(logits,)]
 
+    def test_non_last_pp_sample_materializes_reused_slot_state(self) -> None:
+        cache = self.make_gdn_cache()
+        runtime = HybridRuntimeStub(cache)
+        runner = make_stub_runner(_paged_attention_runtime=runtime)
+        runner.pp = SimpleNamespace(size=2, is_last=False)
+        runner._execute_model_state = object()
+        runner._request_states["done"] = mr.RequestState(
+            token_ids=[1],
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(),
+            generator=None,
+            generated_tokens=0,
+        )
+        runner._paged_request_seq_lens["done"] = 1
+
+        released_slot = runtime.gdn_state_manager.assign_step_slots(["done"])[0]
+        runner._cleanup_finished_requests({"done"}, materialize_runtime_state=False)
+        reused_slot = runtime.gdn_state_manager.assign_step_slots(["next"])[0]
+        assert reused_slot == released_slot
+
+        cache.set_pending_conv_state(
+            0, [reused_slot], mx.full((1, 1, 4), 7, dtype=mx.float32)
+        )
+        cache.set_pending_recurrent_state(
+            0,
+            [reused_slot],
+            mx.full((1, 1, 4, 32), 9, dtype=mx.float32),
+        )
+
+        output = runner.sample_tokens(None)
+
+        assert output is mr.EMPTY_MODEL_RUNNER_OUTPUT
+        assert runner._execute_model_state is None
+        assert not cache.has_pending_conv_state(0)
+        assert not cache.has_pending_recurrent_state(0)
+        mx.eval(cache.conv_states[0], cache.recurrent_states[0])
+        np.testing.assert_array_equal(np.array(cache.conv_states[0][reused_slot]), 7)
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0][reused_slot]),
+            9,
+        )
+        assert runtime.gdn_state_manager.needs_materialize is False
+
 
 class TestV1MetalModelRunnerGDNLifecycle:
     def test_start_paged_forward_assigns_hybrid_slots_in_batch_order(

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import mlx.core as mx
 import numpy as np
 import pytest
+from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 
@@ -1211,6 +1212,19 @@ class TestV1MetalModelRunnerExecuteModel:
 
 
 class TestV1MetalModelRunnerGDNSubmit:
+    def make_gdn_cache(self) -> GDNPagedStateCache:
+        return GDNPagedStateCache(
+            num_layers=1,
+            max_seqs=2,
+            conv_kernel_dim=2,
+            conv_dim=4,
+            num_v_heads=1,
+            value_head_dim=4,
+            key_head_dim=32,
+            initial_seqs=0,
+            dtype=mx.float32,
+        )
+
     def make_runtime_with_side_effects(self) -> ForwardOutputRuntimeStub:
         conv_states = [
             mx.array([1], dtype=mx.float32),
@@ -1226,17 +1240,7 @@ class TestV1MetalModelRunnerGDNSubmit:
         self, monkeypatch
     ) -> None:
         submitted: list[tuple[object, ...]] = []
-        cache = GDNPagedStateCache(
-            num_layers=1,
-            max_seqs=2,
-            conv_kernel_dim=2,
-            conv_dim=4,
-            num_v_heads=1,
-            value_head_dim=4,
-            key_head_dim=32,
-            initial_seqs=0,
-            dtype=mx.float32,
-        )
+        cache = self.make_gdn_cache()
         pending_conv = mx.full((1, 1, 4), 7, dtype=mx.float32)
         pending_recurrent = mx.full((1, 1, 4, 32), 9, dtype=mx.float32)
         cache.ensure_capacity(2)
@@ -1255,20 +1259,101 @@ class TestV1MetalModelRunnerGDNSubmit:
         assert cache.has_pending_conv_state(0)
         assert cache.has_pending_recurrent_state(0)
 
-    def test_hybrid_submits_logits_and_updated_gdn_states(self, monkeypatch) -> None:
+    def test_hybrid_submits_primary_outputs_before_gdn_states(
+        self, monkeypatch
+    ) -> None:
         submitted: list[tuple[object, ...]] = []
         runtime = self.make_runtime_with_side_effects()
         runner = make_stub_runner(_paged_attention_runtime=runtime)
         logits = mx.array([0], dtype=mx.float32)
-        expected_states = runtime._arrays
+        target_hidden_states = mx.array([5], dtype=mx.float32)
         monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
 
-        runner._submit_paged_forward_outputs(logits)
+        runner._submit_paged_forward_outputs(logits, target_hidden_states)
 
         assert len(submitted) == 1
         assert submitted[0][0] is logits
-        assert len(submitted[0][1:]) == len(expected_states)
-        for actual, expected in zip(submitted[0][1:], expected_states, strict=True):
+        assert submitted[0][1] is target_hidden_states
+        for actual, expected in zip(submitted[0][2:], runtime._arrays, strict=True):
+            assert actual is expected
+
+    def test_pooling_forward_submits_runtime_outputs(self, monkeypatch) -> None:
+        submitted: list[tuple[object, ...]] = []
+        runtime = self.make_runtime_with_side_effects()
+        runner = make_stub_runner(
+            _paged_attention_runtime=runtime,
+            _is_pooling=True,
+            _paged_block_size=4,
+            num_layers=0,
+        )
+        pooling_hidden_states = mx.array([[[1.0]]], dtype=mx.float32)
+        monkeypatch.setattr(
+            mr,
+            "forward_sequence_hidden_states",
+            lambda *args, **kwargs: pooling_hidden_states,
+        )
+        monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[
+                mr.PrefillRequest(
+                    req_id="pool-0",
+                    token_ids=[1],
+                    sampling_params=SamplingParams(),
+                    block_ids=[0],
+                    generator=None,
+                    prompt_len=1,
+                    start_pos=0,
+                    full_prompt_token_ids=[1],
+                    pooling_params=PoolingParams(),
+                )
+            ],
+            decode_reqs=[],
+            scheduler_output=SimpleNamespace(scheduled_spec_decode_tokens={}),
+        )
+
+        assert len(submitted) == 1
+        assert submitted[0][0] is pooling_hidden_states
+        for actual, expected in zip(submitted[0][1:], runtime._arrays, strict=True):
+            assert actual is expected
+
+    def test_non_last_pp_send_submits_runtime_outputs(self, monkeypatch) -> None:
+        submitted: list[tuple[object, ...]] = []
+        runtime = self.make_runtime_with_side_effects()
+        runner = make_stub_runner(
+            _paged_attention_runtime=runtime,
+            _paged_block_size=4,
+            num_layers=0,
+        )
+        runner.pp = SimpleNamespace(size=2, is_last=False)
+        stage_output = mx.array([[[1.0]]], dtype=mx.float32)
+        send_handle = mx.array([2.0], dtype=mx.float32)
+        runner._pp_model = lambda input_ids, cache: stage_output
+        monkeypatch.setattr(mr, "pipeline_send", lambda output, pp: send_handle)
+        monkeypatch.setattr(mr.mx, "async_eval", lambda *args: submitted.append(args))
+
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=[
+                mr.PrefillRequest(
+                    req_id="pp-0",
+                    token_ids=[1],
+                    sampling_params=SamplingParams(),
+                    block_ids=[0],
+                    generator=None,
+                    prompt_len=1,
+                    start_pos=0,
+                    full_prompt_token_ids=[1],
+                )
+            ],
+            decode_reqs=[],
+            scheduler_output=SimpleNamespace(scheduled_spec_decode_tokens={}),
+        )
+
+        assert len(submitted) == 1
+        assert submitted[0][0] is send_handle
+        for actual, expected in zip(submitted[0][1:], runtime._arrays, strict=True):
             assert actual is expected
 
     def test_prefill_non_hybrid_submits_logits_only(self, monkeypatch) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -2321,6 +2321,9 @@ class MetalModelRunner:
             # engine collects results from the last stage only.
             if is_non_last_stage(self.pp):
                 self._execute_model_state = None
+                runtime = self._paged_attention_runtime
+                if runtime is not None:
+                    runtime.materialize_pending_state()
                 return EMPTY_MODEL_RUNNER_OUTPUT
             batch, scheduler_output = self._sample_paged_batch(grammar_output)
             runtime = self._paged_attention_runtime

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -519,18 +519,14 @@ class MetalModelRunner:
 
     def _submit_paged_forward_outputs(
         self,
-        logits: mx.array,
-        *,
-        target_hidden_states: mx.array | None = None,
+        *outputs: mx.array,
     ) -> None:
-        """Submit logits, hidden states, and runtime-owned forward side effects."""
-        outputs = [logits]
-        if target_hidden_states is not None:
-            outputs.append(target_hidden_states)
+        """Submit caller outputs first, then runtime-owned side effects."""
+        eval_outputs = list(outputs)
         runtime = self._paged_attention_runtime
         if runtime is not None:
-            runtime.extend_forward_eval_outputs(outputs)
-        mx.async_eval(*outputs)
+            runtime.extend_forward_eval_outputs(eval_outputs)
+        mx.async_eval(*eval_outputs)
 
     def _extract_logits(self, model_output: Any) -> mx.array:
         """Extract logits from model output.
@@ -1041,21 +1037,19 @@ class MetalModelRunner:
         # Submit to GPU — returns immediately, GPU runs in background.
         if has_pooling_work:
             assert pooling_hidden_states is not None
-            mx.async_eval(pooling_hidden_states)
+            self._submit_paged_forward_outputs(pooling_hidden_states)
         elif pp_send_handle is not None:
             # Non-last pipeline stage: no logits, just push the hidden state to
-            # the next stage. async_eval on the send forces both the transfer
-            # and (transitively, via the sent activations) this stage's paged
-            # KV-cache writes.
-            mx.async_eval(pp_send_handle)
+            # the next stage, plus any runtime-owned forward side effects.
+            self._submit_paged_forward_outputs(pp_send_handle)
         else:
             assert logits is not None
             # Runtime-owned forward side effects may not be forced by
             # evaluating logits alone, so submit the complete output set.
-            self._submit_paged_forward_outputs(
-                logits,
-                target_hidden_states=target_hidden_states,
-            )
+            forward_outputs = [logits]
+            if target_hidden_states is not None:
+                forward_outputs.append(target_hidden_states)
+            self._submit_paged_forward_outputs(*forward_outputs)
 
         # ---- build cu_seqlens for logit extraction ----
         cu_seqlens: list[int] = [0]


### PR DESCRIPTION
This PR is:
- To route pooling and non-last PP paged forward submissions through the runtime side-effect seam
- To preserve caller-output ordering while appending runtime-owned GDN state arrays
- To materialize pending runtime state before non-last PP sample exits
- To cover the bypass paths with focused runner tests

Follow-up to #452. That PR moved hybrid GDN request-slot ownership behind the paged runtime seam, but a few runner paths could still bypass the runtime-owned forward side-effect contract.

The runner still decides when to submit and finish each paged forward step. The hybrid runtime still decides which GDN state arrays need to be included and materialized.
