### PR TITLE
Fail fast on missing cached request state

### DIFF
--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
-from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 
 import vllm_metal.v1.model_runner as mr
@@ -424,6 +424,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
 
         assert captured["input_ids"] == [[6]]
         assert captured["decode_info"] == [([0, 1], 1, 1)]
+        assert runner._execute_model_state is not None
         assert runner._execute_model_state.cu_seqlens == [0, 1]
 
     def test_start_paged_forward_skips_hidden_states_without_drafts(
@@ -1221,7 +1222,7 @@ class TestV1MetalModelRunnerExecuteModel:
         finished_req_ids: set[str] | None = None,
         scheduled_spec_decode_tokens: dict[str, list[int]] | None = None,
         num_invalid_spec_tokens: dict[str, int] | None = None,
-        scheduled_new_reqs: list[SimpleNamespace] | None = None,
+        scheduled_new_reqs: list[NewRequestData] | None = None,
     ) -> SchedulerOutput:
         req_ids = cached_req_ids or []
         return SchedulerOutput(
@@ -1245,6 +1246,18 @@ class TestV1MetalModelRunnerExecuteModel:
             free_encoder_mm_hashes=[],
             preempted_req_ids=set(),
             has_structured_output_requests=False,
+        )
+
+    def _make_new_request(self, req_id: str = "new") -> NewRequestData:
+        return NewRequestData(
+            req_id=req_id,
+            prompt_token_ids=[1],
+            mm_features=[],
+            sampling_params=SamplingParams(),
+            pooling_params=None,
+            block_ids=([0],),
+            num_computed_tokens=0,
+            lora_request=None,
         )
 
     def test_returns_empty_output_directly_for_empty_batch(self) -> None:
@@ -1294,7 +1307,7 @@ class TestV1MetalModelRunnerExecuteModel:
         scheduler_output = self._make_scheduler_output(
             finished_req_ids={"done"},
             scheduled_spec_decode_tokens={"req-0": [7]},
-            scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+            scheduled_new_reqs=[self._make_new_request()],
         )
 
         with pytest.raises(NotImplementedError, match="requires paged attention"):
@@ -1326,11 +1339,11 @@ class TestV1MetalModelRunnerExecuteModel:
             ["r0"],
             scheduled_spec_decode_tokens={"r0": [-1]},
             num_invalid_spec_tokens={"r0": 1},
-            scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+            scheduled_new_reqs=[self._make_new_request()],
         )
         scheduler_output.num_scheduled_tokens = {"r0": 2, "new": 1}
         scheduler_output.total_num_scheduled_tokens = 3
-        scheduler_output.scheduled_cached_reqs.new_block_ids = [[[99]]]
+        scheduler_output.scheduled_cached_reqs.new_block_ids = [([99],)]
 
         with pytest.raises(NotImplementedError, match="scheduler-invalid"):
             runner.execute_model(scheduler_output)
@@ -1353,7 +1366,7 @@ class TestV1MetalModelRunnerExecuteModel:
             )
         )
         scheduler_output = self._make_scheduler_output(
-            scheduled_new_reqs=[SimpleNamespace(req_id="new")]
+            scheduled_new_reqs=[self._make_new_request()]
         )
 
         with pytest.raises(NotImplementedError, match="no-async-scheduling"):
@@ -1952,12 +1965,15 @@ class TestDummyForwardOutputsPPRouting:
         real_eval = mx.eval
         cache_readings = iter([100, 180])
         limits: list[int] = []
+
+        def eval_and_record(*arrays: object) -> None:
+            evaled.extend(arrays)
+            real_eval(*arrays)
+
         monkeypatch.setattr(mr.mx, "clear_cache", lambda: None)
         monkeypatch.setattr(mr.mx, "get_cache_memory", lambda: next(cache_readings))
         monkeypatch.setattr(mr.mx, "set_cache_limit", limits.append)
