### PR TITLE
[Spec Decode] Cache draft KV so shared prefixes skip re-ingestion (#482)

### DIFF
--- a/tests/test_draft_prefix_cache.py
+++ b/tests/test_draft_prefix_cache.py
@@ -22,20 +22,20 @@ def test_hash_prefix_blocks_full_only_deterministic_and_chained():
     p = _proposer(block_size=16)
     toks = list(range(40))  # 2 full blocks (32) + 8 trailing partial
 
-    hashes = p._hash_prefix_blocks(toks)
+    hashes = p._hash_prefix_blocks("r1", toks)
     assert len(hashes) == 2  # only full blocks are hashed
-    assert p._hash_prefix_blocks(toks) == hashes  # deterministic
+    assert p._hash_prefix_blocks("r1", toks) == hashes  # cache hit, idempotent
 
     # Chaining: same first block but a different second block -> same h[0],
     # different h[1] (h[1] depends on h[0] as parent, plus its own tokens).
     toks_b = list(range(16)) + list(range(100, 124))
-    hb = p._hash_prefix_blocks(toks_b)
+    hb = p._hash_prefix_blocks("r2", toks_b)
     assert hb[0] == hashes[0]
     assert hb[1] != hashes[1]
 
     # A different first block changes every downstream hash.
     toks_c = list(range(50, 90))
-    hc = p._hash_prefix_blocks(toks_c)
+    hc = p._hash_prefix_blocks("r3", toks_c)
     assert hc[0] != hashes[0]
 
 
@@ -82,14 +82,81 @@ def test_shared_prefix_block_not_freed_while_referenced():
     reused = p2.block_ids[:2]
     p._prune_finished({"r2": object()})  # r1 finishes, r2 still live
     for blk in reused:
-        assert blk not in p._free_blocks  # shared blocks survive
+        # r1's release must only drop the refcount, not free the block: r2
+        # still holds a reference. (A block registered in the prefix cache
+        # is never appended to a raw free list regardless of refcount, so
+        # asserting free-list membership here would pass even if the
+        # refcount bookkeeping were broken -- assert on the count itself.)
+        assert p._pool.blocks[blk].ref_cnt > 0
 
 
 def test_eviction_reuses_idle_cached_block_under_pressure():
-    p = _proposer(block_size=16, num_blocks=4)  # tiny pool
+    # 5 physical blocks -> 4 usable (BlockPool reserves id 0 as a null
+    # placeholder), a tiny pool that exactly fits one requester at a time.
+    p = _proposer(block_size=16, num_blocks=5)
     _warm(p, "a", list(range(48)))  # 3 full blocks cached + 1 partial
     p._prune_finished({})  # a done; 3 idle cached blocks
-    assert len(p._cached) == 3
+    assert len(p._pool.cached_block_hash_to_block) == 3
     p2 = p._make_plan("b", _state(list(range(100, 148))), 4)  # distinct content
     assert p2 is not None  # allocation succeeded by evicting idle cached blocks
-    assert len(p._cached) < 3
+    assert len(p._pool.cached_block_hash_to_block) < 3
+
+
+# -- Adversarial cases from abcgco's PR #500 review (independently verified on
+# an M4 Pro: pass on the prefix-cache branch, fail on its pre-cache base). --
+
+
+def test_partial_prefix_match_reuses_only_leading_run():
+    """A prompt diverging mid-way must reuse exactly the matching leading
+    run of blocks and ingest everything after the divergence."""
+    p = _proposer(block_size=16, num_blocks=64)
+    _warm(p, "r1", list(range(40)))  # blocks 0,1 cached
+    p._prune_finished({})
+    tokens_b = list(range(16)) + list(range(100, 140))  # shares block 0 only
+    p2 = p._make_plan("r2", _state(tokens_b), 4)
+    assert p2 is not None
+    assert p2.draft_seq_len == 16  # block 0 reused, block 1 diverged
+    assert p2.ingest_tokens == tokens_b[16:]
+
+
+def test_multi_turn_history_reuses_generated_blocks():
+    """Turn 2 resubmits turn 1's prompt + generated tokens as its prefix.
+    Full blocks containing generated content are registered too, so the
+    whole turn-1 history is reused, not just the original prompt."""
+    p = _proposer(block_size=16, num_blocks=64)
+    history = list(range(40)) + list(range(200, 224))  # 64 = 4 full blocks
+    _warm(p, "r1", history)
+    p._prune_finished({})
+    turn2 = history + list(range(300, 310))
+    p2 = p._make_plan("r2", _state(turn2), 4)
+    assert p2 is not None
+    assert p2.draft_seq_len == 64
+    assert p2.ingest_tokens == turn2[64:]
+
+
+def test_reused_blocks_never_come_from_free_pool():
+    """A reused block must not simultaneously sit in the pool's free queue
+    (would be handed out again and overwritten under another request)."""
+    p = _proposer(block_size=16, num_blocks=64)
+    _warm(p, "r1", list(range(40)))
+    p._prune_finished({})
+    p2 = p._make_plan("r2", _state(list(range(40))), 4)
+    assert p2 is not None
+    free_ids = {b.block_id for b in p._pool.free_block_queue.get_all_free_blocks()}
+    for blk in p2.block_ids[:2]:
+        assert blk not in free_ids
+
+
+def test_same_content_different_history_not_reused():
+    """A block whose tokens reappear under a different preceding block must
+    not be reused: its KV was computed attending to a different history, and
+    the chained hash (parent-dependent) is what prevents the false hit."""
+    p = _proposer(block_size=16, num_blocks=64)
+    _warm(p, "r1", list(range(40)))  # r1 blocks: [0..16), [16..32)
+    p._prune_finished({})
+    # Same second-block tokens (16..32) behind a different first block.
+    shifted = list(range(100, 116)) + list(range(16, 32)) + list(range(200, 208))
+    p2 = p._make_plan("r2", _state(shifted), 4)
+    assert p2 is not None
+    assert p2.draft_seq_len == 0
+    assert p2.ingest_tokens == shifted

--- a/tests/test_draft_prefix_cache.py
+++ b/tests/test_draft_prefix_cache.py
@@ -1,0 +1,95 @@
+"""Tests for draft-KV prefix caching in DraftModelProposer (#482 direction 1)."""
+
+from types import SimpleNamespace
+
+from vllm_metal.v1.draft_model_proposer import DraftModelProposer
+
+
+def _proposer(block_size: int = 16, num_blocks: int = 64) -> DraftModelProposer:
+    # _make_plan / _hash_prefix_blocks / allocator logic never touch the model,
+    # controller, or extract_logits, so stubs are fine for these tests.
+    return DraftModelProposer(
+        model=None,
+        block_size=block_size,
+        num_blocks=num_blocks,
+        num_layers=1,
+        controller=None,
+        extract_logits=None,
+    )
+
+
+def test_hash_prefix_blocks_full_only_deterministic_and_chained():
+    p = _proposer(block_size=16)
+    toks = list(range(40))  # 2 full blocks (32) + 8 trailing partial
+
+    hashes = p._hash_prefix_blocks(toks)
+    assert len(hashes) == 2  # only full blocks are hashed
+    assert p._hash_prefix_blocks(toks) == hashes  # deterministic
+
+    # Chaining: same first block but a different second block -> same h[0],
+    # different h[1] (h[1] depends on h[0] as parent, plus its own tokens).
+    toks_b = list(range(16)) + list(range(100, 124))
+    hb = p._hash_prefix_blocks(toks_b)
+    assert hb[0] == hashes[0]
+    assert hb[1] != hashes[1]
+
+    # A different first block changes every downstream hash.
+    toks_c = list(range(50, 90))
+    hc = p._hash_prefix_blocks(toks_c)
+    assert hc[0] != hashes[0]
+
+
+def _state(token_ids):
+    return SimpleNamespace(token_ids=list(token_ids))
+
+
+def _warm(p, req_id, tokens, k=4):
+    plan = p._make_plan(req_id, _state(tokens), k)
+    assert plan is not None
+    p._register_prefix(plan)
+    return plan
+
+
+def test_reuses_cached_prefix_after_finish():
+    p = _proposer(block_size=16, num_blocks=64)
+    tokens = list(range(40))  # 2 full blocks + 8-token partial
+    p1 = _warm(p, "r1", tokens)
+    assert p1.draft_seq_len == 0  # cold cache: nothing to reuse
+    p._prune_finished({})  # r1 done; its 2 full blocks stay cached (idle)
+    p2 = p._make_plan("r2", _state(tokens), 4)
+    assert p2 is not None
+    assert p2.draft_seq_len == 32  # 2 full blocks reused
+    assert p2.ingest_tokens == tokens[32:40]  # only the partial suffix
+
+
+def test_reuse_leaves_drafting_position_for_exact_multiple():
+    p = _proposer(block_size=16, num_blocks=64)
+    tokens = list(range(32))  # exactly 2 full blocks, no partial
+    _warm(p, "r1", tokens)
+    p._prune_finished({})
+    p2 = p._make_plan("r2", _state(tokens), 4)
+    assert p2 is not None
+    assert p2.draft_seq_len == 16  # last block kept so a drafting row exists
+    assert p2.ingest_tokens == tokens[16:32]
+
+
+def test_shared_prefix_block_not_freed_while_referenced():
+    p = _proposer(block_size=16, num_blocks=64)
+    tokens = list(range(40))
+    _warm(p, "r1", tokens)  # r1 caches 2 blocks, still live
+    p2 = p._make_plan("r2", _state(tokens), 4)  # r2 reuses them
+    assert p2.draft_seq_len == 32
+    reused = p2.block_ids[:2]
+    p._prune_finished({"r2": object()})  # r1 finishes, r2 still live
+    for blk in reused:
+        assert blk not in p._free_blocks  # shared blocks survive
+
+
+def test_eviction_reuses_idle_cached_block_under_pressure():
+    p = _proposer(block_size=16, num_blocks=4)  # tiny pool
+    _warm(p, "a", list(range(48)))  # 3 full blocks cached + 1 partial
+    p._prune_finished({})  # a done; 3 idle cached blocks
+    assert len(p._cached) == 3
+    p2 = p._make_plan("b", _state(list(range(100, 148))), 4)  # distinct content
+    assert p2 is not None  # allocation succeeded by evicting idle cached blocks
+    assert len(p._cached) < 3

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -48,7 +48,13 @@ import mlx.core as mx
 from mlx_lm import load as mlx_lm_load
 from vllm.logger import init_logger
 from vllm.utils.hashing import sha256_cbor
-from vllm.v1.core.kv_cache_utils import hash_block_tokens, init_none_hash
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    KVCacheBlock,
+    hash_block_tokens,
+    init_none_hash,
+    make_block_hash_with_group_id,
+)
 from vllm.v1.outputs import DraftTokenIds
 
 from vllm_metal.attention.context import (
@@ -70,6 +76,10 @@ if TYPE_CHECKING:
     from vllm_metal.v1.spec_decode import SpeculativeDecodeController
 
 logger = init_logger(__name__)
+
+# The draft cache is a single, non-hybrid KV cache group (draft models here
+# are plain transformers), so every block hash uses the same group id.
+_GROUP_ID = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,16 +128,27 @@ class DraftModelProposer:
         # what the target has committed, so it cannot reuse the target's
         # block_ids (those exactly fit the committed length and run out at the
         # next block boundary). Each request draws draft blocks from this pool.
-        self._free_blocks: list[int] = list(range(num_blocks))
         self._req_blocks: dict[str, list[int]] = {}
         # Content-based prefix cache so shared/repeated draft prefixes reuse
         # draft KV blocks instead of re-prefilling the prompt (#482 direction 1).
+        # BlockPool gives us hash-keyed caching, refcounting, and an
+        # eviction-ordered free queue for free — the same machinery the
+        # target's own KV cache uses — instead of hand-rolling it.
         self._caching_hash_fn = sha256_cbor
         init_none_hash(self._caching_hash_fn)
-        self._cached: dict[Any, int] = {}
-        self._refcount: dict[int, int] = {}
-        self._block_hash: dict[int, Any] = {}
-        self._prefix_reuse_tokens = 0
+        # BlockPool reserves block id 0 as a permanent null placeholder (never
+        # issued), so usable capacity here is num_blocks - 1 -- the same
+        # convention vLLM's own target-side pool uses.
+        self._pool = BlockPool(
+            num_gpu_blocks=num_blocks, enable_caching=True, hash_block_size=block_size
+        )
+        # Per-request incremental hashing/registration progress: how many
+        # full prefix blocks have already been hashed and registered, so a
+        # step only pays for newly-completed blocks instead of rescanning
+        # from token 0 every propose() call. Committed tokens are append-only
+        # for the lifetime of a request id, so this is safe to cache.
+        self._prefix_hashes: dict[str, list[Any]] = {}
+        self._registered_upto: dict[str, int] = {}
 
     # -- construction --------------------------------------------------------
 
@@ -224,26 +245,35 @@ class DraftModelProposer:
     def _prune_finished(self, request_states: Any) -> None:
         for req_id in list(self._req_blocks.keys()):
             if req_id not in request_states:
-                for blk in self._req_blocks.pop(req_id):
-                    self._refcount[blk] -= 1
-                    if self._refcount[blk] == 0:
-                        del self._refcount[blk]
-                        if blk not in self._block_hash:
-                            self._free_blocks.append(blk)
+                blocks = self._req_blocks.pop(req_id)
+                # Free tail-first: mirrors vLLM's own free() convention
+                # (single_type_kv_cache_manager.py) so the pool's eviction
+                # queue prioritizes reclaiming a chain's tail before its
+                # root, and a still-shared root isn't left orphaned by a
+                # premature reclaim of the blocks that depend on it.
+                self._pool.free_blocks(
+                    [self._pool.blocks[blk] for blk in reversed(blocks)]
+                )
+                self._prefix_hashes.pop(req_id, None)
+                self._registered_upto.pop(req_id, None)
         for req_id in list(self._draft_seq_lens.keys()):
             if req_id not in request_states:
                 del self._draft_seq_lens[req_id]
 
     def _register_prefix(self, plan: _DraftPlan) -> None:
-        """Map each newly-filled full prompt block to its physical draft block
-        so a later request sharing that prefix can reuse the KV."""
-        for i, h in enumerate(plan.prefix_hashes):
-            if i >= len(plan.block_ids):
-                break
-            if h not in self._cached:
-                blk = plan.block_ids[i]
-                self._cached[h] = blk
-                self._block_hash[blk] = h
+        """Map each newly-filled prompt block not yet registered for this
+        request to its physical draft block, so a later request sharing this
+        prefix can reuse the KV. Only scans blocks added since the last call
+        for this request id."""
+        start = self._registered_upto.get(plan.req_id, 0)
+        end = min(len(plan.prefix_hashes), len(plan.block_ids))
+        for i in range(start, end):
+            key = make_block_hash_with_group_id(plan.prefix_hashes[i], _GROUP_ID)
+            if self._pool.cached_block_hash_to_block.get_one_block(key) is None:
+                blk = self._pool.blocks[plan.block_ids[i]]
+                blk.set_block_hash(key)
+                self._pool.cached_block_hash_to_block.insert(key, blk)
+        self._registered_upto[plan.req_id] = end
 
     def _collect_draft_plans(
         self, ctx: ProposeContext, num_speculative_tokens: int
@@ -267,15 +297,20 @@ class DraftModelProposer:
                 plans.append(plan)
         return plans
 
-    def _hash_prefix_blocks(self, token_ids: list[int]) -> list[Any]:
+    def _hash_prefix_blocks(self, req_id: str, token_ids: list[int]) -> list[Any]:
         """Chained content hashes, one per full ``_block_size`` block of
         ``token_ids`` (the trailing partial block is not hashed). Each hash
         fingerprints the whole prefix ending at its block boundary, so a hash
-        match implies identical tokens all the way back to the start."""
-        hashes: list[Any] = []
-        parent = None
+        match implies identical tokens all the way back to the start.
+
+        Extends this request's previously computed hashes rather than
+        rehashing from token 0: ``token_ids`` only ever grows for a given
+        request id (committed tokens are never rewritten), so blocks already
+        hashed can't change."""
+        hashes = self._prefix_hashes.setdefault(req_id, [])
         n_full = len(token_ids) // self._block_size
-        for i in range(n_full):
+        parent = hashes[-1] if hashes else None
+        for i in range(len(hashes), n_full):
             block = token_ids[i * self._block_size : (i + 1) * self._block_size]
             h = hash_block_tokens(self._caching_hash_fn, parent, block, None)
             hashes.append(h)
@@ -287,29 +322,31 @@ class DraftModelProposer:
     ) -> _DraftPlan | None:
         committed_len = len(state.token_ids)
         draft_seq_len = self._draft_seq_lens.get(req_id, 0)
-        prefix_hashes = self._hash_prefix_blocks(state.token_ids[:committed_len])
+        prefix_hashes = self._hash_prefix_blocks(
+            req_id, state.token_ids[:committed_len]
+        )
         # Prefix reuse: for a fresh request, reuse cached draft blocks for the
         # longest matching leading run of full prompt blocks, so only the
         # uncached suffix is ingested.
         if draft_seq_len == 0 and req_id not in self._req_blocks:
-            reused: list[int] = []
+            reused: list[KVCacheBlock] = []
             for h in prefix_hashes:
-                blk = self._cached.get(h)
+                key = make_block_hash_with_group_id(h, _GROUP_ID)
+                blk = self._pool.cached_block_hash_to_block.get_one_block(key)
                 if blk is None:
                     break
                 reused.append(blk)
-                self._refcount[blk] = self._refcount.get(blk, 0) + 1
             # A drafting position must remain: never reuse the whole committed
             # length, or there is nothing to ingest and no row to draft from.
             while reused and len(reused) * self._block_size >= committed_len:
-                blk = reused.pop()
-                self._refcount[blk] -= 1
-                if self._refcount[blk] == 0:
-                    del self._refcount[blk]
+                reused.pop()
             if reused:
-                self._req_blocks[req_id] = list(reused)
+                self._pool.touch(reused)
+                self._req_blocks[req_id] = [blk.block_id for blk in reused]
                 draft_seq_len = len(reused) * self._block_size
-                self._prefix_reuse_tokens += draft_seq_len
+                # These blocks are already registered (that's how they were
+                # found); skip re-checking them on the next _register_prefix.
+                self._registered_upto[req_id] = len(reused)
         if draft_seq_len >= committed_len:
             # No newly committed tokens to ingest (should not happen for an
             # accepted decode step or a finalized prefill); skip rather than
@@ -330,31 +367,24 @@ class DraftModelProposer:
         )
 
     def _ensure_draft_blocks(self, req_id: str, num_positions: int) -> list[int]:
