### PR TITLE
[Distributed] Load pipeline stages lazily and prune before materializing

### DIFF
--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
@@ -16,6 +17,7 @@ import vllm_metal.envs as envs
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.config import reset_config
+from vllm_metal.distributed.pipeline import PipelineGroup
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1 import model_lifecycle
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
@@ -268,6 +270,62 @@ class TestModelLifecycle:
         assert request.target_dtype is not None
         assert request.tokenizer_config == {"trust_remote_code": True}
         assert calls == [hf_config]
+
+    def test_generation_load_request_marks_pipeline_stage_lazy(self) -> None:
+        # A pipeline-parallel stage (pp.size > 1) loads weights lazily so it can
+        # prune its non-owned layers before the first eval; a single-stage load
+        # stays eager. lazy_weights is the typed contract the mlx_lm loader reads.
+        class _Adapter:
+            def should_force_text_backbone(self, config: object) -> bool:
+                return False
+
+        class _FakeGroup:
+            def __init__(self, size: int) -> None:
+                self._size = size
+
+            def rank(self) -> int:
+                return 0
+
+            def size(self) -> int:
+                return self._size
+
+        def _lazy_for(pp: PipelineGroup | None) -> bool:
+            runner = make_stub_runner(
+                metal_config=SimpleNamespace(debug=False),
+                model_config=_runner_model_config(),
+                pp=pp,
+            )
+            return GenerationLoadRequest.from_runner(runner, _Adapter()).lazy_weights
+
+        assert _lazy_for(None) is False
+        assert _lazy_for(PipelineGroup(_FakeGroup(1))) is False
+        assert _lazy_for(PipelineGroup(_FakeGroup(2))) is True
+
+    def test_load_mlx_lm_text_model_forwards_lazy_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The pp lazy_weights flag must reach mlx_lm's loader so a stage can prune
+        # its non-owned layers before the first eval; a single-stage load is eager.
+        captured: dict[str, object] = {}
+
+        def _fake_load(
+            path: str, *, tokenizer_config: object, lazy: bool
+        ) -> tuple[object, object]:
+            captured["lazy"] = lazy
+            return object(), object()
+
+        monkeypatch.setattr(model_lifecycle, "mlx_lm_load", _fake_load)
+        monkeypatch.setattr(
+            model_lifecycle,
+            "_mlx_lm_compatible_model_path",
+            lambda name: contextlib.nullcontext(name),
+        )
+        lifecycle, _ = _make_lifecycle()
+
+        lifecycle._load_mlx_lm_text_model("stub", {}, lazy=True)
+        assert captured["lazy"] is True
+        lifecycle._load_mlx_lm_text_model("stub", {}, lazy=False)
+        assert captured["lazy"] is False
 
     def test_load_uses_adapter_override_for_qwen35_fp8_conditional_generation(
         self,

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -16,6 +16,7 @@ from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.attention.state import HybridGDNStateManager
+from vllm_metal.distributed.pipeline import PipelineGroup
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPDraftSeed
 from vllm_metal.v1.proposer import Gemma4MTPProposer
@@ -1632,3 +1633,34 @@ class TestRunnerMlaProperties:
             {"num_hidden_layers": 32, "num_attention_heads": 32, "hidden_size": 4096}
         )
         assert runner.is_mla is False
+
+
+class TestLoadModelPipelineSplitOrdering:
+    def test_split_runs_before_lora_setup_on_pp_stage(self) -> None:
+        # The pipeline split must run adjacent to the (lazy) load and before LoRA
+        # setup, so the stage's non-owned layers are pruned before anything
+        # materializes them. Pin the order so a future edit cannot move the split
+        # back after LoRA and silently reintroduce the full-model peak.
+        events: list[str] = []
+
+        class _FakeGroup:
+            def rank(self) -> int:
+                return 0
+
+            def size(self) -> int:
+                return 2
+
+        runner = make_stub_runner(
+            pp=PipelineGroup(_FakeGroup()),
+            model_config=SimpleNamespace(runner_type="generate", hf_config=None),
+            metal_config=SimpleNamespace(use_paged_attention=True),
+            scheduler_config=SimpleNamespace(max_num_seqs=1, max_num_batched_tokens=1),
+            kv_cache_dtype=None,
+        )
+        runner._model_lifecycle = SimpleNamespace(load=lambda: events.append("load"))
+        runner.apply_pipeline_split = lambda pp: events.append("split")
+        runner._lora = SimpleNamespace(setup=lambda **kwargs: events.append("lora"))
+
+        runner.load_model()
+
+        assert events == ["load", "split", "lora"]

