### PR TITLE
Bump vLLM to 0.24.0

### DIFF
--- a/docs/rust_frontend.md
+++ b/docs/rust_frontend.md
@@ -2,7 +2,7 @@
 
 vllm-metal supports the optional `vllm-rs` Rust frontend as a drop-in replacement for vLLM's Python serving layer. The Rust frontend is hardware-agnostic; vllm-metal continues to run the engine on Metal/MLX inside the spawned Python subprocess.
 
-As of vLLM 0.23.0, the Rust frontend source is vendored in the main vLLM repository under `rust/`. The former `Inferact/vllm-frontend-rs` repository is kept only as a historical archive.
+As of vLLM 0.24.0, the Rust frontend source is vendored in the main vLLM repository under `rust/`. The former `Inferact/vllm-frontend-rs` repository is kept only as a historical archive.
 
 For architecture, flag reference, and usage, see the [upstream README](https://github.com/vllm-project/vllm/tree/main/rust#readme).
 

--- a/install.sh
+++ b/install.sh
@@ -198,7 +198,7 @@ EOF
     exit 1
   fi
 
-  local vllm_v="0.23.0"
+  local vllm_v="0.24.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   local vllm_tmp_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ dependencies = [
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
-    # First allowed Transformers v5 release per vLLM 0.23.0's exclude list.
-    "transformers>=5.5.1",
+    # Keep aligned with vLLM 0.24.0's Transformers lower bound.
+    "transformers>=5.5.3",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
     # Native Metal extension JIT build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,12 @@ dependencies = [
     # Core utilities
     "numpy>=1.24.0",
     "psutil>=5.9.0",
+    # Keep aligned with vLLM 0.24.0's FastAPI/Starlette lower bounds.
     # Temporary cap: fastapi>=0.137 adds a `_IncludedRouter` route type that
     # crashes vLLM's prometheus middleware (vllm-project/vllm#45597).
     # TODO: remove once we bump to a vLLM release that includes vllm#45629.
-    "fastapi[standard]>=0.115.0,<0.137",
+    "fastapi[standard]>=0.133.0,<0.137",
+    "starlette>=1.0.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -61,6 +61,7 @@ def _make_scheduler_output(
         num_invalid_spec_tokens=None,
         num_scheduled_tokens=dict.fromkeys(req_ids, 1),
         total_num_scheduled_tokens=len(req_ids),
+        num_spec_tokens_to_schedule=0,
         scheduled_new_reqs=[],
         scheduled_cached_reqs=SimpleNamespace(
             req_ids=[],

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -80,6 +80,7 @@ def _context(
         request_states=request_states,
         cu_seqlens=[],
         num_decode_segments=len(decode_reqs),
+        num_speculative_tokens=3,
         logitsprocs=None,
     )
 

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -60,6 +60,7 @@ def _context(
     prefill_reqs: list[SimpleNamespace] | None = None,
     prefill_result_modes: list[str] | None = None,
     request_states: dict[str, SimpleNamespace] | None = None,
+    num_speculative_tokens: int = 3,
 ) -> ProposeContext:
     decode_reqs = decode_reqs or []
     prefill_reqs = prefill_reqs or []
@@ -80,7 +81,7 @@ def _context(
         request_states=request_states,
         cu_seqlens=[],
         num_decode_segments=len(decode_reqs),
-        num_speculative_tokens=3,
+        num_speculative_tokens=num_speculative_tokens,
         logitsprocs=None,
     )
 
@@ -104,6 +105,30 @@ class TestNgramProposePropose:
         assert drafts is not None
         assert drafts.req_ids == ["r0"]
         assert drafts.draft_token_ids == [[3, 1, 2]]
+
+    def test_uses_scheduler_selected_num_speculative_tokens(self) -> None:
+        proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
+        state = _request_state([1, 2, 3, 1, 2, 3, 1, 2])
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            num_speculative_tokens=1,
+        )
+
+        drafts = proposer.propose(ctx)
+
+        assert drafts is not None
+        assert drafts.req_ids == ["r0"]
+        assert drafts.draft_token_ids == [[3]]
+
+    def test_scheduler_selected_zero_tokens_returns_none(self) -> None:
+        proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
+        state = _request_state([1, 2, 3, 1, 2, 3, 1, 2])
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            num_speculative_tokens=0,
+        )
+
+        assert proposer.propose(ctx) is None
 
     def test_no_match_returns_none(self) -> None:
         # Non-repeating context shorter than the n-gram window: no draft.

--- a/tests/test_qwen35_smoke.py
+++ b/tests/test_qwen35_smoke.py
@@ -3,7 +3,7 @@
 
 Qwen3.5 uses the `qwen3_5` architecture which requires transformers>=5.0.0.
 This test verifies that the upgraded dependency stack (mlx-lm>=0.31.3,
-mlx-vlm>=0.6.2, llguidance>=1.7.0, transformers>=5.5.1) works correctly
+mlx-vlm>=0.6.2, llguidance>=1.7.0, transformers>=5.5.3) works correctly
 with vLLM on Metal.
 
 Golden token IDs were generated with greedy decoding (temperature=0) on

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -225,12 +225,14 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         num_scheduled_tokens: dict[str, int],
         scheduled_spec_decode_tokens: dict[str, list[int]],
         num_invalid_spec_tokens: dict[str, int] | None = None,