-        """Grow this request's draft block table to cover ``num_positions``."""
+        """Grow this request's draft block table to cover ``num_positions``,
+        drawing new blocks from the pool (which evicts idle cached blocks
+        under pressure) if needed."""
         needed = (num_positions + self._block_size - 1) // self._block_size
         blocks = self._req_blocks.setdefault(req_id, [])
-        while len(blocks) < needed:
-            blk = self._alloc_block(req_id, needed)
-            blocks.append(blk)
-            self._refcount[blk] = self._refcount.get(blk, 0) + 1
+        n_more = needed - len(blocks)
+        if n_more > 0:
+            try:
+                new_blocks = self._pool.get_new_blocks(n_more)
+            except ValueError as e:
+                raise RuntimeError(
+                    f"Draft KV cache exhausted: request {req_id!r} needs "
+                    f"{needed} blocks but the draft pool is empty "
+                    f"({len(self._req_blocks)} active requests). "
+                    "Lower --max-num-seqs or raise VLLM_METAL_MEMORY_FRACTION."
+                ) from e
+            blocks.extend(blk.block_id for blk in new_blocks)
         return blocks
-
-    def _alloc_block(self, req_id: str, needed: int) -> int:
-        """A free physical draft block: from the pool, else by evicting an
-        idle (refcount-0) cached block, else fail loudly."""
-        if self._free_blocks:
-            return self._free_blocks.pop()
-        for h, blk in list(self._cached.items()):
-            if blk not in self._refcount:  # refcount 0 -> idle, safe to evict
-                del self._cached[h]
-                del self._block_hash[blk]
-                return blk
-        raise RuntimeError(
-            f"Draft KV cache exhausted: request {req_id!r} needs "
-            f"{needed} blocks but the draft pool is empty "
-            f"({len(self._req_blocks)} active requests). "
-            "Lower --max-num-seqs or raise VLLM_METAL_MEMORY_FRACTION."
-        )
 
     def _ingest_and_draft_first(
         self, plans: list[_DraftPlan], offset_caches: list[OffsetCache]

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -47,6 +47,8 @@ from typing import TYPE_CHECKING, Any
 import mlx.core as mx
 from mlx_lm import load as mlx_lm_load
 from vllm.logger import init_logger
+from vllm.utils.hashing import sha256_cbor
+from vllm.v1.core.kv_cache_utils import hash_block_tokens, init_none_hash
 from vllm.v1.outputs import DraftTokenIds
 
 from vllm_metal.attention.context import (
@@ -86,6 +88,7 @@ class _DraftPlan:
     committed_len: int
     draft_seq_len: int
     ingest_tokens: list[int]
+    prefix_hashes: list[Any]
 
 
 class DraftModelProposer:
@@ -117,6 +120,14 @@ class DraftModelProposer:
         # next block boundary). Each request draws draft blocks from this pool.
         self._free_blocks: list[int] = list(range(num_blocks))
         self._req_blocks: dict[str, list[int]] = {}
+        # Content-based prefix cache so shared/repeated draft prefixes reuse
+        # draft KV blocks instead of re-prefilling the prompt (#482 direction 1).
+        self._caching_hash_fn = sha256_cbor
+        init_none_hash(self._caching_hash_fn)
+        self._cached: dict[Any, int] = {}
+        self._refcount: dict[int, int] = {}
+        self._block_hash: dict[int, Any] = {}
+        self._prefix_reuse_tokens = 0
 
     # -- construction --------------------------------------------------------
 
@@ -201,6 +212,7 @@ class DraftModelProposer:
         # The draft cache now holds KV through committed_len for each request.
         for plan in plans:
             self._draft_seq_lens[plan.req_id] = plan.committed_len
+            self._register_prefix(plan)
 
         return DraftTokenIds(
             req_ids=[plan.req_id for plan in plans],
@@ -212,10 +224,26 @@ class DraftModelProposer:
     def _prune_finished(self, request_states: Any) -> None:
         for req_id in list(self._req_blocks.keys()):
             if req_id not in request_states:
-                self._free_blocks.extend(self._req_blocks.pop(req_id))
+                for blk in self._req_blocks.pop(req_id):
+                    self._refcount[blk] -= 1
+                    if self._refcount[blk] == 0:
+                        del self._refcount[blk]
+                        if blk not in self._block_hash:
+                            self._free_blocks.append(blk)
         for req_id in list(self._draft_seq_lens.keys()):
             if req_id not in request_states:
                 del self._draft_seq_lens[req_id]
+
+    def _register_prefix(self, plan: _DraftPlan) -> None:
+        """Map each newly-filled full prompt block to its physical draft block
+        so a later request sharing that prefix can reuse the KV."""
+        for i, h in enumerate(plan.prefix_hashes):
+            if i >= len(plan.block_ids):
+                break
+            if h not in self._cached:
+                blk = plan.block_ids[i]
+                self._cached[h] = blk
+                self._block_hash[blk] = h
 
     def _collect_draft_plans(
         self, ctx: ProposeContext, num_speculative_tokens: int
@@ -239,11 +267,49 @@ class DraftModelProposer:
                 plans.append(plan)
         return plans
 
+    def _hash_prefix_blocks(self, token_ids: list[int]) -> list[Any]:
+        """Chained content hashes, one per full ``_block_size`` block of
+        ``token_ids`` (the trailing partial block is not hashed). Each hash
+        fingerprints the whole prefix ending at its block boundary, so a hash
+        match implies identical tokens all the way back to the start."""
+        hashes: list[Any] = []
+        parent = None
+        n_full = len(token_ids) // self._block_size
+        for i in range(n_full):
+            block = token_ids[i * self._block_size : (i + 1) * self._block_size]
+            h = hash_block_tokens(self._caching_hash_fn, parent, block, None)
+            hashes.append(h)
+            parent = h
+        return hashes
+
     def _make_plan(
         self, req_id: str, state: RequestState, num_speculative_tokens: int
     ) -> _DraftPlan | None:
         committed_len = len(state.token_ids)
         draft_seq_len = self._draft_seq_lens.get(req_id, 0)
+        prefix_hashes = self._hash_prefix_blocks(state.token_ids[:committed_len])
+        # Prefix reuse: for a fresh request, reuse cached draft blocks for the
+        # longest matching leading run of full prompt blocks, so only the
+        # uncached suffix is ingested.
+        if draft_seq_len == 0 and req_id not in self._req_blocks:
+            reused: list[int] = []
+            for h in prefix_hashes:
+                blk = self._cached.get(h)
+                if blk is None:
+                    break
+                reused.append(blk)
+                self._refcount[blk] = self._refcount.get(blk, 0) + 1
+            # A drafting position must remain: never reuse the whole committed
+            # length, or there is nothing to ingest and no row to draft from.
+            while reused and len(reused) * self._block_size >= committed_len:
+                blk = reused.pop()
+                self._refcount[blk] -= 1
+                if self._refcount[blk] == 0:
+                    del self._refcount[blk]
+            if reused:
+                self._req_blocks[req_id] = list(reused)
+                draft_seq_len = len(reused) * self._block_size
+                self._prefix_reuse_tokens += draft_seq_len
         if draft_seq_len >= committed_len:
             # No newly committed tokens to ingest (should not happen for an
             # accepted decode step or a finalized prefill); skip rather than
@@ -260,6 +326,7 @@ class DraftModelProposer:
             committed_len=committed_len,
             draft_seq_len=draft_seq_len,
             ingest_tokens=list(state.token_ids[draft_seq_len:committed_len]),
+            prefix_hashes=prefix_hashes,
         )
 
     def _ensure_draft_blocks(self, req_id: str, num_positions: int) -> list[int]:
@@ -267,15 +334,27 @@ class DraftModelProposer:
         needed = (num_positions + self._block_size - 1) // self._block_size
         blocks = self._req_blocks.setdefault(req_id, [])
         while len(blocks) < needed:
-            if not self._free_blocks:
-                raise RuntimeError(
-                    f"Draft KV cache exhausted: request {req_id!r} needs "
-                    f"{needed} blocks but the draft pool is empty "
-                    f"({len(self._req_blocks)} active requests). "
-                    "Lower --max-num-seqs or raise VLLM_METAL_MEMORY_FRACTION."
-                )
-            blocks.append(self._free_blocks.pop())
+            blk = self._alloc_block(req_id, needed)
+            blocks.append(blk)
+            self._refcount[blk] = self._refcount.get(blk, 0) + 1
         return blocks
+
+    def _alloc_block(self, req_id: str, needed: int) -> int:
+        """A free physical draft block: from the pool, else by evicting an
+        idle (refcount-0) cached block, else fail loudly."""
+        if self._free_blocks:
+            return self._free_blocks.pop()
+        for h, blk in list(self._cached.items()):
+            if blk not in self._refcount:  # refcount 0 -> idle, safe to evict
+                del self._cached[h]
+                del self._block_hash[blk]
+                return blk
+        raise RuntimeError(
+            f"Draft KV cache exhausted: request {req_id!r} needs "
+            f"{needed} blocks but the draft pool is empty "
+            f"({len(self._req_blocks)} active requests). "
+            "Lower --max-num-seqs or raise VLLM_METAL_MEMORY_FRACTION."
+        )
 
     def _ingest_and_draft_first(
         self, plans: list[_DraftPlan], offset_caches: list[OffsetCache]


### PR DESCRIPTION
The draft model re-prefills the entire prompt into its KV on every new request. The allocator keys everything by request id and prunes on finish, so nothing carries over, not even an identical resubmitted prompt. On an 8k prefix that first propose is ~4.59s versus ~95ms once warm (#482).

This gives the draft allocator the same prefix caching the target already has. Full prompt blocks are hashed (chained, so a match means the whole prefix matches), cached by content to a physical draft block, and refcounted so shared blocks survive while any request holds them and idle ones are evicted under pressure. A new request reuses the longest matching leading run and only ingests the uncached suffix.

Output is byte-identical, since a hash match means identical tokens and therefore identical KV. Checked on M3 Ultra with an 8B target and 0.6B draft: a repeated 4k prefix reuses 3200 tokens of draft KV and produces the exact same output, and the saving grows with prefix length.

Scope is direction 1 only. Fresh-prompt latency (direction 3) and the steady-state proposer overhead (Problem 2) are separate follow-ons. Tests cover reuse, the exact-block-multiple edge case, refcount sharing, and eviction.