### PR TITLE
Default an unset --max-model-len to vLLM auto-fit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,3 +42,11 @@ model pairing, and memory considerations.
 | `auto` | `1` | Yes | Paged KV path (default); defaults to 0.9 internally |
 | `0.7` | `1` | Yes | Paged KV path with explicit memory budget |
 | `0.7` | `0` | No | Explicit fraction without paged KV is invalid |
+
+On the paged KV path, an unset `--max-model-len` defaults to vLLM's auto-fit:
+if the model's full context does not fit the KV budget, the engine starts at
+the largest length that fits and logs the reduction (upstream CUDA fails
+instead). Pass `--max-model-len` to pin the context length; explicit values
+are never adjusted. Speculative-decoding runs keep the derived default and
+must pin `--max-model-len` themselves. Auto-fit maximizes single-sequence
+context, so pinning a smaller value restores batching headroom.

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -70,6 +70,7 @@ class TestMetalPlatform:
                 disable_custom_all_reduce=False,
             ),
             model_config=None,
+            speculative_config=None,
         )
         with pytest.raises(
             NotImplementedError, match="alone or combined with pipeline"
@@ -97,6 +98,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -140,6 +142,7 @@ class TestMetalPlatform:
                 disable_custom_all_reduce=False,
             ),
             model_config=None,
+            speculative_config=None,
         )
         with pytest.raises(ValueError, match="too high for pipeline_parallel_size"):
             MetalPlatform.check_and_update_config(vllm_config)
@@ -164,6 +167,7 @@ class TestMetalPlatform:
             ),
             model_config=None,
             scheduler_config=SimpleNamespace(async_scheduling=True),
+            speculative_config=None,
         )
         with pytest.raises(NotImplementedError, match="synchronous scheduling"):
             MetalPlatform.check_and_update_config(vllm_config)
@@ -213,6 +217,7 @@ class TestMetalPlatform:
                 model="openai/whisper-tiny",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 multimodal_config=None,
                 hf_config=SimpleNamespace(model_type="whisper"),
                 is_hybrid=False,
@@ -245,6 +250,7 @@ class TestMetalPlatform:
                 disable_custom_all_reduce=False,
             ),
             model_config=None,
+            speculative_config=None,
         )
         with pytest.raises(NotImplementedError, match="single process"):
             MetalPlatform.check_and_update_config(vllm_config)
@@ -260,6 +266,7 @@ class TestMetalPlatform:
                 disable_custom_all_reduce=False,
             ),
             model_config=None,
+            speculative_config=None,
         )
         with pytest.raises(NotImplementedError, match="tensor parallelism"):
             MetalPlatform.check_and_update_config(vllm_config)
@@ -312,6 +319,7 @@ class TestMetalPlatform:
             "disable_cascade_attn": False,
             "tokenizer": None,
             "max_model_len": 32768,
+            "original_max_model_len": None,
             "hf_config": SimpleNamespace(model_type="qwen3"),
             "is_hybrid": False,
         }
@@ -800,6 +808,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -811,6 +820,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -853,6 +863,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -864,6 +875,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -919,6 +931,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -930,6 +943,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             with pytest.raises(NotImplementedError, match=err_match):
@@ -963,6 +977,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -974,6 +989,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=2048,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1009,6 +1025,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -1020,6 +1037,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=65536,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1059,6 +1077,7 @@ class TestMetalPlatform:
                     model="test-model",
                     disable_cascade_attn=False,
                     tokenizer=None,
+                    original_max_model_len=None,
                     max_model_len=32768,
                     multimodal_config=None,
                     hf_config=SimpleNamespace(model_type="qwen3"),
@@ -1070,6 +1089,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=65536,
                     max_num_scheduled_tokens=max_num_scheduled_tokens,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1101,6 +1121,7 @@ class TestMetalPlatform:
                 model="openai/whisper-tiny",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 multimodal_config=None,
                 hf_config=SimpleNamespace(model_type="whisper"),
                 is_hybrid=False,
