### PR TITLE
Clarify GGUF load source ownership

### DIFF
--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -436,13 +436,9 @@ def test_rejects_missing_config(tmp_path):
         ).load()
 
 
-def test_for_model_builds_loader_that_stays_quantized(tmp_path):
-    # The lifecycle-facing factory yields a loader whose model keeps the GGUF
-    # quantized wrappers (Q8_0 in memory), not a dense dequantized fallback.
+def test_direct_loader_keeps_quantized_wrappers(tmp_path):
     gguf_path, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
-    loader = GGUFModelLoader.for_model(
-        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
-    )
+    loader = GGUFModelLoader(gguf_path, config_dir=cfg_dir, target_dtype=mx.float32)
     assert isinstance(loader, GGUFModelLoader)
     model, _ = loader.load()
     hist = _gguf_module_histogram(model)
@@ -450,20 +446,15 @@ def test_for_model_builds_loader_that_stays_quantized(tmp_path):
     assert hist.get("GGUFLinear") == 2 * 7
 
 
-def test_for_model_rejects_remote_reference(tmp_path):
-    # A non-local model id (remote repo:quant) is out of scope; for_model must
-    # fail fast rather than fall through to the generic loader.
+def test_direct_loader_rejects_remote_reference(tmp_path):
     _, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
-    with pytest.raises(GGUFLoadError, match="not a local .gguf file"):
-        GGUFModelLoader.for_model(
+    with pytest.raises(GGUFLoadError, match="Not a local .gguf file"):
+        GGUFModelLoader(
             "org/qwen3-gguf:Q8_0", config_dir=cfg_dir, target_dtype=mx.float32
-        )
+        ).load()
 
 
-def test_for_model_rejects_missing_tokenizer_dir(tmp_path):
-    # --tokenizer omitted: config_dir resolves to the .gguf itself (no config.json).
+def test_direct_loader_rejects_missing_config_dir(tmp_path):
     gguf_path, _ = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
-    with pytest.raises(GGUFLoadError, match="needs --tokenizer"):
-        GGUFModelLoader.for_model(
-            gguf_path, config_dir=gguf_path, target_dtype=mx.float32
-        )
+    with pytest.raises(GGUFLoadError, match="No config.json"):
+        GGUFModelLoader(gguf_path, config_dir=gguf_path, target_dtype=mx.float32).load()

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -869,30 +869,30 @@ class TestModelLifecycle:
         """
         fake_model = SimpleNamespace(config=_text_config())
         fake_tokenizer = object()
-        for_model_calls: list[dict[str, object]] = []
+        loader_calls: list[dict[str, object]] = []
         mlx_lm_load_calls: list[dict[str, object]] = []
 
         class _StubGGUFLoader:
-            @classmethod
-            def for_model(
-                cls,
-                model_name: str,
+            def __init__(
+                self,
+                gguf_path: str,
                 *,
                 config_dir: str,
+                tokenizer_dir: str,
                 target_dtype: object,
                 tokenizer_config: dict[str, object] | None = None,
-            ) -> _StubGGUFLoader:
-                for_model_calls.append(
+            ) -> None:
+                loader_calls.append(
                     {
-                        "model_name": model_name,
+                        "gguf_path": gguf_path,
                         "config_dir": config_dir,
+                        "tokenizer_dir": tokenizer_dir,
                         "target_dtype": target_dtype,
                         "tokenizer_config": (
                             dict(tokenizer_config) if tokenizer_config else None
                         ),
                     }
                 )
-                return cls()
 
             def load(self) -> tuple[object, object]:
                 return fake_model, fake_tokenizer
@@ -926,10 +926,11 @@ class TestModelLifecycle:
             "generic mlx_lm.load must NOT be called when the GGUF owner owns "
             "the load path"
         )
-        assert len(for_model_calls) == 1
-        call = for_model_calls[0]
-        assert call["model_name"] == "stub-model.gguf"
+        assert len(loader_calls) == 1
+        call = loader_calls[0]
+        assert call["gguf_path"] == "stub-model.gguf"
         assert call["config_dir"] == "config-dir"
+        assert call["tokenizer_dir"] == "tokenizer-dir"
         assert call["target_dtype"] is not None, (
             "lifecycle must derive target_dtype from runner.model_config.dtype "
             "and thread it to the owner"
@@ -972,36 +973,30 @@ class TestModelLifecycle:
         assert runner._is_vlm is False
         assert runner.model_args["vocab_size"] == 32000
 
-    def test_gguf_load_uses_each_tokenizer_dir(
+    def test_gguf_load_threads_config_and_tokenizer_sources(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Two loads of the same .gguf with different ``--tokenizer`` dirs must
-        both reach the GGUF owner with their own config dirs. A .gguf carries
-        weights only, so the model and tokenizer are built from the config dir.
-        """
-        for_model_dirs: list[str] = []
+        """GGUF loads keep the config source separate from the tokenizer source."""
+        loader_sources: list[tuple[str, str]] = []
 
         class _StubGGUFLoader:
