### PR TITLE
[GGUF] Add llama GGUF loading with q/k RoPE un-permutation

### DIFF
--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -251,6 +251,257 @@ def test_untied_qwen2_attaches_bias_and_installs_lm_head(tmp_path):
     assert out.shape[-1] == 256
 
 
+def _write_minimal_tokenizer(config_dir: str, vocab_size: int) -> None:
+    """Write a tiny WordLevel fast tokenizer into a synthetic config dir.
+
+    transformers builds a llama tokenizer through ``LlamaTokenizer``, which
+    needs real tokenizer files (unlike qwen, which constructs from config
+    alone), so the llama fixtures must ship a tokenizer to reach ``load()``.
+    """
+
+    def _special(i: int, content: str) -> dict:
+        return {
+            "id": i,
+            "content": content,
+            "special": True,
+            "single_word": False,
+            "lstrip": False,
+            "rstrip": False,
+            "normalized": False,
+        }
+
+    vocab = {"<unk>": 0, "<s>": 1, "</s>": 2}
+    vocab.update({f"t{i}": i for i in range(3, vocab_size)})
+    tokenizer = {
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": [_special(0, "<unk>"), _special(1, "<s>"), _special(2, "</s>")],
+        "normalizer": None,
+        "pre_tokenizer": {"type": "Whitespace"},
+        "post_processor": None,
+        "decoder": None,
+        "model": {"type": "WordLevel", "vocab": vocab, "unk_token": "<unk>"},
+    }
+    dir_path = Path(config_dir)
+    (dir_path / "tokenizer.json").write_text(json.dumps(tokenizer))
+    (dir_path / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "PreTrainedTokenizerFast"})
+    )
+
+
+@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
+def test_loads_dense_llama_installs_wrappers(tmp_path, quant_type):
+    # llama: separate q/k/v, no q/k norm, no attention bias, tied embeddings.
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path, "llama", has_qk_norm=False, quant_type=quant_type
+    )
+    _write_minimal_tokenizer(cfg_dir, 256)
+    model, _ = GGUFModelLoader(
+        gguf_path,
+        config_dir=cfg_dir,
+        target_dtype=mx.float32,
+    ).load()
+    hist = _gguf_module_histogram(model)
+    assert hist.get("GGUFEmbedding") == 1
+    assert hist.get("GGUFLinear") == 2 * 7
+    out = model(mx.array([[1, 2, 3]]))
+    mx.eval(out)
+    assert out.shape == (1, 3, 256)
+
+
+def test_untied_llama_installs_lm_head(tmp_path):
+    # The 8B-shaped path: untied output, no biases (llama attention_bias=False).
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "llama",
+        config_overrides={"tie_word_embeddings": False},
+        has_qk_norm=False,
+        with_bias=False,
+    )
+    _write_minimal_tokenizer(cfg_dir, 256)
+    model, _ = GGUFModelLoader(
+        gguf_path,
+        config_dir=cfg_dir,
+        target_dtype=mx.float32,
+    ).load()
+    q_proj = model.model.layers[0].self_attn.q_proj
+    assert isinstance(q_proj, GGUFLinear)
+    assert "bias" not in q_proj  # llama q/k/v are bias-free
+    assert isinstance(model.lm_head, GGUFLinear)  # untied output -> real lm_head
+    out = model(mx.array([[1, 2, 3]]))
+    mx.eval(out)
+    assert out.shape[-1] == 256
+
+
+def test_llama_skips_tie_redundant_output_when_config_omits_tie_flag(tmp_path):
+    # Omitted-tie branch for the new arch: the loader must read the resolved
+    # model.args tie flag (llama default True), not a config.get default.
+    d = _dims(_tiny_config("llama"))
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "llama",
+        has_qk_norm=False,
+        inject={"output.weight": ("q", (d["vocab"], d["h"]))},
+    )
+    config_path = Path(cfg_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    config.pop("tie_word_embeddings")
+    config_path.write_text(json.dumps(config))
+    _write_minimal_tokenizer(cfg_dir, 256)
+
+    model, _ = GGUFModelLoader(
+        gguf_path,
+        config_dir=cfg_dir,
+        target_dtype=mx.float32,
+    ).load()
+
+    assert not hasattr(model, "lm_head")
+    assert _gguf_module_histogram(model).get("GGUFEmbedding") == 1
+
+
+@pytest.mark.parametrize(
+    "moe_tensor",
+    ["blk.0.ffn_gate_inp.weight", "blk.0.ffn_gate_exps.weight"],
+)
+def test_rejects_out_of_scope_moe_tensor_under_llama_arch(tmp_path, moe_tensor):
+    # Guard-widening regression: admitting "llama" makes llama-family MoE files
+    # (Mixtral et al., general.architecture="llama") reachable. The router
+    # (ffn_gate_inp) and experts (ffn_gate_exps) must both fail fast at preflight,
+    # not slip through to an "unmapped tensor" error deep in the load.
+    d = _dims(_tiny_config("llama"))
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "llama",
+        has_qk_norm=False,
+        inject={moe_tensor: ("f", (2, d["h"]))},
+    )
+    with pytest.raises(GGUFLoadError, match="Out-of-scope GGUF tensor"):
+        GGUFModelLoader(
+            gguf_path,
+            config_dir=cfg_dir,
+            target_dtype=mx.float32,
+        ).load()
+
+
+def _rope_inv_index(out_features, n_head):
+    # Independent reference for llama.cpp's inverse q/k RoPE row permutation.
+    return (
+        mx.arange(out_features)
+        .reshape(n_head, out_features // n_head // 2, 2)
+        .swapaxes(1, 2)
+        .reshape(out_features)
+    )
+
+
+def _plain_qk_fixture(tmp_path, model_type, *, has_qk_norm=False):
+    # A dense fixture whose attn_q/attn_k are written PLAIN (F32), to exercise
+    # the plain-weight branch of _partition (llama.cpp permutes q/k regardless
+    # of qtype, so the plain path must un-permute too).
+    d = _dims(_tiny_config(model_type))
+    drop = {f"blk.{i}.attn_{p}.weight" for i in range(d["layers"]) for p in ("q", "k")}
+    inject = {}
+    for i in range(d["layers"]):
+        inject[f"blk.{i}.attn_q.weight"] = ("f", (d["qd"], d["h"]))
+        inject[f"blk.{i}.attn_k.weight"] = ("f", (d["kvd"], d["h"]))
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path, model_type, has_qk_norm=has_qk_norm, drop=drop, inject=inject
+    )
+    _write_minimal_tokenizer(cfg_dir, 256)
+    return gguf_path, cfg_dir, d
+
+
+def test_plain_llama_qk_are_row_unpermuted(tmp_path):
+    gguf_path, cfg_dir, d = _plain_qk_fixture(tmp_path, "llama")
+    raw_q = mx.load(gguf_path)["blk.0.attn_q.weight"]
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    cfg = _tiny_config("llama")
+    n_head, n_kv = cfg["num_attention_heads"], cfg["num_key_value_heads"]
+    raw_k = mx.load(gguf_path)["blk.0.attn_k.weight"]
+    got_q = model.model.layers[0].self_attn.q_proj.weight
+    got_k = model.model.layers[0].self_attn.k_proj.weight
+    assert bool(mx.array_equal(got_q, raw_q[_rope_inv_index(d["qd"], n_head)]).item())
+    assert bool(mx.array_equal(got_k, raw_k[_rope_inv_index(d["kvd"], n_kv)]).item())
+    # A non-trivial reorder actually happened (not identity), for q and k (GQA).
+    assert not bool(mx.array_equal(got_q, raw_q).item())
+    assert not bool(mx.array_equal(got_k, raw_k).item())
+
+
+def test_plain_qwen_qk_are_not_permuted(tmp_path):
+    # qwen uses the HF RoPE layout: q/k must load byte-identical (no permute).
+    gguf_path, cfg_dir, _ = _plain_qk_fixture(tmp_path, "qwen3", has_qk_norm=True)
+    raw_q = mx.load(gguf_path)["blk.0.attn_q.weight"]
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    got = model.model.layers[0].self_attn.q_proj.weight
+    assert bool(mx.array_equal(got, raw_q).item())
+
+
+def test_llama_loads_when_config_omits_head_dim(tmp_path):
+    # head_dim is resolved onto the built q/k projections, not model.args, so the
+    # permute index must read out_features off the built object (#449 omitted-
+    # default). Every other fixture sets head_dim; this pops it.
+    gguf_path, cfg_dir = _build_dense_fixture(tmp_path, "llama", has_qk_norm=False)
+    _write_minimal_tokenizer(cfg_dir, 256)
+    config_path = Path(cfg_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    config.pop("head_dim")  # derived head_dim == hidden_size // heads == 16
+    config_path.write_text(json.dumps(config))
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    assert _gguf_module_histogram(model).get("GGUFLinear") == 2 * 7
+    out = model(mx.array([[1, 2, 3]]))
+    mx.eval(out)
+    assert out.shape == (1, 3, 256)
+
+
+def test_llama_qk_bias_is_row_unpermuted(tmp_path):
+    # llama.cpp permutes q/k bias with the same RoPE index as the weight; a
+    # llama with attention_bias must un-permute the bias too, or attention is
+    # silently wrong (permuted weight + un-permuted bias). v bias is untouched.
+    d = _dims(_tiny_config("llama"))
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "llama",
+        config_overrides={"attention_bias": True},
+        has_qk_norm=False,
+        with_bias=True,
+        # llama attention_bias also biases o_proj; _dense_tensor_specs only writes
+        # q/k/v biases, so supply the output bias the built model expects.
+        inject={
+            f"blk.{i}.attn_output.bias": ("f", (d["h"],)) for i in range(d["layers"])
+        },
+    )
+    _write_minimal_tokenizer(cfg_dir, 256)
+    arrays = mx.load(gguf_path)
+    raw_q_bias, raw_v_bias = arrays["blk.0.attn_q.bias"], arrays["blk.0.attn_v.bias"]
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    attn = model.model.layers[0].self_attn
+    n_head = _tiny_config("llama")["num_attention_heads"]
+    assert bool(
+        mx.array_equal(
+            attn.q_proj.bias, raw_q_bias[_rope_inv_index(d["qd"], n_head)]
+        ).item()
+    )
+    assert not bool(mx.array_equal(attn.q_proj.bias, raw_q_bias).item())
+    # v bias is not RoPE'd: byte-identical.
+    assert bool(mx.array_equal(attn.v_proj.bias, raw_v_bias).item())
+
+
 def test_completeness_fails_on_dropped_norm(tmp_path):
     gguf_path, cfg_dir = _build_dense_fixture(
         tmp_path, "qwen3", has_qk_norm=True, drop={"blk.1.ffn_norm.weight"}

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -19,6 +19,7 @@ import pytest
 gguf = pytest.importorskip("gguf")
 
 from vllm_metal.gguf.loader import GGUFLoadError, GGUFModelLoader  # noqa: E402
+from vllm_metal.gguf.mlx_native import GGUFMLXQuantizedTensor  # noqa: E402
 from vllm_metal.gguf.wrappers import GGUFLinear  # noqa: E402
 
 QT = gguf.GGMLQuantizationType
@@ -308,6 +309,37 @@ def test_loads_dense_llama_installs_wrappers(tmp_path, quant_type):
     out = model(mx.array([[1, 2, 3]]))
     mx.eval(out)
     assert out.shape == (1, 3, 256)
+
+
+@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
+def test_quantized_llama_qk_are_row_unpermuted(tmp_path, quant_type):
+    # The main quantized-path behavior: installed q/k GGUFLinear tensors carry the
+    # RoPE-un-permuted quantized weight, not the raw (llama.cpp-permuted) one.
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path, "llama", has_qk_norm=False, quant_type=quant_type
+    )
+    _write_minimal_tokenizer(cfg_dir, 256)
+    arrays = mx.load(gguf_path)
+    cfg, d = _tiny_config("llama"), _dims(_tiny_config("llama"))
+    raw_q = GGUFMLXQuantizedTensor.from_mx_load(
+        arrays, "blk.0.attn_q.weight", quant_type
+    )
+    raw_k = GGUFMLXQuantizedTensor.from_mx_load(
+        arrays, "blk.0.attn_k.weight", quant_type
+    )
+    exp_q = raw_q.permute_rows(_rope_inv_index(d["qd"], cfg["num_attention_heads"]))
+    exp_k = raw_k.permute_rows(_rope_inv_index(d["kvd"], cfg["num_key_value_heads"]))
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    got_q = model.model.layers[0].self_attn.q_proj.tensor
+    got_k = model.model.layers[0].self_attn.k_proj.tensor
+    assert bool(mx.array_equal(got_q.qweight, exp_q.qweight).item())
+    assert bool(mx.array_equal(got_k.qweight, exp_k.qweight).item())
+    assert not bool(mx.array_equal(got_q.qweight, raw_q.qweight).item())
+    assert not bool(mx.array_equal(got_k.qweight, raw_k.qweight).item())
 
 
 def test_untied_llama_installs_lm_head(tmp_path):

