### PR TITLE
Bump mlx pin to 0.32.0 — faster and token-exact speculative verify

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # libmlx.dylib carries no SONAME version (compatibility version 0.0.0), so
     # a wheel built against one MLX is only ABI-safe against that exact MLX.
     # Rebuild and re-release the wheel on every MLX bump.
-    "mlx==0.31.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx==0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.


### PR DESCRIPTION
mlx 0.32.0 ships **qmv_wide** (ml-explore/mlx#3764): small-batch quantized matmul that dequantizes each weight group once and amortizes it across the batch, instead of re-streaming the full weight matrix per row. Speculative-decode verification runs the target at m=K+1 rows through every quantized linear, so this lands directly on the verify step.

**Measured** (Qwen3-0.6B draft + Qwen3-8B-4bit target, 8k prose prefix, K=3, greedy, M4 Pro 24 GB; per-step medians of the verify-side phases, adjacent boots at matched thermal state):

| boots | mlx 0.31.2 | mlx 0.32.0 | delta |
|---|---|---|---|
| warm | 87.1 ms/step | 73.0 / 72.1 | **−14 ms** |
| hot | 115.8 | 97.7 | **−18 ms** |

nospec decode is unchanged (34.16 vs 34.12 ms/tok — the m=1 path doesn't use qmv_wide), and affine qmv_wide is gated to gen-15+ GPUs upstream, so older chips simply stay on the current path.

**It's also an accuracy fix for spec decode on quantized targets**: against an fp32 ground truth (explicit `mx.dequantize` + matmul), qmv_wide's error is ~3x smaller than the per-row qmv path's. Practical consequence we hit while benchmarking: on 0.31.2 greedy spec output diverged from nospec on this 4-bit target (batch-shape logit ties — the same class samithaj documented in #482); on 0.32.0 **spec output matches nospec byte-for-byte** (3 boots each, stable shas). Note the flip side: token trajectories on quantized models shift vs 0.31.2 (the new kernel is *more* accurate), so anything pinned to 0.31.2 golden outputs needs a refresh.

Shape-level view (microbench, 4-bit g64, 8B-shaped linears, cost vs m=1): m=4 on the MLP matmul goes 1.89x → 1.47x, m=8: 3.44x → 2.69x. A residual small-m gap remains upstream; filing that separately with ml-explore.

Local validation: `_paged_ops` and the Metal kernels rebuild cleanly against 0.32.0 with no source changes; quick suite passes (1222 passed; multimodal excluded in my env due to an unrelated local mlx-vlm version drift). The prebuilt-wheel re-release this pin requires is noted per the comment in pyproject.
