### PR TITLE
[Spec Decode] Skip n-gram matching for requests that keep missing

### DIFF
--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -11,10 +11,12 @@ intermediate prefills) and the array marshalling into the upstream kernel.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from vllm.sampling_params import SamplingParams
 
+from vllm_metal.v1 import ngram_proposer as ngram_mod
 from vllm_metal.v1.ngram_proposer import NgramProposer
 from vllm_metal.v1.proposer import ProposeContext
 from vllm_metal.v1.spec_decode import SpeculativeDecodeController
@@ -213,6 +215,104 @@ class TestNgramProposePropose:
 
         assert drafts is not None
         assert drafts.req_ids == ["r0"]
+
+
+class TestNgramMissThrottle:
+    """The kernel scans a request's whole history every step whether or not
+    it finds anything, so a request that never matches should stop being
+    handed to the kernel after enough consecutive misses -- these tests
+    mock the wrapped upstream call directly so they exercise only the
+    throttle bookkeeping, independent of the installed vLLM's kernel
+    signature."""
+
+    def test_throttles_after_max_consecutive_misses(self) -> None:
+        proposer = _proposer()
+        state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(
+            proposer._ngram, "propose", return_value=[[]]
+        ) as mock_propose:
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES):
+                assert proposer.propose(ctx) is None
+            calls_before_throttle = mock_propose.call_count
+
+            # One more miss would be the (N+1)th in a row: by now the request
+            # should be on cooldown and skipped before ever reaching the kernel.
+            assert proposer.propose(ctx) is None
+            assert mock_propose.call_count == calls_before_throttle
+
+    def test_hit_resets_the_streak(self) -> None:
+        proposer = _proposer()
+        state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(proposer._ngram, "propose") as mock_propose:
+            mock_propose.return_value = [[]]
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES - 1):
+                assert proposer.propose(ctx) is None
+
+            # A hit right before the threshold must reset the streak, not
+            # just delay the cutoff by one step.
+            mock_propose.return_value = [[1]]
+            assert proposer.propose(ctx) is not None
+
+            mock_propose.return_value = [[]]
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES - 1):
+                assert proposer.propose(ctx) is None
+            calls_before = mock_propose.call_count
+
+            # Still under threshold post-reset: the kernel must still be
+            # reachable, not skipped.
+            proposer.propose(ctx)
+            assert mock_propose.call_count == calls_before + 1
+
+    def test_cooldown_expires_and_retries(self) -> None:
+        proposer = _proposer()
+        state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(
+            proposer._ngram, "propose", return_value=[[]]
+        ) as mock_propose:
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES):
+                proposer.propose(ctx)
+            calls_at_throttle = mock_propose.call_count
+
+            # Every call during cooldown must be skipped before the kernel.
+            for _ in range(ngram_mod._COOLDOWN_STEPS - 1):
+                proposer.propose(ctx)
+            assert mock_propose.call_count == calls_at_throttle
+
+            # The cooldown-th call is the last skipped one; the call after
+            # that must reach the kernel again.
+            proposer.propose(ctx)
+            assert mock_propose.call_count == calls_at_throttle
+            proposer.propose(ctx)
+            assert mock_propose.call_count == calls_at_throttle + 1
+
+    def test_prune_finished_clears_throttle_state(self) -> None:
+        proposer = _proposer()
+        state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(proposer._ngram, "propose", return_value=[[]]):
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES):
+                proposer.propose(ctx)
+        assert "r0" in proposer._cooldown
+
+        # r0 finishes: its bookkeeping must not survive to be misread by a
+        # later, unrelated request that happens to reuse the same id.
+        proposer._prune_finished({})
+        assert "r0" not in proposer._cooldown
+        assert "r0" not in proposer._miss_streak
+
+        with patch.object(
+            proposer._ngram, "propose", return_value=[[1]]
+        ) as mock_propose:
+            drafts = proposer.propose(ctx)
+        assert drafts is not None
+        mock_propose.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -63,6 +63,7 @@ def _context(
     prefill_result_modes: list[str] | None = None,
     request_states: dict[str, SimpleNamespace] | None = None,
     num_speculative_tokens: int = 3,
+    finished_req_ids: set[str] | None = None,
 ) -> ProposeContext:
     decode_reqs = decode_reqs or []
     prefill_reqs = prefill_reqs or []
@@ -85,6 +86,7 @@ def _context(
         num_decode_segments=len(decode_reqs),
         num_speculative_tokens=num_speculative_tokens,
         logitsprocs=None,
+        finished_req_ids=finished_req_ids or set(),
     )
 
 
