### PR TITLE
[Spec Decode] DFlash

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -1,15 +1,15 @@
 # Speculative Decoding
 
-vllm-metal supports three speculative decoding methods on the paged attention
+vllm-metal supports four speculative decoding methods on the paged attention
 path. All require synchronous scheduling and greedy sampling.
 
-| | MTP | Draft Model | N-gram |
-|---|---|---|---|
-| `--speculative-config` method | `mtp` | `draft_model` | `ngram` |
-| Target models | Gemma4 (paged) | Any paged-attention model | Any paged-attention model |
-| Draft source | MTP assistant checkpoint (reads target KV cache) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
-| `num_speculative_tokens` | 1 | Configurable (3–5 typical) | Configurable (3–5 typical) |
-| Extra memory | None (reads target KV cache) | Second un-budgeted KV cache | None |
+| | MTP | DFlash | Draft Model | N-gram |
+|---|---|---|---|---|
+| `--speculative-config` method | `mtp` | `dflash` | `draft_model` | `ngram` |
+| Target models | Gemma4 (paged) | mlx_lm llama/qwen-family text models | Any paged-attention model | Any paged-attention model |
+| Draft source | MTP assistant checkpoint (reads target KV cache) | Speculators-format parallel drafter (consumes target hidden states) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
+| `num_speculative_tokens` | 1 | The trained block size (7 typical) | Configurable (3–5 typical) | Configurable (3–5 typical) |
+| Extra memory | None (reads target KV cache) | Draft weights + small proposer-owned context KV | Second un-budgeted KV cache | None |
 
 All three methods:
 
@@ -102,6 +102,49 @@ tokens per second. Attach those JSON files to performance PRs instead of copying
 machine-specific results into the docs.
 
 ---
