### PR TITLE
Expose live split K/V to vLLM's generic KVConnector contract (replaces #497)

### DIFF
--- a/tests/test_kv_connector_bridge.py
+++ b/tests/test_kv_connector_bridge.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for MetalKVConnectorBridge: register-once, pointer-stability
+fail-fast, and capability detection. No model/server required; uses a fake
+runner + fake MLX KV arrays and a fake vLLM KV-transfer group.
+"""
+import types
+
+import mlx.core as mx
+import pytest
+
+
+def _install_fake_kv_transfer(monkeypatch, connector):
+    """Point vllm.distributed.kv_transfer.{has,get}_kv_transfer_group at a fake."""
+    import vllm.distributed.kv_transfer as kvt
+
+    monkeypatch.setattr(kvt, "has_kv_transfer_group", lambda: connector is not None)
+    monkeypatch.setattr(kvt, "get_kv_transfer_group", lambda: connector)
+    # the bridge imports these names into its own module namespace
+    import vllm_metal.v1.kv_connector as bridge_mod
+
+    monkeypatch.setattr(bridge_mod, "has_kv_transfer_group",
+                        lambda: connector is not None)
+    monkeypatch.setattr(bridge_mod, "get_kv_transfer_group", lambda: connector)
+
+
+class _FakeConnector:
+    def __init__(self):
+        self.register_count = 0
+        self.registered = None
+
+    def register_kv_caches(self, kv_caches):
+        self.register_count += 1
+        self.registered = kv_caches
+
+
+class _FakeKVCache:
+    def __init__(self, key_caches, value_caches):
+        self.key_caches = key_caches
+        self.value_caches = value_caches
+
+
+class _FakeRuntime:
+    def __init__(self, kv_cache):
+        self.kv_cache = kv_cache
+
+
+class _FakeCfgGroup:
+    def __init__(self, layer_names):
+        self.layer_names = layer_names
+
+
+class _FakeKVCacheConfig:
+    def __init__(self, layer_names):
+        self.kv_cache_groups = [_FakeCfgGroup(layer_names)]
+
+
+class _FakeRunner:
+    def __init__(self, num_layers=2, nb=4, bs=8, nh=2, hs=16):
+        keys = [mx.zeros((nb, bs, nh, hs), dtype=mx.float16) for _ in range(num_layers)]
+        vals = [mx.zeros((nb, bs, nh, hs), dtype=mx.float16) for _ in range(num_layers)]
+        mx.eval(*keys, *vals)
+        self._paged_attention_runtime = _FakeRuntime(_FakeKVCache(keys, vals))
+        self.vllm_config = types.SimpleNamespace()
+
+
+def _bridge(runner):
+    from vllm_metal.v1.kv_connector import MetalKVConnectorBridge
+
+    return MetalKVConnectorBridge(runner)
+
+
+def _cfg(n=2):
+    return _FakeKVCacheConfig([f"layer_{i}" for i in range(n)])
+
+
+def test_register_once_no_second_registration(monkeypatch):
+    conn = _FakeConnector()
+    _install_fake_kv_transfer(monkeypatch, conn)
+    runner = _FakeRunner(num_layers=2)
+    b = _bridge(runner)
+    b.on_initialize_kv_cache(_cfg(2))
+    assert conn.register_count == 1
+    # split payload: {name: (k, v)}
+    assert set(conn.registered.keys()) == {"layer_0", "layer_1"}
+    k, v = conn.registered["layer_0"]
+    assert k.data_ptr() != v.data_ptr()
+
+    # Several begin/finish cycles: NO additional registration (pointers stable).
+    from vllm.v1.worker.kv_connector_model_runner_mixin import (
+        KVConnectorModelRunnerMixin,
+    )
+
+    monkeypatch.setattr(
+        KVConnectorModelRunnerMixin, "begin_kv_connector_step",
+        staticmethod(lambda so: object()),
+    )
+    for _ in range(3):
+        b._materialize_live_kv()
+        b._verify_pointer_stability()
+    assert conn.register_count == 1
+
+
+def test_pointer_movement_fails_fast(monkeypatch):
+    conn = _FakeConnector()
+    _install_fake_kv_transfer(monkeypatch, conn)
+    runner = _FakeRunner(num_layers=2)
+    b = _bridge(runner)
+    b.on_initialize_kv_cache(_cfg(2))
+    assert conn.register_count == 1
+
+    # Simulate an out-of-place write: rebind key_caches[0] to a NEW buffer.
+    kv = runner._paged_attention_runtime.kv_cache
+    new_k = mx.ones((4, 8, 2, 16), dtype=mx.float16)
+    mx.eval(new_k)
+    kv.key_caches[0] = new_k
+
+    with pytest.raises(RuntimeError, match="Metal KV storage moved"):
+        b._verify_pointer_stability()
+    # still exactly one registration — no silent second context
+    assert conn.register_count == 1
+
+
+def test_pointer_check_does_not_allocate(monkeypatch):
+    conn = _FakeConnector()
+    _install_fake_kv_transfer(monkeypatch, conn)
+    runner = _FakeRunner(num_layers=3)
+    b = _bridge(runner)
+    b.on_initialize_kv_cache(_cfg(3))
+    before = [k.data_ptr() for k in
+              [__import__("vllm_metal.pytorch_backend.tensor_bridge",
+                          fromlist=["mlx_to_torch"]).mlx_to_torch(a, device="cpu")
+               for a in runner._paged_attention_runtime.kv_cache.key_caches]]
+    b._verify_pointer_stability()  # must not raise, must not move buffers
+    after = [k.data_ptr() for k in
+             [__import__("vllm_metal.pytorch_backend.tensor_bridge",
+                         fromlist=["mlx_to_torch"]).mlx_to_torch(a, device="cpu")
+              for a in runner._paged_attention_runtime.kv_cache.key_caches]]
+    assert before == after
+
+
+def test_layer_count_mismatch_raises(monkeypatch):
+    conn = _FakeConnector()
+    _install_fake_kv_transfer(monkeypatch, conn)
+    runner = _FakeRunner(num_layers=2)
+    b = _bridge(runner)
+    # config claims 3 layers but cache has 2
+    with pytest.raises(ValueError, match="layer count does not match"):
+        b.on_initialize_kv_cache(_cfg(3))
+
+
+def test_capability_error_when_lifecycle_absent(monkeypatch):
+    conn = _FakeConnector()
+    _install_fake_kv_transfer(monkeypatch, conn)
+    runner = _FakeRunner(num_layers=2)
+    b = _bridge(runner)
+    # Simulate an older vLLM missing the lifecycle methods.
+    from vllm.v1.worker.kv_connector_model_runner_mixin import (
+        KVConnectorModelRunnerMixin,
+    )
+
+    from vllm_metal.v1.kv_connector import MetalKVConnectorCapabilityError
+
+    for m in ("begin_kv_connector_step", "finish_kv_connector_step",
+              "abort_kv_connector_step"):
+        monkeypatch.delattr(KVConnectorModelRunnerMixin, m, raising=False)
+    with pytest.raises(MetalKVConnectorCapabilityError, match="imperative KVConnector step lifecycle"):
+        b.on_initialize_kv_cache(_cfg(2))
+
+
+def test_no_connector_is_noop(monkeypatch):
+    _install_fake_kv_transfer(monkeypatch, None)  # has_kv_transfer_group -> False
+    runner = _FakeRunner(num_layers=2)
+    b = _bridge(runner)
+    b.on_initialize_kv_cache(_cfg(2))  # must not raise, must not register
+    assert b._registered_ptrs is None

--- a/vllm_metal/v1/kv_connector.py
+++ b/vllm_metal/v1/kv_connector.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Expose Metal's live MLX KV cache to vLLM's generic KVConnector contract.
+
+This is the *only* Metal-specific KV-connector code. It is connector-agnostic:
+it knows that *a* generic vLLM ``KVConnector`` may be configured, but never
+which one. It contains no KV-cache library name, no cache format/layout, no
+connector metadata parsing, and no per-request block tracking. Its entire job
+is to present Metal's native per-layer MLX key/value arrays to vLLM as ordinary
+CPU ``torch.Tensor`` views, and to drive vLLM's generic connector step lifecycle
+around the Metal forward.
+
+Why this is intrinsic to Metal (and cannot live in vLLM core or in a connector):
+Metal's paged KV cache lives in MLX unified memory as two separate contiguous
+``mx.array`` per layer (key and value). Only Metal can turn those MLX arrays
+into torch views (via the MLX<->torch unified-memory bridge). vLLM core consumes
+``torch.Tensor`` and must not import MLX; a connector consumes whatever tensors
+it is handed and must not import MLX either. The MLX->torch aliasing therefore
+belongs here, in the backend that owns the MLX buffers.
+
+Aliasing: ``mlx_to_torch(arr, device="cpu")`` returns a torch tensor that shares
+the MLX array's unified-memory buffer (verified: write-through in both
+directions, K and V never alias each other, buffer stable for the array's
+lifetime). Because the export is a live alias, a connector's writes on RETRIEVE
+land directly in the live MLX cache and its reads on STORE observe the live KV
+-- with no fused ``torch.stack`` staging buffer, no MLX->staging store copy, and
+no staging->MLX load writeback.
+
+Memory ordering and pointer stability: ``mlx_to_torch`` calls ``mx.eval`` on the
+array, which materializes the lazy attention writes into the buffer before the
+connector reads it. Metal's fused ``reshape_and_cache`` kernel writes IN PLACE,
+so the K/V buffer addresses are stable for the lifetime of the connector
+registration. The bridge therefore registers the live aliases EXACTLY ONCE, and
+per step only (a) materializes pending MLX work (the "make prior writes visible"
+barrier) and (b) verifies the live buffer pointers still match the ones
+registered. If a pointer moved (e.g. a hypothetical out-of-place cache
+implementation), the bridge FAILS FAST -- it does not silently re-register a
+second context (register_kv_caches is not defined as a replace/update
+operation) and does not silently continue with stale pointers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.outputs import KVConnectorOutput
+
+    from vllm_metal.v1.model_runner import MetalModelRunner
+
+logger = init_logger(__name__)
+
+
+# The generic vLLM lifecycle helpers this integration requires. Presence is
+# checked (capability detection) only when a KV connector is actually
+# configured, so importing vllm-metal and running normal inference against an
+# older vLLM that lacks them is unaffected.
+_REQUIRED_LIFECYCLE_METHODS = (
+    "begin_kv_connector_step",
+    "finish_kv_connector_step",
+    "abort_kv_connector_step",
+)
+
+
+class MetalKVConnectorCapabilityError(RuntimeError):
+    """Raised when a KV connector is configured but the installed vLLM lacks the
+    generic imperative KVConnector step lifecycle this integration requires."""
+
+
+class MetalKVConnectorBridge:
+    """Bridge Metal's live MLX KV cache to vLLM's generic KVConnector lifecycle.
+
+    Owns no connector knowledge. All connector calls go through vLLM's generic
+    ``KVConnectorModelRunnerMixin`` step helpers and the public
+    ``get_kv_transfer_group()`` SPI. Holds a back-reference to the runner only to
+    read the current live MLX buffers and their vLLM layer names.
+    """
+
+    def __init__(self, runner: MetalModelRunner) -> None:
+        self._runner = runner
+        self._kv_cache_config: KVCacheConfig | None = None
+        # A step handle kept between execute_model (submit) and sample_tokens
+        # (complete) for the async paged path. None when no step is in flight.
+        self._pending_step = None
+        # The registered K/V buffer identities (data_ptr) and shapes, recorded
+        # once at registration. Used to verify pointer stability before each
+        # external KV access (fail fast if the storage moved).
+        self._registered_ptrs: tuple[int, ...] | None = None
+        self._registered_shapes: tuple[tuple[int, ...], ...] | None = None
+
+    # -- registration -------------------------------------------------------
+
+    def on_initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        """Register Metal's live split K/V views with the configured connector.
+
+        No-op without a connector. When a connector IS configured, first verify
+        the installed vLLM provides the required generic lifecycle (capability
+        detection) and fail early with a clear version error otherwise. The
+        registration payload is ``{layer_name: (key_view, value_view)}`` -- two
+        independent live CPU torch aliases of the layer's MLX key and value
+        arrays. No fused tensor is allocated. vLLM core forwards this mapping
+        verbatim to the connector, which is responsible for interpreting the
+        split representation. Registration happens EXACTLY ONCE; the K/V buffer
+        identities and shapes are recorded for later pointer-stability checks.
+        """
+        self._kv_cache_config = kv_cache_config
+        if not has_kv_transfer_group():
+            return
+        self._require_lifecycle_capability()
+        views = self._export_live_split_kv()
+        if views is None:
+            return
+        get_kv_transfer_group().register_kv_caches(views)
+        self._registered_ptrs = self._live_buffer_ptrs()
+        self._registered_shapes = self._live_buffer_shapes()
+
+    # -- lifecycle (generic; no connector knowledge) ------------------------
+
+    def has_connector(self) -> bool:
+        return has_kv_transfer_group()
+
+    def no_forward(self, scheduler_output: SchedulerOutput):
+        """Drive the connector on a zero-token step (async load completion)."""
+        from vllm.v1.worker.kv_connector_model_runner_mixin import (
+            KVConnectorModelRunnerMixin,
+        )
+
+        return KVConnectorModelRunnerMixin.kv_connector_no_forward(
+            scheduler_output, self._runner.vllm_config
+        )
+
+    def begin_step(self, scheduler_output: SchedulerOutput) -> None:
+        """Begin this step's connector work: bind metadata + start loads.
+
+        Uses vLLM's generic ``begin_kv_connector_step``. Metal's fused KV-write
+        kernel writes IN PLACE, so the aliases registered once in
+        ``on_initialize_kv_cache`` stay valid for the connector's lifetime. The
+        only per-step obligations are (1) memory ordering -- ``mx.eval`` prior
+        lazy KV writes so the connector reads current data on a store -- and (2)
+        pointer stability -- verify the live buffers still match the registered
+        pointers, failing fast otherwise. No re-export, no re-registration, no
+        data copy.
+        """
+        from vllm.v1.worker.kv_connector_model_runner_mixin import (
+            KVConnectorModelRunnerMixin,
+        )
+
+        self._materialize_live_kv()
+        self._verify_pointer_stability()
+        self._pending_step = KVConnectorModelRunnerMixin.begin_kv_connector_step(
+            scheduler_output
+        )
+
+    def finish_step(self) -> KVConnectorOutput | None:
+        """Complete this step's connector work and return its output.
+
+        Uses vLLM's generic ``finish_kv_connector_step`` (wait_for_save,
+        get_finished, invalid blocks, stats/events/meta, clear metadata). No
+        staging sync is performed: the connector already read/wrote the live
+        aliases directly.
+        """
+        from vllm.v1.worker.kv_connector_model_runner_mixin import (
+            KVConnectorModelRunnerMixin,
+        )
+
+        if self._pending_step is None:
+            return None
+        step = self._pending_step
+        self._pending_step = None
+        return KVConnectorModelRunnerMixin.finish_kv_connector_step(step)
+
+    def abort_step(self) -> None:
+        """Abort the in-flight connector step after a failed forward.
+
+        Uses vLLM's generic ``abort_kv_connector_step`` to clear connector
+        metadata exactly once so the next scheduler step does not inherit stale
+        metadata. No-op when no step is in flight. Does not swallow the caller's
+        exception.
+        """
+        from vllm.v1.worker.kv_connector_model_runner_mixin import (
+            KVConnectorModelRunnerMixin,
+        )
+
+        if self._pending_step is None:
+            return
+        step = self._pending_step
+        self._pending_step = None
+        KVConnectorModelRunnerMixin.abort_kv_connector_step(step)
+
+    # -- MLX -> torch live split-K/V export (the intrinsic Metal part) ------
+
+    def _layer_names(self) -> list[str]:
+        cfg = self._kv_cache_config
+        if cfg is None:
+            return []
+        names: list[str] = []
+        for group in cfg.kv_cache_groups:
+            names.extend(group.layer_names)
+        return names
+
+    def _live_kv_arrays(self):
+        """Return ``(key_caches, value_caches)`` MLX arrays, or ``None``."""
+        runtime = self._runner._paged_attention_runtime
+        if runtime is None:
+            return None
+        kv_cache = getattr(runtime, "kv_cache", None)
+        key_caches = getattr(kv_cache, "key_caches", None)
+        value_caches = getattr(kv_cache, "value_caches", None)
+        if not key_caches or not value_caches:
+            return None
+        return key_caches, value_caches
+
+    def _export_live_split_kv(
+        self,
+    ) -> dict[str, tuple[torch.Tensor, torch.Tensor]] | None:
+        """Build ``{layer_name: (key_view, value_view)}`` over live MLX buffers.
+
+        Each view is a zero-copy CPU torch alias of the layer's MLX array. No
+        fused tensor is allocated. Raises if the vLLM layer-name mapping does
+        not match the Metal cache -- layer identity is a correctness property
+        and is never silently invented.
+        """
+        arrays = self._live_kv_arrays()
+        if arrays is None:
+            return None
+        key_caches, value_caches = arrays
+        from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+
+        names = self._layer_names()
+        n = len(key_caches)
+        if len(names) != n:
+            raise ValueError(
+                "Metal KV cache layer count does not match the vLLM "
+                f"KVCacheConfig layer mapping: configured {len(names)} layer "
+                f"name(s) {names!r} but the Metal paged cache has {n} layer(s). "
+                "Layer identity is required for correct KV transfer; refusing "
+                "to fall back to positional layer names."
+            )
+        views: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+        for i, name in enumerate(names):
+            key_view = mlx_to_torch(key_caches[i], device="cpu")
+            value_view = mlx_to_torch(value_caches[i], device="cpu")
+            views[name] = (key_view, value_view)
+        return views
+
+    def _materialize_live_kv(self) -> None:
+        """Force pending lazy MLX KV writes to complete (memory-ordering barrier).
+
+        A prior step's KV writes are lazy in MLX's graph, so ``mx.eval`` them
+        before the connector reads the CPU alias on a store. Cheap eval barrier,
+        not a data copy and not a re-registration.
+        """
+        arrays = self._live_kv_arrays()
+        if arrays is None:
+            return
+        key_caches, value_caches = arrays
+        import mlx.core as mx
+
+        mx.eval(*key_caches, *value_caches)
+
+    def _live_buffer_ptrs(self) -> tuple[int, ...] | None:
+        """Return the data_ptr of every live K/V buffer, or ``None``.
+
+        Cheap and allocation-free: exports zero-copy torch aliases and reads
+        their ``data_ptr`` (``mlx_to_torch`` shares the buffer; no copy).
+        """
+        arrays = self._live_kv_arrays()
+        if arrays is None:
+            return None
+        key_caches, value_caches = arrays
+        from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+
+        ptrs: list[int] = []
+        for arr in list(key_caches) + list(value_caches):
+            ptrs.append(mlx_to_torch(arr, device="cpu").data_ptr())
+        return tuple(ptrs)
+
+    def _live_buffer_shapes(self) -> tuple[tuple[int, ...], ...] | None:
+        """Return the shape of every live K/V buffer, or ``None``."""
+        arrays = self._live_kv_arrays()
+        if arrays is None:
+            return None
+        key_caches, value_caches = arrays
+        return tuple(tuple(a.shape) for a in list(key_caches) + list(value_caches))
+
+    def _verify_pointer_stability(self) -> None:
+        """Fail fast if the live K/V storage moved after registration.
+
+        ``register_kv_caches`` is not a replace/update operation, so this
+        integration requires the Metal KV storage to be stable for the lifetime
+        of the connector registration (guaranteed by the in-place fused
+        ``reshape_and_cache`` kernel). If a live buffer pointer no longer matches
+        the pointer registered at init, raise -- do not silently continue with
+        stale pointers and do not silently register a second context.
+        """
+        if self._registered_ptrs is None:
+            return
+        current = self._live_buffer_ptrs()
+        if current is not None and current != self._registered_ptrs:
+            raise RuntimeError(
+                "Metal KV storage moved after connector registration: the live "
+                "key/value buffer addresses no longer match the ones registered "
+                "at initialization. Dynamic re-registration is not part of the "
+                "current KVConnector contract, so this integration requires a "
+                "cache implementation whose buffers are stable for the lifetime "
+                "of the registration (the fused in-place reshape_and_cache path). "
+                "An out-of-place cache implementation is unsupported here."
+            )
+
+    def _require_lifecycle_capability(self) -> None:
+        """Fail early if the installed vLLM lacks the required step lifecycle.
+
+        Capability detection (not a private-module import): checks the generic
+        ``KVConnectorModelRunnerMixin`` for the imperative lifecycle methods this
+        integration drives. Only called when a KV connector is configured, so
+        importing vllm-metal and running normal inference on an older vLLM is
+        unaffected. The error is generic (no concrete-connector name).
+        """
+        from vllm.v1.worker.kv_connector_model_runner_mixin import (
+            KVConnectorModelRunnerMixin,
+        )
+
+        missing = [
+            m
+            for m in _REQUIRED_LIFECYCLE_METHODS
+            if not hasattr(KVConnectorModelRunnerMixin, m)
+        ]
+        if missing:
+            raise MetalKVConnectorCapabilityError(
+                "This vllm-metal KVConnector integration requires a vLLM version "
+                "that provides the imperative KVConnector step lifecycle "
+                f"(missing: {', '.join(missing)}). Upgrade vLLM to a version that "
+                "includes the generic begin/finish/abort KVConnector step API."
+            )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -290,6 +290,11 @@ class MetalModelRunner:
         self._model_lifecycle = ModelLifecycle(self, self._model_adapter)
         self._lora = MetalLoRARuntime()
         self._spec_decode_controller = SpeculativeDecodeController()
+        # Bridges Metal's live MLX KV cache to vLLM's generic KVConnector
+        # contract. Connector-agnostic; no-op without a kv_transfer_config.
+        from vllm_metal.v1.kv_connector import MetalKVConnectorBridge
+
+        self._kv_connector_bridge = MetalKVConnectorBridge(self)
 
         self.model: Any = None
         self.tokenizer: Any = None
@@ -597,6 +602,10 @@ class MetalModelRunner:
         This method exists to satisfy the engine's initialization protocol.
         """
         self._cache_policy.initialize_kv_cache(kv_cache_config)
