### PR TITLE
Fix packed decode RoPE with vector offsets

### DIFF
--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -226,21 +226,21 @@ class TestPrepare:
 class TestPackedRoPE:
     """Tests for per-request RoPE position reset in packed prefill."""
 
+    class RecordingRoPE(nn.RoPE):
+        def __init__(self) -> None:
+            super().__init__(dims=8, traditional=False, base=10_000.0)
+            self.calls = []
+
+        def __call__(self, x, offset=0):
+            self.calls.append((x.shape, offset))
+            return super().__call__(x, offset=offset)
+
     def test_native_rope_batches_single_token_segments(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,
         )
 
-        class RecordingRoPE(nn.RoPE):
-            def __init__(self) -> None:
-                super().__init__(dims=8, traditional=False, base=10_000.0)
-                self.calls = []
-
-            def __call__(self, x, offset=0):
-                self.calls.append((x.shape, offset))
-                return super().__call__(x, offset=offset)
-
-        rope = RecordingRoPE()
+        rope = self.RecordingRoPE()
         reference_rope = nn.RoPE(dims=8, traditional=False, base=10_000.0)
         module = SimpleNamespace(rope=rope)
         q = mx.arange(1 * 3 * 4 * 8, dtype=mx.float32).reshape(1, 3, 4, 8) / 100
@@ -280,16 +280,7 @@ class TestPackedRoPE:
             apply_packed_rope,
         )
 
-        class RecordingRoPE(nn.RoPE):
-            def __init__(self) -> None:
-                super().__init__(dims=8, traditional=False, base=10_000.0)
-                self.offsets = []
-
-            def __call__(self, x, offset=0):
-                self.offsets.append(offset)
-                return super().__call__(x, offset=offset)
-
-        rope = RecordingRoPE()
+        rope = self.RecordingRoPE()
         module = SimpleNamespace(rope=rope)
         cu_seqlens = [0, 1, 2, 3, 4]
         q = mx.zeros((1, 3, 4, 8), dtype=mx.float32)
@@ -297,27 +288,18 @@ class TestPackedRoPE:
 
         apply_packed_rope(module, q, k, cu_seqlens)
 
-        assert len(rope.offsets) == 2
-        assert rope.offsets[0].shape == (4,)
-        assert rope.offsets[0].tolist() == [0, 0, 0, 0]
-        assert rope.offsets[1].shape == (4,)
-        assert rope.offsets[1].tolist() == [0, 0, 0, 0]
+        assert len(rope.calls) == 2
+        assert rope.calls[0][1].shape == (4,)
+        assert rope.calls[0][1].tolist() == [0, 0, 0, 0]
+        assert rope.calls[1][1].shape == (4,)
+        assert rope.calls[1][1].tolist() == [0, 0, 0, 0]
 
     def test_batched_rope_preserves_keys_when_not_applied(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,
         )
 
-        class RecordingRoPE(nn.RoPE):
-            def __init__(self) -> None:
-                super().__init__(dims=8, traditional=False, base=10_000.0)
-                self.calls = 0
-
-            def __call__(self, x, offset=0):
-                self.calls += 1
-                return super().__call__(x, offset=offset)
-
-        rope = RecordingRoPE()
+        rope = self.RecordingRoPE()
         reference_rope = nn.RoPE(dims=8, traditional=False, base=10_000.0)
         module = SimpleNamespace(rope=rope)
         cu_seqlens = [0, 1, 2, 3, 4]
@@ -342,7 +324,7 @@ class TestPackedRoPE:
         )
         mx.eval(expected_q, q_out)
 
-        assert rope.calls == 1
+        assert len(rope.calls) == 1
         assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
         assert k_out is k
 
@@ -351,16 +333,7 @@ class TestPackedRoPE:
             apply_packed_rope,
         )
 
-        class RecordingRoPE(nn.RoPE):
-            def __init__(self) -> None:
-                super().__init__(dims=8, traditional=False, base=10_000.0)
-                self.calls = []
-
-            def __call__(self, x, offset=0):
-                self.calls.append((x.shape, offset))
-                return super().__call__(x, offset=offset)
-
-        rope = RecordingRoPE()
+        rope = self.RecordingRoPE()
         module = SimpleNamespace(rope=rope)
         q = mx.zeros((1, 2, 6, 8))
         k = mx.zeros((1, 1, 6, 8))

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -7,7 +7,6 @@ Run with:
 
 from __future__ import annotations
 
-from functools import partial
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -227,135 +226,111 @@ class TestPrepare:
 class TestPackedRoPE:
     """Tests for per-request RoPE position reset in packed prefill."""
 
