### PR TITLE
Restore Metal CI after transformers 5.13 breakage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,12 @@ dependencies = [
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
     # Keep aligned with vLLM 0.24.0's Transformers lower bound.
-    "transformers>=5.5.3",
+    # Temporary cap: transformers 5.13.0 (released 2026-07-03) breaks MLX Metal
+    # availability inside the vLLM process on GitHub's macOS runner VMs, so
+    # platform resolution falls back to CPU. Verified A/B on the same runner:
+    # 5.13.0 -> CpuPlatform, 5.12.1 -> MetalPlatform.
+    # TODO: remove once the interaction is understood/fixed upstream.
+    "transformers>=5.5.3,<5.13",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
     # Native Metal extension JIT build

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -174,6 +174,14 @@ main() {
     section "Verifying package import"
     python -c "import vllm_metal; print('vllm_metal imported successfully')"
 
+    # Preflight: assert vLLM resolves the Metal platform before spending
+    # minutes on smokes. When this fails, MLX cannot see Metal inside the
+    # full vLLM process and every smoke dies confusingly on vLLM's CPU
+    # fallback; an unpinned dependency regression can cause this (see
+    # transformers 5.13.0, #471).
+    section "Checking Metal platform resolution"
+    python -c "import sys; from vllm.platforms import current_platform; name = type(current_platform).__name__; print('Resolved platform:', name); sys.exit(0 if name == 'MetalPlatform' else 1)"
+
     smoke_tests
     section "Running tests"
     # Exclude perf/long-running tests by default; run them explicitly via:


### PR DESCRIPTION
CI serve smokes went red on 2026-07-03 evening with no repo change: main was green at 13:42 and red from 18:47, on the identical macos-15 image. The failures looked like memory problems on vLLM's CPU worker, but that was a symptom. vLLM was falling back to its stock CPU platform because MLX stopped seeing Metal inside the full vLLM process, while a bare mlx import on the same runner still saw it.

Bisecting the dependency delta between the last green and the first red run left three candidates, and only transformers 5.13.0 (released 16:05 that day, between the two runs) fits the window. An A/B on the same runner proved it: with the shipped 5.13.0 the platform resolves to CpuPlatform, and after downgrading only transformers to 5.12.1 it resolves to MetalPlatform. A bare "import torch, transformers" does not reproduce it, so the trigger needs the fuller vllm import context; I have not pinned down the exact mechanism yet.

So this PR does two things. It caps transformers below 5.13 in pyproject, the same temporary-cap shape as the existing fastapi pin, which restores the real Metal smokes and pytest on the stock macos-15 runners. And it adds a preflight assertion in scripts/test.sh that fails fast with the resolved platform name when vLLM does not resolve MetalPlatform, so the next regression like this surfaces as one clear line instead of confusing CPU-worker errors. Verified on a fork run with the cap: the full pipeline resolves MetalPlatform, both smokes pass their goldens, and 1361 tests pass.
