### PR TITLE
[GGUF] Restore local GGUF serving under vLLM 0.24

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -63,13 +63,16 @@ for Qwen2.5, Llama 3, and Mistral
 ([#340](https://github.com/vllm-project/vllm-metal/pull/340),
 [#381](https://github.com/vllm-project/vllm-metal/pull/381)).
 
-Local GGUF checkpoints serve by detection like AWQ, with no env flag (vLLM sets
-`quantization=gguf` from the file). A `.gguf` carries weights only, so it pairs
-with a companion config dir (`--tokenizer`) and needs the `gguf` extra; the
-weights stay MLX-native quantized (Q8_0/Q4_0, not a dense fallback). Scope is dense
-`qwen2`/`qwen3` with per-tensor `Q8_0`/`Q4_0`; K-quants, `Q4_1`, fused-QKV, MoE,
-SSM/hybrid, vision, and remote `repo:quant` are rejected with a clear error.
-Verified end-to-end on Qwen3-0.6B Q8_0
+Local GGUF checkpoints serve by detection like AWQ, with no env flag:
+vllm-metal's GGUF engine integration sets `quantization=gguf` from the file
+(vLLM 0.24 moved its in-tree GGUF support to the CUDA/ROCm-only
+[vllm-gguf-plugin](https://github.com/vllm-project/vllm-gguf-plugin)). A
+`.gguf` carries weights only, so it pairs with a companion config dir
+(`--tokenizer`) and needs the `gguf` extra; the weights stay MLX-native
+quantized (Q8_0/Q4_0, not a dense fallback). Scope is dense `qwen2`/`qwen3`
+with per-tensor `Q8_0`/`Q4_0`; K-quants, `Q4_1`, fused-QKV, MoE, SSM/hybrid,
+vision, and remote `repo:quant` are rejected with a clear error. Verified
+end-to-end on Qwen3-0.6B Q8_0
 ([#415](https://github.com/vllm-project/vllm-metal/issues/415)).
 
 | Model | Support | Attention Kernel | Automatic Prefix Cache | Example checkpoint |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,13 @@ Issues = "https://github.com/vllm-project/vllm-metal/issues"
 [project.entry-points."vllm.platform_plugins"]
 metal = "vllm_metal:register"
 
+# GGUF engine integration (vLLM 0.24 moved in-tree GGUF support to the
+# CUDA/ROCm-only vllm-gguf-plugin; this restores the Metal-consumable layer).
+# Loaded by vLLM in EngineArgs.__post_init__ and in the EngineCore/worker
+# subprocesses; the target module stays importable without the `gguf` extra.
+[project.entry-points."vllm.general_plugins"]
+gguf_metal = "vllm_metal.gguf.vllm_integration:register"
+
 # Maturin configuration for mixed Rust/Python project
 [tool.maturin]
 # Build both the Rust extension and include Python source

--- a/tests/test_gguf_vllm_integration.py
+++ b/tests/test_gguf_vllm_integration.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deterministic tests for the GGUF vLLM engine integration.
+
+These exercise the gguf-package-free layer (detection, EngineArgs rewrite,
+marker quantization config) through the public vLLM seams with real
+``EngineArgs`` objects, so they run on a default install: fixtures write dummy
+``.gguf`` files (detection reads the suffix / magic bytes, never the payload)
+and a tiny ``config.json``. The regression test drives
+``create_engine_config()`` end to end — the test that would have caught the
+vLLM 0.24 in-tree GGUF removal (#463) silently breaking GGUF serve.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import vllm.engine.arg_utils as arg_utils_module
+from vllm.engine.arg_utils import EngineArgs
+
+from vllm_metal.gguf import vllm_integration
+from vllm_metal.gguf.vllm_integration import (
+    GGUFEngineIntegration,
+    MetalGGUFConfig,
+)
+
+_TINY_CONFIG = {
+    "model_type": "qwen3",
+    "architectures": ["Qwen3ForCausalLM"],
+    "hidden_size": 64,
+    "num_hidden_layers": 2,
+    "intermediate_size": 128,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "head_dim": 16,
+    "vocab_size": 256,
+    "rms_norm_eps": 1e-6,
+    "rope_theta": 1000000.0,
+    "tie_word_embeddings": True,
+    "max_position_embeddings": 512,
+}
+
+
+@pytest.fixture(autouse=True)
+def _registered() -> None:
+    # The entry point is exercised by a real install; unit tests apply the
+    # registration explicitly (idempotent).
+    vllm_integration.register()
+
+
+@pytest.fixture()
+def config_dir(tmp_path: Path) -> str:
+    directory = tmp_path / "config"
+    directory.mkdir()
+    (directory / "config.json").write_text(json.dumps(_TINY_CONFIG))
+    return str(directory)
+
+
+@pytest.fixture()
+def gguf_file(tmp_path: Path) -> str:
+    # Detection reads the suffix (or magic bytes), never the payload, so a
+    # dummy file stands in for a real checkpoint.
+    path = tmp_path / "tiny.gguf"
+    path.write_bytes(b"GGUF-dummy")
+    return str(path)
+
+
+def _engine_args(**kwargs):
+    return EngineArgs(**kwargs)
+
+
+def test_create_engine_config_routes_local_gguf(gguf_file, config_dir) -> None:
+    """The #463 regression test: a local .gguf drives the FULL engine-config
+    build (speculator probe, model-config rewrite, and the marker quantization
+    config exercised by VllmConfig) and lands with the fields the Metal
+    lifecycle consumes.
+    """
+    vllm_config = _engine_args(
+        model=gguf_file, tokenizer=config_dir
+    ).create_engine_config()
+    model_config = vllm_config.model_config
+
+    assert model_config.quantization == "gguf"
+    assert model_config.model == config_dir
+    assert model_config.model_weights == gguf_file
+    assert model_config.tokenizer == config_dir
+    assert model_config.hf_config.model_type == "qwen3"
+    assert model_config.served_model_name == gguf_file
+
+
+def test_hf_config_path_beats_tokenizer(gguf_file, config_dir, tmp_path) -> None:
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / "config.json").write_text(json.dumps(_TINY_CONFIG))
+
+    model_config = _engine_args(
+        model=gguf_file, tokenizer=str(other), hf_config_path=config_dir
+    ).create_model_config()
+
+    assert model_config.model == config_dir
+
+
+def test_parent_dir_fallback_without_tokenizer(tmp_path) -> None:
+    # config.json next to the .gguf: no --tokenizer needed.
+    (tmp_path / "config.json").write_text(json.dumps(_TINY_CONFIG))
+    gguf_path = tmp_path / "tiny.gguf"
+    gguf_path.write_bytes(b"GGUF-dummy")
+
+    model_config = _engine_args(model=str(gguf_path)).create_model_config()
+
+    assert model_config.model == str(tmp_path)
+    assert model_config.model_weights == str(gguf_path)
+
+
+def test_gguf_tokenizer_is_skipped_in_precedence(tmp_path) -> None:
+    # A tokenizer that is itself a GGUF file cannot be the config source; the
+    # parent dir wins.
+    (tmp_path / "config.json").write_text(json.dumps(_TINY_CONFIG))
+    gguf_path = tmp_path / "tiny.gguf"
+    gguf_path.write_bytes(b"GGUF-dummy")
+
+    model_config = _engine_args(
+        model=str(gguf_path), tokenizer=str(gguf_path)
+    ).create_model_config()
+
+    assert model_config.model == str(tmp_path)
+
+
+def test_missing_config_json_fails_fast(gguf_file, tmp_path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(ValueError) as exc_info:
+        _engine_args(model=gguf_file, tokenizer=str(empty)).create_model_config()
+    assert str(exc_info.value) == (
+        f"Serving GGUF model {gguf_file!r} needs a config source: "
+        f"{str(empty)!r} has no config.json. A .gguf carries weights only; "
+        "pass --tokenizer <dir> pointing at the model's "
+        "config/tokenizer directory."
+    )
+
+
+def test_missing_config_json_via_hf_config_path_fails_fast(gguf_file, tmp_path) -> None:
+    # The hf-config-path branch flows through the same guard as the tokenizer
+    # and parent-dir branches.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(ValueError) as exc_info:
+        _engine_args(model=gguf_file, hf_config_path=str(empty)).create_model_config()
+    assert str(exc_info.value) == (
+        f"Serving GGUF model {gguf_file!r} needs a config source: "
+        f"{str(empty)!r} has no config.json. A .gguf carries weights only; "
+        "pass --tokenizer <dir> pointing at the model's "
+        "config/tokenizer directory."
+    )
+
+
+def test_magic_bytes_without_suffix_fails_fast(tmp_path, config_dir) -> None:
+    # Detected as GGUF by magic bytes, but MLX's loader dispatches on the file
+    # extension, so a suffix-less file must be rejected up front with the
+    # rename hint instead of dying later in the worker.
+    suffixless = tmp_path / "model.bin"
+    suffixless.write_bytes(b"GGUF" + b"\x00" * 8)
+
+    with pytest.raises(ValueError) as exc_info:
+        _engine_args(model=str(suffixless), tokenizer=config_dir).create_model_config()
+    assert str(exc_info.value) == (
+        f"{str(suffixless)!r} is a GGUF file (magic bytes) but "
+        "vllm-metal requires the .gguf extension; add the "
+        f"extension (e.g. {suffixless.name + '.gguf'!r})."
+    )
+
+
+def test_explicit_quantization_is_respected(gguf_file, config_dir) -> None:
+    # A user-chosen quantization must survive the wrap (it only sets when
+    # unset); the rest of the GGUF rewrite still applies.
+    model_config = _engine_args(
+        model=gguf_file, tokenizer=config_dir, quantization="awq"
+    ).create_model_config()
+
+    assert model_config.quantization == "awq"
+    assert model_config.model_weights == gguf_file
+
+
+def test_non_gguf_model_is_untouched(config_dir) -> None:
+    # A plain HF directory flows through the wrap unmodified.
+    args = _engine_args(model=config_dir)
+    model_config = args.create_model_config()
+
+    assert args.model == config_dir
+    assert model_config.quantization is None
+    assert model_config.model_weights == ""
+
+
+def test_remote_gguf_reference_fails_fast() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        _engine_args(
+            model="Qwen/Qwen3-0.6B-GGUF:Q8_0", tokenizer="Qwen/Qwen3-0.6B"
+        ).create_model_config()
+    assert str(exc_info.value) == (
+        "Remote GGUF references (repo_id:quant) are not supported yet by "
+        "vllm-metal; download the .gguf and pass its local path, with "
+        "--tokenizer pointing at the model's config/tokenizer directory."
+    )
+
+
+def test_register_is_idempotent() -> None:
+    before_config = EngineArgs.create_model_config
+    before_probe = arg_utils_module.maybe_override_with_speculators
+    vllm_integration.register()
+    vllm_integration.register()
+
+    assert EngineArgs.create_model_config is before_config
+    assert arg_utils_module.maybe_override_with_speculators is before_probe
+
+
+def test_integration_imports_without_gguf_package(monkeypatch) -> None:
+    """Default-install tripwire: the entry-point module must import and
+    register with the optional ``gguf`` package absent (vLLM loads it on every
+    run).
+    """
+    monkeypatch.setitem(sys.modules, "gguf", None)
+    monkeypatch.delitem(sys.modules, "vllm_metal.gguf.vllm_integration", raising=False)
+    monkeypatch.delitem(sys.modules, "vllm_metal.gguf", raising=False)
+
+    import vllm_metal.gguf.vllm_integration as reimported
+
+    reimported.register()  # must not raise
+
+
+def test_marker_config_survives_pickle() -> None:
+    # The spawn tree pickles the constructed quant config into the
+    # EngineCore/worker processes.
+    config = MetalGGUFConfig()
+
+    restored = pickle.loads(pickle.dumps(config))
+
+    assert type(restored) is MetalGGUFConfig
+    assert restored.get_name() == "gguf"
+
+
+def test_loader_import_without_gguf_names_the_extra(monkeypatch) -> None:
+    """The optional-dep owner gives an actionable hint when the extra is
+    missing (0.24 dropped ``gguf`` from vLLM's own dependencies).
+    """
+    monkeypatch.setitem(sys.modules, "gguf", None)
+    monkeypatch.delitem(sys.modules, "vllm_metal.gguf.loader", raising=False)
+    monkeypatch.delitem(sys.modules, "vllm_metal.gguf.mlx_native", raising=False)
+    monkeypatch.delitem(sys.modules, "vllm_metal.gguf.adapter", raising=False)
+    monkeypatch.delitem(sys.modules, "vllm_metal.gguf.wrappers", raising=False)
+
+    with pytest.raises(ImportError) as exc_info:
+        import vllm_metal.gguf.loader  # noqa: F401
+    assert str(exc_info.value) == (
+        "GGUF support requires the optional 'gguf' dependency. "
+        "Install it with: pip install 'vllm-metal[gguf]'"
+    )
+
+
+def test_probe_preserves_positional_speculative_config(gguf_file) -> None:
+    # The wrap mirrors the upstream signature exactly, so a positionally
+    # passed speculative config must round-trip (the official plugin's
+    # kwargs-only short-circuit would silently drop it).
+    speculative = {"method": "ngram"}
+
+    result = arg_utils_module.maybe_override_with_speculators(
+        gguf_file, "tokenizer-dir", False, None, speculative
+    )
+
+    assert result == (gguf_file, "tokenizer-dir", speculative)
+
+
+def test_broken_official_plugin_does_not_disable_integration(
+    tmp_path, monkeypatch
+) -> None:
+    """A vllm_gguf_plugin that is discoverable but fails to import (today's
+    macOS state: its import pulls triton/CUDA) must NOT make register() defer
+    to it.
+    """
+    broken = tmp_path / "vllm_gguf_plugin"
+    broken.mkdir()
+    (broken / "__init__.py").write_text("raise ImportError('No module named ...')")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "vllm_gguf_plugin", raising=False)
+
+    sentinel = object()
+    monkeypatch.setattr(arg_utils_module, "_metal_gguf_probe_patched", False)
+    monkeypatch.setattr(arg_utils_module, "maybe_override_with_speculators", sentinel)
+
+    vllm_integration.register()
+
+    # register() proceeded past the coexistence guard and re-wrapped the probe.
+    assert arg_utils_module.maybe_override_with_speculators is not sentinel
+
+
+def test_entry_point_mounts_without_manual_register(
+    gguf_file, config_dir, tmp_path
+) -> None:
+    """The regression boundary #463 actually crossed: a fresh process where
+    vLLM itself discovers and loads the ``vllm.general_plugins`` entry point —
+    no manual import or register() — must route a local .gguf. Uses a
+    dist-info scaffold because a PYTHONPATH checkout carries no entry-point
+    metadata.
+    """
+    dist_info = tmp_path / "vllm_metal_eptest-0.0.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: vllm-metal-eptest\nVersion: 0.0.0\n"
+    )
+    (dist_info / "entry_points.txt").write_text(
+        "[vllm.general_plugins]\n"
+        "gguf_metal = vllm_metal.gguf.vllm_integration:register\n"
+    )
+    repo_root = Path(vllm_integration.__file__).resolve().parents[2]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{tmp_path}"
+    script = (
+        "from vllm.engine.arg_utils import EngineArgs\n"
+        f"mc = EngineArgs(model={gguf_file!r}, tokenizer={config_dir!r})"
+        ".create_model_config()\n"
+        "print('EP-OK', mc.quantization, mc.model_weights)\n"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+    assert result.returncode == 0, result.stderr[-2000:]
+    assert f"EP-OK gguf {gguf_file}" in result.stdout
+
+
+def test_remote_reference_grammar() -> None:
+    """Shape-level recognition (deliberately enum-free): quant-looking tags
+    match, ordinary repo:tag strings do not."""
+    recognized = [
+        "Qwen/Qwen3-0.6B-GGUF:Q8_0",
+        "unsloth/Qwen3-30B-A3B-GGUF:Q4_K_M",
+        "unsloth/model-GGUF:UD-Q4_K_XL",
+        "org/model:IQ2_M",
+        "org/model:F16",
+        "org/model:q4_k_m",
+    ]
+    not_recognized = [
+        "org/model:latest",
+        "org/model:main",
+        "Qwen/Qwen3-0.6B",
+        "/local/path/model.gguf",
+    ]
+    for ref in recognized:
+        assert GGUFEngineIntegration.is_remote_gguf_reference(ref), ref
+    for ref in not_recognized:
+        assert not GGUFEngineIntegration.is_remote_gguf_reference(ref), ref

--- a/tests/test_gguf_vllm_integration.py
+++ b/tests/test_gguf_vllm_integration.py
@@ -177,15 +177,11 @@ def test_magic_bytes_without_suffix_fails_fast(tmp_path, config_dir) -> None:
     )
 
 
-def test_explicit_quantization_is_respected(gguf_file, config_dir) -> None:
-    # A user-chosen quantization must survive the wrap (it only sets when
-    # unset); the rest of the GGUF rewrite still applies.
-    model_config = _engine_args(
-        model=gguf_file, tokenizer=config_dir, quantization="awq"
-    ).create_model_config()
-
-    assert model_config.quantization == "awq"
-    assert model_config.model_weights == gguf_file
+def test_explicit_non_gguf_quantization_fails_fast(gguf_file, config_dir) -> None:
+    with pytest.raises(ValueError, match="Cannot serve GGUF model"):
+        _engine_args(
+            model=gguf_file, tokenizer=config_dir, quantization="awq"
+        ).create_model_config()
 
 
 def test_non_gguf_model_is_untouched(config_dir) -> None:

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -84,6 +84,7 @@ def _runner_model_config(**overrides: object) -> object:
         "trust_remote_code": False,
         "dtype": torch.float16,
         "quantization": None,
+        "model_weights": "",
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -859,11 +860,12 @@ class TestModelLifecycle:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """``quantization == "gguf"`` (set by vLLM core for a .gguf) delegates the
-        whole load to ``GGUFModelLoader`` (lazily imported) and never calls generic
-        ``mlx_lm.load`` — detection-routed like the AWQ branch, no env flag. The
-        lifecycle threads the resolved model path, ``--tokenizer`` dir, derived
-        dtype, and tokenizer config to the owner.
+        """``quantization == "gguf"`` (set by the GGUF engine integration for a
+        .gguf) delegates the whole load to ``GGUFModelLoader`` (lazily imported)
+        and never calls generic ``mlx_lm.load`` — detection-routed like the AWQ
+        branch, no env flag. The lifecycle threads the ``.gguf`` path from
+        ``model_config.model_weights``, the ``--tokenizer`` dir, derived dtype,
+        and tokenizer config to the owner.
         """
         fake_model = SimpleNamespace(config=_text_config())
         fake_tokenizer = object()
@@ -910,7 +912,9 @@ class TestModelLifecycle:
 
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
-                quantization="gguf", tokenizer="tokenizer-dir"
+                quantization="gguf",
+                tokenizer="tokenizer-dir",
+                model_weights="stub-model.gguf",
             )
         )
         lifecycle.load()
@@ -923,7 +927,7 @@ class TestModelLifecycle:
         )
         assert len(for_model_calls) == 1
         call = for_model_calls[0]
-        assert call["model_name"] == "stub-model"
+        assert call["model_name"] == "stub-model.gguf"
         assert call["config_dir"] == "tokenizer-dir"
         assert call["target_dtype"] is not None, (
             "lifecycle must derive target_dtype from runner.model_config.dtype "
@@ -1008,7 +1012,9 @@ class TestModelLifecycle:
         def _load_tokenizer_for(tokenizer_dir: str) -> object:
             lifecycle, runner = _make_lifecycle(
                 model_config=_runner_model_config(
-                    quantization="gguf", tokenizer=tokenizer_dir
+                    quantization="gguf",
+                    tokenizer=tokenizer_dir,
+                    model_weights="stub-model.gguf",
                 )
             )
             lifecycle.load()

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -912,6 +912,7 @@ class TestModelLifecycle:
 
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
+                model="config-dir",
                 quantization="gguf",
                 tokenizer="tokenizer-dir",
                 model_weights="stub-model.gguf",
@@ -928,7 +929,7 @@ class TestModelLifecycle:
         assert len(for_model_calls) == 1
         call = for_model_calls[0]
         assert call["model_name"] == "stub-model.gguf"
-        assert call["config_dir"] == "tokenizer-dir"
+        assert call["config_dir"] == "config-dir"
         assert call["target_dtype"] is not None, (
             "lifecycle must derive target_dtype from runner.model_config.dtype "
             "and thread it to the owner"
@@ -1012,6 +1013,7 @@ class TestModelLifecycle:
         def _load_tokenizer_for(tokenizer_dir: str) -> object:
             lifecycle, runner = _make_lifecycle(
                 model_config=_runner_model_config(
+                    model=tokenizer_dir,
                     quantization="gguf",
                     tokenizer=tokenizer_dir,
                     model_weights="stub-model.gguf",

--- a/vllm_metal/gguf/__init__.py
+++ b/vllm_metal/gguf/__init__.py
@@ -1,7 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Experimental GGUF support for vllm-metal (MLX-native quantized execution)."""
+"""Experimental GGUF support for vllm-metal (MLX-native quantized execution).
 
-from vllm_metal.gguf.adapter import GGUFLoadError
-from vllm_metal.gguf.loader import GGUFModelLoader
+Re-exports are lazy: ``vllm_metal.gguf.vllm_integration`` is imported by every
+vLLM run through the ``vllm.general_plugins`` entry point, and a default
+install (no ``gguf`` extra) must not pull the loader's optional ``gguf``
+dependency on that path.
+"""
+
+from typing import Any
 
 __all__ = ["GGUFLoadError", "GGUFModelLoader"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "GGUFLoadError":
+        from vllm_metal.gguf.adapter import GGUFLoadError
+
+        return GGUFLoadError
+    if name == "GGUFModelLoader":
+        from vllm_metal.gguf.loader import GGUFModelLoader
+
+        return GGUFModelLoader
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -23,7 +23,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-import gguf
+try:
+    import gguf
+except ImportError as exc:
+    raise ImportError(
+        "GGUF support requires the optional 'gguf' dependency. "
+        "Install it with: pip install 'vllm-metal[gguf]'"
+    ) from exc
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten
@@ -107,9 +113,9 @@ class GGUFModelLoader:
         owner — the same contract :meth:`AWQQuantLoader.for_model` uses for GPTQ.
 
         Args:
-            model_name: Already-resolved model path
-                (``get_model_download_path(model_config.model)``); for a local
-                GGUF this is the ``.gguf`` file.
+            model_name: Path to the local ``.gguf`` file
+                (``model_config.model_weights``, carried there by the GGUF
+                engine integration).
             config_dir: Companion config/tokenizer directory the user passes via
                 ``--tokenizer`` (``model_config.tokenizer``). A ``.gguf`` carries
                 weights only, so mlx-lm builds the model from this directory.

--- a/vllm_metal/gguf/vllm_integration.py
+++ b/vllm_metal/gguf/vllm_integration.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM engine integration for GGUF references (post vLLM 0.24 removal).
+
+vLLM 0.24 migrated in-tree GGUF support to the CUDA/ROCm-only
+``vllm-project/vllm-gguf-plugin`` (RFC vllm#39583, PR vllm#39612), so nothing
+sets ``quantization="gguf"`` for a ``.gguf`` model anymore and vllm-metal's
+GGUF routing went dead. This module restores the engine-facing layer with the
+same semantics as the official plugin for the fields the Metal path consumes:
+a marker quantization config so ``quantization="gguf"`` validates, and two
+narrow wraps that detect a local GGUF file, carry it in
+``model_config.model_weights``, and point ``model`` at the config source.
+
+Mounted through the ``vllm.general_plugins`` entry point (the official
+plugin's own mechanism), which vLLM loads in ``EngineArgs.__post_init__`` and
+again inside the EngineCore/worker subprocesses, so the registration is
+spawn-safe without import-time patching.
+
+This module must stay importable WITHOUT the optional ``gguf`` package: a
+default install loads it on every vLLM run via the entry point.
+
+# SCAFFOLDING: remove when vllm-project/vllm-gguf-plugin installs and imports
+# on macOS; then depend on it for this layer (register() already no-ops when
+# that plugin is importable).
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import re
+from functools import wraps
+from pathlib import Path
+
+import torch
+from vllm.model_executor.layers.quantization import (
+    QUANTIZATION_METHODS,
+    get_quantization_config,
+    register_quantization_config,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+)
+
+__all__ = ["GGUFEngineIntegration", "MetalGGUFConfig", "register"]
+
+
+class MetalGGUFConfig(QuantizationConfig):
+    """Marker quantization config that lets ``quantization="gguf"`` validate.
+
+    vllm-metal never runs vLLM's quantized layers (the Metal runner loads
+    through mlx-lm), but ``VllmConfig.__post_init__`` bare-constructs the
+    registered config and calls its classmethods on every serve, and the
+    instance is pickled into the spawned EngineCore/worker processes — so the
+    class must live at module top level and every method must return a real
+    value.
+    """
+
+    # The dtypes the Metal runtime actually serves.
+    _SUPPORTED_ACT_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+    # Metal has no CUDA compute capability; -1 passes any >= comparison.
+    _NO_CAPABILITY_GATE = -1
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "gguf"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> list[torch.dtype]:
+        return cls._SUPPORTED_ACT_DTYPES
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return cls._NO_CAPABILITY_GATE
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        # No sidecar quant config file: vLLM bare-constructs the marker.
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict) -> MetalGGUFConfig:
+        return cls()
+
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str) -> None:
+        # Never exercised: vllm-metal bypasses vLLM's model executor.
+        return None
+
+
+class GGUFEngineIntegration:
+    """Owner of the GGUF engine-integration policy.
+
+    Detection, config-source precedence, and the fail-fast rules live here as
+    class constants and private helpers; :meth:`register` is the single
+    entrypoint the ``vllm.general_plugins`` hook calls.
+    """
+
+    _GGUF_SUFFIX = ".gguf"
+    _GGUF_MAGIC = b"GGUF"
+
+    # Shape-level recognition of the official plugin's remote reference syntax
+    # (``repo_id:quant``). Deliberately enum-free: the GGML enums live in the
+    # optional ``gguf`` package this module must not import, and on this
+    # fail-fast-only path over-recognition is harmless. The tag must read like
+    # a GGUF quant name (Q4_K_M, IQ2_M, UD-Q4_K_XL, F16, ...), which keeps
+    # ordinary ``repo:tag`` strings out.
+    _REMOTE_REF_RE = re.compile(
+        r"^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*:[A-Za-z0-9_+-]+$"
+    )
+    _QUANT_TAG_RE = re.compile(
+        r"(?:^|-)(?:I?Q\d[A-Za-z0-9_]*|F16|F32|BF16|MXFP\d[A-Za-z0-9_]*)$",
+        re.IGNORECASE,
+    )
+
+    _REMOTE_UNSUPPORTED_MSG = (
+        "Remote GGUF references (repo_id:quant) are not supported yet by "
+        "vllm-metal; download the .gguf and pass its local path, with "
+        "--tokenizer pointing at the model's config/tokenizer directory."
+    )
+
+    @classmethod
+    def register(cls) -> None:
+        """Register the GGUF engine integration (idempotent).
+
+        No-ops when the official ``vllm_gguf_plugin`` actually IMPORTS — once
+        it works on macOS it owns this layer (see the module removal
+        condition). Discoverable-but-unimportable (today's macOS state: its
+        import pulls triton/CUDA) must NOT disable this integration.
+        """
+        if cls._official_plugin_imports():
+            return
+        if (
+            "gguf" not in QUANTIZATION_METHODS
+            or get_quantization_config("gguf") is not MetalGGUFConfig
+        ):
+            register_quantization_config("gguf")(MetalGGUFConfig)
+        cls._patch_engine_args()
+        cls._patch_speculator_probe()
+
+    @staticmethod
+    def _official_plugin_imports() -> bool:
+        if importlib.util.find_spec("vllm_gguf_plugin") is None:
+            return False
+        try:
+            importlib.import_module("vllm_gguf_plugin")
+        except ImportError:
+            return False
+        return True
+
+    @staticmethod
+    def _is_local_gguf(model: str | None) -> bool:
+        if not model:
+            return False
+        path = Path(model)
+        if not path.is_file():
+            return False
+        if path.suffix == GGUFEngineIntegration._GGUF_SUFFIX:
+            return True
+        try:
+            with path.open("rb") as f:
+                return f.read(4) == GGUFEngineIntegration._GGUF_MAGIC
+        except OSError:
+            return False
+
+    @classmethod
+    def is_remote_gguf_reference(cls, model: str | None) -> bool:
+        """Whether ``model`` reads as the plugin's ``repo_id:quant`` syntax.
+
+        Mirrors the official plugin's public ``is_remote_gguf`` at the shape
+        level (see the class-constant regexes for the deliberate enum-free
+        divergence). Recognized references fail fast in the EngineArgs wrap.
+        """
+        if not model or not cls._REMOTE_REF_RE.fullmatch(model):
+            return False
+        _, tag = model.rsplit(":", 1)
+        return cls._QUANT_TAG_RE.search(tag) is not None
+
+    @classmethod
+    def _resolve_config_source(
+        cls, gguf_model: str, tokenizer: str | None, hf_config_path: str | None
+    ) -> str:
+        """Config source for a local GGUF, with the official plugin's
+        precedence: ``hf_config_path > tokenizer > parent dir``.
+
+        A ``.gguf`` carries weights only, so the resolved LOCAL directory must
+        hold the model's ``config.json``; failing fast here names the actual
+        inputs instead of letting transformers error on a path the user never
+        typed. A non-local source (a Hub repo id) is passed through for vLLM
+        to resolve.
+        """
+        if hf_config_path is not None:
+            source = hf_config_path
+        elif tokenizer and not cls._is_local_gguf(tokenizer):
+            source = tokenizer
+        else:
+            source = str(Path(gguf_model).parent)
+        source_path = Path(source)
+        if source_path.is_dir() and not (source_path / "config.json").is_file():
+            raise ValueError(
+                f"Serving GGUF model {gguf_model!r} needs a config source: "
+                f"{source!r} has no config.json. A .gguf carries weights only; "
+                "pass --tokenizer <dir> pointing at the model's "
+                "config/tokenizer directory."
+            )
+        return source
+
+    @classmethod
+    def _patch_engine_args(cls) -> None:
+        from vllm.engine.arg_utils import EngineArgs
+
+        if getattr(EngineArgs, "_metal_gguf_patched", False):
+            return
+        original = EngineArgs.create_model_config
+
+        @wraps(original)
+        def create_model_config(self, *args, **kwargs):
+            if cls.is_remote_gguf_reference(self.model):
+                raise ValueError(cls._REMOTE_UNSUPPORTED_MSG)
+            if cls._is_local_gguf(self.model):
+                gguf_model = self.model
+                if Path(gguf_model).suffix != cls._GGUF_SUFFIX:
+                    # Detected by magic bytes only: MLX's loader dispatches on
+                    # the file extension, so a suffix-less GGUF would die much
+                    # later in the worker with a misleading error.
+                    raise ValueError(
+                        f"{gguf_model!r} is a GGUF file (magic bytes) but "
+                        "vllm-metal requires the .gguf extension; add the "
+                        f"extension (e.g. {Path(gguf_model).name + '.gguf'!r})."
+                    )
+                # Resolve (and validate) the config source BEFORE touching any
+                # EngineArgs field, so a fail-fast never leaves the args
+                # half-rewritten.
+                config_source = cls._resolve_config_source(
+                    gguf_model,
+                    self.tokenizer if isinstance(self.tokenizer, str) else None,
+                    self.hf_config_path,
+                )
+                if self.quantization is None:
+                    self.quantization = "gguf"
+                if not self.model_weights:
+                    self.model_weights = gguf_model
+                if self.served_model_name is None:
+                    self.served_model_name = [gguf_model]
+                self.model = config_source
+            return original(self, *args, **kwargs)
+
+        EngineArgs.create_model_config = create_model_config
+        EngineArgs._metal_gguf_patched = True
+
+    @classmethod
+    def _patch_speculator_probe(cls) -> None:
+        # create_engine_config probes the model with
+        # maybe_override_with_speculators BEFORE create_model_config runs, so
+        # the probe must skip raw GGUF references too (the official plugin
+        # patches the same two namespaces).
+        import vllm.engine.arg_utils as arg_utils_module
+        import vllm.transformers_utils.config as config_module
+
+        if getattr(arg_utils_module, "_metal_gguf_probe_patched", False):
+            return
+        original = arg_utils_module.maybe_override_with_speculators
+
+        @wraps(original)
+        def maybe_override_with_speculators(
+            model,
+            tokenizer,
+            trust_remote_code,
+            revision=None,
+            vllm_speculative_config=None,
+            hf_token=None,
+            **kwargs,
+        ):
+            # Mirrors the upstream signature so a positionally-passed
+            # speculative config is never silently dropped.
+            if cls._is_local_gguf(model) or cls.is_remote_gguf_reference(model):
+                return model, tokenizer, vllm_speculative_config
+            return original(
+                model,
+                tokenizer,
+                trust_remote_code,
+                revision=revision,
+                vllm_speculative_config=vllm_speculative_config,
+                hf_token=hf_token,
+                **kwargs,
+            )
+
+        arg_utils_module.maybe_override_with_speculators = (
+            maybe_override_with_speculators
+        )
+        config_module.maybe_override_with_speculators = maybe_override_with_speculators
+        arg_utils_module._metal_gguf_probe_patched = True
+
+
+def register() -> None:
+    """``vllm.general_plugins`` entry point."""
+    GGUFEngineIntegration.register()

--- a/vllm_metal/gguf/vllm_integration.py
+++ b/vllm_metal/gguf/vllm_integration.py
@@ -234,8 +234,12 @@ class GGUFEngineIntegration:
                     self.tokenizer if isinstance(self.tokenizer, str) else None,
                     self.hf_config_path,
                 )
-                if self.quantization is None:
-                    self.quantization = "gguf"
+                if self.quantization not in (None, "gguf"):
+                    raise ValueError(
+                        f"Cannot serve GGUF model with quantization={self.quantization!r}; "
+                        "leave quantization unset or use 'gguf'."
+                    )
+                self.quantization = "gguf"
                 if not self.model_weights:
                     self.model_weights = gguf_model
                 if self.served_model_name is None:

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -175,7 +175,6 @@ class ModelLifecycle:
         if is_gguf:
             load_label = "GGUF model"
             model, tokenizer = self._load_gguf_text_model(
-                model_name,
                 model_config,
                 target_dtype,
                 tokenizer_config,
@@ -201,17 +200,19 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
+        # For GGUF the engine integration rewrites model_config.model to the
+        # config source; the weights the user served live in model_weights.
+        loaded_from = model_config.model_weights if is_gguf else model_name
         logger.info(
             "%s loaded in %.2fs: %s",
             load_label,
             time.time() - start_time,
-            model_name,
+            loaded_from,
         )
         return model, tokenizer
 
     def _load_gguf_text_model(
         self,
-        model_name: str,
         model_config: Any,
         target_dtype: Any,
         tokenizer_config: Mapping[str, Any],
@@ -219,8 +220,10 @@ class ModelLifecycle:
         """Load a GGUF checkpoint through the optional GGUF owner."""
         from vllm_metal.gguf.loader import GGUFModelLoader
 
+        # The GGUF engine integration rewrites model_config.model to the config
+        # source and carries the .gguf path in model_config.model_weights.
         loader = GGUFModelLoader.for_model(
-            model_name,
+            model_config.model_weights,
             config_dir=model_config.tokenizer,
             target_dtype=target_dtype,
             tokenizer_config=dict(tokenizer_config),

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -224,7 +224,7 @@ class ModelLifecycle:
         # source and carries the .gguf path in model_config.model_weights.
         loader = GGUFModelLoader.for_model(
             model_config.model_weights,
-            config_dir=model_config.tokenizer,
+            config_dir=model_config.model,
             target_dtype=target_dtype,
             tokenizer_config=dict(tokenizer_config),
         )


### PR DESCRIPTION
vLLM 0.24 removed in-tree GGUF support and moved it to vllm-gguf-plugin (vllm#39583, vllm#39612). We picked up 0.24 in #463, so nothing sets `quantization="gguf"` anymore and the GGUF serving from #453 stopped working. CI didn't catch it because the GGUF serve tests need local checkpoints.

The plugin itself doesn't install on macOS (it builds a CUDA extension and imports triton), so this PR restores the same layer inside vllm-metal. A `vllm.general_plugins` entry point registers a marker quantization config and patches `create_model_config` the same way the plugin does. A local `.gguf` gets `quantization="gguf"`, the weights path goes into `model_weights`, and `model` points at the config source (hf_config_path, then tokenizer, then the parent dir). The lifecycle reads the `.gguf` from `model_config.model_weights`. Remote `repo:quant` is recognized but rejected for now. If the plugin becomes usable on macOS, `register()` already steps aside, so we can delete this and depend on it instead.