-    @staticmethod
-    def _reference_rope(rope, x, cu_seqlens, offsets):
-        parts = []
-        for i, (start, end) in enumerate(
-            zip(cu_seqlens[:-1], cu_seqlens[1:], strict=True)
-        ):
-            offset = offsets[i] if offsets is not None else 0
-            parts.append(rope(x[:, :, start:end, :], offset=offset))
-        return mx.concatenate(parts, axis=2)
-
-    @pytest.mark.parametrize(
-        ("batch", "segment_len", "offsets"),
-        [
-            (1, 1, [3, 11, 29, 47]),
-            (1, 3, [2, 17, 31, 64]),
-            (2, 1, [5, 23, 41, 59]),
-            (2, 2, [13, 13, 13, 13]),
-            (1, 1, None),
-        ],
-    )
-    def test_native_rope_batches_equal_length_segments(
-        self, batch, segment_len, offsets
-    ):
+    def test_native_rope_batches_single_token_segments(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,
         )
 
-        segment_count = 4
-        total_len = segment_count * segment_len
-        cu_seqlens = [i * segment_len for i in range(segment_count + 1)]
-        module = SimpleNamespace(rope=nn.RoPE(dims=8, traditional=False, base=10_000.0))
-        q = mx.random.normal((batch, 3, total_len, 8))
-        k = mx.random.normal((batch, 2, total_len, 8))
+        class RecordingRoPE(nn.RoPE):
+            def __init__(self) -> None:
+                super().__init__(dims=8, traditional=False, base=10_000.0)
+                self.calls = []
 
-        expected_q = self._reference_rope(module.rope, q, cu_seqlens, offsets)
-        expected_k = self._reference_rope(module.rope, k, cu_seqlens, offsets)
-        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
-        mx.eval(expected_q, expected_k, q_out, k_out)
+            def __call__(self, x, offset=0):
+                self.calls.append((x.shape, offset))
+                return super().__call__(x, offset=offset)
 
-        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
-        assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
-
-    @pytest.mark.parametrize("rope_kind", ["nn", "fast"])
-    @pytest.mark.parametrize(
-        "offsets",
-        [None, [5, 5, 5, 5]],
-        ids=["implicit-zero", "equal-nonzero"],
-    )
-    def test_single_token_equal_offsets_avoid_scalar_offset_kernel(
-        self, rope_kind, offsets
-    ):
-        from vllm_metal.attention.impls.varlen_rope_compat import (
-            apply_packed_rope,
-        )
-
-        dims = 128
-        if rope_kind == "nn":
-            rope = nn.RoPE(dims=dims, traditional=False, base=10_000.0)
-        else:
-            rope = partial(
-                mx.fast.rope,
-                dims=dims,
-                traditional=False,
-                base=10_000.0,
-                scale=1.0,
-            )
-
-        # Independently allocated rows trigger MLX #3494. Repeated/aliased
-        # rows can mask the scalar-offset single-token kernel bug.
-        def make_packed_tokens(heads):
-            rows = mx.array(
-                [
-                    mx.random.normal((heads, 1, dims)).astype(mx.float16).tolist()
-                    for _ in range(4)
-                ],
-                dtype=mx.float16,
-            )
-            return mx.transpose(rows, (2, 1, 0, 3))
-
+        rope = RecordingRoPE()
+        reference_rope = nn.RoPE(dims=8, traditional=False, base=10_000.0)
         module = SimpleNamespace(rope=rope)
-        q = make_packed_tokens(3)
-        k = make_packed_tokens(2)
+        q = mx.arange(1 * 3 * 4 * 8, dtype=mx.float32).reshape(1, 3, 4, 8) / 100
+        k = mx.arange(1 * 2 * 4 * 8, dtype=mx.float32).reshape(1, 2, 4, 8) / 100
         cu_seqlens = [0, 1, 2, 3, 4]
+        offsets = [3, 11, 29, 47]
 
-        expected_q = self._reference_rope(rope, q, cu_seqlens, offsets)
-        expected_k = self._reference_rope(rope, k, cu_seqlens, offsets)
+        expected_q = mx.concatenate(
+            [
+                reference_rope(q[:, :, i : i + 1, :], offset=offsets[i])
+                for i in range(4)
+            ],
+            axis=2,
+        )
+        expected_k = mx.concatenate(
+            [
+                reference_rope(k[:, :, i : i + 1, :], offset=offsets[i])
+                for i in range(4)
+            ],
+            axis=2,
+        )
         q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
         mx.eval(expected_q, expected_k, q_out, k_out)
 
+        assert len(rope.calls) == 2
+        assert rope.calls[0][0] == (4, 3, 1, 8)
+        assert rope.calls[1][0] == (4, 2, 1, 8)
+        assert rope.calls[0][1].shape == (4,)
+        assert rope.calls[0][1].tolist() == offsets
+        assert rope.calls[1][1].shape == (4,)
+        assert rope.calls[1][1].tolist() == offsets
         assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
         assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
 
