### PR TITLE
Simplify model lifecycle loading

### DIFF
--- a/tests/quant/test_awq_e2e_dense_matrix.py
+++ b/tests/quant/test_awq_e2e_dense_matrix.py
@@ -38,7 +38,6 @@ import torch
 from mlx.utils import tree_flatten
 
 from tests.stub_runner import make_stub_runner
-from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 
 # (awq_repo, has_regular_quant_bias)
@@ -79,11 +78,7 @@ def _runner_model_config(repo: str, *, dtype):
 
 
 def _release_metal_state() -> None:
-    """Drop the process-level model cache and hand Metal allocations back
-    to the pool. Required between parametrized rows so the next 7-8B AWQ
-    load gets the full budget on a single pytest process.
-    """
-    model_lifecycle.reset_model_cache()
+    """Hand Metal allocations back to the pool between parametrized rows."""
     gc.collect()
     mx.clear_cache()
 
@@ -133,7 +128,6 @@ def _collect_awq_dtype_pins(model, *, expected_non_quant_dtype):
 @pytest.mark.slow
 @pytest.mark.parametrize("awq_repo,has_regular_quant_bias", _DENSE_AWQ_MATRIX)
 def test_awq_load_aligns_non_quant_dtypes_to_runner_target(
-    monkeypatch,
     awq_repo,
     has_regular_quant_bias,
 ):
