### PR TITLE
Clear MLX cache after VLM warm-up

### DIFF
--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -68,6 +68,30 @@ class ForwardOutputRuntimeStub:
         return None
 
 
+class FakeWarmupMX:
+    int32 = object()
+
+    def __init__(self, cache_bytes: int) -> None:
+        self.cache_bytes = cache_bytes
+        self.clear_calls = 0
+        self.eval_calls = 0
+
+    def array(self, values, *, dtype):
+        assert values == [[1, 2, 3]]
+        assert dtype is self.int32
+        return values
+
+    def eval(self, *outputs) -> None:
+        assert outputs
+        self.eval_calls += 1
+
+    def get_cache_memory(self) -> int:
+        return self.cache_bytes
+
+    def clear_cache(self) -> None:
+        self.clear_calls += 1
+
+
 def test_gemma4_mtp_config_installs_gemma4_proposer() -> None:
     runner = make_stub_runner(tokenizer=object())
     runner.vllm_config = SimpleNamespace(
@@ -97,6 +121,65 @@ class TestV1MetalModelRunnerGenerate:
 
         with pytest.raises(RuntimeError, match="dummy forward failed"):
             runner.warm_up()
+
+    def test_warm_up_clears_nonzero_mlx_cache_for_multimodal_model(
+        self, monkeypatch
+    ) -> None:
+        fake_mx = FakeWarmupMX(cache_bytes=123)
+        monkeypatch.setattr(mr, "mx", fake_mx)
+
+        runner = self._make_runner()
+        runner._multimodal_adapter = object()
+        runner._dummy_forward_outputs = Mock(return_value=[object()])
+
+        runner.warm_up()
+
+        assert fake_mx.eval_calls == 1
+        assert fake_mx.clear_calls == 1
+
+    def test_warm_up_keeps_text_only_mlx_cache(self, monkeypatch) -> None:
+        fake_mx = FakeWarmupMX(cache_bytes=123)
+        monkeypatch.setattr(mr, "mx", fake_mx)
+
+        runner = self._make_runner()
+        runner._dummy_forward_outputs = Mock(return_value=[object()])
+
+        runner.warm_up()
+
+        assert fake_mx.eval_calls == 1
+        assert fake_mx.clear_calls == 0
+
+    def test_warm_up_skips_multimodal_clear_when_mlx_cache_empty(
+        self, monkeypatch
+    ) -> None:
+        fake_mx = FakeWarmupMX(cache_bytes=0)
+        monkeypatch.setattr(mr, "mx", fake_mx)
+
+        runner = self._make_runner()
+        runner._multimodal_adapter = object()
+        runner._dummy_forward_outputs = Mock(return_value=[object()])
+
+        runner.warm_up()
+
+        assert fake_mx.eval_calls == 1
+        assert fake_mx.clear_calls == 0
+
+    def test_warm_up_does_not_clear_cache_after_dummy_forward_failure(
+        self, monkeypatch
+    ) -> None:
+        fake_mx = FakeWarmupMX(cache_bytes=123)
+        monkeypatch.setattr(mr, "mx", fake_mx)
+
+        runner = self._make_runner()
+        runner._multimodal_adapter = object()
+        runner._dummy_forward_outputs = Mock(
+            side_effect=RuntimeError("dummy forward failed")
+        )
+
+        with pytest.raises(RuntimeError, match="dummy forward failed"):
+            runner.warm_up()
+
+        assert fake_mx.clear_calls == 0
 
     def test_accumulates_streamed_segments(self, monkeypatch) -> None:
         captured: dict[str, object] = {}

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -758,10 +758,32 @@ class MetalModelRunner:
 
         dummy_tokens = mx.array([[1, 2, 3]], dtype=mx.int32)
         mx.eval(*self._dummy_forward_outputs(dummy_tokens))
-        logger.info("Model warm-up complete")
 
         if self._paged_attention_runtime is not None:
             self._paged_attention_runtime.warm_up()
+        self._clear_mlx_cache_after_multimodal_warmup()
+        logger.info("Model warm-up complete")
+
+    def _clear_mlx_cache_after_multimodal_warmup(self) -> None:
+        """Release MLX buffer-cache memory after successful VLM warm-up.
+
+        The first real multimodal prefill is sensitive to cache pressure left by
+        the warm-up path on memory-constrained Apple Silicon systems. Keep the
+        release VLM-only and skip empty-cache cases so text-only warm-up behavior
+        remains unchanged.
+        """
+        if self._multimodal_adapter is None:
+            return
+
+        cache_bytes = mx.get_cache_memory()
+        if cache_bytes == 0:
+            return
+
+        mx.clear_cache()
+        logger.info(
+            "MLX cache cleared after multimodal model warm-up (%d bytes)",
+            cache_bytes,
+        )
 
     def _make_sampling_metadata(
         self,


### PR DESCRIPTION
## Summary

- clear MLX buffer-cache memory after a successful multimodal model warm-up when the cache is non-empty
- keep text-only warm-up behavior unchanged
- skip the clear when warm-up fails or when MLX reports zero cached bytes
- log the number of cache bytes released

Fixes #515.

## Why

Qwen3-VL first-batch multimodal prefill can start with substantial MLX buffer-cache memory left by warm-up. Releasing that cache after successful VLM warm-up gives the first real multimodal batch a cleaner memory state while avoiding text-only and failed-warm-up paths.

## Tests

- `PYTHONPATH=/Users/panjwaniha/experiment/vllm-docs-bf16-env .venv-vllm-metal/bin/python -m pytest tests/test_v1_model_runner_generate.py -q`
- `PYTHONPATH=/Users/panjwaniha/experiment/vllm-docs-bf16-env .venv-vllm-metal/bin/python -m pytest tests/test_v1_worker.py -q`
- `ruff check vllm_metal/v1/model_runner.py tests/test_v1_model_runner_generate.py`
- `.venv-vllm-metal/bin/python -m py_compile vllm_metal/v1/model_runner.py tests/test_v1_model_runner_generate.py`
- `git diff --check`