@@ -242,30 +244,100 @@ class TestNgramMissThrottle:
             assert proposer.propose(ctx) is None
             assert mock_propose.call_count == calls_before_throttle
 
-    def test_hit_resets_the_streak(self) -> None:
+    def test_capped_streak_returns_to_cooldown_after_one_more_miss(self) -> None:
+        """A retry that misses again right after cooldown must go straight
+        back into cooldown, not get another full _MAX_CONSECUTIVE_MISSES-long
+        grace period -- the streak caps at the threshold instead of clearing
+        when cooldown is set."""
         proposer = _proposer()
+        state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(
+            proposer._ngram, "propose", return_value=[[]]
+        ) as mock_propose:
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES):
+                proposer.propose(ctx)
+            assert "r0" in proposer._cooldown
+
+            for _ in range(ngram_mod._COOLDOWN_STEPS):
+                proposer.propose(ctx)
+            calls_at_retry = mock_propose.call_count
+
+            # The retry itself misses again: this single miss must be enough
+            # to re-cooldown, not the first of another eight.
+            proposer.propose(ctx)
+            assert mock_propose.call_count == calls_at_retry + 1
+            assert "r0" in proposer._cooldown
+
+            calls_after_recooldown = mock_propose.call_count
+            proposer.propose(ctx)
+            assert mock_propose.call_count == calls_after_recooldown
+
+    def test_real_acceptance_resets_the_streak(self) -> None:
+        """A lookup match only counts once the *next* step's committed
+        history shows the target actually accepted it -- not the moment the
+        kernel proposes it."""
+        proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
         state = _request_state([7, 8, 9])
         ctx = _context(decode_reqs=[("r0", state)])
 
         with patch.object(proposer._ngram, "propose") as mock_propose:
             mock_propose.return_value = [[]]
             for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES - 1):
-                assert proposer.propose(ctx) is None
+                proposer.propose(ctx)
+            assert "r0" not in proposer._cooldown
 
-            # A hit right before the threshold must reset the streak, not
-            # just delay the cutoff by one step.
-            mock_propose.return_value = [[1]]
-            assert proposer.propose(ctx) is not None
+            # The kernel finds something...
+            mock_propose.return_value = [[99]]
+            drafts = proposer.propose(ctx)
+            assert drafts is not None
+            # ...and the engine genuinely accepts it (appends exactly what
+            # was proposed to committed history).
+            state.token_ids.append(99)
 
+            # Resolving that acceptance must fully clear the streak, not
+            # just discount it by one.
             mock_propose.return_value = [[]]
-            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES - 1):
-                assert proposer.propose(ctx) is None
-            calls_before = mock_propose.call_count
-
-            # Still under threshold post-reset: the kernel must still be
-            # reachable, not skipped.
             proposer.propose(ctx)
-            assert mock_propose.call_count == calls_before + 1
+            assert proposer._miss_streak.get("r0", 0) <= 1
+
+    def test_lookup_match_without_acceptance_still_throttles(self) -> None:
+        """The kernel finding *something* every step isn't evidence the
+        request benefits -- if the target never actually accepts any of it,
+        this must throttle exactly like true misses would."""
+        proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
+        state = _request_state([1, 2, 3, 1, 2])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        # One resolved miss per call from the second call on (the first has
+        # nothing pending yet to resolve), so the streak needs one extra
+        # call beyond _MAX_CONSECUTIVE_MISSES to actually cross the
+        # threshold and land in cooldown.
+        with patch.object(proposer._ngram, "propose", return_value=[[99]]):
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES + 1):
+                proposer.propose(ctx)
+                # The target never agrees: the engine appends some other
+                # token instead of the proposed 99. (Once throttled, propose
+                # stops even calling the kernel, so this is a no-op then.)
+                state.token_ids.append(123)
+
+        assert "r0" in proposer._cooldown
+
+    def test_short_history_is_not_counted_as_a_miss(self) -> None:
+        """Below prompt_lookup_min, the kernel structurally cannot match --
+        that's not evidence against repetition, just not enough history yet,
+        and must never accumulate toward throttling."""
+        proposer = _proposer(prompt_lookup_min=4, prompt_lookup_max=5)
+        state = _request_state([1, 2])  # shorter than prompt_lookup_min
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(proposer._ngram, "propose", return_value=[[]]):
+            for _ in range(2 * ngram_mod._MAX_CONSECUTIVE_MISSES):
+                assert proposer.propose(ctx) is None
+
+        assert "r0" not in proposer._cooldown
+        assert proposer._miss_streak.get("r0", 0) == 0
 
     def test_cooldown_expires_and_retries(self) -> None:
         proposer = _proposer()