-        monkeypatch.setattr(
-            mr.mx, "eval", lambda *arrays: evaled.extend(arrays) or real_eval(*arrays)
-        )
+        monkeypatch.setattr(mr.mx, "eval", eval_and_record)
 
         overhead = runner.profile_run()
 

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1258,17 +1258,27 @@ class TestV1MetalModelRunnerExecuteModel:
         assert out.sampled_token_ids == []
         assert runner._pending_output is None
 
-    def test_non_paged_cached_request_without_state_emits_placeholder(self) -> None:
+    def test_non_paged_cached_request_without_state_raises(self) -> None:
         runner = self._make_runner()
 
-        out = runner.execute_model(self._make_scheduler_output(["req-0"]))
+        with pytest.raises(RuntimeError, match="req-0"):
+            runner.execute_model(self._make_scheduler_output(["req-0"]))
 
-        assert out is None
-        pending = runner.sample_tokens(grammar_output=None)
-        assert pending is not None
-        assert pending.req_ids == ["req-0"]
-        assert pending.req_id_to_index == {"req-0": 0}
-        assert pending.sampled_token_ids == [[0]]
+        assert runner._pending_output is None
+
+    def test_paged_cached_request_without_state_raises(self) -> None:
+        runner = self._make_runner()
+        runner._paged_attention_runtime = MHAPagedAttentionRuntime(
+            num_layers=1,
+            num_kv_heads=1,
+            head_dim=4,
+            block_size=4,
+            dtype=mx.float32,
+        )
+
+        with pytest.raises(RuntimeError, match="req-0"):
+            runner.execute_model(self._make_scheduler_output(["req-0"]))
+
         assert runner._pending_output is None
 
     def test_non_paged_spec_decode_fails_after_cleanup_before_new_state(self) -> None:

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1294,6 +1294,71 @@ class TestV1MetalModelRunnerExecuteModel:
 
         assert runner._pending_output is None
 
