### PR TITLE
Handle consecutive Whisper timestamps

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -118,6 +118,22 @@ class TestExtractSegments:
         assert len(segments) == 1
         assert segments[0].seek == 1000
 
+    def test_consecutive_timestamps_advance_segment_start(
+        self, transcriber: WhisperTranscriber
+    ) -> None:
+        tokens = [
+            transcriber._get_token_id("<|0.00|>"),
+            transcriber._get_token_id("<|2.00|>"),
+            2425,
+            transcriber._get_token_id("<|4.00|>"),
+        ]
+
+        segments = transcriber._extract_segments(tokens)
+
+        assert len(segments) == 1
+        assert segments[0].start == 2.0
+        assert segments[0].end == 4.0
+
     def test_empty_tokens(self, transcriber: WhisperTranscriber) -> None:
         assert transcriber._extract_segments([]) == []
 

--- a/vllm_metal/stt/whisper/transcriber.py
+++ b/vllm_metal/stt/whisper/transcriber.py
@@ -343,7 +343,9 @@ class WhisperTranscriber:
                             )
                         )
                         seg_id += 1
-                    seg_start = None
+                        seg_start = None
+                    else:
+                        seg_start = ts
                     seg_tokens = []
             else:
                 seg_tokens.append(tid)


### PR DESCRIPTION
## Summary
- keep Whisper timestamp parsing anchored when consecutive timestamp tokens represent an empty/silent span
- add a regression test for `<|0.00|><|2.00|> text <|4.00|>` so the text segment starts at the second timestamp instead of being dropped

## Why
Consecutive timestamp tokens can mark silence. The previous parser decoded an empty segment, cleared the active start timestamp, and then treated the following text as unanchored, so it was discarded when the closing timestamp arrived.

## Related history / duplicate check
This is a latent edge case in the existing Whisper segment parser, not a new subsystem. The parser shape dates back to the STT refactor lineage, and #478 recently fixed a different timestamp metadata issue around chunk `seek` offsets.

I searched open and closed upstream issues/PRs for this specific consecutive timestamp / dropped text behavior. I found related Whisper timestamp work (#477/#478), but no existing fix or issue for consecutive timestamp tokens dropping the following text.

## Validation
- `uv run --extra dev ruff check vllm_metal/stt/whisper/transcriber.py tests/test_transcribe.py`
- `uv run --extra dev ruff format --check vllm_metal/stt/whisper/transcriber.py tests/test_transcribe.py`
- isolated regression harness against real `_extract_segments`: passed

Full `pytest tests/test_transcribe.py -q` could not collect locally because this checkout environment does not provide the external `vllm` package: `ModuleNotFoundError: No module named 'vllm'`.
