### PR TITLE
[Performance] Clear MLX cache after VLM warm-up

### DIFF
--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -89,14 +89,49 @@ class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())
 
-    def test_warm_up_propagates_dummy_forward_failure(self) -> None:
+    def test_warm_up_propagates_dummy_forward_failure(self, monkeypatch) -> None:
+        calls: list[str] = []
         runner = self._make_runner()
+        runner._multimodal_adapter = SimpleNamespace()
         runner._dummy_forward_outputs = Mock(
             side_effect=RuntimeError("dummy forward failed")
         )
+        monkeypatch.setattr(mr.mx, "get_cache_memory", lambda: 128)
+        monkeypatch.setattr(mr.mx, "clear_cache", lambda: calls.append("clear"))
 
         with pytest.raises(RuntimeError, match="dummy forward failed"):
             runner.warm_up()
+
+        assert calls == []
+
+    @pytest.mark.parametrize(
+        ("has_multimodal_adapter", "cache_bytes", "expected_clears"),
+        (
+            (True, 128, 1),
+            (True, 0, 0),
+            (False, 128, 0),
+        ),
+        ids=("multimodal-nonzero-cache", "multimodal-empty-cache", "text-only"),
+    )
+    def test_warm_up_clears_cache_only_for_multimodal_nonzero_cache(
+        self,
+        monkeypatch,
+        has_multimodal_adapter: bool,
+        cache_bytes: int,
+        expected_clears: int,
+    ) -> None:
+        calls: list[str] = []
+        runner = self._make_runner()
+        if has_multimodal_adapter:
+            runner._multimodal_adapter = SimpleNamespace()
+        runner._dummy_forward_outputs = Mock(return_value=[mx.array([1])])
+
+        monkeypatch.setattr(mr.mx, "get_cache_memory", lambda: cache_bytes)
+        monkeypatch.setattr(mr.mx, "clear_cache", lambda: calls.append("clear"))
+
+        runner.warm_up()
+
+        assert calls == ["clear"] * expected_clears
 
     def test_accumulates_streamed_segments(self, monkeypatch) -> None:
         captured: dict[str, object] = {}

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -763,6 +763,16 @@ class MetalModelRunner:
         if self._paged_attention_runtime is not None:
             self._paged_attention_runtime.warm_up()
 