+    def test_missing_cached_request_fails_before_new_prefill(self, monkeypatch) -> None:
+        runner = self._make_runner()
+        monkeypatch.setattr(
+            runner,
+            "_prefill_single",
+            lambda *args, **kwargs: pytest.fail("prefill should not run"),
+        )
+        new_req = self._make_new_request()
+
+        with pytest.raises(RuntimeError, match="missing"):
+            runner.execute_model(
+                self._make_scheduler_output(
+                    ["missing"],
+                    scheduled_new_reqs=[new_req],
+                )
+            )
+
+        assert "new" not in runner._request_states
+        assert runner._pending_output is None
+
+    def test_missing_cached_request_materializes_released_gdn_state(self) -> None:
+        cache = GDNPagedStateCache(
+            num_layers=1,
+            max_seqs=2,
+            conv_kernel_dim=2,
+            conv_dim=4,
+            num_v_heads=1,
+            value_head_dim=4,
+            key_head_dim=32,
+            initial_seqs=0,
+            dtype=mx.float32,
+        )
+        runtime = HybridRuntimeStub(cache)
+        runner = make_stub_runner(_paged_attention_runtime=runtime)
+        runner._request_states["done"] = mr.RequestState(
+            token_ids=[1],
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(),
+            generator=None,
+            generated_tokens=0,
+        )
+        slot = runtime.gdn_state_manager.assign_step_slots(["done"])[0]
+        cache.set_pending_conv_state(0, [slot], mx.full((1, 1, 4), 7, dtype=mx.float32))
+        cache.set_pending_recurrent_state(
+            0,
+            [slot],
+            mx.full((1, 1, 4, 32), 9, dtype=mx.float32),
+        )
+
+        with pytest.raises(RuntimeError, match="missing"):
+            runner.execute_model(
+                self._make_scheduler_output(
+                    ["missing"],
+                    finished_req_ids={"done"},
+                )
+            )
+
+        assert not cache.has_pending_conv_state(0)
+        assert not cache.has_pending_recurrent_state(0)
+        mx.eval(cache.conv_states[0], cache.recurrent_states[0])
+        np.testing.assert_array_equal(np.array(cache.conv_states[0][slot]), 7)
+        np.testing.assert_array_equal(np.array(cache.recurrent_states[0][slot]), 9)
+        assert runtime.gdn_state_manager.needs_materialize is False
+
     def test_non_paged_spec_decode_fails_after_cleanup_before_new_state(self) -> None:
         runner = self._make_runner()
         runner._request_states["done"] = mr.RequestState(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -202,7 +202,6 @@ class _ExecutionBatch:
     new_reqs_by_id: dict[str, NewRequestData] = field(default_factory=dict)
     paged_prefill_entries: list[_PendingPrefillEntry] = field(default_factory=list)
     paged_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
-    scheduled_cached_req_ids: list[str] = field(default_factory=list)
     valid_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
 
     def add_output(
@@ -1885,20 +1884,10 @@ class MetalModelRunner:
     def _update_pp_stage_states(self, scheduler_output: SchedulerOutput) -> None:
         """Maintain ``_request_states`` on a non-last pipeline stage.
 
-        Only the last stage samples, and that is where the normal request-state
-        lifecycle is built (``_sample_paged_batch`` needs the sampled token). A
-        non-last stage would otherwise have no state and emit a placeholder for
-        every cached step in :meth:`_collect_cached_requests`, skipping the
-        forward + ``pipeline_send`` the downstream stage is blocked on (its ring
-        ``recv`` then trips the Metal command-buffer watchdog and aborts).
-
-        Mirror upstream vLLM's ``_update_states`` (``gpu_model_runner.py``, the
-        ``if not is_last_rank`` branch): seed state from the scheduler's
-        ``NewRequestData`` and advance it with the sampled tokens the scheduler
-        broadcasts in ``CachedRequestData.new_token_ids`` — the first stage never
-        samples, it reconstructs the token stream from the scheduler. Block ids
-        are left to :meth:`_update_cached_request_blocks`, which runs next and
-        already guards a missing state.
+        Non-last stages do not sample, so they mirror the scheduler token stream
+        to keep cached steps able to run forward and send activations downstream.
+        Cached-state presence is checked before model work; block ids are
+        updated later from cached scheduler metadata.
         """
         for new_req in scheduler_output.scheduled_new_reqs:
             token_ids = list(new_req.prompt_token_ids or [])
@@ -1915,9 +1904,7 @@ class MetalModelRunner:
         if not cached.new_token_ids:
             return
         for i, req_id in enumerate(cached.req_ids):
-            state = self._request_states.get(req_id)
-            if state is None:
-                continue
+            state = self._request_states[req_id]
             new_token_ids = cached.new_token_ids[i]
             # Append only the tokens not already reflected in token_ids (mirrors
             # upstream's num_new_tokens; tolerates >1 sampled token per step).
@@ -1939,9 +1926,7 @@ class MetalModelRunner:
             return
 
         for i, req_id in enumerate(cached_reqs.req_ids):
-            state = self._request_states.get(req_id)
-            if state is None:
-                continue
+            state = self._request_states[req_id]
 
             new_block_ids = cached_reqs.new_block_ids[i]
             resumed = req_id in cached_reqs.resumed_req_ids
@@ -1966,24 +1951,12 @@ class MetalModelRunner:
             return
 
         if self._paged_attention_runtime is None:
-            batch.scheduled_cached_req_ids.extend(cached_reqs.req_ids)
             for req_id in cached_reqs.req_ids:
-                state = self._request_states.get(req_id)
-                if state is not None:
-                    batch.valid_decode_reqs.append((req_id, state))
+                batch.valid_decode_reqs.append((req_id, self._request_states[req_id]))
             return
 
         for idx, req_id in enumerate(cached_reqs.req_ids):
-            state = self._request_states.get(req_id)
-            if state is None:
-                logger.warning(
-                    "Paged cached request %s has no RequestState; "
-                    "emitting placeholder token. This indicates scheduler/runner "
-                    "state desync.",
-                    req_id,
-                )
-                batch.add_output(req_id, [0])
-                continue
+            state = self._request_states[req_id]
 
             if state.generated_tokens == 0:
                 computed_tokens = cached_reqs.num_computed_tokens[idx]
@@ -2101,11 +2074,8 @@ class MetalModelRunner:
             pooler_output=batch.pooler_outputs,
         )
 
-    def _run_non_paged_decode_batch(
-        self,
-        batch: _ExecutionBatch,
-    ) -> None:
-        """Run non-paged decode work and append placeholder outputs as needed."""
+    def _run_non_paged_decode_batch(self, batch: _ExecutionBatch) -> None:
+        """Run non-paged decode work."""
         if batch.valid_decode_reqs:
             if len(batch.valid_decode_reqs) >= _MIN_BATCH_SIZE_FOR_BATCHING:
                 decode_result = self._batched_decode(batch.valid_decode_reqs)
@@ -2119,10 +2089,6 @@ class MetalModelRunner:
                     else None
                 )
                 batch.add_output(req_id, [decode_result.token_ids[i]], logprobs)
