### PR TITLE
Fix Whisper segment seek offsets after chunking

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -101,8 +101,22 @@ class TestExtractSegments:
         segments = transcriber._extract_segments(tokens, time_offset=10.0)
 
         assert len(segments) == 1
+        assert segments[0].seek == 1000
         assert segments[0].start == pytest.approx(10.0)
         assert segments[0].end == pytest.approx(13.0)
+
+    def test_time_offset_applies_to_unfinished_segment_seek(
+        self, transcriber: WhisperTranscriber
+    ) -> None:
+        start_tok = transcriber._get_token_id("<|0.00|>")
+
+        segments = transcriber._extract_segments(
+            [start_tok, 2425],
+            time_offset=10.0,
+        )
+
+        assert len(segments) == 1
+        assert segments[0].seek == 1000
 
     def test_empty_tokens(self, transcriber: WhisperTranscriber) -> None:
         assert transcriber._extract_segments([]) == []

--- a/vllm_metal/stt/whisper/transcriber.py
+++ b/vllm_metal/stt/whisper/transcriber.py
@@ -335,7 +335,7 @@ class WhisperTranscriber:
                         segments.append(
                             TranscriptionSegment(
                                 id=seg_id,
-                                seek=int(seg_start * SEEK_MULTIPLIER),
+                                seek=int((seg_start + time_offset) * SEEK_MULTIPLIER),
                                 start=round(seg_start + time_offset, 2),
                                 end=round(ts + time_offset, 2),
                                 text=seg_text,
@@ -354,7 +354,7 @@ class WhisperTranscriber:
                 segments.append(
                     TranscriptionSegment(
                         id=seg_id,
-                        seek=int(seg_start * SEEK_MULTIPLIER),
+                        seek=int((seg_start + time_offset) * SEEK_MULTIPLIER),
                         start=round(seg_start + time_offset, 2),
                         end=round(
                             seg_start + time_offset + DEFAULT_SEGMENT_DURATION, 2


### PR DESCRIPTION
## Summary

Make Whisper segment `seek` positions global for long-audio transcription, consistent with the existing global `start` and `end` timestamps.

## Details

- Include each chunk `time_offset` when calculating `TranscriptionSegment.seek`.
- Correct both paired-timestamp and unfinished-segment construction paths.
- Extend segment extraction tests to cover nonzero chunk offsets in both paths.

Before this change, a segment spanning local `0s` to `3s` in a chunk starting at `10s` reported `seek=0`, `start=10`, and `end=13`. It now reports `seek=1000`, `start=10`, and `end=13`.

## Test Plan

- Isolated segment-extraction harness on Python 3.12: verified `(seek, start, end) == (1000, 10.0, 13.0)`.
- `uvx ruff format --check vllm_metal/stt/whisper/transcriber.py tests/test_transcribe.py`
- `uvx ruff check vllm_metal/stt/whisper/transcriber.py tests/test_transcribe.py`
- `python3.12 -m py_compile vllm_metal/stt/whisper/transcriber.py tests/test_transcribe.py`

The complete pytest suite was not run locally because the documented macOS setup requires compiling vLLM from source and that build did not complete during local verification. CI should exercise the regression in the supported integration environment.

## Related Issue

Resolves #477

## AI disclosure

Code and tests were generated with Codex GPT-5. The commit includes `Generated-by: Codex GPT-5` and the required DCO sign-off.

## Reference implementation

[OpenAI Whisper initializes `seek` from the global clip position and writes that value directly into each segment](https://github.com/openai/whisper/blob/04f449b8a437f1bbd3dba5c9f826aca972e7709a/whisper/transcribe.py#L226-L253). It also derives the chunk `time_offset` from that same global seek position. vLLM Metal decodes chunks separately, so adding `time_offset` to the chunk-local timestamp restores the same original-audio coordinate system before converting seconds to 10 ms seek units.