+        # Present Metal's live MLX KV cache to whatever generic vLLM KV-transfer
+        # connector is configured (no-op without one). Metal-specific only in
+        # that it aliases MLX buffers as torch; connector-agnostic otherwise.
+        self._kv_connector_bridge.on_initialize_kv_cache(kv_cache_config)
 
     def reset_mm_cache(self) -> None:
         """Reset profiling-time multimodal cache state when present."""
@@ -2216,9 +2225,34 @@ class MetalModelRunner:
         For the paged attention path, the forward pass is submitted
         asynchronously — sampling and postprocessing are deferred to
         ``sample_tokens`` so the scheduler can run while the GPU computes.
+
+        Thin wrapper: if the body raises after a KV-connector step was begun,
+        abort that step (clear connector metadata exactly once so the next
+        scheduler step does not inherit stale metadata) and re-raise the
+        original exception. No-op without a connector.
         """
+        try:
+            return self._execute_model_impl(scheduler_output)
+        except BaseException:
+            self._kv_connector_bridge.abort_step()
+            raise
+
+    def _execute_model_impl(
+        self, scheduler_output: SchedulerOutput
+    ) -> ModelRunnerOutput | None:
         if self.model is None:
             raise RuntimeError("Model not loaded")
+
+        # vLLM KV-connector host contract (no-op without a kv_transfer_config).
+        # On a zero-token step, drive the connector's async load/save so
+        # requests parked in WAITING_FOR_REMOTE_KVS can complete. Otherwise
+        # begin this step's connector work (bind metadata + start loads); the
+        # loads write directly into the live MLX KV cache via the registered
+        # aliases, so there is no staging writeback.
+        if self._kv_connector_bridge.has_connector():
+            if scheduler_output.total_num_scheduled_tokens == 0:
+                return self._kv_connector_bridge.no_forward(scheduler_output)
+            self._kv_connector_bridge.begin_step(scheduler_output)
 
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
@@ -2343,7 +2377,20 @@ class MetalModelRunner:
         For the paged path, this is where the actual GPU synchronization,
         token sampling, and request state updates happen — allowing the
         scheduler to run while the GPU was computing the forward pass.
+
+        Thin wrapper: if the body raises before the KV-connector step is
+        finished, abort that step (clear metadata once) and re-raise. No-op
+        without a connector or an in-flight step.
         """