+        num_spec_tokens_to_schedule: int = 1,
     ) -> SimpleNamespace:
         return SimpleNamespace(
             num_scheduled_tokens=num_scheduled_tokens,
             total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
             num_invalid_spec_tokens=num_invalid_spec_tokens,
+            num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
             finished_req_ids=set(),
         )
 
@@ -713,6 +715,61 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             block_ids=(0,),
         )
         assert draft_token_ids == DraftTokenIds(["r0"], [[42]])
+
+    def test_gemma4_mtp_honors_scheduler_selected_zero_drafts(self) -> None:
+        class Assistant:
+            forward_ready = True
+
+            def propose_draft_token_ids(
+                self,
+                *,
+                seeds,
+                target_hidden_states,
+                target_input_embeddings,
+            ):
+                del seeds, target_hidden_states, target_input_embeddings
+                raise AssertionError("assistant should not draft when K=0")
+
+        class Adapter:
+            def target_input_embeddings(self, model, input_ids):
+                del model, input_ids
+                raise AssertionError("draft embeddings should not be requested")
+
+        runner = self._make_runner()
+        runner._gemma4_mtp_assistant = Assistant()
+        runner._model_adapter = Adapter()
+        runner._drafter = Gemma4MTPProposer(runner)
+        req_state = self._make_state([1, 6])
+        decode_reqs = [("r0", req_state)]
+        segment = mr.PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6,),
+            start_row=0,
+            num_query_tokens=1,
+            draft_token_ids=(),
+            cache_start_pos=1,
+            block_ids=(0,),
+        )
+        scheduler_output = self._make_scheduler_output(
+            {"r0": 1},
+            {},
+            num_spec_tokens_to_schedule=0,
+        )
+        self._install_paged_state(
+            runner,
+            decode_reqs,
+            (segment,),
+            self._make_logits([9]),
+            scheduler_output,
+            target_hidden_states=mx.array([[1.0, 0.0, 0.0, 0.0]]),
+        )
+
+        output = runner.sample_tokens(grammar_output=None)
+
+        assert output is not None
+        assert output.sampled_token_ids == [[9]]
+        assert req_state.token_ids == [1, 6, 9]
+        assert runner.take_draft_token_ids() is None
 
     def test_sample_paged_batch_stashes_gemma4_prefill_drafts(self) -> None:
         captured: dict[str, object] = {}

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -16,7 +16,8 @@ A :class:`DraftModelProposer` drafts with a *separate* full model (vLLM
   position-for-position across the two caches; only the block table is owned
   separately.
 
-Each scheduler step ``propose()`` runs, batched over the dynamic mixed batch:
+Each scheduler step ``propose()`` runs, batched over the dynamic mixed batch
+with the scheduler-selected speculative token count:
 
 1. **Ingest** — for every drafting request, run the draft model over the
    committed-token suffix it has not yet written into the draft cache
@@ -175,8 +176,12 @@ class DraftModelProposer:
         return False
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        num_speculative_tokens = ctx.num_speculative_tokens
+        if num_speculative_tokens <= 0:
+            return None
+
         self._prune_finished(ctx.request_states)
-        plans = self._collect_draft_plans(ctx)
+        plans = self._collect_draft_plans(ctx, num_speculative_tokens)
         if not plans:
             return None
 
@@ -185,7 +190,7 @@ class DraftModelProposer:
             self._ingest_and_draft_first(plans, self._offset_caches)
         ]
         # Steps 2..K: single-token decode per request.
