### PR TITLE
[GGUF] Add mistral GGUF loading via llama arch alias

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -69,11 +69,12 @@ vllm-metal's GGUF engine integration sets `quantization=gguf` from the file
 [vllm-gguf-plugin](https://github.com/vllm-project/vllm-gguf-plugin)). A
 `.gguf` carries weights only, so it pairs with a companion config dir
 (`--tokenizer`) and needs the `gguf` extra; the weights stay MLX-native
-quantized (Q8_0/Q4_0, not a dense fallback). Scope is dense `qwen2`/`qwen3`
+quantized (Q8_0/Q4_0, not a dense fallback). Scope is dense
+`qwen2`/`qwen3`/`llama`/`mistral` (mistral converts under the llama GGUF arch)
 with per-tensor `Q8_0`/`Q4_0`; K-quants, `Q4_1`, fused-QKV, MoE, SSM/hybrid,
 vision, and remote `repo:quant` are rejected with a clear error. Verified
-end-to-end on Qwen3-0.6B Q8_0
-([#415](https://github.com/vllm-project/vllm-metal/issues/415)).
+end-to-end on Qwen3-0.6B, Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3
+Q8_0 ([#415](https://github.com/vllm-project/vllm-metal/issues/415)).
 
 | Model | Support | Attention Kernel | Automatic Prefix Cache | Example checkpoint |
 | --- | --- | --- | --- | --- |

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -343,11 +343,12 @@ def test_quantized_llama_qk_are_row_unpermuted(tmp_path, quant_type):
     assert not bool(mx.array_equal(got_k.qweight, raw_k.qweight).item())
 
 
-def test_loads_untied_mistral_via_llama_alias(tmp_path):
+def test_loads_untied_mistral_via_llama_arch_mapping(tmp_path):
     # Real Mistral GGUFs declare general.architecture="llama" while the config
-    # says model_type="mistral"; the adapter alias admits the pair and the llama
-    # RoPE q/k un-permutation applies through it. Mirrors the real v0.3 shape:
-    # untied (lm_head present) and head_dim OMITTED (derived hidden // heads).
+    # says model_type="mistral"; the adapter mapping admits the pair and the
+    # llama RoPE q/k un-permutation applies through it. Mirrors the real v0.3
+    # shape: untied (lm_head present) and head_dim OMITTED (hidden // heads).
+    # Arrange
     d = _dims(_tiny_config("mistral"))
     gguf_path, cfg_dir = _build_dense_fixture(
         tmp_path,
@@ -368,10 +369,14 @@ def test_loads_untied_mistral_via_llama_alias(tmp_path):
     exp_q = raw_q.permute_rows(_rope_inv_index(d["qd"], cfg["num_attention_heads"]))
     exp_k = raw_k.permute_rows(_rope_inv_index(d["kvd"], cfg["num_key_value_heads"]))
 
+    # Act
     model, _ = GGUFModelLoader(
         gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
     ).load()
+    out = model(mx.array([[1, 2, 3]]))
+    mx.eval(out)
 
+    # Assert
     assert isinstance(model.lm_head, GGUFLinear)  # untied head installed
     got_q = model.model.layers[0].self_attn.q_proj.tensor
     got_k = model.model.layers[0].self_attn.k_proj.tensor
@@ -380,36 +385,40 @@ def test_loads_untied_mistral_via_llama_alias(tmp_path):
         assert bool(mx.array_equal(got.scales, exp.scales).item())
         assert bool(mx.array_equal(got.biases, exp.biases).item())
         assert not bool(mx.array_equal(got.qweight, raw.qweight).item())
-    out = model(mx.array([[1, 2, 3]]))
-    mx.eval(out)
     assert out.shape == (1, 3, 256)
 
 
-def test_resolve_arch_mistral_alias_contract():
-    # mistral aliases onto llama on either side of the cross-check.
-    assert (
-        GGUFModelAdapter.resolve_arch(gguf_arch="llama", config_model_type="mistral")
-        == "llama"
-    )
-    assert (
-        GGUFModelAdapter.resolve_arch(gguf_arch="mistral", config_model_type="mistral")
-        == "llama"
-    )
-    # The multimodal mistral3/mistral4 archs are NOT aliased: allowlist-rejected.
+def test_resolve_arch_accepts_llama_gguf_with_mistral_config():
+    # The one admitted pairing: a llama-arch .gguf with a mistral config.
+    arch = GGUFModelAdapter.resolve_arch(gguf_arch="llama", config_model_type="mistral")
+
+    assert arch == "llama"
+
+
+@pytest.mark.parametrize("gguf_arch", ["mistral", "mistral3", "mistral4"])
+def test_resolve_arch_rejects_unsupported_mistral_gguf_archs(gguf_arch):
+    # The config-side mapping never widens the .gguf side: a file declaring a
+    # raw "mistral" arch is not a llama.cpp product, and the multimodal
+    # mistral3/mistral4 archs are out of scope; all stay allowlist-rejected.
     with pytest.raises(GGUFLoadError) as not_dense:
-        GGUFModelAdapter.resolve_arch(
-            gguf_arch="mistral3", config_model_type="mistral3"
-        )
+        GGUFModelAdapter.resolve_arch(gguf_arch=gguf_arch, config_model_type="mistral")
+
     assert str(not_dense.value) == (
-        "Architecture 'mistral3' is not a supported dense decoder; the GGUF "
+        f"Architecture {gguf_arch!r} is not a supported dense decoder; the GGUF "
         "loader supports ['llama', 'qwen2', 'qwen3']."
     )
-    # A mismatch names the RAW config model_type, not its aliased canonical form.
+
+
+def test_resolve_arch_mismatch_names_raw_and_mapped_config_type():
+    # The mismatch error shows the GGUF arch, the raw config model_type, and
+    # the GGUF arch that model_type maps to.
     with pytest.raises(GGUFLoadError) as mismatch:
         GGUFModelAdapter.resolve_arch(gguf_arch="qwen2", config_model_type="mistral")
+
     assert str(mismatch.value) == (
         "GGUF architecture 'qwen2' does not match config model_type 'mistral' "
-        "(canonical 'llama'); the .gguf and config_dir describe different models."
+        "(maps to GGUF arch 'llama'); the .gguf and config_dir describe "
+        "different models."
     )
 
 

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -18,6 +18,7 @@ import pytest
 
 gguf = pytest.importorskip("gguf")
 
+from vllm_metal.gguf.adapter import GGUFModelAdapter  # noqa: E402
 from vllm_metal.gguf.loader import GGUFLoadError, GGUFModelLoader  # noqa: E402
 from vllm_metal.gguf.mlx_native import GGUFMLXQuantizedTensor  # noqa: E402
 from vllm_metal.gguf.wrappers import GGUFLinear  # noqa: E402
@@ -340,6 +341,76 @@ def test_quantized_llama_qk_are_row_unpermuted(tmp_path, quant_type):
     assert bool(mx.array_equal(got_k.qweight, exp_k.qweight).item())
     assert not bool(mx.array_equal(got_q.qweight, raw_q.qweight).item())
     assert not bool(mx.array_equal(got_k.qweight, raw_k.qweight).item())
+
+
+def test_loads_untied_mistral_via_llama_alias(tmp_path):
+    # Real Mistral GGUFs declare general.architecture="llama" while the config
+    # says model_type="mistral"; the adapter alias admits the pair and the llama
+    # RoPE q/k un-permutation applies through it. Mirrors the real v0.3 shape:
+    # untied (lm_head present) and head_dim OMITTED (derived hidden // heads).
+    d = _dims(_tiny_config("mistral"))
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "mistral",
+        config_overrides={"tie_word_embeddings": False},
+        has_qk_norm=False,
+        gguf_arch="llama",
+    )
+    _write_minimal_tokenizer(cfg_dir, 256)
+    config_path = Path(cfg_dir) / "config.json"
+    config = json.loads(config_path.read_text())
+    config.pop("head_dim")  # derived head_dim == hidden_size // heads == 16
+    config_path.write_text(json.dumps(config))
+    arrays = mx.load(gguf_path)
+    cfg = _tiny_config("mistral")
+    raw_q = GGUFMLXQuantizedTensor.from_mx_load(arrays, "blk.0.attn_q.weight", QT.Q8_0)
+    raw_k = GGUFMLXQuantizedTensor.from_mx_load(arrays, "blk.0.attn_k.weight", QT.Q8_0)
+    exp_q = raw_q.permute_rows(_rope_inv_index(d["qd"], cfg["num_attention_heads"]))
+    exp_k = raw_k.permute_rows(_rope_inv_index(d["kvd"], cfg["num_key_value_heads"]))
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    assert isinstance(model.lm_head, GGUFLinear)  # untied head installed
+    got_q = model.model.layers[0].self_attn.q_proj.tensor
+    got_k = model.model.layers[0].self_attn.k_proj.tensor
+    for got, exp, raw in ((got_q, exp_q, raw_q), (got_k, exp_k, raw_k)):
+        assert bool(mx.array_equal(got.qweight, exp.qweight).item())
+        assert bool(mx.array_equal(got.scales, exp.scales).item())
+        assert bool(mx.array_equal(got.biases, exp.biases).item())
+        assert not bool(mx.array_equal(got.qweight, raw.qweight).item())
+    out = model(mx.array([[1, 2, 3]]))
+    mx.eval(out)
+    assert out.shape == (1, 3, 256)
+
+
+def test_resolve_arch_mistral_alias_contract():
+    # mistral aliases onto llama on either side of the cross-check.
+    assert (
+        GGUFModelAdapter.resolve_arch(gguf_arch="llama", config_model_type="mistral")
+        == "llama"
+    )
+    assert (
+        GGUFModelAdapter.resolve_arch(gguf_arch="mistral", config_model_type="mistral")
+        == "llama"
+    )
+    # The multimodal mistral3/mistral4 archs are NOT aliased: allowlist-rejected.
+    with pytest.raises(GGUFLoadError) as not_dense:
+        GGUFModelAdapter.resolve_arch(
+            gguf_arch="mistral3", config_model_type="mistral3"
+        )
+    assert str(not_dense.value) == (
+        "Architecture 'mistral3' is not a supported dense decoder; the GGUF "
+        "loader supports ['llama', 'qwen2', 'qwen3']."
+    )
+    # A mismatch names the RAW config model_type, not its aliased canonical form.
+    with pytest.raises(GGUFLoadError) as mismatch:
+        GGUFModelAdapter.resolve_arch(gguf_arch="qwen2", config_model_type="mistral")
+    assert str(mismatch.value) == (
+        "GGUF architecture 'qwen2' does not match config model_type 'mistral' "
+        "(canonical 'llama'); the .gguf and config_dir describe different models."
+    )
 
 
 def test_untied_llama_installs_lm_head(tmp_path):

--- a/tests/test_gguf_serve_golden.py
+++ b/tests/test_gguf_serve_golden.py
@@ -2,33 +2,38 @@
 """Opt-in greedy golden-token parity for the local GGUF serve path.
 
 Loads a real local ``.gguf`` and greedy-decodes a fixed prompt across two slow
-checks:
+checks, parameterized over the supported GGUF model families:
 
-- ``test_gguf_greedy_matches_committed_golden`` pins the first ``N`` token ids to
-  a committed golden sequence — a deterministic regression guard for the served
-  Q8_0 model.
-- ``test_gguf_greedy_matches_dense_reference_prefix`` asserts the leading tokens
-  match an ``mlx_lm`` dense reference of the same checkpoint (loaded at its
-  native dtype), proving the quantized model decodes the same high-confidence
-  prefix as the float reference. The quantized and dense decodes diverge after
-  that prefix (expected from quantization — for Qwen3-0.6B they agree through
-  index 11 and diverge at index 12), so only the agreeing prefix is asserted.
+- ``test_gguf_greedy_matches_committed_golden`` pins the first ``N`` token ids
+  to a committed golden sequence — a deterministic regression guard for the
+  served Q8_0 model.
+- ``test_gguf_greedy_matches_dense_reference_prefix`` asserts the leading
+  tokens match an ``mlx_lm`` dense reference of the same checkpoint (loaded at
+  its native dtype), proving the quantized model decodes the same
+  high-confidence prefix as the float reference. The quantized and dense
+  decodes may diverge after that prefix (expected from quantization), so only
+  each family's agreeing prefix is asserted.
 
-These load the GGUF directly through ``GGUFModelLoader``; the full ``vllm serve``
-HTTP smoke through the Metal paged runner lives in ``tools/gguf_serve_smoke.py``.
-Slow and env-gated (skipped unless the model paths are set); kept OUT of the
-deterministic unit files (real checkpoints, not synthetic fixtures). Run with::
+These load the GGUF directly through ``GGUFModelLoader``; the full
+``vllm serve`` HTTP smoke through the Metal paged runner lives in
+``tools/gguf_serve_smoke.py``. Slow and env-gated (each family skips unless its
+model paths are set); kept OUT of the deterministic unit files (real
+checkpoints, not synthetic fixtures). Run a family with its env trio, e.g.::
 
     VLLM_METAL_MEMORY_FRACTION=0.5 \\
     VLLM_METAL_TEST_GGUF_SERVE_PATH=<...Qwen3-0.6B-Q8_0.gguf> \\
     VLLM_METAL_TEST_GGUF_TOKENIZER_PATH=<...Qwen3-0.6B dir> \\
     VLLM_METAL_TEST_GGUF_DENSE_PATH=<...Qwen3-0.6B dir> \\
     pytest tests/test_gguf_serve_golden.py -m slow
+
+(llama uses ``VLLM_METAL_TEST_GGUF_LLAMA_*`` and mistral
+``VLLM_METAL_TEST_GGUF_MISTRAL_*`` for the same trio.)
 """
 
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -43,34 +48,114 @@ from vllm_metal.gguf.loader import GGUFModelLoader  # noqa: E402
 
 _PROMPT = "The capital of France is"
 _N = 16
-# Greedy decode of _PROMPT through Qwen3-0.6B-Q8_0.gguf (target_dtype=bf16).
-# The leading 12 ids match the dense mlx_lm reference; they diverge at index 12
-# (quantized vs dense), so the full sequence is pinned here as a GGUF-path
-# regression while the prefix is cross-checked against dense below.
-_GOLDEN_IDS = [
-    12095,
-    13,
-    576,
-    6722,
-    315,
-    9625,
-    374,
-    1083,
-    279,
-    6722,
-    315,
-    279,
-    5429,
-    315,
-    9625,
-    13,
-]
-# Compared against the dense reference; safely inside the 12-token agreement.
-_DENSE_AGREE_PREFIX = 8
 
-_GGUF_ENV = "VLLM_METAL_TEST_GGUF_SERVE_PATH"
-_TOK_ENV = "VLLM_METAL_TEST_GGUF_TOKENIZER_PATH"
-_DENSE_ENV = "VLLM_METAL_TEST_GGUF_DENSE_PATH"
+
+@dataclass(frozen=True)
+class _GoldenCase:
+    """One GGUF family's committed golden material and env-gated local paths."""
+
+    label: str
+    gguf_env: str
+    tokenizer_env: str
+    dense_env: str
+    golden_ids: tuple[int, ...]
+    dense_agree_prefix: int
+    target_dtype: mx.Dtype
+
+
+_CASES = [
+    # Qwen3-0.6B-Q8_0.gguf: the leading 12 ids match the dense reference and
+    # diverge at index 12 (quantized vs dense); the asserted prefix stays
+    # safely inside that agreement.
+    _GoldenCase(
+        label="qwen3",
+        gguf_env="VLLM_METAL_TEST_GGUF_SERVE_PATH",
+        tokenizer_env="VLLM_METAL_TEST_GGUF_TOKENIZER_PATH",
+        dense_env="VLLM_METAL_TEST_GGUF_DENSE_PATH",
+        golden_ids=(
+            12095,
+            13,
+            576,
+            6722,
+            315,
+            9625,
+            374,
+            1083,
+            279,
+            6722,
+            315,
+            279,
+            5429,
+            315,
+            9625,
+            13,
+        ),
+        dense_agree_prefix=8,
+        target_dtype=mx.bfloat16,
+    ),
+    # Llama-3.2-1B-Instruct-Q8_0.gguf: agreement through index 12, divergence
+    # at 13. Without the llama.cpp q/k RoPE row-un-permutation this prefix
+    # agreement is only 1 token (attention is broken), so this pins the fix
+    # end-to-end.
+    _GoldenCase(
+        label="llama",
+        gguf_env="VLLM_METAL_TEST_GGUF_LLAMA_SERVE_PATH",
+        tokenizer_env="VLLM_METAL_TEST_GGUF_LLAMA_TOKENIZER_PATH",
+        dense_env="VLLM_METAL_TEST_GGUF_LLAMA_DENSE_PATH",
+        golden_ids=(
+            12366,
+            13,
+            578,
+            469,
+            3168,
+            301,
+            22703,
+            374,
+            7559,
+            304,
+            12366,
+            13,
+            578,
+            9928,
+            49606,
+            16730,
+        ),
+        dense_agree_prefix=13,
+        target_dtype=mx.bfloat16,
+    ),
+    # Mistral-7B-Instruct-v0.3-Q8_0.gguf: the file declares
+    # general.architecture="llama" (mistral converts under the llama arch, so
+    # the q/k RoPE un-permutation applies through the adapter's config-side
+    # mapping); the config dir says model_type="mistral" and omits head_dim.
+    # All 16 ids match the dense reference inside the window.
+    _GoldenCase(
+        label="mistral",
+        gguf_env="VLLM_METAL_TEST_GGUF_MISTRAL_SERVE_PATH",
+        tokenizer_env="VLLM_METAL_TEST_GGUF_MISTRAL_TOKENIZER_PATH",
+        dense_env="VLLM_METAL_TEST_GGUF_MISTRAL_DENSE_PATH",
+        golden_ids=(
+            6233,
+            29493,
+            1330,
+            1040,
+            6333,
+            1070,
+            1040,
+            5717,
+            4610,
+            1117,
+            28566,
+            4573,
+            29491,
+            781,
+            781,
+            1782,
+        ),
+        dense_agree_prefix=16,
+        target_dtype=mx.bfloat16,
+    ),
+]
+_CASE_IDS = [case.label for case in _CASES]
 
 
 def _require_path(env: str) -> str:
@@ -94,178 +179,42 @@ def _greedy_token_ids(model: Any, tokenizer: Any, prompt: str, n: int) -> list[i
 
 
 @pytest.mark.slow
-def test_gguf_greedy_matches_committed_golden() -> None:
-    gguf_path = _require_path(_GGUF_ENV)
-    tokenizer_dir = _require_path(_TOK_ENV)
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_gguf_greedy_matches_committed_golden(case: _GoldenCase) -> None:
+    gguf_path = _require_path(case.gguf_env)
+    tokenizer_dir = _require_path(case.tokenizer_env)
 
     model, tokenizer = GGUFModelLoader(
-        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+        gguf_path, config_dir=tokenizer_dir, target_dtype=case.target_dtype
     ).load()
 
-    assert _greedy_token_ids(model, tokenizer, _PROMPT, _N) == _GOLDEN_IDS
+    ids = _greedy_token_ids(model, tokenizer, _PROMPT, _N)
+    assert ids == list(case.golden_ids)
 
 
 @pytest.mark.slow
-def test_gguf_greedy_matches_dense_reference_prefix() -> None:
-    gguf_path = _require_path(_GGUF_ENV)
-    tokenizer_dir = _require_path(_TOK_ENV)
-    dense_dir = _require_path(_DENSE_ENV)
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_gguf_greedy_matches_dense_reference_prefix(case: _GoldenCase) -> None:
+    gguf_path = _require_path(case.gguf_env)
+    tokenizer_dir = _require_path(case.tokenizer_env)
+    dense_dir = _require_path(case.dense_env)
 
     dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
     dense_ids = _greedy_token_ids(
-        dense_model, dense_tokenizer, _PROMPT, _DENSE_AGREE_PREFIX
+        dense_model, dense_tokenizer, _PROMPT, case.dense_agree_prefix
     )
     del dense_model
     mx.clear_cache()
 
     gguf_model, gguf_tokenizer = GGUFModelLoader(
-        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+        gguf_path, config_dir=tokenizer_dir, target_dtype=case.target_dtype
     ).load()
     gguf_ids = _greedy_token_ids(
-        gguf_model, gguf_tokenizer, _PROMPT, _DENSE_AGREE_PREFIX
+        gguf_model, gguf_tokenizer, _PROMPT, case.dense_agree_prefix
     )
 
     assert gguf_ids == dense_ids, (
-        "Q8_0 GGUF greedy prefix must match the dense mlx_lm reference "
-        f"(gguf={gguf_ids}, dense={dense_ids})"
+        f"{case.label} Q8_0 GGUF greedy prefix must match the dense mlx_lm "
+        f"reference (gguf={gguf_ids}, dense={dense_ids})"
     )
-    assert gguf_ids == _GOLDEN_IDS[:_DENSE_AGREE_PREFIX]
-
-
-# === llama arch (Llama-3.2-1B-Instruct-Q8_0.gguf, target_dtype=bf16) ===
-# Greedy decode of _PROMPT. The leading 13 ids match the dense mlx_lm reference;
-# they diverge at index 13 (quantized vs dense). Without the llama.cpp q/k RoPE
-# row-un-permutation this prefix agreement is only 1 token (attention is broken),
-# so this pins the fix end-to-end.
-_LLAMA_GOLDEN_IDS = [
-    12366,
-    13,
-    578,
-    469,
-    3168,
-    301,
-    22703,
-    374,
-    7559,
-    304,
-    12366,
-    13,
-    578,
-    9928,
-    49606,
-    16730,
-]
-_LLAMA_DENSE_AGREE_PREFIX = 13
-
-_LLAMA_GGUF_ENV = "VLLM_METAL_TEST_GGUF_LLAMA_SERVE_PATH"
-_LLAMA_TOK_ENV = "VLLM_METAL_TEST_GGUF_LLAMA_TOKENIZER_PATH"
-_LLAMA_DENSE_ENV = "VLLM_METAL_TEST_GGUF_LLAMA_DENSE_PATH"
-
-
-@pytest.mark.slow
-def test_llama_gguf_greedy_matches_committed_golden() -> None:
-    gguf_path = _require_path(_LLAMA_GGUF_ENV)
-    tokenizer_dir = _require_path(_LLAMA_TOK_ENV)
-
-    model, tokenizer = GGUFModelLoader(
-        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
-    ).load()
-
-    assert _greedy_token_ids(model, tokenizer, _PROMPT, _N) == _LLAMA_GOLDEN_IDS
-
-
-@pytest.mark.slow
-def test_llama_gguf_greedy_matches_dense_reference_prefix() -> None:
-    gguf_path = _require_path(_LLAMA_GGUF_ENV)
-    tokenizer_dir = _require_path(_LLAMA_TOK_ENV)
-    dense_dir = _require_path(_LLAMA_DENSE_ENV)
-
-    dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
-    dense_ids = _greedy_token_ids(
-        dense_model, dense_tokenizer, _PROMPT, _LLAMA_DENSE_AGREE_PREFIX
-    )
-    del dense_model
-    mx.clear_cache()
-
-    gguf_model, gguf_tokenizer = GGUFModelLoader(
-        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
-    ).load()
-    gguf_ids = _greedy_token_ids(
-        gguf_model, gguf_tokenizer, _PROMPT, _LLAMA_DENSE_AGREE_PREFIX
-    )
-
-    assert gguf_ids == dense_ids, (
-        "llama Q8_0 GGUF greedy prefix must match the dense mlx_lm reference "
-        f"(gguf={gguf_ids}, dense={dense_ids})"
-    )
-    assert gguf_ids == _LLAMA_GOLDEN_IDS[:_LLAMA_DENSE_AGREE_PREFIX]
-
-
-# === mistral arch (Mistral-7B-Instruct-v0.3-Q8_0.gguf, target_dtype=bf16) ===
-# Greedy decode of _PROMPT. The GGUF declares general.architecture="llama"
-# (mistral converts under the llama arch, so the q/k RoPE un-permutation
-# applies through the adapter's mistral->llama alias); the config dir says
-# model_type="mistral" and omits head_dim. All 16 ids match the dense mlx_lm
-# reference (no quantized-vs-dense divergence inside the window).
-_MISTRAL_GOLDEN_IDS = [
-    6233,
-    29493,
-    1330,
-    1040,
-    6333,
-    1070,
-    1040,
-    5717,
-    4610,
-    1117,
-    28566,
-    4573,
-    29491,
-    781,
-    781,
-    1782,
-]
-_MISTRAL_DENSE_AGREE_PREFIX = 16
-
-_MISTRAL_GGUF_ENV = "VLLM_METAL_TEST_GGUF_MISTRAL_SERVE_PATH"
-_MISTRAL_TOK_ENV = "VLLM_METAL_TEST_GGUF_MISTRAL_TOKENIZER_PATH"
-_MISTRAL_DENSE_ENV = "VLLM_METAL_TEST_GGUF_MISTRAL_DENSE_PATH"
-
-
-@pytest.mark.slow
-def test_mistral_gguf_greedy_matches_committed_golden() -> None:
-    gguf_path = _require_path(_MISTRAL_GGUF_ENV)
-    tokenizer_dir = _require_path(_MISTRAL_TOK_ENV)
-
-    model, tokenizer = GGUFModelLoader(
-        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
-    ).load()
-
-    assert _greedy_token_ids(model, tokenizer, _PROMPT, _N) == _MISTRAL_GOLDEN_IDS
-
-
-@pytest.mark.slow
-def test_mistral_gguf_greedy_matches_dense_reference_prefix() -> None:
-    gguf_path = _require_path(_MISTRAL_GGUF_ENV)
-    tokenizer_dir = _require_path(_MISTRAL_TOK_ENV)
-    dense_dir = _require_path(_MISTRAL_DENSE_ENV)
-
-    dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
-    dense_ids = _greedy_token_ids(
-        dense_model, dense_tokenizer, _PROMPT, _MISTRAL_DENSE_AGREE_PREFIX
-    )
-    del dense_model
-    mx.clear_cache()
-
-    gguf_model, gguf_tokenizer = GGUFModelLoader(
-        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
-    ).load()
-    gguf_ids = _greedy_token_ids(
-        gguf_model, gguf_tokenizer, _PROMPT, _MISTRAL_DENSE_AGREE_PREFIX
-    )
-
-    assert gguf_ids == dense_ids, (
-        "mistral Q8_0 GGUF greedy prefix must match the dense mlx_lm reference "
-        f"(gguf={gguf_ids}, dense={dense_ids})"
-    )
-    assert gguf_ids == _MISTRAL_GOLDEN_IDS[:_MISTRAL_DENSE_AGREE_PREFIX]
+    assert gguf_ids == list(case.golden_ids)[: case.dense_agree_prefix]

--- a/tests/test_gguf_serve_golden.py
+++ b/tests/test_gguf_serve_golden.py
@@ -199,3 +199,73 @@ def test_llama_gguf_greedy_matches_dense_reference_prefix() -> None:
         f"(gguf={gguf_ids}, dense={dense_ids})"
     )
     assert gguf_ids == _LLAMA_GOLDEN_IDS[:_LLAMA_DENSE_AGREE_PREFIX]
+
+
+# === mistral arch (Mistral-7B-Instruct-v0.3-Q8_0.gguf, target_dtype=bf16) ===
+# Greedy decode of _PROMPT. The GGUF declares general.architecture="llama"
+# (mistral converts under the llama arch, so the q/k RoPE un-permutation
+# applies through the adapter's mistral->llama alias); the config dir says
+# model_type="mistral" and omits head_dim. All 16 ids match the dense mlx_lm
+# reference (no quantized-vs-dense divergence inside the window).
+_MISTRAL_GOLDEN_IDS = [
+    6233,
+    29493,
+    1330,
+    1040,
+    6333,
+    1070,
+    1040,
+    5717,
+    4610,
+    1117,
+    28566,
+    4573,
+    29491,
+    781,
+    781,
+    1782,
+]
+_MISTRAL_DENSE_AGREE_PREFIX = 16
+
+_MISTRAL_GGUF_ENV = "VLLM_METAL_TEST_GGUF_MISTRAL_SERVE_PATH"
+_MISTRAL_TOK_ENV = "VLLM_METAL_TEST_GGUF_MISTRAL_TOKENIZER_PATH"
+_MISTRAL_DENSE_ENV = "VLLM_METAL_TEST_GGUF_MISTRAL_DENSE_PATH"
+
+
+@pytest.mark.slow
+def test_mistral_gguf_greedy_matches_committed_golden() -> None:
+    gguf_path = _require_path(_MISTRAL_GGUF_ENV)
+    tokenizer_dir = _require_path(_MISTRAL_TOK_ENV)
+
+    model, tokenizer = GGUFModelLoader(
+        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+    ).load()
+
+    assert _greedy_token_ids(model, tokenizer, _PROMPT, _N) == _MISTRAL_GOLDEN_IDS
+
+
+@pytest.mark.slow
+def test_mistral_gguf_greedy_matches_dense_reference_prefix() -> None:
+    gguf_path = _require_path(_MISTRAL_GGUF_ENV)
+    tokenizer_dir = _require_path(_MISTRAL_TOK_ENV)
+    dense_dir = _require_path(_MISTRAL_DENSE_ENV)
+
+    dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
+    dense_ids = _greedy_token_ids(
+        dense_model, dense_tokenizer, _PROMPT, _MISTRAL_DENSE_AGREE_PREFIX
+    )
+    del dense_model
+    mx.clear_cache()
+
+    gguf_model, gguf_tokenizer = GGUFModelLoader(
+        gguf_path, config_dir=tokenizer_dir, target_dtype=mx.bfloat16
+    ).load()
+    gguf_ids = _greedy_token_ids(
+        gguf_model, gguf_tokenizer, _PROMPT, _MISTRAL_DENSE_AGREE_PREFIX
+    )
+
+    assert gguf_ids == dense_ids, (
+        "mistral Q8_0 GGUF greedy prefix must match the dense mlx_lm reference "
+        f"(gguf={gguf_ids}, dense={dense_ids})"
+    )
+    assert gguf_ids == _MISTRAL_GOLDEN_IDS[:_MISTRAL_DENSE_AGREE_PREFIX]

--- a/vllm_metal/gguf/adapter.py
+++ b/vllm_metal/gguf/adapter.py
@@ -69,16 +69,15 @@ class GGUFModelAdapter:
 
     # Archs whose q/k projection weights are stored in llama.cpp's RoPE layout and
     # must be row-un-permuted at load (llama family). qwen2/qwen3 use the HF layout
-    # and are absent here. mistral (a llama-arch family) normalizes to "llama".
+    # and are absent here. mistral (a llama-arch family) maps to "llama".
     _ROPE_PERMUTE_ARCHS = frozenset({"llama"})
 
-    # config model_type -> canonical arch for families llama.cpp folds into an
-    # existing GGUF arch (MistralForCausalLM converts under MODEL_ARCH.LLAMA,
-    # and mlx-lm builds "mistral" configs through its llama module). Exact-key
-    # lookup: a key must never collide with a real gguf MODEL_ARCH_NAMES entry
-    # (gguf-py has no plain "mistral" arch; the multimodal "mistral3"/"mistral4"
-    # archs do not match this key and stay allowlist-rejected).
-    _ARCH_ALIASES = {"mistral": "llama"}
+    # config model_type -> the GGUF arch llama.cpp converts that family under
+    # (MistralForCausalLM converts under MODEL_ARCH.LLAMA, and mlx-lm builds
+    # "mistral" configs through its llama module). Applied to the CONFIG side
+    # only: a .gguf declaring a raw "mistral" arch is not a llama.cpp product
+    # and stays allowlist-rejected, as do the multimodal "mistral3"/"mistral4".
+    _CONFIG_MODEL_TYPE_TO_GGUF_ARCH = {"mistral": "llama"}
 
     def __init__(
         self,
@@ -119,12 +118,12 @@ class GGUFModelAdapter:
                 f"Architecture {arch!r} is not a supported dense decoder; the GGUF "
                 f"loader supports {sorted(cls.SUPPORTED_DENSE_ARCHS)}."
             )
-        config_arch = cls._normalize_arch(config_model_type)
+        config_arch = cls._config_model_type_to_gguf_arch(config_model_type)
         if arch != config_arch:
             raise GGUFLoadError(
                 f"GGUF architecture {arch!r} does not match config model_type "
-                f"{config_model_type!r} (canonical {config_arch!r}); the .gguf "
-                "and config_dir describe different models."
+                f"{config_model_type!r} (maps to GGUF arch {config_arch!r}); "
+                "the .gguf and config_dir describe different models."
             )
         return arch
 
@@ -216,10 +215,15 @@ class GGUFModelAdapter:
             .reshape(out_features)
         )
 
+    @staticmethod
+    def _normalize_arch(name: str) -> str:
+        return name.strip().lower().replace("-", "_")
+
     @classmethod
-    def _normalize_arch(cls, name: str) -> str:
-        arch = name.strip().lower().replace("-", "_")
-        return cls._ARCH_ALIASES.get(arch, arch)
+    def _config_model_type_to_gguf_arch(cls, model_type: str) -> str:
+        """Map a config ``model_type`` to the GGUF arch its family converts under."""
+        arch = cls._normalize_arch(model_type)
+        return cls._CONFIG_MODEL_TYPE_TO_GGUF_ARCH.get(arch, arch)
 
     @classmethod
     def _resolve_arch_enum(cls, gguf: Any, arch: str) -> Any | None:

--- a/vllm_metal/gguf/adapter.py
+++ b/vllm_metal/gguf/adapter.py
@@ -72,6 +72,14 @@ class GGUFModelAdapter:
     # and are absent here. mistral (a llama-arch family) normalizes to "llama".
     _ROPE_PERMUTE_ARCHS = frozenset({"llama"})
 
+    # config model_type -> canonical arch for families llama.cpp folds into an
+    # existing GGUF arch (MistralForCausalLM converts under MODEL_ARCH.LLAMA,
+    # and mlx-lm builds "mistral" configs through its llama module). Exact-key
+    # lookup: a key must never collide with a real gguf MODEL_ARCH_NAMES entry
+    # (gguf-py has no plain "mistral" arch; the multimodal "mistral3"/"mistral4"
+    # archs do not match this key and stay allowlist-rejected).
+    _ARCH_ALIASES = {"mistral": "llama"}
+
     def __init__(
         self,
         *,
@@ -111,11 +119,12 @@ class GGUFModelAdapter:
                 f"Architecture {arch!r} is not a supported dense decoder; the GGUF "
                 f"loader supports {sorted(cls.SUPPORTED_DENSE_ARCHS)}."
             )
-        if arch != cls._normalize_arch(config_model_type):
+        config_arch = cls._normalize_arch(config_model_type)
+        if arch != config_arch:
             raise GGUFLoadError(
                 f"GGUF architecture {arch!r} does not match config model_type "
-                f"{cls._normalize_arch(config_model_type)!r}; the .gguf and "
-                "config_dir describe different models."
+                f"{config_model_type!r} (canonical {config_arch!r}); the .gguf "
+                "and config_dir describe different models."
             )
         return arch
 
@@ -207,9 +216,10 @@ class GGUFModelAdapter:
             .reshape(out_features)
         )
 
-    @staticmethod
-    def _normalize_arch(name: str) -> str:
-        return name.strip().lower().replace("-", "_")
+    @classmethod
+    def _normalize_arch(cls, name: str) -> str:
+        arch = name.strip().lower().replace("-", "_")
+        return cls._ARCH_ALIASES.get(arch, arch)
 
     @classmethod
     def _resolve_arch_enum(cls, gguf: Any, arch: str) -> Any | None:


### PR DESCRIPTION
This adds mistral to the local GGUF loader (#415; qwen2/qwen3 shipped in #466, llama in #480). Classic Mistral GGUFs declare general.architecture="llama" (llama.cpp converts MistralForCausalLM under the llama arch), and mlx-lm itself builds model_type="mistral" through its llama module, so the only thing rejecting the pair was the adapter's gguf-arch-vs-config cross-check. This PR adds a "mistral" to "llama" alias as an adapter class constant folded into the existing normalization helper, and the mismatch error now names the raw config model_type alongside its canonical form. The llama q/k RoPE un-permutation from #480 applies through the alias unchanged, and the real v0.3 config omits head_dim, so the built-object read from #480 gets exercised by a real checkpoint. The docs scope sentence now lists all four archs, which also catches up the llama entry #480 never added.

For evidence, per-op forward cosine of Mistral-7B-Instruct-v0.3 Q8_0 against its dense bf16 mlx-lm reference gives q_proj/k_proj 0.99997 (v/gate 0.99998), greedy decode agrees with the dense reference for all 16 golden tokens, and tools/gguf_serve_smoke.py passes with VLLM_METAL_MEMORY_FRACTION=0.5, the completion matching the golden text verbatim. The slow goldens run with VLLM_METAL_TEST_GGUF_MISTRAL_SERVE_PATH / _TOKENIZER_PATH / _DENSE_PATH set, via `pytest -m slow tests/test_gguf_serve_golden.py -k mistral`. Unit tests cover the untied, head_dim-omitted mistral fixture (q/k asserted un-permuted over qweight, scales, and biases), and the resolve_arch contract pins mistral3/mistral4 staying rejected. Mixtral (MoE) stays rejected by the tensor preflight; sliding-window semantics follow mlx-lm (bare mistral configs have no layer_types, so every layer runs full attention; v0.3 sets it null). Local `.gguf` only, verified on Mistral-7B-Instruct-v0.3 Q8_0.