### PR TITLE
Validate boolean VLLM_METAL_* env vars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,15 @@
 | `VLLM_METAL_VISIBLE_DEVICES` | — | Set automatically by the Ray executor per worker (the device-control var); not user-configurable. See [Distributed](distributed.md). |
 | `VLLM_METAL_RING_BASE_PORT` | `32323` | Base TCP port for the MLX ring data plane under pipeline parallelism; stage *r* binds `base + r` (so the default is `32323`/`32324` for two stages). Set the **same** value on every node to move the ring off a busy port — e.g. when an `mlx.launch` job, a restart still in `TIME_WAIT`, or another PP job holds the default. See [Distributed](distributed.md#pipeline-parallelism). |
 
+### Boolean values
+
+Boolean `VLLM_METAL_*` variables (those with a `0`/`1` default above, plus
+`VLLM_METAL_BUILD_FROM_SOURCE`) accept `1`/`0`, `true`/`false`, `yes`/`no`,
+and `on`/`off`, case-insensitively. Leaving a variable unset or empty keeps
+its default. Any other value is rejected at first read with a `ValueError`
+naming the variable. (`VLLM_USE_MODELSCOPE` is vLLM's own variable and keeps
+vLLM's `True`/`False` convention.)
+
 ## Multimodal Serve Modes
 
 - `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for boolean environment variable parsing in ``vllm_metal.envs``."""
+
+import pytest
+
+import vllm_metal.envs as envs
+
+# The six boolean env vars and their documented defaults.
+BOOL_ENV_DEFAULTS = {
+    "VLLM_METAL_USE_MLX": True,
+    "VLLM_METAL_DEBUG": False,
+    "VLLM_METAL_USE_PAGED_ATTENTION": True,
+    "VLLM_METAL_GDN_LAZY_KERNELS": True,
+    "VLLM_METAL_MLA_KERNEL": False,
+    "VLLM_METAL_BUILD_FROM_SOURCE": False,
+}
+
+TRUE_SPELLINGS = [
+    "1",
+    "true",
+    "True",
+    "TRUE",
+    "yes",
+    "YES",
+    "on",
+    "On",
+    " true ",
+    "\ton\t",
+]
+
+FALSE_SPELLINGS = [
+    "0",
+    "false",
+    "False",
+    "FALSE",
+    "no",
+    "NO",
+    "off",
+    "Off",
+    " false ",
+]
+
+INVALID_VALUES = ["enabled", "disabled", "2", "-1", "tru", "yess", "t", "y"]
+
+
+class TestBoolEnvVars:
+    """Boolean ``VLLM_METAL_*`` vars accept 1/0, true/false, yes/no, on/off."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        """Isolate each test from ambient VLLM_METAL_* environment."""
+        for var in envs.environment_variables:
+            monkeypatch.delenv(var, raising=False)
+
+    def test_all_bool_vars_registered(self) -> None:
+        assert set(BOOL_ENV_DEFAULTS) <= set(envs.environment_variables)
+
+    @pytest.mark.parametrize("name", sorted(BOOL_ENV_DEFAULTS))
+    @pytest.mark.parametrize("value", TRUE_SPELLINGS)
+    def test_true_spellings(self, monkeypatch, name: str, value: str) -> None:
+        monkeypatch.setenv(name, value)
+        assert getattr(envs, name) is True
+
+    @pytest.mark.parametrize("name", sorted(BOOL_ENV_DEFAULTS))
+    @pytest.mark.parametrize("value", FALSE_SPELLINGS)
+    def test_false_spellings(self, monkeypatch, name: str, value: str) -> None:
+        monkeypatch.setenv(name, value)
+        assert getattr(envs, name) is False
+
+    @pytest.mark.parametrize("name,default", sorted(BOOL_ENV_DEFAULTS.items()))
+    def test_unset_uses_default(self, name: str, default: bool) -> None:
+        assert getattr(envs, name) is default
+
+    @pytest.mark.parametrize("name,default", sorted(BOOL_ENV_DEFAULTS.items()))
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_empty_uses_default(
+        self, monkeypatch, name: str, default: bool, value: str
+    ) -> None:
+        monkeypatch.setenv(name, value)
+        assert getattr(envs, name) is default
+
+    @pytest.mark.parametrize("name", sorted(BOOL_ENV_DEFAULTS))
+    @pytest.mark.parametrize("value", INVALID_VALUES)
+    def test_invalid_value_raises(self, monkeypatch, name: str, value: str) -> None:
+        monkeypatch.setenv(name, value)
+        with pytest.raises(ValueError, match=name):
+            getattr(envs, name)
+
+    def test_error_message_lists_accepted_values(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_DEBUG", "enabled")
+        with pytest.raises(ValueError) as excinfo:
+            _ = envs.VLLM_METAL_DEBUG
+        message = str(excinfo.value)
+        assert "VLLM_METAL_DEBUG='enabled'" in message
+        assert "1/0, true/false, yes/no, on/off" in message

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -32,6 +32,34 @@ if TYPE_CHECKING:
     VLLM_METAL_VISIBLE_DEVICES: str | None = None
     VLLM_METAL_RING_BASE_PORT: int = 32323
 
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _bool_env(name: str, *, default: bool) -> bool:
+    """Parse a boolean environment variable.
+
+    Accepts ``1``/``0``, ``true``/``false``, ``yes``/``no`` and ``on``/``off``
+    (case-insensitive, surrounding whitespace ignored).  Unset or empty means
+    ``default``.  Any other value raises ``ValueError`` so typos fail loudly
+    instead of being silently read as false.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if not value:
+        return default
+    if value in _TRUE_VALUES:
+        return True
+    if value in _FALSE_VALUES:
+        return False
+    raise ValueError(
+        f"Invalid {name}={raw!r}. Must be one of: "
+        "1/0, true/false, yes/no, on/off (case-insensitive)."
+    )
+
+
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
     # plugin calculates the minimal amount needed at startup.
@@ -40,14 +68,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
         "VLLM_METAL_MEMORY_FRACTION", "auto"
     ),
     # Whether to use MLX as the compute backend (default True).
-    "VLLM_METAL_USE_MLX": lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
+    "VLLM_METAL_USE_MLX": lambda: _bool_env("VLLM_METAL_USE_MLX", default=True),
     # MLX device type: "gpu" (default) or "cpu".
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
     # Enable verbose debug logging (default False).
-    "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
+    "VLLM_METAL_DEBUG": lambda: _bool_env("VLLM_METAL_DEBUG", default=False),
     # Use native Metal paged attention (default True).
-    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
-        os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"
+    "VLLM_METAL_USE_PAGED_ATTENTION": lambda: _bool_env(
+        "VLLM_METAL_USE_PAGED_ATTENTION", default=True
     ),
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the
@@ -62,8 +90,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MODELSCOPE_CACHE": lambda: os.getenv("VLLM_METAL_MODELSCOPE_CACHE"),
     # Enable lazy GDN kernels by default.
     # Set to "0" to force the eager conv / C++ recurrent fallback path.
-    "VLLM_METAL_GDN_LAZY_KERNELS": lambda: (
-        os.getenv("VLLM_METAL_GDN_LAZY_KERNELS", "1") == "1"
+    "VLLM_METAL_GDN_LAZY_KERNELS": lambda: _bool_env(
+        "VLLM_METAL_GDN_LAZY_KERNELS", default=True
     ),
     # Experimental MLA Metal decode kernel (RFC #360). Off by default —
     # the MLA wrapper uses the MLX SDPA per-request slow path unless
@@ -72,13 +100,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the kernel's instantiated specialization (kv_lora_rank=512,
     # qk_rope_head_dim=64, block_size ∈ {16, 32}, fp16/bf16,
     # decode-only).
-    "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
+    "VLLM_METAL_MLA_KERNEL": lambda: _bool_env("VLLM_METAL_MLA_KERNEL", default=False),
     # When set, compile the native _paged_ops extension from source at runtime
     # instead of loading the prebuilt artifact shipped in the wheel. Intended
     # for kernel developers / source installs; requires Xcode command-line
     # tools (clang++). Default off — release wheels ship the .so prebuilt.
-    "VLLM_METAL_BUILD_FROM_SOURCE": lambda: (
-        os.getenv("VLLM_METAL_BUILD_FROM_SOURCE", "0") == "1"
+    "VLLM_METAL_BUILD_FROM_SOURCE": lambda: _bool_env(
+        "VLLM_METAL_BUILD_FROM_SOURCE", default=False
     ),
     # Per-worker visible-device list set by vLLM's Ray executor (the
     # CUDA_VISIBLE_DEVICES analog for Metal; see MetalPlatform.device_control_env_var).


### PR DESCRIPTION
## Summary

- Centralize boolean env-var parsing in `vllm_metal/envs.py` behind a `_bool_env` helper.
- Accept `1`/`0`, `true`/`false`, `yes`/`no`, `on`/`off` — case-insensitive, surrounding whitespace ignored.
- Unset or empty (e.g. a docker-compose `VAR=${UNSET}` expansion) keeps the variable's default.
- Any other value now fails loudly instead of silently reading as false:
  `ValueError: Invalid VLLM_METAL_DEBUG='enabled'. Must be one of: 1/0, true/false, yes/no, on/off (case-insensitive).`
- Document accepted spellings in `docs/configuration.md`; add `tests/test_envs.py` (~180 parametrized cases across all six boolean vars).

Fixes #517.

## Why

`VLLM_METAL_USE_PAGED_ATTENTION=true` currently *disables* paged attention: every boolean var is compared with `== "1"`. All six parse sites live in the lazy registry in `vllm_metal/envs.py`, and every consumer reads the already-parsed bool, so the helper fixes the whole plugin in one place. Same shape as the merged ring-port validation (#462).

## Behavior changes (intended)

| Input | Before | After |
|---|---|---|
| `true` / `yes` / `on` (any case) | `False` | `True` |
| `false` / `no` / `off` (any case) | `False` | `False` (unchanged) |
| unset | default | default (unchanged) |
| set but empty / whitespace | `False`, even for default-true vars | default |
| anything else (`enabled`, `2`, …) | silently `False` | `ValueError` naming the var, raised at first read |

Notes:
- The error surfaces where the var is first read — engine startup for most vars; the first absorbed-MLA eligibility check for `VLLM_METAL_MLA_KERNEL`.
- vLLM's `compile_factors` calls registered getters inside `try/except`, so an invalid value additionally logs the "Skipping environment variable … while hashing compile factors" warning; the hard error still fires at real use.

Deliberately untouched: `VLLM_USE_MODELSCOPE` (vLLM's own `True`/`False` convention) and `MTL_CAPTURE_ENABLED` (Apple's `=1` convention). Possible follow-ups: a `docs/configuration.md` table row for `VLLM_METAL_BUILD_FROM_SOURCE`; a friendlier error for a non-integer `VLLM_METAL_RING_BASE_PORT`.

## Testing

- `ruff check .`, `ruff format --check .` (210 files clean), `mypy vllm_metal` — all green.
- `pytest tests/test_envs.py tests/test_config.py` — 199 passed.
- Full `pytest -m "not slow" tests/` locally: the only failures (104, all in native Metal-kernel tests) are byte-identical with and without this change on the same machine — pre-existing local-environment findings (no fresh native build), zero new failures.
- Behavior smokes: `VLLM_METAL_USE_MLX=yes` → `True`; `VLLM_METAL_USE_PAGED_ATTENTION=ON` → `True`; `VLLM_METAL_USE_MLX=` (empty) → `True` (default); `VLLM_METAL_DEBUG=enabled` → the `ValueError` above.

Picks up where #518/#519 (self-closed by their author, never reviewed) left off, as a fresh implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