+
+## DFlash
+
+DFlash ([arXiv 2602.06036](https://arxiv.org/abs/2602.06036)) drafts a whole
+block of tokens in **one** forward instead of running a draft model
+autoregressively — a good fit for Metal, where per-step overhead is the main
+tax on draft-model SD. The drafter is a small stack of target-family decoder
+layers; it attends over context K/V projected from the *target's*
+intermediate-layer hidden states (`aux_hidden_state_layer_ids`) and fills K
+mask tokens non-causally in a single pass. Its context K/V lives in
+proposer-owned slabs (~20 KB/token), so there is no second KV cache to budget.
+
+### Serve
+
+```bash
+VLLM_METAL_MEMORY_FRACTION=0.62 \
+vllm serve Qwen/Qwen3-8B \
+  --max-model-len 4096 \
+  --no-async-scheduling \
+  --no-enable-prefix-caching \
+  --speculative-config '{"method":"dflash","model":"RedHatAI/Qwen3-8B-speculator.dflash","num_speculative_tokens":7}'
+```
+
+Use a speculators-format DFlash checkpoint, and set `num_speculative_tokens`
+to its trained block size (7 for the checkpoint above).
+
+### Limitations
+
+- **Prefix caching must be off** (`--no-enable-prefix-caching`, enforced at
+  startup). Cached tokens skip the target forward, so the hidden states DFlash
+  projects its context from would never be produced.
+- **Fixed block size.** A block-diffusion drafter conditions on its whole mask
+  block, so `num_speculative_tokens` must equal the checkpoint's trained K —
+  a smaller value is off-distribution and collapses acceptance, unlike the
+  free K knob of draft-model SD.
+
+### Performance
+
+On an M5 Pro (64 GB) with Qwen3-8B + RedHatAI/Qwen3-8B-speculator.dflash,
+single-stream on natural prompts: **1.19x at the trained K=7** (mean
+acceptance length 2.62). Dropping to K=5 or K=3 falls to ~0.78x as acceptance
+collapses to ~1.6. Acceptance is strongly domain-dependent — math and code
+accept far more than summarization or translation.
 
 ## Draft Model
 

--- a/tests/test_dflash_model.py
+++ b/tests/test_dflash_model.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numerics tests for the MLX DFlash draft model vs a torch reference.
+
+The reference implements the exact math of vLLM 0.24.0's
+``DFlashQwen3ForCausalLM`` (qwen3_dflash.py): fc combine, hidden_norm,
+per-layer context K/V projection with k_norm + neox RoPE, the standard Qwen3
+query path attending non-causally over [context, queries], and the d2t
+draft->target readout. A convention mismatch (RoPE style, norm epsilon,
+GQA layout, mask) shows up as a hard failure here.
+"""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+
+from vllm_metal.v1.dflash_model import (
+    DFlashDraftModel,
+    DFlashModelArgs,
+)
+
+ARGS = DFlashModelArgs(
+    hidden_size=64,
+    num_hidden_layers=2,
+    intermediate_size=96,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=16,
+    rms_norm_eps=1e-6,
+    rope_theta=10000.0,
+    max_position_embeddings=2048,
+    vocab_size=120,
+    draft_vocab_size=48,
+    mask_token_id=110,
+    num_aux_layers=3,
+    target_hidden_size=64,
+)
+
+
+def _rand(rng: np.random.Generator, *shape: int) -> np.ndarray:
+    return (rng.standard_normal(shape) * 0.05).astype(np.float32)
+
+
+def _build_weights(args: DFlashModelArgs, seed: int = 0) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    h, hd = args.hidden_size, args.head_dim
+    nq, nkv = args.num_attention_heads, args.num_key_value_heads
+    weights: dict[str, np.ndarray] = {
+        "embed_tokens.weight": _rand(rng, args.vocab_size, h),
+        "fc.weight": _rand(rng, h, args.target_hidden_size * args.num_aux_layers),
+        "hidden_norm.weight": 1.0 + _rand(rng, h),
+        "norm.weight": 1.0 + _rand(rng, h),
+        "lm_head.weight": _rand(rng, args.draft_vocab_size, h),
+        # Injective draft->target map like real checkpoints: distinct target
+        # ids, stored as offsets (target_id = draft_id + d2t[draft_id]).
+        "d2t": (
+            np.sort(
+                rng.choice(args.vocab_size, size=args.draft_vocab_size, replace=False)
+            )
+            - np.arange(args.draft_vocab_size)
+        ).astype(np.int64),
+    }
+    for i in range(args.num_hidden_layers):
+        p = f"layers.{i}."
+        weights[p + "self_attn.q_proj.weight"] = _rand(rng, nq * hd, h)
+        weights[p + "self_attn.k_proj.weight"] = _rand(rng, nkv * hd, h)
+        weights[p + "self_attn.v_proj.weight"] = _rand(rng, nkv * hd, h)
+        weights[p + "self_attn.o_proj.weight"] = _rand(rng, h, nq * hd)
+        weights[p + "self_attn.q_norm.weight"] = 1.0 + _rand(rng, hd)
+        weights[p + "self_attn.k_norm.weight"] = 1.0 + _rand(rng, hd)
+        weights[p + "input_layernorm.weight"] = 1.0 + _rand(rng, h)
+        weights[p + "post_attention_layernorm.weight"] = 1.0 + _rand(rng, h)
+        weights[p + "mlp.gate_proj.weight"] = _rand(rng, args.intermediate_size, h)
+        weights[p + "mlp.up_proj.weight"] = _rand(rng, args.intermediate_size, h)
+        weights[p + "mlp.down_proj.weight"] = _rand(rng, h, args.intermediate_size)
+    return weights
+
+
+# ---------------------------------------------------------------------------
+# Torch reference (mirrors vllm 0.24.0 qwen3_dflash.py math)
+# ---------------------------------------------------------------------------
+
+
+def _t_rms(x: torch.Tensor, w: torch.Tensor, eps: float) -> torch.Tensor:
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * w
+
+
+def _t_rope(x: torch.Tensor, positions: torch.Tensor, theta: float) -> torch.Tensor:
+    """Neox-style (half-split) RoPE. x: [..., T, head_dim]."""
+    hd = x.shape[-1]
+    inv_freq = 1.0 / (theta ** (torch.arange(0, hd, 2, dtype=torch.float32) / hd))
+    freqs = positions.to(torch.float32)[:, None] * inv_freq[None, :]  # [T, hd/2]
+    cos, sin = freqs.cos(), freqs.sin()
+    x1, x2 = x[..., : hd // 2], x[..., hd // 2 :]
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)
+
+
+class _TorchRef:
+    def __init__(self, args: DFlashModelArgs, w: dict[str, np.ndarray]) -> None:
+        self.args = args
+        self.w = {k: torch.from_numpy(v) for k, v in w.items()}
+
+    def combine(self, aux: torch.Tensor) -> torch.Tensor:
+        return aux @ self.w["fc.weight"].T
+
+    def context_kv(
+        self, combined: torch.Tensor, positions: torch.Tensor
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        a = self.args
+        normed = _t_rms(combined, self.w["hidden_norm.weight"], a.rms_norm_eps)
+        out = []
+        for i in range(a.num_hidden_layers):
+            p = f"layers.{i}.self_attn."
+            k = (normed @ self.w[p + "k_proj.weight"].T).view(
+                -1, a.num_key_value_heads, a.head_dim
+            )
+            k = _t_rms(k, self.w[p + "k_norm.weight"], a.rms_norm_eps)
+            k = _t_rope(k.transpose(0, 1), positions, a.rope_theta)  # [nkv, T, hd]
+            v = (
+                (normed @ self.w[p + "v_proj.weight"].T)
+                .view(-1, a.num_key_value_heads, a.head_dim)
+                .transpose(0, 1)
+            )
+            out.append((k, v))
+        return out
+
+    def forward(
+        self,
+        q_ids: torch.Tensor,
+        ctx_kv: list[tuple[torch.Tensor, torch.Tensor]],
+        q_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        a = self.args
+        group = a.num_attention_heads // a.num_key_value_heads
+        h = self.w["embed_tokens.weight"][q_ids]
+        for i in range(a.num_hidden_layers):
+            p = f"layers.{i}."
+            x = _t_rms(h, self.w[p + "input_layernorm.weight"], a.rms_norm_eps)
+            q = (x @ self.w[p + "self_attn.q_proj.weight"].T).view(
+                -1, a.num_attention_heads, a.head_dim
+            )
+            q = _t_rms(q, self.w[p + "self_attn.q_norm.weight"], a.rms_norm_eps)
+            q = _t_rope(q.transpose(0, 1), q_positions, a.rope_theta)  # [nq, Q, hd]
+            k_new = (x @ self.w[p + "self_attn.k_proj.weight"].T).view(
+                -1, a.num_key_value_heads, a.head_dim
+            )
+            k_new = _t_rms(k_new, self.w[p + "self_attn.k_norm.weight"], a.rms_norm_eps)
+            k_new = _t_rope(k_new.transpose(0, 1), q_positions, a.rope_theta)
+            v_new = (
+                (x @ self.w[p + "self_attn.v_proj.weight"].T)
+                .view(-1, a.num_key_value_heads, a.head_dim)
+                .transpose(0, 1)
+            )
+
+            ck, cv = ctx_kv[i]
+            k = torch.cat([ck, k_new], dim=1)  # [nkv, T+Q, hd]
+            v = torch.cat([cv, v_new], dim=1)
+            k = k.repeat_interleave(group, dim=0)  # [nq, T+Q, hd]
+            v = v.repeat_interleave(group, dim=0)
+            scores = (q @ k.transpose(1, 2)) / math.sqrt(a.head_dim)
+            attn = torch.softmax(scores.to(torch.float32), dim=-1).to(q.dtype) @ v
+            attn = attn.transpose(0, 1).reshape(len(q_ids), -1)
+            h = h + attn @ self.w[p + "self_attn.o_proj.weight"].T
+
+            x = _t_rms(h, self.w[p + "post_attention_layernorm.weight"], a.rms_norm_eps)
+            gate = torch.nn.functional.silu(x @ self.w[p + "mlp.gate_proj.weight"].T)
+            up = x @ self.w[p + "mlp.up_proj.weight"].T
+            h = h + (gate * up) @ self.w[p + "mlp.down_proj.weight"].T
+        return _t_rms(h, self.w["norm.weight"], a.rms_norm_eps)
+
+    def full_vocab_logits(self, hidden: torch.Tensor) -> torch.Tensor:
+        """Upstream compute_logits: scatter draft logits into -inf full vocab."""
+        a = self.args
+        logits = hidden @ self.w["lm_head.weight"].T
+        full = torch.full((hidden.shape[0], a.vocab_size), float("-inf"))
+        targets = torch.arange(a.draft_vocab_size) + self.w["d2t"]
+        full[:, targets] = logits
+        return full
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def setup():
+    """Build model + torch reference, running MLX on CPU.
+
+    On M5-class GPUs MLX routes fp32 GEMMs through reduced-precision tensor
+    cores (~1e-3 relative error), which would drown out real convention bugs.
+    The CPU device gives true fp32 so tolerances can stay tight.
+    """
+    prev_device = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    try:
+        weights = _build_weights(ARGS)
+        model = DFlashDraftModel(ARGS)
+        model.load_weights([(k, mx.array(v)) for k, v in weights.items()], strict=True)
+        mx.eval(model.parameters())
+        yield model, _TorchRef(ARGS, weights), weights
+    finally:
+        mx.set_default_device(prev_device)
+
+
+def test_draft_forward_matches_torch_reference(setup) -> None:
+    """Full draft step vs the torch reference, with context rows starting at
+    a nonzero absolute position (exercises RoPE offsets on both the context
+    projection and the query path). The dense reference softmax also pins the
+    non-causal mask semantics: a causal regression would diverge here."""
+    model, ref, _ = setup
+    rng = np.random.default_rng(7)
+    num_ctx, num_query, ctx_offset = 9, 5, 23
+    aux = (
+        rng.standard_normal((num_ctx, ARGS.target_hidden_size * ARGS.num_aux_layers))
+        * 0.1
+    ).astype(np.float32)
+    q_ids = np.array(
+        [
+            3,
+            ARGS.mask_token_id,
+            ARGS.mask_token_id,
+            ARGS.mask_token_id,
+            ARGS.mask_token_id,
+        ],
+        dtype=np.int32,
+    )
+    query_offset = ctx_offset + num_ctx
+
+    combined = model.combine_hidden_states(mx.array(aux))
+    ck, cv = model.project_context_kv(combined, ctx_offset)
+    hidden = model(mx.array(q_ids), ck, cv, position_offset=query_offset)
+    logits = model.compute_draft_logits(hidden)
+    mx.eval(logits)
+
+    t_combined = ref.combine(torch.from_numpy(aux))
+    t_ctx = ref.context_kv(t_combined, torch.arange(ctx_offset, ctx_offset + num_ctx))
+    t_hidden = ref.forward(
+        torch.from_numpy(q_ids.astype(np.int64)),
+        t_ctx,
+        torch.arange(query_offset, query_offset + num_query),
+    )
+    t_logits = t_hidden @ ref.w["lm_head.weight"].T
+
+    np.testing.assert_allclose(
+        np.array(logits, dtype=np.float32),
+        t_logits.numpy(),
+        rtol=2e-4,
+        atol=2e-4,
+    )
+
+
+def test_d2t_readout_matches_full_vocab_scatter(setup) -> None:
+    """argmax(draft) + d2t offset == argmax over upstream's -inf scatter."""
+    model, ref, _ = setup
+    rng = np.random.default_rng(13)
+    hidden = (rng.standard_normal((6, ARGS.hidden_size)) * 0.3).astype(np.float32)
+
+    draft_ids = mx.argmax(model.compute_draft_logits(mx.array(hidden)), axis=-1)
+    mapped = model.map_draft_to_target(draft_ids)
+    mx.eval(mapped)
+
+    full = ref.full_vocab_logits(torch.from_numpy(hidden))
+    expected = torch.argmax(full, dim=-1).numpy()
+    np.testing.assert_array_equal(np.array(mapped, dtype=np.int64), expected)

--- a/tests/test_dflash_proposer.py
+++ b/tests/test_dflash_proposer.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the DFlash proposer and the aux hidden-state capture.
+
+No engine or real checkpoints: a tiny ``DFlashDraftModel`` (same config as
+``test_dflash_model``) plus hand-built ``ProposeContext`` objects drive the
+proposer; a tiny mlx_lm qwen3 model exercises the adapter's aux capture
+against the stock forward.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from tests.test_dflash_model import ARGS, _build_weights
+from vllm_metal.v1.dflash_model import DFlashDraftModel
+from vllm_metal.v1.dflash_proposer import DFlashProposer, _ContextKVSlab
+from vllm_metal.v1.proposer import ProposeContext
+from vllm_metal.v1.spec_decode import PagedDecodeSegment, SpeculativeDecodeController
+
+K = 3  # speculative tokens per step in these tests
+AUX_DIM = ARGS.target_hidden_size * ARGS.num_aux_layers
+
+
+def _model() -> DFlashDraftModel:
+    weights = _build_weights(ARGS)
+    model = DFlashDraftModel(ARGS)
+    model.load_weights([(k, mx.array(v)) for k, v in weights.items()], strict=True)
+    mx.eval(model.parameters())
+    return model
+
+
+def _proposer() -> DFlashProposer:
+    return DFlashProposer(
+        model=_model(),
+        model_args=ARGS,
+        aux_layer_ids=[0, 1],  # unused by these tests (runner-side contract)
+        controller=SpeculativeDecodeController(),
+    )
+
+
+def _request_state(token_ids: list[int], *, temperature: float = 0.0):
+    return SimpleNamespace(
+        token_ids=list(token_ids),
+        sampling_params=SamplingParams(temperature=temperature),
+        generated_tokens=1,
+    )
+
+
+def _prefill(
+    req_id: str,
+    token_ids: list[int],
+    *,
+    start_pos: int = 0,
+    temperature: float = 0.0,
+):
+    return SimpleNamespace(
+        req_id=req_id,
+        token_ids=list(token_ids),
+        block_ids=[0],
+        start_pos=start_pos,
+        sampling_params=SamplingParams(temperature=temperature),
+    )
+
+
+def _segment(
+    req_id: str,
+    *,
+    start_row: int,
+    cache_start_pos: int,
+    draft_token_ids: tuple[int, ...] = (),
+    last_token: int = 1,
+) -> PagedDecodeSegment:
+    input_token_ids = (last_token, *draft_token_ids)
+    return PagedDecodeSegment(
+        req_id=req_id,
+        input_token_ids=input_token_ids,
+        start_row=start_row,
+        num_query_tokens=len(input_token_ids),
+        draft_token_ids=draft_token_ids,
+        cache_start_pos=cache_start_pos,
+        block_ids=(0,),
+    )
+
+
+def _aux(num_rows: int, seed: int = 0) -> mx.array:
+    rng = np.random.default_rng(seed)
+    return mx.array((rng.standard_normal((num_rows, AUX_DIM)) * 0.1).astype(np.float32))
+
+
+def _ctx(
+    *,
+    aux: mx.array | None,
+    decode_reqs=(),
+    decode_segments=(),
+    decode_token_ids=(),
+    prefill_reqs=(),
+    prefill_token_ids=(),
+    prefill_result_modes=(),
+    request_states=None,
+    cu_seqlens=(0,),
+    num_speculative_tokens: int = K,
+) -> ProposeContext:
+    if request_states is None:
+        request_states = dict(decode_reqs)
+        for prefill in prefill_reqs:
+            request_states.setdefault(
+                prefill.req_id, _request_state(list(prefill.token_ids))
+            )
+    return ProposeContext(
+        target_hidden_states=None,
+        target_aux_hidden_states=aux,
+        decode_reqs=list(decode_reqs),
+        decode_segments=list(decode_segments),
+        decode_token_ids=list(decode_token_ids),
+        prefill_reqs=list(prefill_reqs),
+        prefill_token_ids=list(prefill_token_ids),
+        prefill_result_modes=list(prefill_result_modes),
+        request_states=request_states,
+        cu_seqlens=list(cu_seqlens),
+        num_decode_segments=len(decode_segments),
+        num_speculative_tokens=num_speculative_tokens,
+        logitsprocs=None,
+    )
+
+
+class TestDFlashProposerIngest:
+    def test_intermediate_chunk_ingests_without_drafting(self) -> None:
+        proposer = _proposer()
+        chunk = [5, 6, 7]
+        ctx = _ctx(
+            aux=_aux(len(chunk)),
+            prefill_reqs=[_prefill("r1", chunk)],
+            prefill_token_ids=[0],
+            prefill_result_modes=["intermediate"],
+            request_states={},
+            cu_seqlens=[0, len(chunk)],
+        )
+        assert proposer.propose(ctx) is None
+        assert proposer._slabs["r1"].ctx_len == len(chunk)
+
+        # Continuation chunk starts where the first left off.
+        chunk2 = [8, 9]
+        ctx2 = _ctx(
+            aux=_aux(len(chunk2), seed=1),
+            prefill_reqs=[_prefill("r1", chunk2, start_pos=len(chunk))],
+            prefill_token_ids=[11],
+            prefill_result_modes=["new_final"],
+            cu_seqlens=[0, len(chunk2)],
+        )
+        out = proposer.propose(ctx2)
+        assert out is not None and out.req_ids == ["r1"]
+        assert proposer._slabs["r1"].ctx_len == len(chunk) + len(chunk2)
+
+    def test_decode_ingests_only_accepted_rows(self) -> None:
+        # The load-bearing invariant: a verify step ingests the ACCEPTED-token
+        # count, not the drafted-token count. Anything else desyncs the context
+        # KV from the target and silently corrupts every later draft.
+        proposer = _proposer()
+        prompt = [5, 6, 7, 8]
+        proposer.propose(
+            _ctx(
+                aux=_aux(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+
+        # Verify step: rows [bonus, d1, d2, d3]; only 2 outputs sampled
+        # (one accepted draft + correction) => ingest exactly 2 rows, so the
+        # slab advances 4 -> 6, not 4 -> 7 (the drafted count).
+        state = _request_state(prompt + [9, 10, 42])
+        segment = _segment(
+            "r1",
+            start_row=0,
+            cache_start_pos=4,
+            draft_token_ids=(10, 11, 12),
+            last_token=9,
+        )
+        ctx = _ctx(
+            aux=_aux(4, seed=2),
+            decode_reqs=[("r1", state)],
+            decode_segments=[segment],
+            decode_token_ids=[[10, 42]],
+            cu_seqlens=[0, 4],
+        )
+        out = proposer.propose(ctx)
+        assert out is not None and out.req_ids == ["r1"]
+        assert proposer._slabs["r1"].ctx_len == 6
+
+    def test_non_greedy_requests_are_skipped(self) -> None:
+        proposer = _proposer()
+        prompt = [5, 6, 7]
+        ctx = _ctx(
+            aux=_aux(len(prompt)),
+            prefill_reqs=[_prefill("r1", prompt, temperature=0.8)],
+            prefill_token_ids=[9],
+            prefill_result_modes=["new_final"],
+            request_states={"r1": _request_state(prompt + [9], temperature=0.8)},
+            cu_seqlens=[0, len(prompt)],
+        )
+        assert proposer.propose(ctx) is None
+        assert "r1" not in proposer._slabs
+
+    def test_context_hole_fails_loud(self) -> None:
+        """A forward position gap means hidden states were never observed —
+        unrepairable, so propose must raise rather than draft wrongly."""
+        proposer = _proposer()
+        prompt = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                aux=_aux(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        # Decode step whose first row position (10) skips ahead of ctx_len (3).
+        state = _request_state(prompt + [9, 10])
+        segment = _segment("r1", start_row=0, cache_start_pos=10, last_token=9)
+        ctx = _ctx(
+            aux=_aux(1, seed=3),
+            decode_reqs=[("r1", state)],
+            decode_segments=[segment],
+            decode_token_ids=[[10]],
+            cu_seqlens=[0, 1],
+        )
+        with pytest.raises(RuntimeError, match="hole"):
+            proposer.propose(ctx)
+
+    def test_rewind_truncates_and_reingests(self) -> None:
+        """A scheduler preemption-recompute re-forwards committed tokens from
+        an earlier position; the slab truncates and rebuilds exactly."""
+        proposer = _proposer()
+        prompt = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                aux=_aux(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        # Recompute: the request re-prefills the same span (now 4 tokens) from
+        # position 0. The slab must truncate and rebuild to 4 — not append onto
+        # the stale 3, which would leave 7.
+        out = proposer.propose(
+            _ctx(
+                aux=_aux(4, seed=5),
+                prefill_reqs=[_prefill("r1", prompt + [9], start_pos=0)],
+                prefill_token_ids=[10],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, 4],
+            )
+        )
+        assert out is not None and out.req_ids == ["r1"]
+        assert proposer._slabs["r1"].ctx_len == 4
+
+
+class TestContextKVSlab:
+    def test_append_grows_and_preserves(self) -> None:
+        slab = _ContextKVSlab()
+        k1 = mx.ones((2, 2, 300, 4))
+        v1 = mx.full((2, 2, 300, 4), 2.0)
+        slab.append(k1, v1)
+        assert slab.ctx_len == 300
+        k2 = mx.full((2, 2, 10, 4), 3.0)
+        slab.append(k2, k2)
+        assert slab.ctx_len == 310
+        k_view, v_view = slab.view()
+        mx.eval(k_view, v_view)
+        assert k_view.shape == (2, 2, 310, 4)
+        assert float(k_view[0, 0, 0, 0]) == 1.0
+        assert float(k_view[0, 0, 305, 0]) == 3.0
+        assert float(v_view[0, 0, 299, 0]) == 2.0
+
+
+class TestAuxCapture:
+    def test_adapter_aux_capture_matches_stock_forward(self) -> None:
+        from mlx_lm.models import qwen3 as mlx_qwen3
+
+        from vllm_metal.v1.model_adapter import DefaultModelAdapter
+
+        args = mlx_qwen3.ModelArgs(
+            model_type="qwen3",
+            hidden_size=64,
+            num_hidden_layers=4,
+            intermediate_size=96,
+            num_attention_heads=4,
+            rms_norm_eps=1e-6,
+            vocab_size=128,
+            num_key_value_heads=2,
+            max_position_embeddings=512,
+            rope_theta=10000.0,
+            head_dim=16,
+            tie_word_embeddings=True,
+        )
+        model = mlx_qwen3.Model(args)
+        mx.eval(model.parameters())
+        adapter = DefaultModelAdapter()
+        input_ids = mx.array([[3, 5, 7, 11, 13]], dtype=mx.int32)
+
+        stock = adapter.target_forward(model, input_ids, collect_hidden_states=True)
+        captured = adapter.target_forward(
+            model,
+            input_ids,
+            collect_hidden_states=True,
+            aux_layer_ids=[1, 3],
+        )
+        mx.eval(stock.logits, captured.logits, captured.aux_hidden_states)
+
+        assert captured.aux_hidden_states is not None
+        assert captured.aux_hidden_states.shape == (5, 2 * args.hidden_size)
+        np.testing.assert_allclose(
+            np.array(captured.logits, dtype=np.float32),
+            np.array(stock.logits, dtype=np.float32),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        np.testing.assert_array_equal(
+            np.array(captured.hidden_states, dtype=np.float32),
+            np.array(stock.hidden_states, dtype=np.float32),
+        )
+
+        # The captured slice for layer id i must equal the residual stream
+        # after layer i, computed manually.
+        backbone = model.model
+        from mlx_lm.models.base import create_attention_mask
+
+        h = backbone.embed_tokens(input_ids)
+        mask = create_attention_mask(h, None)
+        expected = {}
+        for i, layer in enumerate(backbone.layers):
+            h = layer(h, mask, None)
+            if i in (1, 3):
+                expected[i] = h
+        aux = captured.aux_hidden_states
+        np.testing.assert_array_equal(
+            np.array(aux[:, : args.hidden_size]),
+            np.array(expected[1][0]),
+        )
+        np.testing.assert_array_equal(
+            np.array(aux[:, args.hidden_size :]),
+            np.array(expected[3][0]),
+        )

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -72,6 +72,7 @@ def _context(
         request_states = dict(decode_reqs)
     return ProposeContext(
         target_hidden_states=None,
+        target_aux_hidden_states=None,
         decode_reqs=decode_reqs,
         decode_segments=[],
         decode_token_ids=decode_token_ids,

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -307,7 +307,9 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, aux_layer_ids=None
+        ):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -357,7 +359,9 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, aux_layer_ids=None
+        ):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -459,7 +463,9 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, aux_layer_ids=None
+        ):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -507,7 +513,9 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, aux_layer_ids=None
+        ):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -564,7 +572,9 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, aux_layer_ids=None
+        ):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -1499,7 +1509,9 @@ class TestV1MetalModelRunnerGDNLifecycle:
 
         captured: dict[str, object] = {}
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, aux_layer_ids=None
+        ):
             del cache, collect_hidden_states
             ctx = mr.get_context()
             assert ctx is not None

--- a/tools/check_sd_lossless.py
+++ b/tools/check_sd_lossless.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify speculative decoding is lossless under greedy sampling.
+
+Greedy SD must produce token-identical output to greedy non-SD: the verifier
+accepts a draft token iff it equals the target argmax, so any divergence means
+the verification forward (or the draft/KV plumbing behind it) is wrong. This
+exercises the whole spec-decode stack end to end — including the attention
+kernel's multi-token verify windows — with no golden files to maintain.
+
+Each engine runs in its own subprocess (clean Metal state between configs).
+
+Usage:
+  python tools/check_sd_lossless.py                          # Qwen3-0.6B self-draft K=3
+  python tools/check_sd_lossless.py --method mtp \
+      --model mlx-community/gemma-4-e2b-it-bf16 \
+      --draft mlx-community/gemma-4-E2B-it-assistant-bf16 -k 1
+  python tools/check_sd_lossless.py --method dflash \
+      --model Qwen/Qwen3-8B --draft RedHatAI/Qwen3-8B-speculator.dflash \
+      -k 7 --memory-fraction 0.62 --max-model-len 2048
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+PROMPTS = [
+    "The capital of France is",
+    "One plus one equals",
+    "Water boils at a temperature of",
+    "The largest planet in our solar system is",
+    "In Python, a list comprehension is",
+    "The theory of relativity states that",
+    "A binary search tree is a data structure where",
+    "Photosynthesis is the process by which",
+    "The French Revolution began in",
+    "To reverse a linked list, you",
+    "The speed of light in a vacuum is",
+    "Machine learning models are trained by",
+]
+
+_WORKER = r"""
+import json, sys, time
+from vllm import LLM, SamplingParams
+
+cfg = json.load(open(sys.argv[1]))
+llm = LLM(
+    model=cfg["model"],
+    max_model_len=cfg["max_model_len"],
+    enable_prefix_caching=False,
+    speculative_config=cfg["speculative_config"],
+    # Both engines run synchronous scheduling: SD on Metal requires it, and
+    # keeping the base engine identical isolates the SD stack as the only
+    # variable in the token-identity comparison.
+    async_scheduling=False,
+    disable_log_stats=False,  # keep spec-decode acceptance counters available
+)
+params = SamplingParams(temperature=0.0, max_tokens=cfg["max_tokens"], ignore_eos=True)
+start = time.perf_counter()
+outputs = llm.generate(cfg["prompts"], params)
+elapsed = time.perf_counter() - start
+result = {o.prompt: list(o.outputs[0].token_ids) for o in outputs}
+gen_tokens = sum(len(v) for v in result.values())
+stats = {"gen_tokens": gen_tokens, "elapsed_s": round(elapsed, 2),
+         "tok_per_s": round(gen_tokens / elapsed, 2)}
+try:
+    for metric in llm.get_metrics():
+        if "spec_decode" in metric.name:
+            key = metric.name.split(":")[-1]
+            value = getattr(metric, "value", None)
+            if value is None:
+                value = getattr(metric, "values", None)
+            stats[key] = value
+except Exception as exc:  # pragma: no cover - metrics API drift
+    stats["metrics_error"] = repr(exc)
+json.dump({"tokens": result, "stats": stats}, open(cfg["out"], "w"))
+"""
+
+
+def run_engine(args, spec_config: dict | None, out_path: str) -> dict[str, list[int]]:
+    cfg = {
+        "model": args.model,
+        "max_model_len": args.max_model_len,
+        "max_tokens": args.max_tokens,
+        "prompts": PROMPTS[: args.num_prompts],
+        "speculative_config": spec_config,
+        "out": out_path,
+    }
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(cfg, f)
+        cfg_path = f.name
+    env = os.environ.copy()
+    env.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    env.setdefault("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+    env.setdefault("VLLM_METAL_MEMORY_FRACTION", args.memory_fraction)
+    label = json.dumps(spec_config) if spec_config else "no-SD"
+    print(f"[check_sd_lossless] running engine: {label}", flush=True)
+    subprocess.run(
+        [sys.executable, "-c", _WORKER, cfg_path],
+        env=env,
+        check=True,
+    )
+    return json.load(open(out_path))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    p.add_argument("--draft", default="Qwen/Qwen3-0.6B")
+    p.add_argument(
+        "--method", default="draft_model", choices=["draft_model", "mtp", "dflash"]
+    )
+    p.add_argument("-k", "--num-speculative-tokens", type=int, default=3)
+    p.add_argument("--max-tokens", type=int, default=64)
+    p.add_argument("--num-prompts", type=int, default=len(PROMPTS))
+    p.add_argument("--max-model-len", type=int, default=512)
+    p.add_argument("--memory-fraction", default="0.35")
+    args = p.parse_args()
+
+    spec = {
+        "method": args.method,
+        "model": args.draft,
+        "num_speculative_tokens": args.num_speculative_tokens,
+    }
+    with tempfile.TemporaryDirectory() as td:
+        base_result = run_engine(args, None, os.path.join(td, "base.json"))
+        sd_result = run_engine(args, spec, os.path.join(td, "sd.json"))
+    base, sd = base_result["tokens"], sd_result["tokens"]
+    print(f"[stats] base: {json.dumps(base_result['stats'])}")
+    print(f"[stats] sd:   {json.dumps(sd_result['stats'])}")
+
+    mismatches = 0
+    for prompt in base:
+        if base[prompt] != sd.get(prompt):
+            mismatches += 1
+            b, s = base[prompt], sd.get(prompt) or []
+            div = next(
+                (i for i, (x, y) in enumerate(zip(b, s, strict=False)) if x != y),
+                min(len(b), len(s)),
+            )
+            print(f"MISMATCH @ token {div}: {prompt!r}")
+            print(f"  base[{div}:{div + 5}] = {b[div : div + 5]}")
+            print(f"  sd  [{div}:{div + 5}] = {s[div : div + 5]}")
+    if mismatches:
+        print(f"FAIL: {mismatches}/{len(base)} prompts diverged — SD is NOT lossless")
+        return 1
+    print(
+        f"PASS: {len(base)} prompts x {args.max_tokens} tokens are token-identical "
+        f"(greedy, method={args.method}, K={args.num_speculative_tokens})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_metal/v1/dflash_model.py
+++ b/vllm_metal/v1/dflash_model.py
@@ -1,0 +1,357 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX draft model for DFlash speculative decoding.
+
+Ports vLLM 0.24.0's ``DFlashQwen3ForCausalLM``
+(``vllm/model_executor/models/qwen3_dflash.py``) to MLX. The draft is a small
+stack of standard Qwen3 decoder layers with two DFlash-specific pieces:
+
+- ``combine_hidden_states``: one ``fc`` projection over the concatenation of N
+  target-layer hidden states (``aux_hidden_state_layer_ids``), producing the
+  context representation.
+- ``project_context_kv``: per-layer K/V projections of the fc-combined context
+  (``hidden_norm`` -> ``k_proj``/``v_proj`` -> ``k_norm`` -> RoPE). Context K/V
+  never flows through the decoder layers; it is attended to directly by the
+  query tokens (bonus + K mask tokens) in a single **non-causal** forward.
+
+Weight names match the checkpoints (``layers.{i}.self_attn.q_proj`` etc.), so
+loading is a direct tree match with no renames beyond upstream's
+``midlayer. -> layers.0.`` compatibility rule.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models import qwen3 as _mlx_qwen3
+from mlx_lm.models.rope_utils import initialize_rope
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_SKIPPED_WEIGHT_PREFIXES = ("t2d",)
+
+
+@dataclass(frozen=True, slots=True)
+class DFlashModelArgs:
+    """Draft-model hyperparameters parsed from a speculators checkpoint."""
+
+    hidden_size: int
+    num_hidden_layers: int
+    intermediate_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    rope_theta: float
+    max_position_embeddings: int
+    vocab_size: int
+    draft_vocab_size: int
+    mask_token_id: int
+    num_aux_layers: int
+    target_hidden_size: int
+    attention_bias: bool = False
+
+    @classmethod
+    def from_checkpoint_config(cls, config: dict) -> DFlashModelArgs:
+        tl = config["transformer_layer_config"]
+        # transformers >=5 serializes rope under ``rope_parameters``; older
+        # checkpoints keep a top-level ``rope_theta``. Upstream defaults to
+        # 1e6 only when the checkpoint carries neither
+        # (set_default_rope_theta in qwen3_dflash.py).
+        rope_parameters = tl.get("rope_parameters") or {}
+        rope_theta = rope_parameters.get("rope_theta")
+        if rope_theta is None:
+            rope_theta = tl.get("rope_theta", 1_000_000.0)
+
+        aux_layer_ids = config["aux_hidden_state_layer_ids"]
+        hidden_size = int(tl["hidden_size"])
+        target_hidden_size = config.get("target_hidden_size") or hidden_size
+
+        num_heads = int(tl["num_attention_heads"])
+        head_dim = int(tl.get("head_dim") or hidden_size // num_heads)
+
+        vocab_size = int(tl["vocab_size"])
+        draft_vocab_size = int(config.get("draft_vocab_size") or vocab_size)
+
+        return cls(
+            hidden_size=hidden_size,
+            num_hidden_layers=int(tl["num_hidden_layers"]),
+            intermediate_size=int(tl["intermediate_size"]),
+            num_attention_heads=num_heads,
+            num_key_value_heads=int(tl["num_key_value_heads"]),
+            head_dim=head_dim,
+            rms_norm_eps=float(tl["rms_norm_eps"]),
+            rope_theta=float(rope_theta),
+            max_position_embeddings=int(tl.get("max_position_embeddings", 40960)),
+            vocab_size=vocab_size,
+            draft_vocab_size=draft_vocab_size,
+            mask_token_id=int(config["mask_token_id"]),
+            num_aux_layers=len(aux_layer_ids),
+            target_hidden_size=int(target_hidden_size),
+            attention_bias=bool(tl.get("attention_bias", False)),
+        )
+
+
+class DFlashAttention(nn.Module):
+    """Qwen3-style attention whose K/V context is supplied externally.
+
+    The forward only projects the query tokens; context K/V comes from
+    ``DFlashDraftModel.project_context_kv`` (target hidden states), so this
+    layer concatenates [context K/V, query K/V] and runs one non-causal SDPA.
+    """
+
+    def __init__(self, args: DFlashModelArgs) -> None:
+        super().__init__()
+        dim = args.hidden_size
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        bias = args.attention_bias
+        self.q_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=bias)
+        self.k_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=bias)
+        self.v_proj = nn.Linear(dim, self.n_kv_heads * self.head_dim, bias=bias)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, dim, bias=bias)
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.rope = initialize_rope(
+            self.head_dim,
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=None,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def project_context_kv(
+        self, normed_context: mx.array, position_offset: int
+    ) -> tuple[mx.array, mx.array]:
+        """Project normed context states to this layer's rotated K and V.
+
+        Args:
+            normed_context: ``[num_ctx, hidden]`` — ``hidden_norm`` output.
+            position_offset: absolute position of the first context row; the
+                rows must be positionally contiguous.
+
+        Returns ``(k, v)`` of shape ``[n_kv_heads, num_ctx, head_dim]``.
+        """
+        num_ctx = normed_context.shape[0]
+        k = self.k_proj(normed_context).reshape(num_ctx, self.n_kv_heads, -1)
+        k = self.k_norm(k).transpose(1, 0, 2)
+        k = self.rope(k, offset=position_offset)
+        v = self.v_proj(normed_context).reshape(num_ctx, self.n_kv_heads, -1)
+        v = v.transpose(1, 0, 2)
+        return k, v
+
+    def __call__(
+        self,
+        x: mx.array,
+        context_k: mx.array,
+        context_v: mx.array,
+        position_offset: int,
+    ) -> mx.array:
+        """Non-causal attention of query tokens over [context, queries].
+
+        Args:
+            x: ``[num_query, hidden]`` query hidden states.
+            context_k / context_v: ``[n_kv_heads, num_ctx, head_dim]``.
+            position_offset: absolute position of the first query token
+                (= number of context tokens for DFlash).
+        """
+        num_query = x.shape[0]
+        q = self.q_proj(x).reshape(num_query, self.n_heads, -1)
+        q = self.q_norm(q).transpose(1, 0, 2)
+        q = self.rope(q, offset=position_offset)
+
+        k = self.k_proj(x).reshape(num_query, self.n_kv_heads, -1)
+        k = self.k_norm(k).transpose(1, 0, 2)
+        k = self.rope(k, offset=position_offset)
+        v = self.v_proj(x).reshape(num_query, self.n_kv_heads, -1).transpose(1, 0, 2)
+
+        keys = mx.concatenate([context_k, k], axis=1)
+        values = mx.concatenate([context_v, v], axis=1)
+
+        # Every query attends to all context and every query (block-diffusion
+        # parallel drafting): a dense SDPA with no mask.
+        out = mx.fast.scaled_dot_product_attention(
+            q[None],
+            keys[None],
+            values[None],
+            scale=self.scale,
+            mask=None,
+        )
+        out = out[0].transpose(1, 0, 2).reshape(num_query, -1)
+        return self.o_proj(out)
+
+
+class DFlashBlock(nn.Module):
+    """Standard Qwen3 decoder block over externally supplied context K/V."""
+
+    def __init__(self, args: DFlashModelArgs) -> None:
+        super().__init__()
+        self.self_attn = DFlashAttention(args)
+        self.mlp = _mlx_qwen3.MLP(args.hidden_size, args.intermediate_size)
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        context_k: mx.array,
+        context_v: mx.array,
+        position_offset: int,
+    ) -> mx.array:
+        h = x + self.self_attn(
+            self.input_layernorm(x), context_k, context_v, position_offset
+        )
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class DFlashDraftModel(nn.Module):
+    """DFlash draft model.
+
+    One proposal step:
+    1. ``combine_hidden_states`` + ``project_context_kv`` append the newly
+       committed tokens' context K/V (owned by the proposer, not this module).
+    2. ``__call__`` runs the query tokens ``[bonus, mask * K]`` through the
+       decoder stack, attending non-causally over context + queries.
+    3. ``compute_draft_logits``/``map_draft_to_target`` read out the drafts.
+    """
+
+    def __init__(self, args: DFlashModelArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DFlashBlock(args) for _ in range(args.num_hidden_layers)]
+        self.fc = nn.Linear(
+            args.target_hidden_size * args.num_aux_layers,
+            args.hidden_size,
+            bias=False,
+        )
+        self.hidden_norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.lm_head = nn.Linear(args.hidden_size, args.draft_vocab_size, bias=False)
+        if args.draft_vocab_size != args.vocab_size:
+            # Offset table: target_id = draft_id + d2t[draft_id]
+            # (matches upstream compute_logits: targets = arange + d2t).
+            self.d2t = mx.zeros((args.draft_vocab_size,), dtype=mx.int64)
+        else:
+            self.d2t = None
+
+    # -- context side ---------------------------------------------------------
+
+    def combine_hidden_states(self, aux_hidden_states: mx.array) -> mx.array:
+        """Project ``[num_tokens, num_aux * target_hidden]`` aux concat via fc."""
+        return self.fc(aux_hidden_states)
+
+    def project_context_kv(
+        self, context_states: mx.array, position_offset: int
+    ) -> tuple[mx.array, mx.array]:
+        """Compute per-layer context K/V from fc-combined target states.
+
+        Mirrors upstream ``precompute_and_store_context_kv``:
+        ``hidden_norm`` once, then per-layer K/V projection + k_norm + RoPE.
+
+        Args:
+            context_states: ``[num_ctx, hidden]`` fc-combined states for
+                positionally contiguous rows starting at ``position_offset``.
+
+        Returns ``(k, v)`` of shape
+        ``[num_layers, n_kv_heads, num_ctx, head_dim]``.
+        """
+        normed = self.hidden_norm(context_states)
+        ks, vs = [], []
+        for layer in self.layers:
+            k, v = layer.self_attn.project_context_kv(normed, position_offset)
+            ks.append(k)
+            vs.append(v)
+        return mx.stack(ks, axis=0), mx.stack(vs, axis=0)
+
+    # -- query side -----------------------------------------------------------
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        context_k: mx.array,
+        context_v: mx.array,
+        position_offset: int,
+    ) -> mx.array:
+        """Run query tokens through the stack; return normed hidden states.
+
+        Args:
+            input_ids: ``[num_query]`` — bonus token followed by mask tokens.
+            context_k / context_v: ``[num_layers, n_kv_heads, num_ctx, hd]``.
+            position_offset: absolute position of the bonus token.
+        """
+        h = self.embed_tokens(input_ids)
+        for i, layer in enumerate(self.layers):
+            h = layer(h, context_k[i], context_v[i], position_offset)
+        return self.norm(h)
+
+    def compute_draft_logits(self, hidden_states: mx.array) -> mx.array:
+        """Draft-vocab logits (no d2t scatter; greedy readout maps ids)."""
+        return self.lm_head(hidden_states)
+
+    def map_draft_to_target(self, draft_token_ids: mx.array) -> mx.array:
+        """Map draft-vocab argmax ids to target-vocab ids via the d2t offsets."""
+        if self.d2t is None:
+            return draft_token_ids
+        return draft_token_ids + self.d2t[draft_token_ids]
+
+
+def load_dflash_draft_model(
+    model_path: str | Path, *, dtype: mx.Dtype = mx.bfloat16
+) -> tuple[DFlashDraftModel, DFlashModelArgs, dict]:
+    """Load a speculators-format DFlash checkpoint into MLX.
+
+    Returns ``(model, args, raw_config)``.
+    """
+    path = Path(model_path)
+    config = json.loads((path / "config.json").read_text())
+    args = DFlashModelArgs.from_checkpoint_config(config)
+    model = DFlashDraftModel(args)
+
+    weight_files = sorted(path.glob("*.safetensors"))
+    if not weight_files:
+        raise FileNotFoundError(f"No safetensors found under {path}")
+    weights: dict[str, mx.array] = {}
+    for wf in weight_files:
+        weights.update(mx.load(str(wf)))
+
+    sanitized: dict[str, mx.array] = {}
+    for name, value in weights.items():
+        # Upstream compatibility rename for single-layer checkpoints.
+        if "midlayer." in name:
+            name = name.replace("midlayer.", "layers.0.")
+        if name.startswith(_SKIPPED_WEIGHT_PREFIXES):
+            continue
+        if name == "d2t":
+            sanitized["d2t"] = value.astype(mx.int64)
+            continue
+        if mx.issubdtype(value.dtype, mx.floating):
+            value = value.astype(dtype)
+        sanitized[name] = value
+
+    model.load_weights(list(sanitized.items()), strict=True)
+    mx.eval(model.parameters())
+    model.eval()
+    logger.info(
+        "Loaded DFlash draft model from %s: layers=%d hidden=%d heads=%d/%d "
+        "head_dim=%d rope_theta=%.0f draft_vocab=%d aux_layers=%d",
+        path,
+        args.num_hidden_layers,
+        args.hidden_size,
+        args.num_attention_heads,
+        args.num_key_value_heads,
+        args.head_dim,
+        args.rope_theta,
+        args.draft_vocab_size,
+        args.num_aux_layers,
+    )
+    return model, args, config

--- a/vllm_metal/v1/dflash_proposer.py
+++ b/vllm_metal/v1/dflash_proposer.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash speculative-decoding proposer for the Metal paged path.
+
+Ports vLLM 0.24.0's DFlash proposer (``vllm/v1/spec_decode/dflash.py``) to the
+Metal proposer seam. Unlike :class:`DraftModelProposer`, the draft model never
+runs autoregressively and never re-reads token ids:
+
+1. **Ingest** — every step, the newly committed rows' *target aux hidden
+   states* (concat of ``aux_hidden_state_layer_ids`` residual streams) are
+   ``fc``-combined and projected into per-layer context K/V, appended to a
+   per-request contiguous KV slab. Decode rows contribute only their accepted
+   prefix; prefill chunks (including intermediate ones — their hidden states
+   exist only in the step that ran them) contribute every row.
+2. **Draft** — one forward over ``[bonus_token, mask * K]`` queries attending
+   non-causally over [context, queries]; each mask row predicts the token at
+   its own position (upstream ``sample_off=1``).
+
+The query tokens' K/V is never persisted: context K/V for accepted tokens is
+always re-projected from target hidden states the following step, so the draft
+needs no paged cache, block tables, or cache-write kernels at all.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import mlx.core as mx
+from vllm.logger import init_logger
+from vllm.v1.outputs import DraftTokenIds
+
+from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.dflash_model import (
+    DFlashDraftModel,
+    DFlashModelArgs,
+    load_dflash_draft_model,
+)
+
+if TYPE_CHECKING:
+    from vllm.config.speculative import SpeculativeConfig
+
+    from vllm_metal.v1.proposer import ProposeContext
+    from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+logger = init_logger(__name__)
+
+# Slab growth quantum (positions), mirroring mlx_lm's KVCache step.
+_SLAB_STEP = 256
+
+
+class _ContextKVSlab:
+    """Per-request growable context K/V for all draft layers.
+
+    Shapes: ``[num_layers, n_kv_heads, capacity, head_dim]``; the first
+    ``ctx_len`` positions are valid. Slice-assignment keeps updates in-place
+    under MLX's lazy evaluation (the mlx_lm KVCache pattern).
+    """
+
+    __slots__ = ("ctx_len", "keys", "values")
+
+    def __init__(self) -> None:
+        self.keys: mx.array | None = None
+        self.values: mx.array | None = None
+        self.ctx_len = 0
+
+    def append(self, k: mx.array, v: mx.array) -> None:
+        """Append ``[L, n_kv, T, hd]`` context K/V at positions ctx_len..+T."""
+        num_new = k.shape[2]
+        needed = self.ctx_len + num_new
+        if self.keys is None or needed > self.keys.shape[2]:
+            capacity = ((needed + _SLAB_STEP - 1) // _SLAB_STEP) * _SLAB_STEP
+            grown_k = mx.zeros(
+                (k.shape[0], k.shape[1], capacity, k.shape[3]), dtype=k.dtype
+            )
+            grown_v = mx.zeros_like(grown_k)
+            if self.keys is not None and self.ctx_len > 0:
+                grown_k[:, :, : self.ctx_len, :] = self.keys[:, :, : self.ctx_len, :]
+                grown_v[:, :, : self.ctx_len, :] = self.values[:, :, : self.ctx_len, :]
+            self.keys, self.values = grown_k, grown_v
+        self.keys[:, :, self.ctx_len : needed, :] = k
+        self.values[:, :, self.ctx_len : needed, :] = v
+        self.ctx_len = needed
+
+    def view(self) -> tuple[mx.array, mx.array]:
+        assert self.keys is not None and self.values is not None
+        return (
+            self.keys[:, :, : self.ctx_len, :],
+            self.values[:, :, : self.ctx_len, :],
+        )
+
+
+class DFlashProposer:
+    """:class:`vllm_metal.v1.proposer.MetalProposer` for DFlash drafts."""
+
+    def __init__(
+        self,
+        *,
+        model: DFlashDraftModel,
+        model_args: DFlashModelArgs,
+        aux_layer_ids: list[int],
+        controller: SpeculativeDecodeController,
+    ) -> None:
+        self._model = model
+        self._args = model_args
+        self._controller = controller
+        # 0-indexed target layers after which the residual stream is captured;
+        # read by the model runner / adapter each forward.
+        self.aux_hidden_state_layer_ids: list[int] = aux_layer_ids
+        self._slabs: dict[str, _ContextKVSlab] = {}
+
+    # -- construction ----------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        speculative_config: SpeculativeConfig,
+        controller: SpeculativeDecodeController,
+        dtype: mx.Dtype,
+    ) -> DFlashProposer:
+        draft_model_config = speculative_config.draft_model_config
+        if draft_model_config is None:
+            raise ValueError("DFlash speculative decoding requires a draft model")
+        model_path = get_model_download_path(draft_model_config.model)
+        if not Path(model_path).is_dir():
+            # HF repo id (get_model_download_path only localizes ModelScope
+            # repos): resolve to the hub snapshot, downloading if needed.
+            from huggingface_hub import snapshot_download
+
+            model_path = snapshot_download(model_path)
+        model, args, raw_config = load_dflash_draft_model(model_path, dtype=dtype)
+
+        checkpoint_aux_ids = raw_config.get("aux_hidden_state_layer_ids")
+        if not checkpoint_aux_ids:
+            raise ValueError(
+                "DFlash checkpoint config is missing aux_hidden_state_layer_ids"
+            )
+        if 0 in checkpoint_aux_ids:
+            raise NotImplementedError(
+                "aux_hidden_state_layer_ids containing 0 (post-embedding "
+                "capture) is not supported on Metal yet"
+            )
+        # Checkpoint ids follow upstream's speculators convention: id ``j``
+        # is the residual stream after 0-indexed target layer ``j - 1``
+        # (vllm 0.24.0 llama.py forward loop + algos.py target_layer_ids).
+        aux_layer_ids = [int(j) - 1 for j in checkpoint_aux_ids]
+
+        algorithm = (raw_config.get("speculators_config") or {}).get("algorithm")
+        logger.info(
+            "DFlash drafter ready: %s (algorithm=%s, aux target layers=%s, "
+            "mask_token=%d, draft_vocab=%d)",
+            draft_model_config.model,
+            algorithm,
+            aux_layer_ids,
+            args.mask_token_id,
+            args.draft_vocab_size,
+        )
+        return cls(
+            model=model,
+            model_args=args,
+            aux_layer_ids=aux_layer_ids,
+            controller=controller,
+        )
+
+    # -- MetalProposer protocol -------------------------------------------------
+
+    def needs_target_hidden_states(
+        self,
+        decode_segments: Any,
+        *,
+        has_final_prefill: bool,
+    ) -> bool:
+        # Context K/V is projected from target hidden states of EVERY
+        # scheduled token — including intermediate prefill chunks, whose
+        # hidden states exist only in the step that ran them. Always collect.
+        return True
+
+    def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        self._prune_finished(ctx.request_states)
+        aux = ctx.target_aux_hidden_states
+        if aux is None:
+            # The runner collects aux states on every paged text forward while
+            # this drafter is installed; their absence means the batch ran an
+            # execution path DFlash does not support (multimodal / pipeline
+            # parallel). Fail loud rather than silently never drafting.
+            raise RuntimeError(
+                "DFlash drafting requires target aux hidden states, but none "
+                "were collected this step; the current execution path "
+                "(multimodal or pipeline-parallel forward) does not support "
+                "DFlash speculative decoding."
+            )
+
+        combined = self._model.combine_hidden_states(aux)
+        updated_slabs = self._ingest(ctx, combined)
+
+        num_spec = ctx.num_speculative_tokens
+        drafts: list[tuple[str, mx.array]] = []
+        if num_spec > 0:
+            drafts = self._draft(ctx, num_spec)
+
+        # Every request drafts the same K tokens, so stack into one
+        # ``[num_drafts, K]`` matrix and read it back with a single sync.
+        draft_matrix = mx.stack([tokens for _, tokens in drafts]) if drafts else None
+
+        # Force this step's slab updates and draft graph together; slabs
+        # updated for requests that did not draft this step (e.g. intermediate
+        # prefill chunks) must not accumulate lazy graphs across steps.
+        eval_targets: list[mx.array] = [
+            slab.keys for slab in updated_slabs if slab.keys is not None
+        ]
+        eval_targets.extend(
+            slab.values for slab in updated_slabs if slab.values is not None
+        )
+        if draft_matrix is not None:
+            eval_targets.append(draft_matrix)
+        if eval_targets:
+            mx.eval(*eval_targets)
+
+        if draft_matrix is None:
+            return None
+        draft_token_ids: list[list[int]] = draft_matrix.tolist()  # type: ignore[assignment]
+        return DraftTokenIds(
+            req_ids=[req_id for req_id, _ in drafts],
+            draft_token_ids=draft_token_ids,
+        )
+
+    # -- ingest ------------------------------------------------------------------
+
+    def _ingest(self, ctx: ProposeContext, combined: mx.array) -> list[_ContextKVSlab]:
+        """Append newly committed rows' context K/V to per-request slabs."""
+        updated: list[_ContextKVSlab] = []
+
+        for i, ((req_id, state), segment) in enumerate(
+            zip(ctx.decode_reqs, ctx.decode_segments, strict=True)
+        ):
+            # Rows 0..len(sampled)-1 carry committed input tokens (accepted
+            # prefix + the row that produced the correction/bonus token);
+            # rejected draft rows must not enter the context.
+            num_valid = len(ctx.decode_token_ids[i])
+            if num_valid == 0 or not self._controller.greedy_sampling_params(
+                state.sampling_params
+            ):
+                continue
+            slab = self._slab_for(req_id, segment.cache_start_pos)
+            rows = combined[segment.start_row : segment.start_row + num_valid]
+            self._append_rows(slab, rows, segment.cache_start_pos)
+            updated.append(slab)
+
+        for i, prefill in enumerate(ctx.prefill_reqs):
+            state = ctx.request_states.get(prefill.req_id)
+            # New requests have no RequestState until their final chunk is
+            # sampled; ingest by the prefill's own sampling params.
+            sampling_params = (
+                state.sampling_params
+                if state is not None
+                else getattr(prefill, "sampling_params", None)
+            )
+            if sampling_params is None or not self._controller.greedy_sampling_params(
+                sampling_params
+            ):
+                continue
+            row_start = ctx.cu_seqlens[ctx.num_decode_segments + i]
+            num_rows = len(prefill.token_ids)
+            slab = self._slab_for(prefill.req_id, prefill.start_pos)
+            rows = combined[row_start : row_start + num_rows]
+            self._append_rows(slab, rows, prefill.start_pos)
+            updated.append(slab)
+
+        return updated
+
+    def _append_rows(
+        self, slab: _ContextKVSlab, rows: mx.array, position_offset: int
+    ) -> None:
+        k, v = self._model.project_context_kv(rows, position_offset)
+        slab.append(k, v)
+
+    def _slab_for(self, req_id: str, first_position: int) -> _ContextKVSlab:
+        """Return the request's slab, positionally aligned to ``first_position``.
+
+        A rewind (``first_position < ctx_len``) is a scheduler
+        preemption-recompute: the same committed tokens are being re-forwarded,
+        so truncating and re-ingesting reproduces the identical context K/V.
+        A forward hole (``first_position > ctx_len``) would mean target hidden
+        states for some positions were never observed — an invariant violation
+        that cannot be repaired — so it fails loud.
+        """
+        slab = self._slabs.get(req_id)
+        if slab is None:
+            slab = _ContextKVSlab()
+            self._slabs[req_id] = slab
+        if first_position < slab.ctx_len:
+            logger.info(
+                "DFlash context KV for request %s rewound from %d to %d "
+                "(scheduler recompute); re-ingesting.",
+                req_id,
+                slab.ctx_len,
+                first_position,
+            )
+            slab.ctx_len = first_position
+        elif first_position > slab.ctx_len:
+            raise RuntimeError(
+                f"DFlash context KV for request {req_id!r} has a hole: next "
+                f"row is at position {first_position} but only "
+                f"{slab.ctx_len} positions were ingested. Target hidden "
+                "states for the gap were never observed."
+            )
+        return slab
+
+    # -- draft -------------------------------------------------------------------
+
+    def _draft(self, ctx: ProposeContext, num_spec: int) -> list[tuple[str, mx.array]]:
+        eligible = self._controller.draft_eligible_requests(
+            ctx.decode_reqs,
+            ctx.decode_token_ids,
+            ctx.prefill_reqs,
+            ctx.prefill_result_modes,
+            ctx.request_states,
+            logitsprocs=ctx.logitsprocs,
+        )
+        if not eligible:
+            return []
+
+        bonus_tokens = self._bonus_tokens(ctx)
+        drafts: list[tuple[str, mx.array]] = []
+        for req_id, _state in eligible:
+            slab = self._slabs.get(req_id)
+            bonus = bonus_tokens.get(req_id)
+            if slab is None or slab.ctx_len == 0 or bonus is None:
+                continue
+            q_ids = mx.array(
+                [bonus] + [self._args.mask_token_id] * num_spec, dtype=mx.int32
+            )
+            ctx_k, ctx_v = slab.view()
+            hidden = self._model(q_ids, ctx_k, ctx_v, position_offset=slab.ctx_len)
+            # Each mask row predicts its own position: greedy over draft vocab.
+            mask_logits = self._model.compute_draft_logits(hidden[1:])
+            tokens = self._model.map_draft_to_target(mx.argmax(mask_logits, axis=-1))
+            drafts.append((req_id, tokens))
+        return drafts
+
+    def _bonus_tokens(self, ctx: ProposeContext) -> dict[str, int]:
+        """Last sampled token per request — the query block's bonus token."""
+        bonus: dict[str, int] = {}
+        for (req_id, _state), sampled in zip(
+            ctx.decode_reqs, ctx.decode_token_ids, strict=True
+        ):
+            if sampled:
+                bonus[req_id] = sampled[-1]
+        for prefill, token_id, mode in zip(
+            ctx.prefill_reqs,
+            ctx.prefill_token_ids,
+            ctx.prefill_result_modes,
+            strict=True,
+        ):
+            if mode != "intermediate" and prefill.req_id not in bonus:
+                bonus[prefill.req_id] = token_id
+        return bonus
+
+    # -- bookkeeping ---------------------------------------------------------------
+
+    def _prune_finished(self, request_states: Any) -> None:
+        for req_id in list(self._slabs):
+            if req_id not in request_states:
+                del self._slabs[req_id]

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -25,6 +25,9 @@ class TargetModelForwardOutput:
 
     logits: mx.array
     hidden_states: mx.array | None = None
+    # Concatenated intermediate-layer residual states ``[num_tokens, n * hidden]``
+    # for drafters that consume EAGLE3/DFlash-style aux hidden states.
+    aux_hidden_states: mx.array | None = None
 
 
 class MultimodalEncodeResult(Protocol):
@@ -137,8 +140,15 @@ class ModelAdapter(Protocol):
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        aux_layer_ids: Sequence[int] | None = None,
     ) -> TargetModelForwardOutput:
-        """Run the target text model and optionally retain target hidden states."""
+        """Run the target text model and optionally retain target hidden states.
+
+        ``aux_layer_ids`` (0-indexed decoder layers; the residual stream is
+        captured *after* each listed layer) additionally returns the
+        concatenated aux hidden states for DFlash-style drafters. Only
+        honored when ``collect_hidden_states`` is set.
+        """
 
     def target_input_embeddings(self, model: Any, input_ids: mx.array) -> mx.array:
         """Return target/backbone-dim token embeddings for ``input_ids``."""
@@ -336,6 +346,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        aux_layer_ids: Sequence[int] | None = None,
     ) -> TargetModelForwardOutput:
         """Run the target model and return logits plus optional hidden states."""
         if not collect_hidden_states:
@@ -345,16 +356,92 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
                 hidden_states=None,
             )
 
-        hidden_states = self._forward_target_hidden_states(
-            model,
-            input_ids,
-            cache=cache,
-        )
+        if aux_layer_ids:
+            hidden_states, aux_hidden_states = self._forward_with_aux_capture(
+                model,
+                input_ids,
+                cache=cache,
+                aux_layer_ids=aux_layer_ids,
+            )
+        else:
+            hidden_states = self._forward_target_hidden_states(
+                model,
+                input_ids,
+                cache=cache,
+            )
+            aux_hidden_states = None
         logits = self._compute_target_logits(model, hidden_states)
         return TargetModelForwardOutput(
             logits=logits,
             hidden_states=self._flatten_target_hidden_states(hidden_states),
+            aux_hidden_states=(
+                self._flatten_target_hidden_states(aux_hidden_states)
+                if aux_hidden_states is not None
+                else None
+            ),
         )
+
+    def _forward_with_aux_capture(
+        self,
+        model: Any,
+        input_ids: mx.array,
+        *,
+        cache: Any | None,
+        aux_layer_ids: Sequence[int],
+    ) -> tuple[mx.array, mx.array]:
+        """Run the backbone loop explicitly, teeing residual states.
+
+        Mirrors mlx_lm's llama/qwen-family ``Model.__call__`` op for op
+        (embed -> shared mask -> per-layer -> final norm) so the final hidden
+        state is identical to the stock forward, while capturing the residual
+        stream *after* each layer listed in ``aux_layer_ids``. The captured
+        tensors are concatenated along the feature dim in list order —
+        DFlash's ``fc`` input layout.
+        """
+        from mlx_lm.models.base import create_attention_mask
+
+        backbone = self._target_backbone(model)
+        if backbone is None:
+            raise NotImplementedError(
+                "Aux hidden-state capture requires a text model with a "
+                "`model` backbone."
+            )
+        layers = getattr(backbone, "layers", None)
+        embed_tokens = getattr(backbone, "embed_tokens", None)
+        final_norm = getattr(backbone, "norm", None)
+        if layers is None or embed_tokens is None or final_norm is None:
+            raise NotImplementedError(
+                "Aux hidden-state capture supports mlx_lm llama/qwen-family "
+                "backbones (embed_tokens / layers / norm); got "
+                f"{type(backbone).__name__}."
+            )
+        if getattr(backbone, "embed_scale", None) not in (None, 1, 1.0):
+            raise NotImplementedError(
+                "Aux hidden-state capture does not support scaled-embedding "
+                "backbones yet."
+            )
+        capture = set(aux_layer_ids)
+        invalid = [i for i in capture if not 0 <= i < len(layers)]
+        if invalid:
+            raise ValueError(
+                f"aux_layer_ids {sorted(invalid)} out of range for "
+                f"{len(layers)}-layer target model"
+            )
+
+        h = embed_tokens(input_ids)
+        layer_caches = cache if cache is not None else [None] * len(layers)
+        mask = create_attention_mask(h, layer_caches[0])
+
+        collected: dict[int, mx.array] = {}
+        for i, (layer, layer_cache) in enumerate(
+            zip(layers, layer_caches, strict=True)
+        ):
+            h = layer(h, mask, layer_cache)
+            if i in capture:
+                collected[i] = h
+
+        aux = mx.concatenate([collected[i] for i in aux_layer_ids], axis=-1)
+        return final_norm(h), aux
 
     def target_input_embeddings(self, model: Any, input_ids: mx.array) -> mx.array:
         """Return target/backbone-dim token embeddings for Gemma4 MTP feedback."""

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -11,6 +11,7 @@ Key contracts:
 - Outputs align with scheduler expectations for paged and non-paged paths.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