--- a/tests/test_gguf_mlx_native.py
+++ b/tests/test_gguf_mlx_native.py
@@ -500,3 +500,51 @@ def test_real_generate_matches_dense():
     assert candidate == reference
     assert calls["linear"] > 0
     assert calls["embedding"] > 0
+
+
+# === permute_rows (llama RoPE q/k un-permutation mechanism) ===
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_permute_rows_matches_dequant_then_gather(tmp_path, qtype):
+    # Reordering the packed qweight + scales + biases together must be bit-exact
+    # to dequantizing then gathering the same rows.
+    qt, oracle = _make_tensor(tmp_path, qtype, shape=(64, 128))
+    index = mx.array(np.random.default_rng(1).permutation(64))
+
+    permuted = qt.permute_rows(index)
+
+    assert permuted.qweight_type == qt.qweight_type
+    assert permuted.logical_shape == qt.logical_shape
+    x = mx.array(np.random.default_rng(2).standard_normal((3, 128)), dtype=mx.float32)
+    got = permuted.matmul(x)
+    want = x @ mx.array(oracle)[index].T
+    assert bool(mx.allclose(got, want, atol=1e-3).item())
+
+
+@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
+def test_permute_rows_round_trips_via_inverse(tmp_path, qtype):
+    # The index is not an involution for head_dim > 4, so the inverse is
+    # argsort(index), not the index itself.
+    qt, oracle = _make_tensor(tmp_path, qtype, shape=(64, 128))
+    index = mx.array(np.random.default_rng(3).permutation(64))
+
+    restored = qt.permute_rows(index).permute_rows(mx.argsort(index))
+
+    x = mx.array(np.random.default_rng(4).standard_normal((2, 128)), dtype=mx.float32)
+    assert bool(mx.allclose(restored.matmul(x), qt.matmul(x), atol=1e-4).item())
+
+
+def test_permute_rows_rejects_non_permutation(tmp_path):
+    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0, shape=(64, 128))
+    with pytest.raises(ValueError) as short:
+        qt.permute_rows(mx.arange(32))
+    assert str(short.value) == (
+        "permute_rows index must be 1-D of length 64 (out_features), got shape (32,)"
+    )
+    with pytest.raises(ValueError) as dup:
+        qt.permute_rows(mx.zeros(64, dtype=mx.int32))  # all-zero: duplicates
+    assert str(dup.value) == (
+        "permute_rows index must be a permutation of range(64); "
+        "got duplicate or out-of-range values"
+    )