@@ -303,7 +375,7 @@ class TestNgramMissThrottle:
 
         # r0 finishes: its bookkeeping must not survive to be misread by a
         # later, unrelated request that happens to reuse the same id.
-        proposer._prune_finished({})
+        proposer._prune_finished({"r0"})
         assert "r0" not in proposer._cooldown
         assert "r0" not in proposer._miss_streak
 
@@ -312,6 +384,40 @@ class TestNgramMissThrottle:
         ) as mock_propose:
             drafts = proposer.propose(ctx)
         assert drafts is not None
+        mock_propose.assert_called_once()
+
+    def test_reused_request_id_does_not_inherit_old_throttle_state(self) -> None:
+        """vLLM can hand a finished request's id straight to a brand-new
+        request in the same scheduler step. The new request is present in
+        request_states under that id from the moment it appears, so pruning
+        on absence from request_states would never catch this -- pruning
+        must key off the scheduler's own finished_req_ids instead."""
+        proposer = _proposer()
+        old_state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", old_state)])
+
+        with patch.object(proposer._ngram, "propose", return_value=[[]]):
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES):
+                proposer.propose(ctx)
+        assert "r0" in proposer._cooldown
+
+        # Same step: r0 finishes and a brand-new request reuses the id, so
+        # it is simultaneously in finished_req_ids and in request_states.
+        new_state = _request_state([1, 2, 3])
+        new_ctx = _context(
+            decode_reqs=[("r0", new_state)],
+            finished_req_ids={"r0"},
+        )
+
+        with patch.object(
+            proposer._ngram, "propose", return_value=[[42]]
+        ) as mock_propose:
+            drafts = proposer.propose(new_ctx)
+
+        # The new request must be evaluated fresh, not skipped as if it
+        # were still the old, throttled one.
+        assert drafts is not None
+        assert drafts.req_ids == ["r0"]
         mock_propose.assert_called_once()
 
 

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -420,6 +420,69 @@ class TestNgramMissThrottle:
         assert drafts.req_ids == ["r0"]
         mock_propose.assert_called_once()
 
+    def test_prune_and_resolve_run_even_when_speculative_tokens_disabled(
+        self,
+    ) -> None:
+        """A step with drafting disabled (num_speculative_tokens <= 0) must
+        still prune finished ids and resolve pending drafts -- that
+        bookkeeping can't be gated behind the same early return that skips
+        drafting, or a request id reused during a disabled step would carry
+        stale throttle state into a later step where drafting resumes."""
+        proposer = _proposer()
+        old_state = _request_state([7, 8, 9])
+        ctx = _context(decode_reqs=[("r0", old_state)])
+
+        with patch.object(proposer._ngram, "propose", return_value=[[]]):
+            for _ in range(ngram_mod._MAX_CONSECUTIVE_MISSES):
+                proposer.propose(ctx)
+        assert "r0" in proposer._cooldown
+
+        # Same id reused by a new request, but this step has speculative
+        # decoding disabled.
+        new_state = _request_state([1, 2, 3])
+        disabled_ctx = _context(
+            decode_reqs=[("r0", new_state)],
+            finished_req_ids={"r0"},
+            num_speculative_tokens=0,
+        )
+        assert proposer.propose(disabled_ctx) is None  # K=0, nothing drafted
+        assert "r0" not in proposer._cooldown  # cleanup must still happen
+        assert "r0" not in proposer._miss_streak
+
+        # A later, enabled step must evaluate the new request fresh.
+        enabled_ctx = _context(decode_reqs=[("r0", new_state)])
+        with patch.object(
+            proposer._ngram, "propose", return_value=[[42]]
+        ) as mock_propose:
+            drafts = proposer.propose(enabled_ctx)
+        assert drafts is not None
+        mock_propose.assert_called_once()
+
+    def test_pending_not_resolved_for_unscheduled_live_request(self) -> None:
+        """A request can be alive in request_states without being scheduled
+        for decode this step (still mid-prefill, paused, preempted). A
+        pending draft for it must not be scored as a miss just because it
+        wasn't verified this particular step."""
+        proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
+        state = _request_state([1, 2, 3])
+        ctx = _context(decode_reqs=[("r0", state)])
+
+        with patch.object(proposer._ngram, "propose", return_value=[[99]]):
+            drafts = proposer.propose(ctx)
+        assert drafts is not None
+        assert "r0" in proposer._pending
+
+        # Next step: r0 is still alive but not scheduled for decode.
+        unscheduled_ctx = _context(
+            decode_reqs=[],
+            request_states={"r0": state},
+        )
+        proposer.propose(unscheduled_ctx)
+
+        # The pending draft must survive untouched, not be scored as a miss.
+        assert "r0" in proposer._pending
+        assert proposer._miss_streak.get("r0", 0) == 0
+
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -19,7 +19,7 @@ from vllm.sampling_params import SamplingParams
 from vllm_metal.v1 import ngram_proposer as ngram_mod
 from vllm_metal.v1.ngram_proposer import NgramProposer
 from vllm_metal.v1.proposer import ProposeContext
