### PR TITLE
[Kernel] Fuse paged K/V cache write via reshape_and_cache

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -607,6 +607,16 @@ class TestSDPAForward:
         captured: dict[str, int] = {}
 
         class _FakeOps:
+            def reshape_and_cache(
+                self,
+                _key,
+                _value,
+                key_cache,
+                value_cache,
+                _slot_mapping,
+            ) -> tuple[mx.array, mx.array]:
+                return key_cache, value_cache
+
             def paged_attention_primitive(
                 self,
                 _query,

--- a/tests/test_reshape_and_cache.py
+++ b/tests/test_reshape_and_cache.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity test for the fused reshape_and_cache K/V paged scatter.
+
+The fused Metal op must produce byte-identical caches to the MLX scatter it
+replaces on the decode path (flat[slot_mapping] = kv).
+"""
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.metal import get_ops
+
+
+def _reference_scatter(key, value, num_blocks, block_size, slot_mapping):
+    h, d = key.shape[1], key.shape[2]
+    kc = mx.zeros((num_blocks, block_size, h, d), dtype=key.dtype)
+    vc = mx.zeros((num_blocks, block_size, h, d), dtype=value.dtype)
+    fk = kc.reshape(-1, h, d)
+    fk[slot_mapping] = key
+    fv = vc.reshape(-1, h, d)
+    fv[slot_mapping] = value
+    kc = fk.reshape(num_blocks, block_size, h, d)
+    vc = fv.reshape(num_blocks, block_size, h, d)
+    mx.eval(kc, vc)
+    return kc, vc
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+@pytest.mark.parametrize("num_kv_heads,head_dim", [(2, 64), (4, 128)])
+def test_reshape_and_cache_matches_scatter(dtype, num_kv_heads, head_dim):
+    if not mx.metal.is_available():
+        pytest.skip("Metal is not available")
+    num_blocks, block_size, num_tokens = 4, 16, 5
+    mx.random.seed(0)
+    key = mx.random.normal((num_tokens, num_kv_heads, head_dim)).astype(dtype)
+    value = mx.random.normal((num_tokens, num_kv_heads, head_dim)).astype(dtype)
+    slot = mx.array([3, 20, 7, 40, 1], dtype=mx.int64)  # all < num_blocks*block_size
+
+    kc = mx.zeros((num_blocks, block_size, num_kv_heads, head_dim), dtype=dtype)
+    vc = mx.zeros((num_blocks, block_size, num_kv_heads, head_dim), dtype=dtype)
+    new_k, new_v = get_ops().reshape_and_cache(key, value, kc, vc, slot)
+    mx.eval(new_k, new_v)
+
+    ref_k, ref_v = _reference_scatter(key, value, num_blocks, block_size, slot)
+    assert mx.array_equal(new_k, ref_k)
+    assert mx.array_equal(new_v, ref_v)
+
+
+def test_reshape_and_cache_skips_negative_slots():
+    if not mx.metal.is_available():
+        pytest.skip("Metal is not available")
+    num_blocks, block_size, num_kv_heads, head_dim = 4, 16, 4, 128
+    mx.random.seed(1)
+    key = mx.random.normal((3, num_kv_heads, head_dim)).astype(mx.float16)
+    value = mx.random.normal((3, num_kv_heads, head_dim)).astype(mx.float16)
+    slot = mx.array([5, -1, 9], dtype=mx.int64)  # padding slot must be ignored
+
+    kc = mx.zeros((num_blocks, block_size, num_kv_heads, head_dim), dtype=mx.float16)
+    vc = mx.zeros((num_blocks, block_size, num_kv_heads, head_dim), dtype=mx.float16)
+    new_k, _ = get_ops().reshape_and_cache(key, value, kc, vc, slot)
+    mx.eval(new_k)
+
+    ref_k, _ = _reference_scatter(
+        key[[0, 2]],
+        value[[0, 2]],
+        num_blocks,
+        block_size,
+        mx.array([5, 9], dtype=mx.int64),
+    )
+    assert mx.array_equal(new_k, ref_k)

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -541,14 +541,17 @@ def sdpa_forward(
         kv_cache.value_scale_caches[layer_idx] = new_value_scale_cache
         kv_cache.key_zero_caches[layer_idx] = new_key_zero_cache
     else:
-        flat_k = kv_cache.key_caches[layer_idx].reshape(-1, cache_kv_heads, head_dim)
-        flat_k[slot_mapping] = k_3d
-        new_k_cache = flat_k.reshape(kv_cache.key_caches[layer_idx].shape)
-
-        flat_v = kv_cache.value_caches[layer_idx].reshape(-1, cache_kv_heads, head_dim)
-        flat_v[slot_mapping] = v_3d
-        new_v_cache = flat_v.reshape(kv_cache.value_caches[layer_idx].shape)
-
+        # Fused K/V paged scatter: one Metal dispatch (reshape_and_cache) writes
+        # both K and V into the paged cache by slot_mapping, replacing the two
+        # per-layer MLX scatters. The outputs alias the input cache buffers in
+        # place and carry graph provenance for the paged_attention read below.
+        new_k_cache, new_v_cache = get_ops().reshape_and_cache(
+            k_3d,
+            v_3d,
+            kv_cache.key_caches[layer_idx],
+            kv_cache.value_caches[layer_idx],
+            slot_mapping,
+        )
         # Rebind so next layer / decode step uses the updated cache
         kv_cache.key_caches[layer_idx] = new_k_cache
         kv_cache.value_caches[layer_idx] = new_v_cache

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -63,6 +63,7 @@ def _build_v2_paged_attention_source() -> str:
         _read_metal_source(_KERNELS_V2_DIR / "float8.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "turboquant.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "reshape_and_cache.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "pagedattention.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "pagedattention_tiled.metal"),
     ]

--- a/vllm_metal/metal/kernels_v2/reshape_and_cache.metal
+++ b/vllm_metal/metal/kernels_v2/reshape_and_cache.metal
@@ -26,7 +26,10 @@ template <> inline bfloat16_t to_cache<bfloat16_t, bfloat16_t>(bfloat16_t v) {
 
 template <> inline half to_cache<half, half>(half v) { return v; }
 
-constant bool use_fp8_scales [[function_constant(10)]];
+// Renamed from use_fp8_scales at function_constant(10): once this kernel is
+// concatenated into the v2 library, both the name and the index collide with an
+// existing constant, so it uses a unique name at a free index (100).
+constant bool rac_use_fp8_scales [[function_constant(100)]];
 
 // Cache layout: [num_blocks, block_size, num_heads, head_size]
 // Both key and value caches use the same token-contiguous layout.
@@ -43,9 +46,9 @@ template <typename KV_T, typename CACHE_T>
     const device int64_t *__restrict__ slot_mapping
     [[buffer(4)]], // [num_tokens]
     const device float *__restrict__ k_scale
-    [[buffer(5), function_constant(use_fp8_scales)]], // [1]
+    [[buffer(5), function_constant(rac_use_fp8_scales)]], // [1]
     const device float *__restrict__ v_scale
-    [[buffer(6), function_constant(use_fp8_scales)]], // [1]
+    [[buffer(6), function_constant(rac_use_fp8_scales)]], // [1]
     device const int &key_stride [[buffer(7)]],
     device const int &value_stride [[buffer(8)]],
     device const int &num_heads [[buffer(9)]],
@@ -79,7 +82,7 @@ template <typename KV_T, typename CACHE_T>
         head_idx * head_size +
         head_offset;
 
-    if (use_fp8_scales) {
+    if (rac_use_fp8_scales) {
       key_cache[tgt_idx] =
           to_cache<KV_T, CACHE_T>(KV_T((float)key[src_key_idx] / *k_scale));
       value_cache[tgt_idx] =
@@ -102,9 +105,9 @@ template <typename KV_T, typename CACHE_T>
       device cache_type *__restrict__ value_cache [[buffer(3)]],               \
       const device int64_t *__restrict__ slot_mapping [[buffer(4)]],           \
       const device float *__restrict__ k_scale                                 \
-      [[buffer(5), function_constant(use_fp8_scales)]],                        \
+      [[buffer(5), function_constant(rac_use_fp8_scales)]],                        \
       const device float *__restrict__ v_scale                                 \
-      [[buffer(6), function_constant(use_fp8_scales)]],                        \
+      [[buffer(6), function_constant(rac_use_fp8_scales)]],                        \
       device const int &key_stride [[buffer(7)]],                              \
       device const int &value_stride [[buffer(8)]],                            \
       device const int &num_heads [[buffer(9)]],                               \

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -839,6 +839,106 @@ static std::vector<array> tq_encode_primitive_fn(
 }
 
 // ---------------------------------------------------------------------------
+// reshape_and_cache — fused K/V paged scatter (non-quantized fp16/bf16/fp32)
+//
+// Replaces the two per-layer MLX scatters on the standard decode path
+// (flat_k[slot_mapping] = k_3d; flat_v[slot_mapping] = v_3d) with one fused
+// Metal dispatch that writes both K and V into the paged cache by slot_mapping,
+// wiring up the pre-existing reshape_and_cache.metal kernel. Same in-place
+// aliasing pattern as TQEncodePrimitive so the writes carry graph provenance
+// for the downstream paged_attention read.
+// ---------------------------------------------------------------------------
+
+class ReshapeAndCachePrimitive : public Primitive {
+ public:
+  explicit ReshapeAndCachePrimitive(Stream stream) : Primitive(stream) {}
+
+  void eval_cpu(const std::vector<array>&, std::vector<array>&) override {
+    throw std::runtime_error("ReshapeAndCachePrimitive only supports GPU");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    // inputs:  0=key, 1=value, 2=key_cache_in, 3=value_cache_in, 4=slot_mapping
+    // outputs: 0=new_key_cache, 1=new_value_cache (alias inputs 2,3 in place)
+    outputs[0].copy_shared_buffer(inputs[2]);
+    outputs[1].copy_shared_buffer(inputs[3]);
+
+    const array& key          = inputs[0];
+    const array& value        = inputs[1];
+    const array& slot_mapping = inputs[4];
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+
+    // key shape: [num_tokens, num_kv_heads, head_size]
+    int num_tokens   = static_cast<int>(key.shape(0));
+    int num_kv_heads = static_cast<int>(key.shape(1));
+    int head_size    = static_cast<int>(key.shape(2));
+    // cache shape: [num_blocks, block_size, num_kv_heads, head_size]
+    int block_size   = static_cast<int>(inputs[2].shape(1));
+
+    auto kv_dt    = dtype_to_metal(key.dtype());
+    auto cache_dt = dtype_to_metal(inputs[2].dtype());
+    std::string kname = "reshape_and_cache_kv_" + kv_dt + "_cache_" + cache_dt;
+
+    // rac_use_fp8_scales (fc 100) = false: non-quantized cache, so the
+    // k_scale/v_scale buffers (5,6) are absent from the signature.
+    bool use_fp8 = false;
+    std::string hash_name = kname + "_fp8_0";
+
+    auto* lib = d.get_library("paged_attention_v2_kern");
+    auto* kernel = d.get_kernel(
+        kname, lib, hash_name,
+        {{&use_fp8, MTL::DataType::DataTypeBool, NS::UInteger(100)}});
+
+    int32_t key_stride_i   = static_cast<int32_t>(num_kv_heads * head_size);
+    int32_t value_stride_i = key_stride_i;
+    int32_t num_heads_i    = static_cast<int32_t>(num_kv_heads);
+    int32_t head_size_i    = static_cast<int32_t>(head_size);
+    int32_t block_size_i   = static_cast<int32_t>(block_size);
+
+    auto& enc = get_command_encoder_compat(d, s);
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_input_array(key,          0);
+    enc.set_input_array(value,        1);
+    enc.set_output_array(outputs[0],  2);
+    enc.set_output_array(outputs[1],  3);
+    enc.set_input_array(slot_mapping, 4);
+    enc.set_bytes(key_stride_i,   7);
+    enc.set_bytes(value_stride_i, 8);
+    enc.set_bytes(num_heads_i,    9);
+    enc.set_bytes(head_size_i,    10);
+    enc.set_bytes(block_size_i,   11);
+
+    int tg = std::min(num_kv_heads * head_size, 256);
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(num_tokens, 1, 1),
+        MTL::Size::Make(tg, 1, 1));
+  }
+
+  const char* name() const override { return "ReshapeAndCache"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    return dynamic_cast<const ReshapeAndCachePrimitive*>(&other) != nullptr;
+  }
+};
+
+static std::vector<array> reshape_and_cache_primitive_fn(
+    const array& key, const array& value,
+    const array& key_cache, const array& value_cache,
+    const array& slot_mapping) {
+  auto prim = std::make_shared<ReshapeAndCachePrimitive>(
+      default_stream(Device::gpu));
+  return array::make_arrays(
+      {key_cache.shape(), value_cache.shape()},
+      {key_cache.dtype(), value_cache.dtype()},
+      prim,
+      {key, value, key_cache, value_cache, slot_mapping});
+}
+
+// ---------------------------------------------------------------------------
 // GDN linear attention — in-place paged state
 // ---------------------------------------------------------------------------
 
@@ -1215,6 +1315,39 @@ NB_MODULE(_paged_ops, m) {
         "QUANT_PARAMS (signed q8_0/int8 at k_bits=8; unsigned uint8/q5_0/"
         "q4_0/int4/uint4/int2/uint2 at k_bits in {2,3,4,5,8}). V supports "
         "any v_bits in [1, 8] via the v_centroids buffer.");
+
+  m.def("reshape_and_cache",
+        [](nb::handle key_h, nb::handle value_h,
+           nb::handle key_cache_h, nb::handle value_cache_h,
+           nb::handle slot_mapping_h) {
+          auto results = reshape_and_cache_primitive_fn(
+              *nb::inst_ptr<array>(key_h),
+              *nb::inst_ptr<array>(value_h),
+              *nb::inst_ptr<array>(key_cache_h),
+              *nb::inst_ptr<array>(value_cache_h),
+              *nb::inst_ptr<array>(slot_mapping_h));
+
+          // Same placeholder dance as tq_encode: mint mx.core.array objects and
+          // overwrite_descriptor to bypass cross-module nanobind RTTI.
+          nb::object mx_core  = nb::module_::import_("mlx.core");
+          nb::object arr_cls  = mx_core.attr("array");
+          nb::object zero_arg = nb::int_(0);
+          nb::object out_k    = arr_cls(zero_arg);
+          nb::object out_v    = arr_cls(zero_arg);
+          nb::inst_ptr<array>(out_k)->overwrite_descriptor(results[0]);
+          nb::inst_ptr<array>(out_v)->overwrite_descriptor(results[1]);
+          return nb::make_tuple(out_k, out_v);
+        },
+        nb::arg("key"), nb::arg("value"),
+        nb::arg("key_cache"), nb::arg("value_cache"),
+        nb::arg("slot_mapping"),
+        "Fused K/V paged scatter for non-quantized (fp16/bf16/fp32) caches. "
+        "Wraps an MLX Primitive whose two cache writes carry graph provenance "
+        "for the downstream paged_attention read; each output aliases its input "
+        "cache buffer in place, so the caller MUST rebind "
+        "kv_cache.<cache>[layer_idx] to the returned value. key/value are "
+        "[num_tokens, num_kv_heads, head_size]; caches are "
+        "[num_blocks, block_size, num_kv_heads, head_size].");
 
   // Paged attention primitive (read-only): dispatches paged_attention_v2_online.
   // Cache writes are handled by MLX-native scatter upstream.


### PR DESCRIPTION
### What

The paged decode path writes K and V into the cache with two per-layer MLX scatters (`flat_k[slot_mapping] = k_3d; flat_v[slot_mapping] = v_3d` in `sdpa_forward`). `reshape_and_cache.metal` already exists under `kernels_v2/` but isn't part of the v2 library source and isn't exposed as an op, so it wasn't being used. This wires it up: it compiles into `paged_attention_v2_kern`, is exposed as a `reshape_and_cache` MLX primitive (same in-place aliasing as `tq_encode`), and `sdpa_forward` calls it in place of the two scatters.

### Why

One fused Metal dispatch instead of two host-driven scatters on the per-layer decode hot path, and two fewer Python-level ops per layer.

Qwen2.5-7B-4bit, M3 Ultra, ctx 256, eager, single-stream decode, 3 interleaved runs each in the same session:

  `baseline:  79.9 / 80.5 / 80.3 tok/s   (mean 80.2)`
  `this PR:   84.0 / 82.4 / 84.3 tok/s   (mean 83.6)`

About +4%, and the ranges do not overlap.

### Correctness

`reshape_and_cache` output is byte-identical to the scatter it replaces (`tests/test_reshape_and_cache.py`: parametrized over fp16/bf16/fp32 and a couple of head geometries, plus a negative-slot padding case). TurboQuant and fp8 paths are untouched; this covers only the non-quantized cache write.

### Note

`reshape_and_cache.metal` declared `use_fp8_scales` at `function_constant(10)`, which clashes by name and index with an existing constant once the kernel is concatenated into the v2 library. Renamed to `rac_use_fp8_scales` at 100.