### PR TITLE
Reject engine KV cache configs larger than the allocated Metal pool

### DIFF
--- a/tests/test_kv_cache_override_guard.py
+++ b/tests/test_kv_cache_override_guard.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guard against an engine KV cache config larger than the allocated pool."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tests.stub_runner import make_stub_runner
+
+
+def _make_policy(allocated_blocks: int | None):
+    """Build a stub runner whose paged runtime reports ``allocated_blocks``."""
+    runtime = (
+        None
+        if allocated_blocks is None
+        else SimpleNamespace(num_blocks=lambda: allocated_blocks)
+    )
+    runner = make_stub_runner(_paged_attention_runtime=runtime)
+    return runner._cache_policy
+
+
+def test_rejects_more_blocks_than_allocated() -> None:
+    """--num-gpu-blocks-override above the profiled capacity must fail fast."""
+    policy = _make_policy(1846)
+
+    with pytest.raises(ValueError, match="cannot grow it afterwards"):
+        policy.initialize_kv_cache(SimpleNamespace(num_blocks=999999))
+
+
+def test_accepts_matching_block_count() -> None:
+    """The normal round-trip, where the engine echoes the allocated count."""
+    policy = _make_policy(1846)
+
+    policy.initialize_kv_cache(SimpleNamespace(num_blocks=1846))
+
+
+def test_accepts_fewer_blocks_than_allocated() -> None:
+    """A smaller override only wastes memory; it is not unsafe."""
+    policy = _make_policy(1846)
+
+    policy.initialize_kv_cache(SimpleNamespace(num_blocks=512))
+
+
+def test_noop_without_paged_runtime() -> None:
+    """Non-paged paths have no pool to validate against."""
+    policy = _make_policy(None)
+
+    policy.initialize_kv_cache(SimpleNamespace(num_blocks=999999))

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -311,7 +311,24 @@ class ModelCachePolicy:
         return specs
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
-        """Accept engine KV cache config for API compatibility."""
+        """Accept engine KV cache config for API compatibility.
+
+        MLX owns the paged pool, which was already allocated from the
+        profiled capacity in ``setup_paged_attention``.  The engine's block
+        count normally round-trips back to that same number, but
+        ``--num-gpu-blocks-override`` replaces it after the fact, so verify
+        the engine is not planning against more blocks than exist.
+        """
+        runtime = self._runner.paged_attention_runtime
+        if runtime is not None and kv_cache_config.num_blocks > runtime.num_blocks():
+            raise ValueError(
+                f"Engine KV cache config requests {kv_cache_config.num_blocks} "
+                f"blocks but the Metal paged pool was allocated with "
+                f"{runtime.num_blocks()}. vllm-metal sizes its pool from "
+                "available Metal memory and cannot grow it afterwards. If "
+                "--num-gpu-blocks-override is set, lower or remove it; "
+                "otherwise this is a capacity-accounting bug, please report it."
+            )
         logger.info(
             "KV cache config received: %d blocks (MLX manages cache internally)",
             kv_cache_config.num_blocks,


### PR DESCRIPTION
## Summary

Fixes #526.

`--num-gpu-blocks-override` is honored by the vLLM scheduler but never reaches vllm-metal's paged KV allocator, so an override above the profiled capacity lets the engine plan against blocks that were never allocated.

The Metal pool is sized and allocated during capacity profiling (`setup_paged_attention` → `backend.initialize(plan.num_blocks)`), and the planner reports that capacity back to the engine as a byte count. That number normally round-trips exactly, so the engine's block count matches what MLX allocated — which is why `initialize_kv_cache` being a no-op has been safe so far.

The override breaks the round trip. vLLM applies it in `may_override_num_blocks` (`vllm/v1/core/kv_cache_utils.py:940-947`) *after* the byte count is converted back to blocks, and rewrites `available_memory` to `override * bytes_per_block` (`kv_cache_utils.py:2076`) so core's own `_check_enough_kv_cache_memory` cannot catch the discrepancy either. Nothing reconciled the two numbers.

The scheduler then issues block IDs past the end of the allocated MLX arrays. `reshape_and_cache.metal:62-65` guards only `slot_idx < 0` for padding and is never passed `num_blocks`, so the result is an out-of-bounds device write rather than a diagnosable error.

This validates the engine's block count against the allocated pool in `initialize_kv_cache` and fails with an actionable message. The runtime is already installed by that point, so the check is local and cheap.

Design notes:

- **Fail fast rather than clamp.** Silently clamping would leave `cache_config.num_gpu_blocks` disagreeing with the scheduler's block pool — the same class of mismatch, just quieter.
- **Smaller overrides stay allowed.** They only waste Metal memory; they are not unsafe.
- **Sizing the pool from the override** (threading it into `_paged_attention_plan`) would be the fuller fix, but it is a larger design change and I did not want to bundle it with the safety guard. Happy to follow up if you'd prefer that shape instead.

## Round-trip coverage

I checked that the guard cannot fire without an override, by driving `vllm.v1.core.kv_cache_utils.get_kv_cache_configs` with metal-shaped specs against a 1000-block pool:

| layout | engine `num_blocks` | vs pool |
| --- | ---: | ---: |
| uniform full attention (36L) | 1000 | 1.00x |
| per-layer shapes → `UniformTypeKVCacheSpecs` (60L) | 1000 | 1.00x |
| MLA (61L) | 500 | 0.50x |
| YOCO (32 spec / 24 cache layers) | 750 | 0.75x |
| hybrid GDN, linear-majority (24/24, 12/36, 20/28, ...) | 714-1000 | ≤ 1.00x |

Every layout vllm-metal can actually produce lands at or below the pool, so the exact round trip holds where it matters and the other paths are strictly conservative. The null-block reservation from #513 patches `_estimate_max_model_len_from_groups` only and never touches the `available_memory` feeding `get_kv_cache_config_from_groups`, so it does not perturb this. Spec-decode drafters, PP, turboquant, and sliding window all move the ratio down. STT and non-paged paths leave `runtime is None`, so the guard is skipped.

One synthetic shape does exceed the pool without an override — attention-majority hybrid GDN (e.g. 36 attn / 12 mamba → 3.00x), because `get_cache_block_size_bytes()` counts only `num_sdpa_layers` for hybrids while vLLM's grouping divides by `min(n_attn, n_mamba)`. vllm-metal derives hybrid layout from `full_attention_interval`, so `n_attn <= n_mamba` always holds and this is unreachable today. Failing there would still be *correct* — the engine really would oversubscribe 3x — so I worded the error so it does not misattribute the cause when no override is set.

Separately, that table shows hybrid/MLA/YOCO capacity accounting is lossy in the conservative direction (MLA reports half the pool; hybrid 20/28 wastes ~29%). That is pre-existing and out of scope here; happy to open a follow-up issue if useful.

## Reproduction

No inference request is needed — the startup log alone shows the divergence:

```console
$ vllm serve mlx-community/Qwen2.5-3B-Instruct-4bit \
    --max-model-len 1024 --gpu-memory-utilization 0.15 \
    --num-gpu-blocks-override 999999
```

Before this change:

```
[cache_policy.py:610] Paged attention enabled: 36 layers patched, 1846 blocks allocated (block_size=16, ...)
[cache_policy.py:651] Paged attention: reporting MPS cache capacity (1846 blocks × 589824 bytes = 1.09 GB)
[kv_cache_utils.py:2146] GPU KV cache size: 15,999,984 tokens
[kv_cache_utils.py:2147] Maximum concurrency for 1,024 tokens per request: 15624.98x
[cache_policy.py:315] KV cache config received: 999999 blocks (MLX manages cache internally)
```

The pool holds 1846 blocks; the engine proceeds with 999999 — a 541x oversubscription — and the server starts and reports healthy. After this change, startup aborts with:

```
ValueError: Engine KV cache config requests 999999 blocks but the Metal paged pool
was allocated with 1846. This usually means --num-gpu-blocks-override exceeds the
profiled capacity; vllm-metal sizes its pool from available Metal memory and cannot
grow it afterwards. Lower or remove the override.
```

I did not drive traffic through the pre-fix configuration, since the expected outcome is an out-of-bounds GPU write.

## Tests

Adds `tests/test_kv_cache_override_guard.py` covering the four cases: oversized config rejected, exact round-trip accepted, smaller override accepted, and no-op when no paged runtime is installed.

```console
$ pytest tests/test_kv_cache_override_guard.py -q
4 passed

$ pytest tests/test_v1_worker.py tests/test_per_layer_kv_cache.py tests/test_block_size_translation.py -q
36 passed
```

`ruff check` and `ruff format --check` pass on both changed files. `mypy vllm_metal/v1/cache_policy.py` reports no new errors (the 4 pre-existing errors are in `vllm_metal/gguf/mlx_native.py`).

Tested on an M4 Mac mini, macOS 15.7.4, MLX 0.32.0, vLLM 0.25.1.

