### PR TITLE
[Distributed] Route PP dummy forwards through the stage shape

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -47,6 +47,7 @@ def make_stub_runner(
         "_draft_token_ids": None,
         "_execute_model_state": None,
         "pp": None,
+        "_pp_model": None,
         "_model_adapter": DefaultModelAdapter(),
         "_spec_decode_controller": SpeculativeDecodeController(),
         "kv_heads_per_layer": None,

--- a/tests/test_pp_pipeline.py
+++ b/tests/test_pp_pipeline.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the pipeline-parallel primitives.
 
-Pure-Python: no model load, no GPU, no MLX distributed launcher. We drive
-``PipelineGroup`` with a fake group object and ``apply_pipeline_split`` with a
-tiny stub backbone whose ``.layers`` is a list of sentinels.
+Pure-Python: no checkpoint download, no GPU, no MLX distributed launcher. We
+drive ``PipelineGroup`` with a fake group object and ``apply_pipeline_split``
+with a tiny stub backbone whose ``.layers`` is a list of sentinels; the
+mlx_lm contract tests build a micro ``qwen3.Model`` from args in-process.
 """
 
 from types import SimpleNamespace
@@ -11,6 +12,7 @@ from types import SimpleNamespace
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
+from mlx_lm.models import qwen3
 
 from vllm_metal.distributed.pipeline import (
     PipelinedModel,
@@ -232,3 +234,176 @@ class TestPipelinedModel:
         assert wrapper._wire_hidden == 32
         assert wrapper._wire_dtype == layer.q_proj.scales.dtype
         assert wrapper._wire_dtype != layer.input_layernorm.weight.dtype
+
+
+class _StageStubModel:
+    """Records which forward the wrapper takes: the top-level (head) call vs the
+    backbone-only call. ``embed_tokens`` raises, pinning that a dummy forward on
+    a non-first stage never touches the embedding."""
+
+    _HIDDEN = 32
+
+    def __init__(self) -> None:
+        layer = _StubLayer(self._HIDDEN)
+        self.args = SimpleNamespace(hidden_size=self._HIDDEN)
+        self.calls: dict[str, object] = {}
+        self.model = self._backbone(layer)
+
+    def _backbone(self, layer: _StubLayer) -> object:
+        calls = self.calls
+        hidden = self._HIDDEN
+        wire_dtype = layer.q_proj.scales.dtype
+
+        class _Backbone:
+            def __init__(self) -> None:
+                self.layers = [layer]
+                self.embed_tokens = _RaisingEmbed()
+
+            def __call__(self, input_ids, *, cache=None, input_embeddings=None):
+                calls["backbone"] = input_embeddings
+                if input_embeddings is None:
+                    # mirror mlx_lm: the backbone embeds ONLY when no hidden is
+                    # provided — this makes the raising embed a LIVE pin.
+                    self.embed_tokens(input_ids)
+                return mx.zeros((1, input_ids.shape[1], hidden), dtype=wire_dtype)
+
+        return _Backbone()
+
+    def __call__(self, input_ids, *, cache=None, input_embeddings=None):
+        self.calls["full"] = input_embeddings
+        return "model-output"
+
+
+class _RaisingEmbed:
+    def __call__(self, input_ids: object) -> mx.array:
+        raise AssertionError("embed_tokens must not be called on this stage")
+
+
+class TestPipelinedModelDummyForward:
+    def test_non_first_stage_feeds_zeros_at_wire_descriptor(self) -> None:
+        # A middle stage profiles from a locally built zeros hidden (no ring
+        # recv, no embedding) shaped by the wire descriptor.
+        stub = _StageStubModel()
+        wrapper = PipelinedModel(stub, _pp(1, 3))
+
+        out = wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+
+        h_in = stub.calls["backbone"]
+        assert isinstance(h_in, mx.array)
+        assert h_in.shape == (1, 4, 32)
+        assert h_in.dtype == wrapper._wire_dtype
+        assert mx.all(h_in == 0)  # zeros, per upstream's empty intermediates
+        assert "full" not in stub.calls  # head path never taken
+        assert out.dtype == wrapper._wire_dtype
+
+    def test_first_stage_embeds_internally(self) -> None:
+        # The first stage owns the embedding: the backbone is called with
+        # input_embeddings=None and embeds the token ids itself.
+        stub = _StageStubModel()
+        stub.model.embed_tokens = nn.Embedding(4, 32)  # first stage owns it
+        wrapper = PipelinedModel(stub, _pp(0, 2))
+
+        wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+
+        assert stub.calls["backbone"] is None
+        assert "full" not in stub.calls
+
+    def test_last_stage_runs_owned_head(self) -> None:
+        # The last stage owns norm + head: the dummy takes the same top-level
+        # call as serving and returns the model output for logits extraction.
+        stub = _StageStubModel()
+        wrapper = PipelinedModel(stub, _pp(1, 2))
+
+        out = wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+
+        assert out == "model-output"
+        h_in = stub.calls["full"]
+        assert isinstance(h_in, mx.array)
+        assert h_in.shape == (1, 4, 32)
+        assert h_in.dtype == wrapper._wire_dtype
+        assert "backbone" not in stub.calls
+
+    def test_inherits_wire_dtype_fail_fast(self) -> None:
+        # The dummy shares the stage body with __call__, so a wire-dtype
+        # mismatch fails at profiling/startup instead of on the first request.
+        stub = _StageStubModel()
+        backbone = stub.model
+
+        class _WrongDtypeBackbone:
+            layers = backbone.layers
+            embed_tokens = backbone.embed_tokens
+
+            def __call__(self, input_ids, *, cache=None, input_embeddings=None):
+                return mx.zeros((1, input_ids.shape[1], 32), dtype=mx.bfloat16)
+
+        wrapper = PipelinedModel(stub, _pp(1, 3))
+        stub.model = _WrongDtypeBackbone()
+
+        with pytest.raises(TypeError) as excinfo:
+            wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+        assert str(excinfo.value) == (
+            "PP stage produced hidden mlx.core.bfloat16, but the wire dtype "
+            "(stage compute dtype) is mlx.core.float32; mismatch deadlocks "
+            "the ring."
+        )
+
+
+def _micro_qwen3(tie_word_embeddings: bool, n_layers: int = 2) -> qwen3.Model:
+    args = qwen3.ModelArgs(
+        model_type="qwen3",
+        hidden_size=32,
+        num_hidden_layers=n_layers,
+        intermediate_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        rms_norm_eps=1e-5,
+        vocab_size=64,
+        max_position_embeddings=128,
+        rope_theta=1000.0,
+        head_dim=8,
+        tie_word_embeddings=tie_word_embeddings,
+    )
+    return qwen3.Model(args)
+
+
+class TestDummyForwardMlxLmContract:
+    """Pin the upstream keyword contract the dummy relies on — a real (micro)
+    mlx_lm model built from args, both tie states, no checkpoint download."""
+
+    @pytest.mark.parametrize("tied", [True, False])
+    def test_first_stage_outputs_hidden_at_wire_dtype(self, tied: bool) -> None:
+        model = _micro_qwen3(tied)
+        pp = _pp(0, 2)
+        apply_pipeline_split(model, pp)
+        wrapper = PipelinedModel(model, pp)
+
+        out = wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+
+        assert out.shape == (1, 4, 32)
+        assert out.dtype == wrapper._wire_dtype
+
+    @pytest.mark.parametrize("tied", [True, False])
+    def test_last_stage_outputs_vocab_logits(self, tied: bool) -> None:
+        model = _micro_qwen3(tied)
+        pp = _pp(1, 2)
+        apply_pipeline_split(model, pp)
+        wrapper = PipelinedModel(model, pp)
+
+        out = wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+
+        assert out.shape == (1, 4, 64)
+
+    def test_middle_stage_never_touches_the_embedding(self) -> None:
+        # The memory win rests on the upstream keyword contract: a backbone
+        # given input_embeddings never calls embed_tokens. Pin it on a real
+        # (micro) qwen3 middle stage by swapping the embedding for a raiser.
+        model = _micro_qwen3(tie_word_embeddings=False, n_layers=3)
+        pp = _pp(1, 3)  # middle: owns neither the embedding nor the head
+        apply_pipeline_split(model, pp)
+        model.model.embed_tokens = _RaisingEmbed()
+        wrapper = PipelinedModel(model, pp)
+
+        out = wrapper.dummy_forward(mx.zeros((1, 4), dtype=mx.int32))
+
+        assert out.shape == (1, 4, 32)
+        assert out.dtype == wrapper._wire_dtype

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1765,3 +1765,112 @@ class TestLoadModelPipelineSplitOrdering:
         runner.load_model()
 
         assert events == ["load", "split", "lora"]
+
+
+class _StageDummyRecorder:
+    """Stands in for PipelinedModel: records the ids the dummy forward gets."""
+
+    def __init__(self, output: object) -> None:
+        self.output = output
+        self.seen: object = None
+
+    def dummy_forward(self, input_ids: object) -> object:
+        self.seen = input_ids
+        return self.output
+
+
+class _FullPathMustNotRun:
+    def __call__(self, input_ids: object) -> object:
+        raise AssertionError("full-model dummy path must not run on a PP stage")
+
+
+class TestDummyForwardOutputsPPRouting:
+    class _Group:
+        def __init__(self, rank: int, size: int) -> None:
+            self._rank, self._size = rank, size
+
+        def rank(self) -> int:
+            return self._rank
+
+        def size(self) -> int:
+            return self._size
+
+    def _pp_runner(self, rank: int, stage: _StageDummyRecorder) -> mr.MetalModelRunner:
+        return make_stub_runner(
+            pp=PipelineGroup(self._Group(rank, 2)),
+            _pp_model=stage,
+            model=_FullPathMustNotRun(),
+        )
+
+    def test_non_last_stage_returns_hidden_unextracted(self) -> None:
+        # A non-last stage's dummy output is the raw hidden state — exactly what
+        # serving evals — so no logits extraction may touch it.
+        sentinel = SimpleNamespace(logits="would-be-extracted")
+        stage = _StageDummyRecorder(sentinel)
+        runner = self._pp_runner(0, stage)
+        ids = mx.zeros((1, 3), dtype=mx.int32)
+
+        outs = runner._dummy_forward_outputs(ids)
+
+        assert outs == [sentinel]  # passthrough: extraction did NOT run
+        assert stage.seen is ids
+
+    def test_last_stage_extracts_logits(self) -> None:
+        stage = _StageDummyRecorder(SimpleNamespace(logits="stage-logits"))
+        runner = self._pp_runner(1, stage)
+
+        outs = runner._dummy_forward_outputs(mx.zeros((1, 3), dtype=mx.int32))
+
+        assert outs == ["stage-logits"]  # extraction ran on the last stage
+
+    def test_single_stage_keeps_full_model_path(self) -> None:
+        class _RecordingModel:
+            seen: object = None
+
+            def __call__(self, input_ids: object) -> object:
+                self.seen = input_ids
+                return SimpleNamespace(logits="full-logits")
+
+        model = _RecordingModel()
+        runner = make_stub_runner(model=model)  # pp/_pp_model default to None
+        ids = mx.zeros((1, 3), dtype=mx.int32)
+
+        outs = runner._dummy_forward_outputs(ids)
+
+        assert outs == ["full-logits"]
+        assert model.seen is ids
+
+    def test_profile_run_profiles_the_stage_shape(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Caller-level, mirroring TestMetalPoolingProfileWarmup: the mx cache
+        # functions are patched so the test cannot clamp the process-wide
+        # allocator, and what profile_run evals must be exactly the stage's
+        # own hidden output — that is what makes the measured peak stage-shaped.
+        hidden = mx.zeros((1, 4, 8), dtype=mx.float16)
+        stage = _StageDummyRecorder(hidden)
+        runner = make_stub_runner(
+            pp=PipelineGroup(self._Group(0, 2)),
+            _pp_model=stage,
+            model=_FullPathMustNotRun(),
+            scheduler_config=SimpleNamespace(max_num_batched_tokens=4),
+        )
+        evaled: list[object] = []
+        real_eval = mx.eval
+        cache_readings = iter([100, 180])
+        limits: list[int] = []
+        monkeypatch.setattr(mr.mx, "clear_cache", lambda: None)
+        monkeypatch.setattr(mr.mx, "get_cache_memory", lambda: next(cache_readings))
+        monkeypatch.setattr(mr.mx, "set_cache_limit", limits.append)
+        monkeypatch.setattr(
+            mr.mx, "eval", lambda *arrays: evaled.extend(arrays) or real_eval(*arrays)
+        )
+
+        overhead = runner.profile_run()
+
+        assert isinstance(stage.seen, mx.array)
+        assert stage.seen.shape == (1, 4)
+        assert stage.seen.dtype == mx.int32
+        assert evaled == [hidden]  # eval saw exactly the stage-shaped output
+        assert overhead == 80
+        assert limits == [80]

--- a/tools/pp_lazy_rss.py
+++ b/tools/pp_lazy_rss.py
@@ -1,22 +1,36 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-"""Measure per-stage peak memory for a pipeline-parallel lazy load vs a full load.
+"""Measure per-stage peak memory for pipeline-parallel lazy loading and profiling.
 
-Evidence for the lazy pipeline-parallel load: a PP stage loads the generic mlx_lm
-weights lazily and prunes its non-owned layers (``apply_pipeline_split``) before the
-first ``mx.eval``, so per-stage peak stays owned-only instead of full-model. This
-mirrors the load -> prune -> eval mechanism ``ModelLifecycle`` uses on the
-``pp.size > 1`` path (calling ``mlx_lm.utils.load_model`` directly and skipping the
-metadata-only lifecycle install steps, which do not materialize weights).
+Weight-materialization modes (evidence for the lazy PP load): a PP stage loads
+the generic mlx_lm weights lazily and prunes its non-owned layers
+(``apply_pipeline_split``) before the first ``mx.eval``, so per-stage peak stays
+owned-only instead of full-model. This mirrors the load -> prune -> eval
+mechanism ``ModelLifecycle`` uses on the ``pp.size > 1`` path (calling
+``mlx_lm.utils.load_model`` directly and skipping the metadata-only lifecycle
+install steps, which do not materialize weights).
 
-Run each mode in its OWN process so the peak is isolated:
+    full        eager load, everything materializes (Phase-0 baseline)
+    lazy        lazy load + prune, then materialize what remains
+
+Dummy-forward modes (evidence for stage-shaped profiling): materialization is
+forward-driven, so what profiling evals decides what a stage pays for. These
+modes eval ONLY the dummy-forward outputs — never ``model.parameters()``:
+
+    dummy-full   the old profile shape: full top-level model(input_ids) call,
+                 embedding + logits on every stage
+    dummy-stage  PipelinedModel.dummy_forward: zeros hidden in place of the
+                 ring recv (no ring I/O, so a mid stage is measurable offline)
+
+Run each mode in its OWN process so the high-water peak is isolated:
 
     python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit full
-    python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit lazy   # last of pp_size=2
+    python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit lazy 2 1
+    python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit dummy-full 3 1
+    python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit dummy-stage 3 1
 
 Reports ``mx.get_peak_memory()`` (MLX allocator high-water) and ``ru_maxrss``
-(process RSS). If anything materialized the full model before the split, the lazy
-peak would match the full peak.
+(process RSS).
 """
 
 from __future__ import annotations
@@ -29,7 +43,15 @@ import mlx.core as mx
 from huggingface_hub import snapshot_download
 from mlx_lm.utils import load_model
 
-from vllm_metal.distributed.pipeline import PipelineGroup, apply_pipeline_split
+from vllm_metal.distributed.pipeline import (
+    PipelinedModel,
+    PipelineGroup,
+    apply_pipeline_split,
+)
+
+# Any small nonzero length works: the dummy profiles the forward SHAPE (which
+# modules materialize), not throughput, so the token count is arbitrary.
+N_DUMMY_TOKENS = 8
 
 
 class _OfflineStage:
@@ -52,7 +74,10 @@ def _rss_gb() -> float:
 
 def main() -> None:
     if len(sys.argv) < 3:
-        sys.exit("usage: pp_lazy_rss.py <hf_model_id> <full|lazy> [pp_size] [rank]")
+        sys.exit(
+            "usage: pp_lazy_rss.py <hf_model_id> "
+            "<full|lazy|dummy-full|dummy-stage> [pp_size] [rank]"
+        )
     repo, mode = sys.argv[1], sys.argv[2]
     pp_size = int(sys.argv[3]) if len(sys.argv) > 3 else 2
     rank = int(sys.argv[4]) if len(sys.argv) > 4 else pp_size - 1
@@ -61,17 +86,26 @@ def main() -> None:
     if mode == "full":
         model, _ = load_model(path, lazy=False)
         total = owned = len(model.model.layers)
-    elif mode == "lazy":
+        mx.eval(model.parameters())
+    elif mode in ("lazy", "dummy-full", "dummy-stage"):
         model, _ = load_model(path, lazy=True, strict=False)
         total = len(model.model.layers)
-        apply_pipeline_split(model, PipelineGroup(_OfflineStage(rank, pp_size)))
+        pp = PipelineGroup(_OfflineStage(rank, pp_size))
+        apply_pipeline_split(model, pp)
         owned = len(model.model.layers)
+        if mode == "lazy":
+            mx.eval(model.parameters())
+        else:
+            ids = mx.zeros((1, N_DUMMY_TOKENS), dtype=mx.int32)
+            if mode == "dummy-full":
+                mx.eval(model(ids))
+            else:
+                mx.eval(PipelinedModel(model, pp).dummy_forward(ids))
     else:
-        sys.exit(f"unknown mode {mode!r}; use full or lazy")
+        sys.exit(f"unknown mode {mode!r}; use full|lazy|dummy-full|dummy-stage")
 
-    mx.eval(model.parameters())
     print(
-        f"{repo}  mode={mode}  owned_layers={owned}/{total}  "
+        f"{repo}  mode={mode}  rank={rank}/{pp_size}  owned_layers={owned}/{total}  "
         f"MLX_peak={mx.get_peak_memory() / 1e9:.3f}GB  "
         f"ru_maxrss={_rss_gb():.3f}GB"
     )

--- a/vllm_metal/distributed/pipeline.py
+++ b/vllm_metal/distributed/pipeline.py
@@ -266,13 +266,34 @@ class PipelinedModel:
         )
 
     def __call__(self, input_ids: mx.array, *, cache: Any = None) -> mx.array:
