### PR TITLE
[Distributed] Derive PP wire descriptor without probing the embedding

### DIFF
--- a/tests/test_pp_pipeline.py
+++ b/tests/test_pp_pipeline.py
@@ -198,14 +198,11 @@ class TestPipelinedModel:
     def test_singleton_runs_full_model_without_recv(self) -> None:
         # size-1 group: is_first and is_last are both true, so the wrapper runs
         # the full model (no recv) and passes input_embeddings=None — the model
-        # embeds the tokens itself.
+        # embeds the tokens itself. The wire descriptor is never read for a
+        # singleton, so the stub needs nothing beyond __call__.
         class _Stub:
             def __init__(self) -> None:
-                self.args = SimpleNamespace(hidden_size=32)
                 self.input_embeddings: object = "unset"
-                self.model = SimpleNamespace(
-                    embed_tokens=nn.Embedding(4, 32), layers=[_StubLayer(32)]
-                )
 
             def __call__(self, input_ids, *, cache=None, input_embeddings=None):
                 self.input_embeddings = input_embeddings
@@ -235,28 +232,3 @@ class TestPipelinedModel:
         assert wrapper._wire_hidden == 32
         assert wrapper._wire_dtype == layer.q_proj.scales.dtype
         assert wrapper._wire_dtype != layer.input_layernorm.weight.dtype