@@ -142,7 +136,6 @@ def test_awq_load_aligns_non_quant_dtypes_to_runner_target(
     have been touched by the alignment step (their dtype is owned by the
     AWQ transform).
     """
-    monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
     # Pre-bind references so the ``finally`` ``del`` works even if the
     # load throws before they would otherwise be assigned.
     runner = None

--- a/tests/quant/test_awq_e2e_qwen25_15b.py
+++ b/tests/quant/test_awq_e2e_qwen25_15b.py
@@ -34,7 +34,6 @@ import torch
 from mlx.utils import tree_flatten
 
 from tests.stub_runner import make_stub_runner
-from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
 
 _AWQ_REPO = "Qwen/Qwen2.5-1.5B-Instruct-AWQ"
@@ -51,14 +50,11 @@ def _runner_model_config(*, dtype):
 
 
 @pytest.mark.slow
-def test_awq_load_aligns_non_quant_dtypes_to_runner_target(monkeypatch):
+def test_awq_load_aligns_non_quant_dtypes_to_runner_target():
     """After AWQ load, non-quantized floating params must match the runner's
     target dtype, and quantized layers' scales/biases must NOT have been
     touched by the alignment step (their dtype is owned by the transform).
     """
-    # Ensure no other test left a cached entry around for this model.
-    monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
-
     runner = make_stub_runner(model_config=_runner_model_config(dtype=torch.bfloat16))
     lifecycle = ModelLifecycle(runner, runner._model_adapter)
 
@@ -151,14 +147,7 @@ def test_awq_e2e_paged_runner_smoke():
                 f"expected 'Paris' in AWQ greedy continuation, got: {text!r}"
             )
     finally:
-        # Order matters: ``ModelLifecycle`` stores the AWQ model in the
-        # process-level ``_MODEL_CACHE``, so ``del llm`` alone cannot
-        # release the weights — the cache holds an independent strong
-        # reference. Drop the cache entry first so the subsequent
-        # ``del`` + ``gc.collect`` actually reclaim the model; otherwise
-        # later slow tests in the same pytest process can OOM on 16 GB
-        # Metal machines.
-        model_lifecycle.reset_model_cache()
+        # Drop Python references before returning Metal allocations to the pool.
         del llm
         gc.collect()
         mx.clear_cache()

--- a/tests/quant/test_awq_loader.py
+++ b/tests/quant/test_awq_loader.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for ``AWQQuantLoader``.
 
-Three test groups covering the public surface of the loader:
+Two test groups covering the public surface of the loader:
 
-* ``TestCacheKey`` — dtype scoping, disjointness from the generic key,
-  and stability of ``cache_key``.
 * ``TestConfigDetection`` — ``for_model``: AWQ accept, non-AWQ silent
   decline, GPTQ explicit reject, ``text_config`` fallback, alias
   normalization, Hub-fetch-error propagation.
@@ -26,24 +24,10 @@ from pathlib import Path
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
-import torch
 from huggingface_hub.utils import HFValidationError
 
-from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_config import UnsupportedQuantizationConfigError
 from vllm_metal.quant.awq_loader import AWQQuantLoader
-from vllm_metal.v1.model_lifecycle import _generation_cache_key
-
-
-def _mlx_dtype(torch_dtype):
-    """Mirror what production does to derive the cache-key dtype: convert a
-    torch dtype through ``torch_to_mlx``. Tests use this instead of literal
-    strings so we pin the *actual* MLX dtype the production path passes
-    (e.g. ``mlx.core.bfloat16``), not just "different strings produce
-    different keys".
-    """
-    return torch_to_mlx(torch.empty(0, dtype=torch_dtype)).dtype
-
 
 _AWQ_INNER = {
     "quant_method": "awq",
@@ -58,43 +42,6 @@ def _write_config(tmp_path: Path, config: dict) -> Path:
     """Drop a config.json into ``tmp_path`` and return the directory."""
     (tmp_path / "config.json").write_text(json.dumps(config))
     return tmp_path
-
-
-class TestCacheKey:
-    """``AWQQuantLoader.cache_key``: shape, dtype scoping, disjointness."""
-
-    def test_isolates_by_dtype(self):
-        """Two engines requesting the same model with different dtypes
-        must NOT share a cache entry, since AWQ post-load alignment
-        mutates the model in place.
-        """
-        bf16_key = AWQQuantLoader.cache_key(
-            "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
-            target_dtype=_mlx_dtype(torch.bfloat16),
-        )
-        fp16_key = AWQQuantLoader.cache_key(
-            "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
-            target_dtype=_mlx_dtype(torch.float16),
-        )
-        assert bf16_key != fp16_key
-
-    def test_pins_loader_segment_with_dtype(self):
-        """Pin the wire format: the second key segment is
-        ``mlx_lm-awq:<dtype>`` (encoding the dtype inside the loader
-        segment, not as a third tuple element). A future refactor that
-        strips the dtype or swaps to torch repr would fail loudly here.
-        """
-        key = AWQQuantLoader.cache_key("foo", target_dtype=_mlx_dtype(torch.bfloat16))
-        assert key == ("foo", f"mlx_lm-awq:{mx.bfloat16}")
-
-    def test_distinct_from_generic_lifecycle_key(self):
-        """AWQ cache key must not collide with the generic mlx_lm key
-        for the same model: an AWQ-mutated cached model must not be
-        served to a non-AWQ caller, nor vice versa.
-        """
-        awq_key = AWQQuantLoader.cache_key("x", target_dtype=_mlx_dtype(torch.bfloat16))
-        generic_key = _generation_cache_key("x", is_vlm=False)
-        assert awq_key != generic_key
 
 
 class TestConfigDetection:
@@ -192,11 +139,7 @@ class TestConfigDetection:
         assert "GPTQ" in str(excinfo.value)
 
     def test_returns_loader_for_awq(self, tmp_path):
-        """AWQ checkpoint: ``for_model`` returns a configured loader.
-
-        Cache-key shape is covered by ``TestCacheKey``; this test only
-        pins detection.
-        """
+        """AWQ checkpoint: ``for_model`` returns a configured loader."""
         model_dir = _write_config(
             tmp_path,
             {"model_type": "qwen2", "quantization_config": _AWQ_INNER},

--- a/tests/test_gemma4_golden.py
+++ b/tests/test_gemma4_golden.py
@@ -318,11 +318,11 @@ def _run_variant(variant: Gemma4Variant) -> dict[str, list[int]]:
     # MetalConfig and assistant state are process-level; reset both so the
     # variant starts from deterministic lifecycle state.
     from vllm_metal.config import reset_config
-    from vllm_metal.v1.model_lifecycle import reset_model_cache
+    from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
 
     previous = os.environ.get("VLLM_METAL_MEMORY_FRACTION")
     os.environ["VLLM_METAL_MEMORY_FRACTION"] = variant.memory_fraction
-    reset_model_cache()
+    Gemma4MTPAssistantLoader.clear_cache()
     reset_config()
     gc.collect()
     try:
@@ -338,7 +338,7 @@ def _run_variant(variant: Gemma4Variant) -> dict[str, list[int]]:
             os.environ.pop("VLLM_METAL_MEMORY_FRACTION", None)
         else:
             os.environ["VLLM_METAL_MEMORY_FRACTION"] = previous
-        reset_model_cache()
+        Gemma4MTPAssistantLoader.clear_cache()
         reset_config()
         gc.collect()
 

--- a/tests/test_gemma4_golden.py
+++ b/tests/test_gemma4_golden.py
@@ -315,8 +315,8 @@ def _run_variant(variant: Gemma4Variant) -> dict[str, list[int]]:
     if not os.path.isdir(model_path):
         pytest.skip(f"{variant.model_env}={model_path} is not a directory")
 
-    # MetalConfig and the model cache are process-level singletons; reset
-    # both and drop any previously-loaded model so the variant starts clean.
+    # MetalConfig and assistant state are process-level; reset both so the
+    # variant starts from deterministic lifecycle state.
     from vllm_metal.config import reset_config
     from vllm_metal.v1.model_lifecycle import reset_model_cache
 

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -467,19 +467,3 @@ def test_for_model_rejects_missing_tokenizer_dir(tmp_path):
         GGUFModelLoader.for_model(
             gguf_path, config_dir=gguf_path, target_dtype=mx.float32
         )
-
-
-def test_cache_key_is_dtype_and_config_dir_scoped(tmp_path):
-    gguf_path, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
-    key = GGUFModelLoader.cache_key(gguf_path, cfg_dir, target_dtype=mx.float16)
-    # dtype-scoped: a different dtype must not be cross-served from cache.
-    assert key != GGUFModelLoader.cache_key(
-        gguf_path, cfg_dir, target_dtype=mx.bfloat16
-    )
-    # config_dir-scoped: the same .gguf with a different --tokenizer dir is a
-    # different model (a .gguf carries weights only) and must not collide.
-    assert key != GGUFModelLoader.cache_key(
-        gguf_path, cfg_dir + "_other", target_dtype=mx.float16
-    )
-    # Full contract: model path + config-dir + dtype-scoped loader segment.
-    assert key == (gguf_path, f"gguf:{cfg_dir}:{mx.float16}")

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -132,7 +132,7 @@ def _qwen35_vlm_model(
     )
 
 
-def _cache_generation_model(
+def _stub_generation_model(
     monkeypatch: pytest.MonkeyPatch,
     *,
     config: object,
@@ -142,11 +142,21 @@ def _cache_generation_model(
 ) -> tuple[object, object]:
     fake_model = model or SimpleNamespace(config=config)
     fake_tokenizer = object() if tokenizer is None else tokenizer
-    cache_key = model_lifecycle._generation_cache_key("stub-model", is_vlm=is_vlm)
+
+    def _load_generation_model(
+        self: ModelLifecycle,
+        model_name: str,
+        actual_is_vlm: bool,
+        **_: object,
+    ) -> tuple[object, object]:
+        assert model_name == "stub-model"
+        assert actual_is_vlm is is_vlm
+        return fake_model, fake_tokenizer
+
     monkeypatch.setattr(
-        model_lifecycle,
-        "_MODEL_CACHE",
-        {cache_key: (fake_model, fake_tokenizer)},
+        ModelLifecycle,
+        "_load_generation_model",
+        _load_generation_model,
     )
     return fake_model, fake_tokenizer
 
@@ -219,7 +229,7 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _cache_generation_model(monkeypatch, config=_text_config())
+        _stub_generation_model(monkeypatch, config=_text_config())
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
                 hf_config=SimpleNamespace(model_type="gemma4"),
@@ -262,7 +272,7 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _cache_generation_model(monkeypatch, config=_text_config())
+        _stub_generation_model(monkeypatch, config=_text_config())
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
                 hf_config=SimpleNamespace(
@@ -283,7 +293,7 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _cache_generation_model(monkeypatch, config=_text_config())
+        _stub_generation_model(monkeypatch, config=_text_config())
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
                 hf_config=SimpleNamespace(
@@ -306,7 +316,7 @@ class TestModelLifecycle:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
         reset_config()
         fake_model = _qwen35_vlm_model()
-        _cache_generation_model(
+        _stub_generation_model(
             monkeypatch,
             config=fake_model.config,
             is_vlm=True,
@@ -339,7 +349,7 @@ class TestModelLifecycle:
             vision_tower=vision_tower,
             language_model=language_model,
         )
-        _cache_generation_model(
+        _stub_generation_model(
             monkeypatch,
             config=fake_model.config,
             is_vlm=True,
@@ -367,7 +377,7 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _cache_generation_model(
+        _stub_generation_model(
             monkeypatch,
             config=SimpleNamespace(text_config=_text_config()),
             is_vlm=True,
@@ -385,7 +395,7 @@ class TestModelLifecycle:
         assert runner._multimodal_adapter is None
         assert runner.encoder_cache is None
 
-    def test_generation_cache_separates_text_and_vlm_variants(
+    def test_load_separates_text_and_vlm_loader_paths(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -393,19 +403,22 @@ class TestModelLifecycle:
         text_tokenizer = object()
         vlm_model = _qwen35_vlm_model()
         vlm_tokenizer = object()
+
+        class _StubAWQLoader:
+            @classmethod
+            def for_model(cls, _model_name: str) -> None:
+                return None
+
+        monkeypatch.setattr(model_lifecycle, "AWQQuantLoader", _StubAWQLoader)
         monkeypatch.setattr(
             model_lifecycle,
-            "_MODEL_CACHE",
-            {
-                model_lifecycle._generation_cache_key("stub-model", is_vlm=False): (
-                    text_model,
-                    text_tokenizer,
-                ),
-                model_lifecycle._generation_cache_key("stub-model", is_vlm=True): (
-                    vlm_model,
-                    vlm_tokenizer,
-                ),
-            },
+            "mlx_lm_load",
+            lambda *_args, **_kwargs: (text_model, text_tokenizer),
+        )
+        monkeypatch.setattr(
+            model_lifecycle,
+            "mlx_vlm_load",
+            lambda _model_name: (vlm_model, vlm_tokenizer),
         )
 
         lifecycle, runner = _make_lifecycle(
@@ -444,7 +457,7 @@ class TestModelLifecycle:
     ) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
         reset_config()
-        _cache_generation_model(
+        _stub_generation_model(
             monkeypatch,
             config=SimpleNamespace(text_config=_text_config()),
             is_vlm=True,
@@ -497,12 +510,12 @@ class TestModelLifecycle:
         finally:
             model_lifecycle.reset_model_cache()
 
-    def test_load_extracts_text_model_config_from_cached_model(
+    def test_load_extracts_text_model_config_from_loaded_model(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         fake_tokenizer = object()
-        fake_model, _ = _cache_generation_model(
+        fake_model, _ = _stub_generation_model(
             monkeypatch,
             config=_text_config(),
             tokenizer=fake_tokenizer,
@@ -531,7 +544,7 @@ class TestModelLifecycle:
                 calls.append(kwargs)
                 return runtime
 
-        _cache_generation_model(monkeypatch, config=_text_config())
+        _stub_generation_model(monkeypatch, config=_text_config())
         monkeypatch.setattr(
             model_lifecycle,
             "Gemma4MTPAssistantLoader",
@@ -567,7 +580,7 @@ class TestModelLifecycle:
             def load_if_needed(self, **kwargs: object) -> object:
                 raise RuntimeError("assistant load failed")
 
-        _cache_generation_model(monkeypatch, config=_text_config())
+        _stub_generation_model(monkeypatch, config=_text_config())
         monkeypatch.setattr(
             model_lifecycle,
             "Gemma4MTPAssistantLoader",
@@ -659,7 +672,7 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _cache_generation_model(
+        _stub_generation_model(
             monkeypatch,
             config=SimpleNamespace(
                 vocab_size=_TEXT_MODEL_ARGS["vocab_size"],
@@ -692,16 +705,7 @@ class TestModelLifecycle:
             text_config=dict(_TEXT_MODEL_ARGS),
         )
         fake_model = SimpleNamespace(args=args)
-        monkeypatch.setattr(
-            model_lifecycle,
-            "_MODEL_CACHE",
-            {
-                model_lifecycle._generation_cache_key("stub-model", is_vlm=False): (
-                    fake_model,
-                    object(),
-                )
-            },
-        )
+        _stub_generation_model(monkeypatch, config=args, model=fake_model)
         lifecycle, runner = _make_lifecycle()
 
         lifecycle.load()
@@ -720,7 +724,7 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _cache_generation_model(
+        _stub_generation_model(
             monkeypatch,
             config=SimpleNamespace(
                 text_config=_SlotTextConfig(
@@ -743,20 +747,24 @@ class TestModelLifecycle:
         assert runner.num_layers == 32
         assert runner.head_dim == 128
 
-    def test_load_stt_model_reuses_cached_model(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
+    def test_load_stt_model_loads_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake_model = SimpleNamespace(
             create_runtime_adapter=lambda model_name: (object(), model_name)
         )
-        monkeypatch.setattr(
-            model_lifecycle,
-            "_MODEL_CACHE",
-            {model_lifecycle._stt_cache_key("stub-model"): (fake_model, None)},
+        calls: list[str] = []
+
+        def _load_model(model_name: str) -> object:
+            calls.append(model_name)
+            return fake_model
+
+        monkeypatch.setitem(
+            sys.modules,
+            "vllm_metal.stt.loader",
+            SimpleNamespace(load_model=_load_model),
         )
 
         assert model_lifecycle.load_stt_model("stub-model") is fake_model
+        assert calls == ["stub-model"]
 
     @pytest.mark.parametrize(
         "is_awq", [True, False], ids=["awq-checkpoint", "non-awq-checkpoint"]
@@ -789,10 +797,6 @@ class TestModelLifecycle:
             def for_model(cls, _model_name: str) -> _StubAWQLoader | None:
                 return cls() if is_awq else None
 
-            @staticmethod
-            def cache_key(model_name: str, *, target_dtype: object) -> tuple[str, str]:
-                return (model_name, f"mlx_lm-awq:{target_dtype}")
-
             def load(
                 self,
                 model_path: str,
@@ -816,7 +820,6 @@ class TestModelLifecycle:
             return fake_model, fake_tokenizer
 
         monkeypatch.setattr(model_lifecycle, "AWQQuantLoader", _StubAWQLoader)
-        monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
         monkeypatch.setattr(model_lifecycle, "mlx_lm_load", _fake_mlx_lm_load)
 
         lifecycle, runner = _make_lifecycle()
@@ -887,12 +890,6 @@ class TestModelLifecycle:
                 )
                 return cls()
 
-            @staticmethod
-            def cache_key(
-                model_name: str, config_dir: str, *, target_dtype: object
-            ) -> tuple[str, str]:
-                return (model_name, f"gguf:{config_dir}:{target_dtype}")
-
             def load(self) -> tuple[object, object]:
                 return fake_model, fake_tokenizer
 
@@ -907,7 +904,6 @@ class TestModelLifecycle:
             "vllm_metal.gguf.loader",
             SimpleNamespace(GGUFModelLoader=_StubGGUFLoader),
         )
-        monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
         monkeypatch.setattr(model_lifecycle, "mlx_lm_load", _fake_mlx_lm_load)
 
         lifecycle, runner = _make_lifecycle(
@@ -941,30 +937,41 @@ class TestModelLifecycle:
         GGUF owner, and the optional ``gguf`` package is never imported.
 
         Tripwire: block the ``gguf`` package itself (``sys.modules[...] = None``
-        raises on import). A clean load through the generic cached path proves a
-        default install with no gguf extra is unaffected — the detection guard
-        short-circuits before the lazy owner import that would pull in ``gguf``.
+        raises on import). A clean generic load proves a default install with no
+        gguf extra is unaffected by the lazy owner import.
         """
+        fake_model = SimpleNamespace(config=_text_config())
+        fake_tokenizer = object()
+
+        class _StubAWQLoader:
+            @classmethod
+            def for_model(cls, _model_name: str) -> None:
+                return None
+
         monkeypatch.setitem(sys.modules, "gguf", None)
-        _cache_generation_model(monkeypatch, config=_text_config())
+        monkeypatch.setattr(model_lifecycle, "AWQQuantLoader", _StubAWQLoader)
+        monkeypatch.setattr(
+            model_lifecycle,
+            "mlx_lm_load",
+            lambda *_args, **_kwargs: (fake_model, fake_tokenizer),
+        )
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config()  # no quantization -> not gguf
         )
 
         lifecycle.load()  # must not raise: the gguf owner import is never reached
 