-from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+from vllm_metal.v1.spec_decode import PagedDecodeSegment, SpeculativeDecodeController
 
 
 def _proposer(
@@ -59,6 +59,7 @@ def _context(
     *,
     decode_reqs: list[tuple[str, SimpleNamespace]] | None = None,
     decode_token_ids: list[list[int]] | None = None,
+    decode_segments: list[PagedDecodeSegment] | None = None,
     prefill_reqs: list[SimpleNamespace] | None = None,
     prefill_result_modes: list[str] | None = None,
     request_states: dict[str, SimpleNamespace] | None = None,
@@ -76,7 +77,7 @@ def _context(
     return ProposeContext(
         target_hidden_states=None,
         decode_reqs=decode_reqs,
-        decode_segments=[],
+        decode_segments=decode_segments or [],
         decode_token_ids=decode_token_ids,
         prefill_reqs=prefill_reqs,
         prefill_token_ids=[0] * len(prefill_reqs),
@@ -87,6 +88,22 @@ def _context(
         num_speculative_tokens=num_speculative_tokens,
         logitsprocs=None,
         finished_req_ids=finished_req_ids or set(),
+    )
+
+
+def _verified_segment(req_id: str, *, has_draft: bool = True) -> PagedDecodeSegment:
+    """A decode_segment for req_id: a real (if trivial) verify row if
+    has_draft, a plain no-draft row otherwise."""
+    draft_token_ids = (0,) if has_draft else ()
+    num_query_tokens = len(draft_token_ids) + 1
+    return PagedDecodeSegment(
+        req_id=req_id,
+        input_token_ids=tuple(range(num_query_tokens)),
+        start_row=0,
+        num_query_tokens=num_query_tokens,
+        draft_token_ids=draft_token_ids,
+        cache_start_pos=0,
+        block_ids=(0,),
     )
 
 
@@ -280,7 +297,10 @@ class TestNgramMissThrottle:
         kernel proposes it."""
         proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
         state = _request_state([7, 8, 9])
-        ctx = _context(decode_reqs=[("r0", state)])
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[_verified_segment("r0")],
+        )
 
         with patch.object(proposer._ngram, "propose") as mock_propose:
             mock_propose.return_value = [[]]
@@ -308,7 +328,10 @@ class TestNgramMissThrottle:
         this must throttle exactly like true misses would."""
         proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
         state = _request_state([1, 2, 3, 1, 2])
-        ctx = _context(decode_reqs=[("r0", state)])
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[_verified_segment("r0")],
+        )
 
         # One resolved miss per call from the second call on (the first has
         # nothing pending yet to resolve), so the streak needs one extra
@@ -482,6 +505,37 @@ class TestNgramMissThrottle:
         # The pending draft must survive untouched, not be scored as a miss.
         assert "r0" in proposer._pending
         assert proposer._miss_streak.get("r0", 0) == 0
+
+    def test_pending_not_resolved_when_segment_carries_no_draft(self) -> None:
+        """A request can be in decode_reqs with an empty decode_segment
+        draft_token_ids -- no draft was scheduled for it at all, or the
+        scheduler padded/dropped a proposed draft on batch admission (see
+        SpeculativeDecodeController.active_spec_decode_tokens). Either way,
+        an older pending draft for it must not be scored just because the
+        request itself shows up in decode_reqs again."""
+        proposer = _proposer(prompt_lookup_min=2, prompt_lookup_max=3)
+        state = _request_state([1, 2, 3])
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[_verified_segment("r0")],
+        )
+
+        with patch.object(proposer._ngram, "propose", side_effect=[[[99]], [[]]]):
+            drafts = proposer.propose(ctx)
+            assert drafts is not None
+            assert proposer._pending["r0"] == (3, (99,))
+
+            # Next step: r0 is still in decode_reqs, but this step's
+            # segment carries no draft at all.
+            state.token_ids.append(123)
+            plain_ctx = _context(
+                decode_reqs=[("r0", state)],
+                decode_segments=[_verified_segment("r0", has_draft=False)],
+            )
+            proposer.propose(plain_ctx)
+
+        # The pending draft from the verified step must survive untouched.
+        assert proposer._pending["r0"] == (3, (99,))
 
 
 if __name__ == "__main__":

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1399,6 +1399,7 @@ class MetalModelRunner:
             num_decode_segments=num_decode_segments,
             num_speculative_tokens=num_speculative_tokens,
             logitsprocs=self._logitsprocs,
+            finished_req_ids=scheduler_output.finished_req_ids,
         )
         self._draft_token_ids = (
             self._drafter.propose(draft_ctx) if self._drafter is not None else None

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -22,6 +22,12 @@ prose, for instance) stops paying the match kernel's per-step scan cost after
 a few misses in a row, with periodic retries in case the content turns
 repetitive later. See ``_record_miss``/``_on_cooldown``.
 
+A lookup match is not itself evidence the request benefits: the target may
+reject every proposed token. ``_resolve_pending`` checks a step's proposal
+against the *next* step's committed history (which already reflects what the
+target actually accepted) to score it as a real hit or a miss, rather than
+trusting the lookup kernel's own optimism.
+
 The verify half is unchanged: drafts are handed back via ``take_draft_token_ids``
 and verified next step by ``SpeculativeDecodeController.verify_greedy``.
 """
@@ -73,16 +79,32 @@ class NgramProposer:
     ) -> None:
         self._controller = controller
         # Per-request consecutive-miss count and, once throttled, remaining
-        # cooldown steps before the next retry. Both pruned each step against
-        # the live request set so they never grow past what's active.
+        # cooldown steps before the next retry. Pruned each step against the
+        # scheduler's own finished-id set, not against absence from
+        # request_states: vLLM can hand a finished id straight back out to a
+        # new request in the same step, and that new request repopulates
+        # request_states under the same id before this wrapper ever sees it.
         self._miss_streak: dict[str, int] = {}
         self._cooldown: dict[str, int] = {}
+        # A lookup match doesn't mean the target accepted any of it. Each
+        # non-empty draft is stashed here (position it starts at, tokens
+        # proposed) and scored against the *next* step's actual committed
+        # history in _resolve_pending, before this step's proposal is
+        # scored as a hit or a miss.
+        self._pending: dict[str, tuple[int, tuple[int, ...]]] = {}
         # Upstream reads only scalar config (prompt_lookup_min/max,
         # num_speculative_tokens, max_model_len, max_num_seqs) and runs a one-time
         # Numba JIT warmup in its constructor — keep that off the hot path.
         self._ngram = VllmNgramProposer(vllm_config)
         spec = vllm_config.speculative_config
         assert spec is not None
+        # Below this many committed tokens, the kernel structurally cannot
+        # match (not enough history to form even the shortest n-gram window)
+        # -- that's not evidence against repetition, just not enough data
+        # yet, so it must not count as a miss. Normalized to a concrete int
+        # by SpeculativeConfig.__post_init__ for method="ngram".
+        assert spec.prompt_lookup_min is not None
+        self._prompt_lookup_min = spec.prompt_lookup_min
 
         # Pre-allocate the int32 token-id buffer once. Upstream only reads
         # ``token_ids_cpu[i, :num_tokens_no_spec[i]]`` per row, so the buffer
@@ -130,7 +152,8 @@ class NgramProposer:
         if ctx.num_speculative_tokens <= 0:
             return None
 
-        self._prune_finished(ctx.request_states)
+        self._prune_finished(ctx.finished_req_ids)
+        self._resolve_pending(ctx.request_states)
 
         drafting = list(
             self._controller.draft_eligible_requests(
@@ -176,11 +199,17 @@ class NgramProposer:
 
         req_ids: list[str] = []
         draft_token_ids: list[list[int]] = []
-        for (req_id, _), draft in zip(drafting, drafts, strict=True):
+        for (req_id, state), draft in zip(drafting, drafts, strict=True):
             if not draft:
-                self._record_miss(req_id)
+                # A too-short history isn't evidence against repetition --
+                # there just isn't enough of it yet to check.
+                if len(state.token_ids) >= self._prompt_lookup_min:
+                    self._record_miss(req_id)
                 continue
-            self._miss_streak.pop(req_id, None)
+            # Don't score this as a hit yet -- the target hasn't verified it.
+            # _resolve_pending scores it next step against what was actually
+            # accepted.
+            self._pending[req_id] = (len(state.token_ids), tuple(draft))
             req_ids.append(req_id)
             # Upstream already yields Python ints via ndarray.tolist() — the
             # old ``[int(t) for t in draft]`` was redundant.
@@ -204,19 +233,43 @@ class NgramProposer:
         return True
 
     def _record_miss(self, req_id: str) -> None:
-        streak = self._miss_streak.get(req_id, 0) + 1
+        # Cap rather than clear: once a request has earned a cooldown, a
+        # miss on the very next retry should send it right back into
+        # cooldown, not grant another full _MAX_CONSECUTIVE_MISSES-long
+        # grace period. Only a genuine hit (_resolve_pending finding real
+        # acceptance) fully clears the streak.
+        streak = min(self._miss_streak.get(req_id, 0) + 1, _MAX_CONSECUTIVE_MISSES)
+        self._miss_streak[req_id] = streak
         if streak >= _MAX_CONSECUTIVE_MISSES:
             self._cooldown[req_id] = _COOLDOWN_STEPS
-            self._miss_streak.pop(req_id, None)
-        else:
-            self._miss_streak[req_id] = streak
 
-    def _prune_finished(self, request_states: Mapping[str, RequestState]) -> None:
-        if not self._miss_streak and not self._cooldown:
+    def _resolve_pending(self, request_states: Mapping[str, RequestState]) -> None:
+        """Score the previous step's proposals against what was actually
+        accepted, now that this step's ``state.token_ids`` reflects it."""
+        if not self._pending:
             return