--- a/tests/test_gguf_serve_golden.py
+++ b/tests/test_gguf_serve_golden.py
@@ -130,3 +130,72 @@ def test_gguf_greedy_matches_dense_reference_prefix() -> None:
         f"(gguf={gguf_ids}, dense={dense_ids})"
     )
     assert gguf_ids == _GOLDEN_IDS[:_DENSE_AGREE_PREFIX]
+
+
+# === llama arch (Llama-3.2-1B-Instruct-Q8_0.gguf, target_dtype=bf16) ===
+# Greedy decode of _PROMPT. The leading 13 ids match the dense mlx_lm reference;
+# they diverge at index 13 (quantized vs dense). Without the llama.cpp q/k RoPE
+# row-un-permutation this prefix agreement is only 1 token (attention is broken),
+# so this pins the fix end-to-end.
+_LLAMA_GOLDEN_IDS = [
+    12366,
+    13,
+    578,
+    469,
+    3168,
+    301,
+    22703,
+    374,
+    7559,
+    304,
+    12366,
+    13,
+    578,
+    9928,
+    49606,
+    16730,
+]
+_LLAMA_DENSE_AGREE_PREFIX = 13
+
+_LLAMA_GGUF_ENV = "VLLM_METAL_TEST_GGUF_LLAMA_SERVE_PATH"
+_LLAMA_TOK_ENV = "VLLM_METAL_TEST_GGUF_LLAMA_TOKENIZER_PATH"
+_LLAMA_DENSE_ENV = "VLLM_METAL_TEST_GGUF_LLAMA_DENSE_PATH"
+
+
+@pytest.mark.slow
+def test_llama_gguf_greedy_matches_committed_golden() -> None:
+    gguf_path = _require_path(_LLAMA_GGUF_ENV)
+    tokenizer_dir = _require_path(_LLAMA_TOK_ENV)
+
+    model, tokenizer = GGUFModelLoader(
+        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+    ).load()
+
+    assert _greedy_token_ids(model, tokenizer, _PROMPT, _N) == _LLAMA_GOLDEN_IDS
+
+
+@pytest.mark.slow
+def test_llama_gguf_greedy_matches_dense_reference_prefix() -> None:
+    gguf_path = _require_path(_LLAMA_GGUF_ENV)
+    tokenizer_dir = _require_path(_LLAMA_TOK_ENV)
+    dense_dir = _require_path(_LLAMA_DENSE_ENV)
+
+    dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
+    dense_ids = _greedy_token_ids(
+        dense_model, dense_tokenizer, _PROMPT, _LLAMA_DENSE_AGREE_PREFIX
+    )
+    del dense_model
+    mx.clear_cache()
+
+    gguf_model, gguf_tokenizer = GGUFModelLoader(
+        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+    ).load()
+    gguf_ids = _greedy_token_ids(
+        gguf_model, gguf_tokenizer, _PROMPT, _LLAMA_DENSE_AGREE_PREFIX
+    )
+
+    assert gguf_ids == dense_ids, (
+        "llama Q8_0 GGUF greedy prefix must match the dense mlx_lm reference "
+        f"(gguf={gguf_ids}, dense={dense_ids})"
+    )
+    assert gguf_ids == _LLAMA_GOLDEN_IDS[:_LLAMA_DENSE_AGREE_PREFIX]

