### PR TITLE
Fix stale AWQ slow-test model configs

### DIFF
--- a/tests/quant/test_awq_e2e_dense_matrix.py
+++ b/tests/quant/test_awq_e2e_dense_matrix.py
@@ -74,6 +74,7 @@ def _runner_model_config(repo: str, *, dtype):
         is_multimodal_model=False,
         trust_remote_code=False,
         dtype=dtype,
+        quantization=None,
     )
 
 

--- a/tests/quant/test_awq_e2e_qwen25_15b.py
+++ b/tests/quant/test_awq_e2e_qwen25_15b.py
@@ -46,6 +46,7 @@ def _runner_model_config(*, dtype):
         is_multimodal_model=False,
         trust_remote_code=False,
         dtype=dtype,
+        quantization=None,
     )
 
 


### PR DESCRIPTION
The GGUF load-source probe added in #467 reads model_config.quantization, but the AWQ lifecycle stubs predate that field.
Set quantization=None so the dtype-alignment tests reach the AWQ checkpoints again.

Tests: pytest tests/quant/ -m slow -v --tb=short
(5 passed, 39 deselected)

Fixes #507