### PR TITLE
[Spec Decode] Route small draft ingests down the decode path

### DIFF
--- a/tests/test_draft_ingest_routing.py
+++ b/tests/test_draft_ingest_routing.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Small draft ingests must ride the decode path, not the tiled prefill.
+
+Regression tests for #482 Problem 2: the proposer's steady-state ingest
+(K+1 committed tokens per accepted round) was submitted as a prefill
+segment, routing the forward to the tiled prefill kernel, which reads the
+whole context regardless of query size (~70 ms vs ~11 ms per pass at 8k).
+"""
+
+import mlx.core as mx
+
+from vllm_metal.attention.context import get_context
+from vllm_metal.v1.draft_model_proposer import (
+    _DECODE_INGEST_MAX_TOKENS,
+    DraftModelProposer,
+    _DraftPlan,
+)
+
+BLOCK_SIZE = 16
+VOCAB = 32
+
+
+class _ContextCapture:
+    """Stub draft model that records the paged-attention context it saw."""
+
+    def __init__(self) -> None:
+        self.ctx = None
+
+    def __call__(self, input_ids: mx.array, cache=None) -> mx.array:
+        self.ctx = get_context()
+        return mx.zeros((1, input_ids.shape[1], VOCAB), dtype=mx.float32)
+
+
+def _proposer(model) -> DraftModelProposer:
+    return DraftModelProposer(
+        model=model,
+        block_size=BLOCK_SIZE,
+        num_blocks=64,
+        num_layers=1,
+        controller=None,
+        extract_logits=lambda logits: logits,
+    )
+
+
+def _plan(n_ingest: int, draft_seq_len: int) -> _DraftPlan:
+    committed = draft_seq_len + n_ingest
+    n_blocks = (committed + BLOCK_SIZE - 1) // BLOCK_SIZE + 1
+    return _DraftPlan(
+        req_id="r1",
+        block_ids=list(range(n_blocks)),
+        committed_len=committed,
+        draft_seq_len=draft_seq_len,
+        ingest_tokens=list(range(100, 100 + n_ingest)),
+    )
+
+
+def test_steady_ingest_prepares_decode_rows() -> None:
+    model = _ContextCapture()
+    plan = _plan(n_ingest=4, draft_seq_len=8192)
+
+    _proposer(model)._ingest_and_draft_first([plan], [])
+
+    ctx = model.ctx
+    assert ctx.num_decode_requests == 1
+    # One single-query segment per ingested token, like verify rows.
+    assert ctx.cu_seqlens == [0, 1, 2, 3, 4]
+    # Rows sit at the committed suffix positions with full-context lens.
+    assert ctx.offsets == [8192, 8193, 8194, 8195]
+    assert ctx.context_lens == [8193, 8194, 8195, 8196]
+
+
+def test_large_ingest_keeps_prefill_path() -> None:
+    model = _ContextCapture()
+    n = _DECODE_INGEST_MAX_TOKENS + 1
+    plan = _plan(n_ingest=n, draft_seq_len=0)
+
+    _proposer(model)._ingest_and_draft_first([plan], [])
+
+    ctx = model.ctx
+    assert ctx.num_decode_requests == 0
+    # A single prefill segment covering all tokens.
+    assert ctx.cu_seqlens == [0, n]
+    assert ctx.offsets == [0]
+
+
+def test_threshold_boundary_takes_decode_path() -> None:
+    model = _ContextCapture()
+    plan = _plan(n_ingest=_DECODE_INGEST_MAX_TOKENS, draft_seq_len=64)
+
+    _proposer(model)._ingest_and_draft_first([plan], [])
+
+    assert model.ctx.num_decode_requests == 1
+    assert len(model.ctx.cu_seqlens) == _DECODE_INGEST_MAX_TOKENS + 1
+
+
+def test_mixed_plans_route_by_largest_ingest() -> None:
+    """One oversized plan sends the whole batch down the prefill path —
+    per-forward routing must stay uniform because the context is global."""
+    model = _ContextCapture()
+    small = _plan(n_ingest=2, draft_seq_len=32)
+    big = _plan(n_ingest=_DECODE_INGEST_MAX_TOKENS + 8, draft_seq_len=0)
+
+    _proposer(model)._ingest_and_draft_first([small, big], [])
+
+    ctx = model.ctx
+    assert ctx.num_decode_requests == 0
+    assert len(ctx.cu_seqlens) == 3  # two prefill segments

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -88,6 +88,13 @@ class _DraftPlan:
     ingest_tokens: list[int]
 
 
+# Ingests at or below this size are submitted as expanded decode rows instead
+# of a prefill segment (see _ingest_and_draft_first). Covers the steady-state
+# K+1-token ingest for any practical num_speculative_tokens while keeping
+# full-prompt catch-up ingests on the tiled prefill kernel.
+_DECODE_INGEST_MAX_TOKENS = 16
+
+
 class DraftModelProposer:
     """:class:`vllm_metal.v1.proposer.MetalProposer` backed by a separate model."""
 
@@ -280,10 +287,6 @@ class DraftModelProposer:
     def _ingest_and_draft_first(
         self, plans: list[_DraftPlan], offset_caches: list[OffsetCache]
     ) -> mx.array:
-        prefill_specs = [
-            (plan.block_ids, len(plan.ingest_tokens), plan.draft_seq_len)
-            for plan in plans
-        ]
         packed: list[int] = []
         last_rows: list[int] = []
         for plan in plans:
@@ -291,7 +294,25 @@ class DraftModelProposer:
             last_rows.append(len(packed) - 1)
         input_ids = mx.array([packed], dtype=mx.int32)
 
-        prepare_unified([], prefill_specs, self._block_size)
+        # The steady-state ingest (K+1 committed tokens per accepted round)
+        # rides the decode path as one single-query segment per token — the
+        # same shape the target's verify rows use. Submitting it as a prefill
+        # segment routes the whole forward to the tiled prefill kernel, which
+        # reads the entire context regardless of query size: ~70 ms vs ~11 ms
+        # per pass at an 8k prefix (#482, Problem 2). Large ingests (the
+        # first-propose catch-up) stay on the tiled path, where it wins.
+        if max(len(plan.ingest_tokens) for plan in plans) <= _DECODE_INGEST_MAX_TOKENS:
+            decode_specs = [
+                (plan.block_ids, plan.draft_seq_len, len(plan.ingest_tokens))
+                for plan in plans
+            ]
+            prepare_unified(decode_specs, [], self._block_size)
+        else:
+            prefill_specs = [
+                (plan.block_ids, len(plan.ingest_tokens), plan.draft_seq_len)
+                for plan in plans
+            ]
+            prepare_unified([], prefill_specs, self._block_size)
         try:
             logits = self._extract_logits(self._model(input_ids, cache=offset_caches))
         finally:


### PR DESCRIPTION
Problem 2 in #482: steady-state propose costs ~95 ms/step at an 8k prefix while a complete nospec engine step of the same model is ~14 ms. Decomposing the propose graph (CPU fences around its single `mx.eval`, then sweeps over K and context) puts ~70 ms of that in the ingest forward alone: ~24 ms context-independent plus ~5.6 µs per context token (35.6 ms at 2k → 69.8 ms at 8k), while each single-token draft step costs ~10.7 ms at 8k on the split-KV path.

The cause is routing, not volume: the proposer submits its steady K+1-token ingest as a prefill segment, so the forward lands on the tiled prefill kernel, which reads the entire context regardless of query size. The target's verify rows have the same shape (a few fresh tokens over a long cache) and ride the decode path as expanded single-query segments. A dispatch probe confirms both sides: on main, steady ingests print the tiled-prefill dispatch; with this change they dispatch as N single-query decode segments — identical to verify rows — and no small ingest hits the tiled path.

The change: ingests of ≤ 16 tokens are submitted as decode specs, one row per token; larger ingests (the first-propose catch-up, where the tiled kernel is the right choice) keep the prefill path.

Measured on an M4 Pro 24 GB (greedy, K=3, prefix caching on, medians over in-run steady proposes):

| setup | propose/step before | after |
|---|---|---|
| draft==target==Qwen3-0.6B, 8k | 94–95 ms (3 boots) | **53.2 / 53.9 ms** (2 boots) |
| draft==target==Qwen3-0.6B, 2k | 48.6 ms | **38.7 ms** |
| Qwen3-0.6B draft + Qwen3-8B-4bit target, 8k prose | 93.7 ms | **49.3 ms** |

Output token ids are unchanged in every configuration (sha-256 over the full greedy id sequence matches the pre-change runs: both prefixes on the 0.6B setup, and the spec-path output on the 8B pair).

Also prototyped direction 2 from the issue (skip re-ingesting accepted tokens whose KV the draft steps already wrote): on top of this change it saves only ~3 ms — rows inside one decode dispatch largely amortize — so it is deliberately left out of scope.

Tests cover the routing decision and the prepared-context shape on both sides of the threshold, plus the mixed-batch case (one oversized plan keeps the whole forward on the prefill path, since the prepared context is global per forward).