-        pp = self._pp
         h_in: mx.array | None = None
-        if not pp.is_first:
+        if not self._pp.is_first:
             h_in = pipeline_recv(
-                pp, input_ids.shape[1], self._wire_hidden, self._wire_dtype
+                self._pp, input_ids.shape[1], self._wire_hidden, self._wire_dtype
             )
-        if pp.is_last:
+        return self._stage_forward(input_ids, h_in, cache=cache)
+
+    def dummy_forward(self, input_ids: mx.array) -> mx.array:
+        """Run this stage's forward locally for profiling/warm-up: no ring I/O.
+
+        Non-first stages take a zeros hidden state at the wire descriptor in
+        place of ``pipeline_recv`` (mirroring upstream vLLM's ``_dummy_run`` +
+        ``make_empty_intermediate_tensors``), so profiling never materializes
+        the embedding a non-first stage does not use; the stage body — and its
+        wire-dtype fail-fast — is shared with ``__call__``.
+        """
+        h_in: mx.array | None = None
+        if not self._pp.is_first:
+            h_in = mx.zeros(
+                (input_ids.shape[0], input_ids.shape[1], self._wire_hidden),
+                dtype=self._wire_dtype,
+            )
+        return self._stage_forward(input_ids, h_in)
+
+    def _stage_forward(
+        self, input_ids: mx.array, h_in: mx.array | None, *, cache: Any = None
+    ) -> mx.array:
+        if self._pp.is_last:
             # full backbone + final norm + tied/explicit head -> model output
             return self._model(input_ids, cache=cache, input_embeddings=h_in)
         # backbone only (norm is nn.Identity on non-last) -> raw hidden state.

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -645,6 +645,15 @@ class MetalModelRunner:
                 model_config=self.model_config,
             )
 