+        try:
+            return self._sample_tokens_impl(grammar_output)
+        except BaseException:
+            self._kv_connector_bridge.abort_step()
+            raise
+
+    def _sample_tokens_impl(
+        self, grammar_output: GrammarOutput | None
+    ) -> ModelRunnerOutput | None:
         # Paged path: wait for MLX forward, apply grammar bitmask, sample tokens.
         if self._execute_model_state is not None:
             # Pipeline parallelism: only the last stage holds logits and samples.
@@ -2361,7 +2408,17 @@ class MetalModelRunner:
             if runtime is not None:
                 runtime.materialize_pending_state()
             self._validate_scheduled_outputs(batch, scheduler_output)
-            return self._build_output(batch)
+            output = self._build_output(batch)
+            # vLLM KV-connector host contract: the forward is complete and the
+            # live MLX KV writes are materialized, so finish this step's
+            # connector work (wait_for_save, drain finished transfers, propagate
+            # invalid blocks) and attach the result. The connector read/wrote
+            # the live aliases directly; no staging sync is performed.
+            if self._kv_connector_bridge.has_connector():
+                kv_out = self._kv_connector_bridge.finish_step()
+                if kv_out is not None:
+                    output.kv_connector_output = kv_out
+            return output
 
         # Non-paged path: return output built by execute_model
         if self._pending_output is not None:

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -247,7 +247,40 @@ class MetalWorker(WorkerBase):
         Args:
             kv_cache_config: KV cache configuration for this worker
         """
+        # vLLM host contract: initialize the configured KV-transfer connector
+        # (if any) before the runner allocates its KV cache, so the worker-side
+        # connector agent exists when the runner registers its caches. No-op
+        # without a kv_transfer_config. Uses vLLM's public API; connector- and
+        # KV-format-agnostic.
+        from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized
+
+        ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
         self.model_runner.initialize_kv_cache(kv_cache_config)
+
+    def get_kv_connector_handshake_metadata(self):
+        """Return this worker's KV-connector handshake metadata, if any.
+
+        Generic vLLM host-contract method: the engine core collects handshake
+        metadata from every worker via ``collective_rpc`` (duck-typed by name)
+        after KV setup. Keyed by ``(pp_rank, tp_rank)``. Returns ``None`` when no
+        connector is configured or the connector needs no handshake. Uses only
+        vLLM's public KV-transfer API; connector-agnostic.
+        """
+        from vllm.distributed.kv_transfer import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
+        )
+        from vllm.distributed.parallel_state import get_pp_group, get_tp_group
+
+        if not has_kv_transfer_group():
+            return None
+        connector = get_kv_transfer_group()
+        metadata = connector.get_handshake_metadata()
+        if metadata is None:
+            return None
+        pp_rank = get_pp_group().rank_in_group
+        tp_rank = get_tp_group().rank_in_group
+        return {(pp_rank, tp_rank): metadata}
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         """Warm up the model for inference."""


### PR DESCRIPTION
> **Draft** — depends on the generic KVConnector step lifecycle in vllm-project/vllm#48464. Will leave draft after rebasing onto the merged vLLM API.

## Summary
Make the Metal worker/runner KV-transfer-capable by exposing Metal's native MLX paged KV cache to whatever generic vLLM `KVConnector` is configured, and driving vLLM's generic connector step lifecycle around the Metal forward.

## Architecture / ownership
- **Configuration** selects the concrete connector (e.g. an `LMCacheMPConnector`); this code never names or imports it.
- **vLLM** owns the generic registration/lifecycle contract and constructs `KVConnectorOutput`.
- **vllm-metal (this PR)** exports stable live split K/V aliases exactly once and drives the generic lifecycle.
- **The connector** validates and interprets the split/fused representation and transfers the live buffers.

## What this PR does
1. **Live split K/V, no staging.** Exposes each layer as an independent `(key_view, value_view)` pair of zero-copy torch aliases over the live MLX arrays — **not** a fused `torch.stack([k, v])`. Connector writes on RETRIEVE land directly in the live MLX cache; reads on STORE observe the live KV. No fused staging buffer, no MLX→staging store copy, no staging→MLX writeback.
2. **Register once; pointer stability is an explicit invariant.** The in-place `reshape_and_cache` kernel keeps K/V buffer addresses stable, so the bridge registers the live aliases **exactly once** and records their data pointers + shapes. Per step it only (a) `mx.eval`-materializes pending MLX writes (memory-ordering barrier) and (b) verifies the live pointers still match the registered ones. `register_kv_caches` is not a replace/update operation, so if a pointer moved the bridge **fails fast** with a clear error rather than silently re-registering or continuing with stale pointers. There is **no dynamic re-registration**.
3. **Lifecycle + abort.** `begin` in `execute_model`, `finish` in `sample_tokens`; both wrappers abort the in-flight step (clear connector metadata exactly once via vLLM's generic `abort_kv_connector_step`) and re-raise if the body fails. No broad-exception retry of `start_load_kv`.
4. **Version dependency via capability detection.** When a KV connector is configured, the bridge checks the generic mixin for the required begin/finish/abort lifecycle and raises a clear, connector-name-agnostic capability error on an incompatible vLLM. Importing vllm-metal and running normal inference **without** a `kv_transfer_config` is unaffected on older supported vLLM (proven: normal generation works with no connector configured).
5. **Strict layer-identity validation.** A mismatch between the vLLM `KVCacheConfig` layer names and the Metal cache raises `ValueError`.

## Accurate scope
- vllm-metal is **connector-name agnostic**; it exposes a generic split-KV registration. A configured connector **must** support that split registration form — this PR does **not** claim every `KVConnector` works on Metal.
- This integration **requires** the vLLM generic begin/finish/abort KVConnector step lifecycle (vllm-project/vllm#48464). It does **not** claim independence from that API.
- The Metal KV storage is registered **once** and required to remain stable; **dynamic re-registration is not supported**.
- No cache-sized staging allocation or KV copy is used.

## Tests
`tests/test_kv_connector_bridge.py` (no model/server): register-once (no second registration across steps), pointer-movement fail-fast, pointer check does not allocate, layer-count mismatch raises, capability error when the lifecycle is absent, and no-connector no-op.

## Cross-repo dependency
Depends only on vllm-project/vllm#48464 (the generic lifecycle + registration type).
