### PR TITLE
Validate Metal boolean env vars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VLLM_METAL_MEMORY_FRACTION` | `auto` | `auto` allocates just enough memory plus a minimal KV cache, or `0.?` for fraction of memory |
-| `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute (1=yes, 0=no) |
+| `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
@@ -16,6 +16,9 @@
 | `VLLM_METAL_MLA_KERNEL` | `0` | Enable the experimental absorbed-MLA single-pass Metal decode kernel ([RFC #360](https://github.com/vllm-project/vllm-metal/issues/360)). Off by default; the MLA wrapper falls back to the MLX SDPA per-request slow path. Set to `1` to route absorbed-MLA decode through the kernel when the workload matches the instantiated specialization (`kv_lora_rank=512`, `qk_rope_head_dim=64`, `block_size ∈ {16, 32}`, fp16/bf16, decode-only). |
 | `VLLM_METAL_VISIBLE_DEVICES` | — | Set automatically by the Ray executor per worker (the device-control var); not user-configurable. See [Distributed](distributed.md). |
 | `VLLM_METAL_RING_BASE_PORT` | `32323` | Base TCP port for the MLX ring data plane under pipeline parallelism; stage *r* binds `base + r` (so the default is `32323`/`32324` for two stages). Set the **same** value on every node to move the ring off a busy port — e.g. when an `mlx.launch` job, a restart still in `TIME_WAIT`, or another PP job holds the default. See [Distributed](distributed.md#pipeline-parallelism). |
+
+Boolean `VLLM_METAL_*` variables accept `1`/`0`, `true`/`false`, `yes`/`no`,
+and `on`/`off` (case-insensitive).
 
 ## Multimodal Serve Modes
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,15 @@ from vllm_metal.config import (
 class TestMetalConfig:
     """Tests for MetalConfig class."""
 
+    BOOL_ENV_DEFAULTS = (
+        ("VLLM_METAL_USE_MLX", True),
+        ("VLLM_METAL_DEBUG", False),
+        ("VLLM_METAL_USE_PAGED_ATTENTION", True),
+        ("VLLM_METAL_GDN_LAZY_KERNELS", True),
+        ("VLLM_METAL_MLA_KERNEL", False),
+        ("VLLM_METAL_BUILD_FROM_SOURCE", False),
+    )
+
     @pytest.fixture(autouse=True)
     def _reset(self, monkeypatch):
         """Reset config singleton before and after each test."""
@@ -59,6 +68,47 @@ class TestMetalConfig:
         config = MetalConfig.from_env()
 
         assert config.use_paged_attention is False
+
+    @pytest.mark.parametrize(
+        "value",
+        ["1", "true", "TRUE", " yes ", "on"],
+    )
+    def test_bool_env_accepts_true_spellings(self, monkeypatch, value) -> None:
+        monkeypatch.setenv("VLLM_METAL_DEBUG", value)
+
+        config = MetalConfig.from_env()
+
+        assert config.debug is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["0", "false", "FALSE", " no ", "off"],
+    )
+    def test_bool_env_accepts_false_spellings(self, monkeypatch, value) -> None:
+        monkeypatch.setenv("VLLM_METAL_USE_MLX", value)
+
+        config = MetalConfig.from_env()
+
+        assert config.use_mlx is False
+
+    def test_invalid_bool_env_rejected(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "enabled")
+
+        with pytest.raises(
+            ValueError, match="Invalid VLLM_METAL_USE_PAGED_ATTENTION"
+        ):
+            MetalConfig.from_env()
+
+    @pytest.mark.parametrize("name,default", BOOL_ENV_DEFAULTS)
+    def test_bool_env_defaults(self, name, default) -> None:
+        assert getattr(envs, name) is default
+
+    @pytest.mark.parametrize("name,_default", BOOL_ENV_DEFAULTS)
+    def test_bool_env_rejects_invalid_values(self, monkeypatch, name, _default) -> None:
+        monkeypatch.setenv(name, "maybe")
+
+        with pytest.raises(ValueError, match=f"Invalid {name}"):
+            getattr(envs, name)
 
     def test_get_config_singleton(self) -> None:
         """Test that get_config returns a singleton."""

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -32,6 +32,26 @@ if TYPE_CHECKING:
     VLLM_METAL_VISIBLE_DEVICES: str | None = None
     VLLM_METAL_RING_BASE_PORT: int = 32323
 
+
+TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _get_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    value = raw.strip().lower()
+    if value in TRUE_VALUES:
+        return True
+    if value in FALSE_VALUES:
+        return False
+
+    accepted = ", ".join(sorted(TRUE_VALUES | FALSE_VALUES))
+    raise ValueError(f"Invalid {name}={raw!r}. Expected one of: {accepted}.")
+
+
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
     # plugin calculates the minimal amount needed at startup.
@@ -40,14 +60,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_METAL_MEMORY_FRACTION", "auto"
     ),
     # Whether to use MLX as the compute backend (default True).
-    "VLLM_METAL_USE_MLX": lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
+    "VLLM_METAL_USE_MLX": lambda: _get_bool("VLLM_METAL_USE_MLX", True),
     # MLX device type: "gpu" (default) or "cpu".
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
     # Enable verbose debug logging (default False).
-    "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
+    "VLLM_METAL_DEBUG": lambda: _get_bool("VLLM_METAL_DEBUG", False),
     # Use native Metal paged attention (default True).
-    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
-        os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
+    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: _get_bool(
+        "VLLM_METAL_USE_PAGED_ATTENTION", True
     ),
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the
@@ -62,8 +82,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MODELSCOPE_CACHE": lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
     # Enable lazy GDN kernels by default.
     # Set to "0" to force the eager conv / C++ recurrent fallback path.
-    "VLLM_METAL_GDN_LAZY_KERNELS": lambda: (
-        os.getenv("VLLM_METAL_GDN_LAZY_KERNELS", "1") == "1"
+    "VLLM_METAL_GDN_LAZY_KERNELS": lambda: _get_bool(
+        "VLLM_METAL_GDN_LAZY_KERNELS", True
     ),
     # Experimental MLA Metal decode kernel (RFC #360). Off by default —
     # the MLA wrapper uses the MLX SDPA per-request slow path unless
@@ -72,13 +92,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the kernel's instantiated specialization (kv_lora_rank=512,
     # qk_rope_head_dim=64, block_size ∈ {16, 32}, fp16/bf16,
     # decode-only).
-    "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
+    "VLLM_METAL_MLA_KERNEL": lambda: _get_bool("VLLM_METAL_MLA_KERNEL", False),
     # When set, compile the native _paged_ops extension from source at runtime
     # instead of loading the prebuilt artifact shipped in the wheel. Intended
     # for kernel developers / source installs; requires Xcode command-line
     # tools (clang++). Default off — release wheels ship the .so prebuilt.
-    "VLLM_METAL_BUILD_FROM_SOURCE": lambda: (
-        os.getenv("VLLM_METAL_BUILD_FROM_SOURCE", "0") == "1"
+    "VLLM_METAL_BUILD_FROM_SOURCE": lambda: _get_bool(
+        "VLLM_METAL_BUILD_FROM_SOURCE", False
     ),
     # Per-worker visible-device list set by vLLM's Ray executor (the
     # CUDA_VISIBLE_DEVICES analog for Metal; see MetalPlatform.device_control_env_var).


### PR DESCRIPTION
## Summary

- centralize parsing for Metal boolean environment variables
- accept common boolean spellings: `1`/`0`, `true`/`false`, `yes`/`no`, and `on`/`off`
- reject unrecognized boolean values with a clear `ValueError` instead of silently treating them as false
- document accepted boolean spellings in the configuration guide

Fixes #517.

## Why

The previous parser compared each boolean env var directly with `"1"`. That meant values like `VLLM_METAL_USE_PAGED_ATTENTION=true` disabled paged attention, and typos such as `enabled` also silently selected the false path.

## Tests

- `.venv-vllm-metal/bin/python -m pytest tests/test_config.py tests/test_macos_defaults.py`
- `ruff check vllm_metal/envs.py tests/test_config.py`
- `.venv-vllm-metal/bin/python -m py_compile vllm_metal/envs.py tests/test_config.py`
- `git diff --check`