### PR TITLE
Use pinned MLX APIs directly

### DIFF
--- a/tests/quant/test_awq_e2e_dense_matrix.py
+++ b/tests/quant/test_awq_e2e_dense_matrix.py
@@ -85,10 +85,7 @@ def _release_metal_state() -> None:
     """
     model_lifecycle.reset_model_cache()
     gc.collect()
-    if hasattr(mx, "clear_cache"):
-        mx.clear_cache()
-    elif hasattr(mx, "metal") and hasattr(mx.metal, "clear_cache"):
-        mx.metal.clear_cache()
+    mx.clear_cache()
 
 
 def _collect_awq_dtype_pins(model, *, expected_non_quant_dtype):

--- a/tests/quant/test_awq_e2e_qwen25_15b.py
+++ b/tests/quant/test_awq_e2e_qwen25_15b.py
@@ -161,7 +161,4 @@ def test_awq_e2e_paged_runner_smoke():
         model_lifecycle.reset_model_cache()
         del llm
         gc.collect()
-        if hasattr(mx, "clear_cache"):
-            mx.clear_cache()
-        elif hasattr(mx, "metal") and hasattr(mx.metal, "clear_cache"):
-            mx.metal.clear_cache()
+        mx.clear_cache()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1316,10 +1316,8 @@ class TestMetalPlatform:
     def test_synchronize_runs_mlx_barrier(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Platform synchronize should use MX barrier when present."""
+        """Platform synchronize should use the pinned MLX barrier."""
         mx = pytest.importorskip("mlx.core")
-        if not hasattr(mx, "synchronize"):
-            pytest.skip("mlx.core.synchronize not available")
 
         called = False
 
@@ -1328,49 +1326,6 @@ class TestMetalPlatform:
             called = True
 
         monkeypatch.setattr(mx, "synchronize", fake_sync)