@@ -1109,6 +1130,7 @@ class TestMetalPlatform:
                 async_scheduling=True,
                 enable_chunked_prefill=False,
             ),
+            speculative_config=None,
         )
 
         MetalPlatform.check_and_update_config(vllm_config)
@@ -1134,6 +1156,7 @@ class TestMetalPlatform:
                 model="openai/whisper-tiny",
                 disable_cascade_attn=False,
                 tokenizer="custom-tokenizer",
+                original_max_model_len=None,
                 multimodal_config=None,
                 hf_config=SimpleNamespace(model_type="whisper"),
                 is_hybrid=False,
@@ -1142,6 +1165,7 @@ class TestMetalPlatform:
                 async_scheduling=True,
                 enable_chunked_prefill=False,
             ),
+            speculative_config=None,
         )
 
         MetalPlatform.check_and_update_config(vllm_config)
@@ -1168,6 +1192,7 @@ class TestMetalPlatform:
                 model="test-model",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 max_model_len=128,
                 multimodal_config=SimpleNamespace(language_model_only=False),
                 hf_config=SimpleNamespace(model_type="gemma4"),
@@ -1191,6 +1216,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1211,6 +1237,7 @@ class TestMetalPlatform:
                 model="test-model",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 max_model_len=128,
                 multimodal_config=SimpleNamespace(language_model_only=False),
                 hf_config=SimpleNamespace(
@@ -1238,6 +1265,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1260,6 +1288,7 @@ class TestMetalPlatform:
                 model="test-model",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 max_model_len=128,
                 multimodal_config=sentinel,
                 hf_config=SimpleNamespace(model_type="qwen3_vl"),
@@ -1283,6 +1312,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1305,6 +1335,7 @@ class TestMetalPlatform:
                 model="test-model",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 max_model_len=128,
                 multimodal_config=sentinel,
                 hf_config=SimpleNamespace(
@@ -1332,6 +1363,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1354,6 +1386,7 @@ class TestMetalPlatform:
                 model="test-model",
                 disable_cascade_attn=False,
                 tokenizer=None,
+                original_max_model_len=None,
                 max_model_len=128,
                 multimodal_config=sentinel,
                 hf_config=SimpleNamespace(model_type="phi3_v"),
@@ -1377,6 +1410,7 @@ class TestMetalPlatform:
                     max_num_batched_tokens=2048,
                     max_num_scheduled_tokens=None,
                 ),
+                speculative_config=None,
             )
 
             MetalPlatform.check_and_update_config(vllm_config)
@@ -1473,3 +1507,175 @@ class TestKvBudgetBytes:
         )
 
         assert budget > 1e9