-        for draft_index in range(1, self._num_speculative_tokens):
+        for draft_index in range(1, num_speculative_tokens):
             draft_cols.append(
                 self._draft_step(
                     plans, draft_cols[-1], draft_index, self._offset_caches
@@ -215,7 +220,9 @@ class DraftModelProposer:
             if req_id not in request_states:
                 del self._draft_seq_lens[req_id]
 
-    def _collect_draft_plans(self, ctx: ProposeContext) -> list[_DraftPlan]:
+    def _collect_draft_plans(
+        self, ctx: ProposeContext, num_speculative_tokens: int
+    ) -> list[_DraftPlan]:
         # Eligibility filter (greedy + non-intermediate prefill + greedy-only
         # sampling) is shared with every greedy drafter; this step then builds
         # per-request ingest plans and drops any row with no newly-committed
@@ -230,12 +237,14 @@ class DraftModelProposer:
         )
         plans: list[_DraftPlan] = []
         for req_id, state in eligible:
-            plan = self._make_plan(req_id, state)
+            plan = self._make_plan(req_id, state, num_speculative_tokens)
             if plan is not None:
                 plans.append(plan)
         return plans
 
-    def _make_plan(self, req_id: str, state: RequestState) -> _DraftPlan | None:
+    def _make_plan(
+        self, req_id: str, state: RequestState, num_speculative_tokens: int
+    ) -> _DraftPlan | None:
         committed_len = len(state.token_ids)
         draft_seq_len = self._draft_seq_lens.get(req_id, 0)
         if draft_seq_len >= committed_len:
@@ -246,7 +255,7 @@ class DraftModelProposer:
         # Draft positions reach committed_len + K - 1; size the draft block
         # table to cover them from the draft's own pool.
         block_ids = self._ensure_draft_blocks(
-            req_id, committed_len + self._num_speculative_tokens
+            req_id, committed_len + num_speculative_tokens
         )
         return _DraftPlan(
             req_id=req_id,

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -98,13 +98,11 @@ class DraftModelProposer:
         block_size: int,
         num_blocks: int,
         num_layers: int,
-        num_speculative_tokens: int,
         controller: SpeculativeDecodeController,
         extract_logits: Callable[[Any], mx.array],
     ) -> None:
         self._model = model
         self._block_size = block_size
-        self._num_speculative_tokens = num_speculative_tokens
         self._controller = controller
         self._extract_logits = extract_logits
         # Stateless RoPE/mask shims for the draft forward (one per layer). The
@@ -158,7 +156,6 @@ class DraftModelProposer:
             block_size=block_size,
             num_blocks=num_blocks,
             num_layers=dims.num_layers,
-            num_speculative_tokens=speculative_config.num_speculative_tokens,
             controller=controller,
             extract_logits=extract_logits,
         )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1365,12 +1365,7 @@ class MetalModelRunner:
             )
             batch.add_output(req_id, decode_token_ids[i], logprobs)
 
-        spec = self.vllm_config.speculative_config
-        num_speculative_tokens = getattr(
-            scheduler_output,
-            "num_spec_tokens_to_schedule",
-            spec.num_speculative_tokens if spec is not None else 0,
-        )
+        num_speculative_tokens = scheduler_output.num_spec_tokens_to_schedule
         draft_ctx = ProposeContext(
             target_hidden_states=target_hidden_states,
             decode_reqs=decode_reqs,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1365,6 +1365,12 @@ class MetalModelRunner:
             )
             batch.add_output(req_id, decode_token_ids[i], logprobs)
 
+        spec = self.vllm_config.speculative_config
+        num_speculative_tokens = getattr(
+            scheduler_output,
+            "num_spec_tokens_to_schedule",
+            spec.num_speculative_tokens if spec is not None else 0,
+        )
         draft_ctx = ProposeContext(
             target_hidden_states=target_hidden_states,
             decode_reqs=decode_reqs,
@@ -1378,6 +1384,7 @@ class MetalModelRunner:
             request_states=self._request_states,
             cu_seqlens=cu_seqlens,
             num_decode_segments=num_decode_segments,
+            num_speculative_tokens=num_speculative_tokens,
             logitsprocs=self._logitsprocs,
         )
         self._draft_token_ids = (

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -9,9 +9,10 @@ and keeps no KV cache: the matching is the pure-Python + Numba KMP kernel that
 vLLM ships in :mod:`vllm.v1.spec_decode.ngram_proposer`, which this class wraps.
 
 The wrapper's only job is to translate the per-step :class:`ProposeContext` into
-the three array arguments that upstream's stateless ``propose`` expects
-(``sampled_token_ids``, ``num_tokens_no_spec``, ``token_ids_cpu``) and hand the
-result back as :class:`DraftTokenIds`. The committed history lives in
+the runtime draft count and array arguments that upstream's stateless
+``propose`` expects (``num_speculative_tokens``, ``sampled_token_ids``,
+``num_tokens_no_spec``, ``token_ids_cpu``) and hand the result back as
+:class:`DraftTokenIds`. The committed history lives in
 ``state.token_ids`` (already updated with this step's accepted/sampled tokens by
 the time the runner builds the context), so no per-request bookkeeping is needed.
 
@@ -130,6 +131,7 @@ class NgramProposer:
         sampled_token_ids: list[list[int]] = [[0]] * num_requests
 
         drafts = self._ngram.propose(
+            ctx.num_speculative_tokens,
             sampled_token_ids,
             num_tokens_no_spec,
             token_ids_cpu,

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -103,6 +103,9 @@ class NgramProposer:
         return False
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        if ctx.num_speculative_tokens <= 0:
+            return None
+
         drafting = list(
             self._controller.draft_eligible_requests(
                 ctx.decode_reqs,

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -105,6 +105,9 @@ class Gemma4MTPProposer:
         )
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        if ctx.num_speculative_tokens <= 0:
+            return None
+
         runner = self._runner
         assistant = runner._gemma4_mtp_assistant
         if (

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -52,6 +52,7 @@ class ProposeContext:
     request_states: Mapping[str, RequestState]
     cu_seqlens: Sequence[int]
     num_decode_segments: int
+    num_speculative_tokens: int
     logitsprocs: LogitsProcessors | None
 
 


### PR DESCRIPTION
Bumps vLLM to 0.24.0 and aligns dependency bounds with the upstream 0.24.0 stack.

Also updates speculative decoding tests for scheduler-selected draft token counts, since vLLM 0.24 now passes the per-step speculative token count through scheduler output.