### PR TITLE
feat: KV offloading for the Metal backend (pageable host pool, disk tier, cross-restart reuse)

### DIFF
--- a/docs/offload-architecture.mmd
+++ b/docs/offload-architecture.mmd
@@ -1,0 +1,112 @@
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "fontFamily": "'Red Hat Text', Arial, Helvetica, sans-serif",
+    "fontSize": "14px",
+    "primaryColor": "#d9dee5",
+    "primaryTextColor": "#1f2933",
+    "primaryBorderColor": "#5c6670",
+    "lineColor": "#667384",
+    "textColor": "#1f2933",
+    "clusterBkg": "#edf0f4",
+    "clusterBorder": "#95a0ae",
+    "edgeLabelBackground": "#eef1f4",
+    "titleColor": "#1f2933"
+  },
+  "flowchart": {
+    "curve": "basis",
+    "nodeSpacing": 70,
+    "rankSpacing": 85,
+    "padding": 12
+  }
+}}%%
+flowchart TB
+  %% Edge semantics: -->  control flow (per-step decisions)
+  %%                 ==>  data flow (KV block bytes)
+  %%                 -.-> config / startup wiring
+
+  subgraph CONFIG["<b>Config / plan time</b>"]
+    PLAT["MetalPlatform<br/>check_and_update_config guards"]
+    CLAMP["compute_safe_kv_budget<br/>hard fit + free-RAM floor"]
+  end
+
+  subgraph PROC["<b>Single engine process</b> — uni executor enforced"]
+    subgraph SS["<b>Scheduler half</b> · control plane"]
+      SCHED["OffloadingConnectorScheduler<br/>lookup accounting, job construction"]
+      TIER["TieringOffloadingManager<br/>CPU + secondary tier orchestration"]
+      MGR["CPUOffloadingManager<br/>block pool, LRU/ARC"]
+      FST["MetalFileSystemTierManager<br/>F_NOCACHE, 0600, .noindex, QoS,<br/>CRC32-verified blocks"]
+    end
+
+    subgraph WS["<b>Worker half</b> · data plane"]
+      CONN["MetalOffloadingConnector<br/>overrides register_kv_caches only"]
+      SPEC["Metal(Tiering)OffloadingSpec<br/>worker from live MLX cache"]
+      WKR["MetalKVOffloadWorker<br/>sync gather / eval / scatter"]
+      GPU["Wired MLX paged KV cache<br/>non-pageable, hard-capped"]
+    end
+
+    REG["MetalSharedOffloadRegion<br/>anonymous RAM host pool, pageable<br/>one buffer, both halves"]
+  end
+
+  subgraph PERSIST["<b>Persistent store</b> — outlives the process"]
+    DISK["NVMe block store<br/>hash-named files, PYTHONHASHSEED-keyed"]
+  end
+
+  %% Config-time / startup wiring
+  PLAT -.->|"rewrites connector,<br/>injects spec_name"| CONN
+  PLAT -.->|"enforces uni executor"| PROC
+  PLAT -.->|"plans wired KV budget"| CLAMP
+  CLAMP -.->|"caps wired cache size"| GPU
+  CONN -.->|"register_kv_caches<br/>at startup"| SPEC
+  SPEC -.->|"builds the<br/>worker"| WKR
+  SPEC -.->|"carves host-pool<br/>views"| REG
+
+  %% Control flow: lookup -> hit/miss -> promotion -> retry
+  SCHED -->|"1: block-hash lookup"| TIER
+  TIER -->|"2: CPU pool hit/miss"| MGR
+  TIER -->|"3: miss — probe disk"| FST
+  TIER -->|"4: promoted, retry<br/>next step"| SCHED
+  SCHED -->|"5: submit_store /<br/>submit_load"| WKR
+
+  %% Data flow: worker mediates GPU<->RAM
+  GPU ==>|"store: gather,<br/>deferred<br/>post-sampling"| WKR
+  WKR ==>|"scatter + rebind,<br/>pre-forward"| GPU
+  WKR ==>|"strided write<br/>into rows"| REG
+  REG ==>|"load:<br/>read rows"| WKR
+
+  %% Data flow: fs tier mediates RAM<->disk via memoryview
+  REG ==>|"spill: rows via<br/>memoryview"| FST
+  FST ==>|"write-through<br/>block files"| DISK
+  DISK ==>|"read block file"| FST
+  FST ==>|"promote: rows via<br/>memoryview"| REG
+
+  subgraph LEG["<b>Legend</b>"]
+    direction LR
+    L1["Inherited upstream"]:::upstream
+    L2["Metal — this PR"]:::metalNew
+    L3["vllm-metal pre-existing"]:::metalBase
+    L4["Persistent store"]:::persistent
+    LC1["·"]:::ghost -->|"control"| LC2["·"]:::ghost
+    LD1["·"]:::ghost ==>|"KV block bytes"| LD2["·"]:::ghost
+    LK1["·"]:::ghost -.->|"config / startup"| LK2["·"]:::ghost
+  end
+
+  %% Provenance / semantics — color encodes origin only
+  classDef upstream fill:#d9dee5,stroke:#5c6670,stroke-width:1.5px,color:#1f2933
+  classDef metalNew fill:#bcd8f6,stroke:#1d5fae,stroke-width:1.5px,color:#0f2a4d
+  classDef metalBase fill:#f9e3b0,stroke:#9c6d12,stroke-width:1.5px,color:#3f2d06
+  classDef persistent fill:#e2daf2,stroke:#63519e,stroke-width:1.5px,color:#29204e,stroke-dasharray:6 4
+  classDef ghost fill:#eef1f4,stroke:#95a0ae,stroke-width:1px,color:#667384
+
+  class SCHED,MGR,TIER,L1 upstream
+  class CONN,SPEC,WKR,REG,FST,PLAT,CLAMP,L2 metalNew
+  class GPU,L3 metalBase
+  class DISK,L4 persistent
+
+  %% Boundaries: process boundary reads heavier; halves are cards inside it
+  style PROC fill:#e2e7ee,stroke:#3d4c60,stroke-width:2px
+  style SS fill:#edf0f4,stroke:#95a0ae,stroke-width:1.25px
+  style WS fill:#edf0f4,stroke:#95a0ae,stroke-width:1.25px
+  style CONFIG fill:#edf0f4,stroke:#95a0ae,stroke-width:1.25px
+  style PERSIST fill:#ece5f6,stroke:#63519e,stroke-width:1.5px,stroke-dasharray:6 4
+  style LEG fill:#edf0f4,stroke:#95a0ae,stroke-width:1px