-        for req_id in list(self._miss_streak):
-            if req_id not in request_states:
-                del self._miss_streak[req_id]
-        for req_id in list(self._cooldown):
-            if req_id not in request_states:
-                del self._cooldown[req_id]
+        for req_id, (position, proposed) in self._pending.items():
+            state = request_states.get(req_id)
+            if state is None:
+                continue
+            actual = state.token_ids[position : position + len(proposed)]
+            accepted = 0
+            # actual may be shorter than proposed if the engine hasn't
+            # committed that many new tokens yet -- strict=False by design.
+            for proposed_id, actual_id in zip(proposed, actual, strict=False):
+                if proposed_id != actual_id:
+                    break
+                accepted += 1
+            if accepted > 0:
+                self._miss_streak.pop(req_id, None)
+            else:
+                self._record_miss(req_id)
+        self._pending.clear()
+
+    def _prune_finished(self, finished_req_ids: set[str]) -> None:
+        if not finished_req_ids:
+            return
+        for req_id in finished_req_ids:
+            self._miss_streak.pop(req_id, None)
+            self._cooldown.pop(req_id, None)
+            self._pending.pop(req_id, None)

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -14,7 +14,13 @@ the runtime draft count and array arguments that upstream's stateless
 ``num_tokens_no_spec``, ``token_ids_cpu``) and hand the result back as
 :class:`DraftTokenIds`. The committed history lives in
 ``state.token_ids`` (already updated with this step's accepted/sampled tokens by
-the time the runner builds the context), so no per-request bookkeeping is needed.
+the time the runner builds the context).
+
+The one piece of per-request bookkeeping this wrapper does keep: a consecutive-
+miss streak per request, so a request with no exploitable repetition (free-form
+prose, for instance) stops paying the match kernel's per-step scan cost after
+a few misses in a row, with periodic retries in case the content turns
+repetitive later. See ``_record_miss``/``_on_cooldown``.
 
 The verify half is unchanged: drafts are handed back via ``take_draft_token_ids``
 and verified next step by ``SpeculativeDecodeController.verify_greedy``.