-        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
-
-        MetalPlatform.synchronize()
-        assert called is True
-
-    def test_synchronize_falls_back_to_eval_when_missing_barrier(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Fallback to evaluation when MX barrier is unavailable."""
-        mx = pytest.importorskip("mlx.core")
-
-        monkeypatch.delattr(mx, "synchronize", raising=False)
-
-        called = False
-
-        def fake_eval(_value: object) -> None:
-            nonlocal called
-            called = True
-
-        monkeypatch.setattr(mx, "eval", fake_eval)
-        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
-
-        MetalPlatform.synchronize()
-        assert called is True
-
-    def test_synchronize_falls_back_to_eval_when_barrier_signature_incompatible(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Fallback if MX barrier exists but can't be called with no args."""
-        mx = pytest.importorskip("mlx.core")
-
-        def fake_sync(_stream: object) -> None:
-            return None
-
-        monkeypatch.setattr(mx, "synchronize", fake_sync)
-
-        called = False
-
-        def fake_eval(_value: object) -> None:
-            nonlocal called
-            called = True
-
-        monkeypatch.setattr(mx, "eval", fake_eval)
         monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
 
         MetalPlatform.synchronize()

--- a/tests/test_tensor_bridge.py
+++ b/tests/test_tensor_bridge.py
@@ -179,9 +179,7 @@ class TestSynchronization:
     def test_sync_mlx_uses_barrier_when_available(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Sync should call the MX barrier when present."""
-        if not hasattr(tensor_bridge.mx, "synchronize"):
-            pytest.skip("mlx.core.synchronize not available")
+        """Sync should call the pinned MLX barrier."""
 
         called = False
 
@@ -190,42 +188,6 @@ class TestSynchronization:
             called = True
 
         monkeypatch.setattr(tensor_bridge.mx, "synchronize", fake_sync)
-        sync_mlx()
-        assert called is True
-
-    def test_sync_mlx_falls_back_to_eval_when_missing_barrier(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """If barrier is absent, we should still force evaluation."""
-        monkeypatch.delattr(tensor_bridge.mx, "synchronize", raising=False)
-
-        called = False
-
-        def fake_eval(value: mx.array) -> None:
-            nonlocal called
-            called = True
-
-        monkeypatch.setattr(tensor_bridge.mx, "eval", fake_eval)
-        sync_mlx()
-        assert called is True
-
-    def test_sync_mlx_falls_back_to_eval_when_barrier_signature_incompatible(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """If barrier exists but can't be called with no args, fall back."""
-
-        def fake_sync(_stream: object) -> None:
-            return None
-
-        monkeypatch.setattr(tensor_bridge.mx, "synchronize", fake_sync)
-
-        called = False
-
-        def fake_eval(value: mx.array) -> None:
-            nonlocal called
-            called = True
-
-        monkeypatch.setattr(tensor_bridge.mx, "eval", fake_eval)
         sync_mlx()
         assert called is True
 

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -1420,7 +1420,7 @@ def section_latency() -> int:
 #     - Per CTA dispatch, freed on completion — never shows in get_active_memory()
 #
 # Protocol:
-#   1. gc.collect() + mx.metal.clear_cache() for clean baseline
+#   1. gc.collect() + mx.clear_cache() for clean baseline
 #   2. Create + eval cache → measure static heap delta
 #   3. Create attention inputs → record pre-attn active
 #   4. mx.metal.reset_peak_memory()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for shared Metal utilities."""
+
+import mlx.core as mx
+
+from vllm_metal.utils import set_wired_limit
+
+
+def test_set_wired_limit_uses_pinned_mlx_api(monkeypatch) -> None:
+    calls: list[int] = []
+
+    monkeypatch.setattr(
+        mx.metal,
+        "device_info",
+        lambda: {"max_recommended_working_set_size": 123},
+    )
+    monkeypatch.setattr(mx, "set_wired_limit", calls.append)
+
+    set_wired_limit()
+
+    assert calls == [123]

--- a/tools/awq_parity.py
+++ b/tools/awq_parity.py
@@ -43,10 +43,7 @@ def _free_metal_cache() -> None:
     """Hand released allocations back to the Metal pool so the next
     model load has the full budget."""
     gc.collect()
-    if hasattr(mx, "clear_cache"):
-        mx.clear_cache()
-    elif hasattr(mx, "metal") and hasattr(mx.metal, "clear_cache"):
-        mx.metal.clear_cache()
+    mx.clear_cache()
 
 
 def _greedy_tokens(model, tokenizer, prompt: str, steps: int) -> list[int]:

--- a/tools/tq_bench.py
+++ b/tools/tq_bench.py
@@ -561,10 +561,7 @@ def bench_paged_attention(
         gc.collect()
         # Force MLX to return cached device buffers so the next (larger) ctx
         # iteration actually has headroom on 8 GB machines.
-        try:
-            mx.metal.clear_cache()
-        except (AttributeError, RuntimeError):
-            pass
+        mx.clear_cache()
 
     print("  " + "─" * 78)
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -200,12 +200,7 @@ class MetalPlatform(Platform):
         """
         import mlx.core as mx
 
-        # Prefer an explicit MLX barrier when available; otherwise force evaluation.
-        # `mx.eval([])` is a no-op, so we evaluate a tiny scalar as a safe fallback.
-        try:
-            mx.synchronize()
-        except (AttributeError, TypeError):
-            mx.eval(mx.array(0, dtype=mx.int32))
+        mx.synchronize()
 
         if torch.backends.mps.is_available():
             torch.mps.synchronize()

--- a/vllm_metal/pytorch_backend/tensor_bridge.py
+++ b/vllm_metal/pytorch_backend/tensor_bridge.py
@@ -167,12 +167,7 @@ def sync_mlx() -> None:
 
     Call this before converting MLX arrays to ensure all operations complete.
     """
-    # Prefer an explicit MLX barrier when available; otherwise force evaluation.
-    # `mx.eval([])` is a no-op, so we evaluate a tiny scalar as a safe fallback.
-    try:
-        mx.synchronize()
-    except (AttributeError, TypeError):
-        mx.eval(mx.array(0, dtype=mx.int32))
+    mx.synchronize()
 
 
 def sync_torch() -> None:

--- a/vllm_metal/utils.py
+++ b/vllm_metal/utils.py
@@ -68,13 +68,7 @@ def set_wired_limit() -> None:
         device_info = mx.metal.device_info()
         max_wired = int(device_info.get("max_recommended_working_set_size", 0))
         if max_wired > 0:
-            if hasattr(mx, "set_wired_limit"):
-                mx.set_wired_limit(max_wired)
-                logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
-            elif hasattr(mx.metal, "set_wired_limit"):
-                mx.metal.set_wired_limit(max_wired)
-                logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
-            else:
-                logger.debug("No set_wired_limit API available, skipping")
+            mx.set_wired_limit(max_wired)
+            logger.info(f"Set Metal wired_limit to {max_wired / (1024**3):.1f} GB")
     except Exception as e:
         logger.warning(f"Failed to set wired_limit: {e}")


### PR DESCRIPTION
This PR is:
- To remove legacy MLX API fallbacks that existed when we supported older MLX versions with different API locations.
- To rely on the current pinned MLX contract instead: `mlx==0.31.2` provides `mx.synchronize()`, `mx.clear_cache()`, and `mx.set_wired_limit(...)`.
- To make MLX API drift fail clearly instead of silently degrading through compatibility shims or skipped cleanup paths.
- To update tests so they assert the supported API surface rather than simulating missing or incompatible MLX APIs.
