### PR TITLE
[Distributed] Track the renamed Ray worker physical-GPU-ids method

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -38,7 +38,7 @@ ray stop
 
 If a node isn't advertising the `mlx` resource, the engine can't place workers: the Ray executor logs `No available node types can fulfill resource request {'mlx': 1.0, ...}` and hangs while creating the placement group. (A separate `current platform cpu does not support ray` error instead means the Metal plugin isn't active or `ray_device_key` is unset — not a missing resource.)
 
-On a healthy boot, each worker logs `vllm_metal: patched Ray V2 worker get_node_and_gpu_ids on RayWorkerProc (Apple-GPU custom Ray resource)` — confirming the custom-resource override fired inside the Ray actor.
+On a healthy boot, each worker logs `vllm_metal: patched Ray V2 worker get_node_and_physical_gpu_ids on RayWorkerProc (Apple-GPU custom Ray resource)` — confirming the custom-resource override fired inside the Ray actor.
 
 ## Quick start (two Macs over Thunderbolt)
 
@@ -121,7 +121,7 @@ Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networ
 ## How it works
 
 - `MetalPlatform` sets `ray_device_key = "mlx"` and `device_control_env_var = "VLLM_METAL_VISIBLE_DEVICES"`, so vLLM's Ray executor takes its generic custom-resource placement path (the same one TPU uses) instead of the CUDA `num_gpus` path.
-- A compatibility shim overrides the Ray worker's `get_node_and_gpu_ids` to read the assigned `mlx` resource — Ray never lists custom resources in `get_accelerator_ids()` — installed in each worker via a Ray `worker_process_setup_hook`.
+- A compatibility shim overrides the Ray worker's `get_node_and_physical_gpu_ids` to read the assigned `mlx` resource — Ray never lists custom resources in `get_accelerator_ids()` — installed in each worker via a Ray `worker_process_setup_hook`.
 
 ## Pipeline parallelism
 
@@ -187,7 +187,7 @@ RAY_ADDRESS=auto VLLM_HOST_IP=10.0.0.1 VLLM_METAL_MEMORY_FRACTION=0.5 \
 - `--data-parallel-size-local 1`: one Apple GPU per Mac means one replica per node.
 - `--data-parallel-address <head-ip>`: pin the DP master to the Ray head's IP so placement finds it. The Ray DP backend otherwise follows `get_ip()` / `VLLM_HOST_IP`, so set it explicitly to avoid a mismatch.
 
-On a healthy boot each Mac logs `patched Ray V2 worker get_node_and_gpu_ids ...` and an `EngineCore` actor is placed on each node IP.
+On a healthy boot each Mac logs `patched Ray V2 worker get_node_and_physical_gpu_ids ...` and an `EngineCore` actor is placed on each node IP.
 
 **Design.** vLLM owns the whole DP control plane (replica placement, the DP coordinator, the request load balancer); `MetalPlatform` only relaxes admission to the supported shape. One Metal-specific detail: Ray honours a `worker_process_setup_hook` only from the **job** runtime_env (`ray.init`), and the DP engine manager connects to Ray without forwarding it — so vllm-metal registers the Apple-GPU worker patch at the job level itself before the engine connects (`MetalPlatform._register_dp_ray_worker_setup_hook`); otherwise the per-replica `RayWorkerProc` would `KeyError` on the custom `mlx` resource.
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -810,8 +810,9 @@ class TestWrapModelSanitize:
 class TestMetalRayLocalGpuIds:
     """Pure-logic coverage for the Ray V2 worker resource resolver.
 
-    Exercises the decision the ``get_node_and_gpu_ids`` override delegates to —
-    no Ray, no cluster — so it runs in CI on the validated single-node path.
+    Exercises the decision the ``get_node_and_physical_gpu_ids`` override
+    delegates to — no Ray, no cluster — so it runs in CI on the validated
+    single-node path.
     """
 
     def test_single_mlx_resource_maps_to_local_index_zero(self) -> None:
@@ -837,3 +838,90 @@ class TestMetalRayLocalGpuIds:
     def test_none_assignment_fails_loud(self) -> None:
         with pytest.raises(RuntimeError, match="was not assigned"):
             compat._metal_ray_local_gpu_ids("node-1", None, "mlx")
+
+
+class _StubWorkerWithMethod:
+    """Stands in for RayWorkerProc: exposes the upstream method name so the
+    override has something to replace."""
+
+    def get_node_and_physical_gpu_ids(self) -> tuple[str, list[int]]:
+        return ("stock", [])
+
+
+class _StubWorkerMissingMethod:
+    """A worker actor without the tracked method — the shape a future upstream
+    rename would produce."""
+
+
+class TestInstallMetalOverride:
+    """Coverage for installing the Metal Ray worker override on a worker class.
+
+    Pins that the override lands on the method vLLM actually calls
+    (``get_node_and_physical_gpu_ids``, renamed from ``get_node_and_gpu_ids`` at
+    vLLM 0.24.0); the old code bound the pre-0.24 name and silently left the
+    stock method — which KeyErrors on the "mlx" custom resource — in place.
+    """
+
+    def test_override_replaces_the_upstream_method_and_resolves_mlx(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ray = pytest.importorskip("ray")
+
+        class _FakeRuntimeContext:
+            def get_node_id(self) -> str:
+                return "node-x"
+
+            def get_assigned_resources(self) -> dict[str, float]:
+                return {"mlx": 1.0}
+
+        monkeypatch.setattr(ray, "get_runtime_context", lambda: _FakeRuntimeContext())
+
+        compat._install_metal_override(_StubWorkerWithMethod)
+
+        assert _StubWorkerWithMethod._metal_patched is True
+        # The override lands on the method upstream calls, NOT the pre-0.24 name.
+        assert not hasattr(_StubWorkerWithMethod, "get_node_and_gpu_ids")
+        resolved = _StubWorkerWithMethod().get_node_and_physical_gpu_ids()
+        assert resolved == ("node-x", [0])
+
+    def test_missing_method_fails_loud(self) -> None:
+        with pytest.raises(RuntimeError) as excinfo:
+            compat._install_metal_override(_StubWorkerMissingMethod)
+        assert str(excinfo.value) == (
+            "Ray worker actor _StubWorkerMissingMethod has no "
+            "'get_node_and_physical_gpu_ids' method; vllm-metal's Metal Ray "
+            "override tracks that upstream name and vLLM appears to have renamed "
+            "it. Update vllm_metal.compat for the installed vLLM version."
+        )
+
+    def test_second_install_is_a_noop(self) -> None:
+        class _Stub:
+            def get_node_and_physical_gpu_ids(self) -> tuple[str, list[int]]:
+                return ("stock", [])
+
+        compat._install_metal_override(_Stub)
+        first = _Stub.get_node_and_physical_gpu_ids
+        compat._install_metal_override(_Stub)
+        assert _Stub.get_node_and_physical_gpu_ids is first
+
+    def test_patch_ray_distributed_targets_real_worker(self) -> None:
+        pytest.importorskip("ray")
+        from vllm.v1.executor.ray_executor_v2 import RayWorkerProc
+
+        original = RayWorkerProc.__dict__.get("get_node_and_physical_gpu_ids")
+        had_sentinel = "_metal_patched" in RayWorkerProc.__dict__
+        try:
+            compat._patch_ray_distributed()
+            assert RayWorkerProc._metal_patched is True
+            assert (
+                RayWorkerProc.__dict__["get_node_and_physical_gpu_ids"] is not original
+            )
+        finally:
+            if original is not None:
+                RayWorkerProc.get_node_and_physical_gpu_ids = original
+            elif "get_node_and_physical_gpu_ids" in RayWorkerProc.__dict__:
+                # Upstream defined it on a base class; drop our install so the
+                # inherited method is visible again.
+                delattr(RayWorkerProc, "get_node_and_physical_gpu_ids")
+            if not had_sentinel and "_metal_patched" in RayWorkerProc.__dict__:
+                delattr(RayWorkerProc, "_metal_patched")

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -149,8 +149,16 @@ def _metal_ray_local_gpu_ids(
     return node_id, list(range(count))
 
 
-def _patch_ray_distributed() -> None:
-    """Override the Ray V2 worker actor's ``get_node_and_gpu_ids`` for Metal.
+# The Ray worker actor method the Metal override tracks. vLLM renamed it from
+# ``get_node_and_gpu_ids`` (<=0.23) to ``get_node_and_physical_gpu_ids`` (0.24.0,
+# #463). The override is permanent (Apple GPUs never become a Ray accelerator
+# family), so only this NAME is version-coupled; ``_install_metal_override``
+# fails loud when it is absent so the next rename surfaces at startup.
+_RAY_WORKER_GPU_IDS_METHOD = "get_node_and_physical_gpu_ids"
+
+
+def _install_metal_override(cls: Any) -> None:
+    """Replace ``cls``'s physical-GPU-ids Ray actor method with the Metal override.
 
     Apple GPUs are not a Ray-recognized accelerator family, so a custom Ray
     resource ("mlx") never appears in
@@ -160,23 +168,20 @@ def _patch_ray_distributed() -> None:
     the assigned custom resource instead (one Apple GPU per node -> local index
     ``[0]``), failing loud if a worker was not scheduled onto an "mlx" resource.
 
-    vllm-metal supports only the default Ray V2 executor, whose worker actor is
-    ``RayWorkerProc``.
-
-    Installed in each Ray worker via the ``worker_process_setup_hook`` wired in
-    ``MetalPlatform.check_and_update_config`` — it runs at worker startup, before
-    the first actor call.  This is the only mechanism that works for real Ray: the
-    driver never calls ``get_node_and_gpu_ids`` locally, actors re-import the class
-    fresh in their own processes, and the lazy plugin-load path inside a worker
-    runs too late (it would fire *inside* the unpatched method's first call).
+    Kept module-level and taking ``cls`` (like ``_metal_ray_local_gpu_ids``) so
+    the install and its fail-fast are unit-testable without a live Ray cluster.
     """
-    from vllm.v1.executor.ray_executor_v2 import RayWorkerProc
-
-    cls: Any = RayWorkerProc
     if getattr(cls, "_metal_patched", False):
         return
+    if not hasattr(cls, _RAY_WORKER_GPU_IDS_METHOD):
+        raise RuntimeError(
+            f"Ray worker actor {cls.__name__} has no {_RAY_WORKER_GPU_IDS_METHOD!r} "
+            "method; vllm-metal's Metal Ray override tracks that upstream name and "
+            "vLLM appears to have renamed it. Update vllm_metal.compat for the "
+            "installed vLLM version."
+        )
 
-    def get_node_and_gpu_ids(self):  # noqa: ANN001, ANN202
+    def get_node_and_physical_gpu_ids(self) -> tuple[str, list[int]]:  # noqa: ANN001
         import ray as _ray
         from vllm.platforms import current_platform
 
@@ -187,12 +192,30 @@ def _patch_ray_distributed() -> None:
             current_platform.ray_device_key,
         )
 
-    cls.get_node_and_gpu_ids = get_node_and_gpu_ids
+    setattr(cls, _RAY_WORKER_GPU_IDS_METHOD, get_node_and_physical_gpu_ids)
     cls._metal_patched = True
     logger.info(
-        "vllm_metal: patched Ray V2 worker get_node_and_gpu_ids on RayWorkerProc "
-        "(Apple-GPU custom Ray resource)"
+        "vllm_metal: patched Ray V2 worker %s on %s (Apple-GPU custom Ray resource)",
+        _RAY_WORKER_GPU_IDS_METHOD,
+        cls.__name__,
     )
+
+
+def _patch_ray_distributed() -> None:
+    """Install the Metal Ray worker override on the default Ray V2 executor.
+
+    vllm-metal supports only the default Ray V2 executor, whose worker actor is
+    ``RayWorkerProc``. Installed in each Ray worker via the
+    ``worker_process_setup_hook`` wired in ``MetalPlatform.check_and_update_config``
+    — it runs at worker startup, before the first actor call. This is the only
+    mechanism that works for real Ray: the driver never calls the method locally,
+    actors re-import the class fresh in their own processes, and the lazy
+    plugin-load path inside a worker runs too late (it would fire *inside* the
+    unpatched method's first call).
+    """
+    from vllm.v1.executor.ray_executor_v2 import RayWorkerProc
+
+    _install_metal_override(RayWorkerProc)
 
 
 def _gemma4_assistant_config_class() -> type[Any]:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -274,8 +274,9 @@ class MetalPlatform(Platform):
         manager connects to Ray without forwarding ``parallel_config.ray_runtime_env``
         to ``ray.init`` (see ``vllm/v1/engine/utils.py``), so the hook wired into
         ``ray_runtime_env`` for the single-stage Ray executor never reaches the
-        per-replica ``RayWorkerProc`` workers, and ``get_node_and_gpu_ids`` would
-        ``KeyError`` on the custom "mlx" resource. We initialize Ray ourselves with
+        per-replica ``RayWorkerProc`` workers, and
+        ``get_node_and_physical_gpu_ids`` would ``KeyError`` on the custom "mlx"
+        resource. We initialize Ray ourselves with
         the hook in the job runtime_env before the engine connects; the engine's
         later ``ray.init`` reuses this session.
 
@@ -382,7 +383,7 @@ class MetalPlatform(Platform):
             )
         elif parallel_config.distributed_executor_backend == "ray":
             # Apple GPUs are not a Ray accelerator family, so the Ray worker
-            # actor's get_node_and_gpu_ids would KeyError on
+            # actor's get_node_and_physical_gpu_ids would KeyError on
             # get_accelerator_ids()[ray_device_key].  Install our override (see
             # vllm_metal.compat._patch_ray_distributed) in every Ray worker via a
             # worker_process_setup_hook, which runs at worker startup before the


### PR DESCRIPTION
Ray across two Macs dies at startup with KeyError: 'mlx'. vLLM renamed the worker actor method get_node_and_gpu_ids to get_node_and_physical_gpu_ids in the 0.24.0 bump (#463), but our shim still patched the old name, so the override was dead and the stock method KeyErrors on the "mlx" custom resource. 