@@ -30,10 +36,11 @@ from vllm.v1.outputs import DraftTokenIds
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer as VllmNgramProposer
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from vllm.config import VllmConfig
 
+    from vllm_metal.v1.model_runner import RequestState
     from vllm_metal.v1.proposer import ProposeContext
     from vllm_metal.v1.spec_decode import (
         PagedDecodeSegment,
@@ -41,6 +48,18 @@ if TYPE_CHECKING:
     )
 
 logger = init_logger(__name__)
+
+# The match kernel scans a request's whole committed history every decode
+# step whether or not it finds anything -- an O(history length) Numba scan
+# plus a full-history copy into token_ids_cpu, paid regardless of outcome.
+# A request whose content has no exploitable repetition (free-form prose,
+# for instance) pays that tax every step for nothing. After this many
+# consecutive misses, stop attempting a request for _COOLDOWN_STEPS steps
+# rather than giving up on it forever -- generation can turn repetitive
+# partway through (e.g. a response that starts as prose and then quotes
+# earlier context), so a permanent cutoff would miss that.
+_MAX_CONSECUTIVE_MISSES = 8
+_COOLDOWN_STEPS = 8
 
 
 class NgramProposer:
@@ -53,6 +72,11 @@ class NgramProposer:
         controller: SpeculativeDecodeController,
     ) -> None:
         self._controller = controller
+        # Per-request consecutive-miss count and, once throttled, remaining
+        # cooldown steps before the next retry. Both pruned each step against
+        # the live request set so they never grow past what's active.
+        self._miss_streak: dict[str, int] = {}
+        self._cooldown: dict[str, int] = {}
         # Upstream reads only scalar config (prompt_lookup_min/max,
         # num_speculative_tokens, max_model_len, max_num_seqs) and runs a one-time
         # Numba JIT warmup in its constructor — keep that off the hot path.