@@ -258,6 +259,8 @@ class _PagedForwardState(NamedTuple):
     # ``_sample_paged_batch`` stashes each onto ``RequestState``.
     mm_prefill_deltas: dict[str, int]
     pooling_hidden_states: mx.array | None = None
+    # DFlash-style concatenated intermediate-layer states ``[T, n * hidden]``.
+    target_aux_hidden_states: mx.array | None = None
 
 
 class MetalModelRunner:
@@ -557,12 +560,14 @@ class MetalModelRunner:
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        aux_layer_ids: Sequence[int] | None = None,
     ) -> TargetModelForwardOutput:
         return self._model_adapter.target_forward(
             self._forward_model,
             input_ids,
             cache=cache,
             collect_hidden_states=collect_hidden_states,
+            aux_layer_ids=aux_layer_ids,
         )
 
     def _target_input_embeddings(self, input_ids: mx.array) -> mx.array:
@@ -692,6 +697,28 @@ class MetalModelRunner:
             return
         if Gemma4MTPAssistantSource.is_gemma4_mtp(spec):
             self._drafter = Gemma4MTPProposer(self)
+        elif spec.use_dflash():
+            from vllm_metal.v1.dflash_proposer import DFlashProposer
+
+            if self.vllm_config.cache_config.enable_prefix_caching:
+                # Prefix-cache hits skip the target forward for cached tokens,
+                # so their hidden states — DFlash's context K/V source — are
+                # never observed. Reject up front instead of silently leaving
+                # affected requests undrafted.
+                raise NotImplementedError(
+                    "DFlash speculative decoding on Metal requires prefix "
+                    "caching to be disabled (--no-enable-prefix-caching): "
+                    "cached prefix tokens never produce the target hidden "
+                    "states the drafter's context is built from."
+                )
+            # DFlash draft KV lives in proposer-owned contiguous slabs
+            # (~num_layers * kv_heads * head_dim * 4 bytes per token), so no
+            # draft paged-cache blocks are needed.
+            self._drafter = DFlashProposer.build(
+                speculative_config=spec,
+                controller=self._spec_decode_controller,
+                dtype=self.kv_cache_dtype,
+            )
         elif spec.uses_draft_model():
             from vllm_metal.v1.draft_model_proposer import DraftModelProposer
 
