### PR TITLE
Hybrid + TurboQuant: size scheduler-visible KV pages with the packed layout

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -874,8 +874,33 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
-    def test_check_and_update_config_rejects_hybrid_prefix_caching(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize(
+        "cache_config,err_match",
+        [
+            (
+                SimpleNamespace(
+                    block_size=None,
+                    enable_prefix_caching=True,
+                    mamba_cache_mode="none",
+                ),
+                "Prefix caching",
+            ),
+            (
+                SimpleNamespace(
+                    block_size=None,
+                    enable_prefix_caching=False,
+                    mamba_cache_mode="all",
+                ),
+                "Mamba cache modes",
+            ),
+        ],
+        ids=["prefix_caching", "mamba_cache_mode"],
+    )
+    def test_check_and_update_config_rejects_hybrid_state_cache_modes(
+        self,
+        cache_config: SimpleNamespace,
+        err_match: str,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
@@ -889,10 +914,7 @@ class TestMetalPlatform:
                     tensor_parallel_size=1,
                     disable_custom_all_reduce=False,
                 ),
-                cache_config=SimpleNamespace(
-                    block_size=None,
-                    enable_prefix_caching=True,
-                ),
+                cache_config=cache_config,
                 model_config=SimpleNamespace(
                     model="test-model",
                     disable_cascade_attn=False,
@@ -910,7 +932,7 @@ class TestMetalPlatform:
                 ),
             )
 
-            with pytest.raises(NotImplementedError, match="Prefix caching"):
+            with pytest.raises(NotImplementedError, match=err_match):
                 MetalPlatform.check_and_update_config(vllm_config)
         finally:
             reset_config()

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -61,7 +61,7 @@ from vllm_metal.metal import get_ops
 from vllm_metal.v1.cache_policy import (
     TurboQuantAttentionSpec,
     _build_turboquant_attention_spec,
-    _turboquant_page_size_bytes,
+    turboquant_page_size_bytes,
 )
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2637,7 +2637,7 @@ def test_tq_spec_real_page_size_bytes_matches_helper(
         k_quant=k_quant,
         v_quant=v_quant,
     )
-    expected = _turboquant_page_size_bytes(
+    expected = turboquant_page_size_bytes(
         block_size=block_size,
         num_kv_heads=num_kv_heads,
         head_dim=head_dim,

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -140,25 +140,6 @@ class TestHybridTurboQuantCachePolicy:
 
             assert is_kv_cache_spec_uniform(specs) is False
 
-    def test_one_sequence_estimate_includes_linear_state(self) -> None:
-        runner = _hybrid_runner()
-        max_model_len = 2048
-        with patch("vllm_metal.v1.cache_policy.get_config", return_value=_tq_config()):
-            estimate = runner._cache_policy.estimate_one_sequence_kv_bytes(
-                max_model_len=max_model_len, block_size=BLOCK_SIZE
-            )
-        linear_bytes = runner._cache_policy.linear_cache_bytes_per_slot()
-
-        aligned_tokens = -(-max_model_len // BLOCK_SIZE) * BLOCK_SIZE
-        sdpa_bytes = len(SDPA_LAYERS) * _turboquant_page_size_bytes(
-            block_size=aligned_tokens,
-            num_kv_heads=KV_HEADS,
-            head_dim=HEAD_DIM,
-            k_quant=K_QUANT,
-            v_quant=V_QUANT,
-        )
-        assert estimate == sdpa_bytes + linear_bytes
-
 
 class TestTurboQuantHybridAlignment:
     """MetalPlatform re-aligns hybrid block size with packed page math."""
@@ -215,46 +196,13 @@ class TestTurboQuantHybridAlignment:
             lambda architecture, model_config: (self._stub_model_cls(), None),
         )
 
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config, None)
 
         expected_block = 16 * -(-self._MAMBA_PAGE // (16 * self._TQ_PAGE_1_TOKEN))
         assert vllm_config.cache_config.block_size == expected_block
         expected_page = expected_block * self._TQ_PAGE_1_TOKEN
         assert expected_page >= self._MAMBA_PAGE
         assert vllm_config.cache_config.mamba_page_size_padded == expected_page
-
-    def test_realign_gates_on_additional_config(self, monkeypatch) -> None:
-        """Workers may run this hook before the metal singleton is populated.
-
-        ``additional_config`` travels with the pickled ``vllm_config``, so
-        gating on it keeps driver and worker processes consistent even when
-        the process-local singleton still has TurboQuant disabled.
-        """
-        vllm_config = self._vllm_config(block_size=544)
-        vllm_config.additional_config = {
-            "turboquant": True,
-            "k_quant": K_QUANT,
-            "v_quant": V_QUANT,
-        }
-        fresh_singleton = MetalConfig(
-            memory_fraction=-1.0,
-            use_mlx=False,
-            mlx_device="gpu",
-            debug=False,
-            use_paged_attention=True,
-        )
-        assert fresh_singleton.turboquant is False
-        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: fresh_singleton)
-        monkeypatch.setattr(
-            ModelRegistry,
-            "resolve_model_cls",
-            lambda architecture, model_config: (self._stub_model_cls(), None),
-        )
-
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
-
-        expected_block = 16 * -(-self._MAMBA_PAGE // (16 * self._TQ_PAGE_1_TOKEN))
-        assert vllm_config.cache_config.block_size == expected_block
 
     def test_realign_noop_without_turboquant(self, monkeypatch) -> None:
         vllm_config = self._vllm_config(block_size=544)
@@ -263,7 +211,7 @@ class TestTurboQuantHybridAlignment:
         config.turboquant = False
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: config)
 
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config, None)
 
         assert vllm_config.cache_config.block_size == 544
         assert vllm_config.cache_config.mamba_page_size_padded == before_padded
@@ -273,6 +221,57 @@ class TestTurboQuantHybridAlignment:
         vllm_config.model_config.is_hybrid = False
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
 
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config, None)
 
         assert vllm_config.cache_config.block_size == 16
+
+    def test_update_block_size_snapshots_user_mamba_before_super(
+        self, monkeypatch
+    ) -> None:
+        """Ordering regression on a real ``CacheConfig``.
+
+        Upstream ``super()._align_hybrid_block_size`` overwrites
+        ``cache_config.mamba_block_size`` with its computed value while leaving
+        ``user_specified_mamba_block_size`` True, so the TurboQuant realign must
+        consume a snapshot taken *before* super(), not the post-super() value.
+        Uses ``--block-size 64`` + ``mamba_cache_mode="all"`` + a user mamba
+        block of 128, the exact case an isolated stub config cannot exercise.
+        """
+        from vllm.config import CacheConfig
+
+        cache_config = CacheConfig(block_size=64, mamba_block_size=128)
+        assert cache_config.user_specified_mamba_block_size is True
+        cache_config.mamba_cache_mode = "all"
+
+        vllm_config = SimpleNamespace(
+            cache_config=cache_config,
+            model_config=SimpleNamespace(is_hybrid=True),
+            parallel_config=SimpleNamespace(),
+        )
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+
+        # Upstream super() overwrites mamba_block_size with its own result.
+        def fake_super(cls, vc) -> None:
+            vc.cache_config.mamba_block_size = 999  # != the user's 128
+
+        monkeypatch.setattr(
+            MetalPlatform.__mro__[1],
+            "update_block_size_for_backend",
+            classmethod(fake_super),
+        )
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            MetalPlatform,
+            "_realign_hybrid_block_size_for_turboquant",
+            classmethod(
+                lambda cls, vc, user_mamba_block_size: captured.update(
+                    umbs=user_mamba_block_size
+                )
+            ),
+        )
+
+        MetalPlatform.update_block_size_for_backend(vllm_config)
+
+        # The realign must receive the user's 128, snapshotted before super()
+        # clobbered cache_config.mamba_block_size with 999.
+        assert captured["umbs"] == 128

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -1,15 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Hybrid + TurboQuant sizing must match the runtime's packed KV layout."""
 
-from math import lcm
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import mlx.core as mx
+import pytest
 import torch
 from vllm.config import CacheConfig
 from vllm.model_executor.models import ModelRegistry
-from vllm.v1.kv_cache_interface import MambaSpec
+from vllm.v1.core.kv_cache_utils import (
+    get_kv_cache_groups,
+    resolve_kv_cache_block_sizes,
+)
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.config import MetalConfig
@@ -158,11 +162,19 @@ class TestTurboQuantHybridAlignment:
             model_config=SimpleNamespace(
                 is_hybrid=True,
                 architecture="StubHybridForCausalLM",
+                dtype=torch.float16,
+                use_mla=False,
                 get_num_kv_heads=lambda parallel_config: KV_HEADS,
                 get_head_size=lambda: HEAD_DIM,
+                get_mamba_chunk_size=lambda: None,
             ),
             cache_config=cache_config,
-            parallel_config=SimpleNamespace(),
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=1,
+                prefill_context_parallel_size=1,
+            ),
+            scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+            kv_transfer_config=None,
         )
 
     def _stub_model_cls(self) -> SimpleNamespace:
@@ -191,7 +203,6 @@ class TestTurboQuantHybridAlignment:
         MetalPlatform._realign_hybrid_block_size_for_turboquant(
             vllm_config,
             user_block_size=None,
-            user_mamba_block_size=None,
             hash_block_size=None,
         )
 
@@ -211,7 +222,6 @@ class TestTurboQuantHybridAlignment:
         MetalPlatform._realign_hybrid_block_size_for_turboquant(
             vllm_config,
             user_block_size=None,
-            user_mamba_block_size=None,
             hash_block_size=None,
         )
 