--- a/tools/pp_lazy_rss.py
+++ b/tools/pp_lazy_rss.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Measure per-stage peak memory for a pipeline-parallel lazy load vs a full load.
+
+Evidence for the lazy pipeline-parallel load: a PP stage loads the generic mlx_lm
+weights lazily and prunes its non-owned layers (``apply_pipeline_split``) before the
+first ``mx.eval``, so per-stage peak stays owned-only instead of full-model. This
+mirrors the load -> prune -> eval mechanism ``ModelLifecycle`` uses on the
+``pp.size > 1`` path (calling ``mlx_lm.utils.load_model`` directly and skipping the
+metadata-only lifecycle install steps, which do not materialize weights).
+
+Run each mode in its OWN process so the peak is isolated:
+
+    python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit full
+    python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit lazy   # last of pp_size=2
+
+Reports ``mx.get_peak_memory()`` (MLX allocator high-water) and ``ru_maxrss``
+(process RSS). If anything materialized the full model before the split, the lazy
+peak would match the full peak.
+"""
+
+from __future__ import annotations
+
+import resource
+import sys
+from pathlib import Path
+
+import mlx.core as mx
+from huggingface_hub import snapshot_download
+from mlx_lm.utils import load_model
+
+from vllm_metal.distributed.pipeline import PipelineGroup, apply_pipeline_split
+
+
+class _OfflineStage:
+    """Minimal PipelineGroup backing for an offline (rank, size) split."""
+
+    def __init__(self, rank: int, size: int) -> None:
+        self._rank, self._size = rank, size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+def _rss_gb() -> float:
+    # macOS ru_maxrss is in bytes.
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1e9
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        sys.exit("usage: pp_lazy_rss.py <hf_model_id> <full|lazy> [pp_size] [rank]")
+    repo, mode = sys.argv[1], sys.argv[2]
+    pp_size = int(sys.argv[3]) if len(sys.argv) > 3 else 2
+    rank = int(sys.argv[4]) if len(sys.argv) > 4 else pp_size - 1
+    path = Path(snapshot_download(repo, local_files_only=True))
+
+    if mode == "full":
+        model, _ = load_model(path, lazy=False)
+        total = owned = len(model.model.layers)
+    elif mode == "lazy":
+        model, _ = load_model(path, lazy=True, strict=False)
+        total = len(model.model.layers)
+        apply_pipeline_split(model, PipelineGroup(_OfflineStage(rank, pp_size)))
+        owned = len(model.model.layers)
+    else:
+        sys.exit(f"unknown mode {mode!r}; use full or lazy")
+
+    mx.eval(model.parameters())
+    print(
+        f"{repo}  mode={mode}  owned_layers={owned}/{total}  "
+        f"MLX_peak={mx.get_peak_memory() / 1e9:.3f}GB  "
+        f"ru_maxrss={_rss_gb():.3f}GB"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -65,6 +65,7 @@ class GenerationLoadRequest:
     target_dtype: Any
     tokenizer_config: Mapping[str, Any]
     gguf_source: GGUFLoadSource | None
+    lazy_weights: bool
 
     @classmethod
     def from_runner(
@@ -80,6 +81,12 @@ class GenerationLoadRequest:
             is_vlm = False
         gguf_source = None if is_vlm else GGUFLoadSource.from_model_config(model_config)
 
+        # A pipeline-parallel stage prunes its non-owned layers right after load, so
+        # the generic mlx_lm weights load lazily and per-stage peak stays owned-only.
+        # Only the mlx_lm path honors this; GGUF/AWQ/VLM ignore it and load eager.
+        pp = runner.pp
+        lazy_weights = pp is not None and pp.size > 1
+
         return cls(
             model_name=(
                 gguf_source.weights_path
@@ -92,6 +99,7 @@ class GenerationLoadRequest:
             target_dtype=torch_to_mlx(torch.empty(0, dtype=model_config.dtype)).dtype,
             tokenizer_config={"trust_remote_code": model_config.trust_remote_code},
             gguf_source=gguf_source,
+            lazy_weights=lazy_weights,
         )
 
 
@@ -148,6 +156,7 @@ class ModelLifecycle:
             target_dtype=request.target_dtype,
             tokenizer_config=request.tokenizer_config,
             gguf_source=request.gguf_source,
+            lazy_weights=request.lazy_weights,
         )
         return LoadedGenerationModel(
             model=model,
@@ -164,6 +173,7 @@ class ModelLifecycle:
         target_dtype: Any | None = None,
         tokenizer_config: Mapping[str, Any] | None = None,
         gguf_source: GGUFLoadSource | None = None,
+        lazy_weights: bool = False,
     ) -> tuple[Any, Any]:
         """Load a text or VLM generation model."""
 
@@ -210,6 +220,7 @@ class ModelLifecycle:
             model, tokenizer = self._load_mlx_lm_text_model(
                 model_name,
                 tokenizer_config,
+                lazy=lazy_weights,
             )
 
         loaded_from = (
@@ -259,11 +270,14 @@ class ModelLifecycle:
         self,
         model_name: str,
         tokenizer_config: Mapping[str, Any],
+        *,
+        lazy: bool = False,
     ) -> tuple[Any, Any]:
         with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
             model, tokenizer = mlx_lm_load(
                 str(compatible_model_name),
                 tokenizer_config=tokenizer_config,
+                lazy=lazy,
             )
         return model, tokenizer
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -439,6 +439,10 @@ class MetalModelRunner:
     def load_model(self) -> None:
         """Load the configured model and derive runtime metadata."""
         self._model_lifecycle.load()
+        # Prune non-owned layers adjacent to the (lazy) load, before LoRA setup or
+        # cache profiling materialize weights. No-op on the single-stage path.
+        if self.pp is not None:
+            self.apply_pipeline_split(self.pp)
         text_config = getattr(self.model_config.hf_config, "get_text_config", None)
         max_position_embeddings = None
         if callable(text_config):
@@ -483,7 +487,9 @@ class MetalModelRunner:
     def apply_pipeline_split(self, pp: PipelineGroup) -> None:
         """Slice the loaded model to this pipeline stage and fix layer counts.
 