--- a/vllm_metal/gguf/adapter.py
+++ b/vllm_metal/gguf/adapter.py
@@ -3,8 +3,10 @@
 
 ``GGUFModelAdapter`` owns everything the loader must not inline: the dense-arch
 allowlist, the out-of-scope tensor markers, the global-tensor name overrides, the
-skip set, architecture normalization and enum resolution, and the per-tensor
-translation from a GGUF name to a live MLX-LM module-parameter path.
+skip set, architecture normalization and enum resolution, the per-tensor
+translation from a GGUF name to a live MLX-LM module-parameter path, and the
+per-arch RoPE weight-layout policy (which q/k tensors need llama.cpp's layout
+undone, and the row-permutation index to undo it).
 
 The name map combines two sources (see ``codex/GGUF_PR3_DESIGN.md`` §6): a small
 static override for the global tensors whose MLX target may be absent from a tied
@@ -16,6 +18,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import mlx.core as mx
 import mlx.nn as nn
 from mlx.utils import tree_flatten
 
@@ -25,21 +28,27 @@ class GGUFLoadError(RuntimeError):
 
 
 class GGUFModelAdapter:
-    """Translate GGUF tensor names into live MLX-LM module-parameter paths."""
+    """Own GGUF name/scope policy: translate tensor names to live MLX-LM
+    parameter paths, and the per-arch RoPE weight-layout policy (which q/k
+    tensors need llama.cpp's layout undone, and the row-permutation index)."""
 
     # Dense decoder architectures this loader is verified against. The scope guard
     # is an allowlist (default-deny): any other arch (linear-attention/SSM hybrid,
     # fused-QKV, MoE, vision-language) is rejected, so a new non-dense arch can
     # never be silently admitted. Grow this set as archs are tested.