@@ -226,84 +236,46 @@ class TestTurboQuantHybridAlignment:
         MetalPlatform._realign_hybrid_block_size_for_turboquant(
             vllm_config,
             user_block_size=None,
-            user_mamba_block_size=None,
             hash_block_size=None,
         )
 
         assert vllm_config.cache_config.block_size == 16
 
-    def test_update_block_size_preserves_user_hash_block_after_super(
-        self, monkeypatch
+    @pytest.mark.parametrize(
+        "cache_kwargs",
+        [
+            {"block_size": 64, "hash_block_size": 64},
+            {"hash_block_size": 64},
+        ],
+        ids=["user_block_and_hash", "hash_only"],
+    )
+    def test_update_block_size_survives_vllm_grouping_with_hash_block(
+        self, cache_kwargs, monkeypatch
     ) -> None:
-        cache_config = CacheConfig(block_size=64, hash_block_size=64)
+        cache_config = CacheConfig(enable_prefix_caching=False, **cache_kwargs)
         cache_config.mamba_cache_mode = "none"
         vllm_config = self._vllm_config_with_cache(cache_config)
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
-        self._patch_model_cls(monkeypatch)
-
-        def fake_super(cls, vc) -> None:
-            vc.cache_config.block_size = 576
-
         monkeypatch.setattr(
-            MetalPlatform.__mro__[1],
-            "update_block_size_for_backend",
-            classmethod(fake_super),
+            "vllm_metal.v1.cache_policy.get_config", lambda: _tq_config()
         )
+        self._patch_model_cls(monkeypatch)
+        runner = _hybrid_runner()
+        runner.cache_config = cache_config
 
         MetalPlatform.update_block_size_for_backend(vllm_config)
+        specs = runner._cache_policy.get_kv_cache_spec()
+        groups = get_kv_cache_groups(vllm_config, specs)
+        scheduler_block_size, hash_block_size = resolve_kv_cache_block_sizes(
+            KVCacheConfig(num_blocks=1, kv_cache_tensors=[], kv_cache_groups=groups),
+            vllm_config,
+        )
 
         expected_block = 64 * -(-self._MAMBA_PAGE // (64 * self._TQ_PAGE_1_TOKEN))
         assert cache_config.block_size == expected_block
         assert cache_config.block_size % cache_config.hash_block_size == 0
-
-    def test_update_block_size_preserves_hash_block_without_user_block(
-        self, monkeypatch
-    ) -> None:
-        cache_config = CacheConfig(hash_block_size=64)
-        cache_config.mamba_cache_mode = "none"
-        vllm_config = self._vllm_config_with_cache(cache_config)
-        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
-        self._patch_model_cls(monkeypatch)
-
-        def fake_super(cls, vc) -> None:
-            vc.cache_config.block_size = 576
-
-        monkeypatch.setattr(
-            MetalPlatform.__mro__[1],
-            "update_block_size_for_backend",
-            classmethod(fake_super),
-        )
-
-        MetalPlatform.update_block_size_for_backend(vllm_config)
-
-        expected_block = 64 * -(-self._MAMBA_PAGE // (64 * self._TQ_PAGE_1_TOKEN))
-        assert cache_config.block_size == expected_block
-        assert cache_config.block_size % cache_config.hash_block_size == 0
-
-    def test_update_block_size_snapshots_user_mamba_before_super(
-        self, monkeypatch
-    ) -> None:
-        cache_config = CacheConfig(block_size=64, mamba_block_size=128)
-        assert cache_config.user_specified_mamba_block_size is True
-        cache_config.mamba_cache_mode = "all"
-        vllm_config = self._vllm_config_with_cache(cache_config)
-        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
-        self._patch_model_cls(monkeypatch)
-
-        def fake_super(cls, vc) -> None:
-            vc.cache_config.block_size = 576
-            vc.cache_config.mamba_block_size = 999
-
-        monkeypatch.setattr(
-            MetalPlatform.__mro__[1],
-            "update_block_size_for_backend",
-            classmethod(fake_super),
-        )
-
-        MetalPlatform.update_block_size_for_backend(vllm_config)
-
-        chunk_size = lcm(128, 64)
-        attn_tokens_per_mamba_state = -(-self._MAMBA_PAGE // self._TQ_PAGE_1_TOKEN)
-        expected_block = chunk_size * -(-attn_tokens_per_mamba_state // chunk_size)
-        assert cache_config.block_size == expected_block
-        assert cache_config.mamba_block_size == expected_block
+        assert {group.kv_cache_spec.page_size_bytes for group in groups} == {
+            cache_config.block_size * self._TQ_PAGE_1_TOKEN
+        }
+        assert scheduler_block_size % cache_config.hash_block_size == 0
+        assert hash_block_size == scheduler_block_size

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -16,7 +16,7 @@ from vllm_metal.config import MetalConfig
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import (
     TurboQuantAttentionSpec,
-    _turboquant_page_size_bytes,
+    turboquant_page_size_bytes,
 )
 
 BLOCK_SIZE = 1056
@@ -27,7 +27,7 @@ HEAD_DIM = 128
 K_QUANT = "q4_0"
 V_QUANT = "q4_0"
 
-TQ_PAGE = _turboquant_page_size_bytes(
+TQ_PAGE = turboquant_page_size_bytes(
     block_size=BLOCK_SIZE,
     num_kv_heads=KV_HEADS,
     head_dim=HEAD_DIM,
@@ -127,7 +127,7 @@ class TestHybridTurboQuantCachePolicy:
 class TestTurboQuantHybridAlignment:
     _MAMBA_SHAPES = ((3, 8192), (32, 128, 128))
     _MAMBA_PAGE = (3 * 8192 + 32 * 128 * 128) * 2
-    _TQ_PAGE_1_TOKEN = _turboquant_page_size_bytes(
+    _TQ_PAGE_1_TOKEN = turboquant_page_size_bytes(
         block_size=1,
         num_kv_heads=KV_HEADS,
         head_dim=HEAD_DIM,

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -192,6 +192,7 @@ class TestTurboQuantHybridAlignment:
             vllm_config,
             user_block_size=None,
             user_mamba_block_size=None,
+            hash_block_size=None,
         )
 
         expected_block = 16 * -(-self._MAMBA_PAGE // (16 * self._TQ_PAGE_1_TOKEN))
@@ -211,6 +212,7 @@ class TestTurboQuantHybridAlignment:
             vllm_config,
             user_block_size=None,
             user_mamba_block_size=None,
+            hash_block_size=None,
         )
 
         assert vllm_config.cache_config.block_size == 544
@@ -225,6 +227,7 @@ class TestTurboQuantHybridAlignment:
             vllm_config,
             user_block_size=None,
             user_mamba_block_size=None,
+            hash_block_size=None,
         )
 
         assert vllm_config.cache_config.block_size == 16
@@ -233,6 +236,30 @@ class TestTurboQuantHybridAlignment:
         self, monkeypatch
     ) -> None:
         cache_config = CacheConfig(block_size=64, hash_block_size=64)
+        cache_config.mamba_cache_mode = "none"
+        vllm_config = self._vllm_config_with_cache(cache_config)
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+        self._patch_model_cls(monkeypatch)
+
+        def fake_super(cls, vc) -> None:
+            vc.cache_config.block_size = 576
+
+        monkeypatch.setattr(
+            MetalPlatform.__mro__[1],
+            "update_block_size_for_backend",
+            classmethod(fake_super),
+        )
+
+        MetalPlatform.update_block_size_for_backend(vllm_config)
+
+        expected_block = 64 * -(-self._MAMBA_PAGE // (64 * self._TQ_PAGE_1_TOKEN))
+        assert cache_config.block_size == expected_block
+        assert cache_config.block_size % cache_config.hash_block_size == 0
+
+    def test_update_block_size_preserves_hash_block_without_user_block(
+        self, monkeypatch
+    ) -> None:
+        cache_config = CacheConfig(hash_block_size=64)
         cache_config.mamba_cache_mode = "none"
         vllm_config = self._vllm_config_with_cache(cache_config)
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -242,19 +242,22 @@ class TestTurboQuantHybridAlignment:
         assert vllm_config.cache_config.block_size == 16
 
     @pytest.mark.parametrize(
-        "cache_kwargs",
+        "cache_kwargs,hash_consumer",
         [
-            {"block_size": 64, "hash_block_size": 64},
-            {"hash_block_size": 64},
+            ({"block_size": 64}, False),
+            ({"block_size": 64, "hash_block_size": 64}, True),
+            ({"hash_block_size": 64}, True),
         ],
-        ids=["user_block_and_hash", "hash_only"],
+        ids=["user_block", "user_block_and_hash", "hash_only"],
     )
-    def test_update_block_size_survives_vllm_grouping_with_hash_block(
-        self, cache_kwargs, monkeypatch
+    def test_update_block_size_survives_vllm_grouping(
+        self, cache_kwargs, hash_consumer, monkeypatch
     ) -> None:
         cache_config = CacheConfig(enable_prefix_caching=False, **cache_kwargs)
         cache_config.mamba_cache_mode = "none"
         vllm_config = self._vllm_config_with_cache(cache_config)
+        if hash_consumer:
+            vllm_config.kv_transfer_config = SimpleNamespace()
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
         monkeypatch.setattr(
             "vllm_metal.v1.cache_policy.get_config", lambda: _tq_config()
@@ -273,9 +276,12 @@ class TestTurboQuantHybridAlignment:
 
         expected_block = 64 * -(-self._MAMBA_PAGE // (64 * self._TQ_PAGE_1_TOKEN))
         assert cache_config.block_size == expected_block
-        assert cache_config.block_size % cache_config.hash_block_size == 0
         assert {group.kv_cache_spec.page_size_bytes for group in groups} == {
             cache_config.block_size * self._TQ_PAGE_1_TOKEN
         }
-        assert scheduler_block_size % cache_config.hash_block_size == 0
-        assert hash_block_size == scheduler_block_size
+        if cache_config.hash_block_size is None:
+            assert hash_block_size == scheduler_block_size
+        else:
+            assert cache_config.block_size % cache_config.hash_block_size == 0
+            assert scheduler_block_size % cache_config.hash_block_size == 0
+            assert hash_block_size == cache_config.hash_block_size

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -93,19 +93,8 @@ class TestHybridTurboQuantCachePolicy:
         assert per_block == len(SDPA_LAYERS) * TQ_PAGE
 
     def test_upstream_uniformity_probe_handles_mixed_hybrid_specs(self) -> None:
-        """vLLM probes spec uniformity by merging and catching AssertionError.
-
-        The probe calls ``values()[0].merge(all_values)``, so the class of
-        the model's FIRST layer answers it. Regression: for hybrids whose
-        first layer is SDPA, ``TurboQuantAttentionSpec.merge`` raised
-        ``TypeError`` for the legitimately mixed dict (TurboQuant SDPA +
-        Mamba linear), which escaped the probe's ``except AssertionError``
-        and aborted engine init.
-        """
         from vllm.v1.core.kv_cache_utils import is_kv_cache_spec_uniform
 
-        # Linear layer first (Mamba answers the probe) and SDPA layer
-        # first (TurboQuant answers the probe) — both must survive.
         for sdpa_layers in ([3, 7], [0, 4]):
             runner = make_stub_runner(
                 model_args={"full_attention_interval": 4},
@@ -136,10 +125,6 @@ class TestHybridTurboQuantCachePolicy:
 
 
 class TestTurboQuantHybridAlignment:
-    """MetalPlatform re-aligns hybrid block size with packed page math."""
-
-    # Large GDN state so the fp16-aligned block is too small for the
-    # packed page: (3*8192 + 32*128*128) * 2 bytes = 1,097,728 per request.
     _MAMBA_SHAPES = ((3, 8192), (32, 128, 128))
     _MAMBA_PAGE = (3 * 8192 + 32 * 128 * 128) * 2
     _TQ_PAGE_1_TOKEN = _turboquant_page_size_bytes(
@@ -199,8 +184,6 @@ class TestTurboQuantHybridAlignment:
     def test_realign_grows_block_and_pads_mamba_to_packed_page(
         self, monkeypatch
     ) -> None:
-        # Simulate the post-super() state: fp16 alignment picked
-        # 16 * cdiv(mamba_page, 16 * fp16_page_1_token) = 544 tokens.
         vllm_config = self._vllm_config(block_size=544)
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
         self._patch_model_cls(monkeypatch)

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Hybrid + TurboQuant sizing must match the runtime's packed KV layout.
+
+Regression tests for #468: ``HybridPagedAttentionRuntime`` compresses the
+SDPA layers when TurboQuant is enabled, but every scheduler-visible sizing
+path (KV cache specs, planner per-block bytes, one-sequence estimates,
+hybrid block-size alignment) used the uncompressed fp16 math, so
+``check_enough_kv_cache_memory`` rejected contexts that fit and the paged
+planner budgeted ~3-4x fewer blocks than the packed cache needs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import mlx.core as mx
+import torch
+from vllm.model_executor.models import ModelRegistry
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.config import MetalConfig
+from vllm_metal.platform import MetalPlatform
+from vllm_metal.v1.cache_policy import (
+    TurboQuantAttentionSpec,
+    _turboquant_page_size_bytes,
+)
+
+BLOCK_SIZE = 1056
+NUM_LAYERS = 8
+SDPA_LAYERS = [3, 7]
+KV_HEADS = 4
+HEAD_DIM = 128
+K_QUANT = "q4_0"
+V_QUANT = "q4_0"
+
+TQ_PAGE = _turboquant_page_size_bytes(
+    block_size=BLOCK_SIZE,
+    num_kv_heads=KV_HEADS,
+    head_dim=HEAD_DIM,
+    k_quant=K_QUANT,
+    v_quant=V_QUANT,
+)
+
+
+def _hybrid_runner():
+    return make_stub_runner(
+        model_args={"full_attention_interval": 4},
+        num_layers=NUM_LAYERS,
+        full_attention_interval=4,
+        sdpa_layer_indices=set(SDPA_LAYERS),
+        num_sdpa_layers=len(SDPA_LAYERS),
+        num_linear_layers=NUM_LAYERS - len(SDPA_LAYERS),
+        num_kv_heads=KV_HEADS,
+        head_dim=HEAD_DIM,
+        kv_cache_dtype=mx.float16,
+        cache_config=SimpleNamespace(
+            block_size=BLOCK_SIZE, mamba_page_size_padded=None
+        ),
+        scheduler_config=SimpleNamespace(max_num_seqs=4),
+        linear_conv_kernel_dim=4,
+        linear_conv_dim=1024,
+        linear_num_v_heads=16,
+        linear_value_head_dim=64,
+        linear_key_head_dim=64,
+    )
+
+
+def _tq_config() -> MetalConfig:
+    return MetalConfig(
+        memory_fraction=-1.0,
+        use_mlx=False,
+        mlx_device="gpu",
+        debug=False,
+        use_paged_attention=True,
+        turboquant=True,
+        k_quant=K_QUANT,
+        v_quant=V_QUANT,
+    )
+
+
+class TestHybridTurboQuantCachePolicy:
+    def test_sdpa_specs_report_packed_pages(self) -> None:
+        runner = _hybrid_runner()
+        with patch("vllm_metal.v1.cache_policy.get_config", return_value=_tq_config()):
+            specs = runner._cache_policy.get_kv_cache_spec()
+
+        for idx in SDPA_LAYERS:
+            spec = specs[f"layers.{idx}.self_attn"]
+            assert isinstance(spec, TurboQuantAttentionSpec)
+            assert spec.page_size_bytes == TQ_PAGE
+        for idx in set(range(NUM_LAYERS)) - set(SDPA_LAYERS):
+            assert isinstance(specs[f"layers.{idx}.linear_attn"], MambaSpec)
+
+    def test_per_block_bytes_use_packed_pages(self) -> None:
+        runner = _hybrid_runner()
+        with patch("vllm_metal.v1.cache_policy.get_config", return_value=_tq_config()):
+            per_block = runner._cache_policy.get_cache_block_size_bytes()
+
+        assert per_block == len(SDPA_LAYERS) * TQ_PAGE
+
+    def test_one_sequence_estimate_includes_linear_state(self) -> None:
+        runner = _hybrid_runner()
+        max_model_len = 2048
+        with patch("vllm_metal.v1.cache_policy.get_config", return_value=_tq_config()):
+            estimate = runner._cache_policy.estimate_one_sequence_kv_bytes(
+                max_model_len=max_model_len, block_size=BLOCK_SIZE
+            )
+        linear_bytes = runner._cache_policy.linear_cache_bytes_per_slot()
+
+        aligned_tokens = -(-max_model_len // BLOCK_SIZE) * BLOCK_SIZE
+        sdpa_bytes = len(SDPA_LAYERS) * _turboquant_page_size_bytes(
+            block_size=aligned_tokens,
+            num_kv_heads=KV_HEADS,
+            head_dim=HEAD_DIM,
+            k_quant=K_QUANT,
+            v_quant=V_QUANT,
+        )
+        assert estimate == sdpa_bytes + linear_bytes
+
+
+class TestTurboQuantHybridAlignment:
+    """MetalPlatform re-aligns hybrid block size with packed page math."""
+
+    # Large GDN state so the fp16-aligned block is too small for the
+    # packed page: (3*8192 + 32*128*128) * 2 bytes = 1,097,728 per request.
+    _MAMBA_SHAPES = ((3, 8192), (32, 128, 128))
+    _MAMBA_PAGE = (3 * 8192 + 32 * 128 * 128) * 2
+    _TQ_PAGE_1_TOKEN = _turboquant_page_size_bytes(
+        block_size=1,
+        num_kv_heads=KV_HEADS,
+        head_dim=HEAD_DIM,
+        k_quant=K_QUANT,
+        v_quant=V_QUANT,
+    )
+
+    def _vllm_config(self, *, block_size: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                is_hybrid=True,
+                architecture="StubHybridForCausalLM",
+                get_num_kv_heads=lambda parallel_config: KV_HEADS,
+                get_head_size=lambda: HEAD_DIM,
+            ),
+            cache_config=SimpleNamespace(
+                block_size=block_size,
+                mamba_cache_mode="none",
+                mamba_block_size=None,
+                user_specified_mamba_block_size=False,
+                mamba_page_size_padded=block_size * 2 * KV_HEADS * HEAD_DIM * 2,
+            ),
+            parallel_config=SimpleNamespace(),
+        )
+
+    def _stub_model_cls(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            get_mamba_state_shape_from_config=lambda vllm_config: self._MAMBA_SHAPES,
+            get_mamba_state_dtype_from_config=lambda vllm_config: (
+                torch.float16,
+                torch.float16,
+            ),
+        )
+
+    def test_realign_grows_block_and_pads_mamba_to_packed_page(
+        self, monkeypatch
+    ) -> None:
+        # Simulate the post-super() state: fp16 alignment picked
+        # 16 * cdiv(mamba_page, 16 * fp16_page_1_token) = 544 tokens.
+        vllm_config = self._vllm_config(block_size=544)
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+        monkeypatch.setattr(
+            ModelRegistry,
+            "resolve_model_cls",
+            lambda architecture, model_config: (self._stub_model_cls(), None),
+        )
+
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+
+        expected_block = 16 * -(-self._MAMBA_PAGE // (16 * self._TQ_PAGE_1_TOKEN))
+        assert vllm_config.cache_config.block_size == expected_block
+        expected_page = expected_block * self._TQ_PAGE_1_TOKEN
+        assert expected_page >= self._MAMBA_PAGE
+        assert vllm_config.cache_config.mamba_page_size_padded == expected_page
+
+    def test_realign_noop_without_turboquant(self, monkeypatch) -> None:
+        vllm_config = self._vllm_config(block_size=544)
+        before_padded = vllm_config.cache_config.mamba_page_size_padded
+        config = _tq_config()
+        config.turboquant = False
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: config)
+
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 544
+        assert vllm_config.cache_config.mamba_page_size_padded == before_padded
+
+    def test_realign_noop_for_non_hybrid(self, monkeypatch) -> None:
+        vllm_config = self._vllm_config(block_size=16)
+        vllm_config.model_config.is_hybrid = False
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+
+        assert vllm_config.cache_config.block_size == 16

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -1,19 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Hybrid + TurboQuant sizing must match the runtime's packed KV layout.
+"""Hybrid + TurboQuant sizing must match the runtime's packed KV layout."""
 
-Regression tests for #468: ``HybridPagedAttentionRuntime`` compresses the
-SDPA layers when TurboQuant is enabled, but every scheduler-visible sizing
-path (KV cache specs, planner per-block bytes, one-sequence estimates,
-hybrid block-size alignment) used the uncompressed fp16 math, so
-``check_enough_kv_cache_memory`` rejected contexts that fit and the paged
-planner budgeted ~3-4x fewer blocks than the packed cache needs.
-"""
-
+from math import lcm
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import mlx.core as mx
 import torch
+from vllm.config import CacheConfig
 from vllm.model_executor.models import ModelRegistry
 from vllm.v1.kv_cache_interface import MambaSpec
 
@@ -174,6 +168,18 @@ class TestTurboQuantHybridAlignment:
             parallel_config=SimpleNamespace(),
         )
 
+    def _vllm_config_with_cache(self, cache_config: CacheConfig) -> SimpleNamespace:
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                is_hybrid=True,
+                architecture="StubHybridForCausalLM",
+                get_num_kv_heads=lambda parallel_config: KV_HEADS,
+                get_head_size=lambda: HEAD_DIM,
+            ),
+            cache_config=cache_config,
+            parallel_config=SimpleNamespace(),
+        )
+
     def _stub_model_cls(self) -> SimpleNamespace:
         return SimpleNamespace(
             get_mamba_state_shape_from_config=lambda vllm_config: self._MAMBA_SHAPES,
@@ -183,6 +189,13 @@ class TestTurboQuantHybridAlignment:
             ),
         )
 
+    def _patch_model_cls(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            ModelRegistry,
+            "resolve_model_cls",
+            lambda architecture, model_config: (self._stub_model_cls(), None),
+        )
+
     def test_realign_grows_block_and_pads_mamba_to_packed_page(
         self, monkeypatch
     ) -> None:
@@ -190,13 +203,13 @@ class TestTurboQuantHybridAlignment:
         # 16 * cdiv(mamba_page, 16 * fp16_page_1_token) = 544 tokens.
         vllm_config = self._vllm_config(block_size=544)
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
-        monkeypatch.setattr(
-            ModelRegistry,
-            "resolve_model_cls",
-            lambda architecture, model_config: (self._stub_model_cls(), None),
-        )
+        self._patch_model_cls(monkeypatch)
 
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config, None)
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(
+            vllm_config,
+            user_block_size=None,
+            user_mamba_block_size=None,
+        )
 
         expected_block = 16 * -(-self._MAMBA_PAGE // (16 * self._TQ_PAGE_1_TOKEN))
         assert vllm_config.cache_config.block_size == expected_block
@@ -211,7 +224,11 @@ class TestTurboQuantHybridAlignment:
         config.turboquant = False
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: config)
 
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config, None)
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(
+            vllm_config,
+            user_block_size=None,
+            user_mamba_block_size=None,
+        )
 
         assert vllm_config.cache_config.block_size == 544
         assert vllm_config.cache_config.mamba_page_size_padded == before_padded
@@ -221,57 +238,62 @@ class TestTurboQuantHybridAlignment:
         vllm_config.model_config.is_hybrid = False
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
 
-        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config, None)
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(
+            vllm_config,
+            user_block_size=None,
+            user_mamba_block_size=None,
+        )
 
         assert vllm_config.cache_config.block_size == 16
 
-    def test_update_block_size_snapshots_user_mamba_before_super(
+    def test_update_block_size_preserves_user_hash_block_after_super(
         self, monkeypatch
     ) -> None:
-        """Ordering regression on a real ``CacheConfig``.
-
-        Upstream ``super()._align_hybrid_block_size`` overwrites
-        ``cache_config.mamba_block_size`` with its computed value while leaving
-        ``user_specified_mamba_block_size`` True, so the TurboQuant realign must
-        consume a snapshot taken *before* super(), not the post-super() value.
-        Uses ``--block-size 64`` + ``mamba_cache_mode="all"`` + a user mamba
-        block of 128, the exact case an isolated stub config cannot exercise.
-        """
-        from vllm.config import CacheConfig
-
-        cache_config = CacheConfig(block_size=64, mamba_block_size=128)
-        assert cache_config.user_specified_mamba_block_size is True
-        cache_config.mamba_cache_mode = "all"
-
-        vllm_config = SimpleNamespace(
-            cache_config=cache_config,
-            model_config=SimpleNamespace(is_hybrid=True),
-            parallel_config=SimpleNamespace(),
-        )
+        cache_config = CacheConfig(block_size=64, hash_block_size=64)
+        cache_config.mamba_cache_mode = "none"
+        vllm_config = self._vllm_config_with_cache(cache_config)
         monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+        self._patch_model_cls(monkeypatch)
 
-        # Upstream super() overwrites mamba_block_size with its own result.
         def fake_super(cls, vc) -> None:
-            vc.cache_config.mamba_block_size = 999  # != the user's 128
+            vc.cache_config.block_size = 576
 
         monkeypatch.setattr(
             MetalPlatform.__mro__[1],
             "update_block_size_for_backend",
             classmethod(fake_super),
         )
-        captured: dict[str, object] = {}
+
+        MetalPlatform.update_block_size_for_backend(vllm_config)
+
+        expected_block = 64 * -(-self._MAMBA_PAGE // (64 * self._TQ_PAGE_1_TOKEN))
+        assert cache_config.block_size == expected_block
+        assert cache_config.block_size % cache_config.hash_block_size == 0
+
+    def test_update_block_size_snapshots_user_mamba_before_super(
+        self, monkeypatch
+    ) -> None:
+        cache_config = CacheConfig(block_size=64, mamba_block_size=128)
+        assert cache_config.user_specified_mamba_block_size is True
+        cache_config.mamba_cache_mode = "all"
+        vllm_config = self._vllm_config_with_cache(cache_config)
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+        self._patch_model_cls(monkeypatch)
+
+        def fake_super(cls, vc) -> None:
+            vc.cache_config.block_size = 576
+            vc.cache_config.mamba_block_size = 999
+
         monkeypatch.setattr(
-            MetalPlatform,
-            "_realign_hybrid_block_size_for_turboquant",
-            classmethod(
-                lambda cls, vc, user_mamba_block_size: captured.update(
-                    umbs=user_mamba_block_size
-                )
-            ),
+            MetalPlatform.__mro__[1],
+            "update_block_size_for_backend",
+            classmethod(fake_super),
         )
 
         MetalPlatform.update_block_size_for_backend(vllm_config)
 
-        # The realign must receive the user's 128, snapshotted before super()
-        # clobbered cache_config.mamba_block_size with 999.
-        assert captured["umbs"] == 128
+        chunk_size = lcm(128, 64)
+        attn_tokens_per_mamba_state = -(-self._MAMBA_PAGE // self._TQ_PAGE_1_TOKEN)
+        expected_block = chunk_size * -(-attn_tokens_per_mamba_state // chunk_size)
+        assert cache_config.block_size == expected_block
+        assert cache_config.mamba_block_size == expected_block

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -98,6 +98,48 @@ class TestHybridTurboQuantCachePolicy:
 
         assert per_block == len(SDPA_LAYERS) * TQ_PAGE
 
+    def test_upstream_uniformity_probe_handles_mixed_hybrid_specs(self) -> None:
+        """vLLM probes spec uniformity by merging and catching AssertionError.
+
+        The probe calls ``values()[0].merge(all_values)``, so the class of
+        the model's FIRST layer answers it. Regression: for hybrids whose
+        first layer is SDPA, ``TurboQuantAttentionSpec.merge`` raised
+        ``TypeError`` for the legitimately mixed dict (TurboQuant SDPA +
+        Mamba linear), which escaped the probe's ``except AssertionError``
+        and aborted engine init.
+        """
+        from vllm.v1.core.kv_cache_utils import is_kv_cache_spec_uniform
+
+        # Linear layer first (Mamba answers the probe) and SDPA layer
+        # first (TurboQuant answers the probe) — both must survive.
+        for sdpa_layers in ([3, 7], [0, 4]):
+            runner = make_stub_runner(
+                model_args={"full_attention_interval": 4},
+                num_layers=NUM_LAYERS,
+                full_attention_interval=4,
+                sdpa_layer_indices=set(sdpa_layers),
+                num_sdpa_layers=len(sdpa_layers),
+                num_linear_layers=NUM_LAYERS - len(sdpa_layers),
+                num_kv_heads=KV_HEADS,
+                head_dim=HEAD_DIM,
+                kv_cache_dtype=mx.float16,
+                cache_config=SimpleNamespace(
+                    block_size=BLOCK_SIZE, mamba_page_size_padded=None
+                ),
+                scheduler_config=SimpleNamespace(max_num_seqs=4),
+                linear_conv_kernel_dim=4,
+                linear_conv_dim=1024,
+                linear_num_v_heads=16,
+                linear_value_head_dim=64,
+                linear_key_head_dim=64,
+            )
+            with patch(
+                "vllm_metal.v1.cache_policy.get_config", return_value=_tq_config()
+            ):
+                specs = runner._cache_policy.get_kv_cache_spec()
+
+            assert is_kv_cache_spec_uniform(specs) is False
+
     def test_one_sequence_estimate_includes_linear_state(self) -> None:
         runner = _hybrid_runner()
         max_model_len = 2048
@@ -180,6 +222,39 @@ class TestTurboQuantHybridAlignment:
         expected_page = expected_block * self._TQ_PAGE_1_TOKEN
         assert expected_page >= self._MAMBA_PAGE
         assert vllm_config.cache_config.mamba_page_size_padded == expected_page
+
+    def test_realign_gates_on_additional_config(self, monkeypatch) -> None:
+        """Workers may run this hook before the metal singleton is populated.
+
+        ``additional_config`` travels with the pickled ``vllm_config``, so
+        gating on it keeps driver and worker processes consistent even when
+        the process-local singleton still has TurboQuant disabled.
+        """
+        vllm_config = self._vllm_config(block_size=544)
+        vllm_config.additional_config = {
+            "turboquant": True,
+            "k_quant": K_QUANT,
+            "v_quant": V_QUANT,
+        }
+        fresh_singleton = MetalConfig(
+            memory_fraction=-1.0,
+            use_mlx=False,
+            mlx_device="gpu",
+            debug=False,
+            use_paged_attention=True,
+        )
+        assert fresh_singleton.turboquant is False
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: fresh_singleton)
+        monkeypatch.setattr(
+            ModelRegistry,
+            "resolve_model_cls",
+            lambda architecture, model_config: (self._stub_model_cls(), None),
+        )
+
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(vllm_config)
+
+        expected_block = 16 * -(-self._MAMBA_PAGE // (16 * self._TQ_PAGE_1_TOKEN))
+        assert vllm_config.cache_config.block_size == expected_block
 
     def test_realign_noop_without_turboquant(self, monkeypatch) -> None:
         vllm_config = self._vllm_config(block_size=544)

--- a/vllm_metal/attention/caches/kv_cache.py
+++ b/vllm_metal/attention/caches/kv_cache.py
@@ -209,10 +209,9 @@ class MetalPagedKVCache:
             )
 
             # Log TurboQuant KV cache memory usage with comparison.
-            # Single source of truth: _turboquant_page_size_bytes in cache_policy.
-            from vllm_metal.v1.cache_policy import _turboquant_page_size_bytes
+            from vllm_metal.v1.cache_policy import turboquant_page_size_bytes
 
-            per_block_bytes = _turboquant_page_size_bytes(
+            per_block_bytes = turboquant_page_size_bytes(
                 block_size=block_size,
                 num_kv_heads=num_kv_heads,
                 head_dim=head_dim,

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -757,7 +757,6 @@ class MetalPlatform(Platform):
         # (``_align_hybrid_block_size``) handles hybrid alignment. The kernel
         # layer (``_pick_kernel_block_size``) validates the final
         # ``block_size`` at request time.
-        #
         cache_config = vllm_config.cache_config
         user_block_size = (
             cache_config.block_size if cache_config.user_specified_block_size else None
@@ -783,20 +782,7 @@ class MetalPlatform(Platform):
         user_block_size: int | None,
         user_mamba_block_size: int | None,
     ) -> None:
-        """Redo hybrid block-size alignment with TurboQuant page sizes.
-
-        Upstream ``Platform._align_hybrid_block_size`` sizes the attention
-        block with the standard dtype page formula, but TurboQuant packs
-        SDPA pages ~3-4x smaller (vllm-metal#468). Keeping the fp16-based
-        block would make every scheduler-visible page disagree with the
-        runtime layout: ``check_enough_kv_cache_memory`` rejects contexts
-        that fit, and the paged-attention planner budgets ~3-4x fewer
-        blocks than the TurboQuant cache actually needs.
-
-        Mirrors the upstream alignment (same mamba-state math, same
-        kernel-alignment source) with ``attn_page_size_1_token`` computed
-        from the packed TurboQuant layout.
-        """
+        """Redo hybrid alignment with TurboQuant's packed SDPA page size."""
         from vllm.model_executor.models import ModelRegistry
         from vllm.utils.math_utils import cdiv
         from vllm.v1.attention.backend import MultipleOf
@@ -808,10 +794,6 @@ class MetalPlatform(Platform):
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
 
-        # The resolved Metal config is authoritative here: ``check_and_update_config``
-        # populates the singleton on the driver, and ``MetalWorker.__init__`` re-applies
-        # TurboQuant from ``additional_config`` in each worker process before this hook
-        # runs, so the singleton already reflects TurboQuant in both cases.
         turboquant = metal_config.turboquant
         k_quant = metal_config.k_quant
         v_quant = metal_config.v_quant
@@ -824,7 +806,6 @@ class MetalPlatform(Platform):
         ):
             return
 
-        # Same mamba-state computation as upstream _align_hybrid_block_size.
         model_cls, _ = ModelRegistry.resolve_model_cls(
             model_config.architecture,
             model_config=model_config,
@@ -837,8 +818,6 @@ class MetalPlatform(Platform):
         if mamba_page_size == 0:
             return
 
-        # _turboquant_page_size_bytes is linear in block_size, so the
-        # one-token value scales exactly to any block size.
         tq_page_size_1_token = _turboquant_page_size_bytes(
             block_size=1,
             num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
@@ -859,8 +838,6 @@ class MetalPlatform(Platform):
         )
 
         if cache_config.mamba_cache_mode == "all":
-            # Mirror upstream: with prefix caching, align to the mamba chunk
-            # size for kernel performance.
             from math import lcm
 
             base_chunk_size = (

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -766,12 +766,14 @@ class MetalPlatform(Platform):
             if cache_config.user_specified_mamba_block_size
             else None
         )
+        hash_block_size = cache_config.hash_block_size
         super().update_block_size_for_backend(vllm_config)
 
         cls._realign_hybrid_block_size_for_turboquant(
             vllm_config,
             user_block_size=user_block_size,
             user_mamba_block_size=user_mamba_block_size,
+            hash_block_size=hash_block_size,
         )
 
     @classmethod
@@ -781,6 +783,7 @@ class MetalPlatform(Platform):
         *,
         user_block_size: int | None,
         user_mamba_block_size: int | None,
+        hash_block_size: int | None,
     ) -> None:
         """Redo hybrid alignment with TurboQuant's packed SDPA page size."""
         metal_config = get_config()
@@ -798,6 +801,8 @@ class MetalPlatform(Platform):
             or not model_config.is_hybrid
         ):
             return
+
+        from math import lcm
 
         from vllm.model_executor.models import ModelRegistry
         from vllm.utils.math_utils import cdiv
@@ -832,14 +837,13 @@ class MetalPlatform(Platform):
             s.base if isinstance(s, MultipleOf) else s
             for s in backend_cls.get_supported_kernel_block_sizes()
         )
-        kernel_block_alignment_size = max(
+        kernel_block_alignment_size = lcm(
             backend_block_alignment_size,
-            user_block_size or backend_block_alignment_size,
+            user_block_size or 1,
+            hash_block_size or 1,
         )
 
         if cache_config.mamba_cache_mode == "all":
-            from math import lcm
-
             base_chunk_size = (
                 user_mamba_block_size or model_config.get_mamba_chunk_size()
             )

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -397,15 +397,17 @@ class MetalPlatform(Platform):
         # Disable features not supported on Metal
         parallel_config.disable_custom_all_reduce = True
 
-        if (
-            model_config is not None
-            and model_config.is_hybrid
-            and vllm_config.cache_config.enable_prefix_caching
-        ):
-            raise NotImplementedError(
-                "Prefix caching is not supported for hybrid GDN models on Metal "
-                "because GDN recurrent state cannot be restored from KV blocks."
-            )
+        if model_config is not None and model_config.is_hybrid:
+            cache_config = vllm_config.cache_config
+            if (
+                cache_config.enable_prefix_caching
+                or cache_config.mamba_cache_mode != "none"
+            ):
+                raise NotImplementedError(
+                    "Prefix caching and Mamba cache modes are not supported for "
+                    "hybrid GDN models on Metal because GDN recurrent state cannot "
+                    "be restored from KV blocks."
+                )
 
         # Pipeline parallelism is supported on Metal/MLX: each stage runs in its
         # own worker process and the inter-stage activations cross the

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -789,8 +789,24 @@ class MetalPlatform(Platform):
         metal_config = get_config()
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
+
+        # Gate on additional_config rather than only the process-local
+        # singleton: executors invoke this hook in worker processes too,
+        # where the singleton may not have been populated yet, while
+        # ``additional_config`` travels with the pickled ``vllm_config``.
+        # Defaults mirror ``check_and_update_config``.
+        add = getattr(vllm_config, "additional_config", None) or {}
+        if add.get("turboquant"):
+            turboquant = True
+            k_quant = add.get("k_quant", "q8_0")
+            v_quant = add.get("v_quant", "q3_0")
+        else:
+            turboquant = metal_config.turboquant
+            k_quant = metal_config.k_quant
+            v_quant = metal_config.v_quant
+
         if (
-            not metal_config.turboquant
+            not turboquant
             or not metal_config.use_paged_attention
             or not model_config
             or not model_config.is_hybrid
@@ -816,8 +832,8 @@ class MetalPlatform(Platform):
             block_size=1,
             num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
             head_dim=model_config.get_head_size(),
-            k_quant=metal_config.k_quant,
-            v_quant=metal_config.v_quant,
+            k_quant=k_quant,
+            v_quant=v_quant,
         )
 
         # Kernel alignment straight from the backend (MultipleOf(16)). The

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -759,6 +759,123 @@ class MetalPlatform(Platform):
         # ``block_size`` at request time.
         super().update_block_size_for_backend(vllm_config)
 
+        cls._realign_hybrid_block_size_for_turboquant(vllm_config)
+
+    @classmethod
+    def _realign_hybrid_block_size_for_turboquant(
+        cls, vllm_config: "VllmConfig"
+    ) -> None:
+        """Redo hybrid block-size alignment with TurboQuant page sizes.
+
+        Upstream ``Platform._align_hybrid_block_size`` sizes the attention
+        block with the standard dtype page formula, but TurboQuant packs
+        SDPA pages ~3-4x smaller (vllm-metal#468). Keeping the fp16-based
+        block would make every scheduler-visible page disagree with the
+        runtime layout: ``check_enough_kv_cache_memory`` rejects contexts
+        that fit, and the paged-attention planner budgets ~3-4x fewer
+        blocks than the TurboQuant cache actually needs.
+
+        Mirrors the upstream alignment (same mamba-state math, same
+        kernel-alignment source) with ``attn_page_size_1_token`` computed
+        from the packed TurboQuant layout.
+        """
+        from vllm.model_executor.models import ModelRegistry
+        from vllm.utils.math_utils import cdiv
+        from vllm.v1.attention.backend import MultipleOf
+        from vllm.v1.kv_cache_interface import MambaSpec
+
+        from vllm_metal.v1.cache_policy import _turboquant_page_size_bytes
+
+        metal_config = get_config()
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        if (
+            not metal_config.turboquant
+            or not metal_config.use_paged_attention
+            or not model_config
+            or not model_config.is_hybrid
+        ):
+            return
+
+        # Same mamba-state computation as upstream _align_hybrid_block_size.
+        model_cls, _ = ModelRegistry.resolve_model_cls(
+            model_config.architecture,
+            model_config=model_config,
+        )
+        mamba_page_size = MambaSpec(
+            shapes=model_cls.get_mamba_state_shape_from_config(vllm_config),
+            dtypes=model_cls.get_mamba_state_dtype_from_config(vllm_config),
+            block_size=-1,
+        ).page_size_bytes
+        if mamba_page_size == 0:
+            return
+
+        # _turboquant_page_size_bytes is linear in block_size, so the
+        # one-token value scales exactly to any block size.
+        tq_page_size_1_token = _turboquant_page_size_bytes(
+            block_size=1,
+            num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
+            head_dim=model_config.get_head_size(),
+            k_quant=metal_config.k_quant,
+            v_quant=metal_config.v_quant,
+        )
+
+        # Kernel alignment straight from the backend (MultipleOf(16)). The
+        # upstream max() against cache_config.block_size is skipped here:
+        # at this point block_size already holds the fp16-aligned result of
+        # super(), not the user's value.
+        backend_cls = cls._find_non_ssm_backend(vllm_config)
+        assert backend_cls is not None
+        kernel_block_alignment_size = min(
+            s.base if isinstance(s, MultipleOf) else s
+            for s in backend_cls.get_supported_kernel_block_sizes()
+        )
+
+        if cache_config.mamba_cache_mode == "all":
+            # Mirror upstream: with prefix caching, align to the mamba chunk
+            # size for kernel performance.
+            from math import lcm
+
+            mamba_block_size = (
+                cache_config.mamba_block_size
+                if cache_config.user_specified_mamba_block_size
+                else None
+            )
+            base_chunk_size = mamba_block_size or model_config.get_mamba_chunk_size()
+            assert base_chunk_size is not None
+            attn_tokens_per_mamba_state = cdiv(mamba_page_size, tq_page_size_1_token)
+            chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
+            attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
+            cache_config.mamba_block_size = attn_block_size
+        else:
+            attn_block_size = kernel_block_alignment_size * cdiv(
+                mamba_page_size,
+                kernel_block_alignment_size * tq_page_size_1_token,
+            )
+
+        if cache_config.block_size < attn_block_size:
+            logger.info(
+                "TurboQuant hybrid alignment: attention block size %s -> %d "
+                "tokens so the packed attention page (%d B/token) still "
+                "covers the mamba page (%d B).",
+                cache_config.block_size,
+                attn_block_size,
+                tq_page_size_1_token,
+                mamba_page_size,
+            )
+            cache_config.block_size = attn_block_size
+
+        if cache_config.mamba_cache_mode == "align":
+            cache_config.mamba_block_size = cache_config.block_size
+
+        # Pad mamba page size to exactly match the packed attention page.
+        attn_page_size = cache_config.block_size * tq_page_size_1_token
+        assert attn_page_size >= mamba_page_size
+        if attn_page_size == mamba_page_size:
+            cache_config.mamba_page_size_padded = None
+            return
+        cache_config.mamba_page_size_padded = attn_page_size
+
     @classmethod
     def get_attn_backend_cls(
         cls,

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -758,25 +758,30 @@ class MetalPlatform(Platform):
         # layer (``_pick_kernel_block_size``) validates the final
         # ``block_size`` at request time.
         #
-        # Snapshot the user's mamba block size before super() runs: upstream
-        # ``_align_hybrid_block_size`` overwrites ``cache_config.mamba_block_size``
-        # with its computed ``attn_block_size`` while leaving
-        # ``user_specified_mamba_block_size`` True, so the TurboQuant realign below
-        # would otherwise consume super()'s result as if it were the user's value.
+        cache_config = vllm_config.cache_config
+        user_block_size = (
+            cache_config.block_size if cache_config.user_specified_block_size else None
+        )
         user_mamba_block_size = (
-            vllm_config.cache_config.mamba_block_size
-            if vllm_config.cache_config.user_specified_mamba_block_size
+            cache_config.mamba_block_size
+            if cache_config.user_specified_mamba_block_size
             else None
         )
         super().update_block_size_for_backend(vllm_config)
 
         cls._realign_hybrid_block_size_for_turboquant(
-            vllm_config, user_mamba_block_size
+            vllm_config,
+            user_block_size=user_block_size,
+            user_mamba_block_size=user_mamba_block_size,
         )
 
     @classmethod
     def _realign_hybrid_block_size_for_turboquant(
-        cls, vllm_config: "VllmConfig", user_mamba_block_size: int | None
+        cls,
+        vllm_config: "VllmConfig",
+        *,
+        user_block_size: int | None,
+        user_mamba_block_size: int | None,
     ) -> None:
         """Redo hybrid block-size alignment with TurboQuant page sizes.
 
@@ -842,16 +847,15 @@ class MetalPlatform(Platform):
             v_quant=v_quant,
         )
 
-        # Kernel alignment straight from the backend (MultipleOf(16)). Upstream's
-        # max() against cache_config.block_size is skipped: the realign only grows
-        # block_size (below), and the post-super() value already encodes both the
-        # user's --block-size floor and the fp16 alignment, so the user floor is
-        # never violated.
         backend_cls = cls._find_non_ssm_backend(vllm_config)
         assert backend_cls is not None
-        kernel_block_alignment_size = min(
+        backend_block_alignment_size = min(
             s.base if isinstance(s, MultipleOf) else s
             for s in backend_cls.get_supported_kernel_block_sizes()
+        )
+        kernel_block_alignment_size = max(
+            backend_block_alignment_size,
+            user_block_size or backend_block_alignment_size,
         )
 
         if cache_config.mamba_cache_mode == "all":

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -757,13 +757,26 @@ class MetalPlatform(Platform):
         # (``_align_hybrid_block_size``) handles hybrid alignment. The kernel
         # layer (``_pick_kernel_block_size``) validates the final
         # ``block_size`` at request time.
+        #
+        # Snapshot the user's mamba block size before super() runs: upstream
+        # ``_align_hybrid_block_size`` overwrites ``cache_config.mamba_block_size``
+        # with its computed ``attn_block_size`` while leaving
+        # ``user_specified_mamba_block_size`` True, so the TurboQuant realign below
+        # would otherwise consume super()'s result as if it were the user's value.
+        user_mamba_block_size = (
+            vllm_config.cache_config.mamba_block_size
+            if vllm_config.cache_config.user_specified_mamba_block_size
+            else None
+        )
         super().update_block_size_for_backend(vllm_config)
 
-        cls._realign_hybrid_block_size_for_turboquant(vllm_config)
+        cls._realign_hybrid_block_size_for_turboquant(
+            vllm_config, user_mamba_block_size
+        )
 
     @classmethod
     def _realign_hybrid_block_size_for_turboquant(
-        cls, vllm_config: "VllmConfig"
+        cls, vllm_config: "VllmConfig", user_mamba_block_size: int | None
     ) -> None:
         """Redo hybrid block-size alignment with TurboQuant page sizes.
 
@@ -790,20 +803,13 @@ class MetalPlatform(Platform):
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
 
-        # Gate on additional_config rather than only the process-local
-        # singleton: executors invoke this hook in worker processes too,
-        # where the singleton may not have been populated yet, while
-        # ``additional_config`` travels with the pickled ``vllm_config``.
-        # Defaults mirror ``check_and_update_config``.
-        add = getattr(vllm_config, "additional_config", None) or {}
-        if add.get("turboquant"):
-            turboquant = True
-            k_quant = add.get("k_quant", "q8_0")
-            v_quant = add.get("v_quant", "q3_0")
-        else:
-            turboquant = metal_config.turboquant
-            k_quant = metal_config.k_quant
-            v_quant = metal_config.v_quant
+        # The resolved Metal config is authoritative here: ``check_and_update_config``
+        # populates the singleton on the driver, and ``MetalWorker.__init__`` re-applies
+        # TurboQuant from ``additional_config`` in each worker process before this hook
+        # runs, so the singleton already reflects TurboQuant in both cases.
+        turboquant = metal_config.turboquant
+        k_quant = metal_config.k_quant
+        v_quant = metal_config.v_quant
 
         if (
             not turboquant
@@ -836,10 +842,11 @@ class MetalPlatform(Platform):
             v_quant=v_quant,
         )
 
-        # Kernel alignment straight from the backend (MultipleOf(16)). The
-        # upstream max() against cache_config.block_size is skipped here:
-        # at this point block_size already holds the fp16-aligned result of
-        # super(), not the user's value.
+        # Kernel alignment straight from the backend (MultipleOf(16)). Upstream's
+        # max() against cache_config.block_size is skipped: the realign only grows
+        # block_size (below), and the post-super() value already encodes both the
+        # user's --block-size floor and the fp16 alignment, so the user floor is
+        # never violated.
         backend_cls = cls._find_non_ssm_backend(vllm_config)
         assert backend_cls is not None
         kernel_block_alignment_size = min(
@@ -852,12 +859,9 @@ class MetalPlatform(Platform):
             # size for kernel performance.
             from math import lcm
 
-            mamba_block_size = (
-                cache_config.mamba_block_size
-                if cache_config.user_specified_mamba_block_size
-                else None
+            base_chunk_size = (
+                user_mamba_block_size or model_config.get_mamba_chunk_size()
             )
-            base_chunk_size = mamba_block_size or model_config.get_mamba_chunk_size()
             assert base_chunk_size is not None
             attn_tokens_per_mamba_state = cdiv(mamba_page_size, tq_page_size_1_token)
             chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -804,7 +804,7 @@ class MetalPlatform(Platform):
         from vllm.v1.attention.backend import MultipleOf
         from vllm.v1.kv_cache_interface import MambaSpec
 
-        from vllm_metal.v1.cache_policy import _turboquant_page_size_bytes
+        from vllm_metal.v1.cache_policy import turboquant_page_size_bytes
 
         model_cls, _ = ModelRegistry.resolve_model_cls(
             model_config.architecture,
@@ -818,7 +818,7 @@ class MetalPlatform(Platform):
         if mamba_page_size == 0:
             return
 
-        tq_page_size_1_token = _turboquant_page_size_bytes(
+        tq_page_size_1_token = turboquant_page_size_bytes(
             block_size=1,
             num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
             head_dim=model_config.get_head_size(),

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -783,13 +783,6 @@ class MetalPlatform(Platform):
         user_mamba_block_size: int | None,
     ) -> None:
         """Redo hybrid alignment with TurboQuant's packed SDPA page size."""
-        from vllm.model_executor.models import ModelRegistry
-        from vllm.utils.math_utils import cdiv
-        from vllm.v1.attention.backend import MultipleOf
-        from vllm.v1.kv_cache_interface import MambaSpec
-
-        from vllm_metal.v1.cache_policy import _turboquant_page_size_bytes
-
         metal_config = get_config()
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
@@ -805,6 +798,13 @@ class MetalPlatform(Platform):
             or not model_config.is_hybrid
         ):
             return
+
+        from vllm.model_executor.models import ModelRegistry
+        from vllm.utils.math_utils import cdiv
+        from vllm.v1.attention.backend import MultipleOf
+        from vllm.v1.kv_cache_interface import MambaSpec
+
+        from vllm_metal.v1.cache_policy import _turboquant_page_size_bytes
 
         model_cls, _ = ModelRegistry.resolve_model_cls(
             model_config.architecture,

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -761,18 +761,12 @@ class MetalPlatform(Platform):
         user_block_size = (
             cache_config.block_size if cache_config.user_specified_block_size else None
         )
-        user_mamba_block_size = (
-            cache_config.mamba_block_size
-            if cache_config.user_specified_mamba_block_size
-            else None
-        )
         hash_block_size = cache_config.hash_block_size
         super().update_block_size_for_backend(vllm_config)
 
         cls._realign_hybrid_block_size_for_turboquant(
             vllm_config,
             user_block_size=user_block_size,
-            user_mamba_block_size=user_mamba_block_size,
             hash_block_size=hash_block_size,
         )
 
@@ -782,7 +776,6 @@ class MetalPlatform(Platform):
         vllm_config: "VllmConfig",
         *,
         user_block_size: int | None,
-        user_mamba_block_size: int | None,
         hash_block_size: int | None,
     ) -> None:
         """Redo hybrid alignment with TurboQuant's packed SDPA page size."""
@@ -843,20 +836,10 @@ class MetalPlatform(Platform):
             hash_block_size or 1,
         )
 
-        if cache_config.mamba_cache_mode == "all":
-            base_chunk_size = (
-                user_mamba_block_size or model_config.get_mamba_chunk_size()
-            )
-            assert base_chunk_size is not None
-            attn_tokens_per_mamba_state = cdiv(mamba_page_size, tq_page_size_1_token)
-            chunk_size = lcm(base_chunk_size, kernel_block_alignment_size)
-            attn_block_size = chunk_size * cdiv(attn_tokens_per_mamba_state, chunk_size)
-            cache_config.mamba_block_size = attn_block_size
-        else:
-            attn_block_size = kernel_block_alignment_size * cdiv(
-                mamba_page_size,
-                kernel_block_alignment_size * tq_page_size_1_token,
-            )
+        attn_block_size = kernel_block_alignment_size * cdiv(
+            mamba_page_size,
+            kernel_block_alignment_size * tq_page_size_1_token,
+        )
 
         if cache_config.block_size < attn_block_size:
             logger.info(
@@ -869,9 +852,6 @@ class MetalPlatform(Platform):
                 mamba_page_size,
             )
             cache_config.block_size = attn_block_size
-
-        if cache_config.mamba_cache_mode == "align":
-            cache_config.mamba_block_size = cache_config.block_size
 
         # Pad mamba page size to exactly match the packed attention page.
         attn_page_size = cache_config.block_size * tq_page_size_1_token

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -80,9 +80,11 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
         # vLLM's ``is_kv_cache_spec_uniform`` probes uniformity by calling
         # ``merge`` on the full spec list and treats AssertionError as "not
         # uniform" (its except clause catches nothing else). Hybrid models
-        # legitimately reach this probe with a mixed TurboQuant+Mamba dict,
-        # so type/config mismatches here must surface as AssertionError,
-        # matching ``KVCacheSpec.merge``'s assert-based contract.
+        # legitimately reach this probe with a mixed TurboQuant+Mamba dict, and
+        # a non-TurboQuant spec in the list is exactly that signal — so it must
+        # surface as AssertionError for the probe to answer "not uniform".
+        # Genuinely broken groups (empty input, mixed k/v quant) are not the
+        # probe's concern and stay ValueError so they fail loudly.
         turbo_specs: list[TurboQuantAttentionSpec] = []
         for spec in specs:
             if not isinstance(spec, TurboQuantAttentionSpec):
@@ -92,12 +94,12 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
                 )
             turbo_specs.append(spec)
         if not turbo_specs:
-            raise AssertionError("TurboQuantAttentionSpec.merge() requires specs")
+            raise ValueError("TurboQuantAttentionSpec.merge() requires specs")
 
         k_set = {s.k_quant for s in turbo_specs}
         v_set = {s.v_quant for s in turbo_specs}
         if len(k_set) != 1 or len(v_set) != 1:
-            raise AssertionError(
+            raise ValueError(
                 "All TurboQuant layers in the same cache group must share the "
                 "same (k_quant, v_quant); mixed-quant groups are not supported."
             )
@@ -416,16 +418,16 @@ class ModelCachePolicy:
         if self._use_turboquant(config):
             # _turboquant_page_size_bytes is parameterised by tokens (block_size);
             # pass aligned_tokens to get the per-sequence byte total directly.
-            tq_bytes = num_kv_layers * _turboquant_page_size_bytes(
+            # TurboQuant requires paged attention, whose capacity is reported via
+            # the paged planner (num_blocks x per-block bytes), not this
+            # single-sequence estimator — so hybrid+TQ never reaches here.
+            return num_kv_layers * _turboquant_page_size_bytes(
                 block_size=aligned_tokens,
                 num_kv_heads=self._runner.num_kv_heads,
                 head_dim=self._runner.head_dim,
                 k_quant=config.k_quant,
                 v_quant=config.v_quant,
             )
-            if self._runner.is_hybrid:
-                return tq_bytes + self.linear_cache_bytes_per_slot()
-            return tq_bytes
 
         sdpa_kv_bytes = (
             self._kv_factor() * aligned_tokens * dtype_size * self._kv_layer_size_sum()

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -77,21 +77,27 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
 
     @classmethod
     def merge(cls, specs: Sequence[FullAttentionSpec]) -> TurboQuantAttentionSpec:
+        # vLLM's ``is_kv_cache_spec_uniform`` probes uniformity by calling
+        # ``merge`` on the full spec list and treats AssertionError as "not
+        # uniform" (its except clause catches nothing else). Hybrid models
+        # legitimately reach this probe with a mixed TurboQuant+Mamba dict,
+        # so type/config mismatches here must surface as AssertionError,
+        # matching ``KVCacheSpec.merge``'s assert-based contract.
         turbo_specs: list[TurboQuantAttentionSpec] = []
         for spec in specs:
             if not isinstance(spec, TurboQuantAttentionSpec):
-                raise TypeError(
+                raise AssertionError(
                     "All attention layers in the same KV cache group must be "
                     "TurboQuantAttentionSpec."
                 )
             turbo_specs.append(spec)
         if not turbo_specs:
-            raise ValueError("TurboQuantAttentionSpec.merge() requires specs")
+            raise AssertionError("TurboQuantAttentionSpec.merge() requires specs")
 
         k_set = {s.k_quant for s in turbo_specs}
         v_set = {s.v_quant for s in turbo_specs}
         if len(k_set) != 1 or len(v_set) != 1:
-            raise ValueError(
+            raise AssertionError(
                 "All TurboQuant layers in the same cache group must share the "
                 "same (k_quant, v_quant); mixed-quant groups are not supported."
             )

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -67,7 +67,7 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
-        return _turboquant_page_size_bytes(
+        return turboquant_page_size_bytes(
             block_size=self.block_size,
             num_kv_heads=self.num_kv_heads,
             head_dim=self.head_size,
@@ -119,7 +119,7 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
         )
 
 
-def _turboquant_page_size_bytes(
+def turboquant_page_size_bytes(
     block_size: int, num_kv_heads: int, head_dim: int, k_quant: str, v_quant: str
 ) -> int:
     """Calculate TurboQuant-compressed page size for one layer."""
@@ -332,7 +332,7 @@ class ModelCachePolicy:
         # TurboQuant uses quantized KV cache with different byte layout
         config = get_config()
         if self._use_turboquant(config):
-            return num_kv_layers * _turboquant_page_size_bytes(
+            return num_kv_layers * turboquant_page_size_bytes(
                 block_size=block_size,
                 num_kv_heads=self._runner.num_kv_heads,
                 head_dim=self._runner.head_dim,
@@ -409,7 +409,7 @@ class ModelCachePolicy:
         # TurboQuant uses quantized KV cache with different byte layout
         config = get_config()
         if self._use_turboquant(config):
-            return num_kv_layers * _turboquant_page_size_bytes(
+            return num_kv_layers * turboquant_page_size_bytes(
                 block_size=aligned_tokens,
                 num_kv_heads=self._runner.num_kv_heads,
                 head_dim=self._runner.head_dim,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -77,14 +77,7 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
 
     @classmethod
     def merge(cls, specs: Sequence[FullAttentionSpec]) -> TurboQuantAttentionSpec:
-        # vLLM's ``is_kv_cache_spec_uniform`` probes uniformity by calling
-        # ``merge`` on the full spec list and treats AssertionError as "not
-        # uniform" (its except clause catches nothing else). Hybrid models
-        # legitimately reach this probe with a mixed TurboQuant+Mamba dict, and
-        # a non-TurboQuant spec in the list is exactly that signal — so it must
-        # surface as AssertionError for the probe to answer "not uniform".
-        # Genuinely broken groups (empty input, mixed k/v quant) are not the
-        # probe's concern and stay ValueError so they fail loudly.
+        # vLLM's uniformity probe treats AssertionError as "mixed spec type".
         turbo_specs: list[TurboQuantAttentionSpec] = []
         for spec in specs:
             if not isinstance(spec, TurboQuantAttentionSpec):
@@ -416,11 +409,6 @@ class ModelCachePolicy:
         # TurboQuant uses quantized KV cache with different byte layout
         config = get_config()
         if self._use_turboquant(config):
-            # _turboquant_page_size_bytes is parameterised by tokens (block_size);
-            # pass aligned_tokens to get the per-sequence byte total directly.
-            # TurboQuant requires paged attention, whose capacity is reported via
-            # the paged planner (num_blocks x per-block bytes), not this
-            # single-sequence estimator — so hybrid+TQ never reaches here.
             return num_kv_layers * _turboquant_page_size_bytes(
                 block_size=aligned_tokens,
                 num_kv_heads=self._runner.num_kv_heads,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -410,13 +410,16 @@ class ModelCachePolicy:
         if self._use_turboquant(config):
             # _turboquant_page_size_bytes is parameterised by tokens (block_size);
             # pass aligned_tokens to get the per-sequence byte total directly.
-            return num_kv_layers * _turboquant_page_size_bytes(
+            tq_bytes = num_kv_layers * _turboquant_page_size_bytes(
                 block_size=aligned_tokens,
                 num_kv_heads=self._runner.num_kv_heads,
                 head_dim=self._runner.head_dim,
                 k_quant=config.k_quant,
                 v_quant=config.v_quant,
             )
+            if self._runner.is_hybrid:
+                return tq_bytes + self.linear_cache_bytes_per_slot()
+            return tq_bytes
 
         sdpa_kv_bytes = (
             self._kv_factor() * aligned_tokens * dtype_size * self._kv_layer_size_sum()
@@ -542,9 +545,11 @@ class ModelCachePolicy:
         return self._runner.num_kv_cache_layers
 
     def _use_turboquant(self, config: MetalConfig) -> bool:
-        return bool(
-            config.turboquant and not self._runner.is_hybrid and not self._runner.is_mla
-        )
+        # Hybrid models compress their SDPA layers too (see
+        # ``_build_hybrid_backend``), so they must not be excluded here:
+        # every scheduler-visible sizing path (specs, per-block bytes,
+        # one-sequence estimates) has to agree with the runtime layout.
+        return bool(config.turboquant and not self._runner.is_mla)
 
     def _kv_factor(self) -> int:
         return 1 if self._runner.is_mla else 2


### PR DESCRIPTION
Fixes #468

The hybrid runtime compresses SDPA layers when TurboQuant is enabled (`_build_hybrid_backend` forwards `turboquant=config.turboquant`), but `_use_turboquant()` excluded hybrid models from every scheduler-visible sizing path. Root-cause analysis with a model-free repro is in [#468 (comment)](https://github.com/vllm-project/vllm-metal/issues/468#issuecomment-4883093460) — the spec page the engine checks is exactly the compression ratio (3.37x for q4_0/q4_0) larger than the page the runtime allocates, so `check_enough_kv_cache_memory` rejects contexts that fit and the planner budgets ~3.4x fewer blocks than the packed cache supports.

What this changes:

- `ModelCachePolicy._use_turboquant()` no longer excludes hybrids: SDPA layers of hybrid models get `TurboQuantAttentionSpec` (packed `real_page_size_bytes`), and `get_cache_block_size_bytes()` budgets the paged pool with the packed page.
- The TurboQuant branch of `estimate_one_sequence_kv_bytes()` now adds the GDN linear state (`linear_cache_bytes_per_slot()`) for hybrids, mirroring the fp16 branch.
- New `MetalPlatform._realign_hybrid_block_size_for_turboquant()`, called after upstream's `update_block_size_for_backend`: upstream `_align_hybrid_block_size` sizes the attention block with the standard dtype formula, so with packed pages the attention page would no longer cover the mamba page and upstream `unify_kv_cache_spec_page_size` would fail (the packed page does not evenly divide the fp16-padded mamba page). The realignment mirrors upstream's math with the packed per-token page: it grows `block_size` accordingly and pads `mamba_page_size_padded` to exactly the packed attention page, so page-size unification sees equal pages by construction.

Testing:

- `pytest tests/test_turboquant_hybrid_sizing.py` — 6 new regression tests (specs / per-block bytes / one-sequence estimate / alignment); all 6 fail before the fix, pass after.
- `pytest -m "not slow" tests/` — 1198 passed, 17 skipped. The 104 failing tests are the Metal-kernel suites failing at import ("Prebuilt native extension not found") in this dev env without prebuilt artifacts — verified identical on `main`.
- `ruff check`, `ruff format --check`, `mypy vllm_metal` — clean.

Worth discussing as a follow-up: vLLM 0.24 has native TurboQuant spec machinery (`TQFullAttentionSpec`, `cache_dtype="turboquant_*"` alignment in `Platform._align_hybrid_block_size`); migrating the plugin's TurboQuant onto it would remove the mirrored alignment added here.