+        if self._multimodal_adapter is not None:
+            cache_bytes = mx.get_cache_memory()
+            if cache_bytes == 0:
+                return
+            mx.clear_cache()
+            logger.info(
+                "MLX cache cleared after multimodal model warm-up (%d bytes)",
+                cache_bytes,
+            )
+
     def _make_sampling_metadata(
         self,
         sampling_params_list: list[SamplingParams],


### PR DESCRIPTION
## Summary

Closes #515.

This PR clears the MLX buffer cache once after a successful native VLM model
warm-up.
The guard is intentionally narrow:

- only applies when the runner has a native multimodal adapter;
- keeps text-only and STT paths unchanged;
- skips `mx.clear_cache()` when MLX reports zero cache memory;
- preserves the current fail-fast warm-up behavior from #510.

The goal is to reduce Qwen3-VL first-batch multimodal prefill / TTFT on memory-constrained Apple Silicon. This is not a decode-throughput optimization.
The code path applies to native multimodal adapters; the benchmark evidence
below is Qwen3-VL-only.

## Benchmark

Small paired ABBA benchmark from #515:

- Hardware: Apple Silicon M-series, 16 GiB unified memory, macOS 26.4
- Model: `mlx-community/Qwen3-VL-4B-Instruct-4bit`
- Workload: `random-mm`, `320x320`, `num_prompts=4`, `max_concurrency=4`, `random_input_len=32`, `random_output_len=1`
- Server: OpenAI chat endpoint, paged attention enabled, `VLLM_METAL_MEMORY_FRACTION=0.70`

Guarded cache-release result:

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Mean TTFT | 4038.35 ms | 2740.72 ms | -32.13% |

Pairwise TTFT changes:

| Pair | Baseline mean TTFT | Candidate mean TTFT | Change |
| --- | ---: | ---: | ---: |
| B1 vs A1 | 5444.45 ms | 3220.82 ms | -40.84% |
| B2 vs A2 | 3461.25 ms | 2952.95 ms | -14.69% |
| B3 vs A3 | 3209.34 ms | 2048.40 ms | -36.17% |

The candidate was faster in 3 / 3 paired rounds.
The second pair narrowly missed 15%, so the claim stays bounded to this Qwen3-VL first-batch TTFT / prefill workload.

Candidate server logs reported MLX cache bytes before `mx.clear_cache()`:

| Candidate run | MLX cache before clear |
| --- | ---: |
| B1 | 929205476 bytes |
| B2 | 618048892 bytes |
| B3 | 562477436 bytes |

Baseline has no corresponding value because it does not call `mx.get_cache_memory()` / `mx.clear_cache()` after warm-up.

The benchmark used `random_output_len=1`, so throughput movement is a consequence of lower TTFT. It should not be read as a decode throughput claim.

### Long-output TPOT no-regression check

I also ran a separate long-output ABBA check to avoid hiding a decode regression behind the TTFT-focused workload:

- Workload: `random-mm`, `320x320`, `num_prompts=4`, `max_concurrency=2`, `random_input_len=32`, `random_output_len=64`
- Ordering: A1, B1, B2, A2, A3, B3; every round restarted the server and used a separate port
- Validation: all runs completed `4 / 0`; candidate server logs showed the cache clear in all 3 candidate rounds

| Metric | Baseline mean | Candidate mean | Change |
| --- | ---: | ---: | ---: |
| Mean TTFT | 1802.56 ms | 1114.82 ms | -38.15% |
| Mean TPOT | 29.05 ms | 28.46 ms | -2.04% |
| P90 TPOT | 29.79 ms | 28.71 ms | -3.64% |
| Mean ITL | 28.82 ms | 28.24 ms | -2.04% |
| Mean E2EL | 3632.83 ms | 2907.77 ms | -19.96% |

Pairwise mean TPOT changes were `-4.15%`, `-1.88%`, and `+0.00%`; pairwise p90 TPOT changes were `-6.26%`, `-4.51%`, and `+0.08%`. This is a no-regression check only; the PR still does not claim decode throughput improvement.

## Tests

```bash
.venv-vllm-metal/bin/python -m pytest tests/test_v1_model_runner_generate.py -q
.venv-vllm-metal/bin/python -m pytest tests/multimodal/test_qwen3_vl.py tests/v1/mm/test_model_runner_multimodal_cache.py tests/test_v1_model_runner_generate.py -q
.venv-vllm-metal/bin/python -m ruff check vllm_metal/v1/model_runner.py tests/test_v1_model_runner_generate.py vllm_metal/multimodal/qwen3_vl/adapter.py tests/multimodal/test_qwen3_vl.py tests/v1/mm/test_model_runner_multimodal_cache.py
git diff --check
```

Local results:

- `tests/test_v1_model_runner_generate.py`: 48 passed
- related multimodal/model-runner suite: 117 passed
- ruff: passed
- `git diff --check`: passed

## Risk boundaries

- Benchmark sample is small: 4 prompts, synthetic `random-mm`, one image per request, low concurrency.
- The code affects native VLM adapters. The measured performance evidence is only for Qwen3-VL.
- Result may be strongest on 16 GiB Apple Silicon systems where MLX buffer-cache state affects the first real VLM requests.
- Larger images, mixed image sizes, longer prompts, or longer decode workloads may behave differently.
- The primary performance claim remains TTFT / prefill. The long-output check is only a TPOT no-regression guard, not a decode-throughput claim.
- `mx.get_cache_memory()` reports MLX buffer-cache bytes before the clear. This PR does not claim to fix a memory leak or release the same amount of system memory.
- Peak RSS is not claimed as improved; the long-output no-regression check showed grouped peak RSS at +3.49% for the candidate.
- This PR does not reintroduce the earlier vision-encoder batching candidate; that path did not show stable end-to-end TTFT gains in the same benchmark work.