+        if self.pp is not None and self.pp.size > 1:
+            # Profile the PP stage shape: non-first stages never embed and
+            # non-last stages never compute logits, in profiling as in serving.
+            assert self._pp_model is not None
+            output = self._pp_model.dummy_forward(input_ids)
+            if not self.pp.is_last:
+                return [output]
+            return [self._extract_logits(output)]
+
         output = self._forward_model(input_ids)
         logits = self._extract_logits(output)
         return [logits]


### PR DESCRIPTION
Our profiling does not behave like serving under pipeline parallelism: profile_run and warm_up run the full top-level model call on every rank, so a middle stage materializes the embedding and head it never uses and computes a full-vocab logits buffer it never produces. On a Qwen3-8B-4bit middle stage (rank 1 of 3) that is 2.014 GB peak against 1.309 GB for the stage shape.

This PR adds PipelinedModel.dummy_forward, which runs the stage locally with a zeros hidden state built from the wire descriptor instead of the ring recv, and routes the runner's dummy forward through it. The stage body is shared with call, so the wire-dtype fail-fast now fires at startup instead of on the first request. This mirrors upstream vLLM's _dummy_run with make_empty_intermediate_tensors on non-first ranks.

For evidence, python tools/pp_lazy_rss.py mlx-community/Qwen3-8B-4bit dummy-full|dummy-stage 3 1 reproduces 2.014 vs 1.309 GB, the 2-stage ring parity check stays bit-exact, and the full not-slow suite passes. At 70B the saving is shape arithmetic, not measured; the 2-node validation pass is the follow-up. Generic mlx_lm text path under pipeline parallelism only.