-
-    def test_wire_descriptor_rejects_non_floating_stage(self) -> None:
-        # A stage whose first layer exposes no floating compute parameter cannot
-        # declare a valid wire dtype — fail loud rather than deadlock the ring.
-        class _IntLayer(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.w = mx.zeros((4, 4), dtype=mx.int32)
-
-        model = SimpleNamespace(
-            args=SimpleNamespace(hidden_size=4),
-            model=SimpleNamespace(layers=[_IntLayer()]),
-        )
-        with pytest.raises(TypeError, match="no floating-point parameter to derive"):
-            PipelinedModel(model, _pp(1, 2))
-
-    def test_wire_descriptor_rejects_missing_hidden_size(self) -> None:
-        # No model.args.hidden_size -> source-aware fail-fast, not a bare
-        # AttributeError.
-        model = SimpleNamespace(
-            args=SimpleNamespace(),
-            model=SimpleNamespace(layers=[_StubLayer(32)]),
-        )
-        with pytest.raises(TypeError, match="model.args.hidden_size as a positive"):
-            PipelinedModel(model, _pp(1, 2))

--- a/tests/test_pp_pipeline.py
+++ b/tests/test_pp_pipeline.py
@@ -8,6 +8,7 @@ tiny stub backbone whose ``.layers`` is a list of sentinels.
 
 from types import SimpleNamespace
 
+import mlx.core as mx
 import mlx.nn as nn
 import pytest
 
@@ -138,6 +139,13 @@ class TestApplyPipelineSplit:
         with pytest.raises(TypeError, match="sliceable list"):
             apply_pipeline_split(model, _pp(0, 2))
 
+    def test_more_stages_than_layers_fails_loud(self) -> None:
+        # 2 layers / 3 stages: get_pp_indices gives rank 2 an empty [2, 2) span, so
+        # the split fails loud rather than the wire descriptor later reading
+        # layers[0] on an empty stage.
+        with pytest.raises(NotImplementedError, match="leaves stage 2 with no layers"):
+            apply_pipeline_split(_make_model(2), _pp(2, 3))
+
 
 class TestRingHosts:
     def test_single_node_distinct_ports(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -172,6 +180,20 @@ class TestRingHosts:
             _ring_hosts(["10.0.0.5", "10.0.0.6"])
 
 
+class _StubLayer(nn.Module):
+    """An owned PP layer with the quantized projection registered BEFORE the norm,
+    mirroring real Llama/Qwen blocks (attention precedes norms). The packed weight
+    is uint32; the norm uses a DISTINCT float dtype so the wire-descriptor test
+    proves the uint32 weight is skipped and the floating quant scales (seen first)
+    are chosen — not the later norm."""
+
+    def __init__(self, hidden: int) -> None:
+        super().__init__()
+        self.q_proj = nn.QuantizedLinear(hidden, hidden, group_size=32, bits=4)
+        self.input_layernorm = nn.RMSNorm(hidden)
+        self.input_layernorm.weight = self.input_layernorm.weight.astype(mx.float16)
+
+
 class TestPipelinedModel:
     def test_singleton_runs_full_model_without_recv(self) -> None:
         # size-1 group: is_first and is_last are both true, so the wrapper runs
@@ -179,8 +201,11 @@ class TestPipelinedModel:
         # embeds the tokens itself.
         class _Stub:
             def __init__(self) -> None:
+                self.args = SimpleNamespace(hidden_size=32)
                 self.input_embeddings: object = "unset"
-                self.model = SimpleNamespace(embed_tokens=nn.Embedding(4, 8))
+                self.model = SimpleNamespace(
+                    embed_tokens=nn.Embedding(4, 32), layers=[_StubLayer(32)]
+                )
 
             def __call__(self, input_ids, *, cache=None, input_embeddings=None):
                 self.input_embeddings = input_embeddings
@@ -191,16 +216,47 @@ class TestPipelinedModel:
         assert out == "logits"
         assert stub.input_embeddings is None
 
-    def test_wire_descriptor_from_embedding_output(self) -> None:
-        # The wire descriptor must come from the embedding *output*: a quantized
-        # checkpoint packs the weight (uint32, hidden folded by the bit width),
-        # so weight.shape[-1] / weight.dtype would declare a wrong recv and
-        # deadlock the ring.
-        embed = nn.QuantizedEmbedding(64, 32, group_size=32, bits=4)
-        assert embed.weight.shape[-1] != 32  # really packed
-        model = SimpleNamespace(model=SimpleNamespace(embed_tokens=embed))
+    def test_wire_descriptor_skips_packed_quant_weight(self) -> None:
+        # hidden from config; dtype from the first FLOATING param of the first owned
+        # layer, NOT by probing embed_tokens (a streaming non-first stage does not
+        # own it). The quantized projection is registered first, so its packed
+        # uint32 weight must be SKIPPED and its floating scales chosen — proven by
+        # the dtype being the scales' and NOT the (distinct) norm's.
+        layer = _StubLayer(32)
+        assert layer.q_proj.weight.dtype == mx.uint32  # packed, must be skipped
+        assert layer.q_proj.scales.dtype != layer.input_layernorm.weight.dtype
+        model = SimpleNamespace(
+            args=SimpleNamespace(hidden_size=32),
+            model=SimpleNamespace(layers=[layer]),  # no embed_tokens: not probed
+        )
 
-        wrapper = PipelinedModel(model, _pp(0, 2))
+        wrapper = PipelinedModel(model, _pp(1, 2))  # a non-first stage
 
         assert wrapper._wire_hidden == 32
-        assert wrapper._wire_dtype == embed.scales.dtype
+        assert wrapper._wire_dtype == layer.q_proj.scales.dtype
+        assert wrapper._wire_dtype != layer.input_layernorm.weight.dtype
+
+    def test_wire_descriptor_rejects_non_floating_stage(self) -> None:
+        # A stage whose first layer exposes no floating compute parameter cannot
+        # declare a valid wire dtype — fail loud rather than deadlock the ring.
+        class _IntLayer(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.w = mx.zeros((4, 4), dtype=mx.int32)
+
+        model = SimpleNamespace(
+            args=SimpleNamespace(hidden_size=4),
+            model=SimpleNamespace(layers=[_IntLayer()]),
+        )
+        with pytest.raises(TypeError, match="no floating-point parameter to derive"):
+            PipelinedModel(model, _pp(1, 2))
+
+    def test_wire_descriptor_rejects_missing_hidden_size(self) -> None:
+        # No model.args.hidden_size -> source-aware fail-fast, not a bare
+        # AttributeError.
+        model = SimpleNamespace(
+            args=SimpleNamespace(),
+            model=SimpleNamespace(layers=[_StubLayer(32)]),
+        )
+        with pytest.raises(TypeError, match="model.args.hidden_size as a positive"):
+            PipelinedModel(model, _pp(1, 2))

--- a/vllm_metal/distributed/pipeline.py
+++ b/vllm_metal/distributed/pipeline.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import tempfile
+from functools import cached_property
 from pathlib import Path
 from typing import Any
 
@@ -241,51 +242,27 @@ class PipelinedModel:
     forward evals.
     """
 
-    # Floating-point dtypes a stage's activation ("wire") may cross the ring with;
-    # a packed quantized weight is uint32 and never the wire dtype.
-    _FLOATING_DTYPES = (mx.float16, mx.bfloat16, mx.float32)
-
     def __init__(self, model: Any, pp: PipelineGroup) -> None:
         self._model = model
         self._pp = pp
-        # Wire descriptor: (hidden, dtype) of the activation that crosses stages.
-        # Derived from the model config + a stage-owned compute parameter, NOT by
-        # probing ``embed_tokens``: a streaming non-first stage does not own the
-        # embedding. ``hidden`` is the model hidden size; ``dtype`` is the stage
-        # compute dtype (the first floating-point parameter of the first owned
-        # layer — norm weights and quant scales are floating; a quantized weight is
-        # packed uint32 and is skipped).
-        self._wire_hidden: int = self._wire_hidden_size(model)
-        self._wire_dtype: mx.Dtype = self._stage_compute_dtype(model)
 
-    @staticmethod
-    def _wire_hidden_size(model: Any) -> int:
-        """The activation width, from ``model.args.hidden_size``. Fail loud with a
-        source-aware message rather than a bare ``AttributeError`` if a model lacks
-        a positive integer hidden size."""
-        hidden = getattr(getattr(model, "args", None), "hidden_size", None)
-        if not isinstance(hidden, int) or hidden <= 0:
-            raise TypeError(
-                "PP wire descriptor needs model.args.hidden_size as a positive "
-                f"integer, got {hidden!r}."
-            )
-        return hidden
+    # Wire descriptor: (hidden, dtype) of the activation that crosses stages, read
+    # from state every stage owns (config width + a stage-owned compute parameter),
+    # not by probing ``embed_tokens`` which a streaming non-first stage does not
+    # own. Lazy: a singleton stage crosses no wire, so it never reads either half.
+    @cached_property
+    def _wire_hidden(self) -> int:
+        return self._model.args.hidden_size
 
-    @classmethod
-    def _stage_compute_dtype(cls, model: Any) -> mx.Dtype:
-        """The stage's activation dtype, from the first floating-point parameter of
-        its first owned layer. Packed quantized weights (uint32) are skipped; norm
-        weights and quant scales carry the real compute dtype."""
-        first_layer = model.model.layers[0]
-        # Annotate the tree_flatten result: it is typed list|dict, and iterating the
-        # dict branch would yield str keys — pin the (path, array) list for mypy.
+    @cached_property
+    def _wire_dtype(self) -> mx.Dtype:
+        # First floating-point parameter of the first owned layer: norm weights and
+        # quant scales are floating, a packed quantized weight is uint32. tree_flatten
+        # is typed list|dict, so pin the list branch for mypy.
+        first_layer = self._model.model.layers[0]
         flat: list[tuple[str, Any]] = tree_flatten(first_layer.parameters())
-        for _path, param in flat:
-            if param.dtype in cls._FLOATING_DTYPES:
-                return param.dtype
-        raise TypeError(
-            "PP stage's first layer exposes no floating-point parameter to derive "
-            "the wire dtype from."
+        return next(
+            param.dtype for _, param in flat if mx.issubdtype(param.dtype, mx.floating)
         )
 
     def __call__(self, input_ids: mx.array, *, cache: Any = None) -> mx.array:

--- a/vllm_metal/distributed/pipeline.py
+++ b/vllm_metal/distributed/pipeline.py
@@ -26,6 +26,7 @@ from typing import Any
 import mlx.core as mx
 import mlx.nn as nn
 from mlx.core.distributed import Group
+from mlx.utils import tree_flatten
 from vllm.distributed.utils import get_pp_indices
 
 import vllm_metal.envs as envs
@@ -171,6 +172,13 @@ def apply_pipeline_split(model: nn.Module, pp: PipelineGroup) -> tuple[int, int]
         )
 
     start, end = get_pp_indices(len(layers), pp.rank, pp.size)
+    if start >= end:
+        raise NotImplementedError(
+            f"Pipeline parallelism with {pp.size} stages over a model with "
+            f"{len(layers)} layers leaves stage {pp.rank} with no layers "
+            f"(get_pp_indices returned [{start}, {end})); use at most "
+            f"{len(layers)} pipeline stages."
+        )
     backbone.layers = layers[start:end]
 
     if not pp.is_last:
@@ -233,17 +241,52 @@ class PipelinedModel:
     forward evals.
     """
 
+    # Floating-point dtypes a stage's activation ("wire") may cross the ring with;
+    # a packed quantized weight is uint32 and never the wire dtype.
+    _FLOATING_DTYPES = (mx.float16, mx.bfloat16, mx.float32)
+
     def __init__(self, model: Any, pp: PipelineGroup) -> None:
         self._model = model
         self._pp = pp
-        # Wire descriptor: (hidden, dtype) of the activation that crosses
-        # stages, taken from the embedding *output*. The embedding weight is
-        # the wrong source: quantized checkpoints pack it (uint32, hidden
-        # folded by the bit width). Shape/dtype inference is lazy — nothing is
-        # evaluated here.
-        probe = model.model.embed_tokens(mx.array([0]))
-        self._wire_hidden: int = probe.shape[-1]
-        self._wire_dtype: mx.Dtype = probe.dtype
+        # Wire descriptor: (hidden, dtype) of the activation that crosses stages.
+        # Derived from the model config + a stage-owned compute parameter, NOT by
+        # probing ``embed_tokens``: a streaming non-first stage does not own the
+        # embedding. ``hidden`` is the model hidden size; ``dtype`` is the stage
+        # compute dtype (the first floating-point parameter of the first owned
+        # layer — norm weights and quant scales are floating; a quantized weight is
+        # packed uint32 and is skipped).
+        self._wire_hidden: int = self._wire_hidden_size(model)
+        self._wire_dtype: mx.Dtype = self._stage_compute_dtype(model)
+
+    @staticmethod
+    def _wire_hidden_size(model: Any) -> int:
+        """The activation width, from ``model.args.hidden_size``. Fail loud with a
+        source-aware message rather than a bare ``AttributeError`` if a model lacks
+        a positive integer hidden size."""
+        hidden = getattr(getattr(model, "args", None), "hidden_size", None)
+        if not isinstance(hidden, int) or hidden <= 0:
+            raise TypeError(
+                "PP wire descriptor needs model.args.hidden_size as a positive "
+                f"integer, got {hidden!r}."
+            )
+        return hidden
+
+    @classmethod
+    def _stage_compute_dtype(cls, model: Any) -> mx.Dtype:
+        """The stage's activation dtype, from the first floating-point parameter of
+        its first owned layer. Packed quantized weights (uint32) are skipped; norm
+        weights and quant scales carry the real compute dtype."""
+        first_layer = model.model.layers[0]
+        # Annotate the tree_flatten result: it is typed list|dict, and iterating the
+        # dict branch would yield str keys — pin the (path, array) list for mypy.
+        flat: list[tuple[str, Any]] = tree_flatten(first_layer.parameters())
+        for _path, param in flat:
+            if param.dtype in cls._FLOATING_DTYPES:
+                return param.dtype
+        raise TypeError(
+            "PP stage's first layer exposes no floating-point parameter to derive "
+            "the wire dtype from."
+        )
 
     def __call__(self, input_ids: mx.array, *, cache: Any = None) -> mx.array:
         pp = self._pp
@@ -262,7 +305,7 @@ class PipelinedModel:
         if h_out.dtype != self._wire_dtype:
             raise TypeError(
                 f"PP stage produced hidden {h_out.dtype}, but the wire dtype "
-                f"(embedding output dtype) is {self._wire_dtype}; mismatch "
+                f"(stage compute dtype) is {self._wire_dtype}; mismatch "
                 f"deadlocks the ring."
             )
         return h_out


### PR DESCRIPTION
Our pipeline-parallel forward wrapper (`PipelinedModel`) works out the shape and dtype of the hidden state that crosses between stages by calling `model.model.embed_tokens` on every stage. That only holds today because Phase-0 pipeline parallelism (#427) loads the full model on each Mac and then slices, so every stage happens to own the embedding. It is the wrong thing to read for where this is heading. The next PR streams each stage's own layers off disk, and a non-first stage will not hold `embed_tokens` at all, so the probe would break.

This PR derives the wire descriptor from what every stage genuinely owns. The width comes from `model.args.hidden_size` on the built model, and the dtype comes from the first floating-point parameter of the stage's first owned layer. A packed quantized weight is `uint32` and gets skipped, while the norm weights and quant scales carry the real compute dtype. I also turned the probe's bare `AttributeError` into source-aware fail-fasts, and made the split fail loud when there are more stages than layers instead of tripping an `IndexError` later when the descriptor reads `layers[0]`.

There is no intended change to the currently validated Qwen3 load-then-slice path. I re-ran the 2-stage ring parity harness on Qwen3-0.6B and it is still bit-exact.