@@ -106,6 +130,8 @@ class NgramProposer:
         if ctx.num_speculative_tokens <= 0:
             return None
 
+        self._prune_finished(ctx.request_states)
+
         drafting = list(
             self._controller.draft_eligible_requests(
                 ctx.decode_reqs,
@@ -116,6 +142,14 @@ class NgramProposer:
                 logitsprocs=ctx.logitsprocs,
             )
         )
+        if not drafting:
+            return None
+
+        drafting = [
+            (req_id, state)
+            for req_id, state in drafting
+            if not self._on_cooldown(req_id)
+        ]
         if not drafting:
             return None
 
@@ -144,7 +178,9 @@ class NgramProposer:
         draft_token_ids: list[list[int]] = []
         for (req_id, _), draft in zip(drafting, drafts, strict=True):
             if not draft:
+                self._record_miss(req_id)
                 continue
+            self._miss_streak.pop(req_id, None)
             req_ids.append(req_id)
             # Upstream already yields Python ints via ndarray.tolist() — the
             # old ``[int(t) for t in draft]`` was redundant.
@@ -154,3 +190,33 @@ class NgramProposer:
             return None
 
         return DraftTokenIds(req_ids=req_ids, draft_token_ids=draft_token_ids)
+
+    # -- miss-streak throttling ----------------------------------------------
+
+    def _on_cooldown(self, req_id: str) -> bool:
+        remaining = self._cooldown.get(req_id, 0)
+        if remaining <= 0:
+            return False
+        if remaining == 1:
+            del self._cooldown[req_id]
+        else:
+            self._cooldown[req_id] = remaining - 1
+        return True
+
+    def _record_miss(self, req_id: str) -> None:
+        streak = self._miss_streak.get(req_id, 0) + 1
+        if streak >= _MAX_CONSECUTIVE_MISSES:
+            self._cooldown[req_id] = _COOLDOWN_STEPS
+            self._miss_streak.pop(req_id, None)
+        else:
+            self._miss_streak[req_id] = streak
+
+    def _prune_finished(self, request_states: Mapping[str, RequestState]) -> None:
+        if not self._miss_streak and not self._cooldown:
+            return
+        for req_id in list(self._miss_streak):
+            if req_id not in request_states:
+                del self._miss_streak[req_id]
+        for req_id in list(self._cooldown):
+            if req_id not in request_states:
+                del self._cooldown[req_id]

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -42,11 +42,10 @@ from vllm.v1.outputs import DraftTokenIds
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer as VllmNgramProposer
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Sequence
 
     from vllm.config import VllmConfig
 
