### PR TITLE
Trim non-paged rotating cache glue

### DIFF
--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -9,19 +9,7 @@ from vllm_metal.v1 import contiguous_cache
 
 
 class TestHybridCacheMergeExtract:
-    """Regression tests for hybrid (KV + ArraysCache) batching.
-
-    Background:
-    - `mlx-lm==0.30.6` removed `MambaCache` and hybrid models now use `ArraysCache`.
-    - vllm-metal keeps a small `ArraysCache` merge/extract path so partially
-      populated state entries still round-trip.
-    - Rotating KV merge is delegated to the current `mlx-lm`
-      `BatchRotatingKVCache.merge` implementation.
-
-    These tests validate that vllm-metal can merge per-request caches into a batched
-    cache, run a batched forward pass, and then extract per-request caches back,
-    without depending on `MambaCache`.
-    """
+    """Non-paged cache merge/extract round-trip tests."""
 
     _ARRAYS_CACHE_ENTRIES = 2
     _ARRAYS_CACHE_FEATURES = 4
@@ -173,13 +161,7 @@ class TestHybridCacheMergeExtract:
         assert extracted_req1.offset == cache_req1.offset
 
     def test_rotating_kvcache_merge_handles_offset_exceeding_max_size(self) -> None:
-        """Merging works when offset > max_size (cache has rotated).
-
-        This protects vllm-metal's reliance on ``BatchRotatingKVCache.merge``:
-        the merge must size by effective sliding-window length, not cumulative
-        offset, after the cache rotates past its maximum size.
-        """
-        # offset=300 >> max_size=8 — the cache has rotated many times
+        """Merging works after the cache has rotated."""
         cache_req0 = self._make_rotating_kv_cache(
             max_size=8, total_tokens=300, value=1.0
         )
@@ -201,12 +183,7 @@ class TestHybridCacheMergeExtract:
         assert extracted_req1.offset == cache_req1.offset
 
     def test_rotating_kvcache_merge_handles_prefill_exceeding_max_size(self) -> None:
