### PR TITLE
Simplify pooling request contract handling

### DIFF
--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -14,9 +14,11 @@ import torch
 pytest.importorskip("vllm", reason="vllm not installed")
 
 from vllm.pooling_params import LateInteractionParams, PoolingParams  # noqa: E402
+from vllm.v1.core.sched.output import NewRequestData  # noqa: E402
 
 from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
@@ -187,10 +189,7 @@ def _make_runner(
 
 
 def _pooling_params(task: str | None = None, **overrides) -> PoolingParams:
-    params = PoolingParams(task=task)
-    for key, value in overrides.items():
-        setattr(params, key, value)
-    return params
+    return PoolingParams(task=task, **overrides)
 
 
 def _new_req(
@@ -201,8 +200,8 @@ def _new_req(
     num_computed_tokens: int = 0,
     block_ids: list[int] | None = None,
     pooling_params: PoolingParams | None = None,
-):
-    return SimpleNamespace(
+) -> NewRequestData:
+    return NewRequestData(
         req_id=req_id,
         prompt_token_ids=token_ids,
         mm_features=[],
@@ -229,7 +228,7 @@ def _cached_req_data(req_ids: list[str], num_computed_tokens: list[int]):
 
 def _scheduler_output(
     *,
-    new_reqs: list[object] | None = None,
+    new_reqs: list[NewRequestData] | None = None,
     cached_req_ids: list[str] | None = None,
     cached_num_computed_tokens: list[int] | None = None,
     num_scheduled_tokens: dict[str, int] | None = None,
@@ -635,31 +634,35 @@ class TestMetalPoolingFailFast:
         with pytest.raises(NotImplementedError, match="LAST"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
-    def test_late_interaction_pooling_fails_fast(self) -> None:
-        runner = _make_runner()
-        params = _pooling_params(
-            late_interaction_params=LateInteractionParams(
-                mode="cache_query",
-                query_key="query-0",
-            )
-        )
-        req = _new_req("req-0", [1, 2], pooling_params=params)
-
-        with pytest.raises(NotImplementedError, match="late-interaction"):
-            runner.execute_model(_scheduler_output(new_reqs=[req]))
-
     def test_multimodal_pooling_fails_fast(self) -> None:
         runner = _make_runner()
         req = _new_req("req-0", [1, 2])
-        req.mm_features = [object()]
+        req.mm_features = [
+            MultiModalFeatureSpec(
+                data=None,
+                modality="image",
+                identifier="image-0",
+                mm_position=PlaceholderRange(offset=0, length=1),
+            )
+        ]
 
-        with pytest.raises(NotImplementedError, match="Multimodal pooling"):
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_unified") as prepare,
+            patch(
+                "vllm_metal.v1.model_runner.forward_sequence_hidden_states"
+            ) as forward,
+            pytest.raises(NotImplementedError, match="Multimodal pooling"),
+        ):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+        prepare.assert_not_called()
+        forward.assert_not_called()
+        assert "req-0" not in runner._request_states
 
     def test_prompt_embeds_pooling_fails_fast_before_forward(self) -> None:
         runner = _make_runner()
         req = _new_req("req-0", [1, 2])
-        req.prompt_embeds = mx.zeros((1, 2, 3), dtype=mx.float32)
+        req.prompt_embeds = torch.zeros((1, 2, 3), dtype=torch.float32)
 
         with (
             patch("vllm_metal.v1.model_runner.prepare_unified") as prepare,
@@ -675,35 +678,38 @@ class TestMetalPoolingFailFast:
         assert "req-0" not in runner._request_states
 
     @pytest.mark.parametrize(
-        ("attr", "value", "message"),
+        ("pooling_params", "message"),
         [
-            ("requires_token_ids", True, "token-level ALL"),
-            ("use_activation", False, "use_activation=False"),
+            (
+                _pooling_params(
+                    late_interaction_params=LateInteractionParams(
+                        mode="cache_query",
+                        query_key="query-0",
+                    )
+                ),
+                "late-interaction",
+            ),
+            (_pooling_params(requires_token_ids=True), "token-level ALL"),
+            (_pooling_params(step_tag_id=1), "STEP"),
+            (_pooling_params(returned_token_ids=[1]), "returned_token_ids"),
+            (_pooling_params(extra_kwargs={"foo": True}), "extra pooling kwargs"),
+            (_pooling_params(use_activation=False), "use_activation=False"),
+            (_pooling_params(dimensions=2), "dimension"),
+            (
+                _pooling_params(requires_token_ids=True, dimensions=2),
+                "token-level ALL",
+            ),
         ],
     )
     def test_unsupported_pooling_options_fail_fast(
         self,
-        attr: str,
-        value: object,
+        pooling_params: PoolingParams,
         message: str,
     ) -> None:
         runner = _make_runner()
-        params = _pooling_params()
-        setattr(params, attr, value)
-        req = _new_req("req-0", [1, 2], pooling_params=params)
+        req = _new_req("req-0", [1, 2], pooling_params=pooling_params)
 
         with pytest.raises(NotImplementedError, match=message):
-            runner.execute_model(_scheduler_output(new_reqs=[req]))
-
-    def test_embedding_dimensions_are_rejected(self) -> None:
-        runner = _make_runner()
-        req = _new_req(
-            "req-0",
-            [1, 2],
-            pooling_params=_pooling_params(dimensions=2),
-        )
-
-        with pytest.raises(NotImplementedError, match="dimension"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
     def test_unknown_hidden_state_shape_fails_fast(self) -> None:

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -9,6 +9,7 @@ import mlx.core as mx
 import torch
 from vllm.pooling_params import PoolingParams
 from vllm.tasks import SupportedTask
+from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 
@@ -258,41 +259,23 @@ def _unsupported_pooling_option(
     pooling_params: PoolingParams,
     model_config: Any,
 ) -> str | None:
-    checks = (
-        (
-            "late-interaction parameters",
-            getattr(pooling_params, "late_interaction_params", None) is not None,
-        ),
-        (
-            "token-level ALL pooling outputs",
-            getattr(pooling_params, "requires_token_ids", False),
-        ),
-        (
-            "STEP pooling parameters",
-            getattr(pooling_params, "step_tag_id", None) is not None,
-        ),
-        (
-            "returned_token_ids",
-            getattr(pooling_params, "returned_token_ids", None) is not None,
-        ),
-        (
-            "extra pooling kwargs",
-            bool(getattr(pooling_params, "extra_kwargs", None)),
-        ),
-        (
-            "use_activation=False",
-            getattr(pooling_params, "task", None) != "classify"
-            and getattr(pooling_params, "use_activation", None) is False,
-        ),
-        (
-            "embedding-dimension truncation",
-            getattr(pooling_params, "dimensions", None) is not None
-            or getattr(_pooler_config(model_config), "dimensions", None) is not None,
-        ),
-    )
-    for reason, unsupported in checks:
-        if unsupported:
-            return reason
+    if pooling_params.late_interaction_params is not None:
+        return "late-interaction parameters"
+    if pooling_params.requires_token_ids:
+        return "token-level ALL pooling outputs"
+    if pooling_params.step_tag_id is not None:
+        return "STEP pooling parameters"
+    if pooling_params.returned_token_ids is not None:
+        return "returned_token_ids"
+    if pooling_params.extra_kwargs:
+        return "extra pooling kwargs"
+    if pooling_params.task != "classify" and pooling_params.use_activation is False:
+        return "use_activation=False"
+    if (
+        pooling_params.dimensions is not None
+        or getattr(_pooler_config(model_config), "dimensions", None) is not None
+    ):
+        return "embedding-dimension truncation"
     return None
 
 
@@ -309,7 +292,7 @@ def validate_pooling_params(
         )
     _reject_unsupported_pooler_config(model_config)
 
-    task = getattr(pooling_params, "task", None)
+    task = pooling_params.task
     if task in (None, "embed"):
         if not _is_decoder_embedding_config(model_config):
             raise NotImplementedError(
@@ -342,7 +325,7 @@ def validate_pooling_params(
 
 
 def validate_pooling_request(
-    new_req: Any,
+    new_req: NewRequestData,
     model_config: Any,
     *,
     paged_attention_enabled: bool,
@@ -357,7 +340,7 @@ def validate_pooling_request(
         raise NotImplementedError(
             "Multimodal pooling inputs are not supported on Metal yet."
         )
-    if getattr(new_req, "prompt_embeds", None) is not None:
+    if new_req.prompt_embeds is not None:
         raise NotImplementedError(
             "Prompt-embedding pooling inputs are not supported on Metal yet."
         )
@@ -442,7 +425,6 @@ def pool_sequence_embedding(
     hidden_states: mx.array,
     *,
     token_index: int,
-    pooling_params: PoolingParams,
     model_config: Any,
 ) -> torch.Tensor:
     """Return a normalized CPU LAST embedding for one finished request."""
@@ -468,13 +450,9 @@ def _classifier_use_activation(
     pooling_params: PoolingParams,
     model_config: Any,
 ) -> bool:
-    request_value = getattr(pooling_params, "use_activation", None)
-    if request_value is not None:
-        return bool(request_value)
-    pooler_value = getattr(_pooler_config(model_config), "use_activation", None)
-    if pooler_value is not None:
-        return bool(pooler_value)
-    return True
+    if pooling_params.use_activation is not None:
+        return pooling_params.use_activation
+    return getattr(_pooler_config(model_config), "use_activation", None) is not False
 
 
 def pool_sequence_classification(
@@ -550,13 +528,12 @@ def pool_sequence_batch(
         if token_index is None:
             outputs.append(None)
             continue
-        task = getattr(params, "task", None)
+        task = params.task
         if task in (None, "embed"):
             outputs.append(
                 pool_sequence_embedding(
                     hidden_states,
                     token_index=token_index,
-                    pooling_params=params,
                     model_config=model_config,
                 )
             )


### PR DESCRIPTION
This PR is:

- To trust vLLM’s typed `PoolingParams` and `NewRequestData` contracts.
- To remove reflective field access and an unused pooling argument.
- To tighten pooling tests around production DTOs and request-level fail-fast behavior.

## Note

This keeps validation at the Metal boundary while trusting vLLM’s typed scheduler objects inside the runtime path. Unsupported pooling options still fail with the existing user-facing errors, but tests now use real `NewRequestData`, real multimodal feature metadata, and Torch prompt embeddings instead of loose stand-ins.