@@ -725,7 +752,7 @@ class MetalModelRunner:
         else:
             raise NotImplementedError(
                 f"Speculative method {spec.method!r} is not supported on Metal "
-                "(supported: Gemma4 MTP, draft_model, ngram)."
+                "(supported: Gemma4 MTP, dflash, draft_model, ngram)."
             )
 
     def estimate_one_sequence_kv_bytes(
@@ -1034,6 +1061,7 @@ class MetalModelRunner:
 
         logits: mx.array | None = None
         target_hidden_states: mx.array | None = None
+        target_aux_hidden_states: mx.array | None = None
         pooling_hidden_states: mx.array | None = None
         mm_prefill_deltas: dict[str, int] = {}
         # Lazy send op for the non-last pipeline stage (None otherwise).
@@ -1088,9 +1116,15 @@ class MetalModelRunner:
                     input_ids,
                     cache=offset_caches,
                     collect_hidden_states=collect_target_hidden_states,
+                    aux_layer_ids=(
+                        getattr(self._drafter, "aux_hidden_state_layer_ids", None)
+                        if collect_target_hidden_states
+                        else None
+                    ),
                 )
                 logits = target_output.logits
                 target_hidden_states = target_output.hidden_states
+                target_aux_hidden_states = target_output.aux_hidden_states
                 del target_output
         finally:
             clear_context()