-    from vllm_metal.v1.model_runner import RequestState
     from vllm_metal.v1.proposer import ProposeContext
     from vllm_metal.v1.spec_decode import (
         PagedDecodeSegment,
@@ -149,11 +148,16 @@ class NgramProposer:
         return False
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        # Bookkeeping runs unconditionally, before the num_speculative_tokens
+        # check: a step with drafting disabled still needs finished ids
+        # pruned and pending drafts resolved, or a request id reused in a
+        # disabled step would carry stale throttle state into the next step
+        # where drafting is enabled again.
+        self._prune_finished(ctx.finished_req_ids)
+        self._resolve_pending(ctx)
+
         if ctx.num_speculative_tokens <= 0:
             return None
-
-        self._prune_finished(ctx.finished_req_ids)
-        self._resolve_pending(ctx.request_states)
 
         drafting = list(
             self._controller.draft_eligible_requests(
@@ -243,15 +247,22 @@ class NgramProposer:
         if streak >= _MAX_CONSECUTIVE_MISSES:
             self._cooldown[req_id] = _COOLDOWN_STEPS
 
-    def _resolve_pending(self, request_states: Mapping[str, RequestState]) -> None:
+    def _resolve_pending(self, ctx: ProposeContext) -> None:
         """Score the previous step's proposals against what was actually
-        accepted, now that this step's ``state.token_ids`` reflects it."""
+        accepted, but only for requests whose draft is actually verified
+        this step (present in ``decode_reqs``). A request can be alive in
+        ``request_states`` without being scheduled this step at all (still
+        mid-prefill, paused, preempted) -- treating "no new tokens visible
+        yet" as a miss for those would blame the request for a step that
+        never verified it."""
         if not self._pending:
             return
-        for req_id, (position, proposed) in self._pending.items():
-            state = request_states.get(req_id)
+        decode_states = dict(ctx.decode_reqs)
+        for req_id in list(self._pending):
+            state = decode_states.get(req_id)
             if state is None:
-                continue
+                continue  # not verified this step; leave pending for later
+            position, proposed = self._pending.pop(req_id)
             actual = state.token_ids[position : position + len(proposed)]
             accepted = 0
             # actual may be shorter than proposed if the engine hasn't
@@ -264,7 +275,6 @@ class NgramProposer:
                 self._miss_streak.pop(req_id, None)
             else:
                 self._record_miss(req_id)
-        self._pending.clear()
 
     def _prune_finished(self, finished_req_ids: set[str]) -> None:
         if not finished_req_ids:

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -249,19 +249,28 @@ class NgramProposer:
 
     def _resolve_pending(self, ctx: ProposeContext) -> None:
         """Score the previous step's proposals against what was actually
-        accepted, but only for requests whose draft is actually verified
-        this step (present in ``decode_reqs``). A request can be alive in
-        ``request_states`` without being scheduled this step at all (still
-        mid-prefill, paused, preempted) -- treating "no new tokens visible
-        yet" as a miss for those would blame the request for a step that
-        never verified it."""
+        accepted, but only for requests whose draft was actually verified
+        this step: present in ``decode_reqs`` *and* the decode_segment for
+        that request carried a non-empty draft. Being in ``decode_reqs``
+        alone isn't enough -- a request can sit there with an empty
+        ``draft_token_ids`` either because no draft was scheduled for it at
+        all (a plain decode row) or because the scheduler padded/dropped a
+        proposed draft on batch admission (see
+        ``SpeculativeDecodeController.active_spec_decode_tokens``). Either
+        way, this step's plain-decode token isn't the verification outcome
+        of the older pending draft, so it must not be scored against it."""
         if not self._pending:
             return
+        verified_req_ids = {
+            segment.req_id for segment in ctx.decode_segments if segment.draft_token_ids
+        }
         decode_states = dict(ctx.decode_reqs)
         for req_id in list(self._pending):
+            if req_id not in verified_req_ids:
+                continue  # not verified this step; leave pending for later
             state = decode_states.get(req_id)
             if state is None:
-                continue  # not verified this step; leave pending for later
+                continue
             position, proposed = self._pending.pop(req_id)
             actual = state.token_ids[position : position + len(proposed)]
             accepted = 0

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -54,6 +54,12 @@ class ProposeContext:
     num_decode_segments: int
     num_speculative_tokens: int
     logitsprocs: LogitsProcessors | None
+    # Request ids the scheduler finished this step. vLLM can hand a finished
+    # id straight back out to a new request in the same step, so a proposer
+    # that keeps its own per-request state must clear against this, not
+    # against absence from request_states (which the new request repopulates
+    # under the same id).
+    finished_req_ids: set[str]
 
 
 class MetalProposer(Protocol):


### PR DESCRIPTION
The match kernel scans a request's whole committed history every decode step whether or not it finds anything, plus a full history copy into the scratch buffer, paid regardless of outcome. A request with nothing exploitable in it, plain prose mostly, pays that cost every step for its whole lifetime with nothing to show for it. That's why n-gram spec decode looked like a dead end when it was first tried here on a prose workload and came back at basically zero gain.

Turns out the technique wasn't the problem, the workload was. On a task that actually reproduces spans from its own context, editing a file or annotating code, it's a real 1.45-1.51x on decode throughput, byte-identical output verified across multiple runs on an 8B target. The difference between doing nothing and 1.5x is just whether the generation echoes back what it already saw.

Rather than expecting a user to know which bucket their traffic falls into before flipping method=ngram, this gives the proposer a memory: after enough consecutive misses for a request, stop scanning it for a while, and retry periodically in case the content turns repetitive partway through, a response that starts as prose and later quotes earlier context, say. A hit resets the count immediately. That's what makes it safe to leave n-gram spec decode on for mixed traffic instead of a per-workload opt-in: the requests that don't benefit stop paying for it on their own, without touching the ones that do.

Everything lives inside the existing NgramProposer wrapper. Nothing upstream or in the verify path changes, and the throttle can only ever skip a proposal, never invent or drop an accepted token, so correctness is untouched by construction. Checked with a token-hash comparison across throttled and unthrottled runs on the repetitive workload, output matches exactly. Tests cover the miss-then-throttle transition, a hit resetting the streak mid-run, cooldown expiry letting a request retry, and bookkeeping getting cleared when a request finishes.

The headline numbers it highlights: 1.45-1.51x decode throughput on repetition-heavy generation, byte-identical correctness, and the structural point, it converts n-gram spec-decode from a niche opt-in into something safe to leave on for all traffic.