--- a/docs/offload-design.md
+++ b/docs/offload-design.md
@@ -1,0 +1,432 @@
+# KV offloading connector for the Metal backend — design
+
+Status: design accepted, implementation in progress (branch `kv-offload-metal`).
+Target: vLLM 0.25.1's `OffloadingConnector` (`--kv-offloading-backend native
+--kv-offloading-size N`) working on Apple Silicon, upstreamable to
+vllm-project/vllm-metal.
+
+## 1. Why offloading makes sense on unified memory
+
+Apple Silicon has one DRAM pool, so "GPU→CPU offload" sounds like a no-op. It
+isn't, because vllm-metal's KV pool is **wired** (non-pageable): the worker
+calls `mx.set_wired_limit` (`vllm_metal/utils.py:56`) and the paged cache is
+budgeted against `max_recommended_working_set_size × VLLM_METAL_MEMORY_FRACTION`
+(`vllm_metal/v1/cache_policy.py:680-709`). The tiers on this platform are:
+
+1. **Wired MLX KV pool** — fast, protected, hard-capped.
+2. **Pageable host memory** (plain `numpy` allocations) — same DRAM, but macOS
+   can reclaim it under pressure; it extends KV capacity beyond the wired cap.
+3. **NVMe disk** (via vLLM's tiering/`fs` secondary tier) — capacity beyond RAM
+   and persistence; Apple NVMe at 5–8 GB/s beats long-prefix recompute.
+
+A note on vocabulary: upstream names the primary offload target the "CPU
+tier" (`CPUOffloadingSpec`, `CPULoadStoreSpec`, `medium() == "CPU"`). That
+device-vs-host framing is wrong for any shared-memory architecture — Apple
+Silicon here, and equally unified-memory machines like NVIDIA DGX Spark
+(Grace-class): there is no second memory, only the wired/pageable boundary
+above. This port keeps upstream's names at the code level to stay a
+minimal-surface change; prose in this document says "host pool" and means
+tier 2. A restore from the host pool saves prefill *compute*, not memory-bus
+distance — that is the entire economics of offloading on this platform.
+
+## 2. What vLLM already provides (all reusable, verified on 0.25.1)
+
+The connector splits into a scheduler half and a worker half; both are
+instantiated from the same class by role
+(`vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py:46`).
+
+Platform-agnostic and reused as-is:
+
+- **Scheduler half** — `OffloadingConnectorScheduler`: lookup/hit accounting,
+  load/store job construction, `jobs_to_flush` fencing. Needs only
+  `spec.get_manager()`.
+- **`CPUOffloadingManager`** (`vllm/v1/kv_offload/cpu/manager.py`) — block
+  pool, ref-counts, LRU/ARC policies, store-threshold filter. Pure Python over
+  block ids and hash bytes.
+- **`OffloadingWorker`** (`vllm/v1/kv_offload/base.py`) — the abstract worker
+  contract (`submit_store`/`submit_load`/`get_finished`/`wait`); the connector
+  worker holds one worker directly and submits jobs to it — no
+  `(src, dst)`-medium routing.
+- **`OffloadingConnectorWorker`** — job bookkeeping, deferred stores,
+  `finished_recving` reporting, bandwidth stats.
+- **Spec/factory plumbing** — `OffloadingSpecFactory` resolves
+  `kv_connector_extra_config["spec_name"]` (default `CPUOffloadingSpec`) with a
+  `spec_module_path` dynamic-import fallback (`vllm/v1/kv_offload/factory.py:37-45`)
+  — an extension hook that requires **zero vLLM edits**.
+- **CLI translation** — `--kv-offloading-size N` + backend `native` →
+  `kv_connector="OffloadingConnector"`, `kv_role="kv_both"`,
+  `extra_config["cpu_bytes_to_use"] = N GiB` (`vllm/config/vllm.py:785-799`).
+- **Tiering** — `TieringOffloadingSpec` + `FileSystemTierManager`
+  (`vllm/v1/kv_offload/tiering/fs/manager.py`) give a disk tier whose I/O path
+  is platform-agnostic (`O_DIRECT` degrades to buffered on macOS). M2 target.
+
+The **only CUDA-bound pieces** are:
+
+- `CPUOffloadingSpec.get_worker` hard-raises unless
+  `is_cuda_alike() or is_xpu()` (`vllm/v1/kv_offload/cpu/spec.py:146-150`).
+- The copy engine `vllm/v1/kv_offload/cpu/gpu_worker.py` — CUDA streams,
+  events, `cudaHostRegister`, `swap_blocks_batch` (`cuMemcpyBatchAsync`),
+  Triton UVA kernel.
+- `SharedOffloadRegion` — Linux `/dev/shm` mmap (no macOS equivalent needed:
+  single-process, plain host allocations suffice).
+- Worker-side canonicalization
+  (`.../kv_connector/v1/offloading/worker.py:50-222`): reinterprets each
+  layer's **torch** KV tensor as an int8 `(num_blocks, page_size_bytes)`
+  storage view.
+
+## 3. Why the torch canonicalization cannot be reused on Metal
+
+vllm-metal's paged KV cache is **per-layer MLX arrays**
+(`vllm_metal/attention/caches/kv_cache.py:34`):
+
+- `key_caches[L]` and `value_caches[L]` are **separate** arrays of shape
+  `(num_blocks, block_size, kv_heads, head_dim)` (fp16/bf16/fp32); TurboQuant
+  adds packed K/V plus three fp16 scale/zero arrays per layer.
+- vLLM's canonical contract wants **one** tensor per layer where one block =
+  `page_size_bytes` **contiguous** bytes covering K and V. Two separate arrays
+  can never satisfy that; a layout change to interleave K/V per block would
+  invalidate the Metal attention kernels.
+- The KV write kernels (`reshape_and_cache`, `tq_encode`,
+  `vllm_metal/attention/impls/sdpa.py:524-557`) mutate the underlying Metal
+  buffers **in place** but return *new* `mx.array` objects (fresh lazy-graph
+  provenance) that are rebound onto `kv_cache.key_caches[L]` every layer call.
+  A torch tensor aliasing the buffer would (a) not see graph provenance, so
+  reads race pending writes, and (b) pin an extra reference that defeats MLX
+  donation. Aliasing is out.
+
+Therefore: **keep vLLM's scheduler half, manager, and worker orchestration;
+replace only the registration entry point and the copy engine with
+MLX-native code.** All block-movement decisions stay upstream; vllm-metal
+contributes a data mover.
+
+## 4. Architecture
+
+New package `vllm_metal/v1/kv_offload/` with three pieces, plus small hooks in
+platform/worker/model-runner:
+
+```
+vLLM scheduler process                 Metal worker (same proc under "uni" executor)
+──────────────────────                 ─────────────────────────────────────────────
+OffloadingConnector(SCHEDULER)         MetalOffloadingConnector(WORKER)  [subclass]
+ └─ OffloadingConnectorScheduler        ├─ OffloadingConnectorWorker (reused)
+     └─ CPUOffloadingManager (reused)   │    └─ MetalKVOffloadWorker         [new]
+                                        │       (implements OffloadingWorker)
+                                        └─ MetalOffloadingSpec               [new]
+                                             ├─ get_manager() → CPUOffloadingManager
+                                             └─ host pool: per-layer numpy arrays
+```
+
+### 4.1 `MetalOffloadingSpec(CPUOffloadingSpec)`
+
+- Inherits all sizing: `num_blocks` (CPU-side) from `cpu_bytes_to_use` ÷
+  bytes-per-offloaded-block, computed from `kv_cache_config.kv_cache_tensors`
+  (`cpu/spec.py:60-104`) — vllm-metal populates these sizes, including the
+  TurboQuant packed layout (see `cache_policy.py`, PR #472).
+- Inherits `get_manager()` unchanged.
+- Overrides `get_metal_worker(...)` to build the Metal worker from the live
+  `MetalPagedKVCache` instead of `CanonicalKVCaches` — no CUDA guard.
+- Selected via `kv_connector_extra_config["spec_name"] = "MetalOffloadingSpec"`
+  + `spec_module_path`, injected by `MetalPlatform.check_and_update_config`.
+
+### 4.2 `MetalOffloadingConnector(OffloadingConnector)`
+
+Registered with `KVConnectorFactory.register_connector(...)` at plugin init;
+`MetalPlatform.check_and_update_config` rewrites
+`kv_transfer_config.kv_connector` from `"OffloadingConnector"` to
+`"MetalOffloadingConnector"` so the user-facing CLI is identical to CUDA.
+
+Overrides exactly one worker-side method:
+
+- `register_kv_caches(kv_caches)` — accepts the `MetalPagedKVCache` (passed by
+  our model runner, which owns the call site) and sets
+  `connector_worker.worker = spec.get_metal_worker(kv_cache)`. No torch
+  canonicalization. Scheduler-side behavior is fully inherited.
+
+### 4.3 `MetalKVOffloadWorker(OffloadingWorker)`
+
+One worker class serving both directions; `submit_store(job_id, src_spec,
+dst_spec)` and `submit_load(job_id, src_spec, dst_spec)` make the direction
+explicit — no `(src, dst)`-medium routing, no handler registration.
+
+**Host pool**: per-layer numpy arrays, one per MLX cache array (K, V, and the
+three TurboQuant side arrays when present), shaped
+`(num_cpu_blocks, block_size_factor × block_size, heads, dim)` with a raw-bytes
+(`uint16` view for bf16) dtype mapping. Plain numpy = pageable = the tier
+semantics we want. No mmap, no pinning.
+
+**Store (GPU→CPU)**, per layer: one gather
+`mx.take(key_caches[L], mx.array(src_block_ids), axis=0)` → `np.asarray` →
+strided write into the host pool rows. Reads go through the **current** list
+entry `kv_cache.key_caches[L]`, whose lazy-graph provenance orders the read
+after all pending in-place writes — this is the same reader-after-writer fence
+the paged-attention kernel itself relies on (`sdpa.py:508-517`).
+
+**Load (CPU→GPU)**, per layer: `mx.array(host_rows)` → index-assign
+`cache[mx.array(dst_block_ids)] = ...` → rebind `kv_cache.key_caches[L]`,
+mirroring the established write-then-rebind idiom so subsequent readers see
+provenance.
+
+**Completion model (M1)**: transfers execute synchronously inside
+`submit_store`/`submit_load` (unified memory: a "transfer" is an on-package copy, and
+stores are already deferred by the connector to post-sampling, when the graph
+is materialized). Results queue for `get_finished()` with real
+`transfer_size`/`transfer_time` so bandwidth stats work. `wait()` is a no-op
+on an empty in-flight set. A follow-up can move stores to `mx.async_eval` or a
+worker thread if profiling justifies it; the `OffloadingWorker` contract
+(`submit_store`/`submit_load`/`get_finished`/`wait`) is already async-shaped.
+
+**Block-size mapping**: the scheduler's GPU block ids index the MLX arrays'
+leading dim directly (same `block_size`; the kernel-block translation in
+`sdpa.py:122-160` is a read-time reshape and irrelevant here). One offloaded
+(CPU) block = `block_size_factor` consecutive GPU blocks, exactly as in the
+CUDA worker.
+
+### 4.4 Worker hooks (`vllm_metal/v1/worker.py`)
+
+- `initialize_from_config`: call
+  `ensure_kv_transfer_initialized(vllm_config, kv_cache_config)` **before**
+  `model_runner.initialize_kv_cache(...)` (mirrors
+  `vllm/v1/worker/gpu_worker.py:591-606`). By this point the paged cache
+  already exists (allocated in `determine_available_memory` →
+  `setup_paged_attention`), so registration can happen immediately after.
+- `get_kv_connector_handshake_metadata`: copied verbatim from
+  `gpu_worker.py:554` — device-agnostic; returns `None` for this connector
+  (base `get_handshake_metadata()` is not overridden), which
+  `EngineCore.__init__` (`v1/engine/core.py:174-190`) handles fine. This fixes
+  the M0 crash (`NotImplementedError` via `collective_rpc`).
+- `shutdown`: `ensure_kv_transfer_shutdown()`.
+
+### 4.5 Model-runner hooks (`vllm_metal/v1/model_runner.py`)
+
+`MetalModelRunner` is standalone (no `GPUModelRunner`, no mixin) and splits a
+step into `execute_model` (submit async MLX forward, return `None`) and
+`sample_tokens` (sync, build `ModelRunnerOutput`). The connector lifecycle maps
+onto that split; `OffloadingConnector.save_kv_layer`/`wait_for_layer_load`/
+`wait_for_save` are documented no-ops, so no per-layer hooks are needed —
+lucky, because the Metal forward is one monolithic MLX call.
+
+- Top of `execute_model` (when `has_kv_transfer_group()`):
+  `handle_preemptions`, `bind_connector_metadata(scheduler_output.kv_connector_metadata)`,
+  `start_load_kv(None)` — loads run synchronously here, strictly before the
+  forward is submitted, so the forward reads restored blocks.
+  (`OffloadingConnector.start_load_kv` ignores its `forward_context` argument;
+  we do not construct a vLLM `ForwardContext`.)
+- No-work steps (`total_num_scheduled_tokens == 0`): run the same
+  bind/start/get_finished sequence and return
+  `ModelRunnerOutput.with_kv_conn_output_only(...)` — the connector must make
+  progress on steps with no forward (mirrors `kv_connector_no_forward`,
+  `vllm/v1/worker/kv_connector_model_runner_mixin.py:36`).
+- End of step, in `sample_tokens` after sampling sync (and on the synchronous
+  non-paged/pooling paths): `get_finished(finished_req_ids)` (which also queues
+  deferred stores), `build_connector_worker_meta()`, assemble
+  `KVConnectorOutput` onto the built `ModelRunnerOutput.kv_connector_output`,
+  then `clear_connector_metadata()`. Stores thus execute on the *next* step's
+  `start_kv_transfers`, after the previous graph materialized — cheap and
+  correctly ordered.
+
+All hooks are gated on `has_kv_transfer_group()`; without offloading flags the
+code path is byte-for-byte unchanged.
+
+### 4.6 Platform wiring (`vllm_metal/platform.py`, `vllm_metal/__init__.py`)
+
+- Plugin registration: `KVConnectorFactory.register_connector("MetalOffloadingConnector", ...)`.
+- `check_and_update_config`: when `kv_transfer_config` is set with
+  `kv_connector == "OffloadingConnector"`, rewrite to the Metal subclass and
+  inject `spec_name`/`spec_module_path` into `kv_connector_extra_config`.
+  Reject configurations we can't serve yet (e.g. `lmcache` backend) with a
+  clear error.
+
+## 5. Correctness analysis
+
+- **Read-after-write (stores)**: store gathers read through the latest rebound
+  cache arrays; MLX's lazy graph serializes them after pending kernel writes.
+  Additionally, stores are deferred by the connector to the step after
+  sampling, when `mx.eval` has already materialized the writes.
+- **Write-before-read (loads)**: loads run synchronously in `execute_model`
+  before the forward graph is even built, and the rebind gives the forward's
+  reads provenance through the scatter.
+- **Logical-free vs physical reuse**: the scheduler only reuses a GPU block
+  after its store job completed (`jobs_to_flush` fencing +
+  `completed_jobs` in the worker meta) — same contract as CUDA; our worker
+  reports completion only after the copy truly finished.
+- **No worker failure path**: the connector worker asserts a successful
+  submission, so errors raised in `submit_store`/`submit_load` propagate, and
+  `OffloadingConnectorWorker.get_finished` asserts `success` (job failure is
+  unsupported upstream); our worker must not report failures for recoverable
+  conditions — validate sizes at registration time instead.
+- **TurboQuant**: packed K/V + scale/zero arrays are all
+  `(num_blocks, ...)`-leading, so the same gather/scatter per-array treatment
+  works; the spec's byte sizing already accounts for the packed page size.
+  Planned but validated after the fp16 path (M1 is fp16-first).
+- **Excluded for now**: hybrid models with Mamba/GDN state (offloading spec
+  only handles attention groups here), MLA cache, pipeline parallelism > 1.
+  Guard with clear errors in `check_and_update_config`.
+
+## 6. Milestones
+
+- **M0 — boot**: worker RPC methods + `ensure_kv_transfer_initialized` +
+  platform wiring + hooks with the real (synchronous) worker. Engine starts
+  with `--kv-offloading-backend native --kv-offloading-size 2`; serves normally.
+- **M1 — CPU tier verified**: with a tiny wired cache
+  (`VLLM_METAL_MEMORY_FRACTION=0.05`) and repeated long prefixes,
+  `vllm:prompt_tokens_by_source_total{source="external_kv_transfer"}` goes
+  nonzero and greedy outputs are identical with/without offloading.
+- **M2 — disk tier** (done, verified 2026-07-15): `MetalTieringOffloadingSpec`
+  + `MetalSharedOffloadRegion` (anonymous in-process RAM behind a per-process
+  registry — macOS has no tmpfs, and a file-backed mmap would write KV churn
+  back to SSD through APFS; the platform hook enforces the single-process
+  `uni` executor for tiering) with the worker's host pool carved as
+  write-through strided numpy views over the region, so vLLM's `fs` tier
+  reads/writes the same bytes via `create_kv_memoryview`. Verified: blocks
+  cascade to disk (re-run on the in-process region: 10,295 `.bin` files /
+  4.4 GB), a prefix evicted from both GPU and CPU tiers restores from disk
+  (`external_kv_transfer` 0→2320, identical greedy output, 0.37s vs 1.55s
+  cold), and — with `PYTHONHASHSEED=0` — the same prefix restores across a
+  full server restart (fresh process, first request, 0.38s).
+
+  Usage:
+
+  ```bash
+  PYTHONHASHSEED=0 VLLM_METAL_MEMORY_FRACTION=0.05 \
+  VLLM_METAL_USE_PAGED_ATTENTION=1 \
+  vllm serve <model> \
+    --kv-offloading-backend native --kv-offloading-size <GiB> \
+    --kv-transfer-config '{"kv_connector_extra_config":
+      {"secondary_tiers": [{"type": "fs", "root_dir": "/path/to/kv-store"}]}}'
+  ```
+
+  `PYTHONHASHSEED` must be fixed for cross-restart / cross-instance reuse
+  (block-content hash filenames are seeded by it; see
+  `FileSystemTierManager`'s docstring).
+
+  The `fs` tier resolves to `MetalFileSystemTierManager`
+  (`vllm_metal/v1/kv_offload/fs_tier.py`), which layers macOS integrations
+  and block-integrity checking over the upstream tier (lookup/store/load
+  scheduling semantics are unchanged; the on-disk block format is not —
+  see the CRC footer below):
+
+  - Block files are `0o600` under a `0o700` root (KV blocks are
+    conversation-derived data, and the deterministic hash filenames allow
+    presence-testing of known prompts by anyone who can list the directory;
+    upstream writes `0o644`).
+  - Blocks land under `<root_dir>/blocks.noindex/` so Spotlight never
+    indexes the churn, and `root_dir` gets a best-effort
+    `tmutil addexclusion` so the store stays out of Time Machine backups and
+    APFS local snapshots.
+  - Block fds get `fcntl(F_NOCACHE)` — upstream's `O_DIRECT` degrades to
+    buffered on macOS, which would flush useful page cache with multi-GB KV
+    churn.
+  - I/O threads set QoS: loads (request critical path)
+    `QOS_CLASS_USER_INITIATED`, stores `QOS_CLASS_UTILITY` (E-core-friendly,
+    doesn't compete with inference on P-cores).
+  - **Block files carry an 8-byte little-endian CRC32 footer**
+    (`<payload><crc>`), verified on every load. A torn write (power loss is
+    likelier to tear with `F_NOCACHE`), bit rot, or a foreign/stale file
+    fails the check *before* poisoned KV reaches the GPU cache; the bad
+    file is deleted so the tier degrades to a clean miss, while transient
+    errors (fd exhaustion, `EIO`) propagate without deleting. It is a
+    corruption check, not an authentication code — store ownership
+    (`0o600`/`0o700`) is the defense against hostile writers, and a
+    per-deployment HMAC is the roadmap control for shared stores (§8).
+  - **Lookups validate file size** (payload + footer), so truncated or
+    foreign-layout files are misses up front, and a **failed-load negative
+    cache** marks keys absent until re-stored — together these prevent a
+    request-level livelock where the scheduler re-promotes a doomed block
+    every step against upstream's per-request lookup cache.
+
+  Note the store has no size cap or GC (upstream behavior): `root_dir` grows
+  until manually cleared.
+- **M3 — upstream PR** to vllm-project/vllm-metal (DCO, deterministic tests,
+  docs page).
+
+### Resume numerics — what "correct" means for restored prefixes
+
+The restore path is **byte-exact**: per-row CRC instrumentation
+(`VLLM_METAL_KV_OFFLOAD_DEBUG=1`) verifies stored bytes == loaded bytes ==
+post-scatter GPU bytes. But an offload restore recomputes the prompt tail
+(the tokens past the last full block) in a *different kernel batch shape*
+than the original chunked prefill, so logits differ by fp16 epsilon
+(~1e-3 nats measured). On prompts with near-tie next-token distributions
+(a repetitive prompt showed a 0.045-nat top-2 margin) greedy argmax can
+flip — deterministically — producing a different-but-legitimate
+continuation. This reproduces **without the connector** (plain GPU
+prefix-cache resume) and is inherent to restore-then-resume on any
+backend, CUDA included. TurboQuant's discontinuous quantizers amplify the
+wobble. Consequence for testing: compare restored output against a
+**no-offload resume** (same batch shapes), never against the cold
+prefill; byte-identical cold-vs-warm assertions are only valid for
+high-margin (non-repetitive) prompts.
+
+## 7. Test plan
+
+- Unit: worker round-trip (store N blocks, zero the GPU blocks, load back,
+  compare exact bytes) for fp16/bf16 and TurboQuant arrays; block_size_factor
+  sub-block striding; spec sizing math vs `kv_cache_config`.
+- CUDA parity: `tests/test_kv_offload_cuda_parity.py` pins the worker's
+  host-pool byte placement to upstream's own `compute_sub_block_ptrs` (the
+  CUDA DMA descriptor math, platform-independent) and asserts the
+  scheduler-side surface is upstream code by function identity.
+- fs tier: io round-trip under the CRC-footer format, corruption cases
+  (truncated file, flipped payload bit → delete + clean miss; missing file →
+  propagate without cleanup), size-aware store dedup, and an end-to-end
+  manager test driving store → hit → corrupt → miss → failed-load negative
+  cache (the livelock guard), mutation-checked against the lookup size check.
+- Integration (slow/local): serve Qwen2.5-1.5B-4bit with FRACTION=0.05 +
+  offloading, drive an evict-then-reuse workload, assert the
+  `external_kv_transfer` counter and compare greedy completions against a
+  no-offload run.
+
+## 8. Future work
+
+Ordered roughly by value. The first three need upstream conversations; the
+rest are Metal-side.
+
+- **Purgeable host pool** (upstream contract change). The maximal use of
+  macOS for the "polite big tier": allocate the host pool as purgeable
+  memory (`vm_allocate` + `VM_FLAGS_PURGABLE`, `vm_purgable_control`) so
+  the kernel *discards* cold KV blocks under memory pressure instead of
+  swapping them to SSD — swap that duplicates the disk tier's job with
+  uncontrolled writes. Blocked today because a purge is a load that can
+  fail, and `OffloadingConnectorWorker.get_finished` asserts success (job
+  failure is unsupported upstream). With write-through tiering, a purged
+  block could be re-promoted from disk if upstream grew a
+  lookup-invalidate / load-retry path.
+- **`madvise(MADV_FREE)` on evicted host blocks** (upstream hook needed).
+  When the LRU evicts a CPU block its pages stay dirty-resident and macOS
+  may swap them pointlessly. The scheduler-side manager doesn't notify the
+  worker/region of eviction; an eviction callback (or consuming the
+  existing KV events stream) would let the region release the row's pages.
+  Rows are page-aligned in the shared region already.
+- **fs-tier GC / disk budget** (upstream-shaped feature). The store grows
+  without bound; a size cap with LRU file eviction, or a TTL sweep, is the
+  missing retention policy. Also a data-retention question: persisted KV
+  blocks are conversation-derived data. (Upstream `0o600` block files are
+  worth proposing regardless.)
+- **Transfer/compute overlap.** Transfers currently run synchronously on
+  the engine thread (~18 ms per 66 MB store observed). `mx.async_eval` on
+  the gather plus deferring the host copy to `get_finished` would
+  approximate CUDA's stream overlap. Profile first: measured copy
+  bandwidth (2.6–3.6 GB/s) is far below the machine's memory bandwidth,
+  so there is also headroom in the copy path itself (fewer, larger
+  gathers; avoiding per-array Python overhead).
+- **Runtime memory-pressure response.** Startup is covered:
+  `compute_safe_kv_budget` (`cache_policy.py`) clamps the paged-attention
+  plan against live host memory — a hard cannot-fit cut plus a soft
+  free-memory floor (`VLLM_METAL_MIN_FREE_FRACTION`, default 15% of RAM,
+  min 4 GB; `VLLM_METAL_DISABLE_MEMORY_GUARD=1` opts out of the floor
+  only). What remains is *runtime* response: subscribe to
+  `kern.memorystatus_vm_pressure_level` (or the dispatch memory-pressure
+  source) and shrink/purge the host pool under critical pressure instead
+  of relying on the startup budget staying valid for the process
+  lifetime.
+- **Hybrid models and multi-rank.** Single KV cache group and single
+  worker rank are explicitly guarded today; lifting them needs per-group
+  worker plumbing (the CUDA worker's `group_sizes` path) and a real
+  cross-process shared region (POSIX shm) respectively.
+- **Encrypted-at-rest guidance and store authentication.** FileVault
+  covers the default case; document pointing `root_dir` at an encrypted
+  APFS volume for stronger isolation on shared machines. For stores that
+  cannot rely on ownership alone (shared or network volumes), a
+  per-deployment keyed HMAC in place of the CRC32 footer would
+  authenticate blocks against hostile writers, not just detect
+  corruption.

--- a/tests/kv_offload_helpers.py
+++ b/tests/kv_offload_helpers.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for the KV offloading tests.
+
+The snapshot/zero helpers mirror the cache kernels' write-then-rebind idiom
+(see vllm_metal/attention/caches/kv_cache.py): mutate through the current
+list entry, then rebind it, so later readers get provenance.
+"""
+
+import mlx.core as mx
+import numpy as np
+from vllm.v1.kv_offload.base import GPULoadStoreSpec
+
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.v1.kv_offload.worker import CACHE_ATTRS
+
+
+def make_cache(dtype: mx.Dtype = mx.float16, **kwargs) -> MetalPagedKVCache:
+    kwargs.setdefault("num_layers", 2)
+    kwargs.setdefault("num_kv_heads", 2)
+    kwargs.setdefault("head_dim", 32)
+    kwargs.setdefault("num_blocks", 8)
+    kwargs.setdefault("block_size", 4)
+    return MetalPagedKVCache(dtype=dtype, **kwargs)
+
+
+def gpu_block_bytes(cache: MetalPagedKVCache) -> int:
+    """Bytes of one GPU block summed across every cache array."""
+    total = 0
+    for attr in CACHE_ATTRS:
+        for arr in getattr(cache, attr):
+            total += int(np.prod(arr.shape[1:])) * arr.dtype.size
+    return total
+
+
+def randomize(cache: MetalPagedKVCache, seed: int = 0) -> None:
+    """Fill every cache array with distinct values."""
+    mx.random.seed(seed)
+    for attr in CACHE_ATTRS:
+        arrays = getattr(cache, attr)
+        for i, arr in enumerate(arrays):
+            if arr.dtype in (mx.float16, mx.bfloat16, mx.float32):
+                arrays[i] = mx.random.normal(arr.shape).astype(arr.dtype)
+            else:
+                arrays[i] = mx.random.randint(0, 255, arr.shape).astype(arr.dtype)
+        mx.eval(*arrays)
+
+
+def snapshot_blocks(cache: MetalPagedKVCache, block_ids: list[int]) -> list[np.ndarray]:
+    """Copy the given blocks of every cache array to numpy (bf16 as uint16)."""
+    out = []
+    for attr in CACHE_ATTRS:
+        for arr in getattr(cache, attr):
+            sl = mx.take(arr, mx.array(block_ids), axis=0)
+            if sl.dtype == mx.bfloat16:
+                sl = mx.view(sl, mx.uint16)
+            out.append(np.array(sl))
+    return out
+
+
+def zero_blocks(cache: MetalPagedKVCache, block_ids: list[int]) -> None:
+    for attr in CACHE_ATTRS:
+        arrays = getattr(cache, attr)
+        for i, arr in enumerate(arrays):
+            arr[mx.array(block_ids)] = mx.zeros(
+                (len(block_ids), *arr.shape[1:]), dtype=arr.dtype
+            )
+            arrays[i] = arr
+            mx.eval(arr)
+
+
+def gpu_spec(block_ids: list[int], block_index: int = 0) -> GPULoadStoreSpec:
+    return GPULoadStoreSpec(
+        block_ids, group_sizes=[len(block_ids)], block_indices=[block_index]
+    )

--- a/tests/test_kv_offload_config.py
+++ b/tests/test_kv_offload_config.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Config-time tests for the KV offloading platform wiring.
+
+MetalPlatform.check_and_update_config performs the --kv-offloading-size ->
+kv_transfer_config translation itself (it runs before vLLM's own translation,
+which would force-set a connector this platform cannot serve) and routes the
+connector/spec lookups to the Metal classes.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_metal.config import reset_config
+from vllm_metal.platform import MetalPlatform
+
+
+def _base_config(**cache_overrides) -> SimpleNamespace:
+    cache_config = SimpleNamespace(
+        block_size=None,
+        enable_prefix_caching=False,
+        kv_offloading_size=None,
+        kv_offloading_backend="native",
+        # vLLM 0.25.1: populated by --kv-cache-dtype turboquant_*; Metal
+        # rejects it up front (TurboQuant runs off --additional-config).
+        kv_cache_dtype_skip_layers=[],
+    )
+    for key, value in cache_overrides.items():
+        setattr(cache_config, key, value)
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            worker_cls="auto",
+            distributed_executor_backend="auto",
+            pipeline_parallel_size=1,
+            tensor_parallel_size=1,
+            disable_custom_all_reduce=False,
+        ),
+        cache_config=cache_config,
+        speculative_config=None,
+        model_config=SimpleNamespace(
+            model="test-model",
+            disable_cascade_attn=False,
+            tokenizer=None,
+            max_model_len=4096,
+            multimodal_config=None,
+            hf_config=SimpleNamespace(model_type="qwen3"),
+            is_hybrid=False,
+        ),
+        scheduler_config=SimpleNamespace(
+            async_scheduling=False,
+            enable_chunked_prefill=True,
+            max_num_batched_tokens=2048,
+            max_num_scheduled_tokens=None,
+        ),
+        kv_transfer_config=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _paged_attention(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+    monkeypatch.setattr(
+        "vllm_metal.platform.MetalPlatform._is_stt_model",
+        staticmethod(lambda *_: False),
+        raising=False,
+    )
+    reset_config()
+    yield
+    reset_config()
+
+
+def test_offloading_size_translates_to_metal_connector() -> None:
+    vllm_config = _base_config(kv_offloading_size=2.0)
+    MetalPlatform.check_and_update_config(vllm_config)
+
+    ktc = vllm_config.kv_transfer_config
+    assert ktc is not None
+    assert ktc.kv_connector == "MetalOffloadingConnector"
+    assert ktc.kv_connector_module_path == "vllm_metal.v1.kv_offload.connector"
+    assert ktc.kv_role == "kv_both"
+    extra = ktc.kv_connector_extra_config
+    assert extra["cpu_bytes_to_use"] == 2 * (1 << 30)
+    assert extra["spec_name"] == "MetalOffloadingSpec"
+    assert extra["spec_module_path"] == "vllm_metal.v1.kv_offload.spec"
+    # Upstream translation must be disarmed (it would force-set a connector
+    # name after this hook has run).
+    assert vllm_config.cache_config.kv_offloading_size is None
+
+
+def test_secondary_tiers_select_tiering_spec() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={
+            "secondary_tiers": [{"type": "fs", "root_dir": "/tmp/kv"}]
+        },
+    )
+    MetalPlatform.check_and_update_config(vllm_config)
+
+    extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+    assert extra["spec_name"] == "MetalTieringOffloadingSpec"
+
+
+def test_tiering_requires_uni_executor() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.parallel_config.distributed_executor_backend = "mp"
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={
+            "secondary_tiers": [{"type": "fs", "root_dir": "/tmp/kv"}]
+        },
+    )
+    with pytest.raises(NotImplementedError, match="single-process executor"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_inert_kv_transfer_config_passes_through() -> None:
+    """A kv_transfer_config with no connector and no offloading request was
+    inert upstream and must stay untouched (no guards, no spec injection)."""
+    vllm_config = _base_config()
+    inert = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role="kv_both",
+        kv_connector_extra_config={},
+    )
+    vllm_config.kv_transfer_config = inert
+    MetalPlatform.check_and_update_config(vllm_config)
+
+    assert vllm_config.kv_transfer_config is inert
+    assert inert.kv_connector is None
+    assert inert.kv_connector_module_path is None
+    assert inert.kv_connector_extra_config == {}
+
+
+def test_unsupported_connector_rejected() -> None:
+    vllm_config = _base_config()
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector="NixlConnector",
+        kv_connector_module_path=None,
+        kv_role="kv_both",
+        kv_connector_extra_config={},
+    )
+    with pytest.raises(NotImplementedError, match="NixlConnector"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_explicit_connector_without_size_rejected() -> None:
+    vllm_config = _base_config()
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector="OffloadingConnector",
+        kv_connector_module_path=None,
+        kv_role="kv_both",
+        kv_connector_extra_config={},
+    )
+    with pytest.raises(NotImplementedError, match="--kv-offloading-size"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_unknown_spec_name_rejected() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={"spec_name": "ARCOffloadingSpec"},
+    )
+    with pytest.raises(NotImplementedError, match="ARCOffloadingSpec"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_simple_kv_offload_env_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("vllm.envs.VLLM_USE_SIMPLE_KV_OFFLOAD", True, raising=False)
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    with pytest.raises(NotImplementedError, match="VLLM_USE_SIMPLE_KV_OFFLOAD"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_offloading_requires_paged_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+    reset_config()
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    with pytest.raises(NotImplementedError, match="paged attention"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_lmcache_backend_rejected() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0, kv_offloading_backend="lmcache")
+    with pytest.raises(NotImplementedError, match="lmcache"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_validate_metal_support_guards() -> None:
+    """The single-group / uniform-attention guard that keeps hybrid and
+    non-attention KV layouts off the offload path (e2e-validated on gemma-4;
+    unit-pinned here)."""
+    from types import SimpleNamespace
+
+    import pytest
+    from vllm.v1.kv_cache_interface import AttentionSpec
+
+    from vllm_metal.v1.kv_offload.spec import _validate_metal_support
+
+    group = lambda spec: SimpleNamespace(kv_cache_spec=spec)  # noqa: E731
+
+    with pytest.raises(NotImplementedError, match="single KV cache group"):
+        _validate_metal_support(
+            SimpleNamespace(kv_cache_groups=[group(None), group(None)])
+        )
+    with pytest.raises(NotImplementedError, match="uniform full-attention"):
+        _validate_metal_support(SimpleNamespace(kv_cache_groups=[group(object())]))
+
+    class _FakeAttention(AttentionSpec):
+        pass
+
+    ok = _FakeAttention.__new__(_FakeAttention)
+    _validate_metal_support(SimpleNamespace(kv_cache_groups=[group(ok)]))  # no raise

--- a/tests/test_kv_offload_cuda_parity.py
+++ b/tests/test_kv_offload_cuda_parity.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional parity of the Metal offload path with vLLM's CUDA path.
+
+The scheduler side needs no parity testing: it *is* the upstream code
+(asserted below by function identity). The worker-side worker is the one
+reimplemented piece, so its observable contract — which bytes land in which
+host-pool slot for a given TransferSpec — is checked here against upstream's
+own placement arithmetic: ``compute_sub_block_ptrs`` from
+``vllm/v1/kv_offload/cpu/gpu_worker.py``, the exact function the CUDA DMA
+path uses to build its copy descriptors (it is pure numpy/torch pointer math
+and runs on any platform).
+
+For every transfer the CUDA worker copies GPU block ``i`` to the byte range
+``[ptrs[i], ptrs[i] + page_size)`` of the CPU tensor, where ``ptrs`` comes
+from ``compute_sub_block_ptrs`` over the CPU tensor with the transfer's
+``skip = block_index % block_size_factor``. The Metal worker must place the
+same bytes at the same offsets of its host pool, per cache array.
+"""
+
+import numpy as np
+import pytest
+import torch
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.gpu_worker import compute_sub_block_ptrs
+
+from tests.kv_offload_helpers import (
+    gpu_spec,
+    make_cache,
+    randomize,
+    snapshot_blocks,
+    zero_blocks,
+)
+from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+NUM_CPU_BLOCKS = 4
+
+CASES = [
+    pytest.param(1, [5, 2, 7], [0, 1, 3], 0, id="factor1"),
+    pytest.param(2, [1, 2, 3, 4], [0, 2], 0, id="factor2-aligned"),
+    pytest.param(2, [5], [2], 3, id="factor2-unaligned"),
+    pytest.param(4, [1, 2, 3], [0, 3], 6, id="factor4-unaligned-spanning"),
+]
+
+
+def _expected_offsets(
+    pool: np.ndarray, factor: int, cpu_blocks: list[int], skip: int, count: int
+) -> np.ndarray:
+    """Byte offsets into ``pool`` where upstream CUDA would place each block.
+
+    ``pool`` is one cache array's host pool, shape
+    (num_cpu_blocks, factor, *block_shape). Upstream sees it as the flat
+    (num_cpu_blocks, row_bytes) int8 CPU tensor it computes pointers over.
+    """
+    rows = pool.reshape(NUM_CPU_BLOCKS, -1).view(np.int8)
+    cpu_tensor = torch.from_numpy(rows)
+    ptrs = np.empty(count, dtype=np.uint64)
+    compute_sub_block_ptrs(
+        np.asarray(cpu_blocks), factor, ptrs, cpu_tensor, skip_count=skip
+    )
+    return (ptrs - np.uint64(cpu_tensor.data_ptr())).astype(np.int64)
+
+
+@pytest.mark.parametrize(("factor", "gpu_blocks", "cpu_blocks", "block_index"), CASES)
+@pytest.mark.parametrize("turboquant", [False, True], ids=["fp16", "turboquant"])
+def test_store_placement_matches_cuda(
+    factor: int,
+    gpu_blocks: list[int],
+    cpu_blocks: list[int],
+    block_index: int,
+    turboquant: bool,
+) -> None:
+    if turboquant:
+        cache = make_cache(head_dim=64, turboquant=True, k_quant="q8_0", v_quant="q3_0")
+    else:
+        cache = make_cache()
+    worker = MetalKVOffloadWorker(
+        cache, block_size_factor=factor, num_cpu_blocks=NUM_CPU_BLOCKS
+    )
+    randomize(cache)
+    original = snapshot_blocks(cache, gpu_blocks)
+
+    assert worker.submit_store(
+        1, gpu_spec(gpu_blocks, block_index), CPULoadStoreSpec(cpu_blocks)
+    )
+    assert [r.job_id for r in worker.get_finished()] == [1]
+
+    skip = block_index % factor
+    for ref, blocks in zip(worker._refs, original, strict=True):
+        pool_bytes = ref.cpu.reshape(-1).view(np.uint8)
+        block_bytes = blocks.reshape(len(gpu_blocks), -1).view(np.uint8)
+        page = block_bytes.shape[1]
+        offsets = _expected_offsets(ref.cpu, factor, cpu_blocks, skip, len(gpu_blocks))
+        for i, off in enumerate(offsets):
+            np.testing.assert_array_equal(
+                pool_bytes[off : off + page],
+                block_bytes[i],
+                err_msg=f"gpu block {gpu_blocks[i]} not at CUDA offset {off}",
+            )
+
+    # Load back through the Metal worker from the CUDA-verified layout, so
+    # both directions are pinned to the same placement.
+    zero_blocks(cache, gpu_blocks)
+    assert worker.submit_load(
+        2, CPULoadStoreSpec(cpu_blocks), gpu_spec(gpu_blocks, block_index)
+    )
+    assert [r.job_id for r in worker.get_finished()] == [2]
+    for a, b in zip(original, snapshot_blocks(cache, gpu_blocks), strict=True):
+        np.testing.assert_array_equal(a, b)
+
+
+def test_scheduler_side_is_upstream_code() -> None:
+    """The scheduler-facing surface is upstream's own functions, not ports."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
+        OffloadingConnector,
+    )
+    from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
+
+    from vllm_metal.v1.kv_offload.connector import MetalOffloadingConnector
+    from vllm_metal.v1.kv_offload.spec import MetalOffloadingSpec
+
+    # The CPU-tier spec inherits the manager (LRU/ARC policies, store
+    # thresholds, block tracking) unmodified.
+    assert MetalOffloadingSpec.get_manager is CPUOffloadingSpec.get_manager
+
+    # The connector overrides only worker-side KV-cache registration; every
+    # scheduler-side hook is inherited.
+    overridden = {
+        name for name in vars(MetalOffloadingConnector) if not name.startswith("_")
+    }
+    assert overridden == {"register_kv_caches"}, overridden
+    for name in (
+        "get_num_new_matched_tokens",
+        "update_state_after_alloc",
+        "build_connector_meta",
+        "request_finished",
+        "take_events",
+    ):
+        assert getattr(MetalOffloadingConnector, name) is getattr(
+            OffloadingConnector, name
+        ), name

--- a/tests/test_kv_offload_fs_tier.py
+++ b/tests/test_kv_offload_fs_tier.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the macOS-tuned fs secondary tier (vllm_metal/v1/kv_offload/fs_tier.py).
+
+The io functions must keep upstream's semantics (atomic replace, dedup on
+existing files, remove-on-unreadable) while adding the macOS integrations:
+0o600 files, 0o700 directories, .noindex nesting, thread QoS, and the
+CRC32-footer on-disk format (<payload><8-byte LE CRC32>).
+"""
+
+import os
+import stat
+import sys
+import threading
+import zlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vllm_metal.v1.kv_offload.fs_tier import (
+    _CRC_FOOTER_BYTES,
+    NOINDEX_DIRNAME,
+    QOS_CLASS_UTILITY,
+    MetalFileSystemTierManager,
+    load_block,
+    on_disk_block_size,
+    prepare_root_dir,
+    set_current_thread_qos,
+    store_block,
+)
+
+BLOCK = 4096
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def _on_disk_bytes(payload: bytes) -> bytes:
+    """A block file exactly as store_block would write it."""
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    return payload + crc.to_bytes(_CRC_FOOTER_BYTES, "little")
+
+
+def test_store_load_roundtrip(tmp_path: Path) -> None:
+    data = np.random.default_rng(0).integers(0, 256, BLOCK * 2, dtype=np.uint8)
+    dest = tmp_path / "ab" / "cd_g0" / "hash.bin"
+
+    store_block(str(dest), memoryview(data), BLOCK, BLOCK)
+
+    assert _mode(dest) == 0o600
+    assert [p.name for p in dest.parent.iterdir()] == ["hash.bin"]  # no .tmp left
+
+    out = np.zeros(BLOCK * 2, dtype=np.uint8)
+    load_block(str(dest), memoryview(out), BLOCK, BLOCK)
+    np.testing.assert_array_equal(out[BLOCK:], data[BLOCK:])
+    np.testing.assert_array_equal(out[:BLOCK], 0)
+
+
+def test_store_skips_existing(tmp_path: Path) -> None:
+    """Content-hash dedup parity with upstream: existing files are kept."""
+    dest = tmp_path / "hash.bin"
+    first = np.full(BLOCK, 1, dtype=np.uint8)
+    second = np.full(BLOCK, 2, dtype=np.uint8)
+
+    store_block(str(dest), memoryview(first), 0, BLOCK)
+    store_block(str(dest), memoryview(second), 0, BLOCK)
+
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    load_block(str(dest), memoryview(out), 0, BLOCK)
+    np.testing.assert_array_equal(out, first)
+
+
+def test_store_overwrites_wrong_size_existing(tmp_path: Path) -> None:
+    """Size-aware dedup: a stale/foreign file of the wrong length must not
+    mask the honest write (unlike upstream's bare exists() dedup)."""
+    dest = tmp_path / "hash.bin"
+    dest.write_bytes(b"x" * (BLOCK // 2))  # wrong size — no footer, truncated
+    data = np.full(BLOCK, 3, dtype=np.uint8)
+
+    store_block(str(dest), memoryview(data), 0, BLOCK)
+
+    assert dest.stat().st_size == on_disk_block_size(BLOCK)
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    load_block(str(dest), memoryview(out), 0, BLOCK)
+    np.testing.assert_array_equal(out, data)
+
+
+def test_load_removes_unreadable_file(tmp_path: Path) -> None:
+    dest = tmp_path / "short.bin"
+    dest.write_bytes(b"x" * (BLOCK // 2))
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    with pytest.raises(OSError, match="Short/oversized read"):
+        load_block(str(dest), memoryview(out), 0, BLOCK)
+    assert not dest.exists()
+
+
+def test_load_rejects_crc_mismatch_and_removes_file(tmp_path: Path) -> None:
+    """A right-sized file with corrupt payload fails the CRC and is deleted,
+    so the next lookup is a clean miss instead of poisoned KV on the GPU."""
+    dest = tmp_path / "rot.bin"
+    good = _on_disk_bytes(bytes(range(256)) * (BLOCK // 256))
+    flipped = bytearray(good)
+    flipped[BLOCK // 2] ^= 0x01  # single bit of rot in the payload
+    dest.write_bytes(bytes(flipped))
+
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    with pytest.raises(OSError, match="CRC mismatch"):
+        load_block(str(dest), memoryview(out), 0, BLOCK)
+    assert not dest.exists()
+
+
+def test_load_missing_file_raises_without_cleanup(tmp_path: Path) -> None:
+    """A transient-style failure (here: file vanished) propagates as-is —
+    load_block must not attempt deletion when it never validated the file."""
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    with pytest.raises(FileNotFoundError):
+        load_block(str(tmp_path / "gone.bin"), memoryview(out), 0, BLOCK)
+
+
+def test_prepare_root_dir(tmp_path: Path) -> None:
+    root = tmp_path / "kv-store"
+    store_dir = prepare_root_dir(str(root))
+
+    assert store_dir == str(root / NOINDEX_DIRNAME)
+    assert _mode(root) == 0o700
+    assert _mode(Path(store_dir)) == 0o700
+    # Idempotent against an existing store.
+    assert prepare_root_dir(str(root)) == store_dir
+
+
+def test_prepare_root_dir_respects_noindex_name(tmp_path: Path) -> None:
+    root = tmp_path / "kv-store.noindex"
+    assert prepare_root_dir(str(root)) == str(root)
+    assert _mode(root) == 0o700
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Time Machine")
+def test_time_machine_exclusion_applies(tmp_path: Path) -> None:
+    """The fire-and-forget tmutil thread really lands the sticky exclusion
+    (tmutil blocks ~10s per call on backupd XPC, hence the slow marker)."""
+    import subprocess
+
+    from vllm_metal.v1.kv_offload.fs_tier import _exclude_from_time_machine
+
+    root = tmp_path / "kv-store"
+    root.mkdir()
+    _exclude_from_time_machine(str(root)).join(timeout=60)
+    result = subprocess.run(
+        ["tmutil", "isexcluded", str(root)], capture_output=True, text=True, timeout=60
+    )
+    assert "[Excluded]" in result.stdout
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS QoS")
+def test_thread_qos_settable() -> None:
+    results: list[bool] = []
+    t = threading.Thread(
+        target=lambda: results.append(set_current_thread_qos(QOS_CLASS_UTILITY))
+    )
+    t.start()
+    t.join()
+    assert results == [True]
+
+
+def test_tiering_scope_routes_fs_tier() -> None:
+    """MetalTieringOffloadingSpec.get_manager resolves 'fs' to the Metal tier
+    (and the shared region to the Metal region) only within its scope."""
+    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+    from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
+    from vllm.v1.kv_offload.tiering.fs.manager import FileSystemTierManager
+
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+    from vllm_metal.v1.kv_offload.spec import _metal_tiering_classes
+
+    assert SecondaryTierFactory._registry["fs"]() is FileSystemTierManager
+    with _metal_tiering_classes():
+        assert SecondaryTierFactory._registry["fs"]() is MetalFileSystemTierManager
+        assert tiering_spec_module.SharedOffloadRegion is MetalSharedOffloadRegion
+    assert SecondaryTierFactory._registry["fs"]() is FileSystemTierManager
+    assert tiering_spec_module.SharedOffloadRegion is not MetalSharedOffloadRegion
+
+
+def test_metric_definitions_resolve_metal_tier_classes(monkeypatch) -> None:
+    """build_metric_definitions runs at stat-logger construction, OUTSIDE
+    get_manager's rebinding scope — the override must route the tier-class
+    lookup to the Metal classes or a Metal tier's metrics would silently not
+    register (then KeyError at first observation)."""
+    from vllm_metal.v1.kv_offload.spec import MetalTieringOffloadingSpec
+
+    sentinel = {"metal_fs_metric": object()}
+    monkeypatch.setattr(
+        MetalFileSystemTierManager,
+        "build_metric_definitions",
+        classmethod(lambda cls, cfg: sentinel),
+    )
+    metrics = MetalTieringOffloadingSpec.build_metric_definitions(
+        {"secondary_tiers": [{"type": "fs", "root_dir": "/tmp/unused"}]}
+    )
+    assert "metal_fs_metric" in metrics
+
+
+def test_region_alignment_matches_upstream_snapshot() -> None:
+    """TieringOffloadingSpec snapshots SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    at import time; a Metal override of the class attr would never be seen by
+    that snapshot, so pin the two to be equal."""
+    from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
+
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+    assert (
+        MetalSharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+        == TieringOffloadingSpec.BLOCK_SIZE_ALIGNMENT
+    )
+
+
+def test_layout_signature_disjoint_and_deterministic() -> None:
+    """Same model, different KV byte layout => different store paths.
+    Upstream FileMapper can't see this on Metal (cache_dtype is 'auto',
+    TurboQuant lives in additional_config)."""
+    from types import SimpleNamespace
+
+    from vllm_metal.v1.kv_offload.fs_tier import layout_signature
+
+    def spec(block_bytes, dtype, add):
+        return SimpleNamespace(
+            kv_bytes_per_offloaded_block=block_bytes,
+            vllm_config=SimpleNamespace(
+                model_config=SimpleNamespace(dtype=dtype),
+                additional_config=add,
+            ),
+        )
+
+    fp16 = layout_signature(spec(458752, "float16", {}))
+    bf16 = layout_signature(spec(458752, "bfloat16", {}))
+    tq = layout_signature(spec(179200, "float16", {"turboquant": True}))
+    tq2 = layout_signature(
+        spec(179200, "float16", {"turboquant": True, "k_quant": "q5_0"})
+    )
+    assert len({fp16, bf16, tq, tq2}) == 4  # all disjoint
+    assert fp16 == layout_signature(spec(458752, "float16", {}))  # deterministic
+
+
+def test_make_private_dir_does_not_chmod_existing(tmp_path: Path) -> None:
+    """Pointing root_dir at a pre-existing (e.g. shared) directory must not
+    strip other users' permissions."""
+    from vllm_metal.v1.kv_offload.fs_tier import _make_private_dir
+
+    pre = tmp_path / "shared"
+    pre.mkdir()
+    os.chmod(pre, 0o755)
+    _make_private_dir(str(pre))
+    assert _mode(pre) == 0o755  # untouched (warning logged instead)
+
+    fresh = tmp_path / "fresh"
+    _make_private_dir(str(fresh))
+    assert _mode(fresh) == 0o700
+
+
+def _fake_spec(block_bytes: int):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        block_size_factor=1,
+        kv_bytes_per_offloaded_block=block_bytes,
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(model="test-model", dtype="float16"),
+            cache_config=SimpleNamespace(block_size=16, cache_dtype="auto"),
+            parallel_config=SimpleNamespace(
+                tensor_parallel_size=1,
+                pipeline_parallel_size=1,
+                prefill_context_parallel_size=1,
+                decode_context_parallel_size=1,
+                rank=0,
+            ),
+            additional_config={},
+            use_v2_model_runner=False,
+        ),
+        kv_cache_config=SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    kv_cache_spec=SimpleNamespace(block_size=16),
+                    layer_names=["layer0"],
+                )
+            ]
+        ),
+    )
+
+
+def _await_lookup(tier, key, ctx, timeout: float = 10.0):
+    """Drive the async lookup loop (lookup -> flush -> drain) to a verdict."""
+    import time as _time
+
+    from vllm.v1.kv_offload.base import LookupResult, ScheduleEndContext
+
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        result = tier.lookup(key, ctx)
+        if result is not LookupResult.RETRY:
+            return result
+        tier.on_schedule_end(ScheduleEndContext(set(), set()))
+        _time.sleep(0.05)
+    raise TimeoutError("lookup never resolved")
+
+
+def test_manager_end_to_end_and_livelock_guard(tmp_path: Path) -> None:
+    """Constructs the real MetalFileSystemTierManager and pins: store/load
+    round-trip, size-validating lookups (truncated file == miss), and the
+    failed-load negative cache that breaks the promotion livelock."""
+    import time as _time
+
+    import numpy as np
+    from vllm.v1.kv_offload.base import LookupResult, ReqContext
+    from vllm.v1.kv_offload.tiering.base import JobMetadata
+
+    num_blocks, block_bytes = 4, 4096
+    pool = np.zeros((num_blocks, block_bytes), dtype=np.uint8)
+    tier = MetalFileSystemTierManager(
+        offloading_spec=_fake_spec(block_bytes),
+        primary_kv_view=memoryview(pool),
+        tier_type="fs",
+        root_dir=str(tmp_path / "kv-store"),
+        n_read_threads=2,
+        n_write_threads=2,
+    )
+    try:
+        import hashlib
+
+        key = hashlib.sha256(b"block-A").digest() + (0).to_bytes(4, "big")
+        path = Path(tier.file_mapper.get_file_name(key))
+
+        # Store block 0.
+        pool[0] = 7
+        tier.submit_store(
+            JobMetadata(
+                job_id=1,
+                keys=[key],
+                block_ids=np.array([0]),
+                is_promotion=False,
+                req_context=ReqContext(req_id="r-store"),
+            )
+        )
+        tier.drain_jobs()
+        results = list(tier.get_finished_jobs())
+        assert [(r.job_id, r.success) for r in results] == [(1, True)]
+        assert path.stat().st_size == on_disk_block_size(block_bytes)
+
+        # Size-validated lookup: healthy (footer-sized) file hits...
+        ctx1 = ReqContext(req_id="r-1")
+        assert _await_lookup(tier, key, ctx1, timeout=15) is LookupResult.HIT
+        tier.on_request_finished(ctx1)
+
+        # ...truncated file is a clean MISS, not a doomed promotion...
+        path.write_bytes(b"x" * (block_bytes // 2))
+        ctx2 = ReqContext(req_id="r-2")
+        assert _await_lookup(tier, key, ctx2, timeout=15) is LookupResult.MISS
+        tier.on_request_finished(ctx2)
+
+        # ...and so is a legacy payload-only file (pre-CRC-footer layout):
+        # the lookup's expected size must include the footer.
+        path.write_bytes(b"y" * block_bytes)
+        ctx2b = ReqContext(req_id="r-2b")
+        assert _await_lookup(tier, key, ctx2b, timeout=15) is LookupResult.MISS
+        tier.on_request_finished(ctx2b)
+
+        # Livelock guard: cache a True verdict, THEN corrupt, then fail the
+        # load — the negative cache must answer False despite the stale True.
+        store_ok = np.full(block_bytes, 9, dtype=np.uint8)
+        path.write_bytes(_on_disk_bytes(store_ok.tobytes()))
+        ctx3 = ReqContext(req_id="r-3")
+        assert _await_lookup(tier, key, ctx3, timeout=15) is LookupResult.HIT
+        path.write_bytes(b"x" * 10)  # corrupt AFTER the cached True
+        tier.submit_load(
+            JobMetadata(
+                job_id=2,
+                keys=[key],
+                block_ids=np.array([1]),
+                is_promotion=True,
+                req_context=ctx3,
+            )
+        )
+        tier.drain_jobs()
+        _time.sleep(0.1)
+        results = list(tier.get_finished_jobs())
+        assert [(r.job_id, r.success) for r in results] == [(2, False)]
+        assert tier.lookup(key, ctx3) is LookupResult.MISS  # stale HIT overridden
+        # A fresh store lifts the negative cache.
+        tier.submit_store(
+            JobMetadata(
+                job_id=3,
+                keys=[key],
+                block_ids=np.array([0]),
+                is_promotion=False,
+                req_context=ReqContext(req_id="r-restore"),
+            )
+        )
+        tier.drain_jobs()
+        list(tier.get_finished_jobs())
+        assert key not in tier._failed_load_keys
+    finally:
+        tier.shutdown()

--- a/tests/test_kv_offload_tiering.py
+++ b/tests/test_kv_offload_tiering.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the tiering (shared-region) variant of Metal KV offloading.
+
+The tiering worker carves its host pool out of a MetalSharedOffloadRegion —
+anonymous RAM shared between the scheduler-side manager and the worker-side
+worker within one process — so that secondary tiers (disk) can address whole
+CPU blocks as raw byte rows via ``create_kv_memoryview``. These tests
+exercise the worker round-trip through the region and the byte-level
+contract the fs tier relies on: store via the worker, read/write the same
+block through the memoryview, load back via the worker.
+"""
+
+import mmap
+import uuid
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+from tests.kv_offload_helpers import (
+    gpu_block_bytes,
+    gpu_spec,
+    make_cache,
+    randomize,
+    snapshot_blocks,
+    zero_blocks,
+)
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+NUM_CPU_BLOCKS = 4
+FACTOR = 2
+
+
+def _region_geometry(cache: MetalPagedKVCache) -> tuple[int, int]:
+    raw_row = gpu_block_bytes(cache) * FACTOR
+    aligned_row = -(-raw_row // mmap.PAGESIZE) * mmap.PAGESIZE
+    return aligned_row, raw_row
+
+
+def _make_regions(
+    cache: MetalPagedKVCache,
+) -> tuple[MetalSharedOffloadRegion, MetalSharedOffloadRegion]:
+    """Worker-rank and scheduler-rank attachments to one shared region."""
+    aligned_row, raw_row = _region_geometry(cache)
+    instance = f"test-{uuid.uuid4().hex[:8]}"
+    worker = MetalSharedOffloadRegion(
+        instance_id=instance,
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=0,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    scheduler = MetalSharedOffloadRegion(
+        instance_id=instance,
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=None,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    return worker, scheduler
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_region_backed_roundtrip(dtype: mx.Dtype) -> None:
+    cache = make_cache(dtype)
+    worker_region, scheduler_region = _make_regions(cache)
+    worker = MetalKVOffloadWorker(
+        cache,
+        block_size_factor=FACTOR,
+        num_cpu_blocks=NUM_CPU_BLOCKS,
+        region=worker_region,
+    )
+    try:
+        randomize(cache)
+        original = snapshot_blocks(cache, [1, 2, 5, 6])
+
+        assert worker.submit_store(1, gpu_spec([1, 2, 5, 6]), CPULoadStoreSpec([0, 2]))
+        assert len(worker.get_finished()) == 1
+
+        zero_blocks(cache, [1, 2, 5, 6])
+        assert worker.submit_load(2, CPULoadStoreSpec([0, 2]), gpu_spec([1, 2, 5, 6]))
+        assert len(worker.get_finished()) == 1
+
+        restored = snapshot_blocks(cache, [1, 2, 5, 6])
+        for a, b in zip(original, restored, strict=True):
+            np.testing.assert_array_equal(a, b)
+    finally:
+        worker.shutdown()
+        scheduler_region.cleanup()
+
+
+def test_memoryview_sees_worker_stores_and_feeds_loads() -> None:
+    """Byte-level contract used by the fs tier: whole-block rows round-trip
+    through the scheduler-side memoryview."""
+    cache = make_cache()
+    worker_region, scheduler_region = _make_regions(cache)
+    worker = MetalKVOffloadWorker(
+        cache,
+        block_size_factor=FACTOR,
+        num_cpu_blocks=NUM_CPU_BLOCKS,
+        region=worker_region,
+    )
+    view = scheduler_region.create_kv_memoryview()
+    flat = view.cast("B")
+    try:
+        randomize(cache)
+        original = snapshot_blocks(cache, [3, 4])
+
+        # Handler stores GPU blocks 3,4 into CPU block 1...
+        assert worker.submit_store(1, gpu_spec([3, 4]), CPULoadStoreSpec([1]))
+        worker.get_finished()
+
+        # ...the scheduler-side view of CPU block 1 must carry those bytes.
+        # Address it exactly like the fs tier does (tiering/fs/io.py): flat
+        # byte cast, block b at [b * strides[0], (b + 1) * strides[0]).
+        assert view.strides is not None
+        row_stride = view.strides[0]
+        stored_bytes = bytes(flat[row_stride : 2 * row_stride])
+        assert any(stored_bytes)  # not all zero
+
+        # Simulate the fs tier: persist the row, scribble over the CPU
+        # block, then restore the row through the same memoryview.
+        flat[row_stride : 2 * row_stride] = b"\x00" * row_stride
+        assert not any(bytes(flat[row_stride : 2 * row_stride]))
+        flat[row_stride : 2 * row_stride] = stored_bytes
+
+        # A worker load from that CPU block must reproduce the GPU blocks.
+        zero_blocks(cache, [3, 4])
+        assert worker.submit_load(2, CPULoadStoreSpec([1]), gpu_spec([3, 4]))
+        worker.get_finished()
+
+        restored = snapshot_blocks(cache, [3, 4])
+        for a, b in zip(original, restored, strict=True):
+            np.testing.assert_array_equal(a, b)
+    finally:
+        del flat, view
+        worker.shutdown()
+        scheduler_region.cleanup()
+
+
+def test_region_registry_shares_and_releases() -> None:
+    """Two attachments to one instance id share bytes; distinct ids do not;
+    cleanup releases the registry entry only when the last ref drops."""
+    cache = make_cache()
+    aligned_row, raw_row = _region_geometry(cache)
+    instance = f"test-{uuid.uuid4().hex[:8]}"
+
+    def attach(rank):
+        return MetalSharedOffloadRegion(
+            instance_id=instance,
+            num_blocks=NUM_CPU_BLOCKS,
+            rank=rank,
+            kv_bytes_per_block=aligned_row,
+            cpu_page_size=raw_row,
+        )
+
+    a = attach(0)
+    b = attach(None)
+    a._base[0] = 42
+    assert int(b._base[0]) == 42, "attachments must share the same buffer"
+
+    other = MetalSharedOffloadRegion(
+        instance_id=f"other-{uuid.uuid4().hex[:8]}",
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=None,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    assert int(other._base[0]) == 0, "distinct instance ids must not share"
+    other.cleanup()
+
+    a.cleanup()
+    # Buffer still alive through b.
+    assert int(b._base[0]) == 42
+    b.cleanup()
+
+    # A fresh attachment after full release gets a new zeroed buffer.
+    c = attach(None)
+    assert int(c._base[0]) == 0
+    c.cleanup()
+
+
+def test_region_geometry_mismatch_rejected() -> None:
+    cache = make_cache()
+    aligned_row, raw_row = _region_geometry(cache)
+    instance = f"test-{uuid.uuid4().hex[:8]}"
+    a = MetalSharedOffloadRegion(
+        instance_id=instance,
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=0,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    try:
+        with pytest.raises(AssertionError, match="mismatched geometry"):
+            MetalSharedOffloadRegion(
+                instance_id=instance,
+                num_blocks=NUM_CPU_BLOCKS + 1,
+                rank=None,
+                kv_bytes_per_block=aligned_row,
+                cpu_page_size=raw_row,
+            )
+    finally:
+        a.cleanup()
+
+
+def test_region_backed_roundtrip_turboquant() -> None:
+    """TurboQuant packed + scale/zero arrays through the shared region and
+    the byte-level memoryview contract the disk tier relies on — the region
+    carve is most fragile exactly here (mixed dtypes, packed layouts)."""
+    cache = make_cache(head_dim=64, turboquant=True, k_quant="q8_0", v_quant="q3_0")
+    worker_region, scheduler_region = _make_regions(cache)
+    worker = MetalKVOffloadWorker(
+        cache,
+        block_size_factor=FACTOR,
+        num_cpu_blocks=NUM_CPU_BLOCKS,
+        region=worker_region,
+    )
+    randomize(cache)
+    gpu_blocks = [1, 2, 3, 4]
+    original = snapshot_blocks(cache, gpu_blocks)
+    assert worker.submit_store(1, gpu_spec(gpu_blocks), CPULoadStoreSpec([0, 2]))
+    worker.get_finished()
+
+    # Byte-level round trip through the scheduler-side memoryview (what the
+    # fs tier reads/writes): copy row bytes out and back, then restore.
+    # Access exactly as the fs tier does (io.py): flat byte cast + slice.
+    mv = scheduler_region.create_kv_memoryview().cast("B")
+    row_bytes = (
+        scheduler_region.row_stride
+        if hasattr(scheduler_region, "row_stride")
+        else len(mv) // NUM_CPU_BLOCKS
+    )
+    row_copy = bytes(mv[0:row_bytes])
+    mv[0:row_bytes] = b"\x00" * row_bytes
+    mv[0:row_bytes] = row_copy
+
+    zero_blocks(cache, gpu_blocks)
+    assert worker.submit_load(2, CPULoadStoreSpec([0, 2]), gpu_spec(gpu_blocks))
+    worker.get_finished()
+    for a, b in zip(original, snapshot_blocks(cache, gpu_blocks), strict=True):
+        np.testing.assert_array_equal(a, b)
+    worker.shutdown()
+    scheduler_region.cleanup()

--- a/tests/test_kv_offload_worker.py
+++ b/tests/test_kv_offload_worker.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the Metal KV offloading worker (plain-numpy host pool).
+
+Round-trips blocks through the host pool and asserts byte-exact restoration,
+including bf16 (numpy-dtype-less) caches, TurboQuant packed caches, and
+offloaded blocks spanning multiple GPU blocks (block_size_factor > 1) with an
+unaligned first block.
+"""
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.v1.kv_offload.base import GPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+from tests.kv_offload_helpers import (
+    gpu_spec,
+    make_cache,
+    randomize,
+    snapshot_blocks,
+    zero_blocks,
+)
+from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+
+def _run_roundtrip(
+    cache,
+    *,
+    block_size_factor: int = 1,
+    gpu_blocks: list[int],
+    cpu_blocks: list[int],
+    block_index: int = 0,
+) -> None:
+    worker = MetalKVOffloadWorker(
+        cache, block_size_factor=block_size_factor, num_cpu_blocks=4
+    )
+
+    randomize(cache)
+    original = snapshot_blocks(cache, gpu_blocks)
+
+    # Store GPU -> CPU.
+    ok = worker.submit_store(
+        1, gpu_spec(gpu_blocks, block_index), CPULoadStoreSpec(cpu_blocks)
+    )
+    assert ok
+    finished = worker.get_finished()
+    assert [r.job_id for r in finished] == [1]
+    assert finished[0].success
+    assert finished[0].transfer_size > 0
+
+    # Clobber the GPU blocks, then load them back CPU -> GPU.
+    zero_blocks(cache, gpu_blocks)
+    ok = worker.submit_load(
+        2, CPULoadStoreSpec(cpu_blocks), gpu_spec(gpu_blocks, block_index)
+    )
+    assert ok
+    finished = worker.get_finished()
+    assert [r.job_id for r in finished] == [2]
+
+    restored = snapshot_blocks(cache, gpu_blocks)
+    for a, b in zip(original, restored, strict=True):
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+def test_roundtrip_dtypes(dtype: mx.Dtype) -> None:
+    cache = make_cache(dtype)
+    _run_roundtrip(cache, gpu_blocks=[5, 2, 7], cpu_blocks=[0, 1, 3])
+
+
+def test_roundtrip_turboquant() -> None:
+    cache = make_cache(
+        head_dim=64,
+        turboquant=True,
+        k_quant="q8_0",
+        v_quant="q3_0",
+    )
+    _run_roundtrip(cache, gpu_blocks=[1, 6], cpu_blocks=[2, 0])
+
+
+def test_roundtrip_block_size_factor() -> None:
+    """One CPU block spans two GPU blocks."""
+    cache = make_cache()
+    _run_roundtrip(
+        cache,
+        block_size_factor=2,
+        gpu_blocks=[3, 4, 5, 6],
+        cpu_blocks=[1, 3],
+    )
+
+
+def test_roundtrip_unaligned_first_block() -> None:
+    """Request enters its first offloaded block mid-block (skip one sub-slot)."""
+    cache = make_cache()
+    worker = MetalKVOffloadWorker(cache, block_size_factor=2, num_cpu_blocks=4)
+    randomize(cache)
+
+    # First store gpu blocks [2,3] as the two sub-slots of CPU block 1.
+    assert worker.submit_store(
+        1, gpu_spec([2, 3], block_index=0), CPULoadStoreSpec([1])
+    )
+
+    # Now store one more gpu block at logical block index 3: skip = 3 % 2 = 1,
+    # so the worker must place it in the second sub-slot of CPU block 2.
+    assert worker.submit_store(2, gpu_spec([5], block_index=3), CPULoadStoreSpec([2]))
+    assert len(worker.get_finished()) == 2
+
+    original = snapshot_blocks(cache, [5])
+    zero_blocks(cache, [5])
+    assert worker.submit_load(3, CPULoadStoreSpec([2]), gpu_spec([5], block_index=3))
+    assert len(worker.get_finished()) == 1
+    restored = snapshot_blocks(cache, [5])
+    for a, b in zip(original, restored, strict=True):
+        np.testing.assert_array_equal(a, b)
+
+
+def test_unknown_spec_types_raise() -> None:
+    """Errors must propagate: the connector-side caller asserts a successful
+    submission (job failure is unsupported upstream), so raising here surfaces
+    the root cause instead of a bare assert — swallowing it would hide it."""
+    cache = make_cache()
+    worker = MetalKVOffloadWorker(cache, block_size_factor=1, num_cpu_blocks=4)
+    with pytest.raises(ValueError, match="unexpected load spec types"):
+        worker.submit_load(1, CPULoadStoreSpec([0]), CPULoadStoreSpec([1]))
+    with pytest.raises(ValueError, match="unexpected store spec types"):
+        worker.submit_store(2, CPULoadStoreSpec([0]), CPULoadStoreSpec([1]))
+    assert worker.get_finished() == []
+
+
+def test_uncovered_per_block_array_rejected() -> None:
+    """CACHE_ATTRS completeness guard: a per-block array list the offload
+    inventory doesn't know about must fail registration, not silently drop
+    state (the 'new model family' corruption mode)."""
+    cache = make_cache()
+    cache.gdn_conv_state = [
+        mx.zeros((cache.num_blocks, 4, 8)) for _ in range(2)
+    ]  # simulate a new model family's extra per-block state
+    with pytest.raises(NotImplementedError, match="gdn_conv_state"):
+        MetalKVOffloadWorker(cache, block_size_factor=1, num_cpu_blocks=4)
+
+
+def test_out_of_range_block_ids_raise() -> None:
+    """OOB ids corrupt silently at the MLX layer (take returns garbage,
+    scatter drops writes) — the worker must fail fast instead."""
+    cache = make_cache()  # 8 GPU blocks
+    worker = MetalKVOffloadWorker(cache, block_size_factor=1, num_cpu_blocks=4)
+    with pytest.raises(ValueError, match="GPU block ids out of range"):
+        worker.submit_store(1, gpu_spec([5, 99]), CPULoadStoreSpec([0, 1]))
+    with pytest.raises(ValueError, match="CPU block ids out of range"):
+        worker.submit_store(2, gpu_spec([5, 2]), CPULoadStoreSpec([0, 7]))
+    with pytest.raises(ValueError, match="CPU block ids out of range"):
+        worker.submit_store(3, gpu_spec([5]), CPULoadStoreSpec([-1]))
+    assert worker.get_finished() == []
+
+
+def test_expected_block_bytes_overrun_raises() -> None:
+    """Carving MORE than the spec sized (row overrun) is fatal; carving less
+    is upstream's alignment padding and must be accepted (TurboQuant blocks
+    are rarely page-aligned — found live on a clean-machine e2e)."""
+    cache = make_cache()
+    with pytest.raises(ValueError, match="rows would overrun"):
+        MetalKVOffloadWorker(
+            cache,
+            block_size_factor=1,
+            num_cpu_blocks=4,
+            expected_block_bytes=100,  # far below the real carve
+        )
+
+
+def test_expected_block_bytes_padding_accepted() -> None:
+    """Upstream tiering rounds blocks up to SharedOffloadRegion's
+    BLOCK_SIZE_ALIGNMENT — mmap.PAGESIZE (16384 on Apple Silicon)."""
+    import mmap
+
+    from tests.kv_offload_helpers import gpu_block_bytes
+
+    cache = make_cache()
+    page = mmap.PAGESIZE
+    aligned = -(-gpu_block_bytes(cache) // page) * page  # upstream round_up
+    MetalKVOffloadWorker(
+        cache,
+        block_size_factor=1,
+        num_cpu_blocks=4,
+        expected_block_bytes=aligned,
+    )
+
+
+def test_expected_block_bytes_match_accepted() -> None:
+    from tests.kv_offload_helpers import gpu_block_bytes
+
+    cache = make_cache()
+    MetalKVOffloadWorker(
+        cache,
+        block_size_factor=1,
+        num_cpu_blocks=4,
+        expected_block_bytes=gpu_block_bytes(cache),
+    )
+
+
+def test_unsupported_cache_dtype_rejected() -> None:
+    cache = make_cache()
+    cache.key_caches[0] = mx.zeros(cache.key_caches[0].shape, dtype=mx.int64)
+    with pytest.raises(NotImplementedError, match="unsupported cache dtype"):
+        MetalKVOffloadWorker(cache, block_size_factor=1, num_cpu_blocks=4)
+
+
+def test_too_few_cpu_blocks_raise() -> None:
+    cache = make_cache()
+    worker = MetalKVOffloadWorker(cache, block_size_factor=2, num_cpu_blocks=4)
+    with pytest.raises(ValueError, match="CPU blocks too few"):
+        worker.submit_store(1, gpu_spec([1, 2, 3]), CPULoadStoreSpec([0]))
+
+
+def test_empty_group_is_a_successful_noop() -> None:
+    cache = make_cache()
+    worker = MetalKVOffloadWorker(cache, block_size_factor=1, num_cpu_blocks=4)
+    spec = GPULoadStoreSpec([], group_sizes=[0], block_indices=[0])
+    assert worker.submit_store(1, spec, CPULoadStoreSpec([]))
+    (result,) = worker.get_finished()
+    assert result.success and result.transfer_size == 0

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -9,7 +9,11 @@ for a 1.5B model and drove free memory to 11% (observed live, 2026-07-17).
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
 
 GB = 1 << 30
-SLACK = WorkerCachePlanner.MEMORY_GUARD_SLACK_BYTES
+
+
+def eff_slack(total: int) -> int:
+    """Mirror of the guard's machine-scaled slack (capped at RAM/16)."""
+    return min(WorkerCachePlanner.MEMORY_GUARD_SLACK_BYTES, total // 16)
 
 
 def clamp(kv, other, avail, total, frac=0.15, disabled=False):
@@ -38,14 +42,14 @@ def test_studio_incident_is_clamped() -> None:
     assert reason and "clamped" in reason
     # Post-clamp: wired total leaves at least the floor free.
     floor = max(4 * GB, int(137 * GB * 0.15))
-    assert budget + 2 * GB + SLACK <= 114 * GB - floor
+    assert budget + 2 * GB + eff_slack(137 * GB) <= 114 * GB - floor
 
 
 def test_hard_limit_when_plan_exceeds_available() -> None:
     """A plan bigger than available memory is cut regardless of the guard
     (serving would thrash immediately)."""
     budget, reason = clamp(120 * GB, 2 * GB, 100 * GB, 137 * GB, disabled=True)
-    assert budget + 2 * GB + SLACK <= 100 * GB - 1 * GB
+    assert budget + 2 * GB + eff_slack(137 * GB) <= 100 * GB - 1 * GB
     assert reason and "cannot-fit" in reason
 
 
@@ -75,3 +79,26 @@ def test_floor_fraction_scales() -> None:
 def test_never_negative() -> None:
     budget, _ = clamp(50 * GB, 10 * GB, 8 * GB, 16 * GB)
     assert budget == 0
+
+
+def test_tiny_ci_runner_stays_serving_viable() -> None:
+    """Replays the GitHub macos-15 runner numbers that zeroed the budget in
+    upstream CI (PR #530, run 2026-07-20): ~7GB total RAM, ~4.5GB available
+    at plan time, ~1.25GB model+overhead. A flat 4GB absolute floor demands
+    57% of the machine and clamps every budget to zero; the floor's absolute
+    minimum must scale down (min(4GB, 25% of RAM)) so a small runner still
+    serves a small model."""
+    budget, reason = clamp(int(2.76 * GB), int(1.25 * GB), int(4.5 * GB), 7 * GB)
+    assert reason is not None  # the guard still engages on a small host
+    assert budget > 0.75 * GB  # but leaves a serving-viable budget
+    # Floor actually honored post-clamp.
+    floor = max(min(4 * GB, int(7 * GB * 0.25)), int(7 * GB * 0.15))
+    assert budget + int(1.25 * GB) + eff_slack(7 * GB) <= int(4.5 * GB) - floor
+
+
+def test_sixteen_gb_floor_unchanged_by_small_ram_cap() -> None:
+    """The small-RAM cap must not weaken the 16GB-class floor: at 16GB the
+    absolute minimum is still the full 4GB (25% of 16GB == 4GB)."""
+    with_cap, _ = clamp(int(10.6 * GB), 1 * GB, 13 * GB, 16 * GB)
+    floor = 4 * GB  # unchanged from the pre-cap formula
+    assert with_cap + 1 * GB + eff_slack(16 * GB) <= 13 * GB - floor

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -82,18 +82,19 @@ def test_never_negative() -> None:
 
 
 def test_tiny_ci_runner_stays_serving_viable() -> None:
-    """Replays the GitHub macos-15 runner numbers that zeroed the budget in
-    upstream CI (PR #530, run 2026-07-20): ~7GB total RAM, ~4.5GB available
-    at plan time, ~1.25GB model+overhead. A flat 4GB absolute floor demands
-    57% of the machine and clamps every budget to zero; the floor's absolute
-    minimum must scale down (min(4GB, 25% of RAM)) so a small runner still
-    serves a small model."""
-    budget, reason = clamp(int(2.76 * GB), int(1.25 * GB), int(4.5 * GB), 7 * GB)
+    """Replays the GitHub macos-15 runner that zeroed the budget in upstream
+    CI (PR #530, runs 2026-07-20): 6GB total RAM, 2.6GB available at plan
+    time, 2.77GB fraction-derived budget, ~0.05GB overhead still to come
+    (model weights are already resident and thus already out of available —
+    they must NOT appear in planned_other_bytes). Flat 4GB floor/slack
+    constants exceed the whole machine; scaled constants must leave a
+    serving-viable budget for a 0.6B model."""
+    budget, reason = clamp(int(2.77 * GB), int(0.05 * GB), int(2.6 * GB), 6 * GB)
     assert reason is not None  # the guard still engages on a small host
-    assert budget > 0.75 * GB  # but leaves a serving-viable budget
+    assert budget > 0.5 * GB  # but leaves a serving-viable budget
     # Floor actually honored post-clamp.
-    floor = max(min(4 * GB, int(7 * GB * 0.25)), int(7 * GB * 0.15))
-    assert budget + int(1.25 * GB) + eff_slack(7 * GB) <= int(4.5 * GB) - floor
+    floor = max(min(4 * GB, int(6 * GB * 0.25)), int(6 * GB * 0.15))
+    assert budget + int(0.05 * GB) + eff_slack(6 * GB) <= int(2.6 * GB) - floor
 
 
 def test_sixteen_gb_floor_unchanged_by_small_ram_cap() -> None:

--- a/tests/test_memory_guard.py
+++ b/tests/test_memory_guard.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the KV-cache memory-safety clamp (cache_policy.compute_safe_kv_budget).
+
+The clamp exists because fraction-derived KV budgets are wired (non-pageable)
+and know nothing about host state: fraction 0.8 on a 128GB machine wired ~90GB
+for a 1.5B model and drove free memory to 11% (observed live, 2026-07-17).
+"""
+
+from vllm_metal.v1.cache_policy import WorkerCachePlanner
+
+GB = 1 << 30
+SLACK = WorkerCachePlanner.MEMORY_GUARD_SLACK_BYTES
+
+
+def clamp(kv, other, avail, total, frac=0.15, disabled=False):
+    return WorkerCachePlanner.compute_safe_kv_budget(
+        kv,
+        planned_other_bytes=other,
+        available_bytes=avail,
+        total_bytes=total,
+        min_free_fraction=frac,
+        guard_disabled=disabled,
+    )
+
+
+def test_small_plan_untouched() -> None:
+    """A modest plan on a big machine passes through unchanged."""
+    budget, reason = clamp(10 * GB, 2 * GB, 110 * GB, 137 * GB)
+    assert budget == 10 * GB and reason is None
+
+
+def test_studio_incident_is_clamped() -> None:
+    """The observed live incident: 90.4GB budget, 114GB available, 137GB
+    total. The soft floor (15% = 20.6GB) must clamp the budget so free
+    memory never approaches the observed 11%."""
+    budget, reason = clamp(int(90.4 * GB), 2 * GB, 114 * GB, 137 * GB)
+    assert budget < int(90.4 * GB)
+    assert reason and "clamped" in reason
+    # Post-clamp: wired total leaves at least the floor free.
+    floor = max(4 * GB, int(137 * GB * 0.15))
+    assert budget + 2 * GB + SLACK <= 114 * GB - floor
+
+
+def test_hard_limit_when_plan_exceeds_available() -> None:
+    """A plan bigger than available memory is cut regardless of the guard
+    (serving would thrash immediately)."""
+    budget, reason = clamp(120 * GB, 2 * GB, 100 * GB, 137 * GB, disabled=True)
+    assert budget + 2 * GB + SLACK <= 100 * GB - 1 * GB
+    assert reason and "cannot-fit" in reason
+
+
+def test_disable_env_skips_soft_floor_only() -> None:
+    """Opt-out disables the floor clamp but never the cannot-fit cut."""
+    kv = int(90.4 * GB)
+    budget, reason = clamp(kv, 2 * GB, 114 * GB, 137 * GB, disabled=True)
+    assert budget == kv and reason is None  # fits in available: untouched
+
+
+def test_small_machine_recipe_mostly_preserved() -> None:
+    """fraction 0.8 on a 16GB CI Mac: the clamp trims rather than guts the
+    budget (floor = max(4GB, 2.4GB) = 4GB)."""
+    # 0.8 * 14.5GB metal limit ~ 11.6GB usable; model+overhead ~1GB
+    budget, reason = clamp(int(10.6 * GB), 1 * GB, 13 * GB, 16 * GB)
+    assert reason is not None  # small machines do get clamped
+    assert budget > 3 * GB  # but a serving-viable budget remains
+
+
+def test_floor_fraction_scales() -> None:
+    """A stricter floor clamps more."""
+    loose, _ = clamp(int(90.4 * GB), 2 * GB, 114 * GB, 137 * GB, frac=0.10)
+    strict, _ = clamp(int(90.4 * GB), 2 * GB, 114 * GB, 137 * GB, frac=0.30)
+    assert strict < loose
+
+
+def test_never_negative() -> None:
+    budget, _ = clamp(50 * GB, 10 * GB, 8 * GB, 16 * GB)
+    assert budget == 0

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     VLLM_METAL_BUILD_FROM_SOURCE: bool = False
     VLLM_METAL_VISIBLE_DEVICES: str | None = None
     VLLM_METAL_RING_BASE_PORT: int = 32323
+    VLLM_METAL_MIN_FREE_FRACTION: float = 0.15
+    VLLM_METAL_DISABLE_MEMORY_GUARD: bool = False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # Fraction of unified memory to use.  "auto" (the default) means the
@@ -43,6 +45,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_USE_MLX": lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
     # MLX device type: "gpu" (default) or "cpu".
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
+    # Minimum fraction of TOTAL system RAM the KV cache plan must leave
+    # un-wired (free for the OS, pager, and other processes). The paged
+    # KV budget is clamped (with a warning) to honor this floor. The KV
+    # pool is wired/non-pageable, so macOS cannot reclaim it under
+    # pressure; breaching the floor has hardware-reset machines.
+    "VLLM_METAL_MIN_FREE_FRACTION": lambda: float(
+        os.getenv("VLLM_METAL_MIN_FREE_FRACTION", "0.15")
+    ),
+    # Disable the memory-safety clamp entirely (power users who manage
+    # system memory themselves). The hard cannot-fit error still applies.
+    "VLLM_METAL_DISABLE_MEMORY_GUARD": lambda: (
+        os.getenv("VLLM_METAL_DISABLE_MEMORY_GUARD", "0") == "1"
+    ),
     # Enable verbose debug logging (default False).
     "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
     # Use native Metal paged attention (default True).

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -568,6 +568,134 @@ class MetalPlatform(Platform):
             # rejections (multimodal, STT) further below, so an unsupported DP
             # config fails fast before any ray.init side effect.
 
+        # KV offloading / KV connectors. vLLM's own translation of
+        # --kv-offloading-size N into kv_transfer_config runs AFTER this hook
+        # (_post_init_kv_transfer_config, vllm/config/vllm.py) and would
+        # force-set a connector name this platform cannot serve. So the
+        # translation is performed here instead — kv_offloading_size is
+        # cleared afterwards, which disarms the upstream translation (it
+        # returns early when the size is unset) — and the connector is routed
+        # to the Metal subclass via kv_connector_module_path. A
+        # kv_transfer_config with no connector and no offloading request is
+        # inert upstream and passes through untouched.
+        cache_config = getattr(vllm_config, "cache_config", None)
+        kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+        kv_offloading_size = getattr(cache_config, "kv_offloading_size", None)
+        explicit_connector = (
+            kv_transfer_config.kv_connector if kv_transfer_config is not None else None
+        )
+        if explicit_connector not in (
+            None,
+            "OffloadingConnector",
+            "MetalOffloadingConnector",
+        ):
+            raise NotImplementedError(
+                f"KV connector '{explicit_connector}' is not supported on "
+                "Metal; only the KV offloading connector "
+                "(--kv-offloading-size N) is available."
+            )
+        if kv_offloading_size is not None or explicit_connector is not None:
+            kv_offloading_backend = getattr(
+                cache_config, "kv_offloading_backend", "native"
+            )
+            if kv_offloading_size is not None and kv_offloading_backend != "native":
+                raise NotImplementedError(
+                    "Metal supports only --kv-offloading-backend native; "
+                    f"'{kv_offloading_backend}' is not supported."
+                )
+            import vllm.envs as vllm_envs
+
+            if getattr(vllm_envs, "VLLM_USE_SIMPLE_KV_OFFLOAD", False):
+                raise NotImplementedError(
+                    "VLLM_USE_SIMPLE_KV_OFFLOAD is not supported on Metal; "
+                    "unset it to use the native KV offloading connector."
+                )
+            if not config.use_paged_attention:
+                raise NotImplementedError(
+                    "KV offloading on Metal requires paged attention "
+                    "(VLLM_METAL_USE_PAGED_ATTENTION=1)."
+                )
+            if parallel_config.pipeline_parallel_size > 1:
+                raise NotImplementedError(
+                    "KV offloading on Metal does not support pipeline "
+                    "parallelism yet; run with pipeline_parallel_size=1."
+                )
+            if kv_transfer_config is None:
+                from vllm.config import KVTransferConfig
+
+                kv_transfer_config = KVTransferConfig()
+                vllm_config.kv_transfer_config = kv_transfer_config
+            kv_transfer_config.kv_connector = "MetalOffloadingConnector"
+            kv_transfer_config.kv_connector_module_path = (
+                "vllm_metal.v1.kv_offload.connector"
+            )
+            # Force-normalize like upstream _post_init_kv_transfer_config
+            # (vllm/config/vllm.py): offloading always runs kv_both. A
+            # passed-through kv_producer would silently disable the
+            # scheduler's defer_block_free protection (freed-block race).
+            if kv_transfer_config.kv_role not in (None, "kv_both"):
+                logger.warning(
+                    "KV offloading on Metal overrides kv_role=%r to 'kv_both'.",
+                    kv_transfer_config.kv_role,
+                )
+            kv_transfer_config.kv_role = "kv_both"
+            extra = kv_transfer_config.kv_connector_extra_config
+            if kv_offloading_size is not None:
+                # Mirrors upstream _post_init_kv_transfer_config (GiB).
+                extra["cpu_bytes_to_use"] = int(kv_offloading_size * (1 << 30))
+                cache_config.kv_offloading_size = None
+            elif "cpu_bytes_to_use" not in extra:
+                raise NotImplementedError(
+                    "KV offloading on Metal needs a host pool size: pass "
+                    "--kv-offloading-size N (GiB) alongside the connector."
+                )
+            # Remap upstream spec names to their Metal counterparts; pick the
+            # tiering spec whenever secondary tiers (e.g. a disk tier) are
+            # configured. Unknown names fail here rather than resolving to a
+            # CUDA-bound spec deep inside engine start.
+            spec_name = extra.get("spec_name")
+            use_tiering = bool(extra.get("secondary_tiers")) or spec_name in (
+                "TieringOffloadingSpec",
+                "MetalTieringOffloadingSpec",
+            )
+            # Secondary tier types are gated here: the upstream "obj" tier
+            # needs NIXL, which has no macOS build — without this guard it
+            # crashes ungracefully deep inside engine start.
+            for tier in extra.get("secondary_tiers") or []:
+                tier_type = tier.get("type") if isinstance(tier, dict) else None
+                if tier_type not in ("fs",):
+                    raise NotImplementedError(
+                        f"Secondary KV tier type '{tier_type}' is not "
+                        "supported on Metal; only 'fs' (filesystem) is "
+                        "available (the 'obj' tier requires NIXL, which has "
+                        "no macOS build)."
+                    )
+            if spec_name not in (
+                None,
+                "CPUOffloadingSpec",
+                "TieringOffloadingSpec",
+                "MetalOffloadingSpec",
+                "MetalTieringOffloadingSpec",
+            ):
+                raise NotImplementedError(
+                    f"Offloading spec '{spec_name}' is not supported on Metal."
+                )
+            extra["spec_name"] = (
+                "MetalTieringOffloadingSpec" if use_tiering else "MetalOffloadingSpec"
+            )
+            extra["spec_module_path"] = "vllm_metal.v1.kv_offload.spec"
+            # The tiering host pool is anonymous RAM shared between the
+            # scheduler and the worker within one process (macOS has no
+            # tmpfs; a file-backed region would write KV churn back to SSD).
+            # That requires the single-process executor.
+            if use_tiering and parallel_config.distributed_executor_backend != "uni":
+                raise NotImplementedError(
+                    "KV offloading with secondary tiers on Metal requires "
+                    "the single-process executor "
+                    "(--distributed-executor-backend uni); got "
+                    f"'{parallel_config.distributed_executor_backend}'."
+                )
+
         scheduler_config = vllm_config.scheduler_config
 
         # Pipeline parallelism relays each sampled token to the first stage via the

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -641,6 +641,9 @@ class MetalPlatform(Platform):
             kv_transfer_config.kv_role = "kv_both"
             extra = kv_transfer_config.kv_connector_extra_config
             if kv_offloading_size is not None:
+                # A non-None kv_offloading_size implies cache_config exists
+                # (it was read off cache_config above).
+                assert cache_config is not None
                 # Mirrors upstream _post_init_kv_transfer_config (GiB).
                 extra["cpu_bytes_to_use"] = int(kv_offloading_size * (1 << 30))
                 cache_config.kv_offloading_size = None

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -781,9 +781,14 @@ class WorkerCachePlanner:
         import vllm_metal.envs as metal_envs
 
         vmem = psutil.virtual_memory()
+        # planned_other_bytes = allocations still to come. The model weights
+        # are already resident when available is sampled (the plan runs
+        # after load), so counting model_memory here would double-subtract
+        # it — harmless noise on a 128GB host, fatal on a 6GB CI runner
+        # where it zeroes the budget.
         kv_budget, clamp_reason = self.compute_safe_kv_budget(
             kv_budget,
-            planned_other_bytes=model_memory + overhead + reservation.total_bytes,
+            planned_other_bytes=overhead + reservation.total_bytes,
             available_bytes=vmem.available,
             total_bytes=vmem.total,
             min_free_fraction=metal_envs.VLLM_METAL_MIN_FREE_FRACTION,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -702,13 +702,23 @@ class WorkerCachePlanner:
           cannot-fit error upstream if violated.
         - SOFT floor (default on, ``VLLM_METAL_DISABLE_MEMORY_GUARD=1`` to
           opt out): after wiring, at least ``min_free_fraction`` of TOTAL
-          RAM (min 4GB) must remain free. The budget is reduced to honor
-          the floor; the caller logs the returned reason prominently.
+          RAM must remain free, with an absolute minimum of 4GB capped at
+          25% of RAM — on a 16GB+ machine the minimum is the full 4GB, but
+          on small hosts (e.g. 7GB CI runners) demanding 4GB free would
+          consume most of RAM and zero every budget, so the minimum scales
+          down to a quarter of the machine instead. The budget is reduced
+          to honor the floor; the caller logs the returned reason
+          prominently.
 
         Returns (possibly-clamped budget, human-readable clamp reason or
         None).
         """
-        slack = WorkerCachePlanner.MEMORY_GUARD_SLACK_BYTES
+        # Slack (headroom for plan underestimation) and the floor's absolute
+        # minimum are both sized for >=16GB-class machines; on small hosts
+        # (7GB CI runners) flat 4GB constants exceed what the machine can
+        # give and zero every budget. Scale both to the machine: slack is
+        # capped at 1/16th of RAM (4GB at 64GB+, ~0.4GB on a 7GB runner).
+        slack = min(WorkerCachePlanner.MEMORY_GUARD_SLACK_BYTES, total_bytes // 16)
         planned_total = kv_budget + planned_other_bytes + slack
 
         hard_limit = available_bytes - (1 << 30)
@@ -727,7 +737,8 @@ class WorkerCachePlanner:
         if guard_disabled:
             return kv_budget, clamp_reason
 
-        floor = max(4 << 30, int(total_bytes * min_free_fraction))
+        absolute_min = min(4 << 30, int(total_bytes * 0.25))
+        floor = max(absolute_min, int(total_bytes * min_free_fraction))
         soft_limit = available_bytes - floor
         planned_total = kv_budget + planned_other_bytes + slack
         if planned_total > soft_limit:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -676,6 +676,75 @@ class WorkerCachePlanner:
         """Return Metal-memory budget before hybrid GDN reservation."""
         return int(metal_limit * fraction) - model_memory - overhead
 
+    # Headroom for wired allocations outside the planned budget (MLX buffer
+    # cache, tokenizer/server processes) observed at ~4-7GB on live serves.
+    MEMORY_GUARD_SLACK_BYTES = 4 << 30
+
+    @staticmethod
+    def compute_safe_kv_budget(
+        kv_budget: int,
+        *,
+        planned_other_bytes: int,
+        available_bytes: int,
+        total_bytes: int,
+        min_free_fraction: float,
+        guard_disabled: bool,
+    ) -> tuple[int, str | None]:
+        """Clamp the KV budget so the plan cannot destabilize the host.
+
+        The KV pool is wired (non-pageable): macOS cannot reclaim it under
+        pressure, and plans sized purely from ``fraction`` have driven
+        machines to hard resets. Two independent limits:
+
+        - HARD (always on): the full plan must fit in currently-available
+          memory with minimal slack — otherwise serving would thrash from
+          the first request. Returns a budget that triggers the standard
+          cannot-fit error upstream if violated.
+        - SOFT floor (default on, ``VLLM_METAL_DISABLE_MEMORY_GUARD=1`` to
+          opt out): after wiring, at least ``min_free_fraction`` of TOTAL
+          RAM (min 4GB) must remain free. The budget is reduced to honor
+          the floor; the caller logs the returned reason prominently.
+
+        Returns (possibly-clamped budget, human-readable clamp reason or
+        None).
+        """
+        slack = WorkerCachePlanner.MEMORY_GUARD_SLACK_BYTES
+        planned_total = kv_budget + planned_other_bytes + slack
+
+        hard_limit = available_bytes - (1 << 30)
+        if planned_total > hard_limit:
+            hard_budget = max(0, hard_limit - planned_other_bytes - slack)
+            reason = (
+                f"plan needs {planned_total / 1e9:.1f}GB but only "
+                f"{available_bytes / 1e9:.1f}GB is available; KV budget cut "
+                f"{kv_budget / 1e9:.1f}GB -> {hard_budget / 1e9:.1f}GB "
+                "(cannot-fit hard limit)"
+            )
+            kv_budget, clamp_reason = hard_budget, reason
+        else:
+            clamp_reason = None
+
+        if guard_disabled:
+            return kv_budget, clamp_reason
+
+        floor = max(4 << 30, int(total_bytes * min_free_fraction))
+        soft_limit = available_bytes - floor
+        planned_total = kv_budget + planned_other_bytes + slack
+        if planned_total > soft_limit:
+            soft_budget = max(0, soft_limit - planned_other_bytes - slack)
+            clamp_reason = (
+                f"wiring {planned_total / 1e9:.1f}GB would leave less than "
+                f"the {floor / 1e9:.1f}GB free-memory floor "
+                f"({min_free_fraction:.0%} of {total_bytes / 1e9:.0f}GB "
+                f"RAM); KV budget clamped {kv_budget / 1e9:.1f}GB -> "
+                f"{soft_budget / 1e9:.1f}GB. Lower "
+                "VLLM_METAL_MEMORY_FRACTION to size the cache "
+                "intentionally, or set VLLM_METAL_DISABLE_MEMORY_GUARD=1 "
+                "to accept the risk"
+            )
+            kv_budget = soft_budget
+        return kv_budget, clamp_reason
+
     def _paged_attention_plan(self, *, overhead: int) -> _PagedAttentionPlan:
         block_size = self._worker.vllm_config.cache_config.block_size
         fraction = self._memory_fraction()
@@ -691,6 +760,27 @@ class WorkerCachePlanner:
         )
         reservation = self._hybrid_gdn_reservation()
         kv_budget = base_kv_budget - reservation.total_bytes
+
+        # Memory-safety clamp: fraction-derived budgets know nothing about
+        # what the host can actually afford (observed live: fraction 0.8 on
+        # a 128GB machine wired ~90GB for a 1.5B model and drove free
+        # memory to 11%). See compute_safe_kv_budget.
+        import psutil
+
+        import vllm_metal.envs as metal_envs
+
+        vmem = psutil.virtual_memory()
+        kv_budget, clamp_reason = self.compute_safe_kv_budget(
+            kv_budget,
+            planned_other_bytes=model_memory + overhead + reservation.total_bytes,
+            available_bytes=vmem.available,
+            total_bytes=vmem.total,
+            min_free_fraction=metal_envs.VLLM_METAL_MIN_FREE_FRACTION,
+            guard_disabled=metal_envs.VLLM_METAL_DISABLE_MEMORY_GUARD,
+        )
+        if clamp_reason:
+            logger.warning("Memory-safety guard: %s", clamp_reason)
+
         plan = _PagedAttentionPlan(
             block_size=block_size,
             fraction=fraction,

--- a/vllm_metal/v1/kv_offload/__init__.py
+++ b/vllm_metal/v1/kv_offload/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV offloading support for the Metal backend.
+
+Implements the worker-side pieces of vLLM's OffloadingConnector for the MLX
+paged KV cache: an OffloadingSpec that sizes and manages the host pool, an
+OffloadingWorker that moves blocks between the wired MLX cache and pageable
+host memory, and a connector subclass that registers them.
+
+See docs/offload-design.md for the architecture.
+"""

--- a/vllm_metal/v1/kv_offload/connector.py
+++ b/vllm_metal/v1/kv_offload/connector.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OffloadingConnector subclass for the Metal backend.
+
+The stock worker half canonicalizes torch KV tensors into int8
+``(num_blocks, page_size_bytes)`` storage views — impossible for vllm-metal's
+per-layer split K/V MLX arrays. This subclass overrides only the registration
+entry point; the scheduler half, job bookkeeping, deferred stores, and
+completion reporting are all inherited unchanged.
+
+``MetalModelRunner`` owns the ``register_kv_caches`` call site and passes the
+live ``MetalPagedKVCache`` instead of a torch tensor dict.
+
+``MetalPlatform.check_and_update_config`` routes here by setting
+``kv_transfer_config.kv_connector = "MetalOffloadingConnector"`` +
+``kv_connector_module_path`` (it performs the ``--kv-offloading-size``
+translation itself, before vLLM's own translation would run).
+
+No mlx import at module scope: this module is also imported by the
+scheduler/engine-core process to resolve the SCHEDULER-role connector class,
+which must not initialize MLX.
+"""
+
+from __future__ import annotations
+
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
+    OffloadingConnector,
+)
+
+from vllm_metal.v1.kv_offload.spec import MetalOffloadingSpecBase
+
+
+class MetalOffloadingConnector(OffloadingConnector):
+    def register_kv_caches(self, kv_caches) -> None:  # type: ignore[override]
+        from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+
+        assert self.connector_worker is not None
+        if not isinstance(kv_caches, MetalPagedKVCache):
+            raise TypeError(
+                "MetalOffloadingConnector.register_kv_caches expects the "
+                f"MetalPagedKVCache, got {type(kv_caches).__name__}"
+            )
+        spec = self.connector_worker.spec
+        if not isinstance(spec, MetalOffloadingSpecBase):
+            raise TypeError(
+                "MetalOffloadingConnector requires a Metal offloading spec "
+                f"(got {type(spec).__name__}); check kv_connector_extra_config"
+            )
+        # Mirrors OffloadingConnectorWorker.register_kv_caches minus the
+        # torch canonicalization: _init_worker's only job is populating
+        # self.worker from the spec.
+        self.connector_worker.worker = spec.get_metal_worker(kv_caches)

--- a/vllm_metal/v1/kv_offload/fs_tier.py
+++ b/vllm_metal/v1/kv_offload/fs_tier.py
@@ -364,7 +364,7 @@ class MetalFileSystemTierManager(FileSystemTierManager):
         # Replace the exists()-based lookup manager with the size-validating
         # one (shut down the upstream instance's thread first).
         self._lookup_manager.shutdown()
-        self._lookup_manager = MetalFsAsyncLookupManager(
+        self._lookup_manager: MetalFsAsyncLookupManager = MetalFsAsyncLookupManager(
             tier=self, tier_type=self.tier_type
         )
         # Negative cache breaking the failed-promotion livelock: keys whose

--- a/vllm_metal/v1/kv_offload/fs_tier.py
+++ b/vllm_metal/v1/kv_offload/fs_tier.py
@@ -31,6 +31,7 @@ Scheduler-side only (no mlx import): ``MetalTieringOffloadingSpec`` routes the
 from __future__ import annotations
 
 import ctypes
+import fcntl
 import functools
 import os
 import stat
@@ -62,11 +63,9 @@ QOS_CLASS_UTILITY = 0x11
 
 NOINDEX_DIRNAME = "blocks.noindex"
 
-_F_NOCACHE: int | None = None
-if sys.platform == "darwin":
-    import fcntl
-
-    _F_NOCACHE = getattr(fcntl, "F_NOCACHE", None)
+# Only the F_NOCACHE constant is Darwin-specific (fcntl itself is POSIX,
+# imported unconditionally above so non-darwin mypy runs resolve the name).
+_F_NOCACHE: int | None = getattr(fcntl, "F_NOCACHE", None)
 
 
 def set_current_thread_qos(qos_class: int) -> bool:

--- a/vllm_metal/v1/kv_offload/fs_tier.py
+++ b/vllm_metal/v1/kv_offload/fs_tier.py
@@ -1,0 +1,426 @@
+# SPDX-License-Identifier: Apache-2.0
+"""macOS-tuned filesystem secondary tier for Metal KV offloading.
+
+Subclasses upstream ``FileSystemTierManager`` to use the operating system
+properly on macOS; the tier semantics (file naming, atomic writes, dedup,
+lookup) are inherited unchanged:
+
+- **F_NOCACHE** on block file descriptors. Upstream opens with ``O_DIRECT``,
+  which silently degrades to ``0`` on macOS, so multi-GB KV churn would flow
+  through the Unified Buffer Cache and evict genuinely useful page cache.
+  ``fcntl(F_NOCACHE)`` is the macOS idiom for this write-once/read-rarely
+  streaming pattern (advisory, no alignment requirements).
+- **0o600 block files under a 0o700 root.** KV blocks are conversation-derived
+  data (prompt content is recoverable from them), and with ``PYTHONHASHSEED``
+  pinned the content-hash filenames let anyone who can list the directory
+  test for the presence of known prompts. Upstream creates 0o644 files.
+- **Spotlight and Time Machine exclusion.** Blocks are stored under a
+  ``blocks.noindex`` subdirectory (the ``.noindex`` name suffix is the
+  reliable per-directory Spotlight opt-out) and the root gets a best-effort
+  ``tmutil addexclusion`` so cache churn never bloats backups or lingers in
+  APFS local snapshots after deletion.
+- **Thread QoS.** Load-priority I/O threads run ``QOS_CLASS_USER_INITIATED``
+  (restores are on the request critical path); store-priority threads run
+  ``QOS_CLASS_UTILITY`` so bulk writes are steered toward E-cores instead of
+  competing with inference on P-cores.
+
+Scheduler-side only (no mlx import): ``MetalTieringOffloadingSpec`` routes the
+``fs`` tier type here for the duration of manager construction.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import functools
+import os
+import stat
+import subprocess
+import sys
+import threading
+import zlib
+from typing import TYPE_CHECKING
+
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import LookupResult
+from vllm.v1.kv_offload.tiering.fs import manager as _fs_manager_module
+
+# Pinned to vLLM 0.25.1 (like the SharedOffloadRegion rebinding in spec.py):
+# the tmp-suffix and mkdir helpers are reused so the atomic-replace protocol
+# cannot drift from upstream's.
+from vllm.v1.kv_offload.tiering.fs.io import _ensure_dirs, _get_tmp_suffix
+from vllm.v1.kv_offload.tiering.fs.manager import FileSystemTierManager
+from vllm.v1.kv_offload.tiering.fs.thread_pool import DualQueueThreadPool
+
+if TYPE_CHECKING:
+    from vllm.v1.kv_offload.tiering.base import JobMetadata
+
+logger = init_logger(__name__)
+
+# macOS pthread/qos.h constants.
+QOS_CLASS_USER_INITIATED = 0x19
+QOS_CLASS_UTILITY = 0x11
+
+NOINDEX_DIRNAME = "blocks.noindex"
+
+_F_NOCACHE: int | None = None
+if sys.platform == "darwin":
+    import fcntl
+
+    _F_NOCACHE = getattr(fcntl, "F_NOCACHE", None)
+
+
+def set_current_thread_qos(qos_class: int) -> bool:
+    """Set the calling thread's macOS QoS class; False if unavailable."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        fn = libc.pthread_set_qos_class_self_np
+    except (OSError, AttributeError):
+        return False
+    return int(fn(ctypes.c_uint(qos_class), ctypes.c_int(0))) == 0
+
+
+def _set_nocache(fd: int) -> None:
+    """Advise the UBC not to retain pages for this fd (best-effort)."""
+    if _F_NOCACHE is None:
+        return
+    try:
+        fcntl.fcntl(fd, _F_NOCACHE, 1)
+    except OSError as exc:
+        logger.warning_once("F_NOCACHE failed: %s", exc)
+
+
+# On-disk layout: <block_size KV bytes><8-byte little-endian CRC32 footer>.
+# The footer catches silent corruption a size check cannot — a torn write
+# (F_NOCACHE makes power-loss torn pages more likely), bit rot, or a
+# foreign/stale writer in a shared store — before poisoned KV reaches the GPU
+# cache. It is a corruption check, NOT an authentication code: a hostile
+# writer who controls the file can forge the CRC. The defense against that is
+# store ownership (see _make_private_dir); a per-deployment HMAC is the
+# roadmap control for adversarial-writer stores. layout_signature already
+# fences this format change, so no migration for existing fp16 stores.
+_CRC_FOOTER_BYTES = 8
+
+
+def on_disk_block_size(block_size: int) -> int:
+    """File size for a KV block of ``block_size`` payload bytes (incl footer)."""
+    return block_size + _CRC_FOOTER_BYTES
+
+
+def _footer(crc: int) -> bytes:
+    return crc.to_bytes(_CRC_FOOTER_BYTES, "little")
+
+
+def store_block(
+    dest_path: str,
+    buffer: memoryview,
+    offset: int,
+    block_size: int,
+) -> None:
+    """Upstream ``io.store_block`` with F_NOCACHE, 0o600 files, CRC footer.
+
+    Dedup is size-aware: a pre-existing file of the wrong length (a stale or
+    hostile placement) does not mask the honest write."""
+    payload_len = block_size + _CRC_FOOTER_BYTES
+    try:
+        if os.path.getsize(dest_path) == payload_len:
+            return  # already stored, correct size — trust the CRC on load
+    except OSError:
+        pass  # absent (or unstatable) — (re)write it
+
+    tmp_path = dest_path + _get_tmp_suffix()
+    _ensure_dirs(dest_path)
+
+    view_slice = buffer.cast("B")[offset : offset + block_size]
+    footer = _footer(zlib.crc32(view_slice) & 0xFFFFFFFF)
+    try:
+        fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC, 0o600)
+        try:
+            _set_nocache(fd)
+            written = os.write(fd, view_slice) + os.write(fd, footer)
+            if written < payload_len:
+                raise OSError(
+                    f"Short write: expected {payload_len} bytes, wrote {written}"
+                )
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, dest_path)
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except OSError as cleanup_exc:
+            logger.warning("Failed to remove temp file %s: %s", tmp_path, cleanup_exc)
+        raise
+
+
+def load_block(
+    source_path: str,
+    view: memoryview,
+    offset: int,
+    block_size: int,
+) -> None:
+    """Read one KV block and verify its CRC footer.
+
+    A bad file (short/size-mismatched/CRC-mismatched) is deleted so the tier
+    turns it into a clean miss; a *transient* error (fd exhaustion, EIO) is
+    propagated WITHOUT deleting — mass-unlinking valid blocks under an EMFILE
+    burst would be worse than a retry."""
+    fd: int | None = None
+    view_slice = view.cast("B")[offset : offset + block_size]
+    footer = bytearray(_CRC_FOOTER_BYTES)
+    bad_file = False
+    try:
+        fd = os.open(source_path, os.O_RDONLY)
+        _set_nocache(fd)
+        bytes_read = os.readv(fd, [view_slice, footer])
+        if bytes_read != block_size + _CRC_FOOTER_BYTES:
+            bad_file = True
+            raise OSError(
+                f"Short/oversized read: expected {block_size + _CRC_FOOTER_BYTES} "
+                f"bytes, read {bytes_read}"
+            )
+        expected = int.from_bytes(footer, "little")
+        actual = zlib.crc32(view_slice) & 0xFFFFFFFF
+        if actual != expected:
+            bad_file = True
+            raise OSError(
+                f"KV block CRC mismatch (got {actual:#010x}, expected "
+                f"{expected:#010x}); corrupt or tampered store"
+            )
+    except Exception:
+        if bad_file:
+            try:
+                os.remove(source_path)
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Failed to remove bad block file %s: %s", source_path, cleanup_exc
+                )
+        raise
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def _exclude_from_time_machine(path: str) -> threading.Thread:
+    """Sticky-exclude ``path`` from Time Machine, off the startup path.
+
+    ``tmutil addexclusion`` blocks ~10s on an XPC round-trip to backupd
+    (measured on macOS 15), so it runs in a fire-and-forget daemon thread:
+    the exclusion is best-effort and must not delay engine start. Returns the
+    thread (for tests)."""
+
+    def run() -> None:
+        try:
+            result = subprocess.run(
+                ["tmutil", "addexclusion", path],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            logger.warning("Time Machine exclusion unavailable for %s: %s", path, exc)
+            return
+        if result.returncode != 0:
+            logger.warning(
+                "tmutil addexclusion %s failed: %s", path, result.stderr.strip()
+            )
+
+    thread = threading.Thread(target=run, name="vllm_kv_tmutil", daemon=True)
+    thread.start()
+    return thread
+
+
+def _make_private_dir(path: str) -> None:
+    """mkdir -p; chmod 0700 only if WE created it. chmod-ing a pre-existing
+    user directory (root_dir=/tmp, a shared mount, ...) would strip other
+    users' access and e.g. /tmp's sticky bit — warn instead."""
+    if os.path.isdir(path):
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        if mode & 0o077:
+            logger.warning(
+                "KV store directory %s is group/world-accessible (%o); KV "
+                "blocks encode conversation-derived data — consider "
+                "chmod 700.",
+                path,
+                mode,
+            )
+        return
+    os.makedirs(path, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def prepare_root_dir(root_dir: str) -> str:
+    """Harden the KV store directory and return the directory to store under.
+
+    Owner-only permissions (on directories this code creates), Time Machine
+    exclusion, and a ``.noindex`` nesting level so Spotlight never indexes
+    the block churn. Idempotent; safe to call on every startup against an
+    existing store.
+    """
+    _make_private_dir(root_dir)
+    _exclude_from_time_machine(root_dir)
+    if os.path.basename(os.path.normpath(root_dir)).endswith(".noindex"):
+        return root_dir
+    nested = os.path.join(root_dir, NOINDEX_DIRNAME)
+    _make_private_dir(nested)
+    return nested
+
+
+def layout_signature(offloading_spec) -> str:
+    """Directory component binding stored blocks to the KV byte layout.
+
+    Upstream ``FileMapper`` hashes ``cache_config.cache_dtype`` — which on
+    Metal is always "auto" (the real cache dtype follows model_config.dtype)
+    — and knows nothing of TurboQuant (``additional_config``). Two runs of
+    the SAME model with different ``--dtype`` or quant settings would
+    therefore share block paths with incompatible byte layouts: loads where
+    the on-disk file is larger than the reader's block silently restore
+    wrong-layout bytes, and short reads DELETE the other config's valid
+    files. Binding the store path to (block bytes, cache dtype, quant
+    config) makes the layouts disjoint on disk. Deterministic across
+    restarts for a fixed config, so cross-restart reuse is preserved.
+    """
+    block_bytes = int(getattr(offloading_spec, "kv_bytes_per_offloaded_block", 0))
+    dtype = str(offloading_spec.vllm_config.model_config.dtype).replace("torch.", "")
+    sig = f"layout-{block_bytes}B-{dtype}"
+    add = getattr(offloading_spec.vllm_config, "additional_config", None) or {}
+    if isinstance(add, dict) and add.get("turboquant"):
+        sig += f"-tq-{add.get('k_quant', 'q8_0')}-{add.get('v_quant', 'q3_0')}"
+    return sig
+
+
+class MetalDualQueueThreadPool(DualQueueThreadPool):
+    """DualQueueThreadPool whose workers set a macOS QoS class on entry."""
+
+    def _worker(self, load_priority: bool) -> None:
+        qos = QOS_CLASS_USER_INITIATED if load_priority else QOS_CLASS_UTILITY
+        if not set_current_thread_qos(qos):
+            logger.debug_once("Thread QoS unavailable; using default scheduling")
+        super()._worker(load_priority)
+
+
+class MetalFsAsyncLookupManager(_fs_manager_module.FsAsyncLookupManager):
+    """Lookup that validates file SIZE, not just existence.
+
+    A truncated or foreign-layout block file passes a bare exists() check and
+    then fails fatally at load time; worse, the failed load DELETES the file
+    while the lookup cache keeps answering True for the lifetime of the
+    requesting request — re-initiating the same doomed promotion every step
+    (request-level livelock, verified against upstream
+    tiering/manager.py::complete_store(success=False) + async_lookup.py cache
+    semantics). Size validation turns bad files into clean misses up front.
+    """
+
+    def batch_lookup(self, keys, req_context):
+        expected = on_disk_block_size(self._tier._block_size)
+        results = []
+        for key in keys:
+            path = self._tier.file_mapper.get_file_name(key)
+            try:
+                ok = os.path.getsize(path) == expected
+            except OSError:
+                ok = False
+            if not ok and os.path.exists(path):
+                logger.warning(
+                    "fs tier: %s exists but is not %d bytes; treating as miss",
+                    path,
+                    expected,
+                )
+            results.append(ok)
+        return results
+
+
+class MetalFileSystemTierManager(FileSystemTierManager):
+    """FileSystemTierManager with the macOS integrations described above."""
+
+    def __init__(
+        self,
+        offloading_spec,
+        primary_kv_view: memoryview,
+        tier_type: str,
+        root_dir: str,
+        **kwargs,
+    ) -> None:
+        store_dir = os.path.join(
+            prepare_root_dir(root_dir), layout_signature(offloading_spec)
+        )
+        _make_private_dir(store_dir)
+        if store_dir != root_dir:
+            logger.info("KV store blocks live under %s (Spotlight-excluded)", store_dir)
+        # The upstream constructor instantiates its module-global
+        # DualQueueThreadPool; rebind it around the super() call so the pool
+        # gets QoS-aware workers (single-process on Metal, so this cannot
+        # race another constructor).
+        original_pool = _fs_manager_module.DualQueueThreadPool
+        _fs_manager_module.DualQueueThreadPool = MetalDualQueueThreadPool  # type: ignore[misc]
+        try:
+            super().__init__(
+                offloading_spec, primary_kv_view, tier_type, store_dir, **kwargs
+            )
+        finally:
+            _fs_manager_module.DualQueueThreadPool = original_pool  # type: ignore[misc]
+        # Replace the exists()-based lookup manager with the size-validating
+        # one (shut down the upstream instance's thread first).
+        self._lookup_manager.shutdown()
+        self._lookup_manager = MetalFsAsyncLookupManager(
+            tier=self, tier_type=self.tier_type
+        )
+        # Negative cache breaking the failed-promotion livelock: keys whose
+        # load failed are answered False at lookup until re-stored, because
+        # the async lookup cache would otherwise keep answering a stale True
+        # for the lifetime of the requesting request.
+        self._failed_load_keys: set = set()
+        self._inflight_load_keys: dict = {}
+
+    def lookup(self, key, req_context):
+        if key in self._failed_load_keys:
+            return LookupResult.MISS
+        return super().lookup(key, req_context)
+
+    def get_finished_jobs(self):
+        for result in super().get_finished_jobs():
+            keys = self._inflight_load_keys.pop(result.job_id, None)
+            if keys is not None and not result.success:
+                self._failed_load_keys.update(keys)
+                logger.warning(
+                    "fs tier: load failed for %d block(s); marking them "
+                    "absent so the scheduler recomputes instead of "
+                    "re-promoting (livelock guard)",
+                    len(keys),
+                )
+            yield result
+
+    # Upstream's submit_store/submit_load bind the plain io callbacks from
+    # their module namespace; re-issue them with the F_NOCACHE versions.
+    def submit_store(self, job_metadata: JobMetadata) -> None:
+        # A fresh store re-creates the file: lift the livelock negative-cache.
+        self._failed_load_keys.difference_update(job_metadata.keys)
+        tasks = (
+            functools.partial(
+                store_block,
+                self.file_mapper.get_file_name(key),
+                self._primary_kv_view,
+                int(bid) * self._block_size,
+                self._block_size,
+            )
+            for key, bid in zip(job_metadata.keys, job_metadata.block_ids, strict=True)
+        )
+        self._pool.enqueue_store(job_metadata.job_id, len(job_metadata.keys), tasks)
+
+    def submit_load(self, job_metadata: JobMetadata) -> None:
+        # Track keys per job so a failed load can negative-cache them
+        # (see get_finished_jobs).
+        self._inflight_load_keys[job_metadata.job_id] = list(job_metadata.keys)
+        tasks = (
+            functools.partial(
+                load_block,
+                self.file_mapper.get_file_name(key),
+                self._primary_kv_view,
+                int(bid) * self._block_size,
+                self._block_size,
+            )
+            for key, bid in zip(job_metadata.keys, job_metadata.block_ids, strict=True)
+        )
+        self._pool.enqueue_load(job_metadata.job_id, len(job_metadata.keys), tasks)

--- a/vllm_metal/v1/kv_offload/shared_region.py
+++ b/vllm_metal/v1/kv_offload/shared_region.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+"""macOS replacement for vLLM's SharedOffloadRegion.
+
+The upstream region (vllm/v1/kv_offload/cpu/shared_offload_region.py) backs
+the CPU offload tier with a /dev/shm mmap so the scheduler-side tiering
+manager and the worker-side handlers see the same bytes across processes.
+macOS has no tmpfs: a file-backed mmap would sit on APFS, where the pager
+writes dirty KV pages back to SSD — turning the "RAM tier" into a second
+disk tier (and leaking multi-GB files on crash).
+
+On Metal the scheduler and worker always share one process: KV offloading
+enforces the "uni" executor at config time (MetalPlatform), so the region
+can simply be anonymous RAM shared through a per-process registry keyed by
+instance id. The scheduler-role spec and the worker-role spec each construct
+a MetalSharedOffloadRegion with the same instance_id and get views over the
+same numpy buffer. Layout, ``create_next_view``, ``create_kv_memoryview``,
+and cleanup bookkeeping are inherited from the upstream class unchanged.
+
+If a cross-process executor is ever supported, this class must move to real
+shared memory (e.g. POSIX shm) — a registry miss in another process would
+silently create a disjoint buffer, which is why the executor guard exists.
+"""
+
+from __future__ import annotations
+
+import mmap
+import threading
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class _RegionState:
+    buffer: np.ndarray  # 1-D uint8 of num_blocks * row_stride bytes
+    num_blocks: int
+    row_stride: int
+    refs: int
+
+
+_registry: dict[str, _RegionState] = {}
+_registry_lock = threading.Lock()
+
+
+class MetalSharedOffloadRegion(SharedOffloadRegion):
+    """SharedOffloadRegion over anonymous RAM, shared within one process."""
+
+    def __init__(
+        self,
+        instance_id: str,
+        num_blocks: int,
+        rank: int | None,
+        kv_bytes_per_block: int,
+        cpu_page_size: int,
+    ) -> None:
+        # Full override of the upstream constructor (it is not parameterized
+        # over its /dev/shm + madvise mechanism); every attribute consumed by
+        # the inherited methods is established here.
+        self.page_size = mmap.PAGESIZE
+        assert kv_bytes_per_block % self.page_size == 0
+
+        self.num_blocks = num_blocks
+        self._row_stride = kv_bytes_per_block
+        self.total_size_bytes = self.num_blocks * self._row_stride
+
+        self.rank = rank
+        if rank is not None:
+            self._worker_offset = rank * cpu_page_size
+            self._worker_area_end = (rank + 1) * cpu_page_size
+
+        self._instance_id = instance_id
+        with _registry_lock:
+            state = _registry.get(instance_id)
+            if state is None:
+                # np.zeros pages fault in lazily on first touch (calloc), so
+                # a large pool costs no RSS until blocks are actually stored.
+                state = _RegionState(
+                    buffer=np.zeros(self.total_size_bytes, dtype=np.uint8),
+                    num_blocks=num_blocks,
+                    row_stride=self._row_stride,
+                    refs=1,
+                )
+                _registry[instance_id] = state
+                logger.info(
+                    "Created in-process offload region %s (%.2f GB)",
+                    instance_id,
+                    self.total_size_bytes / 1e9,
+                )
+            else:
+                assert (
+                    state.num_blocks == num_blocks
+                    and state.row_stride == self._row_stride
+                ), (
+                    f"offload region {instance_id} attached with mismatched "
+                    f"geometry: {num_blocks}x{self._row_stride} vs existing "
+                    f"{state.num_blocks}x{state.row_stride}"
+                )
+                state.refs += 1
+        self._state: _RegionState | None = state
+
+        self._base = torch.frombuffer(memoryview(state.buffer), dtype=torch.int8)
+        self._views: list[torch.Tensor] = []
+        self.is_pinned = False
+        # Inherited cleanup() checks these; there is no file behind this
+        # region, so they are inert.
+        self.mmap_obj = None
+        self.fd = None
+        self.mmap_path = None
+        self._creator = False
+
+    def cleanup(self) -> None:
+        super().cleanup()
+        state = self._state
+        self._state = None
+        if state is None:
+            return
+        with _registry_lock:
+            state.refs -= 1
+            if state.refs <= 0 and _registry.get(self._instance_id) is state:
+                del _registry[self._instance_id]
+                logger.info("Released in-process offload region %s", self._instance_id)

--- a/vllm_metal/v1/kv_offload/spec.py
+++ b/vllm_metal/v1/kv_offload/spec.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OffloadingSpecs for the Metal backend.
+
+Both specs reuse their upstream parents' host-pool sizing
+(``cpu_bytes_to_use`` / bytes-per-offloaded-block, computed from
+``kv_cache_config.kv_cache_tensors``) and scheduler-side managers. Only the
+worker-side construction differs: the OffloadingWorker is built from the live
+``MetalPagedKVCache`` (per-layer MLX arrays) instead of torch
+``CanonicalKVCaches``, which cannot represent vllm-metal's split K/V layout.
+
+- ``MetalOffloadingSpec`` (CPU tier only): host pool is plain numpy memory.
+- ``MetalTieringOffloadingSpec`` (CPU + secondary tiers, e.g. ``fs`` disk):
+  host pool lives in a shared region so the scheduler-side secondary tiers
+  read/write the same bytes.
+
+Selected via ``kv_connector_extra_config["spec_name"]`` (+
+``spec_module_path``), injected by ``MetalPlatform.check_and_update_config``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, override
+
+import vllm.v1.kv_offload.tiering.spec as _tiering_spec_module
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
+from vllm.v1.kv_offload.base import (
+    CanonicalKVCaches,
+    OffloadingManager,
+    OffloadingMetricMetadata,
+    OffloadingWorker,
+)
+from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
+from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
+
+if TYPE_CHECKING:
+    from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+    from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+logger = init_logger(__name__)
+
+
+def _validate_metal_support(kv_cache_config: KVCacheConfig) -> None:
+    groups = kv_cache_config.kv_cache_groups
+    if len(groups) != 1:
+        raise NotImplementedError(
+            "KV offloading on Metal currently supports a single KV cache "
+            f"group; got {len(groups)} (hybrid/sliding-window models are "
+            "not supported yet)"
+        )
+    if not isinstance(groups[0].kv_cache_spec, AttentionSpec):
+        # Hybrid models (e.g. gemma-4's mixed sliding/full layer_types) reach
+        # here as UniformTypeKVCacheSpecs rather than as multiple groups.
+        raise NotImplementedError(
+            "KV offloading on Metal currently supports uniform full-attention "
+            f"KV caches only; got {type(groups[0].kv_cache_spec).__name__} "
+            "(hybrid/sliding-window models are not supported yet)"
+        )
+
+
+@contextmanager
+def _metal_tiering_classes() -> Iterator[None]:
+    """Route upstream tiering machinery to the Metal classes.
+
+    Upstream ``TieringOffloadingSpec.get_manager`` hardcodes its module-global
+    ``SharedOffloadRegion`` (a /dev/shm + Linux-madvise mmap) and resolves the
+    ``fs`` tier through ``SecondaryTierFactory``'s registry (buffered I/O,
+    0o644 files). Rebinding both around the ``super().get_manager()`` call
+    inherits the whole orchestration without copying it. Safe because the
+    CUDA path never runs in this process.
+    """
+    from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
+
+    from vllm_metal.v1.kv_offload.fs_tier import MetalFileSystemTierManager
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+    original_region = _tiering_spec_module.SharedOffloadRegion
+    original_fs = SecondaryTierFactory._registry.get("fs")
+    _tiering_spec_module.SharedOffloadRegion = MetalSharedOffloadRegion  # type: ignore[misc]
+    SecondaryTierFactory._registry["fs"] = lambda: MetalFileSystemTierManager
+    try:
+        yield
+    finally:
+        _tiering_spec_module.SharedOffloadRegion = original_region  # type: ignore[misc]
+        if original_fs is None:
+            del SecondaryTierFactory._registry["fs"]
+        else:
+            SecondaryTierFactory._registry["fs"] = original_fs
+
+
+class MetalOffloadingSpecBase:
+    """Mixin giving a spec a Metal (MLX) worker-side OffloadingWorker.
+
+    MetalOffloadingConnector.register_kv_caches recognizes specs by this
+    base and calls get_metal_worker with the live MetalPagedKVCache.
+    """
+
+    _metal_worker: MetalKVOffloadWorker | None = None
+
+    def get_worker(self, kv_caches: CanonicalKVCaches) -> OffloadingWorker:
+        raise NotImplementedError(
+            "Metal offloading specs build their worker from the MLX KV cache "
+            "via MetalOffloadingConnector.register_kv_caches, not from torch "
+            "CanonicalKVCaches"
+        )
+
+    def _make_worker_region(self) -> MetalSharedOffloadRegion | None:
+        """Shared region backing the host pool; None keeps plain numpy."""
+        return None
+
+    def get_metal_worker(self, kv_cache: MetalPagedKVCache) -> MetalKVOffloadWorker:
+        if self._metal_worker is None:
+            # Imported here so the scheduler-side spec (which only calls
+            # get_manager) never imports mlx.
+            from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+            self._metal_worker = MetalKVOffloadWorker(
+                kv_cache,
+                block_size_factor=self.block_size_factor,  # type: ignore[attr-defined]
+                num_cpu_blocks=self.num_blocks,  # type: ignore[attr-defined]
+                region=self._make_worker_region(),
+                expected_block_bytes=self.kv_bytes_per_offloaded_block,  # type: ignore[attr-defined]
+            )
+        return self._metal_worker
+
+
+def _warn_if_pool_undersized(
+    spec: CPUOffloadingSpec, kv_cache_config: KVCacheConfig
+) -> None:
+    """A host pool smaller than the GPU cache silently defeats evict-then-
+    reuse: the LRU drops blocks before the GPU cache would have re-requested
+    them, and every offload lookup misses (observed live: 32B model, 4 MiB
+    blocks, restore count stayed 0). Warn loudly at init."""
+    pool_gpu_blocks = spec.num_blocks * spec.block_size_factor
+    if 0 < pool_gpu_blocks < kv_cache_config.num_blocks:
+        logger.warning(
+            "KV offloading host pool (%d GPU-block equivalents) is SMALLER "
+            "than the GPU KV cache (%d blocks). Prefixes evicted from the "
+            "GPU will usually already be evicted from the pool too, so "
+            "offload restores will rarely hit. Increase "
+            "--kv-offloading-size (or add a disk tier via secondary_tiers).",
+            pool_gpu_blocks,
+            kv_cache_config.num_blocks,
+        )
+
+
+class MetalOffloadingSpec(MetalOffloadingSpecBase, CPUOffloadingSpec):
+    """CPU-tier-only offloading spec for Metal."""
+
+    def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
+        super().__init__(vllm_config, kv_cache_config)
+        _validate_metal_support(kv_cache_config)
+        _warn_if_pool_undersized(self, kv_cache_config)
+
+
+class MetalTieringOffloadingSpec(MetalOffloadingSpecBase, TieringOffloadingSpec):
+    """Multi-tier offloading spec for Metal (CPU primary + e.g. ``fs`` disk).
+
+    Inherits TieringOffloadingSpec wholesale — configuration surface
+    (``secondary_tiers`` et al.) and the scheduler-side ``get_manager``
+    orchestration — swapping only the two platform-bound pieces: the
+    ``/dev/shm`` SharedOffloadRegion (→ MetalSharedOffloadRegion) and the
+    CUDA worker (→ MetalKVOffloadWorker over the region).
+    """
+
+    def __init__(self, vllm_config: VllmConfig, kv_cache_config: KVCacheConfig):
+        super().__init__(vllm_config, kv_cache_config)
+        _validate_metal_support(kv_cache_config)
+        # Tiering: a small RAM pool is fine (disk holds the working set), so
+        # no pool-size warning here — but persistent tiers key files by
+        # PYTHONHASHSEED-dependent content hashes.
+        if os.environ.get("PYTHONHASHSEED") is None:
+            logger.warning(
+                "Secondary KV tiers are configured but PYTHONHASHSEED is "
+                "unset: block filenames are hash-seeded per process, so "
+                "blocks written now will NOT be found after a server "
+                "restart (or by other instances sharing the store). Set "
+                "PYTHONHASHSEED=0 for cross-restart reuse."
+            )
+
+    def _make_region(self, rank: int | None) -> MetalSharedOffloadRegion:
+        from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+        return MetalSharedOffloadRegion(
+            instance_id=self.vllm_config.instance_id,
+            num_blocks=self.num_blocks,
+            rank=rank,
+            kv_bytes_per_block=self.kv_bytes_per_offloaded_block,
+            cpu_page_size=self.cpu_page_size_per_worker,
+        )
+
+    @override
+    def _make_worker_region(self) -> MetalSharedOffloadRegion:
+        # Metal runs scheduler and worker in one process (the platform hook
+        # enforces the "uni" executor for tiering) with a single worker rank.
+        return self._make_region(rank=0)
+
+    @override
+    def get_manager(self) -> OffloadingManager:
+        """Delegate to the upstream body with the Metal classes routed in
+        (shared region and macOS-tuned ``fs`` tier; see
+        ``_metal_tiering_classes``)."""
+        with _metal_tiering_classes():
+            return super().get_manager()
+
+    @classmethod
+    @override
+    def build_metric_definitions(
+        cls, extra_config: dict[str, Any]
+    ) -> dict[str, OffloadingMetricMetadata]:
+        """Resolve secondary-tier metric definitions against the METAL tier
+        classes. The upstream body resolves each tier via
+        ``SecondaryTierFactory.get_tier_class`` at stat-logger construction —
+        outside ``get_manager``'s rebinding scope — so without this the ``fs``
+        tier's definitions would come from the upstream class and any metric
+        a Metal tier registers would KeyError at observation time."""
+        with _metal_tiering_classes():
+            return super().build_metric_definitions(extra_config)

--- a/vllm_metal/v1/kv_offload/worker.py
+++ b/vllm_metal/v1/kv_offload/worker.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OffloadingWorker moving KV blocks between the MLX cache and host memory.
+
+The wired MLX KV pool is the fast tier; the host pool is plain (pageable)
+memory that macOS may reclaim under pressure. On unified memory a "transfer"
+is an on-package copy, so transfers execute synchronously inside
+``submit_store``/``submit_load`` and are reported complete on the next
+``get_finished`` poll — the OffloadingWorker contract stays async-shaped for
+a later move to ``mx.async_eval`` if profiling justifies it.
+
+Errors propagate out of ``submit_store``/``submit_load``: the upstream
+OffloadingConnectorWorker asserts a successful submission (job failure is
+unsupported upstream), so raising here surfaces the root cause directly
+instead of tripping a bare ``assert success`` with no context.
+
+Ordering rules (see docs/offload-design.md and kv_cache.py): the cache write
+kernels mutate Metal buffers in place but rebind ``kv_cache.<name>[layer]`` to
+fresh array objects carrying graph provenance. Stores therefore always gather
+through the *current* list entry, and loads index-assign then rebind, exactly
+like the kernels do.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+
+import mlx.core as mx
+import numpy as np
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import (
+    GPULoadStoreSpec,
+    LoadStoreSpec,
+    OffloadingWorker,
+    TransferResult,
+)
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+logger = init_logger(__name__)
+
+# Every MLX array list on MetalPagedKVCache that holds per-block state and
+# must therefore be offloaded together. The TurboQuant side arrays are empty
+# lists on the fp16/bf16 path.
+CACHE_ATTRS = (
+    "key_caches",
+    "value_caches",
+    "key_scale_caches",
+    "value_scale_caches",
+    "key_zero_caches",
+)
+
+# MLX dtype -> numpy dtype for the host pool. bfloat16 has no numpy dtype and
+# is round-tripped through a uint16 reinterpret view (mx.view).
+_MX_TO_NP = {
+    mx.float16: np.float16,
+    mx.float32: np.float32,
+    mx.bfloat16: np.uint16,
+    mx.int8: np.int8,
+    mx.uint8: np.uint8,
+    mx.uint16: np.uint16,
+    mx.uint32: np.uint32,
+    mx.int16: np.int16,
+    mx.int32: np.int32,
+}
+
+
+@dataclass
+class _CacheArrayRef:
+    """One MLX cache array (layer x kind) and its host-pool mirror."""
+
+    arrays: list[mx.array]  # the live list on MetalPagedKVCache
+    layer: int
+    is_bf16: bool
+    # (num_cpu_blocks, block_size_factor, block_size, heads, last_dim)
+    cpu: np.ndarray
+
+    @property
+    def gpu(self) -> mx.array:
+        # Read through the list entry: the write kernels rebind it to fresh
+        # array objects whose provenance orders reads after pending writes.
+        return self.arrays[self.layer]
+
+    @gpu.setter
+    def gpu(self, arr: mx.array) -> None:
+        self.arrays[self.layer] = arr
+
+
+class MetalKVOffloadWorker(OffloadingWorker):
+    """Bidirectional GPU<->CPU block mover for the MLX paged KV cache.
+
+    One worker serves both directions: ``submit_store`` (GPU -> host pool)
+    and ``submit_load`` (host pool -> GPU) share the ``_transfer`` core.
+    """
+
+    def __init__(
+        self,
+        kv_cache: MetalPagedKVCache,
+        *,
+        block_size_factor: int,
+        num_cpu_blocks: int,
+        region: MetalSharedOffloadRegion | None = None,
+        expected_block_bytes: int | None = None,
+    ) -> None:
+        self.kv_cache = kv_cache
+        self.block_size_factor = block_size_factor
+        self.num_cpu_blocks = num_cpu_blocks
+        self.region = region
+        self._finished: list[TransferResult] = []
+        self._sub_slots = np.arange(block_size_factor)
+        self._num_gpu_blocks = int(kv_cache.num_blocks)
+
+        # Completeness guard: CACHE_ATTRS is the offload inventory. A
+        # per-block array list on the cache that is NOT in the inventory
+        # would be silently omitted from offload, and restored blocks would
+        # be rebuilt missing part of their state — the exact "new model
+        # family" silent-corruption mode. Fail fast at registration instead.
+        for name, value in vars(kv_cache).items():
+            if name in CACHE_ATTRS or not isinstance(value, list) or not value:
+                continue
+            if all(isinstance(a, mx.array) and a.ndim > 0 for a in value) and any(
+                a.shape[0] == self._num_gpu_blocks for a in value
+            ):
+                raise NotImplementedError(
+                    f"KV offloading: cache array list {name!r} on "
+                    f"{type(kv_cache).__name__} looks per-block "
+                    f"(leading dim == num_blocks) but is not in the offload "
+                    "inventory (CACHE_ATTRS); offloading this model would "
+                    "silently drop that state. Add it to CACHE_ATTRS with a "
+                    "round-trip test."
+                )
+
+        if region is not None:
+            # Tiering: the host pool lives in the shared region so the
+            # scheduler-side secondary tiers (disk, ...) read/write the same
+            # bytes through region.create_kv_memoryview(). Each cache array
+            # claims its slice of every block row via the region's own
+            # cursor (create_next_view), keeping the row layout arithmetic
+            # in one place.
+            assert region.num_blocks == num_cpu_blocks
+
+        self._refs: list[_CacheArrayRef] = []
+        host_bytes = 0
+        for attr in CACHE_ATTRS:
+            arrays: list[mx.array] = getattr(kv_cache, attr)
+            for layer, arr in enumerate(arrays):
+                np_dtype = _MX_TO_NP.get(arr.dtype)
+                if np_dtype is None:
+                    raise NotImplementedError(
+                        f"KV offloading: unsupported cache dtype {arr.dtype} "
+                        f"({attr}[{layer}])"
+                    )
+                shape = (num_cpu_blocks, block_size_factor, *arr.shape[1:])
+                if region is None:
+                    cpu = np.empty(shape, dtype=np_dtype)
+                else:
+                    itemsize = np.dtype(np_dtype).itemsize
+                    tensor_page = (
+                        int(np.prod(arr.shape[1:])) * itemsize * block_size_factor
+                    )
+                    view = region.create_next_view(tensor_page)
+                    cpu = view.numpy().view(np_dtype).reshape(shape)
+                    # The disk tier reads these bytes through the region's
+                    # memoryview; a silent numpy copy here would corrupt it.
+                    assert cpu.ctypes.data == view.data_ptr(), (
+                        "host-pool view is not zero-copy over the shared "
+                        f"region ({attr}[{layer}])"
+                    )
+                self._refs.append(
+                    _CacheArrayRef(
+                        arrays=arrays,
+                        layer=layer,
+                        is_bf16=arr.dtype == mx.bfloat16,
+                        cpu=cpu,
+                    )
+                )
+                host_bytes += cpu.nbytes
+        # Two-sided carve check: the scheduler sizes the pool from vLLM's
+        # torch-side kv_cache_config (spec.kv_bytes_per_offloaded_block);
+        # the handler carves from the live MLX arrays. The spec value may
+        # exceed the carve by alignment padding (upstream tiering rounds
+        # blocks up to BLOCK_SIZE_ALIGNMENT — the "maybe-pad" tail; fp16
+        # blocks are often exactly aligned, TurboQuant's rarely are). Padding
+        # is safe: rows are addressed by the padded stride on both sides.
+        # A carve LARGER than the spec sizing would overrun rows — fatal.
+        if expected_block_bytes is not None and num_cpu_blocks > 0:
+            actual = host_bytes // num_cpu_blocks
+            if actual > expected_block_bytes:
+                raise ValueError(
+                    f"KV offloading: handler carves {actual} bytes per "
+                    f"offloaded block from the MLX cache but the spec sized "
+                    f"the pool at {expected_block_bytes}; rows would overrun"
+                )
+            if actual < expected_block_bytes:
+                logger.debug(
+                    "KV offloading: %d bytes/block alignment padding "
+                    "(spec %d vs carve %d)",
+                    expected_block_bytes - actual,
+                    expected_block_bytes,
+                    actual,
+                )
+        logger.info(
+            "KV offloading host pool: %.1f MB (%d CPU blocks x %d GPU "
+            "blocks/CPU block, %d cache arrays, %s)",
+            host_bytes / 1e6,
+            num_cpu_blocks,
+            block_size_factor,
+            len(self._refs),
+            "shared region" if region is not None else "plain numpy",
+        )
+
+    def submit_store(
+        self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
+    ) -> bool:
+        if not isinstance(src_spec, GPULoadStoreSpec) or not isinstance(
+            dst_spec, CPULoadStoreSpec
+        ):
+            raise ValueError(
+                f"KV offloading: unexpected store spec types "
+                f"{type(src_spec).__name__} -> {type(dst_spec).__name__}"
+            )
+        start = time.perf_counter()
+        num_bytes = self._transfer(src_spec, dst_spec, gpu_to_cpu=True)
+        self._record_finished(job_id, num_bytes, start)
+        return True
+
+    def submit_load(
+        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: GPULoadStoreSpec
+    ) -> bool:
+        if not isinstance(src_spec, CPULoadStoreSpec) or not isinstance(
+            dst_spec, GPULoadStoreSpec
+        ):
+            raise ValueError(
+                f"KV offloading: unexpected load spec types "
+                f"{type(src_spec).__name__} -> {type(dst_spec).__name__}"
+            )
+        start = time.perf_counter()
+        num_bytes = self._transfer(dst_spec, src_spec, gpu_to_cpu=False)
+        self._record_finished(job_id, num_bytes, start)
+        return True
+
+    def _record_finished(self, job_id: int, num_bytes: int, start: float) -> None:
+        self._finished.append(
+            TransferResult(
+                job_id=job_id,
+                success=True,
+                transfer_size=num_bytes,
+                transfer_time=time.perf_counter() - start,
+            )
+        )
+
+    def _transfer(
+        self,
+        gpu_spec: GPULoadStoreSpec,
+        cpu_spec: CPULoadStoreSpec,
+        *,
+        gpu_to_cpu: bool,
+    ) -> int:
+        """Copy blocks between the MLX cache and the host pool.
+
+        One offloaded (CPU) block holds ``block_size_factor`` GPU-block-sized
+        sub-blocks. The first CPU block of a transfer may be entered
+        mid-block: ``block_indices[0] % block_size_factor`` sub-slots are
+        skipped, mirroring the CUDA handler
+        (vllm/v1/kv_offload/cpu/gpu_worker.py).
+        """
+        # MetalOffloadingSpecBase enforces a single KV cache group.
+        # Real raises, not asserts: these guard silent corruption (OOB
+        # mx.take returns garbage rows; OOB MLX scatter drops writes;
+        # negative numpy ids wrap) and must survive `python -O`. Raising
+        # fails the submission loudly (job failure is unsupported upstream).
+        if len(gpu_spec.group_sizes) != 1:
+            raise ValueError(
+                f"KV offloading: expected a single KV cache group, got "
+                f"group_sizes={gpu_spec.group_sizes!r}"
+            )
+        group_size = gpu_spec.group_sizes[0]
+        if group_size == 0:
+            return 0
+
+        gpu_ids = gpu_spec.block_ids
+        if len(gpu_ids) != group_size:
+            raise ValueError(
+                f"KV offloading: {len(gpu_ids)} GPU block ids != group size "
+                f"{group_size}"
+            )
+        if int(gpu_ids.min()) < 0 or int(gpu_ids.max()) >= self._num_gpu_blocks:
+            raise ValueError(
+                f"KV offloading: GPU block ids out of range "
+                f"[{int(gpu_ids.min())}, {int(gpu_ids.max())}] vs "
+                f"{self._num_gpu_blocks} cache blocks"
+            )
+        factor = self.block_size_factor
+        skip = gpu_spec.block_indices[0] % factor
+
+        cpu_ids = cpu_spec.block_ids
+        if int(cpu_ids.min()) < 0 or int(cpu_ids.max()) >= self.num_cpu_blocks:
+            raise ValueError(
+                f"KV offloading: CPU block ids out of range "
+                f"[{int(cpu_ids.min())}, {int(cpu_ids.max())}] vs pool of "
+                f"{self.num_cpu_blocks} blocks"
+            )
+        if len(cpu_ids) * factor < skip + group_size:
+            raise ValueError(
+                f"CPU blocks too few: {len(cpu_ids)} x {factor} < {skip} + {group_size}"
+            )
+        # Expand CPU block ids into flat (block, sub-slot) coordinates,
+        # skipping the unaligned head of the first block.
+        cpu_blocks = np.repeat(cpu_ids, factor)[skip : skip + group_size]
+        cpu_subs = np.tile(self._sub_slots, len(cpu_ids))[skip : skip + group_size]
+
+        mx_gpu_ids = mx.array(gpu_ids)
+        num_bytes = 0
+        _dbg = os.environ.get("VLLM_METAL_KV_OFFLOAD_DEBUG") == "1"
+        if gpu_to_cpu:
+            # Gather all arrays lazily, evaluate once, then copy out. The
+            # evaluated gathers expose the buffer protocol, so the host copy
+            # reads them zero-copy through frombuffer.
+            gathered = []
+            for ref in self._refs:
+                g = mx.take(ref.gpu, mx_gpu_ids, axis=0)
+                if ref.is_bf16:
+                    g = mx.view(g, mx.uint16)
+                gathered.append(g)
+            mx.eval(*gathered)
+            for ref, g in zip(self._refs, gathered, strict=True):
+                host = np.frombuffer(memoryview(g), dtype=ref.cpu.dtype).reshape(
+                    g.shape
+                )
+                ref.cpu[cpu_blocks, cpu_subs] = host
+                num_bytes += host.nbytes
+        else:
+            written = []
+            for ref in self._refs:
+                # Advanced indexing yields a fresh contiguous copy, so the
+                # host pool row can be safely reused right after this call.
+                host = ref.cpu[cpu_blocks, cpu_subs]
+                vals = mx.array(host)
+                if ref.is_bf16:
+                    vals = mx.view(vals, mx.bfloat16)
+                arr = ref.gpu
+                arr[mx_gpu_ids] = vals
+                # Rebind, mirroring the write-then-rebind idiom of the cache
+                # kernels so later readers see the scatter's provenance.
+                ref.gpu = arr
+                written.append(arr)
+                num_bytes += host.nbytes
+            mx.eval(*written)
+
+        if _dbg:
+            # Debug (env-gated): CRC the moved bytes from BOTH sides of the
+            # copy so store-vs-load divergence and host-vs-GPU divergence can
+            # be separated when hunting live corruption.
+            import zlib
+
+            # Per-CPU-row CRCs so a row can be compared between the store
+            # that wrote it and the (possibly differently-shaped) load that
+            # read it. crc_gpu covers the same rows from the GPU side.
+            # Blind spot: on the store path both CRCs derive from gathers
+            # through the same (rebound) array, so their agreement cannot by
+            # itself exclude a stale first gather — cross-check against a
+            # no-offload control when hunting divergence (2026-07-15 audit).
+            n = len(cpu_blocks)
+            row_host = [0] * n
+            row_gpu = [0] * n
+            for ref in self._refs:
+                g = mx.take(ref.gpu, mx_gpu_ids, axis=0)
+                if ref.is_bf16:
+                    g = mx.view(g, mx.uint16)
+                mx.eval(g)
+                g_np = np.array(g)
+                for i in range(n):
+                    row = np.ascontiguousarray(ref.cpu[cpu_blocks[i], cpu_subs[i]])
+                    row_host[i] = zlib.crc32(row.tobytes(), row_host[i])
+                    row_gpu[i] = zlib.crc32(g_np[i].tobytes(), row_gpu[i])
+            for i in range(n):
+                logger.info(
+                    "KVDBG dir=%s row=(%d,%d) gpu=%d crc_host=%08x crc_gpu=%08x",
+                    "store" if gpu_to_cpu else "load",
+                    cpu_blocks[i],
+                    cpu_subs[i],
+                    int(gpu_ids[i]),
+                    row_host[i],
+                    row_gpu[i],
+                )
+        return num_bytes
+
+    def get_finished(self) -> list[TransferResult]:
+        finished = self._finished
+        self._finished = []
+        return finished
+
+    def wait(self, job_ids: set[int]) -> None:
+        # Transfers complete synchronously in submit_store/submit_load;
+        # nothing is ever in flight by the time wait() can be called.
+        return
+
+    def shutdown(self) -> None:
+        self._refs.clear()
+        if self.region is not None:
+            self.region.cleanup()
+            self.region = None

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -11,6 +11,7 @@ Key contracts:
 - Outputs align with scheduler expectations for paged and non-paged paths.
 """
 
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from typing import Any, Literal, NamedTuple, TypeAlias
 
@@ -20,6 +21,11 @@ import torch
 from mlx_lm import stream_generate
 from mlx_lm.models.cache import make_prompt_cache
 from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
@@ -36,12 +42,16 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
     DraftTokenIds,
+    KVConnectorOutput,
     LogprobsLists,
     ModelRunnerOutput,
 )
 from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
+from vllm.v1.worker.kv_connector_model_runner_mixin import (
+    KVConnectorModelRunnerMixin,
+)
 
 from vllm_metal.attention.context import (
     OffsetCache,
@@ -266,6 +276,12 @@ class MetalModelRunner:
     Uses true batched decode with BatchKVCache for efficient parallel processing.
     """
 
+    # Class-level defaults so partially-constructed runners (tests build
+    # instances via __new__ + selective attributes) are safe on paths that
+    # check connector state, e.g. the non-last-PP sample early return.
+    _kv_connector_stack: ExitStack | None = None
+    _kv_connector_output: KVConnectorOutput | None = None
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -323,6 +339,10 @@ class MetalModelRunner:
         # vLLM v1 async scheduling calls sample_tokens after execute_model.
         # Keep the latest execution output so sample_tokens can return it.
         self._pending_output: ModelRunnerOutput | None = None
+        # KV connector step context, held open across the execute_model /
+        # sample_tokens split (see _kv_connector_start_step).
+        self._kv_connector_stack: ExitStack | None = None
+        self._kv_connector_output: KVConnectorOutput | None = None
         self._draft_token_ids: DraftTokenIds | None = None
 
         # Paged attention state (set by worker when enabled)
@@ -596,6 +616,68 @@ class MetalModelRunner:
         This method exists to satisfy the engine's initialization protocol.
         """
         self._cache_policy.initialize_kv_cache(kv_cache_config)
+
+    def register_kv_connector_caches(self) -> None:
+        """Hand the live MLX paged KV cache to the KV connector.
+
+        Called by the worker after ``initialize_kv_cache`` when a KV connector
+        (KV offloading) is configured. The MetalOffloadingConnector accepts
+        the ``MetalPagedKVCache`` directly instead of vLLM's torch-tensor
+        registration path (see docs/offload-design.md).
+        """
+        from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+
+        runtime = self._paged_attention_runtime
+        kv_cache = getattr(runtime, "kv_cache", None) if runtime else None
+        if not isinstance(kv_cache, MetalPagedKVCache):
+            raise NotImplementedError(
+                "KV offloading on Metal requires the paged attention runtime "
+                "with an MLX paged KV cache; this model/backend combination "
+                f"provides {type(kv_cache).__name__ if kv_cache else 'none'}."
+            )
+        get_kv_transfer_group().register_kv_caches(kv_cache)
+
+    def _kv_connector_start_step(self, scheduler_output: SchedulerOutput) -> None:
+        """Enter the upstream connector lifecycle for this step.
+
+        Reuses KVConnectorModelRunnerMixin's context manager — which binds
+        metadata, runs this step's KV load transfers, and on exit populates a
+        KVConnectorOutput (get_finished also queues deferred store jobs) and
+        clears the metadata — held open across the async execute_model /
+        sample_tokens split via an ExitStack, so the population sequence has
+        exactly one owner (upstream).
+
+        Must run before the forward graph is built: loads scatter into the
+        cache arrays and rebind them, so attention reads see the restored
+        blocks through the arrays' provenance.
+        """
+        if self._kv_connector_stack is not None:
+            # A previous step raised between start and attach; the engine is
+            # tearing down, but close the stale context defensively.
+            logger.warning("Closing leaked KV connector step context.")
+            self._close_kv_connector_step()
+        stack = ExitStack()
+        stack.enter_context(set_forward_context(None, self.vllm_config))
+        self._kv_connector_output = stack.enter_context(
+            KVConnectorModelRunnerMixin._get_kv_connector_output(scheduler_output)
+        )
+        self._kv_connector_stack = stack
+
+    def _close_kv_connector_step(self) -> KVConnectorOutput | None:
+        stack = self._kv_connector_stack
+        output = self._kv_connector_output
+        self._kv_connector_stack = None
+        self._kv_connector_output = None
+        if stack is not None:
+            stack.close()  # populates `output` via the mixin's finally block
+        return output
+
+    def _attach_kv_connector_output(
+        self, output: ModelRunnerOutput
+    ) -> ModelRunnerOutput:
+        if has_kv_transfer_group() and self._kv_connector_stack is not None:
+            output.kv_connector_output = self._close_kv_connector_step()
+        return output
 
     def reset_mm_cache(self) -> None:
         """Reset profiling-time multimodal cache state when present."""
@@ -2250,6 +2332,23 @@ class MetalModelRunner:
                 "to use structured output."
             )
 
+        if has_kv_transfer_group():
+            kv_connector_metadata = scheduler_output.kv_connector_metadata
+            assert kv_connector_metadata is not None
+            get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
+            if scheduler_output.total_num_scheduled_tokens == 0:
+                # KV transfers must progress even on steps with no forward
+                # (e.g. every running request blocked on an async KV load).
+                # Pending runtime releases queued by the reconcile above must
+                # still be applied — every execute_model exit does this.
+                runtime = self._paged_attention_runtime
+                if runtime is not None:
+                    runtime.materialize_pending_state()
+                return KVConnectorModelRunnerMixin.kv_connector_no_forward(
+                    scheduler_output, self.vllm_config
+                )
+            self._kv_connector_start_step(scheduler_output)
+
         batch = _ExecutionBatch()
         self._handle_new_requests(
             batch, scheduler_output.scheduled_new_reqs, scheduler_output
@@ -2283,7 +2382,7 @@ class MetalModelRunner:
                 if runtime is not None:
                     runtime.materialize_pending_state()
                 self._validate_scheduled_outputs(batch, scheduler_output)
-                return self._build_output(batch)
+                return self._attach_kv_connector_output(self._build_output(batch))
             return None
 
         # Defensive invariant: the vLLM scheduler sets has_structured_output_requests
@@ -2310,11 +2409,14 @@ class MetalModelRunner:
             runtime.materialize_pending_state()
         self._validate_scheduled_outputs(batch, scheduler_output)
         if not batch.req_ids:
-            return self._build_output(batch)
+            return self._attach_kv_connector_output(self._build_output(batch))
         output = self._build_output(batch)
         if self._is_pooling:
-            return output
-        self._pending_output = output
+            return self._attach_kv_connector_output(output)
+        # Finish the connector step now (no-op without a KV connector): the
+        # stashed output is returned verbatim by sample_tokens, which must
+        # not leave the step's bound metadata dangling.
+        self._pending_output = self._attach_kv_connector_output(output)
         return None
 
     def sample_tokens(
@@ -2334,6 +2436,11 @@ class MetalModelRunner:
             # downstream), so clear the stash and return an empty output — the
             # engine collects results from the last stage only.
             if is_non_last_stage(self.pp):
+                # KV offloading + PP is rejected at config time
+                # (MetalPlatform.check_and_update_config); if that guard is
+                # ever relaxed, this early return must also finish the
+                # connector step or non-last stages will leak bound metadata.
+                assert self._kv_connector_stack is None
                 self._execute_model_state = None
                 runtime = self._paged_attention_runtime
                 if runtime is not None:
@@ -2344,7 +2451,7 @@ class MetalModelRunner:
             if runtime is not None:
                 runtime.materialize_pending_state()
             self._validate_scheduled_outputs(batch, scheduler_output)
-            return self._build_output(batch)
+            return self._attach_kv_connector_output(self._build_output(batch))
 
         # Non-paged path: return output built by execute_model
         if self._pending_output is not None:

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -13,6 +13,16 @@ from vllm.distributed import (
     ensure_model_parallel_initialized,
     init_distributed_environment,
 )
+from vllm.distributed.kv_transfer import (
+    ensure_kv_transfer_initialized,
+    ensure_kv_transfer_shutdown,
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+)
+from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.tasks import SupportedTask
@@ -247,7 +257,41 @@ class MetalWorker(WorkerBase):
         Args:
             kv_cache_config: KV cache configuration for this worker
         """
+        # Create the worker-side KV connector before KV cache initialization,
+        # mirroring vllm.v1.worker.gpu_worker.Worker.initialize_from_config.
+        # No-op unless kv_transfer_config is set (e.g. --kv-offloading-size).
+        ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
         self.model_runner.initialize_kv_cache(kv_cache_config)
+        if has_kv_transfer_group():
+            if not hasattr(self.model_runner, "register_kv_connector_caches"):
+                raise NotImplementedError(
+                    "KV offloading is not supported for STT models on Metal."
+                )
+            # The MLX paged cache already exists (allocated during
+            # determine_available_memory -> setup_paged_attention), so the
+            # connector can be handed the live cache immediately.
+            self.model_runner.register_kv_connector_caches()
+
+    def get_kv_connector_handshake_metadata(
+        self,
+    ) -> dict[tuple[int, int], KVConnectorHandshakeMetadata] | None:
+        """Get KV connector handshake metadata, keyed by (pp_rank, tp_rank).
+
+        Called by the engine core via ``collective_rpc`` whenever a KV
+        connector is configured. Copied from
+        ``vllm.v1.worker.gpu_worker.Worker`` (device-agnostic); the offloading
+        connector needs no handshake and yields ``None``.
+        """
+        if not has_kv_transfer_group():
+            return None
+
+        connector = get_kv_transfer_group()
+        if (metadata := connector.get_handshake_metadata()) is None:
+            return None
+
+        pp_rank = get_pp_group().rank_in_group
+        tp_rank = get_tp_group().rank_in_group
+        return {(pp_rank, tp_rank): metadata}
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         """Warm up the model for inference."""
@@ -392,6 +436,12 @@ class MetalWorker(WorkerBase):
 
     def shutdown(self) -> None:
         """Shutdown the worker and cleanup resources."""
+        try:
+            ensure_kv_transfer_shutdown()
+        except Exception:
+            # Never let connector teardown block profiler/model cleanup.
+            logger.exception("KV transfer shutdown failed; continuing")
+
         if self._metal_profiler is not None:
             self._metal_profiler.shutdown()
             self._metal_profiler = None


### PR DESCRIPTION
### Why

The cost of long-context inference lives in prefill. System prompts, RAG
contexts, and multi-turn sessions re-process the same tokens over and over,
and on Apple Silicon — where prefill compute is the scarce resource — that
tax is paid in full every time a prefix falls out of the GPU cache. vLLM
already solved this class of problem with the `OffloadingConnector` (KV
blocks spill to host RAM and secondary tiers, and are restored instead of
recomputed), but the implementation is CUDA-only. Macs get nothing.

A note on what "offloading" means on unified memory, since there is no
separate device memory to offload *from*: the tier boundary on Metal is
**wired vs pageable**, not device vs host. The MLX paged KV cache lives in
wired (non-pageable) memory, hard-capped by the memory-fraction budget —
that budget is the scarce resource. The offload pool is plain pageable
memory *outside* that budget, free for macOS to reclaim under pressure, and
the disk tier sits below it. Offloading extends effective KV capacity beyond
the wired cap; what a restore saves is prefill compute, not memory-bus
distance.

That framing is also why this is backwards for the platform, twice over:

- **Unified memory makes offloading unusually cheap here.** On CUDA, a
  restore crosses PCIe from pinned host pools; on Apple Silicon it's an
  on-package copy at 5–9 GB/s with no pinning, no staging, no DMA
  descriptors. The feature costs *less* on Metal than where it was invented.
- **The win grows exactly where Macs hurt most.** Measured restore-vs-
  recompute advantage scales with model size: **6× at 1.5B, 8× at 32B, 11×
  at 70B** (78.8s cold prefill → 7.1s disk restore for Llama-3.3-70B). The
  bigger the model, the more an evicted prefix costs to recompute — and the
  more this pays back.

With the disk tier and `PYTHONHASHSEED` pinned, reuse also survives server
restarts: a fresh process restores a previously-served prefix from disk on
its first request (0.37s vs 1.42s cold at 1.5B; 7.3s vs 78.8s at 70B). A Mac
that has prefilled a context once never pays full price for it again.

### What this PR does

Wires vLLM's native offloading (`--kv-offloading-size`, upstream's
`OffloadingConnector`) into vllm-metal, with a pageable host-pool tier, an
`fs` disk tier, and cross-restart persistence:

- **The scheduler side is upstream code, unmodified.** Tests assert this by
  function identity, and byte placement in the host pool is pinned to
  upstream's own `compute_sub_block_ptrs` math (the CUDA DMA descriptor
  layout, runnable on any platform) across block-size factors, alignment
  cases, and KV dtypes.
- Only the worker-side data plane is Metal: `MetalKVOffloadWorker`
  (implements 0.25.1's `OffloadingWorker`) moves blocks between the wired
  MLX paged KV cache and a host pool, following the cache kernels'
  write-then-rebind idiom so MLX graph provenance orders reads after writes.
- The **`fs` disk tier** is upstream's tier with macOS behavior layered on:
  `0o600` files / `0o700` dirs (KV blocks are conversation-derived data with
  presence-testable hash names), `blocks.noindex` so Spotlight never indexes
  churn, async Time Machine exclusion, `F_NOCACHE` (upstream's `O_DIRECT`
  silently degrades to buffered on macOS), QoS-tagged I/O threads, and an
  **8-byte CRC32 footer per block file** verified on every load — torn
  writes and bit rot become clean misses instead of poisoned KV.
- **Config-time guards, not runtime surprises**: hybrid/sliding-window
  models (e.g. gemma-4), NIXL `obj` tiers, heterogeneous KV dtypes, and
  unsupported connector configs are rejected at startup with actionable
  messages. A memory-safety guard clamps the paged-attention plan against
  live host memory (hard cannot-fit cut + configurable free-RAM floor), so
  oversized fractions degrade gracefully instead of wiring the machine into
  the ground.
- The tier's lookup also works around a live upstream defect we found while
  testing: the tiering async-lookup cache is never invalidated when a load
  fails, which livelocks a request into re-promoting a deleted block forever.
  The Metal tier validates file size at lookup and negative-caches failed
  loads (upstream issue to follow — the fix here is self-contained).

### Deliberate deltas vs the CUDA path

Studied and intentionally not ported, with reasons: pinned host pools and
`cudaHostRegister` (no-ops on unified memory), page prefaulting (actively
harmful — wires cold pages), stream/descriptor pooling and GDS (no
equivalent I/O path). Transfers currently run synchronously in the submit
hooks; the worker API is shaped for a later move to `mx.async_eval` +
thread-local streams (MLX ≥0.32), which is the top item in the design doc's
future work.

### On "warm output differs from cold" — read before testing

If you drive this with a repetitive prompt and diff greedy outputs against
cold prefill, you will eventually see a divergence and suspect corruption.
It is not. The restore path is **byte-exact** (env-gated per-row CRC
instrumentation verifies stored == loaded == post-scatter GPU bytes), and
the divergence **reproduces with no offloading configured** — plain GPU
prefix-cache resume. Mechanism: restored-prefix + short-tail recompute is a
different kernel batch shape than chunked cold prefill; fp16 logits differ
by ~1e-3 nats, and on near-tie tokens (we measured a 0.045-nat top-2 margin
at a flip point) greedy argmax flips deterministically. This is inherent to
resume-then-continue on any backend, CUDA included. The correct oracle —
used by our tests — compares restored output against a **no-offload resume**
of the same prefix, which is byte-identical across all tested models.

### Evidence

E2E matrix (local harness, resume oracle above; byte-identical output in
every cell):

| Model | serve | host pool | disk cascade | cross-restart | cold → disk restore |
|---|---|---|---|---|---|
| Qwen2.5-1.5B-4bit | pass | pass | pass | pass | 2.0s → 0.33s |
| Qwen2.5-1.5B + TurboQuant KV | pass | pass | pass | pass | — |
| Qwen2.5-7B-4bit | pass | pass | pass | pass | 7.8s → 0.8s |
| Llama-3.2-3B-4bit | pass | pass | pass | pass | 3.3s → 0.45s |
| Llama-3.2-1B (bf16 KV) | pass | pass | pass | pass | 1.0s → 0.34s |
| gemma-2-2b-4bit | pass | pass | pass | pass | 1.5s → 0.37s |
| Qwen2.5-32B-4bit | pass | pass | pass | pass | 33.6s → 4.1s (8.3×) |
| Qwen3-30B-A3B-4bit (MoE) | pass | pass | pass | pass | 3.6s → 0.64s |
| gemma-4-e4b / gemma-4-31b (hybrid) | pass | guarded | guarded | guarded | clean config-time rejection |
| Llama-3.3-70B-4bit | pass | — | pass | pass | **78.8s → 7.1s (11.1×)** |

*"guarded" = enabling offloading for this model is rejected at startup with
a `NotImplementedError` naming the reason (hybrid attention: mixed
sliding/full layers need per-group KV handling the single-group port doesn't
have yet); plain serving without offloading is unaffected. Rejection is the
designed behavior, not a failure: accepting these configs would offload only
part of each block's state and restore corrupted KV silently. The guard path
itself is under test — these two models are e2e cells asserting the
rejection fires cleanly.*

- Transfer bandwidth 5–9 GB/s across sizes; disk stores up to 18.9 GB
  cascaded and restored.
- **No serving regression** (`vllm bench serve`, sonnet dataset, 100
  prompts, per the contributing guide): connector overhead 1.9–4.6% —
  median TTFT +1.9%, TPOT +2.3%, E2EL +3.5%, P99s within 3.1%, throughput
  unchanged within noise.
- 56 offload unit/parity tests; full non-slow suite (1,541) green;
  `scripts/lint.sh` and `scripts/test.sh` green. The stack was additionally
  validated end-to-end from a scratch install on a second machine (M-series
  Studio), same byte-exactness and scaling behavior.
- Targets vLLM 0.25.1 (`OffloadingWorker` / `LookupResult` interfaces);
  rebased on current `main`.

### Known limitations (guarded, documented, future work in the design doc)

- Single KV cache group / uniform full attention — hybrid and
  sliding-window models are cleanly rejected at config time (three gemma
  variants tested for the rejection path). gemma-2 works where
  `sliding_window == max_model_len`; beyond-window is untested.
- Single worker rank; synchronous transfers (no compute/transfer overlap
  yet).
- The disk store has no GC or size cap (upstream behavior); retention and
  eviction are listed in the design doc's future work, alongside a
  purgeable host pool, `MADV_FREE` eviction hooks, and streams overlap.

### Try it

```bash
PYTHONHASHSEED=0 VLLM_METAL_USE_PAGED_ATTENTION=1 \
vllm serve mlx-community/Qwen2.5-1.5B-Instruct-4bit \
  --kv-offloading-backend native --kv-offloading-size 8 \
  --kv-transfer-config '{"kv_connector_extra_config":
    {"secondary_tiers": [{"type": "fs", "root_dir": "/tmp/kv-store"}]}}'
```

Serve a long prompt, evict it (fill the cache with other traffic or restart
the server), send it again, and watch
`vllm:prompt_tokens_by_source_total{source="external_kv_transfer"}` go
nonzero while the response returns in a fraction of the cold time.

Design doc: `docs/offload-design.md` (architecture, correctness analysis,
resume-numerics writeup, future work). Diagram:
`docs/offload-architecture.mmd`.

---

Generated with [Claude Code](https://claude.com/claude-code)