+
+
+class TestAutoFitMaxModelLenDefault:
+    """MetalPlatform defaults an omitted --max-model-len to vLLM's auto-fit.
+
+    On the paged path the platform flips ``model_config.original_max_model_len``
+    from None (flag omitted) to -1 (vLLM's auto-fit sentinel) so the engine
+    boots at the largest context that fits instead of failing the KV admission
+    check (#505). Explicit values, speculative-decode runs, and the non-paged
+    path keep today's behavior.
+    """
+
+    @staticmethod
+    def _patch_stt_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "vllm_metal.utils.get_model_download_path",
+            lambda model: model,
+        )
+        monkeypatch.setattr(
+            "vllm_metal.stt.detection.is_stt_model", lambda _model: False
+        )
+
+    @staticmethod
+    def _vllm_config(
+        *,
+        original_max_model_len: int | None = None,
+        speculative_config: object = None,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                worker_cls="auto",
+                distributed_executor_backend="auto",
+                pipeline_parallel_size=1,
+                tensor_parallel_size=1,
+                disable_custom_all_reduce=False,
+            ),
+            cache_config=SimpleNamespace(block_size=None, enable_prefix_caching=False),
+            model_config=SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                original_max_model_len=original_max_model_len,
+                max_model_len=262144,
+                multimodal_config=None,
+                hf_config=SimpleNamespace(model_type="qwen3"),
+                is_hybrid=False,
+            ),
+            scheduler_config=SimpleNamespace(
+                async_scheduling=False,
+                enable_chunked_prefill=True,
+                max_num_batched_tokens=2048,
+                max_num_scheduled_tokens=None,
+            ),
+            speculative_config=speculative_config,
+        )
+
+    def test_omitted_max_model_len_defaults_to_auto_fit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An omitted --max-model-len becomes the -1 auto-fit sentinel."""
+        self._patch_stt_resolution(monkeypatch)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = self._vllm_config(original_max_model_len=None)
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.model_config.original_max_model_len == -1
+            # The derived length is resolved later by the engine's auto-fit,
+            # not by the platform hook.
+            assert vllm_config.model_config.max_model_len == 262144
+        finally:
+            reset_config()
+
+    @pytest.mark.parametrize(
+        "explicit_value", [16384, -1], ids=["pinned", "explicit_auto_fit"]
+    )
+    def test_explicit_max_model_len_is_untouched(
+        self, monkeypatch: pytest.MonkeyPatch, explicit_value: int
+    ) -> None:
+        """User-provided --max-model-len values pass through unchanged."""
+        self._patch_stt_resolution(monkeypatch)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = self._vllm_config(original_max_model_len=explicit_value)
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.model_config.original_max_model_len == explicit_value
+            assert vllm_config.model_config.max_model_len == 262144
+        finally:
+            reset_config()
+
+    def test_speculative_decoding_keeps_derived_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Spec-decode runs are excluded: MetalWorker.update_max_model_len does
+        not refresh drafter-side lengths, so auto-fit must not engage."""
+        self._patch_stt_resolution(monkeypatch)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = self._vllm_config(
+                original_max_model_len=None,
+                speculative_config=SimpleNamespace(method="ngram"),
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.model_config.original_max_model_len is None
+            assert vllm_config.model_config.max_model_len == 262144
+        finally:
+            reset_config()
+
+    def test_explicit_auto_fit_with_speculative_decoding_is_rejected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit --max-model-len -1 with spec decode must fail fast: the
+        Metal worker does not refresh drafter-side lengths after auto-fit."""
+        self._patch_stt_resolution(monkeypatch)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = self._vllm_config(
+                original_max_model_len=-1,
+                speculative_config=SimpleNamespace(method="ngram"),
+            )
+
+            with pytest.raises(
+                NotImplementedError, match="not supported with speculative decoding"
+            ):
+                MetalPlatform.check_and_update_config(vllm_config)
+        finally:
+            reset_config()
+
+    def test_non_paged_path_keeps_derived_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The MLX path reports exactly one max-length sequence of memory, so
+        auto-fit could never reduce there; the sentinel is not flipped."""
+        self._patch_stt_resolution(monkeypatch)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        reset_config()
+        try:
+            vllm_config = self._vllm_config(original_max_model_len=None)
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.model_config.original_max_model_len is None
+        finally:
+            reset_config()
+
+    def test_auto_fit_default_is_idempotent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """check_and_update_config may run more than once (DP re-entry); the
+        flip must be stable across repeated calls."""
+        self._patch_stt_resolution(monkeypatch)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = self._vllm_config(original_max_model_len=None)
+
+            MetalPlatform.check_and_update_config(vllm_config)
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert vllm_config.model_config.original_max_model_len == -1
+            assert vllm_config.model_config.max_model_len == 262144
+        finally:
+            reset_config()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -11,7 +11,10 @@ import torch
 from vllm.config import ParallelConfig
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
+from vllm.v1.core.kv_cache_utils import get_kv_cache_configs, max_memory_usage_bytes
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
+from vllm_metal.compat import ensure_vllm_auto_fit_null_block_patch
 from vllm_metal.config import reset_config
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
@@ -1679,3 +1682,139 @@ class TestAutoFitMaxModelLenDefault:
             assert vllm_config.model_config.max_model_len == 262144
         finally:
             reset_config()
+
+
+class TestAutoFitMaxModelLenChain:
+    """The -1 sentinel drives upstream auto-fit through public entry points.
+
+    Builds the gemma-4-31B KV shape (the all-FullAttentionSpec specs vllm-metal
+    emits today: 50 sliding-shaped 16x256 layers + 10 global-shaped 4x512
+    layers) and runs vLLM's ``get_kv_cache_configs`` against fixed synthetic
+    memory budgets, asserting the resolved ``max_model_len``.
+    """
+
+    _NUM_LAYERS = 60
+    _FULL_EVERY = 6  # gemma-4's 5:1 sliding:full layer pattern
+
+    @pytest.fixture(autouse=True)
+    def _ensure_compat_patches(self) -> None:
+        """The null-block auto-fit patch (compat.py) is part of the contract
+        under test; ensure it directly because plugin activation can skip it
+        while vLLM is partially imported."""
+        ensure_vllm_auto_fit_null_block_patch()
+
+    _BLOCK_SIZE = 16
+    # 16 tokens x (50 x 16 x 256 + 10 x 4 x 512) heads*dims x K/V x bf16 —
+    # equals the packed per-block bytes the Metal pool reports.
+    _PACKED_BLOCK_BYTES = 14_417_920
+    _DERIVED_MAX_LEN = 262_144
+
+    @classmethod
+    def _specs(cls) -> dict[str, KVCacheSpec]:
+        """Fresh specs per call: upstream grouping mutates specs in place."""
+        specs: dict[str, KVCacheSpec] = {}
+        for i in range(cls._NUM_LAYERS):
+            is_full = (i + 1) % cls._FULL_EVERY == 0
+            specs[f"layers.{i}.self_attn"] = FullAttentionSpec(
+                block_size=cls._BLOCK_SIZE,
+                num_kv_heads=4 if is_full else 16,
+                head_size=512 if is_full else 256,
+                dtype=torch.bfloat16,
+            )
+        return specs
+
+    @classmethod
+    def _vllm_config(cls, *, original_max_model_len: int | None) -> SimpleNamespace:
+        return SimpleNamespace(
+            model_config=SimpleNamespace(
+                max_model_len=cls._DERIVED_MAX_LEN,
+                original_max_model_len=original_max_model_len,
+            ),
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=1,
+                prefill_context_parallel_size=1,
+            ),
+            scheduler_config=SimpleNamespace(
+                max_num_batched_tokens=2048,
+                disable_hybrid_kv_cache_manager=False,
+            ),
+            cache_config=SimpleNamespace(
+                num_gpu_blocks_override=None,
+                kv_cache_memory_bytes=None,
+            ),
+        )
+
+    @classmethod
+    def _largest_fitting_len(cls, available: int) -> int:
+        """Independent expectation: bisect the largest length whose demand
+        (public ``max_memory_usage_bytes``) fits ``available`` minus one pool
+        block (BlockPool's null-block reservation, restored by the compat
+        patch so requests at the fitted length stay schedulable)."""
+        budget = available - cls._PACKED_BLOCK_BYTES
+        probe = cls._vllm_config(original_max_model_len=-1)
+        lo, hi, best = 1, cls._DERIVED_MAX_LEN, 0
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            probe.model_config.max_model_len = mid
+            if max_memory_usage_bytes(probe, cls._specs().values()) <= budget:
+                best, lo = mid, mid + 1
+            else:
+                hi = mid - 1
+        return best
+
+    def test_reduces_omitted_default_to_largest_fitting_length(self) -> None:
+        available = 1500 * self._PACKED_BLOCK_BYTES
+        expected = self._largest_fitting_len(available)
+        vllm_config = self._vllm_config(original_max_model_len=-1)
+
+        get_kv_cache_configs(vllm_config, [self._specs()], [available])
+
+        assert expected < self._DERIVED_MAX_LEN
+        assert vllm_config.model_config.max_model_len == expected
+
+    def test_reduced_length_reserves_the_null_block(self) -> None:
+        """The fitted length must never need the whole pool: BlockPool keeps
+        block 0 as the null placeholder, so a request at the fitted length
+        would otherwise starve in the scheduler forever."""
+        num_pool_blocks = 1500
+        available = num_pool_blocks * self._PACKED_BLOCK_BYTES
+        vllm_config = self._vllm_config(original_max_model_len=-1)
+
+        get_kv_cache_configs(vllm_config, [self._specs()], [available])
+
+        resolved_blocks = -(-vllm_config.model_config.max_model_len // 16)
+        assert resolved_blocks == num_pool_blocks - 1
+
+    def test_full_context_fits_is_a_no_op(self) -> None:
+        # Full 262144 context needs 16384 packed blocks; give a little more.
+        available = 16_500 * self._PACKED_BLOCK_BYTES
+        vllm_config = self._vllm_config(original_max_model_len=-1)
+
+        get_kv_cache_configs(vllm_config, [self._specs()], [available])
+
+        assert vllm_config.model_config.max_model_len == self._DERIVED_MAX_LEN
+
+    def test_without_sentinel_constrained_memory_raises_admission_error(self) -> None:
+        """The #505 failure shape: no sentinel, derived 262144, small budget."""
+        available = 1500 * self._PACKED_BLOCK_BYTES
+        vllm_config = self._vllm_config(original_max_model_len=None)
+
+        with pytest.raises(ValueError, match="To serve at least one request"):
+            get_kv_cache_configs(vllm_config, [self._specs()], [available])
+
+    def test_insufficient_memory_for_one_block_raises(self) -> None:
+        available = self._PACKED_BLOCK_BYTES - 1
+        vllm_config = self._vllm_config(original_max_model_len=-1)
+
+        with pytest.raises(ValueError, match="Cannot auto-fit max_model_len"):
+            get_kv_cache_configs(vllm_config, [self._specs()], [available])
+
+    def test_chain_is_stable_across_reruns(self) -> None:
+        available = 1500 * self._PACKED_BLOCK_BYTES
+        vllm_config = self._vllm_config(original_max_model_len=-1)
+
+        get_kv_cache_configs(vllm_config, [self._specs()], [available])
+        first = vllm_config.model_config.max_model_len
+        get_kv_cache_configs(vllm_config, [self._specs()], [available])
+
+        assert vllm_config.model_config.max_model_len == first

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -418,3 +419,53 @@ class TestPagedAttentionPlanDiagnostics:
         assert "kv_budget_before_hybrid" not in message
         assert "--max-num-seqs" not in message
         assert "kv_budget=-1.10GB" in message
+
+
+class TestUpdateMaxModelLen:
+    """update_max_model_len applies the engine value and surfaces reductions."""
+
+    @staticmethod
+    def _make_worker(derived_max_model_len: int) -> MetalWorker:
+        worker = MetalWorker.__new__(MetalWorker)
+        worker.model_config = SimpleNamespace(max_model_len=derived_max_model_len)
+        worker._derived_max_model_len = derived_max_model_len
+        return worker
+
+    def test_reduction_warns_with_derived_and_new_value(self, caplog) -> None:
+        worker = self._make_worker(262144)
+        # The uni executor shares vllm_config with the engine, so the in-place
+        # auto-fit mutation is visible on model_config BEFORE the RPC arrives;
+        # the warning must compare against the captured derived length.
+        worker.model_config.max_model_len = 19216
+        metal_logger = logging.getLogger("vllm_metal")
+        original_level = metal_logger.level
+        metal_logger.addHandler(caplog.handler)
+        metal_logger.setLevel(logging.WARNING)
+
+        try:
+            MetalWorker.update_max_model_len(worker, 19216)
+        finally:
+            metal_logger.removeHandler(caplog.handler)
+            metal_logger.setLevel(original_level)
+
+        assert worker.model_config.max_model_len == 19216
+        assert (
+            "Auto-fit reduced max_model_len from 262144 to 19216 to fit Metal "
+            "memory; pass --max-model-len to pin the context length"
+        ) in caplog.text
+
+    def test_unreduced_length_does_not_warn(self, caplog) -> None:
+        worker = self._make_worker(16384)
+        metal_logger = logging.getLogger("vllm_metal")
+        original_level = metal_logger.level
+        metal_logger.addHandler(caplog.handler)
+        metal_logger.setLevel(logging.WARNING)
+
+        try:
+            MetalWorker.update_max_model_len(worker, 16384)
+        finally:
+            metal_logger.removeHandler(caplog.handler)
+            metal_logger.setLevel(original_level)
+
+        assert worker.model_config.max_model_len == 16384
+        assert "Auto-fit reduced max_model_len" not in caplog.text

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -29,9 +29,56 @@ def apply_compat_patches() -> None:
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
     _patch_vllm_bytelevel_tokenizer_loading()
+    ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_mlx_lm_gemma4_kv_shared_sanitize()
     _patch_transformers_exaone4_config()
+
+
+def ensure_vllm_auto_fit_null_block_patch() -> None:
+    """Reserve the null block in vLLM's auto-fit max_model_len estimate.
+
+    ``_estimate_max_model_len_from_groups`` accepts the largest length whose KV
+    demand fits the reported memory, but ``BlockPool`` permanently takes one of
+    ``num_blocks`` as the null placeholder block, so a request at the
+    auto-fitted length needs one more block than the pool can ever allocate.
+    The scheduler admits it, allocation falls one block short, and the request
+    preempts and requeues forever (observed live: gemma-4-31B-it at its fitted
+    length sat in Waiting with 0% KV cache usage indefinitely). Shrink the
+    searched budget by one pool block so every admissible length stays
+    schedulable.
+
+    Idempotent and safe to call repeatedly: plugin activation runs while vLLM
+    is still partially initialized (the import below can fail there), so
+    ``MetalPlatform.update_block_size_for_backend`` re-ensures it inside the
+    engine process after vLLM is fully imported, before KV sizing runs.
+
+    SCAFFOLDING: remove when upstream ``_estimate_max_model_len_from_groups``
+    accounts for the null-block reservation.
+    """
+    try:
+        from vllm.v1.core import kv_cache_utils
+    except ImportError as exc:
+        logger.debug("Skipping vLLM auto-fit null-block patch: %s", exc)
+        return
+
+    if getattr(kv_cache_utils, "_vllm_metal_auto_fit_null_block_patched", False):
+        return
+
+    original = kv_cache_utils._estimate_max_model_len_from_groups
+    pool_bytes_per_block = kv_cache_utils._pool_bytes_per_block
+
+    def _patched_estimate(
+        vllm_config: Any, kv_cache_groups: Any, available_memory: int
+    ) -> int:
+        reserved = pool_bytes_per_block(vllm_config, kv_cache_groups)
+        return original(
+            vllm_config, kv_cache_groups, max(0, available_memory - reserved)
+        )
+
+    kv_cache_utils._estimate_max_model_len_from_groups = _patched_estimate
+    kv_cache_utils._vllm_metal_auto_fit_null_block_patched = True
+    logger.debug("Installed vLLM auto-fit null-block reservation patch")
 
 
 def _patch_transformers_exaone4_config() -> None:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -610,6 +610,40 @@ class MetalPlatform(Platform):
                     scheduler_config.max_num_batched_tokens,
                 )
 