-    SUPPORTED_DENSE_ARCHS = frozenset({"qwen2", "qwen3"})
+    SUPPORTED_DENSE_ARCHS = frozenset({"qwen2", "qwen3", "llama"})
 
     # Substrings flagging an out-of-scope tensor regardless of the declared arch:
-    # fused QKV, SSM/Mamba, MoE experts, vision/mmproj. Defense in depth behind the
-    # arch allowlist; none of these appear in a dense decoder's tensor names.
+    # fused QKV, SSM/Mamba, MoE experts + router, vision/mmproj. Defense in depth
+    # behind the arch allowlist; none appear in a dense decoder's tensor names.
+    # ``ffn_gate_inp`` is the MoE router: llama-family MoE (e.g. Mixtral) declares
+    # general.architecture "llama", so its expert tensors (caught by ``_exps``)
+    # and router (this) are reachable once "llama" is admitted.
     OUT_OF_SCOPE_TENSOR_SUBSTRINGS = (
         "attn_qkv",
         "ssm_",
         "_exps",
+        "ffn_gate_inp",
         "mmproj",
         "mm.",
         "v.blk",
@@ -58,14 +67,35 @@ class GGUFModelAdapter:
     # GGUF tensors with no MLX-LM counterpart (precomputed buffers MLX recreates).
     _KNOWN_SKIP = frozenset({"rope_freqs.weight"})
 
-    def __init__(self, *, translation_map: dict[str, str | None]) -> None:
+    # Archs whose q/k projection weights are stored in llama.cpp's RoPE layout and
+    # must be row-un-permuted at load (llama family). qwen2/qwen3 use the HF layout
+    # and are absent here. mistral (a llama-arch family) normalizes to "llama".
+    _ROPE_PERMUTE_ARCHS = frozenset({"llama"})
+
+    def __init__(
+        self,
+        *,
+        translation_map: dict[str, str | None],
+        permute_index: dict[str, mx.array] | None = None,
+    ) -> None:
         self._translation_map = translation_map
+        self._permute_index = permute_index or {}
 
     def translate(self, gguf_name: str) -> str | None:
         """Return the live MLX-LM parameter path for a GGUF tensor name."""
         if gguf_name not in self._translation_map:
             raise GGUFLoadError(f"Unmapped GGUF tensor {gguf_name!r}.")
         return self._translation_map[gguf_name]
+
+    def rope_permute_index(self, gguf_name: str) -> mx.array | None:
+        """Row-permutation index that undoes llama.cpp's RoPE q/k layout.
+
+        Returns the precomputed index for a q/k weight that needs it, or ``None``
+        for every other tensor / arch (a plain table lookup, like
+        :meth:`translate`). The loader applies it to the weight, quantized or
+        plain, before install.
+        """
+        return self._permute_index.get(gguf_name)
 
     @classmethod
     def resolve_arch(cls, *, gguf_arch: str, config_model_type: str) -> str:
@@ -131,7 +161,51 @@ class GGUFModelAdapter:
         translation_map.update(cls._STATIC_GLOBAL_OVERRIDE)
         for name in cls._KNOWN_SKIP:
             translation_map[name] = None
-        return cls(translation_map=translation_map)
+        permute_index = cls._build_permute_index(model, arch, num_hidden_layers)
+        return cls(translation_map=translation_map, permute_index=permute_index)
+
+    @classmethod
+    def _build_permute_index(
+        cls, model: nn.Module, arch: str, num_hidden_layers: int
+    ) -> dict[str, mx.array]:
+        """Precompute the RoPE row-permutation index per q/k GGUF tensor name.
+
+        Empty for archs in the HF RoPE layout (qwen). For llama-family archs the
+        index reorders each head's interleaved pairs back to the HF half-split.
+        ``out_features`` is read off the BUILT q/k projections (whose head_dim is
+        already resolved), not ``args.head_dim`` which stays ``None`` when the
+        config omits it (the #449 omitted-default trap). llama.cpp permutes both
+        the q/k weight AND its bias, so the same index covers ``.bias``.
+        """
+        if arch not in cls._ROPE_PERMUTE_ARCHS:
+            return {}
+        args = model.args
+        attn = model.model.layers[0].self_attn
+        idx_q = cls._rope_permute_index(
+            attn.q_proj.weight.shape[0], args.num_attention_heads
+        )
+        idx_k = cls._rope_permute_index(
+            attn.k_proj.weight.shape[0], args.num_key_value_heads
+        )
+        permute_index: dict[str, mx.array] = {}
+        for i in range(num_hidden_layers):
+            for suffix, idx in ((".weight", idx_q), (".bias", idx_q)):
+                permute_index[f"blk.{i}.attn_q{suffix}"] = idx
+            for suffix, idx in ((".weight", idx_k), (".bias", idx_k)):
+                permute_index[f"blk.{i}.attn_k{suffix}"] = idx
+        return permute_index
+
+    @staticmethod
+    def _rope_permute_index(out_features: int, n_head: int) -> mx.array:
+        """Inverse of llama.cpp's HF->GGUF q/k RoPE permutation, as an out-axis
+        row index. Reorders each head's interleaved (2, head_dim//2) pairs back
+        to the (head_dim//2, 2) half-split HF layout."""
+        return (
+            mx.arange(out_features)
+            .reshape(n_head, out_features // n_head // 2, 2)
+            .swapaxes(1, 2)
+            .reshape(out_features)
+        )
 
     @staticmethod
     def _normalize_arch(name: str) -> str:

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -201,25 +201,27 @@ class GGUFModelLoader:
 
             # llama.cpp permutes q/k rows for its RoPE layout regardless of qtype;
             # the adapter returns the row index to undo it (None for every other
-            # tensor / arch), applied identically to the quantized or plain weight.
+            # tensor / arch). GGUF is a file boundary: validate the source tensor
+            # shape BEFORE permuting, so a malformed row count fails fast instead
+            # of being masked into an expected shape by the gather.
             permute = adapter.rope_permute_index(name)
 
             if suffix == _BIAS_SUFFIX:
-                bias = arrays[name][permute] if permute is not None else arrays[name]
+                bias = arrays[name]
                 self._validate_plain_shape(model, translated, bias, name)
-                biases[module_path] = bias
+                biases[module_path] = bias[permute] if permute is not None else bias
             elif tensor.tensor_type in MLX_NATIVE_GGUF_TYPES:
                 qt = GGUFMLXQuantizedTensor.from_mx_load(
                     arrays, name, tensor.tensor_type
                 )
-                if permute is not None:
-                    qt = qt.permute_rows(permute)
                 self._validate_quant_shape(module_path, current, qt, name)
-                quant[module_path] = qt
+                quant[module_path] = (
+                    qt.permute_rows(permute) if permute is not None else qt
+                )
             else:  # plain F32/F16/BF16
-                weight = arrays[name][permute] if permute is not None else arrays[name]
+                weight = arrays[name]
                 self._validate_plain_shape(model, translated, weight, name)
-                plain[translated] = weight
+                plain[translated] = weight[permute] if permute is not None else weight
 
         # A bias whose weight is plain (not quantized) loads through the normal
         # path; only biases paired with a quant weight go to GGUFLinear.

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -199,18 +199,27 @@ class GGUFModelLoader:
                     f"{module_path!r} is absent from the model."
                 ) from exc
 
+            # llama.cpp permutes q/k rows for its RoPE layout regardless of qtype;
+            # the adapter returns the row index to undo it (None for every other
+            # tensor / arch), applied identically to the quantized or plain weight.
+            permute = adapter.rope_permute_index(name)
+
             if suffix == _BIAS_SUFFIX:
-                self._validate_plain_shape(model, translated, arrays[name], name)
-                biases[module_path] = arrays[name]
+                bias = arrays[name][permute] if permute is not None else arrays[name]
+                self._validate_plain_shape(model, translated, bias, name)
+                biases[module_path] = bias
             elif tensor.tensor_type in MLX_NATIVE_GGUF_TYPES:
                 qt = GGUFMLXQuantizedTensor.from_mx_load(
                     arrays, name, tensor.tensor_type
                 )
+                if permute is not None:
+                    qt = qt.permute_rows(permute)
                 self._validate_quant_shape(module_path, current, qt, name)
                 quant[module_path] = qt
             else:  # plain F32/F16/BF16
-                self._validate_plain_shape(model, translated, arrays[name], name)
-                plain[translated] = arrays[name]
+                weight = arrays[name][permute] if permute is not None else arrays[name]
+                self._validate_plain_shape(model, translated, weight, name)
+                plain[translated] = weight
 
         # A bias whose weight is plain (not quantized) loads through the normal
         # path; only biases paired with a quant weight go to GGUFLinear.

--- a/vllm_metal/gguf/mlx_native.py
+++ b/vllm_metal/gguf/mlx_native.py
@@ -251,6 +251,35 @@ class GGUFMLXQuantizedTensor:
         )
         return rows.astype(output_dtype)
 