-
-        for req_id in batch.scheduled_cached_req_ids:
-            if req_id not in batch.req_id_to_index:
-                batch.add_output(req_id, [0])
 
     def _validate_scheduled_outputs(
         self,
@@ -2227,6 +2193,12 @@ class MetalModelRunner:
 
         self._free_encoder_outputs(scheduler_output.free_encoder_mm_hashes)
         evicted_req_ids = self._finished_req_ids(scheduler_output)
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        missing_cached_state_req_ids = [
+            req_id
+            for req_id in cached_reqs.req_ids
+            if req_id in evicted_req_ids or req_id not in self._request_states
+        ]
         has_scheduled_encoder_inputs = bool(scheduler_output.scheduled_encoder_inputs)
         spec_decode_error: Exception | None = None
         try:
@@ -2241,6 +2213,7 @@ class MetalModelRunner:
             has_scheduled_encoder_inputs
             or spec_decode_error is not None
             or has_unsupported_non_paged_structured_output
+            or bool(missing_cached_state_req_ids)
         )
 
         # Scheduler cleanup is independent of whether this step's work is
@@ -2252,6 +2225,12 @@ class MetalModelRunner:
             resumed_req_ids=scheduler_output.scheduled_cached_reqs.resumed_req_ids,
             materialize_runtime_state=will_fail_fast_before_model_work,
         )
+        if missing_cached_state_req_ids:
+            raise RuntimeError(
+                "Scheduled cached request(s) have no RequestState: "
+                f"{missing_cached_state_req_ids[:16]}. "
+                "This is a scheduler/runner state desync."
+            )
         # Pre-register mm_features so a new request whose first encoder input
         # lands in the same SchedulerOutput is already known to the encoder
         # cache when dispatch runs.
@@ -2284,7 +2263,6 @@ class MetalModelRunner:
         if is_non_last_stage(self.pp):
             self._update_pp_stage_states(scheduler_output)
 
-        cached_reqs = scheduler_output.scheduled_cached_reqs
         self._update_cached_request_blocks(cached_reqs)
         self._collect_cached_requests(batch, cached_reqs, scheduler_output)
 


### PR DESCRIPTION
This PR is:
- To stop returning token `0` when a cached request is missing runner state.
- To raise before new request setup, prefill, block updates, or model work.
- To still run lifecycle cleanup before raising, including hybrid GDN cleanup.
- To update the affected tests to use real scheduler DTOs.

Note: token `0` was used earlier as a placeholder to keep output shapes aligned. That is unsafe here because `0` is a real token, so it can hide a runner/scheduler state bug as normal output.