-            def __init__(self, config_dir: str) -> None:
-                self._config_dir = config_dir
-
-            @classmethod
-            def for_model(
-                cls,
-                model_name: str,
+            def __init__(
+                self,
+                gguf_path: str,
                 *,
                 config_dir: str,
+                tokenizer_dir: str,
                 target_dtype: object,
                 tokenizer_config: dict[str, object] | None = None,
-            ) -> _StubGGUFLoader:
-                for_model_dirs.append(config_dir)
-                return cls(config_dir)
+            ) -> None:
+                loader_sources.append((config_dir, tokenizer_dir))
+                self._tokenizer_dir = tokenizer_dir
 
             def load(self) -> tuple[object, object]:
                 return (
                     SimpleNamespace(config=_text_config()),
-                    f"tokenizer::{self._config_dir}",
+                    f"tokenizer::{self._tokenizer_dir}",
                 )
 
         monkeypatch.setitem(
@@ -1013,7 +1008,7 @@ class TestModelLifecycle:
         def _load_tokenizer_for(tokenizer_dir: str) -> object:
             lifecycle, runner = _make_lifecycle(
                 model_config=_runner_model_config(
-                    model=tokenizer_dir,
+                    model="/config-dir",
                     quantization="gguf",
                     tokenizer=tokenizer_dir,
                     model_weights="stub-model.gguf",
@@ -1025,9 +1020,7 @@ class TestModelLifecycle:
         first = _load_tokenizer_for("/dir-a")
         second = _load_tokenizer_for("/dir-b")
 
-        assert for_model_dirs == ["/dir-a", "/dir-b"], (
-            "for_model must run for each distinct --tokenizer dir"
-        )
+        assert loader_sources == [("/config-dir", "/dir-a"), ("/config-dir", "/dir-b")]
         assert first == "tokenizer::/dir-a"
         assert second == "tokenizer::/dir-b"
 

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -1,21 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX-native local GGUF loader (dense decoder-only, Q8_0/Q4_0).
-
-Joins PR 1's ``GGUFMLXQuantizedTensor`` (MLX-native repack) and PR 2's
-``GGUFLinear``/``GGUFEmbedding`` wrappers into a working mlx-lm model. The model
-skeleton is built through the public ``mlx_lm.utils.load_model(..., strict=False)``
-path; this loader layers the GGUF-specific orchestration on top: preflight, read,
-partition, install the quantized wrappers, load the plain tensors, and verify
-every parameter ended up populated.
-
-``GGUFModelLoader`` is the owner. Model-family name/scope policy lives in
-:class:`vllm_metal.gguf.adapter.GGUFModelAdapter`. Design rationale is in
-``codex/GGUF_PR3_DESIGN.md`` §5.
-
-Scope: dense decoder-only, Q8_0/Q4_0 per tensor. Linear-attention/SSM hybrids,
-fused-QKV, MoE, K-quants, Q4_1, vision and remote ``repo:quant`` references are
-out of scope and fail fast at the arch allowlist or in preflight.
-"""
+"""MLX-native local GGUF loader for dense Q8_0/Q4_0 decoder checkpoints."""
 
 from __future__ import annotations
 
@@ -37,11 +21,11 @@ from mlx_lm.utils import load_config, load_model, load_tokenizer
 
 from vllm_metal.gguf.adapter import GGUFLoadError, GGUFModelAdapter
 from vllm_metal.gguf.mlx_native import MLX_NATIVE_GGUF_TYPES, GGUFMLXQuantizedTensor
+from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.gguf.wrappers import GGUFEmbedding, GGUFLinear
 
 __all__ = ["GGUFLoadError", "GGUFModelLoader"]
 
-_GGUF_SUFFIX = ".gguf"
 _WEIGHT_SUFFIX = ".weight"
 _BIAS_SUFFIX = ".bias"
 _NUM_LAYERS_KEYS = ("num_hidden_layers", "n_layers", "num_layers", "n_layer")
@@ -72,84 +56,26 @@ class GGUFModelLoader:
 
     Args:
         gguf_path: Path to a local ``.gguf`` file (dense decoder, Q8_0/Q4_0).
-        config_dir: Directory with the companion HF ``config.json`` + tokenizer
-            that define the mlx-lm skeleton (GGUF files carry weights only).
+        config_dir: Companion HF config source that defines the mlx-lm skeleton.
+        tokenizer_dir: Companion tokenizer source. Defaults to ``config_dir``.
         target_dtype: Compute dtype for dequantized embedding rows / activations.
         tokenizer_config: Extra kwargs forwarded to mlx_lm tokenizer loading.
     """
 
     def __init__(
         self,
-        gguf_path: str,
+        gguf_path: str | Path,
         *,
-        config_dir: str,
+        config_dir: str | Path,
+        tokenizer_dir: str | Path | None = None,
         target_dtype: mx.Dtype,
         tokenizer_config: dict[str, Any] | None = None,
     ) -> None:
         self._gguf_path = Path(gguf_path)
         self._config_dir = Path(config_dir)
+        self._tokenizer_dir = Path(tokenizer_dir or config_dir)
         self._target_dtype = target_dtype
         self._tokenizer_config = dict(tokenizer_config or {})
-
-    @classmethod
-    def for_model(
-        cls,
-        model_name: str,
-        *,
-        config_dir: str,
-        target_dtype: mx.Dtype,
-        tokenizer_config: dict[str, Any] | None = None,
-    ) -> GGUFModelLoader:
-        """Build a loader for a GGUF model the lifecycle has already routed here.
-
-        Called only after the lifecycle confirmed ``model_config.quantization ==
-        "gguf"`` and lazily imported this module (which imports the optional
-        ``gguf`` package) — mirroring how the AWQ branch routes on detected
-        config. This factory does the GGUF-specific input validation before
-        constructing the loader.
-
-        It raises rather than returning ``None`` so a confirmed-GGUF checkpoint
-        can never silently fall through to the generic loader and bypass this
-        owner — the same contract :meth:`AWQQuantLoader.for_model` uses for GPTQ.
-
-        Args:
-            model_name: Path to the local ``.gguf`` file
-                (``model_config.model_weights``, carried there by the GGUF
-                engine integration).
-            config_dir: Companion config/tokenizer directory the user passes via
-                ``--tokenizer`` (``model_config.tokenizer``). A ``.gguf`` carries
-                weights only, so mlx-lm builds the model from this directory.
-            target_dtype: Compute dtype for dequantized embedding rows /
-                activations, threaded to the constructed loader.
-            tokenizer_config: Extra kwargs forwarded to mlx-lm tokenizer loading
-                (e.g. ``trust_remote_code``).
-
-        Raises:
-            GGUFLoadError: ``model_name`` is not a local ``.gguf`` file (remote
-                ``repo:quant`` / Hub references are not supported yet), or
-                ``config_dir`` has no ``config.json`` (``--tokenizer`` omitted or
-                pointing at a directory without the companion config).
-        """
-        gguf_path = Path(model_name)
-        if gguf_path.suffix != _GGUF_SUFFIX or not gguf_path.is_file():
-            raise GGUFLoadError(
-                f"{model_name!r} is a GGUF model, but it is not a local .gguf "
-                "file. Remote GGUF (repo:quant / Hub download) is not supported "
-                "yet; pass a path to a local .gguf file."
-            )
-        if not (Path(config_dir) / "config.json").is_file():
-            raise GGUFLoadError(
-                "Serving a GGUF model needs --tokenizer pointing at a directory "
-                f"with config.json and the tokenizer files; got {config_dir!r}. A "
-                ".gguf carries weights only, so mlx-lm builds the model from that "
-                "directory."
-            )
-        return cls(
-            model_name,
-            config_dir=config_dir,
-            target_dtype=target_dtype,
-            tokenizer_config=tokenizer_config,
-        )
 
     def load(self) -> tuple[nn.Module, Any]:
         """Run the full load workflow and return ``(model, tokenizer)``.
@@ -187,14 +113,17 @@ class GGUFModelLoader:
 
         # Build the tokenizer from the companion config directory and return both.
         tokenizer = load_tokenizer(
-            self._config_dir,
+            self._tokenizer_dir,
             tokenizer_config_extra=self._tokenizer_config,
             eos_token_ids=config.get("eos_token_id"),
         )
         return model, tokenizer
 
     def _open_inputs(self) -> tuple[Any, dict[str, Any]]:
-        if self._gguf_path.suffix != _GGUF_SUFFIX or not self._gguf_path.is_file():
+        if (
+            not GGUFLoadSource.is_weights_path(str(self._gguf_path))
+            or not self._gguf_path.is_file()
+        ):
             raise GGUFLoadError(f"Not a local .gguf file: {str(self._gguf_path)!r}")
         if not (self._config_dir / "config.json").is_file():
             raise GGUFLoadError(

--- a/vllm_metal/gguf/source.py
+++ b/vllm_metal/gguf/source.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resolved GGUF load identity carried from vLLM config to the loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class GGUFLoadSource:
+    """Local GGUF weights plus companion config/tokenizer sources."""
+
+    weights_path: str
+    config_dir: str
+    tokenizer_dir: str
+
+    @classmethod
+    def from_model_config(cls, model_config: Any) -> GGUFLoadSource | None:
+        if model_config.quantization != "gguf":
+            return None
+
+        weights_path = model_config.model_weights
+        if not cls.is_weights_path(weights_path):
+            raise ValueError(
+                "GGUF model_config must carry the local .gguf weights path in "
+                f"model_weights; got {weights_path!r}."
+            )
+
+        config_dir = model_config.model
+        return cls(
+            weights_path=weights_path,
+            config_dir=config_dir,
+            tokenizer_dir=model_config.tokenizer or config_dir,
+        )
+
+    @staticmethod
+    def is_weights_path(value: str) -> bool:
+        return value.endswith(".gguf")

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -78,9 +78,7 @@ class GenerationLoadRequest:
         is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
         if model_adapter.should_force_text_backbone(hf_config):
             is_vlm = False
-        gguf_source = (
-            None if is_vlm else GGUFLoadSource.from_model_config(model_config)
-        )
+        gguf_source = None if is_vlm else GGUFLoadSource.from_model_config(model_config)
 
         return cls(
             model_name=(
@@ -214,7 +212,9 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
-        loaded_from = gguf_source.weights_path if gguf_source is not None else model_name
+        loaded_from = (
+            gguf_source.weights_path if gguf_source is not None else model_name
+        )
         logger.info(
             "%s loaded in %.2fs: %s",
             load_label,
@@ -232,9 +232,10 @@ class ModelLifecycle:
         """Load a GGUF checkpoint through the optional GGUF owner."""
         from vllm_metal.gguf.loader import GGUFModelLoader
 
-        loader = GGUFModelLoader.for_model(
+        loader = GGUFModelLoader(
             source.weights_path,
             config_dir=source.config_dir,
+            tokenizer_dir=source.tokenizer_dir,
             target_dtype=target_dtype,
             tokenizer_config=dict(tokenizer_config),
         )

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -15,6 +15,7 @@ from vllm.logger import init_logger
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.compat import apply_compat_patches
+from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
 from vllm_metal.utils import get_model_download_path
@@ -63,6 +64,7 @@ class GenerationLoadRequest:
     is_vlm: bool
     target_dtype: Any
     tokenizer_config: Mapping[str, Any]
+    gguf_source: GGUFLoadSource | None
 
     @classmethod
     def from_runner(
@@ -76,14 +78,22 @@ class GenerationLoadRequest:
         is_vlm = bool(getattr(model_config, "is_multimodal_model", False))
         if model_adapter.should_force_text_backbone(hf_config):
             is_vlm = False
+        gguf_source = (
+            None if is_vlm else GGUFLoadSource.from_model_config(model_config)
+        )
 
         return cls(
-            model_name=get_model_download_path(model_config.model),
+            model_name=(
+                gguf_source.weights_path
+                if gguf_source is not None
+                else get_model_download_path(model_config.model)
+            ),
             model_config=model_config,
             hf_config=hf_config,
             is_vlm=is_vlm,
             target_dtype=torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype,
             tokenizer_config={"trust_remote_code": model_config.trust_remote_code},
+            gguf_source=gguf_source,
         )
 
 
@@ -139,6 +149,7 @@ class ModelLifecycle:
             model_config=request.model_config,
             target_dtype=request.target_dtype,
             tokenizer_config=request.tokenizer_config,
+            gguf_source=request.gguf_source,
         )
         return LoadedGenerationModel(
             model=model,
@@ -154,6 +165,7 @@ class ModelLifecycle:
         model_config: Any | None = None,
         target_dtype: Any | None = None,
         tokenizer_config: Mapping[str, Any] | None = None,
+        gguf_source: GGUFLoadSource | None = None,
     ) -> tuple[Any, Any]:
         """Load a text or VLM generation model."""
 
@@ -169,13 +181,15 @@ class ModelLifecycle:
             target_dtype = torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype
 
         start_time = time.time()
-        is_gguf = not is_vlm and model_config.quantization == "gguf"
+        if gguf_source is None and not is_vlm:
+            gguf_source = GGUFLoadSource.from_model_config(model_config)
+        is_gguf = gguf_source is not None
         awq_loader = None if is_gguf or is_vlm else AWQQuantLoader.for_model(model_name)
 
         if is_gguf:
             load_label = "GGUF model"
             model, tokenizer = self._load_gguf_text_model(
-                model_config,
+                gguf_source,
                 target_dtype,
                 tokenizer_config,
             )
@@ -200,9 +214,7 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
-        # For GGUF the engine integration rewrites model_config.model to the
-        # config source; the weights the user served live in model_weights.
-        loaded_from = model_config.model_weights if is_gguf else model_name
+        loaded_from = gguf_source.weights_path if gguf_source is not None else model_name
         logger.info(
             "%s loaded in %.2fs: %s",
             load_label,
@@ -213,18 +225,16 @@ class ModelLifecycle:
 
     def _load_gguf_text_model(
         self,
-        model_config: Any,
+        source: GGUFLoadSource,
         target_dtype: Any,
         tokenizer_config: Mapping[str, Any],
     ) -> tuple[Any, Any]:
         """Load a GGUF checkpoint through the optional GGUF owner."""
         from vllm_metal.gguf.loader import GGUFModelLoader
 
-        # The GGUF engine integration rewrites model_config.model to the config
-        # source and carries the .gguf path in model_config.model_weights.
         loader = GGUFModelLoader.for_model(
-            model_config.model_weights,
-            config_dir=model_config.model,
+            source.weights_path,
+            config_dir=source.config_dir,
             target_dtype=target_dtype,
             tokenizer_config=dict(tokenizer_config),
         )


### PR DESCRIPTION
This PR is:
- To follow up #466 with an internal cleanup of the local GGUF load path.
- To introduce `GGUFLoadSource` so lifecycle code no longer reads GGUF admission fields directly.
- To simplify `GGUFModelLoader` around explicit local weights, config, and tokenizer sources.
- To keep `--hf-config-path X --tokenizer Y` separation covered in lifecycle tests.

This does not expand GGUF support beyond the local-file path restored in #466. Remote `repo:quant` serving remains a future UX improvement.