+    def permute_rows(self, index: mx.array) -> GGUFMLXQuantizedTensor:
+        """Return a copy with output rows reordered by ``index`` (load-time).
+
+        ``index`` must be a permutation of ``range(out_features)``. The packed
+        ``qweight`` and its affine ``scales``/``biases`` all carry output rows
+        on axis 0 and quantize along the (untouched) input axis, so gathering
+        the three together stays bit-exact to a dequantize-permute-requantize
+        and keeps the tensor MLX-native quantized. Used to undo llama.cpp's
+        RoPE weight layout on q/k projections at load time.
+        """
+        out_features = self.out_features
+        if index.ndim != 1 or index.shape[0] != out_features:
+            raise ValueError(
+                f"permute_rows index must be 1-D of length {out_features} "
+                f"(out_features), got shape {tuple(index.shape)}"
+            )
+        ordered = mx.sort(index)
+        if not bool(mx.all(ordered == mx.arange(out_features)).item()):
+            raise ValueError(
+                "permute_rows index must be a permutation of "
+                f"range({out_features}); got duplicate or out-of-range values"
+            )
+        return GGUFMLXQuantizedTensor(
+            qweight=self.qweight[index],
+            scales=self.scales[index],
+            biases=self.biases[index],
+            qweight_type=self.qweight_type,
+        )
+
     def eval_arrays(self) -> None:
         """Materialize the packed arrays backing this quantized tensor."""
         mx.eval(self.qweight, self.scales, self.biases)