+        # Auto-fit shrinks the target's max_model_len at engine init, but
+        # MetalWorker.update_max_model_len does not refresh drafter-side
+        # lengths the way upstream's GPU runner does, so the drafter would
+        # keep the stale pre-reduction context. Reject rather than run it.
+        if (
+            model_config is not None
+            and model_config.original_max_model_len == -1
+            and vllm_config.speculative_config is not None
+        ):
+            raise NotImplementedError(
+                "Auto-fit --max-model-len (-1/'auto') is not supported with "
+                "speculative decoding on Metal; the worker does not refresh "
+                "drafter-side lengths after the reduction. Pin --max-model-len "
+                "explicitly or remove --speculative-config."
+            )
+
+        # Default an omitted --max-model-len to vLLM's auto-fit (-1 sentinel):
+        # the packed KV layout prices every layer at the full derived context,
+        # so oversized defaults fail engine init outright (gemma-4-31B derives
+        # 262144 and demands 220 GiB, #505). Explicit values are never touched;
+        # speculative decoding keeps the derived default (rejected above when
+        # auto-fit is requested explicitly).
+        if (
+            model_config is not None
+            and config.use_paged_attention
+            and model_config.original_max_model_len is None
+            and vllm_config.speculative_config is None
+        ):
+            model_config.original_max_model_len = -1
+            logger.info(
+                "Metal: --max-model-len not set; defaulting to auto-fit "
+                "(pass --max-model-len to pin the context length)"
+            )
+
         # Disable cascade attention (not supported), then let the adapter
         # apply any model-specific normalisations (e.g. clearing
         # ``multimodal_config`` for model types served on the text-only

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -746,7 +746,13 @@ class MetalPlatform(Platform):
         a hybrid model, explaining the cache-block-size translation mechanism
         (PR #235).
         """
+        from vllm_metal.compat import ensure_vllm_auto_fit_null_block_patch
         from vllm_metal.config import get_config
+
+        # Runs in the engine process after vLLM is fully imported, right before
+        # KV sizing: the reliable spot to (re-)install the auto-fit null-block
+        # patch that plugin activation may have skipped mid-import.
+        ensure_vllm_auto_fit_null_block_patch()
 
         metal_config = get_config()
         model_config = vllm_config.model_config

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -110,6 +110,11 @@ class MetalWorker(WorkerBase):
         # default single-stage path (no group object, no behavior change).
         self.pp: PipelineGroup | None = None
 
+        # Captured before engine KV sizing: the uni executor shares vllm_config
+        # with the engine, so by the time update_max_model_len is called the
+        # in-place auto-fit mutation is already visible on self.model_config.
+        self._derived_max_model_len = self.model_config.max_model_len
+
     def init_device(self) -> None:
         """Initialize the Metal device and distributed environment."""
         # Set up MLX device
@@ -299,6 +304,13 @@ class MetalWorker(WorkerBase):
     def update_max_model_len(self, max_model_len: int) -> None:
         """Update max_model_len after engine auto-fits context to GPU memory."""
         self.model_config.max_model_len = max_model_len
+        if max_model_len < self._derived_max_model_len:
+            logger.warning(
+                "Auto-fit reduced max_model_len from %d to %d to fit Metal "
+                "memory; pass --max-model-len to pin the context length",
+                self._derived_max_model_len,
+                max_model_len,
+            )
 
     def get_cache_block_size_bytes(self) -> int:
         """Get the size of a single cache block in bytes.


### PR DESCRIPTION
gemma-4-31B-it fails engine init on any 128GB Mac (#505, docker/model-runner#1009). The config derives `max_model_len=262144` and the packed KV layout prices all 60 layers at full length, so the admission check asks for 220 GiB before anything can serve.

This PR defaults an omitted `--max-model-len` to vLLM's own auto-fit on the paged path, by setting `original_max_model_len` to `-1`, the same value `--max-model-len auto` writes (vllm-project/vllm#29431). The engine then boots at the largest context that fits and the worker warns with the old and new lengths. Explicit values are untouched. Spec decode keeps the old behavior because our worker does not refresh drafter lengths after a reduction.

The second commit reserves BlockPool's null block in the auto-fit estimate. Without it, the fitted length lands exactly on pool capacity and a request at that length waits forever; I hit this live while validating. The bug exists upstream too; I'll file it there and the SCAFFOLDING patch goes away once it's fixed.

For evidence, the main one is the before/after serve: main dies with the 220 GiB error, this branch boots at 23968 and greedy chat answers normally. Greedy token ids match the mlx_lm reference, an explicit 16384 stays 16384, and the 31B goldens pass. Ran on my M2 Ultra 192GB at `VLLM_METAL_MEMORY_FRACTION=0.5`. Full 262144 still needs sliding-window KV groups, which I'll write up as a design issue.
