### PR TITLE
Skip the redundant pre-sampling logits eval in the decode path

### DIFF
--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1177,11 +1177,13 @@ class MetalModelRunner:
         assert logits is not None
 
         # ---- wait for MLX forward to complete ----
+        # Only force logits here when something before sampling consumes them
+        # eagerly: the Gemma4 MTP drafter (target_hidden_states) or the
+        # structured-output bitmask. Otherwise the sampler's own eval pulls the
+        # forward through, so a separate wait here is a redundant per-step sync.
         if target_hidden_states is not None:
-            # The Gemma4 MTP assistant drafter will consume these rows after
-            # sampling; evaluate them with logits so the retained state is ready.
             mx.eval(logits, target_hidden_states)
-        else:
+        elif grammar_output is not None:
             mx.eval(logits)
 
         # ---- apply structured output bitmask if present ----


### PR DESCRIPTION
The decode path evals the logits to wait for the forward, then samples right after. But the sampler already evals what it needs on its own, the argmax result for greedy or the sliced logits for the torch path, and that pulls the forward through anyway. So the eval before sampling is a second sync on every decode step that doesn't buy anything.

The only things that actually need logits materialized before sampling are the Gemma4 MTP drafter (target_hidden_states) and the structured output bitmask (grammar), so I kept the eval for those two and dropped it otherwise.

Same computation, one fewer sync per step, output is byte-identical.

Single stream on an M3 Ultra, Qwen3 4-bit: 8B goes 11.33 to 10.99 ms/token (~3%), 0.6B ~5.6%. Greedy output is token-for-token unchanged, and the sampling, pec-decode, grammar and ngram tests all pass.