### PR TITLE
Gate native greedy sampling on logits-processor activity, not presence

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Metal sampling with vLLM Sampler integration."""
 
+from types import SimpleNamespace
+
 import mlx.core as mx
 import numpy as np
 import pytest
@@ -11,7 +13,7 @@ from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor
 from vllm.v1.outputs import LogprobsLists
-from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
@@ -304,13 +306,17 @@ class TestV1SeededSamplingGenerator:
 
 class TestV1SamplingBatch:
     @staticmethod
-    def _batch(params_list: list[SamplingParams]) -> SamplingBatch:
+    def _batch(
+        params_list: list[SamplingParams],
+        logitsprocs: LogitsProcessors | None = None,
+    ) -> SamplingBatch:
         return SamplingBatch(
             params_list,
             [[1]] * len(params_list),
             [[]] * len(params_list),
             vocab_size=VOCAB_SIZE,
             device=torch.device("cpu"),
+            logitsprocs=logitsprocs,
         )
 
     def test_can_use_native_greedy_requires_greedy_without_filters(self) -> None:
@@ -347,62 +353,62 @@ class TestV1SamplingBatch:
         bad_sp._bad_words_token_ids = [[99]]
         assert not self._batch([bad_sp]).can_use_native_greedy()
 
-    def test_native_greedy_gates_on_builtin_logitsproc_activity(self) -> None:
-        """Always-registered MinTokens/LogitBias builtins are non-argmax-invariant,
-        but standard greedy must still take the native MLX path (they are no-ops
-        unless their params are set). Active params, or any unrecognized
-        non-argmax-invariant processor, must fall back to the vLLM sampler."""
-        from types import SimpleNamespace
-
-        from vllm.v1.sample.logits_processor import (
-            LogitsProcessors,
-            build_logitsprocs,
+    def test_native_greedy_allows_dormant_builtin_logits_processors(self) -> None:
+        vllm_config = SimpleNamespace(
+            speculative_config=None,
+            scheduler_config=SimpleNamespace(max_num_seqs=4),
         )
+        logitsprocs = build_logitsprocs(
+            vllm_config,
+            torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+        )
+        batch = self._batch([SamplingParams(temperature=0.0)], logitsprocs)
 
-        def _builtins() -> LogitsProcessors:
-            config = SimpleNamespace(
-                speculative_config=None,
-                scheduler_config=SimpleNamespace(max_num_seqs=4),
-            )
-            return build_logitsprocs(
-                config,
-                torch.device("cpu"),
-                is_pin_memory=False,
-                is_pooling_model=False,
-            )
+        assert batch.can_use_native_greedy()
 
-        def _batch(sp: SamplingParams, procs: LogitsProcessors) -> SamplingBatch:
-            return SamplingBatch(
-                [sp],
-                [[1, 2, 3]],
-                [[]],
-                vocab_size=VOCAB_SIZE,
-                device=torch.device("cpu"),
-                logitsprocs=procs,
-            )
+    @pytest.mark.parametrize(
+        ("logit_bias", "min_tokens"),
+        [
+            ({1: 5.0}, 0),
+            (None, 5),
+        ],
+        ids=["logit_bias", "min_tokens"],
+    )
+    def test_native_greedy_rejects_active_builtin_logits_processors(
+        self,
+        logit_bias: dict[int, float] | None,
+        min_tokens: int,
+    ) -> None:
+        vllm_config = SimpleNamespace(
+            speculative_config=None,
+            scheduler_config=SimpleNamespace(max_num_seqs=4),
+        )
+        logitsprocs = build_logitsprocs(
+            vllm_config,
+            torch.device("cpu"),
+            is_pin_memory=False,
+            is_pooling_model=False,
+        )
+        sampling_params = SamplingParams(
+            temperature=0.0,
+            logit_bias=logit_bias,
+            min_tokens=min_tokens,
+        )
+        batch = self._batch([sampling_params], logitsprocs)
 
-        # Dormant builtins: native greedy still allowed despite their presence.
-        assert _batch(
-            SamplingParams(temperature=0.0), _builtins()
-        ).can_use_native_greedy()
-        # Active logit_bias must fall back so the bias is actually applied.
-        assert not _batch(
-            SamplingParams(temperature=0.0, logit_bias={1: 5.0}), _builtins()
-        ).can_use_native_greedy()
-        # Active min_tokens must fall back so EOS masking is applied.
-        assert not _batch(
-            SamplingParams(temperature=0.0, min_tokens=5), _builtins()
-        ).can_use_native_greedy()
+        assert not batch.can_use_native_greedy()
 
-        # An unrecognized non-argmax-invariant processor forces the safe path.
+    def test_native_greedy_rejects_unknown_non_argmax_processor(self) -> None:
         class _UnknownNonArgmax:
             def is_argmax_invariant(self) -> bool:
                 return False
 
-        assert not _batch(
-            SamplingParams(temperature=0.0),
-            LogitsProcessors([_UnknownNonArgmax()]),
-        ).can_use_native_greedy()
+        logitsprocs = LogitsProcessors([_UnknownNonArgmax()])
+        batch = self._batch([SamplingParams(temperature=0.0)], logitsprocs)
+
+        assert not batch.can_use_native_greedy()
 
     def test_allowed_token_ids_constrains_greedy_sampling(self) -> None:
         """Greedy with allowed_token_ids must fall back and the constraint works."""

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -347,6 +347,63 @@ class TestV1SamplingBatch:
         bad_sp._bad_words_token_ids = [[99]]
         assert not self._batch([bad_sp]).can_use_native_greedy()
 
+    def test_native_greedy_gates_on_builtin_logitsproc_activity(self) -> None:
+        """Always-registered MinTokens/LogitBias builtins are non-argmax-invariant,
+        but standard greedy must still take the native MLX path (they are no-ops
+        unless their params are set). Active params, or any unrecognized
+        non-argmax-invariant processor, must fall back to the vLLM sampler."""
+        from types import SimpleNamespace
+
+        from vllm.v1.sample.logits_processor import (
+            LogitsProcessors,
+            build_logitsprocs,
+        )
+
+        def _builtins() -> LogitsProcessors:
+            config = SimpleNamespace(
+                speculative_config=None,
+                scheduler_config=SimpleNamespace(max_num_seqs=4),
+            )
+            return build_logitsprocs(
+                config,
+                torch.device("cpu"),
+                is_pin_memory=False,
+                is_pooling_model=False,
+            )
+
+        def _batch(sp: SamplingParams, procs: LogitsProcessors) -> SamplingBatch:
+            return SamplingBatch(
+                [sp],
+                [[1, 2, 3]],
+                [[]],
+                vocab_size=VOCAB_SIZE,
+                device=torch.device("cpu"),
+                logitsprocs=procs,
+            )
+
+        # Dormant builtins: native greedy still allowed despite their presence.
+        assert _batch(
+            SamplingParams(temperature=0.0), _builtins()
+        ).can_use_native_greedy()
+        # Active logit_bias must fall back so the bias is actually applied.
+        assert not _batch(
+            SamplingParams(temperature=0.0, logit_bias={1: 5.0}), _builtins()
+        ).can_use_native_greedy()
+        # Active min_tokens must fall back so EOS masking is applied.
+        assert not _batch(
+            SamplingParams(temperature=0.0, min_tokens=5), _builtins()
+        ).can_use_native_greedy()
+
+        # An unrecognized non-argmax-invariant processor forces the safe path.
+        class _UnknownNonArgmax:
+            def is_argmax_invariant(self) -> bool:
+                return False
+
+        assert not _batch(
+            SamplingParams(temperature=0.0),
+            LogitsProcessors([_UnknownNonArgmax()]),
+        ).can_use_native_greedy()
+
     def test_allowed_token_ids_constrains_greedy_sampling(self) -> None:
         """Greedy with allowed_token_ids must fall back and the constraint works."""
         logits = mx.array([[10.0, 1.0, 5.0, 1.0]], dtype=mx.float32)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -13,7 +13,12 @@ from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor
 from vllm.v1.outputs import LogprobsLists
-from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
+from vllm.v1.sample.logits_processor import (
+    BatchUpdate,
+    LogitsProcessor,
+    LogitsProcessors,
+    build_logitsprocs,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
@@ -401,9 +406,18 @@ class TestV1SamplingBatch:
         assert not batch.can_use_native_greedy()
 
     def test_native_greedy_rejects_unknown_non_argmax_processor(self) -> None:
-        class _UnknownNonArgmax:
+        class _UnknownNonArgmax(LogitsProcessor):
+            def __init__(self, *_args: object) -> None:
+                return None
+
+            def apply(self, logits: torch.Tensor) -> torch.Tensor:
+                return logits
+
             def is_argmax_invariant(self) -> bool:
                 return False
+
+            def update_state(self, batch_update: BatchUpdate | None) -> None:
+                return None
 
         logitsprocs = LogitsProcessors([_UnknownNonArgmax()])
         batch = self._batch([SamplingParams(temperature=0.0)], logitsprocs)

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -14,6 +14,10 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.outputs import LogprobsLists
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor.builtin import (
+    LogitBiasLogitsProcessor,
+    MinTokensLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
@@ -166,7 +170,15 @@ class SamplingBatch:
 
     def can_use_native_greedy(self) -> bool:
         """Return whether MLX argmax matches the requested sampling behavior."""
-        if any(self.logitsprocs.non_argmax_invariant):
+        # MinTokens and LogitBias are the only non-argmax-invariant builtins, and
+        # both are no-ops unless their request params are set. Gate on those params
+        # below so standard greedy decode uses native MLX argmax instead of bridging
+        # the full-vocab logits to the torch sampler every step. Any other
+        # non-argmax-invariant processor forces the safe torch path.
+        if any(
+            type(proc) not in (MinTokensLogitsProcessor, LogitBiasLogitsProcessor)
+            for proc in self.logitsprocs.non_argmax_invariant
+        ):
             return False
         return all(
             sampling_params.temperature < GREEDY_TEMPERATURE_EPS
@@ -178,6 +190,8 @@ class SamplingBatch:
             and sampling_params.logprobs is None
             and not sampling_params.allowed_token_ids
             and not sampling_params.bad_words_token_ids
+            and not sampling_params.logit_bias
+            and (sampling_params.min_tokens or 0) == 0
             for sampling_params in self.sampling_params_list
         )
 


### PR DESCRIPTION
Found this while profiling why single-stream greedy decode trails mlx-lm on the same model and kernels.

can_use_native_greedy() bails to the torch sampler whenever any non-argmax-invariant logits processor is registered. The problem is that build_logitsprocs() always registers the MinTokens and LogitBias builtins, so that condition is true for essentially every request. The result is that greedy decode never actually takes the native MLX argmax path. Every step it copies the full-vocab logits out to torch and samples there, even when nothing is set that could change the argmax.

Those builtins are no-ops unless a request sets min_tokens or logit_bias, so the fix is to gate on whether they're active rather than merely present. The check now skips the bridge only when no request sets logit_bias or min_tokens, and it still forces the torch path for any non-argmax-invariant processor it doesn't recognize, so it stays correct if new ones are added. Output is identical either way, since the skipped builtins wouldn't have touched the logits for these requests.

<img width="406" height="92" alt="image" src="https://github.com/user-attachments/assets/f27debfd-15dd-4bac-b2fc-51710d85c397" />

Smaller models gain more, since the fixed bridge cost is a bigger share of the step.

The existing test built a batch with an empty processor set, which is why this never showed up. Added a test that registers the real builtins: it fails on current main, passes with the change, and also checks that active logit_bias/min_tokens and unrecognized processors still fall back to the torch sampler.