### PR TITLE
Fail fast on model warm-up errors

### DIFF
--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import mlx.core as mx
 import numpy as np
@@ -87,6 +88,15 @@ def test_gemma4_mtp_config_installs_gemma4_proposer() -> None:
 class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())
+
+    def test_warm_up_propagates_dummy_forward_failure(self) -> None:
+        runner = self._make_runner()
+        runner._dummy_forward_outputs = Mock(
+            side_effect=RuntimeError("dummy forward failed")
+        )
+
+        with pytest.raises(RuntimeError, match="dummy forward failed"):
+            runner.warm_up()
 
     def test_accumulates_streamed_segments(self, monkeypatch) -> None:
         captured: dict[str, object] = {}

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -756,13 +756,9 @@ class MetalModelRunner:
 
         logger.info("Warming up model...")
 
-        # Run a small dummy inference.
-        try:
-            dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
-            mx.eval(*self._dummy_forward_outputs(dummy_tokens))
-            logger.info("Model warm-up complete")
-        except Exception as e:
-            logger.warning(f"Model warm-up failed: {e}")
+        dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
+        mx.eval(*self._dummy_forward_outputs(dummy_tokens))
+        logger.info("Model warm-up complete")
 
         if self._paged_attention_runtime is not None:
             self._paged_attention_runtime.warm_up()


### PR DESCRIPTION
This PR is:
- To stop swallowing exceptions from `MetalModelRunner.warm_up()`
- To fail startup at the original warm-up error when dummy forward/eval breaks
- To add a focused regression test for warm-up error propagation

Note: Warm-up is an internal startup validation path, not an optional fallback. If it fails, continuing only hides the real issue until a later request path