@@ -1110,6 +1144,8 @@ class MetalModelRunner:
             forward_outputs = [logits]
             if target_hidden_states is not None:
                 forward_outputs.append(target_hidden_states)
+            if target_aux_hidden_states is not None:
+                forward_outputs.append(target_aux_hidden_states)
             self._submit_paged_forward_outputs(*forward_outputs)
 
         # ---- build cu_seqlens for logit extraction ----
@@ -1126,6 +1162,7 @@ class MetalModelRunner:
             scheduler_output=scheduler_output,
             logits=logits,
             target_hidden_states=target_hidden_states,
+            target_aux_hidden_states=target_aux_hidden_states,
             pooling_hidden_states=pooling_hidden_states,
             cu_seqlens=cu_seqlens,
             decode_segments=decode_segments,
@@ -1151,6 +1188,7 @@ class MetalModelRunner:
         scheduler_output = paged_state.scheduler_output
         logits = paged_state.logits
         target_hidden_states = paged_state.target_hidden_states
+        target_aux_hidden_states = paged_state.target_aux_hidden_states
         pooling_hidden_states = paged_state.pooling_hidden_states
         cu_seqlens = paged_state.cu_seqlens
         decode_segments = paged_state.decode_segments
@@ -1178,9 +1216,12 @@ class MetalModelRunner:
 
         # ---- wait for MLX forward to complete ----
         if target_hidden_states is not None:
-            # The Gemma4 MTP assistant drafter will consume these rows after
-            # sampling; evaluate them with logits so the retained state is ready.
-            mx.eval(logits, target_hidden_states)
+            # The drafter will consume these rows after sampling; evaluate
+            # them with logits so the retained state is ready.
+            if target_aux_hidden_states is not None:
+                mx.eval(logits, target_hidden_states, target_aux_hidden_states)
+            else:
+                mx.eval(logits, target_hidden_states)
         else:
             mx.eval(logits)
 
@@ -1368,6 +1409,7 @@ class MetalModelRunner:
         num_speculative_tokens = scheduler_output.num_spec_tokens_to_schedule
         draft_ctx = ProposeContext(
             target_hidden_states=target_hidden_states,
+            target_aux_hidden_states=target_aux_hidden_states,
             decode_reqs=decode_reqs,
             decode_segments=decode_segments,
             decode_token_ids=decode_token_ids,

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -43,6 +43,9 @@ class ProposeContext:
     """
 
     target_hidden_states: mx.array | None
+    # DFlash-style concatenated intermediate-layer states ``[T, n * hidden]``,
+    # collected only for drafters exposing ``aux_hidden_state_layer_ids``.
+    target_aux_hidden_states: mx.array | None
     decode_reqs: Sequence[tuple[str, RequestState]]
     decode_segments: Sequence[PagedDecodeSegment]
     decode_token_ids: Sequence[Sequence[int]]

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -414,6 +414,25 @@ class SpeculativeDecodeController:
 
         return eligible
 
+    @staticmethod
+    def greedy_sampling_params(sampling_params: Any) -> bool:
+        """Request-lifetime greedy check (excludes transient min_tokens state).
+
+        Single source of truth shared by verify-side validation and drafters'
+        ingest eligibility, so the two cannot drift.
+        """
+        return not (
+            sampling_params.temperature >= GREEDY_TEMPERATURE_EPS
+            or sampling_params.top_k > 0
+            or sampling_params.top_p != 1.0
+            or sampling_params.frequency_penalty != 0.0
+            or sampling_params.presence_penalty != 0.0
+            or sampling_params.repetition_penalty != 1.0
+            or sampling_params.logprobs is not None
+            or bool(sampling_params.allowed_token_ids)
+            or bool(sampling_params.bad_words_token_ids)
+        )
+
     def _validate_greedy_sampling(
         self,
         decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
@@ -422,18 +441,7 @@ class SpeculativeDecodeController:
     ) -> None:
         for _, request_state in decode_reqs:
             sampling_params = request_state.sampling_params
-            unsupported = (
-                sampling_params.temperature >= GREEDY_TEMPERATURE_EPS
-                or sampling_params.top_k > 0
-                or sampling_params.top_p != 1.0
-                or sampling_params.frequency_penalty != 0.0
-                or sampling_params.presence_penalty != 0.0
-                or sampling_params.repetition_penalty != 1.0
-                or sampling_params.logprobs is not None
-                or bool(sampling_params.allowed_token_ids)
-                or bool(sampling_params.bad_words_token_ids)
-            )
-            if unsupported:
+            if not self.greedy_sampling_params(sampling_params):
                 raise NotImplementedError(
                     "Speculative decode verification on Metal currently "
                     "supports greedy sampling only (temperature=0, no "


### PR DESCRIPTION
## Benchmark (single-stream, Qwen3-8B, natural-data spec bench, greedy)

`vllm bench serve`, spec_bench dataset, 30 prompts × 128 output tokens, seed 0, concurrency 1, sync scheduling for all rows, prefix cache hit rate 0%. Apple M5 Pro, bf16.

| config | out tok/s | accept len | speedup |
|---|---|---|---|
| baseline (sync) | 16.51 | — | 1.00x |
| **DFlash K=7** | **19.70** | **2.62** | **1.19x** |
| DFlash K=5 / K=3 | 12.96 / 12.65 | ~1.6 | 0.78x |
| draft_model Qwen3-0.6B K=3 (reference) | 21.53 | 2.95 | 1.30x |

## Limitation

same with #447 