-    def test_fast_rope_partial_batches_equal_length_segments(self):
+    def test_native_rope_uses_vector_zero_offsets_for_implicit_offsets(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,
         )
 
-        rope = partial(
-            mx.fast.rope,
-            dims=8,
-            traditional=False,
-            base=10_000.0,
-            scale=1.0,
-        )
+        class RecordingRoPE(nn.RoPE):
+            def __init__(self) -> None:
+                super().__init__(dims=8, traditional=False, base=10_000.0)
+                self.offsets = []
+
+            def __call__(self, x, offset=0):
+                self.offsets.append(offset)
+                return super().__call__(x, offset=offset)
+
+        rope = RecordingRoPE()
         module = SimpleNamespace(rope=rope)
         cu_seqlens = [0, 1, 2, 3, 4]
-        offsets = [7, 19, 43, 71]
-        q = mx.random.normal((1, 3, 4, 8))
-        k = mx.random.normal((1, 2, 4, 8))
+        q = mx.zeros((1, 3, 4, 8), dtype=mx.float32)
+        k = mx.zeros((1, 2, 4, 8), dtype=mx.float32)
 
-        expected_q = self._reference_rope(rope, q, cu_seqlens, offsets)
-        expected_k = self._reference_rope(rope, k, cu_seqlens, offsets)
-        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
-        mx.eval(expected_q, expected_k, q_out, k_out)
+        apply_packed_rope(module, q, k, cu_seqlens)
 
-        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
-        assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
+        assert len(rope.offsets) == 2
+        assert rope.offsets[0].shape == (4,)
+        assert rope.offsets[0].tolist() == [0, 0, 0, 0]
+        assert rope.offsets[1].shape == (4,)
+        assert rope.offsets[1].tolist() == [0, 0, 0, 0]
 
     def test_batched_rope_preserves_keys_when_not_applied(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,
         )
 
-        module = SimpleNamespace(rope=nn.RoPE(dims=8, traditional=False, base=10_000.0))
+        class RecordingRoPE(nn.RoPE):
+            def __init__(self) -> None:
+                super().__init__(dims=8, traditional=False, base=10_000.0)
+                self.calls = 0
+
+            def __call__(self, x, offset=0):
+                self.calls += 1
+                return super().__call__(x, offset=offset)
+
+        rope = RecordingRoPE()
+        reference_rope = nn.RoPE(dims=8, traditional=False, base=10_000.0)
+        module = SimpleNamespace(rope=rope)
         cu_seqlens = [0, 1, 2, 3, 4]
         offsets = [3, 17, 41, 83]
-        q = mx.random.normal((1, 3, 4, 8))
-        k = mx.random.normal((1, 2, 4, 8))
-        expected_q = self._reference_rope(module.rope, q, cu_seqlens, offsets)
+        q = mx.arange(1 * 3 * 4 * 8, dtype=mx.float32).reshape(1, 3, 4, 8) / 100
+        k = mx.zeros((1, 2, 4, 8), dtype=mx.float32)
+        expected_q = mx.concatenate(
+            [
+                reference_rope(q[:, :, i : i + 1, :], offset=offsets[i])
+                for i in range(4)
+            ],
+            axis=2,
+        )
 
         q_out, k_out = apply_packed_rope(
             module,
@@ -367,8 +342,39 @@ class TestPackedRoPE:
         )
         mx.eval(expected_q, q_out)
 
+        assert rope.calls == 1
         assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
         assert k_out is k