### PR DESCRIPTION
This adds the llama architecture to the local GGUF loader (#415; qwen2/qwen3 shipped in #466). A llama `.gguf` was rejected at the arch allowlist before; now it loads and serves.

The load-bearing part is a real correctness bug I only caught with golden parity. llama.cpp stores `q_proj` / `k_proj` in its own RoPE-permuted row layout, while mlx builds the HF layout, so a llama `.gguf` loads cleanly but produces broken attention. Per-op forward cosine against the mlx_lm dense reference was `mlp.gate_proj` 0.99998 and `embed` 0.99997, but `q_proj` 0.014 and `k_proj` 0.042 (orthogonal). qwen is unaffected because llama.cpp does not permute its q/k. The inverse is a pure reorder of the output rows, and applying it restored q and k to cosine 1.0000, including GQA.

I kept the ownership where the merged code already puts it. The row reorder is a `permute_rows` method on `GGUFMLXQuantizedTensor`; it owns its packed `qweight` / `scales` / `biases`, so the three gather together and the weight stays quantized with no dense copy. Which arch's q/k need it, and the precomputed index, are adapter-owned: a `permute_index` table built in `from_model` next to the translation map, read off the built q/k projections so an omitted `head_dim` can't bite. The loader consults the adapter and applies it in both the quantized and plain branches, and to the q/k bias, with no arch conditional. Adding llama also makes Mixtral/MoE-llama files (`architecture=llama`) reachable, so `ffn_gate_inp` joins the out-of-scope preflight next to `_exps`.