### PR TITLE
Bump MLX to 0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # libmlx.dylib carries no SONAME version (compatibility version 0.0.0), so
     # a wheel built against one MLX is only ABI-safe against that exact MLX.
     # Rebuild and re-release the wheel on every MLX bump.
-    "mlx==0.31.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx==0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.

--- a/tests/test_paged_attention.py
+++ b/tests/test_paged_attention.py
@@ -281,53 +281,6 @@ class TestPackedRoPE:
         assert mx.allclose(q_out, expected_q, rtol=1e-5, atol=1e-5).item()
         assert mx.allclose(k_out, expected_k, rtol=1e-5, atol=1e-5).item()
 
-    def test_native_rope_matches_segment_reference_for_float16_rows(self):
-        from vllm_metal.attention.impls.varlen_rope_compat import (
-            apply_packed_rope,
-        )
-
-        dims = 128
-        segment_count = 4
-        offsets = [5, 5, 5, 5]
-        cu_seqlens = [0, 1, 2, 3, 4]
-        rope = nn.RoPE(dims=dims, traditional=False, base=10_000.0)
-        reference_rope = nn.RoPE(dims=dims, traditional=False, base=10_000.0)
-        module = SimpleNamespace(rope=rope)
-        q_rows = [
-            (mx.arange(3 * dims, dtype=mx.float32).reshape(3, 1, dims) / 100 + row)
-            .astype(mx.float16)
-            .tolist()
-            for row in range(segment_count)
-        ]
-        k_rows = [
-            (mx.arange(2 * dims, dtype=mx.float32).reshape(2, 1, dims) / 100 + row)
-            .astype(mx.float16)
-            .tolist()
-            for row in range(segment_count)
-        ]
-        q = mx.transpose(mx.array(q_rows, dtype=mx.float16), (2, 1, 0, 3))
-        k = mx.transpose(mx.array(k_rows, dtype=mx.float16), (2, 1, 0, 3))
-
-        expected_q = mx.concatenate(
-            [
-                reference_rope(q[:, :, i : i + 1, :], offset=offsets[i])
-                for i in range(segment_count)
-            ],
-            axis=2,
-        )
-        expected_k = mx.concatenate(
-            [
-                reference_rope(k[:, :, i : i + 1, :], offset=offsets[i])
-                for i in range(segment_count)
-            ],
-            axis=2,
-        )
-        q_out, k_out = apply_packed_rope(module, q, k, cu_seqlens, offsets=offsets)
-        mx.eval(expected_q, expected_k, q_out, k_out)
-
-        assert mx.allclose(q_out, expected_q, rtol=1e-3, atol=1e-3).item()
-        assert mx.allclose(k_out, expected_k, rtol=1e-3, atol=1e-3).item()
-
     @pytest.mark.parametrize(
         "rope",
         [

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -211,10 +211,7 @@ def apply_packed_rope(
         and all(cu_seqlens[i] == i for i in range(segment_count + 1))
         and isinstance(rope_fn, _VECTOR_OFFSET_ROPE_TYPES)
     ):
-        # MLX 0.31.2 corrupts rows after the first for [B, H, 1, D] RoPE
-        # with a scalar offset (MLX #3494). Vector offsets select the correct
-        # kernel, including when every request has the same offset.
-        # Remove this workaround after an MLX bump that fixes the pinned wheel.
+        # Batch packed decode rows while preserving each row's absolute offset.
         batch_offsets = (
             mx.zeros((segment_count,), dtype=mx.int32)
             if offsets is None

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -94,44 +94,6 @@ static int min_decode_grid() {
   return v;
 }
 
-// MLX 0.31.2 moved stream-scoped encoder/temporary management from
-// ``metal::Device`` onto ``metal::CommandEncoder`` plus a free
-// ``metal::get_command_encoder(Stream)`` helper.  Keep a tiny shim here so the
-// paged-kernel bridge compiles against both 0.31.1 and 0.31.2.
-#if MLX_VERSION_NUMERIC >= 31002
-static metal::CommandEncoder& get_command_encoder_compat(
-    metal::Device& d,
-    Stream s) {
-  (void)d;
-  return metal::get_command_encoder(s);
-}
-
-static void add_temporary_compat(
-    metal::CommandEncoder& enc,
-    const array& arr,
-    metal::Device& d,
-    Stream s) {
-  (void)d;
-  (void)s;
-  enc.add_temporary(arr);
-}
-#else
-static metal::CommandEncoder& get_command_encoder_compat(
-    metal::Device& d,
-    Stream s) {
-  return d.get_command_encoder(s.index);
-}
-
-static void add_temporary_compat(
-    metal::CommandEncoder& enc,
-    const array& arr,
-    metal::Device& d,
-    Stream s) {
-  (void)enc;
-  d.add_temporary(arr, s.index);
-}
-#endif
-
 void init_v2_library(const std::string& v2_src) {
   v2_paged_attention_source_ = v2_src;
   auto& d = metal::device(Device::gpu);
@@ -336,7 +298,7 @@ static void dispatch_paged_attention_tiled(
       (cfg.BQ + 2 * cfg.TILE_KV) * ld * t_size);  // Q + K + V, padded
 
   int num_heads = static_cast<int>(query.shape(1));
-  auto& enc = get_command_encoder_compat(d, s);
+  auto& enc = metal::get_command_encoder(s);
   enc.set_compute_pipeline_state(kernel);
   enc.set_threadgroup_memory_length(shmem, 0);
 
@@ -449,7 +411,7 @@ static void dispatch_paged_attention_v2_online(
                     * static_cast<int>(sizeof(float));
   size_t shmem = static_cast<size_t>(std::max(warp_scores_bytes, merge_bytes));
 
-  auto& enc = get_command_encoder_compat(d, s);
+  auto& enc = metal::get_command_encoder(s);
 
   // TurboQuant scale/zero/centroid buffers (slots 22-27); shared by both paths.
   auto bind_turboquant = [&]() {
@@ -488,7 +450,7 @@ static void dispatch_paged_attention_v2_online(
   auto make_temp = [&](Shape shape, Dtype dtype) {
     array a(std::move(shape), dtype, nullptr, {});
     a.set_data(allocator::malloc(a.nbytes()));
-    add_temporary_compat(enc, a, d, s);
+    enc.add_temporary(a);
     return a;
   };
   array tmp_out = make_temp(
@@ -755,7 +717,7 @@ class TQEncodePrimitive : public Primitive {
     int32_t num_kv_heads_i = static_cast<int32_t>(num_kv_heads);
     int32_t block_size_i   = static_cast<int32_t>(block_size);
 
-    auto& enc = get_command_encoder_compat(d, s);
+    auto& enc = metal::get_command_encoder(s);
     enc.set_compute_pipeline_state(kernel);
     enc.set_input_array(key,                0);
     enc.set_input_array(value,              1);
@@ -899,7 +861,7 @@ class ReshapeAndCachePrimitive : public Primitive {
     int32_t head_size_i    = static_cast<int32_t>(head_size);
     int32_t block_size_i   = static_cast<int32_t>(block_size);
 
-    auto& enc = get_command_encoder_compat(d, s);
+    auto& enc = metal::get_command_encoder(s);
     enc.set_compute_pipeline_state(kernel);
     enc.set_input_array(key,          0);
     enc.set_input_array(value,        1);
@@ -1072,7 +1034,7 @@ static void dispatch_mla_paged_attention(
   size_t shmem =
       static_cast<size_t>((2 * heads_per_tg * BN + BD * BD) * sizeof(float));
 
-  auto& enc = get_command_encoder_compat(d, s);
+  auto& enc = metal::get_command_encoder(s);
   enc.set_compute_pipeline_state(kernel);
   enc.set_threadgroup_memory_length(shmem, 0);
 
@@ -1196,7 +1158,7 @@ void gdn_linear_attention_impl(
   auto* lib = d.get_library("gdn_kern");
   auto* kernel = d.get_kernel(kname, lib, kname, {});
 
-  auto& enc = get_command_encoder_compat(d, s);
+  auto& enc = metal::get_command_encoder(s);
   enc.set_compute_pipeline_state(kernel);
 
   enc.set_input_array(q, 0);
@@ -1220,15 +1182,15 @@ void gdn_linear_attention_impl(
       MTL::Size::Make(Dv, 1, num_requests * Hv),
       MTL::Size::Make(32, 1, 1));
 
-  add_temporary_compat(enc, q, d, s);
-  add_temporary_compat(enc, k, d, s);
-  add_temporary_compat(enc, v, d, s);
-  add_temporary_compat(enc, g, d, s);
-  add_temporary_compat(enc, beta, d, s);
-  add_temporary_compat(enc, state_pool, d, s);
-  add_temporary_compat(enc, cu_seqlens, d, s);
-  add_temporary_compat(enc, slot_mapping, d, s);
-  add_temporary_compat(enc, y, d, s);
+  enc.add_temporary(q);
+  enc.add_temporary(k);
+  enc.add_temporary(v);
+  enc.add_temporary(g);
+  enc.add_temporary(beta);
+  enc.add_temporary(state_pool);
+  enc.add_temporary(cu_seqlens);
+  enc.add_temporary(slot_mapping);
+  enc.add_temporary(y);
 }
 // ---------------------------------------------------------------------------
 // nanobind module


### PR DESCRIPTION
This PR is:
- To bump the exact MLX runtime pin from `0.31.2` to `0.32.0`.
- To compile the native Metal bridge against the current MLX command-encoder API instead of keeping old compatibility shims
- To trim stale RoPE workaround comments/tests now that the MLX scalar-offset fix used by #496 is in the pinned wheel

note:

PR #496 added the packed decode RoPE batching path and used vector offsets to avoid the MLX 0.31.2 scalar-offset corruption. MLX 0.32.0 includes the upstream fix for that bug, so this branch moves the exact pin forward and removes the local code that only existed to support the old pinned wheel.