-        """Merging works when prefill length exceeds max_size.
-
-        After a large prefill the internal buffer may temporarily be larger than
-        ``max_size``.  The merge must trim to the effective sliding-window length.
-        """
-        # Prefill 128 tokens into a cache with max_size=70
+        """Merging works when prefill length exceeds max_size."""
         cache_req0 = contiguous_cache.RotatingKVCache(max_size=70)
         big_k = mx.full(
             (1, self._KV_NUM_HEADS, 128, self._KV_HEAD_DIM), 1.0, dtype=mx.float32
@@ -231,12 +208,7 @@ class TestHybridCacheMergeExtract:
         assert extracted_req1.offset == cache_req1.offset
 
     def test_rotating_kvcache_merge_decode_extract_roundtrip(self) -> None:
-        """Merged cache can be used for a batched decode step and extracted back.
-
-        This verifies that the internal state (_idx, _offset) returned by
-        ``BatchRotatingKVCache.merge`` is compatible with
-        ``BatchRotatingKVCache.update_and_fetch`` and ``extract``.
-        """
+        """Merged rotating cache can decode once and extract back."""
         cache_req0 = self._make_rotating_kv_cache(
             max_size=8, total_tokens=20, value=1.0
         )
@@ -246,12 +218,10 @@ class TestHybridCacheMergeExtract:
         batch_cache = merged[0]
         assert isinstance(batch_cache, contiguous_cache.BatchRotatingKVCache)
 
-        # Simulate one batched decode step (S=1)
         decode_k = mx.ones((2, self._KV_NUM_HEADS, 1, self._KV_HEAD_DIM))
         decode_v = mx.ones((2, self._KV_NUM_HEADS, 1, self._KV_HEAD_DIM))
         batch_cache.update_and_fetch(decode_k, decode_v)
 
-        # Extract back to per-request caches
         extracted_req0 = batch_cache.extract(0)
         extracted_req1 = batch_cache.extract(1)
 
@@ -261,14 +231,7 @@ class TestHybridCacheMergeExtract:
         assert extracted_req1.offset == cache_req1.offset + 1
 
     def test_extracted_rotating_cache_can_decode_after_rotation(self) -> None:
-        """Extracted RotatingKVCache can continue decoding after offset > max_size.
-
-        After merge -> extract, the extracted cache may have offset > max_size
-        but keys.shape[2] < max_size (buffer sliced by extract).  Without the
-        buffer padding fix in ``_extract_kv_cache``, the next
-        ``_update_in_place`` call would compute a negative ``new_size`` and
-        crash with ``ValueError: [full] Negative dimensions not allowed``.
-        """
+        """Extracted rotating cache can keep decoding after rotation."""
         cache_req0 = self._make_rotating_kv_cache(
             max_size=8, total_tokens=300, value=1.0
         )
@@ -283,7 +246,6 @@ class TestHybridCacheMergeExtract:
         assert extracted_req0.offset > extracted_req0.max_size
         assert extracted_req0.keys.shape[2] == extracted_req0.max_size
 
-        # This would crash without the buffer padding fix
         decode_k = mx.ones(
             (1, self._KV_NUM_HEADS, 1, self._KV_HEAD_DIM), dtype=mx.float32
         )

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -13,11 +13,14 @@ class TestHybridCacheMergeExtract:
 
     Background:
     - `mlx-lm==0.30.6` removed `MambaCache` and hybrid models now use `ArraysCache`.
-    - Older mlx-lm versions don't provide `ArraysCache.merge()` / `extract()`.
+    - vllm-metal keeps a small `ArraysCache` merge/extract path so partially
+      populated state entries still round-trip.
+    - Rotating KV merge is delegated to the current `mlx-lm`
+      `BatchRotatingKVCache.merge` implementation.
 
     These tests validate that vllm-metal can merge per-request caches into a batched
     cache, run a batched forward pass, and then extract per-request caches back,
-    without depending on `MambaCache` or new mlx-lm APIs.
+    without depending on `MambaCache`.
     """
 
     _ARRAYS_CACHE_ENTRIES = 2
@@ -172,9 +175,9 @@ class TestHybridCacheMergeExtract:
     def test_rotating_kvcache_merge_handles_offset_exceeding_max_size(self) -> None:
         """Merging works when offset > max_size (cache has rotated).
 
-        This is a regression test for a bug in ``BatchRotatingKVCache.merge``
-        (mlx-lm <= 0.29.1) where using ``c.offset`` instead of ``len(c)`` caused
-        a broadcast shape error after the cache rotated past its maximum size.
+        This protects vllm-metal's reliance on ``BatchRotatingKVCache.merge``:
+        the merge must size by effective sliding-window length, not cumulative
+        offset, after the cache rotates past its maximum size.
         """
         # offset=300 >> max_size=8 — the cache has rotated many times
         cache_req0 = self._make_rotating_kv_cache(
@@ -230,8 +233,8 @@ class TestHybridCacheMergeExtract:
     def test_rotating_kvcache_merge_decode_extract_roundtrip(self) -> None:
         """Merged cache can be used for a batched decode step and extracted back.
 
-        This verifies that the internal state (_idx, _offset) set by
-        ``_merge_rotating_kv_caches`` is compatible with
+        This verifies that the internal state (_idx, _offset) returned by
+        ``BatchRotatingKVCache.merge`` is compatible with
         ``BatchRotatingKVCache.update_and_fetch`` and ``extract``.
         """
         cache_req0 = self._make_rotating_kv_cache(

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -77,79 +77,6 @@ def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
     return extracted
 
 
-def _merge_rotating_kv_caches(
-    caches: list[RotatingKVCache],
-) -> BatchRotatingKVCache:
-    """Merge per-request RotatingKVCache objects into a single BatchRotatingKVCache.
-
-    This mirrors ``BatchRotatingKVCache.merge`` but pre-computes the temporal-ordered
-    keys/values, trims them to ``len(cache)`` (the effective sliding-window length),
-    and uses that length for the copy width.  The upstream implementation in
-    mlx-lm <= 0.29.1 uses ``c.offset`` which can exceed the underlying array size
-    after the cache has rotated, causing a broadcast shape error.
-
-    This workaround can be removed once vllm-metal can depend on an mlx-lm version
-    that includes the upstream fix (ml-explore/mlx-lm#738) and has been verified
-    to work with gpt-oss models end-to-end.
-    """
-    if not caches:
-        raise ValueError("caches must be non-empty")
-
-    if any(c.keys is None or c.values is None for c in caches):
-        raise ValueError(
-            "Cannot merge unpopulated RotatingKVCache (keys/values is None)"
-        )
-
-    if not all(c.max_size == caches[0].max_size for c in caches):
-        raise ValueError(
-            "BatchRotatingKVCache can only merge caches with the same maximum size"
-        )
-
-    # Pre-compute temporal-ordered keys/values and trim to the effective
-    # sliding-window length.  ``_temporal_order`` may return an array larger
-    # than ``len(cache)`` when the internal buffer has not been trimmed yet
-    # (e.g. after a large prefill), so we trim via ``_trim`` to preserve
-    # the ``keep`` prefix semantics used by RotatingKVCache internally.
-    ordered: list[tuple[mx.array, mx.array]] = []
-    for c in caches:
-        effective_len = c.size() if hasattr(c, "size") else len(c)
-        ordered_keys = c._temporal_order(c.keys)
-        ordered_values = c._temporal_order(c.values)
-        if ordered_keys.shape[2] > effective_len:
-            trim_size = ordered_keys.shape[2] - effective_len
-            ordered_keys = c._trim(trim_size, ordered_keys)
-            ordered_values = c._trim(trim_size, ordered_values)
-        else:
-            ordered_keys = ordered_keys[..., :effective_len, :]
-            ordered_values = ordered_values[..., :effective_len, :]
-        ordered.append((ordered_keys, ordered_values))
-
-    lengths = [k.shape[2] for k, _ in ordered]
-    max_length = max(lengths)
-    padding = [max_length - length for length in lengths]
-    batch_size = len(caches)
-    n_heads = max(k.shape[1] for k, _ in ordered)
-    k_dim = max(k.shape[3] for k, _ in ordered)
-    v_dim = max(v.shape[3] for _, v in ordered)
-    dtype = next(iter(k.dtype for k, _ in ordered))
-
-    keys = mx.zeros((batch_size, n_heads, max_length, k_dim), dtype=dtype)
-    values = mx.zeros((batch_size, n_heads, max_length, v_dim), dtype=dtype)
-    for i, (pad, (k, v)) in enumerate(zip(padding, ordered, strict=True)):
-        n = k.shape[2]
-        keys[i : i + 1, :, pad : pad + n] = k
-        values[i : i + 1, :, pad : pad + n] = v
-
-    cache = BatchRotatingKVCache(caches[0].max_size, padding)
-    cache.keys = keys
-    cache.values = values
-    cache.offset = mx.array([c.offset for c in caches])
-    cache._idx = keys.shape[2]
-    cache._offset = keys.shape[2]
-
-    return cache
-
-
 def _merge_kv_caches(
     caches_list: list[list[AnyCache]],
 ) -> list[BatchKVCache | BatchRotatingKVCache | ArraysCache]:
@@ -186,7 +113,7 @@ def _merge_kv_caches(
                         "Mixed cache types in a single layer: expected RotatingKVCache"
                     )
                 rotating_caches.append(cache)
-            batch_cache = _merge_rotating_kv_caches(rotating_caches)
+            batch_cache = BatchRotatingKVCache.merge(rotating_caches)
         elif isinstance(layer_caches[0], KVCache):
             kv_caches: list[KVCache] = []
             for cache in layer_caches:

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -37,9 +37,10 @@ AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
 def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
     """Merge per-request ArraysCache objects into a single batched ArraysCache.
 
-    This mirrors the behavior of `mlx_lm.models.cache.ArraysCache.merge` but is
-    implemented here for compatibility with older mlx-lm versions that do not
-    provide `merge()` / `extract()`.
+    Keep this local instead of delegating to
+    ``mlx_lm.models.cache.ArraysCache.merge`` so entries that are ``None`` for
+    every request round-trip as ``None`` instead of depending on upstream's
+    non-empty-entry assumption.
     """
     if not caches:
         raise ValueError("caches must be non-empty")
@@ -68,7 +69,7 @@ def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
 
 
 def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
-    """Extract a single request's ArraysCache from a batched ArraysCache."""
+    """Extract one request's ArraysCache, preserving all-``None`` entries."""
     state = batch_cache.state
     extracted = ArraysCache(len(state))
     extracted.state = [

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -1,11 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Contiguous KV cache utilities (non-paged code path).
-
-Batched KV cache merge/extract helpers for the contiguous KV cache path,
-used when paged attention is disabled. KV state is stored as contiguous
-mx.array tensors per request, in contrast to the fixed-block layout used
-by paged attention.
-"""
+"""Merge/extract helpers for the non-paged KV cache path."""
 
 from typing import TypeAlias
 
@@ -21,27 +15,12 @@ from mlx_lm.models.cache import (
 # Minimum requests to use BatchKVCache for batched decode
 _MIN_BATCH_SIZE_FOR_BATCHING = 2
 
-# Type alias for any per-layer cache type supported by the model.
-#
-# Notes:
-# - Some models (e.g. gpt_oss) use `RotatingKVCache` for sliding-window attention.
-# - Hybrid models use `ArraysCache` for non-attention state.
+# Per-layer cache types used by non-paged decode.
 AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
 
 
-# ---------------------------------------------------------------------------
-# Batched KV cache merge / extract helpers (legacy non-paged decode path)
-# ---------------------------------------------------------------------------
-
-
 def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
-    """Merge per-request ArraysCache objects into a single batched ArraysCache.
-
-    Keep this local instead of delegating to
-    ``mlx_lm.models.cache.ArraysCache.merge`` so entries that are ``None`` for
-    every request round-trip as ``None`` instead of depending on upstream's
-    non-empty-entry assumption.
-    """
+    """Merge ArraysCache while preserving entries that are all ``None``."""
     if not caches:
         raise ValueError("caches must be non-empty")
 
@@ -81,14 +60,7 @@ def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
 def _merge_kv_caches(
     caches_list: list[list[AnyCache]],
 ) -> list[BatchKVCache | BatchRotatingKVCache | ArraysCache]:
-    """Merge multiple per-request caches into batched caches.
-
-    Args:
-        caches_list: List of per-request caches, each is a list of per-layer caches
-
-    Returns:
-        List of batched caches, one per layer
-    """
+    """Merge per-request layer caches into batched layer caches."""
     if not caches_list:
         return []
 
@@ -135,26 +107,14 @@ def _merge_kv_caches(
 def _extract_kv_cache(
     batch_caches: list[BatchKVCache | BatchRotatingKVCache | ArraysCache], idx: int
 ) -> list[AnyCache]:
-    """Extract a single request's cache from batched caches.
-
-    Args:
-        batch_caches: List of batched caches, one per layer
-        idx: Index of the request in the batch
-
-    Returns:
-        List of caches for the request, one per layer
-    """
+    """Extract one request's layer caches from batched layer caches."""
     extracted: list[AnyCache] = []
     for cache in batch_caches:
         if isinstance(cache, ArraysCache):
             extracted.append(_extract_arrays_cache(cache, idx))
         else:
             c = cache.extract(idx)
-            # After extract, RotatingKVCache may have offset > max_size but
-            # keys.shape[2] < max_size (buffer was sliced).  Pad the buffer
-            # back to max_size so _update_in_place won't try to grow it
-            # (which would compute a negative new_size).  The padded region
-            # is dead space that will be overwritten on the next rotation.
+            # Pad sliced rotating buffers so later decode can update in place.
             if (
                 isinstance(c, RotatingKVCache)
                 and c.keys is not None

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -750,7 +750,7 @@ class MetalModelRunner:
 
         logger.info("Warming up model...")
 
-        # Run a small dummy inference (standard MLX path)
+        # Run a small dummy inference.
         try:
             dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
             mx.eval(*self._dummy_forward_outputs(dummy_tokens))

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -220,7 +220,7 @@ class MetalWorker(WorkerBase):
         """Determine available memory for KV cache.
 
         Paged attention: reports the actual MPS paged cache capacity.
-        MLX path (default): reports one max-length sequence of KV cache
+        MLX path: reports one max-length sequence of KV cache
         so the scheduler budgets for one concurrent sequence.
 
         Returns:


### PR DESCRIPTION
This PR is:
- To remove stale local rotating-cache merge code now owned by upstream `mlx-lm`
- To keep the non-paged path as minimal compatibility/reference code
- To avoid turning this into a broader non-paged deprecation PR

Note: the non-paged MLX path is no longer vllm-metal's main runtime path, but it is still reachable through `VLLM_METAL_USE_PAGED_ATTENTION=0`. This PR trims duplicated upstream internals without removing that compatibility path.