+
+    def test_multi_token_segments_keep_per_segment_call_contract(self):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        class RecordingRoPE(nn.RoPE):
+            def __init__(self) -> None:
+                super().__init__(dims=8, traditional=False, base=10_000.0)
+                self.calls = []
+
+            def __call__(self, x, offset=0):
+                self.calls.append((x.shape, offset))
+                return super().__call__(x, offset=offset)
+
+        rope = RecordingRoPE()
+        module = SimpleNamespace(rope=rope)
+        q = mx.zeros((1, 2, 6, 8))
+        k = mx.zeros((1, 1, 6, 8))
+
+        apply_packed_rope(module, q, k, [0, 2, 4, 6], offsets=[3, 5, 8])
+
+        assert rope.calls == [
+            ((1, 2, 2, 8), 3),
+            ((1, 1, 2, 8), 3),
+            ((1, 2, 2, 8), 5),
+            ((1, 1, 2, 8), 5),
+            ((1, 2, 2, 8), 8),
+            ((1, 1, 2, 8), 8),
+        ]
 
     def test_custom_rope_keeps_per_segment_call_contract(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -12,6 +12,12 @@ from types import SimpleNamespace
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
+from mlx_lm.models.rope_utils import (
+    Llama3RoPE,
+    ProportionalRoPE,
+    SuScaledRoPE,
+    YarnRoPE,
+)
 
 from vllm_metal.attention.context import (
     OffsetCache,
@@ -321,6 +327,48 @@ class TestPackedRoPE:
 
         assert mx.allclose(q_out, expected_q, rtol=1e-3, atol=1e-3).item()
         assert mx.allclose(k_out, expected_k, rtol=1e-3, atol=1e-3).item()
+
+    @pytest.mark.parametrize(
+        "rope",
+        [
+            Llama3RoPE(
+                8,
+                scaling_config={
+                    "factor": 8.0,
+                    "low_freq_factor": 1.0,
+                    "high_freq_factor": 4.0,
+                    "original_max_position_embeddings": 8192,
+                },
+            ),
+            ProportionalRoPE(8, 8),
+            SuScaledRoPE(8),
+            YarnRoPE(8),
+        ],
+    )
+    def test_mlx_lm_rope_wrappers_match_segment_reference(self, rope):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        module = SimpleNamespace(rope=rope)
+        q = mx.arange(1 * 3 * 4 * 8, dtype=mx.float32).reshape(1, 3, 4, 8) / 100
+        k = mx.arange(1 * 2 * 4 * 8, dtype=mx.float32).reshape(1, 2, 4, 8) / 100
+        cu_seqlens = [0, 1, 2, 3, 4]
+        offsets = [3, 11, 29, 47]
+
+        expected_q = mx.concatenate(
+            [rope(q[:, :, i : i + 1, :], offset=offsets[i]) for i in range(4)],
+            axis=2,
+        )
+        expected_k = mx.concatenate(
+            [rope(k[:, :, i : i + 1, :], offset=offsets[i]) for i in range(4)],
+            axis=2,
+        )
+        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
+        mx.eval(expected_q, expected_k, q_out, k_out)
+
+        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
+        assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
 
     def test_native_rope_uses_vector_zero_offsets_for_implicit_offsets(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -275,6 +275,53 @@ class TestPackedRoPE:
         assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
         assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
 
+    def test_native_rope_matches_segment_reference_for_float16_rows(self):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        dims = 128
+        segment_count = 4
+        offsets = [5, 5, 5, 5]
+        cu_seqlens = [0, 1, 2, 3, 4]
+        rope = nn.RoPE(dims=dims, traditional=False, base=10_000.0)
+        reference_rope = nn.RoPE(dims=dims, traditional=False, base=10_000.0)
+        module = SimpleNamespace(rope=rope)
+        q_rows = [
+            (mx.arange(3 * dims, dtype=mx.float32).reshape(3, 1, dims) / 100 + row)
+            .astype(mx.float16)
+            .tolist()
+            for row in range(segment_count)
+        ]
+        k_rows = [
+            (mx.arange(2 * dims, dtype=mx.float32).reshape(2, 1, dims) / 100 + row)
+            .astype(mx.float16)
+            .tolist()
+            for row in range(segment_count)
+        ]
+        q = mx.transpose(mx.array(q_rows, dtype=mx.float16), (2, 1, 0, 3))
+        k = mx.transpose(mx.array(k_rows, dtype=mx.float16), (2, 1, 0, 3))
+
+        expected_q = mx.concatenate(
+            [
+                reference_rope(q[:, :, i : i + 1, :], offset=offsets[i])
+                for i in range(segment_count)
+            ],
+            axis=2,
+        )
+        expected_k = mx.concatenate(
+            [
+                reference_rope(k[:, :, i : i + 1, :], offset=offsets[i])
+                for i in range(segment_count)
+            ],
+            axis=2,
+        )
+        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
+        mx.eval(expected_q, expected_k, q_out, k_out)
+
+        assert mx.allclose(q_out, expected_q, rtol=1e-3, atol=1e-3).item()
+        assert mx.allclose(k_out, expected_k, rtol=1e-3, atol=1e-3).item()
+
     def test_native_rope_uses_vector_zero_offsets_for_implicit_offsets(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -7,7 +7,11 @@ Run with:
 
 from __future__ import annotations
 
+from functools import partial
+from types import SimpleNamespace
+
 import mlx.core as mx
+import mlx.nn as nn
 import pytest
 
 from vllm_metal.attention.context import (
@@ -222,6 +226,123 @@ class TestPrepare:
 
 class TestPackedRoPE:
     """Tests for per-request RoPE position reset in packed prefill."""
+
+    @staticmethod
+    def _reference_rope(rope, x, cu_seqlens, offsets):
+        parts = []
+        for i, (start, end) in enumerate(
+            zip(cu_seqlens[:-1], cu_seqlens[1:], strict=True)
+        ):
+            offset = offsets[i] if offsets is not None else 0
+            parts.append(rope(x[:, :, start:end, :], offset=offset))
+        return mx.concatenate(parts, axis=2)
+
+    @pytest.mark.parametrize(
+        ("batch", "segment_len", "offsets"),
+        [
+            (1, 1, [3, 11, 29, 47]),
+            (1, 3, [2, 17, 31, 64]),
+            (2, 1, [5, 23, 41, 59]),
+            (2, 2, [13, 13, 13, 13]),
+            (1, 1, None),
+        ],
+    )
+    def test_native_rope_batches_equal_length_segments(
+        self, batch, segment_len, offsets
+    ):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        segment_count = 4
+        total_len = segment_count * segment_len
+        cu_seqlens = [i * segment_len for i in range(segment_count + 1)]
+        module = SimpleNamespace(rope=nn.RoPE(dims=8, traditional=False, base=10_000.0))
+        q = mx.random.normal((batch, 3, total_len, 8))
+        k = mx.random.normal((batch, 2, total_len, 8))
+
+        expected_q = self._reference_rope(module.rope, q, cu_seqlens, offsets)
+        expected_k = self._reference_rope(module.rope, k, cu_seqlens, offsets)
+        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
+        mx.eval(expected_q, expected_k, q_out, k_out)
+
+        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
+        assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
+
+    def test_fast_rope_partial_batches_equal_length_segments(self):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        rope = partial(
+            mx.fast.rope,
+            dims=8,
+            traditional=False,
+            base=10_000.0,
+            scale=1.0,
+        )
+        module = SimpleNamespace(rope=rope)
+        cu_seqlens = [0, 1, 2, 3, 4]
+        offsets = [7, 19, 43, 71]
+        q = mx.random.normal((1, 3, 4, 8))
+        k = mx.random.normal((1, 2, 4, 8))
+
+        expected_q = self._reference_rope(rope, q, cu_seqlens, offsets)
+        expected_k = self._reference_rope(rope, k, cu_seqlens, offsets)
+        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
+        mx.eval(expected_q, expected_k, q_out, k_out)
+
+        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
+        assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
+
+    def test_batched_rope_preserves_keys_when_not_applied(self):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        module = SimpleNamespace(rope=nn.RoPE(dims=8, traditional=False, base=10_000.0))
+        cu_seqlens = [0, 1, 2, 3, 4]
+        offsets = [3, 17, 41, 83]
+        q = mx.random.normal((1, 3, 4, 8))
+        k = mx.random.normal((1, 2, 4, 8))
+        expected_q = self._reference_rope(module.rope, q, cu_seqlens, offsets)
+
+        q_out, k_out = apply_packed_rope(
+            module,
+            q,
+            k,
+            cu_seqlens,
+            offsets=offsets,
+            apply_keys=False,
+        )
+        mx.eval(expected_q, q_out)
+
+        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
+        assert k_out is k
+
+    def test_custom_rope_keeps_per_segment_call_contract(self):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        class RecordingRoPE:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, x, offset=0):
+                self.calls.append((x.shape, offset))
+                return x + offset
+
+        rope = RecordingRoPE()
+        module = SimpleNamespace(rope=rope)
+        q = mx.zeros((1, 2, 3, 8))
+        k = mx.zeros((1, 1, 3, 8))
+
+        q_out, k_out = apply_packed_rope(module, q, k, [0, 1, 2, 3], offsets=[3, 5, 8])
+
+        assert [offset for _, offset in rope.calls] == [3, 3, 5, 5, 8, 8]
+        assert q_out[0, 0, :, 0].tolist() == [3.0, 5.0, 8.0]
+        assert k_out[0, 0, :, 0].tolist() == [3.0, 5.0, 8.0]
 
     def test_positions_reset_per_request(self):
         """Each packed request's RoPE should start from position 0."""

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -269,6 +269,56 @@ class TestPackedRoPE:
         assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
         assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
 
+    @pytest.mark.parametrize("rope_kind", ["nn", "fast"])
+    @pytest.mark.parametrize(
+        "offsets",
+        [None, [5, 5, 5, 5]],
+        ids=["implicit-zero", "equal-nonzero"],
+    )
+    def test_single_token_equal_offsets_avoid_scalar_offset_kernel(
+        self, rope_kind, offsets
+    ):
+        from vllm_metal.attention.impls.varlen_rope_compat import (
+            apply_packed_rope,
+        )
+
+        dims = 128
+        if rope_kind == "nn":
+            rope = nn.RoPE(dims=dims, traditional=False, base=10_000.0)
+        else:
+            rope = partial(
+                mx.fast.rope,
+                dims=dims,
+                traditional=False,
+                base=10_000.0,
+                scale=1.0,
+            )
+
+        # Independently allocated rows trigger MLX #3494. Repeated/aliased
+        # rows can mask the scalar-offset single-token kernel bug.
+        def make_packed_tokens(heads):
+            rows = mx.array(
+                [
+                    mx.random.normal((heads, 1, dims)).astype(mx.float16).tolist()
+                    for _ in range(4)
+                ],
+                dtype=mx.float16,
+            )
+            return mx.transpose(rows, (2, 1, 0, 3))
+
+        module = SimpleNamespace(rope=rope)
+        q = make_packed_tokens(3)
+        k = make_packed_tokens(2)
+        cu_seqlens = [0, 1, 2, 3, 4]
+
+        expected_q = self._reference_rope(rope, q, cu_seqlens, offsets)
+        expected_k = self._reference_rope(rope, k, cu_seqlens, offsets)
+        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
+        mx.eval(expected_q, expected_k, q_out, k_out)
+
+        assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
+        assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
+
     def test_fast_rope_partial_batches_equal_length_segments(self):
         from vllm_metal.attention.impls.varlen_rope_compat import (
             apply_packed_rope,

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from functools import partial
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -55,71 +54,17 @@ def _apply_mrope_segment_with_positions(
 
 
 def _supports_batched_offsets(rope_fn: object) -> bool:
-    """Return whether a RoPE callable supports vectorized MLX offsets."""
-    return isinstance(rope_fn, nn.RoPE) or (
-        isinstance(rope_fn, partial) and rope_fn.func is mx.fast.rope
-    )
+    return isinstance(rope_fn, nn.RoPE)
 
 
-def _apply_equal_length_batched_rope(
+def _apply_single_token_batched_rope(
     rope_fn: Callable[..., mx.array],
     x: mx.array,
-    segment_count: int,
-    segment_len: int,
-    batch_offsets: int | mx.array,
+    offsets: mx.array,
 ) -> mx.array:
-    """Apply native RoPE to equal-length packed segments as one batch."""
-    batch, heads, _, head_dim = x.shape
-
-    if segment_len == 1:
-        batched = mx.reshape(
-            mx.transpose(x, (0, 2, 1, 3)),
-            (batch * segment_count, heads, 1, head_dim),
-        )
-    else:
-        batched = mx.reshape(
-            mx.transpose(
-                mx.reshape(
-                    x,
-                    (batch, heads, segment_count, segment_len, head_dim),
-                ),
-                (0, 2, 1, 3, 4),
-            ),
-            (batch * segment_count, heads, segment_len, head_dim),
-        )
-
-    if batch == 1 or isinstance(batch_offsets, int):
-        effective_offsets = batch_offsets
-    else:
-        effective_offsets = mx.reshape(
-            mx.broadcast_to(
-                batch_offsets[None, :],
-                (batch, segment_count),
-            ),
-            (-1,),
-        )
-
-    rotated = rope_fn(batched, offset=effective_offsets)
-
-    if segment_len == 1:
-        return mx.transpose(
-            mx.reshape(
-                rotated,
-                (batch, segment_count, heads, head_dim),
-            ),
-            (0, 2, 1, 3),
-        )
-
-    return mx.reshape(
-        mx.transpose(
-            mx.reshape(
-                rotated,
-                (batch, segment_count, heads, segment_len, head_dim),
-            ),
-            (0, 2, 1, 3, 4),
-        ),
-        x.shape,
-    )
+    batched = mx.transpose(x, (2, 1, 0, 3))
+    rotated = rope_fn(batched, offset=offsets)
+    return mx.transpose(rotated, (2, 1, 0, 3))
 
 
 def apply_precomputed_mrope(
@@ -245,41 +190,25 @@ def apply_packed_rope(
         rope_fn is not None
         and positions is None
         and segment_count > 1
-        and cu_seqlens[0] == 0
-        and cu_seqlens[-1] == queries.shape[2]
-        and (not apply_keys or cu_seqlens[-1] == keys.shape[2])
+        and queries.shape[0] == 1
+        and queries.shape[2] == segment_count
+        and (not apply_keys or keys.shape[2] == segment_count)
+        and all(cu_seqlens[i] == i for i in range(segment_count + 1))
         and _supports_batched_offsets(rope_fn)
     ):
-        segment_len = cu_seqlens[1]
-        if segment_len > 0 and all(
-            cu_seqlens[i + 1] == (i + 1) * segment_len for i in range(1, segment_count)
-        ):
-            batch_offsets: int | mx.array
-            # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D]
-            # RoPE with a scalar offset (MLX #3494). Vector offsets select the
-            # correct kernel, including when every request has the same offset.
-            if segment_len == 1:
-                batch_offsets = (
-                    mx.zeros((segment_count,), dtype=mx.int32)
-                    if offsets is None
-                    else mx.array(offsets[:segment_count])
-                )
-            elif offsets is None:
-                batch_offsets = 0
-            elif all(offsets[i] == offsets[0] for i in range(1, segment_count)):
-                batch_offsets = offsets[0]
-            else:
-                batch_offsets = mx.array(offsets[:segment_count])
-
-            rotated_q = _apply_equal_length_batched_rope(
-                rope_fn, queries, segment_count, segment_len, batch_offsets
-            )
-            if not apply_keys:
-                return rotated_q, keys
-            rotated_k = _apply_equal_length_batched_rope(
-                rope_fn, keys, segment_count, segment_len, batch_offsets
-            )
-            return rotated_q, rotated_k
+        # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D] RoPE
+        # with a scalar offset (MLX #3494). Vector offsets select the correct
+        # kernel, including when every request has the same offset.
+        batch_offsets = (
+            mx.zeros((segment_count,), dtype=mx.int32)
+            if offsets is None
+            else mx.array(offsets, dtype=mx.int32)
+        )
+        rotated_q = _apply_single_token_batched_rope(rope_fn, queries, batch_offsets)
+        if not apply_keys:
+            return rotated_q, keys
+        rotated_k = _apply_single_token_batched_rope(rope_fn, keys, batch_offsets)
+        return rotated_q, rotated_k
 
     q_parts = []
     k_parts = []

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -53,10 +53,6 @@ def _apply_mrope_segment_with_positions(
     return apply_multimodal_rotary_pos_emb(q_seg, k_seg, cos, sin)
 
 
-def _supports_batched_offsets(rope_fn: object) -> bool:
-    return isinstance(rope_fn, nn.RoPE)
-
-
 def _apply_single_token_batched_rope(
     rope_fn: Callable[..., mx.array],
     x: mx.array,
@@ -194,7 +190,7 @@ def apply_packed_rope(
         and queries.shape[2] == segment_count
         and (not apply_keys or keys.shape[2] == segment_count)
         and all(cu_seqlens[i] == i for i in range(segment_count + 1))
-        and _supports_batched_offsets(rope_fn)
+        and isinstance(rope_fn, nn.RoPE)
     ):
         # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D] RoPE
         # with a scalar offset (MLX #3494). Vector offsets select the correct

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -58,6 +58,11 @@ def _apply_single_token_batched_rope(
     x: mx.array,
     offsets: mx.array,
 ) -> mx.array:
+    """Apply RoPE to packed decode rows as one native batch.
+
+    ``x`` is ``(1, heads, segment_count, head_dim)`` and each segment is one
+    token, so ``offsets`` must be the vector ``(segment_count,)``.
+    """
     batched = mx.transpose(x, (2, 1, 0, 3))
     rotated = rope_fn(batched, offset=offsets)
     return mx.transpose(rotated, (2, 1, 0, 3))

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from functools import partial
 
 import mlx.core as mx
+import mlx.nn as nn
 
 
 def _apply_mrope_segment(
@@ -50,6 +52,74 @@ def _apply_mrope_segment_with_positions(
 
     cos, sin = rotary_emb(q_seg, position_ids)  # type: ignore[operator]
     return apply_multimodal_rotary_pos_emb(q_seg, k_seg, cos, sin)
+
+
+def _supports_batched_offsets(rope_fn: object) -> bool:
+    """Return whether a RoPE callable supports vectorized MLX offsets."""
+    return isinstance(rope_fn, nn.RoPE) or (
+        isinstance(rope_fn, partial) and rope_fn.func is mx.fast.rope
+    )
+
+
+def _apply_equal_length_batched_rope(
+    rope_fn: Callable[..., mx.array],
+    x: mx.array,
+    segment_count: int,
+    segment_len: int,
+    batch_offsets: int | mx.array,
+) -> mx.array:
+    """Apply native RoPE to equal-length packed segments as one batch."""
+    batch, heads, _, head_dim = x.shape
+
+    if segment_len == 1:
+        batched = mx.reshape(
+            mx.transpose(x, (0, 2, 1, 3)),
+            (batch * segment_count, heads, 1, head_dim),
+        )
+    else:
+        batched = mx.reshape(
+            mx.transpose(
+                mx.reshape(
+                    x,
+                    (batch, heads, segment_count, segment_len, head_dim),
+                ),
+                (0, 2, 1, 3, 4),
+            ),
+            (batch * segment_count, heads, segment_len, head_dim),
+        )
+
+    if batch == 1 or isinstance(batch_offsets, int):
+        effective_offsets = batch_offsets
+    else:
+        effective_offsets = mx.reshape(
+            mx.broadcast_to(
+                batch_offsets[None, :],
+                (batch, segment_count),
+            ),
+            (-1,),
+        )
+
+    rotated = rope_fn(batched, offset=effective_offsets)
+
+    if segment_len == 1:
+        return mx.transpose(
+            mx.reshape(
+                rotated,
+                (batch, segment_count, heads, head_dim),
+            ),
+            (0, 2, 1, 3),
+        )
+
+    return mx.reshape(
+        mx.transpose(
+            mx.reshape(
+                rotated,
+                (batch, segment_count, heads, segment_len, head_dim),
+            ),
+            (0, 2, 1, 3, 4),
+        ),
+        x.shape,
+    )
 
 
 def apply_precomputed_mrope(
@@ -170,9 +240,40 @@ def apply_packed_rope(
     rope_fn = getattr(attn_module, "rope", None)
     rotary_emb = getattr(attn_module, "rotary_emb", None) if rope_fn is None else None
 
+    segment_count = len(cu_seqlens) - 1
+    if (
+        rope_fn is not None
+        and positions is None
+        and segment_count > 1
+        and cu_seqlens[0] == 0
+        and cu_seqlens[-1] == queries.shape[2]
+        and (not apply_keys or cu_seqlens[-1] == keys.shape[2])
+        and _supports_batched_offsets(rope_fn)
+    ):
+        segment_len = cu_seqlens[1]
+        if segment_len > 0 and all(
+            cu_seqlens[i + 1] == (i + 1) * segment_len for i in range(1, segment_count)
+        ):
+            if offsets is None:
+                batch_offsets: int | mx.array = 0
+            elif all(offsets[i] == offsets[0] for i in range(1, segment_count)):
+                batch_offsets = offsets[0]
+            else:
+                batch_offsets = mx.array(offsets[:segment_count])
+
+            rotated_q = _apply_equal_length_batched_rope(
+                rope_fn, queries, segment_count, segment_len, batch_offsets
+            )
+            if not apply_keys:
+                return rotated_q, keys
+            rotated_k = _apply_equal_length_batched_rope(
+                rope_fn, keys, segment_count, segment_len, batch_offsets
+            )
+            return rotated_q, rotated_k
+
     q_parts = []
     k_parts = []
-    for i in range(len(cu_seqlens) - 1):
+    for i in range(segment_count):
         start = cu_seqlens[i]
         end = cu_seqlens[i + 1]
         off = offsets[i] if offsets is not None else 0

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -200,6 +200,7 @@ def apply_packed_rope(
         # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D] RoPE
         # with a scalar offset (MLX #3494). Vector offsets select the correct
         # kernel, including when every request has the same offset.
+        # Remove this workaround after an MLX bump that fixes the pinned wheel.
         batch_offsets = (
             mx.zeros((segment_count,), dtype=mx.int32)
             if offsets is None

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -254,8 +254,18 @@ def apply_packed_rope(
         if segment_len > 0 and all(
             cu_seqlens[i + 1] == (i + 1) * segment_len for i in range(1, segment_count)
         ):
-            if offsets is None:
-                batch_offsets: int | mx.array = 0
+            batch_offsets: int | mx.array
+            # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D]
+            # RoPE with a scalar offset (MLX #3494). Vector offsets select the
+            # correct kernel, including when every request has the same offset.
+            if segment_len == 1:
+                batch_offsets = (
+                    mx.zeros((segment_count,), dtype=mx.int32)
+                    if offsets is None
+                    else mx.array(offsets[:segment_count])
+                )
+            elif offsets is None:
+                batch_offsets = 0
             elif all(offsets[i] == offsets[0] for i in range(1, segment_count)):
                 batch_offsets = offsets[0]
             else:

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -7,6 +7,20 @@ from collections.abc import Callable
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_lm.models.rope_utils import (
+    Llama3RoPE,
+    ProportionalRoPE,
+    SuScaledRoPE,
+    YarnRoPE,
+)
+
+_VECTOR_OFFSET_ROPE_TYPES = (
+    nn.RoPE,
+    Llama3RoPE,
+    ProportionalRoPE,
+    SuScaledRoPE,
+    YarnRoPE,
+)
 
 
 def _apply_mrope_segment(
@@ -195,7 +209,7 @@ def apply_packed_rope(
         and queries.shape[2] == segment_count
         and (not apply_keys or keys.shape[2] == segment_count)
         and all(cu_seqlens[i] == i for i in range(segment_count + 1))
-        and isinstance(rope_fn, nn.RoPE)
+        and isinstance(rope_fn, _VECTOR_OFFSET_ROPE_TYPES)
     ):
         # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D] RoPE
         # with a scalar offset (MLX #3494). Vector offsets select the correct


### PR DESCRIPTION
This PR is:
- To batch the current single-token packed decode RoPE path.
- To pass vector offsets into native `nn.RoPE`, avoiding MLX scalar-offset corruption for batched one-token rows.
- To keep custom RoPE, `B > 1`, and multi-token/prefill segments on the existing per-segment path.

## Context

MLX can produce wrong results for batched `[B, H, 1, D]` RoPE when using a scalar offset. The paged decode path already packs multiple one-token segments as `[1, H, N, D]`, so this PR transposes that into `[N, H, 1, D]` and calls native `nn.RoPE` once for Q and once for K with vector offsets.

This keeps the real decode-path win without adding broader RoPE batching semantics that current callers do not own.