+        assert runner.model is fake_model
         assert runner._is_vlm is False
         assert runner.model_args["vocab_size"] == 32000
 
-    def test_gguf_cache_key_separates_tokenizer_dirs(
+    def test_gguf_load_uses_each_tokenizer_dir(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Two loads of the same .gguf with different ``--tokenizer`` dirs must
-        not collide in the process cache. A .gguf carries weights only, so the
-        model and tokenizer are built from the config dir; returning the first's
-        result for the second (and bypassing the config-dir fail-fast once the
-        cache is warm) would be a silent wrong load.
+        both reach the GGUF owner with their own config dirs. A .gguf carries
+        weights only, so the model and tokenizer are built from the config dir.
         """
         for_model_dirs: list[str] = []
 
@@ -984,12 +991,6 @@ class TestModelLifecycle:
                 for_model_dirs.append(config_dir)
                 return cls(config_dir)
 
-            @staticmethod
-            def cache_key(
-                model_name: str, config_dir: str, *, target_dtype: object
-            ) -> tuple[str, str]:
-                return (model_name, f"gguf:{config_dir}:{target_dtype}")
-
             def load(self) -> tuple[object, object]:
                 return (
                     SimpleNamespace(config=_text_config()),
@@ -1001,7 +1002,6 @@ class TestModelLifecycle:
             "vllm_metal.gguf.loader",
             SimpleNamespace(GGUFModelLoader=_StubGGUFLoader),
         )
-        monkeypatch.setattr(model_lifecycle, "_MODEL_CACHE", {})
 
         def _load_tokenizer_for(tokenizer_dir: str) -> object:
             lifecycle, runner = _make_lifecycle(
@@ -1016,8 +1016,7 @@ class TestModelLifecycle:
         second = _load_tokenizer_for("/dir-b")
 
         assert for_model_dirs == ["/dir-a", "/dir-b"], (
-            "for_model must run for each distinct --tokenizer dir, not be skipped "
-            "by a colliding cache key"
+            "for_model must run for each distinct --tokenizer dir"
         )
         assert first == "tokenizer::/dir-a"
         assert second == "tokenizer::/dir-b"

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -490,7 +490,7 @@ class TestModelLifecycle:
 
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
         reset_config()
-        model_lifecycle.reset_model_cache()
+        Gemma4MTPAssistantLoader.clear_cache()
         _patch_mlx_lm_qwen35_fp8_sanitize()
 
         hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=False)
@@ -508,7 +508,7 @@ class TestModelLifecycle:
             assert runner.model is not None
             assert int(runner.model_args["vocab_size"]) > 0
         finally:
-            model_lifecycle.reset_model_cache()
+            Gemma4MTPAssistantLoader.clear_cache()
 
     def test_load_extracts_text_model_config_from_loaded_model(
         self,
@@ -604,7 +604,9 @@ class TestModelLifecycle:
 
         assert runner._gemma4_mtp_assistant is None
 
-    def test_reset_model_cache_clears_gemma4_mtp_assistant_cache(self) -> None:
+    def test_gemma4_mtp_assistant_loader_clear_cache_resets_cached_load(
+        self,
+    ) -> None:
         load_model_calls = 0
 
         def _load_model(
@@ -658,7 +660,7 @@ class TestModelLifecycle:
         assert first is second
         assert load_model_calls == 1
 
-        model_lifecycle.reset_model_cache()
+        Gemma4MTPAssistantLoader.clear_cache()
 
         third = loader.load_if_needed(
             speculative_config=spec_config,

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -145,25 +145,6 @@ class GGUFModelLoader:
             tokenizer_config=tokenizer_config,
         )
 
-    @staticmethod
-    def cache_key(
-        model_name: str, config_dir: str, *, target_dtype: mx.Dtype
-    ) -> tuple[str, str]:
-        """Process-cache key for a GGUF load.
-
-        A ``.gguf`` carries weights only; the model skeleton and tokenizer are
-        built from ``config_dir`` (the ``--tokenizer`` dir), so the key MUST
-        include it — two LLMs for the same ``.gguf`` with different config dirs
-        are different models and must not collide (else the second is served the
-        first's tokenizer/skeleton, and the config-dir fail-fast is bypassed once
-        the cache is warm). ``target_dtype`` is encoded too, dtype-scoped like the
-        AWQ owner's: a model first served as bf16 must not be returned when fp16
-        is later requested. Static so the lifecycle can compute the key and probe
-        the shared cache before building a loader; the 2-tuple shape matches
-        ``_generation_cache_key``.
-        """
-        return (model_name, f"gguf:{config_dir}:{target_dtype}")
-
     def load(self) -> tuple[nn.Module, Any]:
         """Run the full load workflow and return ``(model, tokenizer)``.
 

--- a/vllm_metal/quant/__init__.py
+++ b/vllm_metal/quant/__init__.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Quantization helpers for vllm-metal load paths.
 
-The AWQ load flow (entry-point preflight, ``mlx_lm.load`` invocation,
-dtype-scoped cache key, post-load alignment of non-quantized floating
-params) is owned end-to-end by ``awq_loader.AWQQuantLoader``;
-``model_lifecycle`` dispatches the quantized branch to it. The actual
-quantized GEMM kernel is ``mx.quantized_matmul`` in MLX core; mlx_lm
-0.31.3+ provides the AWQ -> MLX-affine repack via
+The AWQ load flow (entry-point preflight, ``mlx_lm.load`` invocation, and
+post-load alignment of non-quantized floating params) is owned end-to-end by
+``awq_loader.AWQQuantLoader``; ``model_lifecycle`` dispatches the quantized
+branch to it. The actual quantized GEMM kernel is ``mx.quantized_matmul`` in
+MLX core; mlx_lm 0.31.3+ provides the AWQ -> MLX-affine repack via
 ``_transform_awq_weights``.
 """

--- a/vllm_metal/quant/awq_loader.py
+++ b/vllm_metal/quant/awq_loader.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """AWQ load owner for vllm-metal.
 
-Encapsulates the entry-point preflight, the ``mlx_lm.load`` invocation
-with a normalized ``model_config={"quantization_config": ...}`` kwarg,
-the dtype-scoped cache key, and the post-load alignment of non-quantized
-floating params. ``ModelLifecycle`` delegates the entire AWQ branch to
-instances of this class so quantization policy stays cohesive in one
-place rather than leaking into the generic loader flow.
+Encapsulates the entry-point preflight, the ``mlx_lm.load`` invocation with a
+normalized ``model_config={"quantization_config": ...}`` kwarg, and the
+post-load alignment of non-quantized floating params. ``ModelLifecycle``
+delegates the entire AWQ branch to instances of this class so quantization
+policy stays cohesive in one place rather than leaking into the generic loader
+flow.
 
 GPTQ checkpoints are explicitly rejected at the entry point. mlx-lm's
 ``_transform_awq_weights`` accepts ``quant_method="gptq"`` at the
@@ -49,9 +49,8 @@ class AWQQuantLoader:
 
     Construct via :meth:`for_model`, which inspects the checkpoint's
     ``config.json`` and returns ``None`` when the checkpoint is not AWQ.
-    Lifecycle dispatches the quantized branch to this owner so the
-    dtype-scoped cache key and the post-load alignment policy do not
-    bleed into generic loader code paths.
+    Lifecycle dispatches the quantized branch to this owner so post-load
+    alignment policy does not bleed into generic loader code paths.
     """
 
     def __init__(self, normalized_quant_config: Mapping[str, Any]) -> None:
@@ -92,25 +91,6 @@ class AWQQuantLoader:
         if quant_method != "awq":
             return None
         return cls(normalize_quant_config(raw_qc))
-
-    @staticmethod
-    def cache_key(model_name: str, *, target_dtype: Any) -> tuple[str, str]:
-        """Cache key for an AWQ load.
-
-        ``target_dtype`` is encoded into the loader segment because the
-        post-load alignment mutates the model in place: a model first
-        loaded with bf16 and later requested as fp16 must NOT be served
-        from cache, since the cached object would carry the wrong dtype
-        on its non-quantized floating params. Encoding the dtype inside
-        the loader segment keeps the cache key shape identical to the
-        generic ``_generation_cache_key`` (a 2-tuple), so dtype scoping
-        is a property of this owner rather than of the generic cache.
-
-        Static so lifecycle can compute the speculative AWQ cache key
-        before deciding whether to invoke detection (which involves an
-        HF Hub config fetch on cache miss).
-        """
-        return (model_name, f"mlx_lm-awq:{target_dtype}")
 
     def load(
         self,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -120,55 +120,14 @@ class ModelLifecycle:
             request,
         )
 
-    def _install_generation_model(
-        self,
-        loaded_model: LoadedGenerationModel,
-        request: GenerationLoadRequest,
-    ) -> None:
-        """Install loaded generation state used by runner execution paths."""
-
-        runner = self._runner
-        runner.model = loaded_model.model
-        runner.tokenizer = loaded_model.tokenizer
-        runner._is_vlm = request.is_vlm
-
-        # Adapter state follows the effective VLM mode, not the raw config flag.
-        multimodal_adapter = (
-            self._model_adapter.build_multimodal_adapter(
-                loaded_model.model, request.hf_config
-            )
-            if request.is_vlm
-            else None
-        )
-        runner._multimodal_adapter = multimodal_adapter
-        runner.encoder_cache = (
-            EncoderCache() if multimodal_adapter is not None else None
-        )
-
-        # Dimension resolution reads model_args immediately after this phase.
-        runner.model_args = loaded_model.model_args
-        runner._vocab_size = int(loaded_model.model_args["vocab_size"])
-        if runner.metal_config.debug:
-            logger.info("Model args: %s", loaded_model.model_args)
-
-    def _install_runtime_extensions(
-        self,
-        model_args: Mapping[str, Any],
-        request: GenerationLoadRequest,
-    ) -> None:
-        """Install optional runtime extensions after model dimensions resolve."""
-
-        runner = self._runner
-
-        # Clear stale extension state before loading replacement extensions.
-        runner._gemma4_mtp_assistant = None
-        gemma4_mtp_assistant = Gemma4MTPAssistantLoader().load_if_needed(
-            speculative_config=runner.vllm_config.speculative_config,
-            target_hf_config=request.hf_config,
-            target_model_args=model_args,
-        )
-        runner.kv_cache_dtype = request.target_dtype
-        runner._gemma4_mtp_assistant = gemma4_mtp_assistant
+    def resolve_model_dims(self) -> None:
+        """Resolve loaded model args into runner attention/cache dimensions."""
+        args = self._runner.model_args
+        default_head_dim = self._install_runner_attention_dims(args)
+        self._install_yoco_cache_mapping(args)
+        self._install_per_layer_attention_metadata(args, default_head_dim)
+        self._reject_pipeline_parallel_with_per_layer_metadata()
+        self._install_hybrid_attention_dims(args)
 
     def _load_generation(
         self,
@@ -213,7 +172,6 @@ class ModelLifecycle:
         is_gguf = not is_vlm and model_config.quantization == "gguf"
         awq_loader = None if is_gguf or is_vlm else AWQQuantLoader.for_model(model_name)
 
-        # GGUF text checkpoints use the local GGUF owner.
         if is_gguf:
             load_label = "GGUF model"
             model, tokenizer = self._load_gguf_text_model(
@@ -223,12 +181,10 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
-        # VLM checkpoints use mlx-vlm directly.
         elif is_vlm:
             load_label = "MLX-VLM model"
             model, tokenizer = mlx_vlm_load(model_name)
 
-        # AWQ text checkpoints own detection, load config, and dtype alignment.
         elif awq_loader is not None:
             load_label = "AWQ model"
             model, tokenizer = self._load_awq_text_model(
@@ -238,7 +194,6 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
-        # Plain text checkpoints use mlx-lm with vllm-metal path adaptation.
         else:
             load_label = "MLX-LM model"
             model, tokenizer = self._load_mlx_lm_text_model(
@@ -253,6 +208,24 @@ class ModelLifecycle:
             model_name,
         )
         return model, tokenizer
+
+    def _load_gguf_text_model(
+        self,
+        model_name: str,
+        model_config: Any,
+        target_dtype: Any,
+        tokenizer_config: Mapping[str, Any],
+    ) -> tuple[Any, Any]:
+        """Load a GGUF checkpoint through the optional GGUF owner."""
+        from vllm_metal.gguf.loader import GGUFModelLoader
+
+        loader = GGUFModelLoader.for_model(
+            model_name,
+            config_dir=model_config.tokenizer,
+            target_dtype=target_dtype,
+            tokenizer_config=dict(tokenizer_config),
+        )
+        return loader.load()
 
     def _load_awq_text_model(
         self,
@@ -280,26 +253,39 @@ class ModelLifecycle:
             )
         return model, tokenizer
 
-    def _load_gguf_text_model(
+    def _install_generation_model(
         self,
-        model_name: str,
-        model_config: Any,
-        target_dtype: Any,
-        tokenizer_config: Mapping[str, Any],
-    ) -> tuple[Any, Any]:
-        """Load a GGUF checkpoint through the optional GGUF owner."""
-        from vllm_metal.gguf.loader import GGUFModelLoader
+        loaded_model: LoadedGenerationModel,
+        request: GenerationLoadRequest,
+    ) -> None:
+        """Install loaded generation state used by runner execution paths."""
 
-        loader = GGUFModelLoader.for_model(
-            model_name,
-            config_dir=model_config.tokenizer,
-            target_dtype=target_dtype,
-            tokenizer_config=dict(tokenizer_config),
+        runner = self._runner
+        runner.model = loaded_model.model
+        runner.tokenizer = loaded_model.tokenizer
+        runner._is_vlm = request.is_vlm
+
+        # Adapter state follows the effective VLM mode, not the raw config flag.
+        multimodal_adapter = (
+            self._model_adapter.build_multimodal_adapter(
+                loaded_model.model, request.hf_config
+            )
+            if request.is_vlm
+            else None
         )
-        return loader.load()
+        runner._multimodal_adapter = multimodal_adapter
+        runner.encoder_cache = (
+            EncoderCache() if multimodal_adapter is not None else None
+        )
 
-    def resolve_model_dims(self) -> None:
-        args = self._runner.model_args
+        # Dimension resolution reads model_args immediately after this phase.
+        runner.model_args = loaded_model.model_args
+        runner._vocab_size = int(loaded_model.model_args["vocab_size"])
+        if runner.metal_config.debug:
+            logger.info("Model args: %s", loaded_model.model_args)
+
+    def _install_runner_attention_dims(self, args: dict[str, Any]) -> int | None:
+        """Install runner-wide attention dims and return the default head_dim."""
         num_layers = args.get("num_hidden_layers") or args.get("n_layers")
         num_attention_heads = args.get("num_attention_heads")
         num_kv_heads = (
@@ -308,62 +294,59 @@ class ModelLifecycle:
             or num_attention_heads
         )
         hidden_size = args.get("hidden_size")
-        base_head_dim = args.get("head_dim") or (
+        default_head_dim = args.get("head_dim") or (
             hidden_size // num_attention_heads
             if hidden_size and num_attention_heads
             else None
         )
-        head_dim = self._model_adapter.resolve_max_head_dim(args, base_head_dim)
+        head_dim = self._model_adapter.resolve_max_head_dim(args, default_head_dim)
 
-        missing = []
-        if not num_layers:
-            missing.append("num_layers (num_hidden_layers / n_layers)")
-        if not num_kv_heads:
-            missing.append("num_kv_heads (num_key_value_heads / n_kv_heads)")
-        if not head_dim:
-            missing.append("head_dim")
-        if missing:
+        if not num_layers or not num_kv_heads or not head_dim:
             raise ValueError(
-                f"Cannot resolve model dimensions: {', '.join(missing)}. "
+                "Cannot resolve model dimensions from model_args: "
+                f"num_layers={num_layers!r}, num_kv_heads={num_kv_heads!r}, "
+                f"head_dim={head_dim!r}. "
                 f"Available keys: {sorted(args.keys())}"
             )
 
-        self._runner.num_layers = int(num_layers)
-        self._runner.num_attention_heads = (
+        runner = self._runner
+        runner.num_layers = int(num_layers)
+        runner.num_attention_heads = (
             int(num_attention_heads) if num_attention_heads is not None else None
         )
-        self._runner.num_kv_heads = int(num_kv_heads)
-        self._runner.hidden_size = int(hidden_size) if hidden_size is not None else None
-        self._runner.head_dim = int(head_dim)
+        runner.num_kv_heads = int(num_kv_heads)
+        runner.hidden_size = int(hidden_size) if hidden_size is not None else None
+        runner.head_dim = int(head_dim)
 
-        if self._runner.is_mla:
-            self._runner.num_kv_heads = 1
-            self._runner.head_dim = int(args["kv_lora_rank"]) + int(
+        if runner.is_mla:
+            runner.num_kv_heads = 1
+            runner.head_dim = int(args["kv_lora_rank"]) + int(
                 args.get("qk_rope_head_dim", MLA_DEFAULT_QK_ROPE_HEAD_DIM)
             )
+        return int(default_head_dim) if default_head_dim is not None else None
 
+    def _install_yoco_cache_mapping(self, args: dict[str, Any]) -> None:
+        """Install YOCO layer-to-cache mapping when the model uses shared KV."""
         yoco = self._model_adapter.build_yoco_cache_mapping(args)
         self._runner._yoco_cache_mapping = yoco
         self._runner.num_kv_cache_layers = (
             yoco[0] if yoco is not None else self._runner.num_layers
         )
 
-        # Per-layer KV shapes for heterogeneous models (Gemma4 26B/31B).
-        # Uses the unresolved ``base_head_dim`` so sliding-attention layers
-        # get their true head_dim (256) rather than the max-with-global used
-        # for cache allocation (512).  Returns None for uniform models,
-        # leaving the scalar paths on the runner unchanged.
-        #
-        # ``base_head_dim`` is None only when neither ``head_dim`` nor
-        # ``hidden_size / num_attention_heads`` could be resolved — the
-        # missing-check above already raises in that case, but we guard
-        # here too so ``int()`` never receives None.
-        if base_head_dim is not None:
+    def _install_per_layer_attention_metadata(
+        self,
+        args: dict[str, Any],
+        default_head_dim: int | None,
+    ) -> None:
+        """Install per-layer KV and sliding-window metadata."""
+        # Use the default head_dim before any global-attention widening so
+        # sliding-attention layers keep their true cache shape.
+        if default_head_dim is not None:
             per_layer = self._model_adapter.build_per_layer_kv_shapes(
                 args,
                 num_layers=self._runner.num_layers,
                 num_kv_heads=self._runner.num_kv_heads,
-                head_dim=int(base_head_dim),
+                head_dim=default_head_dim,
             )
         else:
             per_layer = None
@@ -379,13 +362,9 @@ class ModelLifecycle:
             )
         )
 
-        # Pipeline parallelism slices layers by index but leaves these per-layer
-        # KV lists at full length, so a non-first stage would index them by LOCAL
-        # layer and read the wrong global layer. They are non-None only for non-
-        # uniform models (e.g. Gemma4 interleaved sliding/full attention); reject
-        # PP for them until the split slices the lists too. ``pp`` is the runner's
-        # canonical PP signal (set by the worker before load, mirroring the
-        # forward path's ``self.pp`` checks).
+    def _reject_pipeline_parallel_with_per_layer_metadata(self) -> None:
+        """Reject PP until per-layer metadata is stage-sliced."""
+        # PP layer indices are stage-local; these metadata lists are still global.
         if (
             self._runner.pp is not None
             and self._runner.pp.size > 1
@@ -401,6 +380,8 @@ class ModelLifecycle:
                 "head dims, e.g. Gemma4)."
             )
 
+    def _install_hybrid_attention_dims(self, args: dict[str, Any]) -> None:
+        """Install hybrid linear-attention dimensions for GDN-style models."""
         if self._runner.is_hybrid:
             fai = int(args["full_attention_interval"])
             self._runner.full_attention_interval = fai
@@ -421,6 +402,25 @@ class ModelLifecycle:
                 self._runner.linear_num_k_heads * self._runner.linear_key_head_dim * 2
                 + self._runner.linear_num_v_heads * self._runner.linear_value_head_dim
             )
+
+    def _install_runtime_extensions(
+        self,
+        model_args: Mapping[str, Any],
+        request: GenerationLoadRequest,
+    ) -> None:
+        """Install optional runtime extensions after model dimensions resolve."""
+
+        runner = self._runner
+
+        # Clear stale extension state before loading replacement extensions.
+        runner._gemma4_mtp_assistant = None
+        gemma4_mtp_assistant = Gemma4MTPAssistantLoader().load_if_needed(
+            speculative_config=runner.vllm_config.speculative_config,
+            target_hf_config=request.hf_config,
+            target_model_args=model_args,
+        )
+        runner.kv_cache_dtype = request.target_dtype
+        runner._gemma4_mtp_assistant = gemma4_mtp_assistant
 
     def _extract_model_args(self, model: Any, is_vlm: bool) -> dict[str, Any]:
         # Both the .args (mlx-lm) and .config (HF) paths may expose a nested

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -37,11 +37,6 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-def reset_model_cache() -> None:
-    """Clear lifecycle-owned assistant caches."""
-    Gemma4MTPAssistantLoader.clear_cache()
-
-
 def load_stt_model(model_name: str) -> Any:
     """Load an STT model.
 
@@ -213,41 +208,43 @@ class ModelLifecycle:
         )
         if not is_vlm and target_dtype is None:
             target_dtype = torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype
-        logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
-        start_time = time.time()
 
-        # GGUF is a text load format; keep optional dependency handling there.
-        if not is_vlm and model_config.quantization == "gguf":
+        start_time = time.time()
+        is_gguf = not is_vlm and model_config.quantization == "gguf"
+        awq_loader = None if is_gguf or is_vlm else AWQQuantLoader.for_model(model_name)
+
+        # GGUF text checkpoints use the local GGUF owner.
+        if is_gguf:
             load_label = "GGUF model"
-            model, tokenizer = self._load_gguf_generation_model(
+            model, tokenizer = self._load_gguf_text_model(
                 model_name,
-                model_config=model_config,
-                target_dtype=target_dtype,
-                tokenizer_config=tokenizer_config,
+                model_config,
+                target_dtype,
+                tokenizer_config,
             )
 
-        # VLM checkpoints use mlx-vlm; text checkpoints use mlx-lm paths.
+        # VLM checkpoints use mlx-vlm directly.
         elif is_vlm:
-            load_label = "Model"
-            logger.info("Using mlx-vlm for vision-language model")
+            load_label = "MLX-VLM model"
             model, tokenizer = mlx_vlm_load(model_name)
 
-        # AWQ owns detection and dtype alignment; generic text falls through.
+        # AWQ text checkpoints own detection, load config, and dtype alignment.
+        elif awq_loader is not None:
+            load_label = "AWQ model"
+            model, tokenizer = self._load_awq_text_model(
+                model_name,
+                awq_loader,
+                target_dtype,
+                tokenizer_config,
+            )
+
+        # Plain text checkpoints use mlx-lm with vllm-metal path adaptation.
         else:
-            load_label = "Model"
-            awq_loader = AWQQuantLoader.for_model(model_name)
-            if awq_loader is None:
-                model, tokenizer = self._load_mlx_lm_generation_model(
-                    model_name,
-                    tokenizer_config=tokenizer_config,
-                )
-            else:
-                model, tokenizer = self._load_awq_generation_model(
-                    model_name,
-                    awq_loader,
-                    target_dtype=target_dtype,
-                    tokenizer_config=tokenizer_config,
-                )
+            load_label = "MLX-LM model"
+            model, tokenizer = self._load_mlx_lm_text_model(
+                model_name,
+                tokenizer_config,
+            )
 
         logger.info(
             "%s loaded in %.2fs: %s",
@@ -257,11 +254,10 @@ class ModelLifecycle:
         )
         return model, tokenizer
 
-    def _load_awq_generation_model(
+    def _load_awq_text_model(
         self,
         model_name: str,
         awq_loader: AWQQuantLoader,
-        *,
         target_dtype: Any,
         tokenizer_config: Mapping[str, Any],
     ) -> tuple[Any, Any]:
@@ -272,10 +268,9 @@ class ModelLifecycle:
                 tokenizer_config=tokenizer_config,
             )
 
-    def _load_mlx_lm_generation_model(
+    def _load_mlx_lm_text_model(
         self,
         model_name: str,
-        *,
         tokenizer_config: Mapping[str, Any],
     ) -> tuple[Any, Any]:
         with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
@@ -285,7 +280,7 @@ class ModelLifecycle:
             )
         return model, tokenizer
 
-    def _load_gguf_generation_model(
+    def _load_gguf_text_model(
         self,
         model_name: str,
         model_config: Any,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
-from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -37,61 +36,24 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-_MODEL_CACHE: dict[tuple[str, str], tuple[Any, Any]] = {}
-_MODEL_CACHE_LOCK = Lock()
-
 
 def reset_model_cache() -> None:
-    """Clear the process-level model cache.
-
-    Intended for tests that load multiple large models in sequence and
-    need a deterministic start between variants.  Uses the same lock
-    that protects every other ``_MODEL_CACHE`` access.
-
-    This is a narrow, test-oriented API so callers do not need to reach
-    into the private module global directly.
-    """
-    with _MODEL_CACHE_LOCK:
-        _MODEL_CACHE.clear()
+    """Clear lifecycle-owned assistant caches."""
     Gemma4MTPAssistantLoader.clear_cache()
 
 
-def _generation_cache_key(model_name: str, *, is_vlm: bool) -> tuple[str, str]:
-    loader = "mlx_vlm" if is_vlm else "mlx_lm"
-    return (model_name, loader)
-
-
-def _stt_cache_key(model_name: str) -> tuple[str, str]:
-    return (model_name, "stt")
-
-
 def load_stt_model(model_name: str) -> Any:
-    """Load an STT model, reusing the process-level model cache.
+    """Load an STT model.
 
     Returns the loaded STT model. The caller (``STTModelRunner``) builds the
-    per-model runtime adapter and wires it onto the runner. Shares
-    ``_MODEL_CACHE`` with generation loads so ``reset_model_cache`` clears it.
+    per-model runtime adapter and wires it onto the runner.
     """
     start_time = time.time()
-    cache_key = _stt_cache_key(model_name)
-
-    with _MODEL_CACHE_LOCK:
-        cached = _MODEL_CACHE.get(cache_key)
-    if cached is not None:
-        model, _ = cached
-        logger.info(
-            "STT model loaded from cache in %.3fs: %s",
-            time.time() - start_time,
-            model_name,
-        )
-        return model
 
     from vllm_metal.stt.loader import load_model as stt_load_model
 
     logger.info("Loading STT model: %s", model_name)
     model = stt_load_model(model_name)
-    with _MODEL_CACHE_LOCK:
-        _MODEL_CACHE[cache_key] = (model, None)
     logger.info("STT model loaded in %.2fs: %s", time.time() - start_time, model_name)
     return model
 
@@ -239,7 +201,7 @@ class ModelLifecycle:
         target_dtype: Any | None = None,
         tokenizer_config: Mapping[str, Any] | None = None,
     ) -> tuple[Any, Any]:
-        """Load and cache a text or VLM generation model."""
+        """Load a text or VLM generation model."""
 
         model_config = (
             self._runner.model_config if model_config is None else model_config
@@ -254,70 +216,78 @@ class ModelLifecycle:
         logger.info("Loading model: %s (VLM: %s)", model_name, is_vlm)
         start_time = time.time()
 
-        # EngineArgs normalizes local GGUF inputs to quantization="gguf";
-        # the GGUF owner handles format-specific validation and loading.
+        # GGUF is a text load format; keep optional dependency handling there.
         if not is_vlm and model_config.quantization == "gguf":
-            return self._load_gguf_generation_model(
+            load_label = "GGUF model"
+            model, tokenizer = self._load_gguf_generation_model(
                 model_name,
-                start_time,
                 model_config=model_config,
                 target_dtype=target_dtype,
                 tokenizer_config=tokenizer_config,
             )
 
-        # AWQ checkpoints are owned end-to-end by AWQQuantLoader
-        # (preflight, mlx_lm.load invocation, dtype alignment, dtype-scoped
-        # cache key). Detection involves an HF Hub config fetch on cache
-        # miss, so first do a speculative cache lookup against both the
-        # AWQ and generic candidate keys; only invoke detection on miss.
-        # Probe the AWQ-specific key first so a previously cached AWQ load
-        # is served correctly even if the current detection call would
-        # have failed (e.g. transient Hub error after the cache was warmed).
-        generic_key = _generation_cache_key(model_name, is_vlm=is_vlm)
-        awq_key: tuple[str, str] | None = None
-        if not is_vlm:
-            awq_key = AWQQuantLoader.cache_key(model_name, target_dtype=target_dtype)
-
-        with _MODEL_CACHE_LOCK:
-            cached = _MODEL_CACHE.get(awq_key) if awq_key is not None else None
-            if cached is None:
-                cached = _MODEL_CACHE.get(generic_key)
-        if cached is not None:
-            logger.info(
-                "Model loaded from cache in %.3fs: %s",
-                time.time() - start_time,
-                model_name,
-            )
-            return cached
-
-        awq_loader = None if is_vlm else AWQQuantLoader.for_model(model_name)
-        cache_key = awq_key if awq_loader is not None else generic_key
-        if is_vlm:
+        # VLM checkpoints use mlx-vlm; text checkpoints use mlx-lm paths.
+        elif is_vlm:
+            load_label = "Model"
             logger.info("Using mlx-vlm for vision-language model")
             model, tokenizer = mlx_vlm_load(model_name)
-        elif awq_loader is not None:
-            with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
-                model, tokenizer = awq_loader.load(
-                    str(compatible_model_name),
+
+        # AWQ owns detection and dtype alignment; generic text falls through.
+        else:
+            load_label = "Model"
+            awq_loader = AWQQuantLoader.for_model(model_name)
+            if awq_loader is None:
+                model, tokenizer = self._load_mlx_lm_generation_model(
+                    model_name,
+                    tokenizer_config=tokenizer_config,
+                )
+            else:
+                model, tokenizer = self._load_awq_generation_model(
+                    model_name,
+                    awq_loader,
                     target_dtype=target_dtype,
                     tokenizer_config=tokenizer_config,
                 )
-        else:
-            with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
-                model, tokenizer = mlx_lm_load(
-                    str(compatible_model_name),
-                    tokenizer_config=tokenizer_config,
-                )
 
-        with _MODEL_CACHE_LOCK:
-            _MODEL_CACHE[cache_key] = (model, tokenizer)
-        logger.info("Model loaded in %.2fs: %s", time.time() - start_time, model_name)
+        logger.info(
+            "%s loaded in %.2fs: %s",
+            load_label,
+            time.time() - start_time,
+            model_name,
+        )
+        return model, tokenizer
+
+    def _load_awq_generation_model(
+        self,
+        model_name: str,
+        awq_loader: AWQQuantLoader,
+        *,
+        target_dtype: Any,
+        tokenizer_config: Mapping[str, Any],
+    ) -> tuple[Any, Any]:
+        with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
+            return awq_loader.load(
+                str(compatible_model_name),
+                target_dtype=target_dtype,
+                tokenizer_config=tokenizer_config,
+            )
+
+    def _load_mlx_lm_generation_model(
+        self,
+        model_name: str,
+        *,
+        tokenizer_config: Mapping[str, Any],
+    ) -> tuple[Any, Any]:
+        with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
+            model, tokenizer = mlx_lm_load(
+                str(compatible_model_name),
+                tokenizer_config=tokenizer_config,
+            )
         return model, tokenizer
 
     def _load_gguf_generation_model(
         self,
         model_name: str,
-        start_time: float,
         model_config: Any,
         target_dtype: Any,
         tokenizer_config: Mapping[str, Any],
@@ -325,32 +295,13 @@ class ModelLifecycle:
         """Load a GGUF checkpoint through the optional GGUF owner."""
         from vllm_metal.gguf.loader import GGUFModelLoader
 
-        cache_key = GGUFModelLoader.cache_key(
-            model_name, model_config.tokenizer, target_dtype=target_dtype
-        )
-        with _MODEL_CACHE_LOCK:
-            cached = _MODEL_CACHE.get(cache_key)
-        if cached is not None:
-            logger.info(
-                "Model loaded from cache in %.3fs: %s",
-                time.time() - start_time,
-                model_name,
-            )
-            return cached
-
         loader = GGUFModelLoader.for_model(
             model_name,
             config_dir=model_config.tokenizer,
             target_dtype=target_dtype,
             tokenizer_config=dict(tokenizer_config),
         )
-        model, tokenizer = loader.load()
-        with _MODEL_CACHE_LOCK:
-            _MODEL_CACHE[cache_key] = (model, tokenizer)
-        logger.info(
-            "GGUF model loaded in %.2fs: %s", time.time() - start_time, model_name
-        )
-        return model, tokenizer
+        return loader.load()
 
     def resolve_model_dims(self) -> None:
         args = self._runner.model_args


### PR DESCRIPTION
This PR is:

- To remove the process-level lifecycle model cache, which added global state and test coupling without a clear runtime payoff for one-model-per-worker loading.
- To delete obsolete AWQ/GGUF cache-key APIs and cache-key-only tests that only existed for that cache.
- To make generation loading dispatch explicit across GGUF, MLX-VLM, AWQ, and MLX-LM paths.
- To keep `resolve_model_dims()` as a readable lifecycle phase with private helpers ordered by the runner state they install.

Model selection and runner wiring behavior are preserved: GGUF still routes through `GGUFModelLoader`, AWQ detection stays owned by `AWQQuantLoader`, VLM still uses `mlx-vlm`, and plain text still uses `mlx-lm` with the existing path adaptation.