-        Called by the worker after ``load_model`` (Phase 0 load-then-slice).
+        Runs inside ``load_model`` right after the (lazy) weight load, before LoRA
+        setup and cache profiling, so the stage's non-owned layers are pruned
+        before anything materializes them.
         Delegates the in-place backbone slice to the adapter, then resets the
         runner's layer accounting to the LOCAL slice so per-layer offset caches
         (``_start_paged_forward``) and the KV-cache spec size only this stage's

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -196,11 +196,6 @@ class MetalWorker(WorkerBase):
     def load_model(self) -> None:
         """Load the model onto the Metal device."""
         self.model_runner.load_model()
-        # Phase 0 = load-then-slice: every stage loaded full weights above; now
-        # drop the layers (and, off the last stage, the final norm) this stage
-        # does not own. No-op when self.pp is None (single-stage path).
-        if self.pp is not None:
-            self.model_runner.apply_pipeline_split(self.pp)
 
     def _one_sequence_kv_bytes(self) -> int:
         """Bytes for one max-length sequence of cache state.


### PR DESCRIPTION
This PR makes a pipeline stage load the generic mlx_lm weights with lazy=True and moves apply_pipeline_split from the worker into MetalModelRunner.load_model, right after the lifecycle load and before LoRA setup and cache profiling. MLX lazy weights are never materialized until the first eval, so pruning the non-owned layers adjacent to the load keeps per-stage peak at owned-only. The decision is a typed lazy_weights field on GenerationLoadRequest, derived from pp.size > 1 with no new flag; only the mlx_lm path honors it, GGUF/AWQ/VLM keep loading eager, and PP+LoRA/spec/async were already rejected at config time.

For evidence, the main one is tools/pp_lazy_rss.py: full load peaks at 4.608 GB, lazy plus prune at 2.654 GB on Qwen3-8B-4bit. The 2-stage ring parity check stays bit-exact and the full not-slow suite passes.

This lowers per-stage peak; actually serving a model too large for one stage is the follow-up with 2-node numbers, not validated here. Generic mlx_lm text path only.