### PR TITLE
Describe the KV layout that was actually allocated for MLA and YOCO

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -59,6 +59,7 @@ def make_stub_runner(
         "_logitsprocs": None,
         "_structured_output_applier": MetalStructuredOutputApplier(),
         "_lora": MetalLoRARuntime(),
+        "_yoco_cache_mapping": None,
         "model_args": _model_args,
     }
 

--- a/tests/test_kv_cache_spec_capacity.py
+++ b/tests/test_kv_cache_spec_capacity.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The scheduler-visible spec must describe the pool that was allocated."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import torch
+from vllm.v1.core.kv_cache_utils import get_uniform_page_size
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec
+
+from tests.stub_runner import make_stub_runner
+
+BLOCK_SIZE = 16
+DTYPE = torch.bfloat16
+POOL_BLOCKS = 1000
+
+
+def _engine_blocks(specs: dict, metal_per_block: int) -> int:
+    """Replicate vLLM's sizing: available_memory // page_size // group_size."""
+    available = POOL_BLOCKS * metal_per_block
+    return available // get_uniform_page_size(list(specs.values())) // len(specs)
+
+
+def _policy(*, num_layers, is_mla=False, yoco=None, num_kv_heads=4, head_dim=256):
+    # ``is_mla``/``is_hybrid`` are derived from the model config, not settable.
+    model_args = {"kv_lora_rank": head_dim} if is_mla else {}
+    runner = make_stub_runner(
+        model_args=model_args,
+        num_layers=num_layers,
+        _yoco_cache_mapping=yoco,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        kv_cache_dtype=mx.bfloat16,
+        cache_config=SimpleNamespace(block_size=BLOCK_SIZE),
+        kv_heads_per_layer=None,
+        head_dim_per_layer=None,
+    )
+    return runner._cache_policy
+
+
+def test_mla_spec_matches_single_latent_cache() -> None:
+    """MLA stores one latent tensor, so its spec must not bill K and V."""
+    layers, latent = 61, 576
+    policy = _policy(num_layers=layers, is_mla=True, head_dim=latent, num_kv_heads=1)
+    specs = policy.get_kv_cache_spec()
+
+    assert all(isinstance(s, MLAAttentionSpec) for s in specs.values())
+
+    # _kv_factor() == 1 for MLA
+    metal_per_block = 1 * BLOCK_SIZE * DTYPE.itemsize * layers * 1 * latent
+    assert _engine_blocks(specs, metal_per_block) == POOL_BLOCKS
+
+
+def test_yoco_shared_layers_get_no_spec() -> None:
+    """Only the layers that own a cache may appear in the spec."""
+    layers, owned = 35, 15
+    policy = _policy(num_layers=layers, yoco=(owned, list(range(owned))))
+    specs = policy.get_kv_cache_spec()
+
+    assert len(specs) == owned
+
+    metal_per_block = 2 * BLOCK_SIZE * DTYPE.itemsize * owned * 4 * 256
+    assert _engine_blocks(specs, metal_per_block) == POOL_BLOCKS
+
+
+def test_plain_attention_spec_is_unchanged() -> None:
+    """Non-MLA, non-YOCO models keep emitting one FullAttentionSpec per layer."""
+    layers = 36
+    policy = _policy(num_layers=layers)
+    specs = policy.get_kv_cache_spec()
+
+    assert len(specs) == layers
+    assert all(type(s) is FullAttentionSpec for s in specs.values())
+
+    metal_per_block = 2 * BLOCK_SIZE * DTYPE.itemsize * layers * 4 * 256
+    assert _engine_blocks(specs, metal_per_block) == POOL_BLOCKS

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -10,7 +10,12 @@ from typing import TYPE_CHECKING, Literal
 import mlx.core as mx
 import torch
 from vllm.logger import init_logger
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpec
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    MLAAttentionSpec,
+)
 
 from vllm_metal.attention.caches.turboquant import (
     BLOCK_SIZE as TQ_BLOCK_SIZE,
@@ -273,8 +278,17 @@ class ModelCachePolicy:
         use_turboquant = self._use_turboquant(config)
 
         kv_heads, head_dims = self._cache_layer_shapes(self._runner.num_layers)
+        # Under YOCO KV sharing only the leading ``num_cache_layers`` layers own
+        # a cache; the trailing ones reuse it (see ``_mha_cache_layout``, whose
+        # mapping assigns the owners first).  Emit no spec for the sharers, so
+        # the engine sizes against the layers that were actually allocated --
+        # the same way upstream expresses sharing by omission in
+        # ``GPUModelRunner.get_kv_cache_spec``.
+        num_spec_layers = self._runner.num_layers
+        if self._runner._yoco_cache_mapping is not None:
+            num_spec_layers, _ = self._runner._yoco_cache_mapping
         specs: dict[str, KVCacheSpec] = {}
-        for layer_idx in range(self._runner.num_layers):
+        for layer_idx in range(num_spec_layers):
             if (
                 self._runner.is_hybrid
                 and layer_idx not in self._runner.sdpa_layer_indices
@@ -301,7 +315,16 @@ class ModelCachePolicy:
                 )
             else:
                 layer_name = f"layers.{layer_idx}.self_attn"
-                specs[layer_name] = FullAttentionSpec(
+                # MLA caches a single latent tensor per layer, not separate K
+                # and V (see ``MLAPagedLatentCache``), which is why
+                # ``_kv_factor`` bills it at 1.  ``FullAttentionSpec`` hardcodes
+                # the 2x K/V factor in ``real_page_size_bytes``, so describing
+                # MLA with it makes the engine halve the block count it plans
+                # against relative to the pool actually allocated.
+                spec_cls = (
+                    MLAAttentionSpec if self._runner.is_mla else FullAttentionSpec
+                )
+                specs[layer_name] = spec_cls(
                     block_size=block_size,
                     num_kv_heads=kv_heads[layer_idx],
                     head_size=head_dims[layer_idx],

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -589,7 +589,7 @@ class ModelCachePolicy:
     def _kv_factor(self) -> int:
         return 1 if self._runner.is_mla else 2
 
-    def _mha_cache_layout(self) -> tuple[int, list[int] | None]:
+    def _mha_cache_layout(self) -> tuple[int, dict[int, int] | None]:
         if self._runner._yoco_cache_mapping is None:
             return self._runner.num_kv_cache_layers, None
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -358,6 +358,12 @@ class MetalModelRunner:
         # Structured-output bitmask applier for the paged path.
         self._structured_output_applier = MetalStructuredOutputApplier()
 
+        # YOCO layer->cache mapping, replaced by _install_yoco_cache_mapping
+        # during model load.  Declared here so readers can treat it as always
+        # present: it is consulted on the KV-sizing path, which runs for every
+        # model, not only the YOCO ones that install a real mapping.
+        self._yoco_cache_mapping: tuple[int, dict[int, int]] | None = None
+
     @property
     def is_mla(self) -> bool:
         """Whether the model uses Multi-head Latent Attention (MLA).


### PR DESCRIPTION
## Purpose

Fixes #528.

`determine_available_memory` reports the paged pool to the engine as a **byte budget**, and vLLM converts it back to a block count by dividing by the page size its own specs imply (`kv_cache_utils.py:967-987`). For uniform attention both sides agree and the count round-trips exactly. For MLA and YOCO, `get_kv_cache_spec` describes a layout the plugin does not allocate, so the engine plans against a fraction of the pool while the Metal buffers sit allocated and unreachable.

**MLA.** `MLAPagedLatentCache` allocates a single latent tensor per layer (`attention/caches/mla_cache.py:37`) — which is why `_kv_factor()` bills it at 1 (`cache_policy.py:566-567`). But `get_kv_cache_spec` emitted a plain `FullAttentionSpec`, whose `real_page_size_bytes` hardcodes the 2x K/V factor (`vllm/v1/kv_cache_interface.py:196-202`). vLLM's divisor came out twice the truth and halved the block count.

This emits `MLAAttentionSpec` instead — upstream's class for exactly this layout, which omits the `2 *` (`kv_cache_interface.py:363`). It is registered with `FullAttentionManager` and `uniform_type_base_spec=FullAttentionSpec` (`single_type_kv_cache_manager.py:1539`) and is included in the block-table / prefix-caching type checks (`:274,307`), so grouping and addressing are unchanged. The MLA-specific group-splitting path is gated on `SlidingWindowMLASpec`, which this never emits. Fields are left at their defaults — `cache_dtype_str`, `alignment`, `compress_ratio` are DeepSeek-V3.2/V4 FlashMLA concerns and are inert here.

`TurboQuantAttentionSpec`'s own docstring already cites `MLAAttentionSpec` as the pattern it mirrors (`cache_policy.py:65-66`); this applies the same pattern to MLA itself.

**YOCO.** Only the leading `num_cache_layers` own a cache and the rest reuse it (`_mha_cache_layout`, `cache_policy.py:569-579`; `model_lifecycle.py:360-362`), but a spec was emitted for every layer, so `group_size` counted layers that hold nothing.

This emits specs only for the owning layers, mirroring upstream, which expresses sharing by omission — `GPUModelRunner.get_kv_cache_spec` skips such layers "*so that KV cache management logic will act as this layer does not exist*" (`vllm/v1/worker/gpu_model_runner.py:7574-7585`). `initialize_kv_cache` consumes only `kv_cache_config.num_blocks` and ignores `kv_cache_groups`/`layer_names` (`cache_policy.py:313-334`), and MLX routes layers via its own `cache_idx_map`, so dropping the shared layer names changes no addressing. `build_yoco_cache_mapping` assigns owners first, so the sharers are exactly the trailing layers and `_cache_layer_shapes` already slices `[:num_cache_layers]`.

Deliberately **not** changing the byte budget: it is physically correct, and inflating it would encode a known-false figure into `estimate_max_model_len` and the breakdown log at `cache_policy.py:668-674`.

## Test Plan

New `tests/test_kv_cache_spec_capacity.py` asserts the spec describes the pool that was allocated, by replicating vLLM's sizing (`available // page_size // group_size`) against a fixed 1000-block pool:

- `test_mla_spec_matches_single_latent_cache` — MLA emits `MLAAttentionSpec` and round-trips
- `test_yoco_shared_layers_get_no_spec` — only owning layers appear
- `test_plain_attention_spec_is_unchanged` — the common path is untouched

```bash
pytest tests/test_kv_cache_spec_capacity.py -q
pytest tests/test_v1_worker.py tests/test_per_layer_kv_cache.py tests/test_kv_cache_override_guard.py -q
```

## Test Result

Engine `num_blocks` against a 1000-block pool:

| layout | before | after |
|---|---:|---:|
| MLA, 61L latent 576 | 500 (0.500) | **1000** |
| YOCO — Gemma4 E2B (35L, 15 owning) | 428 (0.428) | **1000** |
| YOCO — Gemma4 E4B (42L, 24 owning) | 571 (0.571) | **1000** |
| uniform full attention, 36L | 1000 | 1000 (unchanged) |

Without the fix the new tests fail as expected (`assert 35 == 15`). With it: `3 passed`. Regression set: `28 passed`. `ruff check` and `ruff format --check` clean on both files.

I also verified the hybrid path is unaffected by actually serving `Qwen/Qwen3.5-0.8B` — 308 blocks allocated, 308 received by the engine, exact round-trip.

**Validated on real weights** (M1 Max 64 GB, macOS 15.7.1): `mlx-community/MiniCPM3-4B-4bit` goes 0.500 → 1.000 and `mlx-community/gemma-4-e2b-it-4bit` goes 0.4286 → 1.000, with max concurrency at 4,096 tokens rising 75.19x → 150.02x and 123.18x → 287.43x. Outputs are identical before and after, and 24 concurrent requests completed cleanly against each. Measured numbers are in the comment below.
