### PR TITLE
[Spec Decode] Native MTP speculative decoding for GLM-4.7-Flash

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -1,23 +1,25 @@
 # Speculative Decoding
 
-vllm-metal supports three speculative decoding methods on the paged attention
-path. All require synchronous scheduling and greedy sampling.
+vllm-metal supports the following speculative decoding methods on the paged
+attention path. All require synchronous scheduling and greedy sampling.
 
-| | MTP | Draft Model | N-gram |
-|---|---|---|---|
-| `--speculative-config` method | `mtp` | `draft_model` | `ngram` |
-| Target models | Gemma4 (paged) | Any paged-attention model | Any paged-attention model |
-| Draft source | MTP assistant checkpoint (reads target KV cache) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
-| `num_speculative_tokens` | 1 | Configurable (3–5 typical) | Configurable (3–5 typical) |
-| Extra memory | None (reads target KV cache) | Second un-budgeted KV cache | None |
+| | Gemma4 MTP | Native MTP (GLM) | Draft Model | N-gram |
+|---|---|---|---|---|
+| `--speculative-config` method | `mtp` | `mtp` | `draft_model` | `ngram` |
+| Target models | Gemma4 (paged) | GLM-4.7-Flash (paged) | Any paged-attention model | Any paged-attention model |
+| Draft source | MTP assistant checkpoint (reads target KV cache) | Hosted nextn head (own 1-layer KV slab) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
+| `num_speculative_tokens` | 1 | 1 | Configurable (3–5 typical) | Configurable (3–5 typical) |
+| Extra memory | None (reads target KV cache) | ~1.2 KB/token/request (compressed MLA latent) | Second un-budgeted KV cache | None |
+| Prefix caching | Tolerated | Must be off (`--no-enable-prefix-caching`) | Tolerated | Tolerated |
 
-All three methods:
+All methods:
 
 - Require `--no-async-scheduling` (vLLM auto-disables async for most spec-decode
   methods; pass it explicitly to be safe).
 - Only accelerate greedy requests (`temperature=0`). Non-greedy requests skip
   drafting silently.
-- Are lossless under greedy decoding.
+- Are lossless under greedy decoding, up to the target's own kernel numerics —
+  see the tie-flip note in the GLM section for MLA targets.
 
 ---
 
@@ -100,6 +102,115 @@ The JSON records the model paths, runtime package versions, relevant
 environment variables, prompts, generated token IDs, elapsed time, and output
 tokens per second. Attach those JSON files to performance PRs instead of copying
 machine-specific results into the docs.
+
+---
+
+## GLM-4.7-Flash MTP (native head)
+
+GLM-4.7-Flash ships one trained nextn (MTP) layer inside the target checkpoint
+(`num_nextn_predict_layers: 1`). vllm-metal runs it as a native drafter: each
+step, the head projects the target's post-final-norm hidden states plus the
+committed tokens through one decoder layer and proposes exactly one draft token.
+The head keeps its own per-request KV history (the layer's compressed MLA
+latent, ~1.2 KB per token per request) — it never touches the target's paged
+KV, needs no second block allocator, and never re-ingests the prompt.
+
+### Get the head
+
+The `mlx-community` 4-bit target mirror strips the nextn layer. The head ships
+separately as a hosted, revision-pinned MLX checkpoint — use it directly, no
+local extraction step:
+
+- [`samithaj/GLM-4.7-Flash-MTP-4bit`](https://huggingface.co/samithaj/GLM-4.7-Flash-MTP-4bit)
+  (default)
+- [`samithaj/GLM-4.7-Flash-MTP-bf16`](https://huggingface.co/samithaj/GLM-4.7-Flash-MTP-bf16)
+  (unquantized)
+
+The 4-bit head is strongly recommended: the head's cost is dominated by its
+untied lm_head, and a bf16 head spends a large fraction of a target decode step
+on it.
+
+To build a head from a different source revision or your own quantization, split
+one with the mlx-vlm drafter tool
+([Blaizzy/mlx-vlm#1570](https://github.com/Blaizzy/mlx-vlm/pull/1570)), which
+emits the exact checkpoint this loader consumes:
+
+```bash
+python -m mlx_vlm.speculative.drafters.glm4_moe_lite_mtp.split \
+  --model zai-org/GLM-4.7-Flash \
+  --revision 7dd20894a642a0aa287e9827cb1a1f7f91386b67 \
+  --output GLM-4.7-Flash-MTP-4bit \
+  --q-bits 4 --q-group-size 64
+```
+
+### Serve
+
+Point `--speculative-config` `model` at the hosted head:
+
+```bash
+vllm serve mlx-community/GLM-4.7-Flash-4bit \
+  --max-model-len 4096 \
+  --no-async-scheduling \
+  --no-enable-prefix-caching \
+  --speculative-config '{"method":"mtp","model":"samithaj/GLM-4.7-Flash-MTP-4bit","num_speculative_tokens":1}'
+```
+
+Pin `revision` in the JSON when publishing benchmark numbers. Confirm it is
+active: the server log shows
+`Native MTP proposer ready: head=glm4_moe_lite_mtp (...)` at startup and
+periodic `SpecDecoding metrics ... Avg Draft acceptance rate`.
+
+### Benchmark
+
+Use the offline benchmark (thin sibling of the Gemma4 one; it forces prefix
+caching off and records acceptance counters in the JSON). One mode per process:
+omit `--assistant-model` for the baseline, add it for MTP. `--chat` renders
+prompts through the chat template, which is strongly recommended for
+representative acceptance rates.
+
+```bash
+python -m tools.benchmark.native_mtp_benchmark \
+  --model mlx-community/GLM-4.7-Flash-4bit \
+  --batch-size 1 --max-tokens 128 --repeats 3 --warmup 1 \
+  --ignore-eos --chat --max-model-len 1024 \
+  --label baseline-bs1 --output-json /tmp/glm-mtp-baseline-bs1.json
+
+python -m tools.benchmark.native_mtp_benchmark \
+  --model mlx-community/GLM-4.7-Flash-4bit \
+  --assistant-model samithaj/GLM-4.7-Flash-MTP-4bit \
+  --batch-size 1 --max-tokens 128 --repeats 3 --warmup 1 \
+  --ignore-eos --chat --max-model-len 1024 \
+  --label mtp-bs1 --output-json /tmp/glm-mtp-bs1.json
+```
+
+Attach the JSON files to performance PRs instead of copying machine-specific
+results into the docs.
+
+### Constraints
+
+- **Greedy only, K=1.** The head is trained for one extra token
+  (`num_speculative_tokens` above 1 is rejected at startup), and only
+  `temperature=0` requests draft.
+- **Prefix caching must be off** (`--no-enable-prefix-caching`). Cached prompt
+  tokens skip the target forward that produces the hidden states the head
+  consumes, so their draft-side state could never be built. The server rejects
+  the config at startup otherwise. (Gemma4 MTP tolerates prefix caching because
+  its assistant reads the target's paged KV instead of hidden states.)
+- **MTP head required.** Pointing `model` at the raw `zai-org` target repo (or
+  the stripped `mlx-community` mirror) fails at startup: the loader keys on the
+  head's top-level `model_type` (`glm4_moe_lite_mtp`), and its message names the
+  hosted heads and the mlx-vlm split tool.
+- **No pipeline parallelism.** The head consumes the target's final hidden
+  states, which a non-last pipeline stage never produces; `pipeline_parallel_size
+  > 1` is rejected when the drafter is built, not mid-run.
+- **MLA tie-flip note.** On this target, greedy token-identity between SD and
+  non-SD runs (and even between two non-SD runs with different batch sizes) is
+  not bit-exact: the 4-bit MoE + MLA kernels are not batch-shape-invariant, so
+  positions where the target's top-2 logits are close can flip either way.
+  Parity is therefore judged tie-aware: at every divergence, the base model's
+  fp32 top-2 logit gap must be within the same range that no-SD batching
+  perturbations flip — divergences at gaps beyond that range indicate a real
+  verify bug. The PR for this feature carries the calibration data.
 
 ---
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -7,6 +7,7 @@ import builtins
 import importlib.util
 import json
 import os
+import pickle
 import sys
 from types import ModuleType
 
@@ -90,6 +91,65 @@ def _write_gemma4_assistant_config(path) -> None:
         },
         "tie_word_embeddings": True,
         "use_ordered_embeddings": True,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm4_moe_lite_mtp_config(path) -> None:
+    # The literal hosted-checkpoint schema emitted by the mlx-vlm drafter split:
+    # a top-level glm4_moe_lite_mtp with NO top-level architectures, the source
+    # model config nested under text_config (which carries architectures, the
+    # shape fields, and num_nextn_predict_layers).
+    config = {
+        "block_size": 2,
+        "model_type": "glm4_moe_lite_mtp",
+        "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "quantization_config": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "text_config": {
+            "architectures": ["Glm4MoeLiteForCausalLM"],
+            "model_type": "glm4_moe_lite",
+            "hidden_size": 2048,
+            "vocab_size": 154880,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64,
+            "qk_nope_head_dim": 192,
+            "v_head_dim": 256,
+            "num_attention_heads": 20,
+            "num_key_value_heads": 20,
+            "n_routed_experts": 64,
+            "n_shared_experts": 1,
+            "moe_intermediate_size": 1536,
+            "intermediate_size": 10240,
+            "first_k_dense_replace": 1,
+            "num_hidden_layers": 47,
+            "num_nextn_predict_layers": 1,
+            "rope_theta": 1000000.0,
+            "rms_norm_eps": 1e-5,
+            "tie_word_embeddings": False,
+        },
+        "tie_word_embeddings": False,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm4_moe_lite_target_config(path) -> None:
+    # A minimal raw glm4_moe_lite target config (the checkpoint the head drafts
+    # for), enough for a download-free target ModelConfig.
+    config = {
+        "architectures": ["Glm4MoeLiteForCausalLM"],
+        "model_type": "glm4_moe_lite",
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "num_key_value_heads": 20,
+        "num_hidden_layers": 47,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+        "max_position_embeddings": 4096,
     }
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
@@ -282,10 +342,170 @@ class TestGemma4MTPConfigCompatPatch:
             "_patch_mlx_lm_gemma4_kv_shared_sanitize",
             lambda: calls.append("gemma4_kv"),
         )
+        # Stub the GLM MTP config patch too, so this unrelated test does not run
+        # the real one (which would register glm4_moe_lite_mtp with AutoConfig).
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_glm4_moe_lite_mtp_config_loading",
+            lambda: calls.append("glm4_mtp"),
+        )
 
         compat.apply_compat_patches()
 
-        assert calls == ["bytelevel", "qwen35_fp8", "gemma4_kv"]
+        assert calls == ["glm4_mtp", "bytelevel", "qwen35_fp8", "gemma4_kv"]
+
+
+class TestGlm4MoeLiteMTPConfigCompatPatch:
+    def test_transformers_autoconfig_loads_raw_glm4_moe_lite_mtp_config(
+        self,
+        tmp_path,
+    ) -> None:
+        from transformers import AutoConfig
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        assert config.model_type == "glm4_moe_lite_mtp"
+        # architectures and the nextn depth are promoted out of the nested
+        # text_config so vLLM's top-level-keyed MTP override can run.
+        assert config.architectures == ["Glm4MoeLiteForCausalLM"]
+        assert config.num_nextn_predict_layers == 1
+        assert config.get_text_config().model_type == "glm4_moe_lite"
+        assert config.get_text_config().num_hidden_layers == 47
+        assert config.get_text_config().hidden_size == 2048
+
+    def test_compat_config_survives_pickle_round_trip(self, tmp_path) -> None:
+        # vLLM's spawn-based EngineCore pickles the draft config into the worker
+        # process, so the promoted head config must round-trip through pickle
+        # (a closure-scoped config class cannot, and fails only in the real
+        # engine, not in-process config tests).
+        from transformers import AutoConfig
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        restored = pickle.loads(pickle.dumps(config))
+
+        assert restored.model_type == "glm4_moe_lite_mtp"
+        assert restored.architectures == ["Glm4MoeLiteForCausalLM"]
+        assert restored.num_nextn_predict_layers == 1
+        assert restored.get_text_config().model_type == "glm4_moe_lite"
+        assert restored.get_text_config().num_hidden_layers == 47
+
+    def test_vllm_get_config_applies_existing_glm4_moe_lite_mtp_override(
+        self,
+        tmp_path,
+    ) -> None:
+        from vllm.config.speculative import SpeculativeConfig
+        from vllm.transformers_utils.config import get_config
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        config = get_config(
+            tmp_path,
+            trust_remote_code=False,
+            hf_overrides_fn=SpeculativeConfig.hf_config_override,
+        )
+
+        # vLLM's override normalizes the promoted top-level config into the MTP
+        # wrapper form (this is the front door that crashed on the raw hosted
+        # config before the shim promoted architectures + nextn depth).
+        assert config.model_type == "glm4_moe_lite_mtp"
+        assert config.architectures == ["Glm4MoeLiteMTPModel"]
+        assert config.num_hidden_layers == 0
+        assert config.n_predict == 1
+
+    def test_speculative_config_builds_from_hosted_head(self, tmp_path) -> None:
+        from vllm.config import ModelConfig, ParallelConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        _write_glm4_moe_lite_target_config(target_dir)
+        draft_dir = tmp_path / "draft"
+        draft_dir.mkdir()
+        _write_glm4_moe_lite_mtp_config(draft_dir)
+
+        target = ModelConfig(
+            model=str(target_dir),
+            tokenizer=str(target_dir),
+            trust_remote_code=False,
+            dtype="bfloat16",
+            seed=0,
+            skip_tokenizer_init=True,
+        )
+        spec = SpeculativeConfig(
+            target_model_config=target,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            model=str(draft_dir),
+            num_speculative_tokens=1,
+        )
+
+        assert spec.method == "mtp"
+        assert spec.num_speculative_tokens == 1
+        draft_hf = spec.draft_model_config.hf_config
+        assert draft_hf.model_type == "glm4_moe_lite_mtp"
+        assert draft_hf.architectures == ["Glm4MoeLiteMTPModel"]
+        assert draft_hf.n_predict == 1
+
+    def test_missing_glm4_config_module_does_not_stop_other_patches(
+        self,
+        monkeypatch,
+    ) -> None:
+        calls: list[str] = []
+
+        monkeypatch.setattr(compat, "_APPLIED", False)
+        monkeypatch.setattr(
+            compat,
+            "_transformers_knows_glm4_moe_lite_mtp",
+            lambda _auto_config: False,
+        )
+
+        def _raise_missing_glm4_config():
+            raise ModuleNotFoundError(
+                "No module named 'transformers.models.glm4_moe_lite'"
+            )
+
+        monkeypatch.setattr(
+            compat,
+            "_glm4_moe_lite_mtp_config_class",
+            _raise_missing_glm4_config,
+        )
+        # Stub the surrounding patches so only the caught behavior of the GLM
+        # config patch is exercised.
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_gemma4_mtp_config_loading",
+            lambda: calls.append("gemma4_mtp"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_bytelevel_tokenizer_loading",
+            lambda: calls.append("bytelevel"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_qwen35_fp8_sanitize",
+            lambda: calls.append("qwen35_fp8"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_gemma4_kv_shared_sanitize",
+            lambda: calls.append("gemma4_kv"),
+        )
+
+        # The GLM patch swallows the missing-module import error and returns, so
+        # every other patch still runs.
+        compat.apply_compat_patches()
+
+        assert calls == ["gemma4_mtp", "bytelevel", "qwen35_fp8", "gemma4_kv"]
 
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):

--- a/tests/test_glm4_moe_lite_mtp_e2e.py
+++ b/tests/test_glm4_moe_lite_mtp_e2e.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Engine-level tests for the GLM native MTP drafter on a tiny generated checkpoint.
+
+Builds a randomly initialised ``glm4_moe_lite`` target and a matching MTP head on
+disk (~1 MB, no checkpoint download) from the real model classes, then drives a
+real ``LLM`` through the normal front door so the drafter runs the served path.
+
+Run with: ``pytest -m slow tests/test_glm4_moe_lite_mtp_e2e.py``
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+# Shapes are the smallest that keep every structural feature the head depends on:
+# an MoE layer past first_k_dense_replace, absorbed MLA with a rope split, and a
+# trained nextn depth of one.
+_TARGET_CONFIG: dict[str, Any] = {
+    "architectures": ["Glm4MoeLiteForCausalLM"],
+    "model_type": "glm4_moe_lite",
+    "attention_bias": False,
+    "attention_dropout": 0.0,
+    "dtype": "bfloat16",
+    "first_k_dense_replace": 1,
+    "hidden_act": "silu",
+    "norm_topk_prob": True,
+    "num_nextn_predict_layers": 1,
+    "partial_rotary_factor": 1.0,
+    "rms_norm_eps": 1e-05,
+    "rope_scaling": None,
+    "rope_theta": 1000000,
+    "routed_scaling_factor": 1.8,
+    "tie_word_embeddings": False,
+    "topk_method": "noaux_tc",
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "moe_intermediate_size": 32,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "n_routed_experts": 8,
+    "num_experts_per_tok": 2,
+    "n_shared_experts": 1,
+    "n_group": 1,
+    "topk_group": 1,
+    "kv_lora_rank": 32,
+    "q_lora_rank": 32,
+    "qk_nope_head_dim": 16,
+    "qk_rope_head_dim": 16,
+    "v_head_dim": 16,
+    "vocab_size": 512,
+    "max_position_embeddings": 1024,
+    "eos_token_id": 2,
+    "pad_token_id": 3,
+}
+
+_PROMPTS = [
+    "<t5> <t6> <t7> <t8>",
+    "<t100> <t101> <t102>",
+    "<t200> <t201> <t202> <t203> <t204>",
+    "<t300> <t301>",
+]
+# Eight concurrent streams over a 32-block budget cannot be resident at once, so
+# the scheduler must preempt and resume mid-generation.
+_PRESSURE_PROMPTS = [f"<t{i}> <t{i + 1}> <t{i + 2}>" for i in range(0, 128, 16)]
+_PRESSURE_BLOCKS = 32
+
+
+@dataclass(frozen=True)
+class _Checkpoints:
+    """Filesystem paths of the generated target/head pairs."""
+
+    target: Path
+    head: Path
+    accept_all_target: Path
+    accept_all_head: Path
+
+
+@dataclass(frozen=True)
+class _RunResult:
+    """Generated token ids plus the engine counters for one engine run."""
+
+    tokens: list[list[int]]
+    counters: dict[str, Any]
+
+    @property
+    def drafted(self) -> int:
+        return self.counters.get("spec_decode_num_draft_tokens") or 0
+
+    @property
+    def accepted(self) -> int:
+        return self.counters.get("spec_decode_num_accepted_tokens") or 0
+
+    @property
+    def preemptions(self) -> int:
+        return self.counters.get("num_preemptions") or 0
+
+
+def _write_tokenizer(directory: Path) -> None:
+    from tokenizers import Tokenizer, models, pre_tokenizers
+
+    specials = ["<unk>", "<bos>", "<eos>", "<pad>"]
+    vocab = {token: index for index, token in enumerate(specials)}
+    for index in range(_TARGET_CONFIG["vocab_size"] - len(specials)):
+        vocab[f"<t{index}>"] = len(vocab)
+    tokenizer = Tokenizer(models.WordLevel(vocab, unk_token="<unk>"))
+    tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer.save(str(directory / "tokenizer.json"))
+    (directory / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "PreTrainedTokenizerFast",
+                "unk_token": "<unk>",
+                "bos_token": "<bos>",
+                "eos_token": "<eos>",
+                "pad_token": "<pad>",
+                "model_max_length": _TARGET_CONFIG["max_position_embeddings"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _save_random_weights(model: Any, directory: Path) -> None:
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+
+    weights = {
+        name: value.astype(mx.bfloat16)
+        for name, value in dict(tree_flatten(model.parameters())).items()
+    }
+    mx.save_safetensors(str(directory / "model.safetensors"), weights)
+
+
+def _build_target(directory: Path) -> None:
+    from mlx_lm.utils import _get_classes
+
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "config.json").write_text(json.dumps(_TARGET_CONFIG), encoding="utf-8")
+    _write_tokenizer(directory)
+    model_class, args_class = _get_classes(_TARGET_CONFIG)
+    _save_random_weights(model_class(args_class.from_dict(_TARGET_CONFIG)), directory)
+
+
+def _build_head(directory: Path, target: Path) -> None:
+    """Write the head in the hosted drafter-split schema (shape under text_config)."""
+    from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import (
+        Glm4MoeLiteMTPArgs,
+        Glm4MoeLiteMTPModel,
+    )
+
+    directory.mkdir(parents=True, exist_ok=True)
+    config = {
+        "model_type": "glm4_moe_lite_mtp",
+        "block_size": 2,
+        "tie_word_embeddings": False,
+        "text_config": _TARGET_CONFIG,
+    }
+    (directory / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    for name in ("tokenizer.json", "tokenizer_config.json"):
+        shutil.copy(target / name, directory / name)
+    _save_random_weights(
+        Glm4MoeLiteMTPModel(Glm4MoeLiteMTPArgs.from_dict(config)), directory
+    )
+
+
+def _copy_with_zeroed_lm_head(source: Path, destination: Path) -> None:
+    """Copy a checkpoint with a zeroed ``lm_head`` so greedy decoding always emits token 0.
+
+    Target and head then agree on every position, which pins acceptance at 1.0 and
+    makes the accept/bonus-token path deterministic instead of weight-dependent.
+    """
+    import mlx.core as mx
+
+    shutil.copytree(source, destination)
+    weights = mx.load(str(destination / "model.safetensors"))
+    weights["lm_head.weight"] = mx.zeros_like(weights["lm_head.weight"])
+    mx.save_safetensors(str(destination / "model.safetensors"), weights)
+
+
+@pytest.fixture(scope="session")
+def checkpoints(tmp_path_factory: pytest.TempPathFactory) -> _Checkpoints:
+    root = tmp_path_factory.mktemp("tiny_glm4_moe_lite")
+    target, head = root / "target", root / "head"
+    _build_target(target)
+    _build_head(head, target)
+    accept_all_target, accept_all_head = (
+        root / "target_accept_all",
+        root / "head_accept_all",
+    )
+    _copy_with_zeroed_lm_head(target, accept_all_target)
+    _copy_with_zeroed_lm_head(head, accept_all_head)
+    return _Checkpoints(target, head, accept_all_target, accept_all_head)
+
+
+def _generate(
+    target: Path,
+    head: Path | None,
+    prompts: list[str],
+    *,
+    max_tokens: int,
+    num_blocks: int | None = None,
+) -> _RunResult:
+    """Boot one engine, generate greedily, and return its tokens and counters."""
+    from vllm import LLM, SamplingParams
+
+    kwargs: dict[str, Any] = {
+        "model": str(target),
+        "max_model_len": 256,
+        "gpu_memory_utilization": 0.20,
+        "enable_prefix_caching": False,
+        "async_scheduling": False,
+        "disable_log_stats": False,
+        "enforce_eager": True,
+    }
+    if head is not None:
+        kwargs["speculative_config"] = {
+            "method": "mtp",
+            "model": str(head),
+            "num_speculative_tokens": 1,
+        }
+    if num_blocks is not None:
+        kwargs["num_gpu_blocks_override"] = num_blocks
+
+    llm = LLM(**kwargs)
+    try:
+        outputs = llm.generate(
+            prompts,
+            SamplingParams(temperature=0.0, max_tokens=max_tokens, ignore_eos=True),
+        )
+        tokens = [list(output.outputs[0].token_ids) for output in outputs]
+        counters: dict[str, Any] = {}
+        for metric in llm.get_metrics():
+            value = getattr(metric, "value", None)
+            if value is None:
+                value = getattr(metric, "values", None)
+            counters[metric.name.split(":")[-1]] = value
+        return _RunResult(tokens=tokens, counters=counters)
+    finally:
+        del llm
+        gc.collect()
+
+
+@pytest.fixture(scope="session")
+def baseline(checkpoints: _Checkpoints) -> _RunResult:
+    return _generate(checkpoints.target, None, _PROMPTS, max_tokens=32)
+
+
+@pytest.fixture(scope="session")
+def speculative(checkpoints: _Checkpoints) -> _RunResult:
+    return _generate(checkpoints.target, checkpoints.head, _PROMPTS, max_tokens=32)
+
+
+@pytest.fixture(scope="session")
+def pressure_baseline(checkpoints: _Checkpoints) -> _RunResult:
+    return _generate(checkpoints.target, None, _PRESSURE_PROMPTS, max_tokens=160)
+
+
+@pytest.fixture(scope="session")
+def pressure_speculative(checkpoints: _Checkpoints) -> _RunResult:
+    return _generate(
+        checkpoints.target,
+        checkpoints.head,
+        _PRESSURE_PROMPTS,
+        max_tokens=160,
+        num_blocks=_PRESSURE_BLOCKS,
+    )
+
+
+@pytest.fixture(scope="session")
+def accept_all(checkpoints: _Checkpoints) -> _RunResult:
+    return _generate(
+        checkpoints.accept_all_target,
+        checkpoints.accept_all_head,
+        _PROMPTS,
+        max_tokens=32,
+    )
+
+
+@pytest.fixture(scope="session")
+def accept_all_under_pressure(checkpoints: _Checkpoints) -> _RunResult:
+    return _generate(
+        checkpoints.accept_all_target,
+        checkpoints.accept_all_head,
+        _PRESSURE_PROMPTS,
+        max_tokens=160,
+        num_blocks=_PRESSURE_BLOCKS,
+    )
+
+
+def test_speculative_decoding_drafts_and_stays_lossless(
+    baseline: _RunResult, speculative: _RunResult
+) -> None:
+    assert speculative.drafted > 0
+    assert speculative.tokens == baseline.tokens
+
+
+def test_accepted_drafts_are_lossless_and_counted(accept_all: _RunResult) -> None:
+    assert accept_all.accepted == accept_all.drafted > 0
+    assert all(set(row) == {0} for row in accept_all.tokens)
+
+
+def test_preemption_keeps_generation_lossless(
+    pressure_baseline: _RunResult, pressure_speculative: _RunResult
+) -> None:
+    assert pressure_speculative.preemptions > 0
+    assert pressure_speculative.drafted > 0
+    assert pressure_speculative.tokens == pressure_baseline.tokens
+
+
+def test_preemption_releases_head_state(
+    monkeypatch: pytest.MonkeyPatch, checkpoints: _Checkpoints
+) -> None:
+    """A preempted request hands its slab back instead of holding it while it waits.
+
+    Output equality cannot show this: rejected drafts leave generation unchanged
+    either way, so the run is observed through the release seam itself.
+    """
+    monkeypatch.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    from vllm_metal.v1.mtp_proposer import NativeMTPProposer
+
+    released: list[set[str]] = []
+    release_requests = NativeMTPProposer.release_requests
+
+    def record(self: NativeMTPProposer, req_ids: set[str]) -> None:
+        released.append(set(req_ids))
+        return release_requests(self, req_ids)
+
+    monkeypatch.setattr(NativeMTPProposer, "release_requests", record)
+    result = _generate(
+        checkpoints.target,
+        checkpoints.head,
+        _PRESSURE_PROMPTS,
+        max_tokens=160,
+        num_blocks=_PRESSURE_BLOCKS,
+    )
+
+    assert result.preemptions > 0
+    assert any(released)
+
+
+def test_accepted_drafts_survive_preemption(
+    accept_all_under_pressure: _RunResult,
+) -> None:
+    assert accept_all_under_pressure.preemptions > 0
+    assert accept_all_under_pressure.accepted == accept_all_under_pressure.drafted > 0
+    assert all(len(row) == 160 for row in accept_all_under_pressure.tokens)

--- a/tests/test_glm4_moe_lite_mtp_head.py
+++ b/tests/test_glm4_moe_lite_mtp_head.py
@@ -1,0 +1,638 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for GLM-4.7-Flash native MTP head loading and validation contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import (
+    GLM4_MOE_LITE_MTP_MODEL_TYPE,
+    GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+    Glm4MoeLiteMTPArgs,
+    Glm4MoeLiteMTPHeadLoader,
+    Glm4MoeLiteMTPHeadMetadata,
+    Glm4MoeLiteMTPModel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_head_cache():
+    Glm4MoeLiteMTPHeadLoader.clear_cache()
+    yield
+    Glm4MoeLiteMTPHeadLoader.clear_cache()
+
+
+# Identity lives at the top level; the source model config is nested under
+# ``text_config`` (the hosted drafter-split schema). Overrides route to the top
+# level for these keys, else into ``text_config``.
+_TOP_LEVEL_KEYS = frozenset(
+    {"model_type", "block_size", "tie_word_embeddings", "model_file"}
+)
+
+
+def _head_config(**overrides: object) -> dict[str, object]:
+    """A hosted GLM-4.7-Flash MTP head config (drafter-split ``text_config`` schema)."""
+    text: dict[str, object] = {
+        "architectures": ["Glm4MoeLiteForCausalLM"],
+        "model_type": GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+        "num_hidden_layers": 47,
+        "num_nextn_predict_layers": 1,
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+    }
+    config: dict[str, object] = {
+        "model_type": GLM4_MOE_LITE_MTP_MODEL_TYPE,
+        "block_size": 2,
+        "tie_word_embeddings": False,
+    }
+    for key, value in overrides.items():
+        target = config if key in _TOP_LEVEL_KEYS else text
+        target[key] = value
+    config["text_config"] = text
+    return config
+
+
+def _target_config(**overrides: object) -> dict[str, object]:
+    config: dict[str, object] = {
+        "model_type": "glm4_moe_lite",
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+    }
+    config.update(overrides)
+    return config
+
+
+def _speculative_config(
+    *,
+    model_type: str = GLM4_MOE_LITE_MTP_MODEL_TYPE,
+    model: str = "/head",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        method="mtp",
+        draft_model_config=SimpleNamespace(
+            model=model,
+            revision=None,
+            hf_config=SimpleNamespace(model_type=model_type),
+        ),
+    )
+
+
+def _fake_head_model(*, missing: tuple[str, ...] = ()) -> object:
+    params: dict[str, object] = {
+        "lm_head": {"weight": mx.zeros((1,))},
+        "model": {"embed_tokens": {"weight": mx.zeros((1,))}},
+    }
+    if "lm_head.weight" in missing:
+        params["lm_head"] = {}
+    if "model.embed_tokens.weight" in missing:
+        params["model"] = {}
+
+    class _FakeModel:
+        def parameters(self) -> dict[str, object]:
+            return params
+
+    return _FakeModel()
+
+
+# --------------------------------------------------------------------------
+# Metadata parsing
+# --------------------------------------------------------------------------
+
+
+def test_from_config_parses_valid_head() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    assert metadata.model_type == GLM4_MOE_LITE_MTP_MODEL_TYPE
+    assert metadata.architectures == ("Glm4MoeLiteForCausalLM",)
+    assert metadata.hidden_size == 2048
+    assert metadata.vocab_size == 154880
+    assert metadata.kv_lora_rank == 512
+    assert metadata.num_nextn_predict_layers == 1
+
+
+def test_from_config_rejects_missing_text_config() -> None:
+    config = _head_config()
+    del config["text_config"]
+
+    with pytest.raises(ValueError, match="text_config"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(config)
+
+
+def test_from_config_rejects_missing_num_nextn() -> None:
+    config = _head_config()
+    del config["text_config"]["num_nextn_predict_layers"]
+
+    with pytest.raises(ValueError, match="num_nextn_predict_layers"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(config)
+
+
+def test_from_config_rejects_missing_block_size() -> None:
+    config = _head_config()
+    del config["block_size"]
+
+    with pytest.raises(ValueError, match="block_size"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(config)
+
+
+def test_from_config_rejects_wrong_model_type() -> None:
+    with pytest.raises(ValueError, match="got 'glm4_moe_lite'"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(model_type="glm4_moe_lite"))
+
+
+def test_from_config_rejects_bad_num_nextn() -> None:
+    with pytest.raises(ValueError, match="num_nextn_predict_layers=1"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(num_nextn_predict_layers=2))
+
+
+def test_from_config_rejects_inconsistent_block_size() -> None:
+    # block_size must equal num_nextn_predict_layers + 1 (the drafter-split
+    # schema's MTP-depth field); an inconsistent value fails loud.
+    with pytest.raises(ValueError, match="block_size must be"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(block_size=3))
+
+
+def test_from_config_rejects_non_integer_field() -> None:
+    with pytest.raises(ValueError, match="hidden_size must be positive"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(hidden_size=0))
+
+
+# --------------------------------------------------------------------------
+# Target compatibility
+# --------------------------------------------------------------------------
+
+
+def test_validate_compatible_accepts_match() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    metadata.validate_compatible_with(_target_config())
+
+
+def test_validate_compatible_reads_nested_text_config() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    metadata.validate_compatible_with({"text_config": _target_config()})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hidden_size", 4096),
+        ("vocab_size", 32000),
+        ("kv_lora_rank", 256),
+        ("qk_rope_head_dim", 32),
+        ("qk_nope_head_dim", 128),
+        ("v_head_dim", 128),
+        ("num_attention_heads", 32),
+        ("rope_theta", 500000.0),
+        ("rms_norm_eps", 1e-6),
+    ],
+)
+def test_validate_compatible_rejects_each_field_mismatch(
+    field: str,
+    value: object,
+) -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    with pytest.raises(ValueError, match=f"head {field} must match target {field}"):
+        metadata.validate_compatible_with(_target_config(**{field: value}))
+
+
+def test_validate_compatible_reports_both_values() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    with pytest.raises(ValueError, match="head=2048, target=4096"):
+        metadata.validate_compatible_with(_target_config(hidden_size=4096))
+
+
+def test_validate_compatible_rejects_missing_target_field() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+    target = _target_config()
+    del target["kv_lora_rank"]
+
+    with pytest.raises(ValueError, match="missing 'kv_lora_rank'"):
+        metadata.validate_compatible_with(target)
+
+
+def test_validate_compatible_rejects_wrong_target_model_type() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    with pytest.raises(
+        ValueError, match="requires a 'glm4_moe_lite' target model"
+    ) as excinfo:
+        metadata.validate_compatible_with(_target_config(model_type="llama"))
+    assert "model_type='llama'" in str(excinfo.value)
+
+
+def test_validate_compatible_rejects_missing_target_model_type() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+    target = _target_config()
+    del target["model_type"]
+
+    with pytest.raises(ValueError, match="model_type=None"):
+        metadata.validate_compatible_with(target)
+
+
+def test_validate_compatible_reads_target_model_type_in_text_config() -> None:
+    # model_type lives only inside the nested text_config; the head still
+    # accepts it (mirrors how vLLM nests the backbone config).
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    metadata.validate_compatible_with({"text_config": _target_config()})
+
+
+# --------------------------------------------------------------------------
+# Loader
+# --------------------------------------------------------------------------
+
+
+def test_get_model_classes_returns_head_classes() -> None:
+    model_cls, args_cls = Glm4MoeLiteMTPHeadLoader._get_model_classes(_head_config())
+
+    assert model_cls is Glm4MoeLiteMTPModel
+    assert args_cls is Glm4MoeLiteMTPArgs
+
+
+def test_get_model_classes_rejects_wrong_model_type() -> None:
+    with pytest.raises(ValueError, match="mlx_vlm") as excinfo:
+        Glm4MoeLiteMTPHeadLoader._get_model_classes(
+            _head_config(model_type="glm4_moe_lite")
+        )
+    # Points users at the alternative head sources, not a deleted local script.
+    assert "GLM-4.7-Flash-MTP" in str(excinfo.value)
+
+
+def test_loader_loads_and_validates_with_injected_fakes() -> None:
+    load_calls: list[dict[str, object]] = []
+    download_calls: list[tuple[str, str | None]] = []
+    fake_model = _fake_head_model()
+
+    def _load_model(model_path: object, *args: object, **kwargs: object):
+        load_calls.append({"path": model_path, "kwargs": kwargs})
+        get_model_classes = kwargs["get_model_classes"]
+        assert callable(get_model_classes)
+        assert get_model_classes(_head_config()) == (
+            Glm4MoeLiteMTPModel,
+            Glm4MoeLiteMTPArgs,
+        )
+        return fake_model, _head_config()
+
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=_load_model,
+        download_fn=lambda name, rev: download_calls.append((name, rev)) or Path(name),
+    )
+
+    runtime = loader.load_if_needed(
+        speculative_config=_speculative_config(),
+        target_config=_target_config(),
+    )
+
+    assert runtime.model is fake_model
+    assert runtime.metadata.hidden_size == 2048
+    assert download_calls == [("/head", None)]
+    assert load_calls[0]["kwargs"]["strict"] is True
+
+
+def test_loader_caches_runtime_and_revalidates_target() -> None:
+    load_calls = 0
+
+    def _load_model(*args: object, **kwargs: object):
+        nonlocal load_calls
+        load_calls += 1
+        return _fake_head_model(), _head_config()
+
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=_load_model,
+        download_fn=lambda name, rev: Path(name),
+        model_path_resolver=lambda name: name,
+    )
+
+    first = loader.load_if_needed(
+        speculative_config=_speculative_config(),
+        target_config=_target_config(),
+    )
+    second = loader.load_if_needed(
+        speculative_config=_speculative_config(),
+        target_config=_target_config(),
+    )
+
+    assert first is second
+    assert load_calls == 1
+
+    with pytest.raises(ValueError, match="head hidden_size must match"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(hidden_size=4096),
+        )
+    assert load_calls == 1
+
+
+def test_loader_keeps_revisions_in_separate_cache_slots() -> None:
+    load_calls = 0
+    download_calls: list[tuple[str, str | None]] = []
+
+    def _load_model(*args: object, **kwargs: object):
+        nonlocal load_calls
+        load_calls += 1
+        return _fake_head_model(), _head_config()
+
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=_load_model,
+        download_fn=lambda name, rev: download_calls.append((name, rev)) or Path(name),
+        model_path_resolver=lambda name: name,
+    )
+    spec_a = _speculative_config()
+    spec_a.revision = "rev-a"
+    spec_a.draft_model_config.revision = "rev-a"
+    spec_b = _speculative_config()
+    spec_b.revision = "rev-b"
+    spec_b.draft_model_config.revision = "rev-b"
+
+    first = loader.load_if_needed(
+        speculative_config=spec_a, target_config=_target_config()
+    )
+    again = loader.load_if_needed(
+        speculative_config=spec_a, target_config=_target_config()
+    )
+    other = loader.load_if_needed(
+        speculative_config=spec_b, target_config=_target_config()
+    )
+
+    assert first is again
+    assert first is not other
+    assert load_calls == 2
+    assert download_calls == [("/head", "rev-a"), ("/head", "rev-b")]
+
+
+def test_loader_rejects_custom_model_file_before_load(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(_head_config(model_file="modeling_glm.py"))
+    )
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="custom model_file"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_loader_rejects_raw_target_repo_config(tmp_path: Path) -> None:
+    # Pointing at the raw GLM-4.7-Flash target repo (top-level
+    # model_type=glm4_moe_lite) is rejected before load: only the MTP head, whose
+    # top-level model_type is glm4_moe_lite_mtp, is a valid source.
+    (tmp_path / "config.json").write_text(json.dumps(_target_config()))
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="glm4_moe_lite_mtp") as excinfo:
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+    assert "mlx_vlm" in str(excinfo.value)
+
+
+def test_loader_prevalidates_config_file_before_load(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(_head_config(hidden_size=4096)))
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="head hidden_size must match"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_default_loader_rejects_missing_config_before_load(tmp_path: Path) -> None:
+    loader = Glm4MoeLiteMTPHeadLoader(
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="must contain config.json"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_loader_rejects_invalid_json_config(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text("{", encoding="utf-8")
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+@pytest.mark.parametrize("missing", ["lm_head.weight", "model.embed_tokens.weight"])
+def test_loader_asserts_head_tensors_present(missing: str) -> None:
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: (
+            _fake_head_model(missing=(missing,)),
+            _head_config(),
+        ),
+        download_fn=lambda name, rev: Path(name),
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match=f"missing {missing!r}"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_default_loader_snapshot_allow_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    huggingface_hub = pytest.importorskip("huggingface_hub")
+    (tmp_path / "config.json").write_text(json.dumps(_head_config()))
+    (tmp_path / "model.safetensors").write_text("", encoding="utf-8")
+    snapshot_calls: list[dict[str, object]] = []
+
+    def _snapshot_download(*args: object, **kwargs: object) -> str:
+        snapshot_calls.append({"args": args, "kwargs": kwargs})
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snapshot_download)
+    spec = _speculative_config(model="zai-org/GLM-4.7-Flash-mtp-head")
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: (_fake_head_model(), _head_config()),
+    )
+
+    loader.load_if_needed(speculative_config=spec, target_config=_target_config())
+
+    assert snapshot_calls == [
+        {
+            "args": ("zai-org/GLM-4.7-Flash-mtp-head",),
+            "kwargs": {
+                "revision": None,
+                "allow_patterns": [
+                    "config.json",
+                    "*.safetensors",
+                    "*.safetensors.index.json",
+                ],
+            },
+        }
+    ]
+
+
+def test_default_loader_loads_real_head_from_disk(tmp_path: Path) -> None:
+    # Load-bearing positive path: a real on-disk head checkpoint flows through the
+    # default loader + mlx_lm.load_model, validates against a matching target, and
+    # produces finite logits. Small dims are nested under text_config (the hosted
+    # drafter-split schema); from_dict promotes them to build the tiny model.
+    from mlx.utils import tree_flatten
+    from mlx_lm.models.cache import KVCache
+
+    dims: dict[str, object] = {
+        "vocab_size": 32,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "moe_intermediate_size": 32,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "n_shared_experts": 1,
+        "n_routed_experts": 4,
+        "kv_lora_rank": 16,
+        "q_lora_rank": 32,
+        "qk_rope_head_dim": 8,
+        "qk_nope_head_dim": 16,
+        "v_head_dim": 16,
+        "num_experts_per_tok": 2,
+        "first_k_dense_replace": 1,
+        "moe_layer_freq": 1,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+    }
+
+    mx.random.seed(0)
+    model = Glm4MoeLiteMTPModel(Glm4MoeLiteMTPArgs(**dims))
+    mx.eval(model.parameters())
+    mx.save_safetensors(
+        str(tmp_path / "model.safetensors"), dict(tree_flatten(model.parameters()))
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": GLM4_MOE_LITE_MTP_MODEL_TYPE,
+                "block_size": 2,
+                "text_config": {
+                    "model_type": GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+                    "architectures": ["Glm4MoeLiteForCausalLM"],
+                    "num_hidden_layers": 47,
+                    "num_nextn_predict_layers": 1,
+                    **dims,
+                },
+            }
+        )
+    )
+    target = _target_config(
+        hidden_size=64,
+        vocab_size=32,
+        kv_lora_rank=16,
+        qk_rope_head_dim=8,
+        qk_nope_head_dim=16,
+        v_head_dim=16,
+        num_attention_heads=4,
+    )
+
+    loader = Glm4MoeLiteMTPHeadLoader(model_path_resolver=lambda name: name)
+    runtime = loader.load_if_needed(
+        speculative_config=_speculative_config(model=str(tmp_path)),
+        target_config=target,
+    )
+
+    assert isinstance(runtime.model, Glm4MoeLiteMTPModel)
+    assert runtime.metadata.hidden_size == 64
+    assert runtime.metadata.num_nextn_predict_layers == 1
+
+    x = runtime.model.build_slot_inputs(mx.array([1, 2, 3]), mx.zeros((3, 64)), 0)
+    logits = runtime.model.compute_logits(runtime.model.forward_slots(x, KVCache()))
+    mx.eval(logits)
+    assert tuple(logits.shape) == (3, 32)
+    assert bool(mx.all(mx.isfinite(logits)))
+
+
+# --------------------------------------------------------------------------
+# Args
+# --------------------------------------------------------------------------
+
+
+def test_args_reject_wrong_model_type() -> None:
+    with pytest.raises(ValueError, match="model_type"):
+        Glm4MoeLiteMTPArgs(model_type="glm4_moe_lite")
+
+
+def test_args_reject_bad_num_nextn() -> None:
+    with pytest.raises(ValueError, match="num_nextn_predict_layers"):
+        Glm4MoeLiteMTPArgs(num_nextn_predict_layers=2)
+
+
+def test_args_reject_layer_idx_that_would_not_be_moe() -> None:
+    # first_k_dense_replace=1 (default) is not divisible by moe_layer_freq=2, so
+    # stock Glm4MoeLiteDecoderLayer would build a *dense* mtp_block, not the MoE
+    # the trained nextn head requires. Fail fast rather than mis-build.
+    with pytest.raises(ValueError, match="must be divisible by"):
+        Glm4MoeLiteMTPArgs(moe_layer_freq=2)
+
+
+def test_args_accept_layer_idx_divisible_by_moe_layer_freq() -> None:
+    # first_k_dense_replace=2 is divisible by moe_layer_freq=2 -> MoE layer.
+    args = Glm4MoeLiteMTPArgs(first_k_dense_replace=2, moe_layer_freq=2)
+
+    assert args.first_k_dense_replace == 2
+    assert args.moe_layer_freq == 2
+
+
+def test_args_reject_non_positive_moe_layer_freq() -> None:
+    with pytest.raises(ValueError, match="moe_layer_freq to be a positive"):
+        Glm4MoeLiteMTPArgs(moe_layer_freq=0)
+
+
+def test_args_from_dict_ignores_extra_config_keys() -> None:
+    args = Glm4MoeLiteMTPArgs.from_dict({**_head_config(), "unrelated": 123})
+
+    assert args.model_type == GLM4_MOE_LITE_MTP_MODEL_TYPE
+    assert args.hidden_size == 2048
+    backbone = args.backbone_args()
+    assert backbone.model_type == "glm4_moe_lite"
+    assert backbone.hidden_size == 2048

--- a/tests/test_glm4_moe_lite_mtp_model.py
+++ b/tests/test_glm4_moe_lite_mtp_model.py
@@ -1,0 +1,613 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numeric parity tests for the GLM-4.7-Flash native MTP head MLX model.
+
+A self-contained numpy reference implements the upstream nextn math (enorm /
+hnorm / eh_proj concat, position-0 embedding zeroing, absorbed-MLA attention with
+traditional RoPE, noaux_tc sigmoid gating with e_score_correction_bias, shared
+expert add, shared_head norm + head readout). The MLX head must match it within
+fp32 tolerance, incremental slab forwards must equal a single multi-row forward
+and a recompute-from-scratch, and ``convert_nextn_weights`` must produce the exact
+module tree the model loads under a strict ``load_weights``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_unflatten
+from mlx_lm.models.cache import KVCache
+
+from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import (
+    Glm4MoeLiteMTPArgs,
+    Glm4MoeLiteMTPModel,
+    convert_nextn_weights,
+)
+
+# Tiny dims (plan): hidden 64, kv_lora_rank 16, qk_rope 8, qk_nope 16, v_head 16,
+# 4 experts top-2, n_group 1, topk_group 1, vocab 32. q_lora_rank set so the
+# q_a_proj/q_a_layernorm/q_b_proj path (as in the real GLM-4.7-Flash) is exercised.
+H = 64
+NH = 4
+QL = 32
+KVL = 16
+ROPE = 8
+NOPE = 16
+VH = 16
+NROUT = 4
+NSHR = 1
+TOPK = 2
+MOEI = 32
+VOCAB = 32
+SCALE_F = 1.5
+EPS = 1e-5
+THETA = 1_000_000.0
+QHD = NOPE + ROPE
+
+
+def _args() -> Glm4MoeLiteMTPArgs:
+    return Glm4MoeLiteMTPArgs(
+        vocab_size=VOCAB,
+        hidden_size=H,
+        intermediate_size=128,
+        moe_intermediate_size=MOEI,
+        num_attention_heads=NH,
+        num_key_value_heads=NH,
+        n_shared_experts=NSHR,
+        n_routed_experts=NROUT,
+        kv_lora_rank=KVL,
+        q_lora_rank=QL,
+        qk_rope_head_dim=ROPE,
+        qk_nope_head_dim=NOPE,
+        v_head_dim=VH,
+        num_experts_per_tok=TOPK,
+        n_group=1,
+        topk_group=1,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+        routed_scaling_factor=SCALE_F,
+        rms_norm_eps=EPS,
+        rope_theta=THETA,
+        norm_topk_prob=True,
+    )
+
+
+def _random_flat_weights(rng: np.random.Generator) -> dict[str, np.ndarray]:
+    def rnd(*shape: int) -> np.ndarray:
+        return (rng.standard_normal(shape) * 0.1).astype(np.float32)
+
+    def norm(*shape: int) -> np.ndarray:
+        return (1.0 + rnd(*shape)).astype(np.float32)
+
+    weights: dict[str, np.ndarray] = {
+        "model.embed_tokens.weight": rnd(VOCAB, H),
+        "model.enorm.weight": norm(H),
+        "model.hnorm.weight": norm(H),
+        "model.eh_proj.weight": rnd(H, 2 * H),
+        "model.mtp_block.input_layernorm.weight": norm(H),
+        "model.mtp_block.post_attention_layernorm.weight": norm(H),
+        "model.mtp_block.self_attn.q_a_proj.weight": rnd(QL, H),
+        "model.mtp_block.self_attn.q_a_layernorm.weight": norm(QL),
+        "model.mtp_block.self_attn.q_b_proj.weight": rnd(NH * QHD, QL),
+        "model.mtp_block.self_attn.kv_a_proj_with_mqa.weight": rnd(KVL + ROPE, H),
+        "model.mtp_block.self_attn.kv_a_layernorm.weight": norm(KVL),
+        "model.mtp_block.self_attn.kv_b_proj.weight": rnd(NH * (NOPE + VH), KVL),
+        "model.mtp_block.self_attn.o_proj.weight": rnd(H, NH * VH),
+        "model.mtp_block.mlp.gate.weight": rnd(NROUT, H),
+        "model.mtp_block.mlp.gate.e_score_correction_bias": rnd(NROUT),
+        "model.mtp_block.mlp.shared_experts.gate_proj.weight": rnd(MOEI, H),
+        "model.mtp_block.mlp.shared_experts.up_proj.weight": rnd(MOEI, H),
+        "model.mtp_block.mlp.shared_experts.down_proj.weight": rnd(H, MOEI),
+        "model.shared_head_norm.weight": norm(H),
+        "lm_head.weight": rnd(VOCAB, H),
+    }
+    for e in range(NROUT):
+        weights[f"model.mtp_block.mlp.experts.{e}.gate_proj.weight"] = rnd(MOEI, H)
+        weights[f"model.mtp_block.mlp.experts.{e}.up_proj.weight"] = rnd(MOEI, H)
+        weights[f"model.mtp_block.mlp.experts.{e}.down_proj.weight"] = rnd(H, MOEI)
+    return weights
+
+
+def _rms(x: np.ndarray, w: np.ndarray) -> np.ndarray:
+    return (x / np.sqrt((x**2).mean(-1, keepdims=True) + EPS)) * w
+
+
+def _rope_traditional(x: np.ndarray, pos: np.ndarray) -> np.ndarray:
+    # x: (T, num_heads, ROPE) — interleaved-pair rotation (mlx traditional=True).
+    d = x.shape[-1]
+    half = d // 2
+    inv = THETA ** (-(2 * np.arange(half)) / d)
+    ang = np.outer(pos, inv)
+    cos = np.cos(ang)[:, None, :]
+    sin = np.sin(ang)[:, None, :]
+    x0 = x[..., 0::2]
+    x1 = x[..., 1::2]
+    out = np.empty_like(x)
+    out[..., 0::2] = x0 * cos - x1 * sin
+    out[..., 1::2] = x0 * sin + x1 * cos
+    return out
+
+
+def _silu(x: np.ndarray) -> np.ndarray:
+    return x / (1.0 + np.exp(-x))
+
+
+def _reference_forward(
+    weights: dict[str, np.ndarray],
+    token_ids: np.ndarray,
+    hidden_rows: np.ndarray,
+    first_position: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    def w(name: str) -> np.ndarray:
+        return weights[name]
+
+    num_slots = len(token_ids)
+    positions = first_position + np.arange(num_slots)
+
+    emb = w("model.embed_tokens.weight")[token_ids]
+    emb = emb * (positions != 0)[:, None]
+    fused = np.concatenate(
+        [
+            _rms(emb, w("model.enorm.weight")),
+            _rms(hidden_rows, w("model.hnorm.weight")),
+        ],
+        axis=-1,
+    )
+    x = fused @ w("model.eh_proj.weight").T
+
+    # --- absorbed MLA attention (un-absorbed reference form) ---
+    residual = x
+    xin = _rms(x, w("model.mtp_block.input_layernorm.weight"))
+    qa = _rms(
+        xin @ w("model.mtp_block.self_attn.q_a_proj.weight").T,
+        w("model.mtp_block.self_attn.q_a_layernorm.weight"),
+    )
+    q = (qa @ w("model.mtp_block.self_attn.q_b_proj.weight").T).reshape(
+        num_slots, NH, QHD
+    )
+    q_nope, q_pe = q[..., :NOPE], q[..., NOPE:]
+    compressed = xin @ w("model.mtp_block.self_attn.kv_a_proj_with_mqa.weight").T
+    kv_c, k_pe = compressed[:, :KVL], compressed[:, KVL:]
+    kv_latent = _rms(kv_c, w("model.mtp_block.self_attn.kv_a_layernorm.weight"))
+
+    q_pe = _rope_traditional(q_pe, positions)
+    k_pe = _rope_traditional(k_pe[:, None, :], positions)[:, 0, :]
+
+    kv_b = (kv_latent @ w("model.mtp_block.self_attn.kv_b_proj.weight").T).reshape(
+        num_slots, NH, NOPE + VH
+    )
+    k_nope, value = kv_b[..., :NOPE], kv_b[..., NOPE:]
+    k_pe_heads = np.broadcast_to(k_pe[:, None, :], (num_slots, NH, ROPE))
+    keys = np.concatenate([k_nope, k_pe_heads], axis=-1)
+    queries = np.concatenate([q_nope, q_pe], axis=-1)
+
+    scale = QHD**-0.5
+    causal = np.triu(np.ones((num_slots, num_slots), dtype=bool), 1)
+    head_outs = []
+    for h in range(NH):
+        scores = (queries[:, h, :] @ keys[:, h, :].T) * scale
+        scores = np.where(causal, -np.inf, scores)
+        scores = scores - scores.max(-1, keepdims=True)
+        probs = np.exp(scores)
+        probs = probs / probs.sum(-1, keepdims=True)
+        head_outs.append(probs @ value[:, h, :])
+    attn = np.concatenate(head_outs, axis=-1)
+    attn_out = attn @ w("model.mtp_block.self_attn.o_proj.weight").T
+    hidden = residual + attn_out
+
+    # --- MoE (noaux_tc sigmoid gating + shared expert) ---
+    residual = hidden
+    xmlp = _rms(hidden, w("model.mtp_block.post_attention_layernorm.weight"))
+    gates = xmlp @ w("model.mtp_block.mlp.gate.weight").T
+    sig = 1.0 / (1.0 + np.exp(-gates))
+    biased = sig + w("model.mtp_block.mlp.gate.e_score_correction_bias")
+
+    routed = np.zeros((num_slots, H), dtype=np.float32)
+    for t in range(num_slots):
+        idx = np.argsort(-biased[t])[:TOPK]
+        weight = sig[t, idx].copy()
+        weight = weight / (weight.sum() + 1e-20)
+        weight = weight * SCALE_F
+        acc = np.zeros(H, dtype=np.float32)
+        for k, e in enumerate(idx):
+            gate = xmlp[t] @ w(f"model.mtp_block.mlp.experts.{e}.gate_proj.weight").T
+            up = xmlp[t] @ w(f"model.mtp_block.mlp.experts.{e}.up_proj.weight").T
+            expert = (_silu(gate) * up) @ w(
+                f"model.mtp_block.mlp.experts.{e}.down_proj.weight"
+            ).T
+            acc += weight[k] * expert
+        routed[t] = acc
+
+    shared_gate = xmlp @ w("model.mtp_block.mlp.shared_experts.gate_proj.weight").T
+    shared_up = xmlp @ w("model.mtp_block.mlp.shared_experts.up_proj.weight").T
+    shared = (_silu(shared_gate) * shared_up) @ w(
+        "model.mtp_block.mlp.shared_experts.down_proj.weight"
+    ).T
+    hidden = residual + routed + shared
+
+    out_hidden = _rms(hidden, w("model.shared_head_norm.weight"))
+    logits = out_hidden @ w("lm_head.weight").T
+    return out_hidden, logits
+
+
+def _build_model(
+    weights: dict[str, np.ndarray],
+) -> Glm4MoeLiteMTPModel:
+    model = Glm4MoeLiteMTPModel(_args())
+    converted = convert_nextn_weights(
+        {k: mx.array(v) for k, v in weights.items()},
+        model.args,
+    )
+    model.update(tree_unflatten(list(converted.items())))
+    mx.eval(model.parameters())
+    return model
+
+
+@pytest.fixture()
+def fixture():  # noqa: ANN201
+    rng = np.random.default_rng(1234)
+    weights = _random_flat_weights(rng)
+    model = _build_model(weights)
+    token_ids = rng.integers(0, VOCAB, size=6).astype(np.int32)
+    hidden_rows = (rng.standard_normal((6, H)) * 0.5).astype(np.float32)
+    return model, weights, token_ids, hidden_rows
+
+
+def test_forward_matches_numpy_reference(fixture) -> None:  # noqa: ANN001
+    model, weights, token_ids, hidden_rows = fixture
+
+    cache = KVCache()
+    x = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    hidden = model.forward_slots(x, cache)
+    logits = model.compute_logits(hidden)
+    mx.eval(hidden, logits)
+
+    ref_hidden, ref_logits = _reference_forward(weights, token_ids, hidden_rows, 0)
+
+    assert np.allclose(np.array(hidden), ref_hidden, atol=2e-4, rtol=2e-4)
+    assert np.allclose(np.array(logits), ref_logits, atol=2e-4, rtol=2e-4)
+    assert (
+        np.array(mx.argmax(logits, axis=-1)).tolist() == ref_logits.argmax(-1).tolist()
+    )
+
+
+def test_position_zero_embedding_is_masked(fixture) -> None:  # noqa: ANN001
+    model, weights, token_ids, hidden_rows = fixture
+
+    # Row at absolute position 0 must ignore its token embedding: swapping the
+    # position-0 token cannot change the slot input.
+    x0 = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    swapped = token_ids.copy()
+    swapped[0] = (int(swapped[0]) + 7) % VOCAB
+    x1 = model.build_slot_inputs(mx.array(swapped), mx.array(hidden_rows), 0)
+    mx.eval(x0, x1)
+    assert np.allclose(np.array(x0[0]), np.array(x1[0]), atol=1e-6)
+
+    # But with a non-zero first_position, row 0 is a real position and does use
+    # its embedding.
+    x2 = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 3)
+    x3 = model.build_slot_inputs(mx.array(swapped), mx.array(hidden_rows), 3)
+    mx.eval(x2, x3)
+    assert not np.allclose(np.array(x2[0]), np.array(x3[0]), atol=1e-6)
+
+
+def test_incremental_slots_equal_full_forward(fixture) -> None:  # noqa: ANN001
+    model, _weights, token_ids, hidden_rows = fixture
+    num_slots = len(token_ids)
+
+    full_cache = KVCache()
+    x_full = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    full = model.forward_slots(x_full, full_cache, expected_offset=0)
+    mx.eval(full)
+    full_np = np.array(full)
+
+    inc_cache = KVCache()
+    rows = []
+    for i in range(num_slots):
+        xi = model.build_slot_inputs(
+            mx.array(token_ids[i : i + 1]),
+            mx.array(hidden_rows[i : i + 1]),
+            i,
+        )
+        # The cache offset and the caller's first_position must agree per slot.
+        hi = model.forward_slots(xi, inc_cache, expected_offset=i)
+        mx.eval(hi)
+        rows.append(np.array(hi))
+    incremental = np.concatenate(rows, axis=0)
+
+    assert incremental.shape == full_np.shape
+    assert np.allclose(incremental, full_np, atol=2e-4, rtol=2e-4)
+    assert inc_cache.offset == num_slots
+
+
+def test_split_prefill_then_decode_equals_full(fixture) -> None:  # noqa: ANN001
+    model, _weights, token_ids, hidden_rows = fixture
+    num_slots = len(token_ids)
+
+    x_full = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    full = model.forward_slots(x_full, KVCache())
+    mx.eval(full)
+    full_np = np.array(full)
+
+    # Prefill the first `split` rows in one shot, then feed the remainder one at
+    # a time, mirroring a decode-after-prefill sequence.
+    split = 4
+    cache = KVCache()
+    x_prefill = model.build_slot_inputs(
+        mx.array(token_ids[:split]), mx.array(hidden_rows[:split]), 0
+    )
+    prefill = model.forward_slots(x_prefill, cache, expected_offset=0)
+    mx.eval(prefill)
+    rows = [np.array(prefill)]
+    for i in range(split, num_slots):
+        xi = model.build_slot_inputs(
+            mx.array(token_ids[i : i + 1]),
+            mx.array(hidden_rows[i : i + 1]),
+            i,
+        )
+        hi = model.forward_slots(xi, cache, expected_offset=i)
+        mx.eval(hi)
+        rows.append(np.array(hi))
+    combined = np.concatenate(rows, axis=0)
+
+    assert np.allclose(combined, full_np, atol=2e-4, rtol=2e-4)
+
+
+def test_convert_nextn_weights_round_trips_into_model() -> None:
+    rng = np.random.default_rng(7)
+    weights = _random_flat_weights(rng)
+    model = Glm4MoeLiteMTPModel(_args())
+
+    converted = convert_nextn_weights(
+        {k: mx.array(v) for k, v in weights.items()},
+        model.args,
+    )
+
+    # The transformed weights must be exactly the module tree — strict load
+    # rejects any missing or extra key.
+    model.load_weights(list(converted.items()), strict=True)
+
+    # kv_b_proj is consumed; embed_q / unembed_out are produced with the right
+    # absorbed shapes; experts are stacked into switch_mlp.
+    assert "model.mtp_block.self_attn.kv_b_proj.weight" not in converted
+    assert converted["model.mtp_block.self_attn.embed_q.weight"].shape == (
+        NH,
+        KVL,
+        NOPE,
+    )
+    assert converted["model.mtp_block.self_attn.unembed_out.weight"].shape == (
+        NH,
+        VH,
+        KVL,
+    )
+    assert converted["model.mtp_block.mlp.switch_mlp.gate_proj.weight"].shape == (
+        NROUT,
+        MOEI,
+        H,
+    )
+    assert "model.mtp_block.mlp.experts.0.gate_proj.weight" not in converted
+
+
+def test_convert_nextn_weights_is_idempotent() -> None:
+    rng = np.random.default_rng(9)
+    weights = _random_flat_weights(rng)
+    args = _args()
+
+    once = convert_nextn_weights({k: mx.array(v) for k, v in weights.items()}, args)
+    twice = convert_nextn_weights(once, args)
+
+    assert set(once) == set(twice)
+    for key in once:
+        assert np.array_equal(np.array(once[key]), np.array(twice[key]))
+
+
+def test_convert_nextn_weights_reports_missing_expert() -> None:
+    # A checkpoint with fewer experts than n_routed_experts must fail with a
+    # descriptive error (naming the first missing expert + a head source),
+    # not a bare KeyError leaking from the stacking pop.
+    rng = np.random.default_rng(3)
+    weights = _random_flat_weights(rng)
+    args = _args()
+    dropped = f"model.mtp_block.mlp.experts.{NROUT - 1}.gate_proj.weight"
+    del weights[dropped]
+
+    with pytest.raises(ValueError) as excinfo:
+        convert_nextn_weights({k: mx.array(v) for k, v in weights.items()}, args)
+
+    message = str(excinfo.value)
+    assert f"missing expert {NROUT - 1}" in message
+    assert dropped in message
+    assert f"n_routed_experts={NROUT}" in message
+    assert "mlx_vlm" in message
+
+
+def test_from_dict_reads_nested_text_config_not_defaults() -> None:
+    # The hosted drafter-split schema nests the shape under text_config with the
+    # head identity at the top level. from_dict must read the nested (non-default)
+    # dims -- tiny values distinct from this class's GLM-4.7-Flash field defaults
+    # -- rather than silently building the head with the defaults.
+    config = {
+        "model_type": "glm4_moe_lite_mtp",
+        "block_size": 2,
+        "quantization": {"group_size": 32, "bits": 4},
+        "text_config": {
+            "model_type": "glm4_moe_lite",
+            "hidden_size": 128,
+            "vocab_size": 1024,
+            "num_attention_heads": 4,
+            "kv_lora_rank": 32,
+            "num_nextn_predict_layers": 1,
+        },
+    }
+
+    args = Glm4MoeLiteMTPArgs.from_dict(config)
+
+    assert args.model_type == "glm4_moe_lite_mtp"
+    assert args.hidden_size == 128
+    assert args.vocab_size == 1024
+    assert args.num_attention_heads == 4
+    assert args.kv_lora_rank == 32
+    assert args.quantization == {"group_size": 32, "bits": 4}
+
+
+def test_from_dict_rejects_non_mapping_text_config() -> None:
+    with pytest.raises(ValueError, match="text_config must be a mapping"):
+        Glm4MoeLiteMTPArgs.from_dict(
+            {"model_type": "glm4_moe_lite_mtp", "text_config": "nope"}
+        )
+
+
+def test_forward_slots_expected_offset_guards_against_desync(fixture) -> None:  # noqa: ANN001
+    model, _weights, token_ids, hidden_rows = fixture
+
+    cache = KVCache()
+    x = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    # Fresh cache is at offset 0 — matching expected_offset passes.
+    first = model.forward_slots(x, cache, expected_offset=0)
+    mx.eval(first)
+    assert cache.offset == len(token_ids)
+
+    # Re-using the now-advanced cache while still claiming offset 0 is a
+    # position anchor desync and must fail loud.
+    x2 = model.build_slot_inputs(mx.array(token_ids[:1]), mx.array(hidden_rows[:1]), 0)
+    with pytest.raises(ValueError, match="does not match expected_offset"):
+        model.forward_slots(x2, cache, expected_offset=0)
+
+
+# ---------------------------------------------------------------------------
+# Quantized weight transform (convert_nextn_weights on a 4-bit checkpoint)
+# ---------------------------------------------------------------------------
+
+# mx.quantize requires group_size in {32, 64, 128} and the quantized last dim
+# divisible by it, so the quantized fixture uses coarser dims than the fp32
+# tests above.
+QH = 32  # hidden / head dims (all multiples of the group size)
+QNH = 2  # attention heads
+QKVL = 32  # kv_lora_rank
+QNOPE = 32  # qk_nope_head_dim
+QVH = 32  # v_head_dim
+QNROUT = 2  # routed experts
+QMOEI = 32  # moe intermediate
+QBITS = 4
+QGROUP = 32
+
+
+def _quant_args() -> Glm4MoeLiteMTPArgs:
+    return Glm4MoeLiteMTPArgs(
+        vocab_size=64,
+        hidden_size=QH,
+        intermediate_size=64,
+        moe_intermediate_size=QMOEI,
+        num_attention_heads=QNH,
+        num_key_value_heads=QNH,
+        n_shared_experts=1,
+        n_routed_experts=QNROUT,
+        kv_lora_rank=QKVL,
+        q_lora_rank=QH,
+        qk_rope_head_dim=QGROUP,
+        qk_nope_head_dim=QNOPE,
+        v_head_dim=QVH,
+        num_experts_per_tok=1,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+    )
+
+
+def _quantize(w: np.ndarray) -> tuple[mx.array, mx.array, mx.array]:
+    q, s, b = mx.quantize(mx.array(w), bits=QBITS, group_size=QGROUP)
+    mx.eval(q, s, b)
+    return q, s, b
+
+
+def _dequant(q: mx.array, s: mx.array, b: mx.array) -> np.ndarray:
+    d = mx.dequantize(q, s, b, bits=QBITS, group_size=QGROUP)
+    mx.eval(d)
+    return np.array(d)
+
+
+def test_convert_nextn_weights_quantized_kv_b_proj_round_trips() -> None:
+    rng = np.random.default_rng(11)
+    prefix = "model.mtp_block.self_attn"
+    # kv_b_proj: (num_heads * (qk_nope + v_head), kv_lora_rank).
+    kv_b_fp32 = (rng.standard_normal((QNH * (QNOPE + QVH), QKVL)) * 0.1).astype(
+        np.float32
+    )
+    q, s, b = _quantize(kv_b_fp32)
+    weights = {
+        f"{prefix}.kv_b_proj.weight": q,
+        f"{prefix}.kv_b_proj.scales": s,
+        f"{prefix}.kv_b_proj.biases": b,
+    }
+
+    out = convert_nextn_weights(weights, _quant_args())
+
+    # Fused kv_b_proj is consumed; absorbed embed_q / unembed_out appear with
+    # quantized triplets.
+    assert f"{prefix}.kv_b_proj.weight" not in out
+    for name in ("embed_q", "unembed_out"):
+        for suffix in ("weight", "scales", "biases"):
+            assert f"{prefix}.{name}.{suffix}" in out
+    assert out[f"{prefix}.embed_q.weight"].shape[0] == QNH
+    assert out[f"{prefix}.unembed_out.weight"].shape[0] == QNH
+
+    # Numeric round-trip: reproduce the reference by splitting the *unquantized*
+    # weights and quantizing, then compare dequantized values (4-bit tolerance).
+    v = kv_b_fp32.reshape(QNH, QNOPE + QVH, QKVL)
+    wk_ref = np.ascontiguousarray(v[:, :QNOPE, :].swapaxes(-1, -2))
+    wv_ref = np.ascontiguousarray(v[:, QNOPE:, :])
+    ek = _dequant(*_quantize(wk_ref))
+    ev = _dequant(*_quantize(wv_ref))
+    got_ek = _dequant(
+        out[f"{prefix}.embed_q.weight"],
+        out[f"{prefix}.embed_q.scales"],
+        out[f"{prefix}.embed_q.biases"],
+    )
+    got_ev = _dequant(
+        out[f"{prefix}.unembed_out.weight"],
+        out[f"{prefix}.unembed_out.scales"],
+        out[f"{prefix}.unembed_out.biases"],
+    )
+    # The convert path quantizes -> dequantizes -> splits -> re-quantizes (two
+    # 4-bit rounds) vs the reference's single round on the exact fp32 split, so
+    # compare dequantized values within a 4-bit-appropriate tolerance.
+    assert np.allclose(got_ek, ek, atol=0.08)
+    assert np.allclose(got_ev, ev, atol=0.08)
+
+
+def test_convert_nextn_weights_stacks_quantized_experts() -> None:
+    rng = np.random.default_rng(13)
+    prefix = "model.mtp_block.mlp"
+    per_expert: dict[str, mx.array] = {}
+    expected: dict[str, list[tuple[mx.array, mx.array, mx.array]]] = {
+        "gate_proj": [],
+        "up_proj": [],
+        "down_proj": [],
+    }
+    shapes = {
+        "gate_proj": (QMOEI, QH),
+        "up_proj": (QMOEI, QH),
+        "down_proj": (QH, QMOEI),
+    }
+    for e in range(QNROUT):
+        for proj, shape in shapes.items():
+            w = (rng.standard_normal(shape) * 0.1).astype(np.float32)
+            q, s, b = _quantize(w)
+            per_expert[f"{prefix}.experts.{e}.{proj}.weight"] = q
+            per_expert[f"{prefix}.experts.{e}.{proj}.scales"] = s
+            per_expert[f"{prefix}.experts.{e}.{proj}.biases"] = b
+            expected[proj].append((q, s, b))
+
+    out = convert_nextn_weights(per_expert, _quant_args())
+
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        # Per-expert keys are consumed.
+        assert f"{prefix}.experts.0.{proj}.weight" not in out
+        for si, suffix in enumerate(("weight", "scales", "biases")):
+            stacked = out[f"{prefix}.switch_mlp.{proj}.{suffix}"]
+            assert stacked.shape[0] == QNROUT
+            # Stacking preserves each expert's quantized tensor exactly (no
+            # dequant): row e equals expert e's tensor.
+            for e in range(QNROUT):
+                np.testing.assert_array_equal(
+                    np.array(stacked[e]), np.array(expected[proj][e][si])
+                )

--- a/tests/test_glm4_mtp_head.py
+++ b/tests/test_glm4_mtp_head.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the GLM-4.7-Flash native MTP head and its registration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_metal.v1.mtp_heads.glm4 import Glm4MoeLiteMTPHead
+from vllm_metal.v1.mtp_heads.registry import (
+    NativeMTPBuildContext,
+    NativeMTPHeadRegistry,
+)
+
+
+def _mtp_config(*, model_type: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        method="mtp",
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type=model_type),
+        ),
+    )
+
+
+def _context(
+    *,
+    num_speculative_tokens: int = 1,
+    enable_prefix_caching: bool = False,
+    pipeline_parallel_size: int = 1,
+    target_config: dict | None = None,
+) -> NativeMTPBuildContext:
+    return NativeMTPBuildContext(
+        speculative_config=SimpleNamespace(
+            num_speculative_tokens=num_speculative_tokens
+        ),
+        controller=object(),
+        vllm_config=SimpleNamespace(
+            cache_config=SimpleNamespace(enable_prefix_caching=enable_prefix_caching),
+            parallel_config=SimpleNamespace(
+                pipeline_parallel_size=pipeline_parallel_size
+            ),
+        ),
+        target_config=target_config if target_config is not None else {},
+    )
+
+
+def test_glm_head_is_registered_under_its_model_type() -> None:
+    head = NativeMTPHeadRegistry.find(_mtp_config(model_type="glm4_moe_lite_mtp"))
+
+    assert isinstance(head, Glm4MoeLiteMTPHead)
+    assert "glm4_moe_lite_mtp" in NativeMTPHeadRegistry.registered_types()
+
+
+def test_unsupported_message_points_at_glm_head() -> None:
+    message = NativeMTPHeadRegistry.unsupported_message(_mtp_config(model_type="eagle"))
+
+    assert "glm4_moe_lite_mtp" in message
+
+
+def test_build_proposer_rejects_prefix_caching() -> None:
+    with pytest.raises(NotImplementedError, match="no-enable-prefix-caching"):
+        Glm4MoeLiteMTPHead().build_proposer(_context(enable_prefix_caching=True))
+
+
+def test_build_proposer_rejects_multi_token_spec() -> None:
+    with pytest.raises(NotImplementedError, match="at most 1 speculative"):
+        Glm4MoeLiteMTPHead().build_proposer(_context(num_speculative_tokens=2))
+
+
+def test_build_proposer_rejects_pipeline_parallelism() -> None:
+    with pytest.raises(NotImplementedError, match="pipeline parallel"):
+        Glm4MoeLiteMTPHead().build_proposer(_context(pipeline_parallel_size=2))
+
+
+def test_build_proposer_delegates_to_native_mtp_proposer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import vllm_metal.v1.mtp_proposer as mtp_proposer
+
+    captured: dict[str, object] = {}
+
+    # A fake head returns a proposer-shaped object, not a bare sentinel.
+    class _FakeProposer:
+        def needs_target_hidden_states(self, *args: object, **kwargs: object) -> bool:
+            return True
+
+        def propose(self, ctx: object) -> None:
+            return None
+
+        def release_requests(self, req_ids: set[str]) -> None:
+            return None
+
+    proposer = _FakeProposer()
+
+    def _fake_build(**kwargs: object) -> _FakeProposer:
+        captured.update(kwargs)
+        return proposer
+
+    monkeypatch.setattr(mtp_proposer.NativeMTPProposer, "build", _fake_build)
+    context = _context(target_config={"hidden_size": 2048})
+
+    result = Glm4MoeLiteMTPHead().build_proposer(context)
+
+    assert result is proposer
+    assert captured["speculative_config"] is context.speculative_config
+    assert captured["controller"] is context.controller
+    assert captured["model_type"] == "glm4_moe_lite_mtp"
+    assert captured["target_config"] == {"hidden_size": 2048}
+    from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import Glm4MoeLiteMTPHeadLoader
+
+    assert isinstance(captured["loader"], Glm4MoeLiteMTPHeadLoader)

--- a/tests/test_mtp_head_registry.py
+++ b/tests/test_mtp_head_registry.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for native MTP head registry behavior."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm_metal.v1.mtp_heads.registry import (
+    NativeMTPBuildContext,
+    NativeMTPHeadRegistry,
+)
+
+
+def _mtp_config(*, model_type: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        method="mtp",
+        draft_model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type=model_type),
+        ),
+    )
+
+
+class _FakeProposer:
+    def needs_target_hidden_states(
+        self, decode_segments: Any, *, has_final_prefill: bool
+    ) -> bool:
+        return False
+
+    def propose(self, ctx: Any) -> None:
+        return None
+
+
+class _FakeHead:
+    def __init__(self, model_type: str = "dummy_mtp") -> None:
+        self.model_type = model_type
+
+    def build_proposer(self, context: NativeMTPBuildContext) -> _FakeProposer:
+        return _FakeProposer()
+
+
+@pytest.fixture(autouse=True)
+def _empty_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(NativeMTPHeadRegistry, "_heads", {})
+
+
+def test_find_returns_none_for_unregistered_model_type() -> None:
+    config = _mtp_config(model_type="eagle")
+
+    head = NativeMTPHeadRegistry.find(config)
+
+    assert head is None
+
+
+def test_returns_registered_head_for_matching_model_type() -> None:
+    head = _FakeHead()
+    config = _mtp_config(model_type="dummy_mtp")
+
+    NativeMTPHeadRegistry.register(head)
+    found = NativeMTPHeadRegistry.find(config)
+
+    assert found is head
+    assert NativeMTPHeadRegistry.registered_types() == ["dummy_mtp"]
+
+
+def test_unsupported_message_names_model_type_and_supported_path() -> None:
+    config = _mtp_config(model_type="eagle")
+
+    message = NativeMTPHeadRegistry.unsupported_message(config)
+
+    assert "'eagle'" in message
+    assert "Gemma4 MTP" in message
+
+
+def test_unsupported_message_names_registered_heads() -> None:
+    head = _FakeHead("glm4_moe_lite_mtp")
+    config = _mtp_config(model_type="eagle")
+
+    NativeMTPHeadRegistry.register(head)
+    message = NativeMTPHeadRegistry.unsupported_message(config)
+
+    assert "'eagle'" in message
+    assert "glm4_moe_lite_mtp" in message

--- a/tests/test_mtp_proposer.py
+++ b/tests/test_mtp_proposer.py
@@ -1,0 +1,648 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the native MTP-head proposer and its per-request KV slab.
+
+No engine or real checkpoints: a tiny stub head model that captures its calls
+(and advances the slab through ``update_and_fetch`` like the real head) plus
+hand-built ``ProposeContext`` objects drive the proposer. Structure mirrors
+``test_dflash_proposer.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_metal.v1.mtp_proposer import MTPSlab, NativeMTPProposer
+from vllm_metal.v1.proposer import ProposeContext
+from vllm_metal.v1.spec_decode import PagedDecodeSegment, SpeculativeDecodeController
+
+# Head/slab dims. The slab holds different k/v feature dims (latent vs rope),
+# inferred from the first append — never hardcoded in the proposer.
+HIDDEN = 8
+LATENT = 4
+ROPE = 2
+VOCAB = 100
+
+
+class _StubHead:
+    """Head model stand-in: passes the last committed token through so the
+    draft token is deterministic, and advances the slab exactly like the real
+    ``forward_slots`` (which appends the layer's MLA latent as an attention
+    side effect)."""
+
+    def __init__(self) -> None:
+        # (tokens, first_position, hidden_shape) per build_slot_inputs call.
+        self.slot_calls: list[tuple[list[int], int, tuple[int, ...]]] = []
+        # (num_slots, expected_offset, offset_before) per forward_slots call.
+        self.forward_calls: list[tuple[int, int | None, int]] = []
+        # Number of compute_logits calls (one per drafted row).
+        self.logits_calls = 0
+
+    def build_slot_inputs(
+        self, token_ids: mx.array, hidden_rows: mx.array, first_position: int
+    ) -> mx.array:
+        toks = [int(t) for t in token_ids.tolist()]
+        self.slot_calls.append((toks, first_position, tuple(hidden_rows.shape)))
+        n = token_ids.shape[0]
+        col0 = token_ids.astype(mx.float32).reshape(n, 1)
+        return mx.concatenate([col0, mx.zeros((n, HIDDEN - 1))], axis=1)
+
+    def forward_slots(
+        self, x: mx.array, cache: MTPSlab, *, expected_offset: int | None = None
+    ) -> mx.array:
+        n = x.shape[0]
+        offset_before = cache.offset
+        if expected_offset is not None and cache.offset != expected_offset:
+            raise ValueError(
+                f"cache offset {cache.offset} != expected_offset {expected_offset}"
+            )
+        cache.update_and_fetch(mx.ones((1, 1, n, LATENT)), mx.ones((1, 1, n, ROPE)))
+        self.forward_calls.append((n, expected_offset, offset_before))
+        return x  # column 0 carries the embedding token id
+
+    def compute_logits(self, hidden: mx.array) -> mx.array:
+        self.logits_calls += 1
+        col0 = mx.round(hidden[:, 0]).astype(mx.int32) % VOCAB
+        return (mx.arange(VOCAB)[None, :] == col0[:, None]).astype(mx.float32)
+
+
+def _proposer() -> tuple[NativeMTPProposer, _StubHead]:
+    head = _StubHead()
+    proposer = NativeMTPProposer(
+        model=head,
+        controller=SpeculativeDecodeController(),
+    )
+    return proposer, head
+
+
+def _request_state(token_ids: list[int], *, temperature: float = 0.0):
+    return SimpleNamespace(
+        token_ids=list(token_ids),
+        sampling_params=SamplingParams(temperature=temperature),
+        generated_tokens=1,
+    )
+
+
+def _prefill(
+    req_id: str,
+    token_ids: list[int],
+    *,
+    start_pos: int = 0,
+    temperature: float = 0.0,
+):
+    return SimpleNamespace(
+        req_id=req_id,
+        token_ids=list(token_ids),
+        block_ids=[0],
+        start_pos=start_pos,
+        sampling_params=SamplingParams(temperature=temperature),
+    )
+
+
+def _segment(
+    req_id: str,
+    *,
+    start_row: int,
+    cache_start_pos: int,
+    draft_token_ids: tuple[int, ...] = (),
+    last_token: int = 1,
+) -> PagedDecodeSegment:
+    input_token_ids = (last_token, *draft_token_ids)
+    return PagedDecodeSegment(
+        req_id=req_id,
+        input_token_ids=input_token_ids,
+        start_row=start_row,
+        num_query_tokens=len(input_token_ids),
+        draft_token_ids=draft_token_ids,
+        cache_start_pos=cache_start_pos,
+        block_ids=(0,),
+    )
+
+
+def _hidden(num_rows: int) -> mx.array:
+    # Values are irrelevant to the stub head; distinct rows aid debugging.
+    return mx.arange(num_rows * HIDDEN).reshape(num_rows, HIDDEN).astype(mx.float32)
+
+
+def _ctx(
+    *,
+    hidden: mx.array | None,
+    decode_reqs=(),
+    decode_segments=(),
+    decode_token_ids=(),
+    prefill_reqs=(),
+    prefill_token_ids=(),
+    prefill_result_modes=(),
+    request_states=None,
+    cu_seqlens=(0,),
+    num_speculative_tokens: int = 1,
+    finished_req_ids=(),
+) -> ProposeContext:
+    if request_states is None:
+        request_states = dict(decode_reqs)
+        for prefill in prefill_reqs:
+            request_states.setdefault(
+                prefill.req_id, _request_state(list(prefill.token_ids))
+            )
+    return ProposeContext(
+        target_hidden_states=hidden,
+        decode_reqs=list(decode_reqs),
+        decode_segments=list(decode_segments),
+        decode_token_ids=list(decode_token_ids),
+        prefill_reqs=list(prefill_reqs),
+        prefill_token_ids=list(prefill_token_ids),
+        prefill_result_modes=list(prefill_result_modes),
+        request_states=request_states,
+        cu_seqlens=list(cu_seqlens),
+        num_decode_segments=len(decode_segments),
+        num_speculative_tokens=num_speculative_tokens,
+        logitsprocs=None,
+        finished_req_ids=set(finished_req_ids),
+    )
+
+
+class TestNativeMTPProposerIngest:
+    def test_intermediate_chunk_ingests_without_drafting(self) -> None:
+        proposer, head = _proposer()
+        chunk = [5, 6, 7]  # positions 0,1,2
+        ctx = _ctx(
+            hidden=_hidden(len(chunk)),
+            prefill_reqs=[_prefill("r1", chunk)],
+            prefill_token_ids=[0],
+            prefill_result_modes=["intermediate"],
+            request_states={"r1": _request_state(chunk)},
+            cu_seqlens=[0, len(chunk)],
+        )
+        # Intermediate chunk drafts nothing; ingests the ready rows (0,1) and
+        # defers the last row (position 2) into pending.
+        assert proposer.propose(ctx) is None
+        assert proposer._slabs["r1"].offset == 2
+        assert "r1" in proposer._pending_last_hidden
+        assert proposer._pending_last_hidden["r1"][0] == 2
+        # Ready slots embed the within-chunk next tokens at position 0.
+        assert head.slot_calls[0] == ([6, 7], 0, (2, HIDDEN))
+
+    def test_deferred_last_slot_consumed_by_next_chunk(self) -> None:
+        proposer, head = _proposer()
+        chunk1 = [5, 6, 7]  # positions 0,1,2
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(chunk1)),
+                prefill_reqs=[_prefill("r1", chunk1)],
+                prefill_token_ids=[0],
+                prefill_result_modes=["intermediate"],
+                request_states={"r1": _request_state(chunk1)},
+                cu_seqlens=[0, len(chunk1)],
+            )
+        )
+        assert proposer._slabs["r1"].offset == 2
+
+        chunk2 = [8, 9]  # positions 3,4
+        out = proposer.propose(
+            _ctx(
+                hidden=_hidden(len(chunk2)),
+                prefill_reqs=[_prefill("r1", chunk2, start_pos=len(chunk1))],
+                prefill_token_ids=[11],  # sampled final token
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(chunk2)],
+            )
+        )
+        # Pending (position 2) prepended, then chunk2 rows -> contiguous 2,3,4.
+        assert out is not None
+        assert out.req_ids == ["r1"]
+        assert out.draft_token_ids == [[11]]  # last slot embeds sampled token 11
+        assert proposer._slabs["r1"].offset == 5
+        assert "r1" not in proposer._pending_last_hidden
+        # Second forward starts at the pending position and covers 3 slots.
+        assert head.forward_calls[-1] == (3, 2, 2)
+        assert head.slot_calls[-1] == ([8, 9, 11], 2, (3, HIDDEN))
+
+    def test_decode_ingests_only_accepted_rows(self) -> None:
+        # The load-bearing invariant: a verify step ingests the ACCEPTED-token
+        # count, not the drafted-token count.
+        proposer, head = _proposer()
+        prompt = [5, 6, 7, 8]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        assert proposer._slabs["r1"].offset == 4
+
+        # Verify step: rows [bonus, d1, d2, d3]; 2 outputs sampled (one accepted
+        # draft + correction) => ingest exactly 2 rows, slab 4 -> 6 (not 4 -> 7).
+        state = _request_state(prompt + [9, 10, 42])
+        segment = _segment(
+            "r1",
+            start_row=0,
+            cache_start_pos=4,
+            draft_token_ids=(10, 11, 12),
+            last_token=9,
+        )
+        out = proposer.propose(
+            _ctx(
+                hidden=_hidden(4),
+                decode_reqs=[("r1", state)],
+                decode_segments=[segment],
+                decode_token_ids=[[10, 42]],
+                cu_seqlens=[0, 4],
+            )
+        )
+        assert out is not None and out.req_ids == ["r1"]
+        assert out.draft_token_ids == [[42]]  # last committed token embedded
+        assert proposer._slabs["r1"].offset == 6
+        assert head.forward_calls[-1] == (2, 4, 4)
+
+    def test_non_greedy_request_is_skipped_entirely(self) -> None:
+        proposer, _ = _proposer()
+        prompt = [5, 6, 7]
+        ctx = _ctx(
+            hidden=_hidden(len(prompt)),
+            prefill_reqs=[_prefill("r1", prompt, temperature=0.8)],
+            prefill_token_ids=[9],
+            prefill_result_modes=["new_final"],
+            request_states={"r1": _request_state(prompt + [9], temperature=0.8)},
+            cu_seqlens=[0, len(prompt)],
+        )
+        assert proposer.propose(ctx) is None
+        assert "r1" not in proposer._slabs
+        assert "r1" not in proposer._pending_last_hidden
+
+    def test_rewind_truncates_and_reingests(self) -> None:
+        """A scheduler preemption-recompute re-forwards committed tokens from an
+        earlier position; the slab truncates and rebuilds exactly."""
+        proposer, _ = _proposer()
+        prompt = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        assert proposer._slabs["r1"].offset == 3
+
+        # Recompute: re-prefill the same span (now 4 tokens) from position 0. The
+        # slab must truncate and rebuild to 4 — not append onto the stale 3.
+        out = proposer.propose(
+            _ctx(
+                hidden=_hidden(4),
+                prefill_reqs=[_prefill("r1", prompt + [9], start_pos=0)],
+                prefill_token_ids=[10],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, 4],
+            )
+        )
+        assert out is not None and out.req_ids == ["r1"]
+        assert proposer._slabs["r1"].offset == 4
+
+    def test_rewind_drops_stale_pending(self) -> None:
+        """A recompute that lands mid-prefill drops the deferred (pending) row
+        from before the preemption; a fresh intermediate defer replaces it."""
+        proposer, _ = _proposer()
+        chunk1 = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(chunk1)),
+                prefill_reqs=[_prefill("r1", chunk1)],
+                prefill_token_ids=[0],
+                prefill_result_modes=["intermediate"],
+                request_states={"r1": _request_state(chunk1)},
+                cu_seqlens=[0, len(chunk1)],
+            )
+        )
+        assert proposer._pending_last_hidden["r1"][0] == 2
+
+        # Recompute from position 0 as a fresh intermediate chunk of 2 tokens.
+        recompute = [5, 6]
+        assert (
+            proposer.propose(
+                _ctx(
+                    hidden=_hidden(len(recompute)),
+                    prefill_reqs=[_prefill("r1", recompute, start_pos=0)],
+                    prefill_token_ids=[0],
+                    prefill_result_modes=["intermediate"],
+                    request_states={"r1": _request_state(recompute)},
+                    cu_seqlens=[0, len(recompute)],
+                )
+            )
+            is None
+        )
+        # Slab rewound to 0 then ingested 1 ready row (position 0); the fresh
+        # defer is at position 1, replacing the stale pending at position 2.
+        assert proposer._slabs["r1"].offset == 1
+        assert proposer._pending_last_hidden["r1"][0] == 1
+
+    def test_hole_fails_loud(self) -> None:
+        """A forward position gap means hidden states were never observed —
+        unrepairable, so propose must raise rather than draft wrongly."""
+        proposer, _ = _proposer()
+        prompt = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        # Decode step whose first row position (10) skips ahead of offset (3).
+        state = _request_state(prompt + [9, 10])
+        segment = _segment("r1", start_row=0, cache_start_pos=10, last_token=9)
+        ctx = _ctx(
+            hidden=_hidden(1),
+            decode_reqs=[("r1", state)],
+            decode_segments=[segment],
+            decode_token_ids=[[10]],
+            cu_seqlens=[0, 1],
+        )
+        with pytest.raises(RuntimeError, match="hole"):
+            proposer.propose(ctx)
+
+    def test_prune_on_finish_removes_slab_and_pending(self) -> None:
+        proposer, _ = _proposer()
+        chunk = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(chunk)),
+                prefill_reqs=[_prefill("r1", chunk)],
+                prefill_token_ids=[0],
+                prefill_result_modes=["intermediate"],
+                request_states={"r1": _request_state(chunk)},
+                cu_seqlens=[0, len(chunk)],
+            )
+        )
+        assert "r1" in proposer._slabs
+        assert "r1" in proposer._pending_last_hidden
+
+        # Next step: the scheduler reports r1 finished -> its state is dropped.
+        assert (
+            proposer.propose(_ctx(hidden=_hidden(1), finished_req_ids=["r1"])) is None
+        )
+        assert "r1" not in proposer._slabs
+        assert "r1" not in proposer._pending_last_hidden
+
+    def test_finished_id_reused_in_the_same_step_rebuilds_from_zero(self) -> None:
+        proposer, _ = _proposer()
+        first = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(first)),
+                prefill_reqs=[_prefill("r1", first)],
+                prefill_token_ids=[0],
+                prefill_result_modes=["intermediate"],
+                request_states={"r1": _request_state(first)},
+                cu_seqlens=[0, len(first)],
+            )
+        )
+
+        # vLLM can hand a finished id straight back to a new request in the same
+        # step, so the reused id must restart rather than continue the old slab.
+        reused = [11, 12]
+        reuse_ctx = {
+            "prefill_reqs": [_prefill("r1", reused)],
+            "prefill_token_ids": [0],
+            "prefill_result_modes": ["intermediate"],
+            "request_states": {"r1": _request_state(reused)},
+            "cu_seqlens": [0, len(reused)],
+        }
+        proposer.propose(
+            _ctx(hidden=_hidden(len(reused)), finished_req_ids=["r1"], **reuse_ctx)
+        )
+
+        fresh, _ = _proposer()
+        fresh.propose(_ctx(hidden=_hidden(len(reused)), **reuse_ctx))
+        assert proposer._slabs["r1"].offset == fresh._slabs["r1"].offset
+
+    def test_release_requests_frees_slab_then_recompute_rebuilds_from_zero(
+        self,
+    ) -> None:
+        """Preemption releases the slab (and any deferred row); a resumed
+        recompute rebuilds from position 0 without tripping the hole guard."""
+        proposer, _ = _proposer()
+        prompt = [5, 6, 7]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[0],
+                prefill_result_modes=["intermediate"],
+                request_states={"r1": _request_state(prompt)},
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        slab = proposer._slabs["r1"]
+        assert slab.offset > 0 and slab.keys is not None
+        assert "r1" in proposer._pending_last_hidden
+
+        # Preemption: the runner releases the request's drafter state. The slab
+        # (and its k/v arrays) and the deferred row are dropped, not retained.
+        proposer.release_requests({"r1"})
+
+        assert "r1" not in proposer._slabs
+        assert "r1" not in proposer._pending_last_hidden
+
+        # Resume: recompute re-forwards the committed tokens from position 0. A
+        # fresh slab is built at offset 0 and rebuilds to 4 -- the hole guard
+        # (first_position > offset) must not fire on the rebuild.
+        out = proposer.propose(
+            _ctx(
+                hidden=_hidden(4),
+                prefill_reqs=[_prefill("r1", prompt + [9], start_pos=0)],
+                prefill_token_ids=[10],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, 4],
+            )
+        )
+        assert out is not None and out.req_ids == ["r1"]
+        assert proposer._slabs["r1"].offset == 4
+
+    def test_missing_hidden_states_fails_loud(self) -> None:
+        proposer, _ = _proposer()
+        ctx = _ctx(
+            hidden=None,
+            prefill_reqs=[_prefill("r1", [5, 6, 7])],
+            prefill_token_ids=[9],
+            prefill_result_modes=["new_final"],
+            cu_seqlens=[0, 3],
+        )
+        with pytest.raises(RuntimeError, match="target hidden states"):
+            proposer.propose(ctx)
+
+    def test_position_zero_zeroing_reaches_build_slot_inputs(self) -> None:
+        # first_position must propagate so the head can zero the absolute
+        # position-0 embedding. A chunk from position 0 sees first_position 0;
+        # a decode segment sees its cache_start_pos.
+        proposer, head = _proposer()
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(3),
+                prefill_reqs=[_prefill("r1", [5, 6, 7])],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, 3],
+            )
+        )
+        assert head.slot_calls[0][1] == 0
+
+        state = _request_state([5, 6, 7, 9, 20])
+        segment = _segment("r1", start_row=0, cache_start_pos=3, last_token=9)
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(1),
+                decode_reqs=[("r1", state)],
+                decode_segments=[segment],
+                decode_token_ids=[[20]],
+                cu_seqlens=[0, 1],
+            )
+        )
+        assert head.slot_calls[-1][1] == 3
+
+    def test_zero_spec_tokens_ingests_without_drafting_then_resumes(self) -> None:
+        # Zero spec tokens: no drafting, but committed slots still ingest so
+        # the slab stays contiguous for when speculation re-enables.
+        proposer, head = _proposer()
+        prompt = [5, 6, 7, 8]
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(len(prompt)),
+                prefill_reqs=[_prefill("r1", prompt)],
+                prefill_token_ids=[9],
+                prefill_result_modes=["new_final"],
+                cu_seqlens=[0, len(prompt)],
+            )
+        )
+        assert proposer._slabs["r1"].offset == 4
+        logits_calls_after_seed = head.logits_calls
+
+        # Verify step with 2 committed rows, but speculation disabled this step.
+        state = _request_state(prompt + [9, 10, 42])
+        segment = _segment(
+            "r1",
+            start_row=0,
+            cache_start_pos=4,
+            draft_token_ids=(10, 11, 12),
+            last_token=9,
+        )
+        out = proposer.propose(
+            _ctx(
+                hidden=_hidden(4),
+                decode_reqs=[("r1", state)],
+                decode_segments=[segment],
+                decode_token_ids=[[10, 42]],
+                cu_seqlens=[0, 4],
+                num_speculative_tokens=0,
+            )
+        )
+        assert out is None
+        assert head.logits_calls == logits_calls_after_seed
+        # The 2 committed rows were still ingested: slab 4 -> 6.
+        assert proposer._slabs["r1"].offset == 6
+
+        # Speculation re-enabled at the now-contiguous position: drafting
+        # resumes without tripping the hole guard.
+        state = _request_state(prompt + [9, 10, 42, 43])
+        segment = _segment("r1", start_row=0, cache_start_pos=6, last_token=42)
+        out = proposer.propose(
+            _ctx(
+                hidden=_hidden(1),
+                decode_reqs=[("r1", state)],
+                decode_segments=[segment],
+                decode_token_ids=[[43]],
+                cu_seqlens=[0, 1],
+                num_speculative_tokens=1,
+            )
+        )
+        assert out is not None and out.req_ids == ["r1"]
+        assert head.logits_calls == logits_calls_after_seed + 1
+        assert proposer._slabs["r1"].offset == 7
+
+
+class TestMTPSlab:
+    def test_dim_inference_and_growth_across_step_boundary(self) -> None:
+        slab = MTPSlab()
+        # k feature dim 5, v feature dim 3 — inferred, not hardcoded.
+        k1 = mx.ones((1, 1, 250, 5))
+        v1 = mx.full((1, 1, 250, 3), 2.0)
+        fk, fv = slab.update_and_fetch(k1, v1)
+        assert slab.offset == 250
+        assert fk.shape == (1, 1, 250, 5)
+        assert fv.shape == (1, 1, 250, 3)
+
+        # 250 -> 270 crosses the 256 growth boundary; history is preserved.
+        k2 = mx.full((1, 1, 20, 5), 3.0)
+        v2 = mx.full((1, 1, 20, 3), 4.0)
+        fk, fv = slab.update_and_fetch(k2, v2)
+        assert slab.offset == 270
+        assert fk.shape == (1, 1, 270, 5)
+        assert fv.shape == (1, 1, 270, 3)
+        mx.eval(fk, fv)
+        assert float(fk[0, 0, 0, 0]) == 1.0
+        assert float(fk[0, 0, 260, 0]) == 3.0
+        assert float(fv[0, 0, 249, 0]) == 2.0
+        assert float(fv[0, 0, 269, 0]) == 4.0
+
+    def test_truncate_to_rewinds_offset_and_reingest_overwrites(self) -> None:
+        slab = MTPSlab()
+        slab.update_and_fetch(mx.ones((1, 1, 10, 5)), mx.ones((1, 1, 10, 3)))
+        assert slab.offset == 10
+
+        slab.truncate_to(4)
+        assert slab.offset == 4
+        fk, _ = slab.update_and_fetch(
+            mx.full((1, 1, 2, 5), 7.0), mx.full((1, 1, 2, 3), 7.0)
+        )
+        assert slab.offset == 6
+        assert fk.shape == (1, 1, 6, 5)
+        mx.eval(fk)
+        # Rows 4,5 were overwritten by the re-ingest.
+        assert float(fk[0, 0, 4, 0]) == 7.0
+
+    def test_truncate_to_rejects_out_of_range(self) -> None:
+        slab = MTPSlab()
+        slab.update_and_fetch(mx.ones((1, 1, 5, 5)), mx.ones((1, 1, 5, 3)))
+        with pytest.raises(ValueError, match="non-negative"):
+            slab.truncate_to(-1)
+        with pytest.raises(ValueError, match="cannot advance"):
+            slab.truncate_to(6)
+
+
+class TestNativeMTPProposerBuild:
+    def test_build_loads_and_constructs_over_runtime_model(self) -> None:
+        model = object()
+        runtime = SimpleNamespace(model=model, model_name="/fake-head")
+        calls: list[dict] = []
+
+        class _Loader:
+            def load_if_needed(self, *, speculative_config, target_config):
+                calls.append(
+                    {
+                        "speculative_config": speculative_config,
+                        "target_config": target_config,
+                    }
+                )
+                return runtime
+
+        target_config = {"hidden_size": 2048}
+
+        proposer = NativeMTPProposer.build(
+            speculative_config=SimpleNamespace(),
+            controller=SpeculativeDecodeController(),
+            loader=_Loader(),
+            model_type="glm4_moe_lite_mtp",
+            target_config=target_config,
+        )
+
+        assert isinstance(proposer, NativeMTPProposer)
+        assert proposer._model is model
+        assert calls and calls[0]["target_config"] is target_config

--- a/tests/test_native_mtp_benchmark.py
+++ b/tests/test_native_mtp_benchmark.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pure unit tests for the native MTP benchmark helper (thin gemma4 sibling)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tools.benchmark import native_mtp_benchmark as bench
+
+
+def test_parser_extends_gemma4_parser_with_chat_flag() -> None:
+    args = bench.build_parser().parse_args(["--model", "m"])
+
+    assert args.chat is False
+    assert args.async_scheduling is False
+
+    args = bench.build_parser().parse_args(["--model", "m", "--chat"])
+    assert args.chat is True
+
+
+def test_spec_decode_metrics_computes_acceptance_rate() -> None:
+    class _Llm:
+        def get_metrics(self):
+            return [
+                SimpleNamespace(name="vllm:spec_decode_num_drafts", value=10),
+                SimpleNamespace(name="vllm:spec_decode_num_draft_tokens", value=10),
+                SimpleNamespace(name="vllm:spec_decode_num_accepted_tokens", value=8),
+                SimpleNamespace(name="vllm:other_metric", value=1),
+            ]
+
+    metrics = bench.spec_decode_metrics(_Llm(), require=True)
+
+    assert metrics["spec_decode_num_draft_tokens"] == 10
+    assert metrics["spec_decode_num_accepted_tokens"] == 8
+    assert metrics["acceptance_rate"] == 0.8
+    assert "other_metric" not in metrics
+
+
+def test_spec_decode_metrics_requires_counters_for_mtp_run() -> None:
+    class _Llm:
+        def get_metrics(self):
+            return [SimpleNamespace(name="vllm:other_metric", value=1)]
+
+    # An MTP run whose engine reports no draft/accepted counters fails loud
+    # rather than emitting a result with the promised acceptance evidence missing.
+    with pytest.raises(RuntimeError, match="spec_decode_num_draft_tokens"):
+        bench.spec_decode_metrics(_Llm(), require=True)
+
+
+def test_spec_decode_metrics_baseline_allows_missing_counters() -> None:
+    class _Llm:
+        def get_metrics(self):
+            return [SimpleNamespace(name="vllm:other_metric", value=1)]
+
+    metrics = bench.spec_decode_metrics(_Llm(), require=False)
+
+    assert "acceptance_rate" not in metrics

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -21,6 +21,10 @@ from vllm_metal.attention.state import HybridGDNStateManager
 from vllm_metal.distributed.pipeline import PipelineGroup
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPDraftSeed
+from vllm_metal.v1.mtp_heads.registry import (
+    NativeMTPBuildContext,
+    NativeMTPHeadRegistry,
+)
 from vllm_metal.v1.proposer import Gemma4MTPProposer
 
 
@@ -83,6 +87,134 @@ def test_gemma4_mtp_config_installs_gemma4_proposer() -> None:
     runner.install_drafter(num_blocks=1, block_size=16)
 
     assert isinstance(runner._drafter, Gemma4MTPProposer)
+
+
+class _FakeMTPProposer:
+    def needs_target_hidden_states(self, *args, **kwargs) -> bool:
+        return False
+
+    def propose(self, ctx) -> None:
+        return None
+
+
+class _RecordingMTPHead:
+    model_type = "recording_mtp"
+
+    def __init__(self) -> None:
+        self.contexts: list[object] = []
+        self.proposer = _FakeMTPProposer()
+
+    def build_proposer(self, context: NativeMTPBuildContext) -> _FakeMTPProposer:
+        self.contexts.append(context)
+        return self.proposer
+
+
+class TestInstallDrafterMtpDispatch:
+    def _make_mtp_spec(
+        self, *, model_type: str, num_speculative_tokens: int = 1
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            method="mtp",
+            uses_draft_model=lambda: False,
+            num_speculative_tokens=num_speculative_tokens,
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type=model_type),
+            ),
+        )
+
+    def _make_vllm_config(
+        self, spec: SimpleNamespace, *, enable_prefix_caching: bool = False
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            speculative_config=spec,
+            cache_config=SimpleNamespace(enable_prefix_caching=enable_prefix_caching),
+        )
+
+    def test_registered_head_builds_and_installs_its_proposer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        head = _RecordingMTPHead()
+        monkeypatch.setattr(NativeMTPHeadRegistry, "_heads", {})
+        NativeMTPHeadRegistry.register(head)
+        runner = make_stub_runner(
+            tokenizer=object(),
+            model_args={"target": "cfg"},
+        )
+        spec = self._make_mtp_spec(model_type=head.model_type)
+        runner.vllm_config = SimpleNamespace(speculative_config=spec)
+
+        runner.install_drafter(num_blocks=1, block_size=16)
+
+        assert runner._drafter is head.proposer
+        (context,) = head.contexts
+        assert isinstance(context, NativeMTPBuildContext)
+        assert context.speculative_config is spec
+        assert context.controller is runner._spec_decode_controller
+        assert context.vllm_config is runner.vllm_config
+        assert context.target_config is runner.model_args
+
+    def test_unregistered_mtp_draft_raises_naming_model_type(self) -> None:
+        runner = make_stub_runner(tokenizer=object())
+        runner.vllm_config = SimpleNamespace(
+            speculative_config=self._make_mtp_spec(model_type="eagle"),
+        )
+
+        with pytest.raises(NotImplementedError) as excinfo:
+            runner.install_drafter(num_blocks=1, block_size=16)
+
+        message = str(excinfo.value)
+        assert "'eagle'" in message
+        assert "Gemma4 MTP" in message
+
+    def test_glm_head_rejects_prefix_caching_through_install_drafter(self) -> None:
+        runner = make_stub_runner(tokenizer=object(), kv_cache_dtype=None)
+        runner.vllm_config = self._make_vllm_config(
+            self._make_mtp_spec(model_type="glm4_moe_lite_mtp"),
+            enable_prefix_caching=True,
+        )
+
+        with pytest.raises(NotImplementedError, match="no-enable-prefix-caching"):
+            runner.install_drafter(num_blocks=1, block_size=16)
+
+    def test_glm_head_rejects_multi_token_through_install_drafter(self) -> None:
+        runner = make_stub_runner(tokenizer=object(), kv_cache_dtype=None)
+        runner.vllm_config = self._make_vllm_config(
+            self._make_mtp_spec(
+                model_type="glm4_moe_lite_mtp", num_speculative_tokens=2
+            ),
+        )
+
+        with pytest.raises(NotImplementedError, match="at most 1 speculative"):
+            runner.install_drafter(num_blocks=1, block_size=16)
+
+
+class TestDrafterReleaseOnLifecycle:
+    def test_reconcile_releases_drafter_state_for_invalidated_requests(self) -> None:
+        released: list[set[str]] = []
+
+        class _RecordingDrafter:
+            def needs_target_hidden_states(self, *args, **kwargs) -> bool:
+                return False
+
+            def propose(self, ctx) -> None:
+                return None
+
+            def release_requests(self, req_ids: set[str]) -> None:
+                released.append(set(req_ids))
+
+        runner = make_stub_runner(tokenizer=object())
+        runner._drafter = _RecordingDrafter()
+
+        # Eviction + preemption + resume all invalidate the drafter's per-request
+        # state, mirroring the runtime recurrent-state release path.
+        runner._reconcile_request_lifecycle(
+            {"done"},
+            preempted_req_ids={"paused"},
+            resumed_req_ids={"back"},
+            materialize_runtime_state=False,
+        )
+
+        assert released == [{"done", "paused", "back"}]
 
 
 class TestV1MetalModelRunnerGenerate:

--- a/tools/benchmark/native_mtp_benchmark.py
+++ b/tools/benchmark/native_mtp_benchmark.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline native MTP-head throughput benchmark (GLM-4.7-Flash first).
+
+Thin sibling of ``gemma4_mtp_benchmark.py`` (whose prompt/measurement helpers it
+reuses) for native MTP heads run by ``NativeMTPProposer``. Differences from the
+Gemma4 tool, both forced by the native-MTP contract:
+
+- ``enable_prefix_caching=False`` is always passed: cached prompt tokens skip
+  the target forward that produces the hidden states the head consumes, so the
+  runner rejects native MTP with prefix caching on (Gemma4 MTP tolerates it by
+  reading target paged KV instead).
+- ``--chat`` renders each prompt through the tokenizer's chat template
+  (``add_generation_prompt=True``); raw continuation prompts drive thinking
+  models into degenerate loops that distort acceptance rates.
+
+It also records the engine's ``spec_decode`` counters (drafts / accepted) in
+the output JSON so acceptance travels with every benchmark artifact.
+
+Usage (baseline, then MTP; one mode per process):
+  python tools/benchmark/native_mtp_benchmark.py \
+      --model mlx-community/GLM-4.7-Flash-4bit \
+      --batch-size 1 --max-tokens 128 --repeats 3 --warmup 1 \
+      --ignore-eos --chat --output-json baseline_bs1.json
+  python tools/benchmark/native_mtp_benchmark.py \
+      --model mlx-community/GLM-4.7-Flash-4bit \
+      --assistant-model samithaj/GLM-4.7-Flash-MTP-4bit \
+      --batch-size 1 --max-tokens 128 --repeats 3 --warmup 1 \
+      --ignore-eos --chat --output-json mtp_bs1.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+if __package__ in (None, ""):
+    # Executed as a script: make the repo root importable for tools.benchmark.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tools.benchmark.gemma4_mtp_benchmark import (  # noqa: E402
+    RunResult,
+    _build_llm_kwargs,
+    _run_generate,
+    _summary,
+    environment_metadata,
+    select_prompts,
+)
+from tools.benchmark.gemma4_mtp_benchmark import (  # noqa: E402
+    build_parser as _gemma4_build_parser,
+)
+
+
+def spec_decode_metrics(llm: Any, *, require: bool) -> dict[str, Any]:
+    """Read the engine's cumulative spec-decode counters (drafts / accepted).
+
+    ``require`` fails loud when the draft/accepted counters are absent: for an MTP
+    run they are the benchmark's promised evidence, so a silent miss must not pass
+    as a result. A baseline run (no drafter) reports none and passes
+    ``require=False``.
+    """
+    metrics: dict[str, Any] = {}
+    for metric in llm.get_metrics():
+        if "spec_decode" not in metric.name:
+            continue
+        value = getattr(metric, "value", None)
+        if value is None:
+            value = getattr(metric, "values", None)
+        metrics[metric.name.split(":")[-1]] = value
+    drafted = metrics.get("spec_decode_num_draft_tokens")
+    accepted = metrics.get("spec_decode_num_accepted_tokens")
+    if require and (drafted is None or accepted is None):
+        raise RuntimeError(
+            "Native MTP benchmark expected the engine's spec-decode draft/accepted "
+            "counters (spec_decode_num_draft_tokens / "
+            "spec_decode_num_accepted_tokens) but they were not reported; got "
+            f"{sorted(metrics)}."
+        )
+    if drafted and accepted is not None:
+        metrics["acceptance_rate"] = round(accepted / drafted, 4)
+    return metrics
+
+
+def _measured_delta(
+    cumulative: dict[str, Any], warmup: dict[str, Any]
+) -> dict[str, Any]:
+    """Subtract the post-warmup counter snapshot from the final counters.
+
+    Numeric counters (and per-position lists) become measured-runs-only values;
+    ``acceptance_rate`` is recomputed from the deltas.
+    """
+    delta: dict[str, Any] = {}
+    for name, value in cumulative.items():
+        if name == "acceptance_rate":
+            continue
+        base = warmup.get(name)
+        if isinstance(value, (int, float)) and isinstance(base, (int, float)):
+            delta[name] = value - base
+        elif isinstance(value, list) and isinstance(base, list):
+            delta[name] = [
+                v - b
+                if isinstance(v, (int, float)) and isinstance(b, (int, float))
+                else v
+                for v, b in zip(value, base, strict=True)
+            ]
+        else:
+            delta[name] = value
+    drafted = delta.get("spec_decode_num_draft_tokens")
+    accepted = delta.get("spec_decode_num_accepted_tokens")
+    if drafted and accepted is not None:
+        delta["acceptance_rate"] = round(accepted / drafted, 4)
+    return delta
+
+
+def chat_render(llm: Any, prompts: Sequence[str]) -> list[str]:
+    """Render each prompt as a single-turn chat with a generation prompt."""
+    tokenizer = llm.get_tokenizer()
+    return [
+        tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for prompt in prompts
+    ]
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    """Run the requested benchmark and return JSON-serializable results."""
+    from vllm import LLM, SamplingParams
+
+    prompts = select_prompts(
+        batch_size=args.num_prompts or args.batch_size,
+        prompts=args.prompt,
+        prompt_file=args.prompt_file,
+    )
+    llm_kwargs = _build_llm_kwargs(args)
+    # Native MTP hard requirement (see module docstring); the runner would
+    # reject the speculative config otherwise.
+    llm_kwargs["enable_prefix_caching"] = False
+    # LLM() defaults stats off; keep them on so the spec-decode acceptance
+    # counters land in the output JSON alongside the throughput numbers.
+    llm_kwargs["disable_log_stats"] = False
+    llm = LLM(**llm_kwargs)
+    if args.chat:
+        prompts = chat_render(llm, prompts)
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        max_tokens=args.max_tokens,
+        ignore_eos=args.ignore_eos,
+    )
+
+    # A repeat runs the whole prompt corpus in slices of ``batch_size`` (one
+    # generate() per slice), so ``--num-prompts 8 --batch-size 1`` measures 8
+    # distinct serialized requests instead of the first prompt alone.
+    slices = [
+        prompts[i : i + args.batch_size]
+        for i in range(0, len(prompts), args.batch_size)
+    ]
+
+    def run_corpus(engine: Any, *, include_text: bool) -> RunResult:
+        parts = [
+            _run_generate(engine, chunk, sampling_params, include_text=include_text)
+            for chunk in slices
+        ]
+        elapsed_s = sum(part.elapsed_s for part in parts)
+        prompt_tokens = sum(part.prompt_tokens for part in parts)
+        output_tokens = sum(part.output_tokens for part in parts)
+        total_tokens = prompt_tokens + output_tokens
+        return RunResult(
+            elapsed_s=elapsed_s,
+            prompt_tokens=prompt_tokens,
+            output_tokens=output_tokens,
+            output_tokens_per_s=output_tokens / elapsed_s if elapsed_s else 0.0,
+            total_tokens_per_s=total_tokens / elapsed_s if elapsed_s else 0.0,
+            outputs=[out for part in parts for out in part.outputs],
+        )
+
+    for _ in range(args.warmup):
+        run_corpus(llm, include_text=False)
+
+    # The engine's spec-decode counters are cumulative, so snapshot after warmup
+    # and report the measured-runs delta — otherwise warmup drafts pollute the
+    # reported acceptance rate.
+    warmup_metrics = spec_decode_metrics(llm, require=False)
+
+    results = [
+        run_corpus(llm, include_text=args.include_text) for _ in range(args.repeats)
+    ]
+    cumulative = spec_decode_metrics(llm, require=bool(args.assistant_model))
+    metrics = _measured_delta(cumulative, warmup_metrics)
+
+    # Let short-lived benchmark processes release MLX buffers before exit logs.
+    del llm
+    gc.collect()
+
+    mode = "native_mtp" if args.assistant_model else "baseline"
+    return {
+        "schema": "native-mtp-benchmark-v1",
+        "mode": mode,
+        "label": args.label or mode,
+        "config": {
+            "model": args.model,
+            "assistant_model": args.assistant_model,
+            "batch_size": args.batch_size,
+            "num_prompts": args.num_prompts or args.batch_size,
+            "max_tokens": args.max_tokens,
+            "max_model_len": args.max_model_len,
+            "max_num_batched_tokens": args.max_num_batched_tokens,
+            "gpu_memory_utilization": args.gpu_memory_utilization,
+            "speculative_method": "mtp" if args.assistant_model else None,
+            "num_speculative_tokens": (
+                args.num_speculative_tokens if args.assistant_model else None
+            ),
+            "enable_prefix_caching": False,
+            "chat": args.chat,
+            "ignore_eos": args.ignore_eos,
+            "async_scheduling": args.async_scheduling,
+            "warmup": args.warmup,
+            "repeats": args.repeats,
+        },
+        "environment": environment_metadata(),
+        "prompts": prompts,
+        "spec_decode_metrics": metrics,
+        "spec_decode_metrics_cumulative": cumulative,
+        "summary": _summary(results),
+        "runs": [asdict(result) for result in results],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = _gemma4_build_parser()
+    parser.prog = Path(__file__).name
+    parser.add_argument(
+        "--num-prompts",
+        type=int,
+        default=None,
+        help="Total distinct prompts per repeat, run serialized in batch_size "
+        "slices (default: batch_size).",
+    )
+    parser.description = __doc__
+    parser.add_argument(
+        "--chat",
+        action="store_true",
+        help="Render prompts through the tokenizer chat template.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = run_benchmark(args)
+    text = json.dumps(result, indent=2, sort_keys=True)
+    if args.output_json is not None:
+        args.output_json.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -15,6 +15,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from transformers.configuration_utils import PretrainedConfig
+
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
@@ -28,6 +30,7 @@ def apply_compat_patches() -> None:
         return
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
+    _patch_vllm_glm4_moe_lite_mtp_config_loading()
     _patch_vllm_bytelevel_tokenizer_loading()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
@@ -289,6 +292,117 @@ def _patch_vllm_gemma4_mtp_config_loading() -> None:
     # override runs.
     AutoConfig.register("gemma4_assistant", config_cls, exist_ok=True)
     logger.debug("Registered Gemma4 assistant config compatibility")
+
+
+@lru_cache(maxsize=1)
+def _glm4_moe_lite_config_cls() -> type[Any]:
+    """The base Transformers config the nextn head nests under ``text_config``.
+
+    Imported lazily so a Transformers release without ``glm4_moe_lite`` raises
+    here (caught by the caller) rather than at module import.
+    """
+    from transformers.models.glm4_moe_lite.configuration_glm4_moe_lite import (
+        Glm4MoeLiteConfig,
+    )
+
+    return Glm4MoeLiteConfig
+
+
+class Glm4MoeLiteMTPCompatConfig(PretrainedConfig):
+    """Transformers config for the GLM-4.7-Flash nextn head.
+
+    The mlx-vlm drafter split nests the source model config under ``text_config``
+    and leaves the head's own ``architectures`` / ``num_nextn_predict_layers`` out
+    of the top level. vLLM's MTP override keys on the top-level ``architectures[0]``
+    (``Glm4MoeLiteForCausalLM``) and ``num_nextn_predict_layers`` to normalize the
+    draft into ``Glm4MoeLiteMTPModel`` (``num_hidden_layers=0``, ``n_predict=1``),
+    so promote both from the nested config before that override runs.
+
+    Defined at module scope (not a closure) so vLLM's spawn-based EngineCore can
+    pickle a config instance by qualified name into the worker process.
+    """
+
+    model_type = "glm4_moe_lite_mtp"
+
+    def __init__(self, text_config: Any | None = None, **kwargs: Any) -> None:
+        base = _glm4_moe_lite_config_cls()
+        if text_config is None:
+            self.text_config = base()
+        elif isinstance(text_config, base):
+            self.text_config = text_config
+        elif isinstance(text_config, Mapping):
+            self.text_config = base(**text_config)
+        else:
+            self.text_config = text_config
+        kwargs.setdefault(
+            "architectures", getattr(self.text_config, "architectures", None)
+        )
+        if "num_nextn_predict_layers" not in kwargs:
+            nextn = getattr(self.text_config, "num_nextn_predict_layers", None)
+            if nextn is not None:
+                kwargs["num_nextn_predict_layers"] = nextn
+        super().__init__(**kwargs)
+
+    def get_text_config(self, decoder: bool = False) -> Any:
+        return self.text_config
+
+
+def _glm4_moe_lite_mtp_config_class() -> type[Any]:
+    """Return the GLM-4.7-Flash nextn head config, wiring its nested
+    ``text_config`` sub-config. Raises if the pinned Transformers lacks
+    ``glm4_moe_lite`` (caught by the caller).
+    """
+    Glm4MoeLiteMTPCompatConfig.sub_configs = {
+        "text_config": _glm4_moe_lite_config_cls()
+    }
+    return Glm4MoeLiteMTPCompatConfig
+
+
+def _transformers_knows_glm4_moe_lite_mtp(auto_config: Any) -> bool:
+    try:
+        auto_config.for_model("glm4_moe_lite_mtp")
+    except ValueError:
+        return False
+    return True
+
+
+def _patch_vllm_glm4_moe_lite_mtp_config_loading() -> None:
+    """Register the GLM-4.7-Flash ``glm4_moe_lite_mtp`` draft config for the pin.
+
+    vLLM normalizes a ``Glm4MoeLiteForCausalLM`` draft config into the
+    ``glm4_moe_lite_mtp`` MTP wrapper (``num_hidden_layers=0``,
+    ``n_predict=num_nextn_predict_layers``), but the pinned Transformers release
+    has no ``glm4_moe_lite_mtp`` AutoConfig entry, so parsing the head
+    checkpoint's ``model_type`` fails before that override runs. Keep the shim to
+    config loading only; model construction stays owned by vllm-metal's native
+    MTP head modules. Mirrors ``_patch_vllm_gemma4_mtp_config_loading``.
+    """
+    try:
+        from transformers import AutoConfig
+    except ImportError as exc:
+        logger.warning(
+            "Could not install GLM4 MoE-lite MTP config compatibility patch: %s",
+            exc,
+        )
+        return
+
+    if _transformers_knows_glm4_moe_lite_mtp(AutoConfig):
+        return
+
+    try:
+        config_cls = _glm4_moe_lite_mtp_config_class()
+    except ImportError as exc:
+        logger.warning(
+            "Could not install GLM4 MoE-lite MTP config compatibility patch "
+            "because Glm4MoeLite config classes are unavailable: %s",
+            exc,
+        )
+        return
+
+    # TODO: remove once the supported dependency stack parses raw
+    # ``model_type=glm4_moe_lite_mtp`` configs before vLLM's MTP override runs.
+    AutoConfig.register("glm4_moe_lite_mtp", config_cls, exist_ok=True)
+    logger.debug("Registered GLM4 MoE-lite MTP config compatibility")
 
 
 def _decoder_tree_contains_type(value: Any, decoder_type: str) -> bool:

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -207,6 +207,17 @@ class DraftModelProposer:
             draft_token_ids=[[int(token) for token in row] for row in rows],
         )
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # Return a preempted/evicted request's draft KV blocks to the free pool
+        # and drop its committed-length bookkeeping, so it does not pin draft
+        # cache while it waits; a resumed request re-ingests from the paged
+        # context. Mirrors _prune_finished for an explicit lifecycle set.
+        for req_id in req_ids:
+            blocks = self._req_blocks.pop(req_id, None)
+            if blocks is not None:
+                self._free_blocks.extend(blocks)
+            self._draft_seq_lens.pop(req_id, None)
+
     # -- internals -----------------------------------------------------------
 
     def _prune_finished(self, request_states: Any) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -83,6 +83,10 @@ from vllm_metal.v1.model_adapter import (
     TargetModelForwardOutput,
 )
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
+from vllm_metal.v1.mtp_heads.registry import (
+    NativeMTPBuildContext,
+    NativeMTPHeadRegistry,
+)
 from vllm_metal.v1.pooling import (
     finish_paged_pooling_batch,
     forward_sequence_hidden_states,
@@ -771,10 +775,24 @@ class MetalModelRunner:
                 vllm_config=self.vllm_config,
                 controller=self._spec_decode_controller,
             )
+        elif spec.method == "mtp":
+            head = NativeMTPHeadRegistry.find(spec)
+            if head is None:
+                raise NotImplementedError(
+                    NativeMTPHeadRegistry.unsupported_message(spec)
+                )
+            context = NativeMTPBuildContext(
+                speculative_config=spec,
+                controller=self._spec_decode_controller,
+                vllm_config=self.vllm_config,
+                target_config=self.model_args,
+            )
+            self._drafter = head.build_proposer(context)
         else:
             raise NotImplementedError(
                 f"Speculative method {spec.method!r} is not supported on Metal "
-                "(supported: Gemma4 MTP, draft_model, ngram)."
+                "(supported: Gemma4 MTP, native MTP heads "
+                f"{NativeMTPHeadRegistry.registered_types()}, draft_model, ngram)."
             )
 
     def estimate_one_sequence_kv_bytes(
@@ -2208,14 +2226,22 @@ class MetalModelRunner:
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
 
+        invalidated = set(evicted_req_ids)
+        if preempted_req_ids:
+            invalidated.update(preempted_req_ids)
+        if resumed_req_ids:
+            invalidated.update(resumed_req_ids)
+
+        # A drafter that pins per-request state (native MTP's KV slab, draft-model
+        # cache blocks) releases it on the same events as the runtime's recurrent
+        # state (#489 release-don't-hold): a waiting request must not hold the
+        # resource, and a resumed request rebuilds it during recompute.
+        if invalidated and self._drafter is not None:
+            self._drafter.release_requests(invalidated)
+
         if runtime is not None:
-            runtime_invalidated = set(evicted_req_ids)
-            if preempted_req_ids:
-                runtime_invalidated.update(preempted_req_ids)
-            if resumed_req_ids:
-                runtime_invalidated.update(resumed_req_ids)
-            if runtime_invalidated:
-                runtime.release_requests(runtime_invalidated)
+            if invalidated:
+                runtime.release_requests(invalidated)
             if materialize_runtime_state:
                 runtime.materialize_pending_state()
 

--- a/vllm_metal/v1/mtp_heads/__init__.py
+++ b/vllm_metal/v1/mtp_heads/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MTP head implementations."""
+
+from vllm_metal.v1.mtp_heads import glm4 as _glm4  # noqa: F401

--- a/vllm_metal/v1/mtp_heads/glm4.py
+++ b/vllm_metal/v1/mtp_heads/glm4.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-4.7-Flash native MTP head."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vllm_metal.v1.mtp_heads.registry import (
+    NativeMTPBuildContext,
+    NativeMTPHeadRegistry,
+)
+
+if TYPE_CHECKING:
+    from vllm_metal.v1.proposer import MetalProposer
+
+
+class Glm4MoeLiteMTPHead:
+    """Native MTP head for GLM-4.7-Flash (``glm4_moe_lite_mtp``)."""
+
+    model_type = "glm4_moe_lite_mtp"
+    max_num_speculative_tokens = 1
+
+    def build_proposer(self, context: NativeMTPBuildContext) -> MetalProposer:
+        speculative_config = context.speculative_config
+        if context.vllm_config.cache_config.enable_prefix_caching:
+            raise NotImplementedError(
+                "Native MTP speculative decoding on Metal requires prefix "
+                "caching to be OFF: cached prompt tokens skip the target "
+                "forward that produces the hidden states the MTP head "
+                "consumes, so their slots could never be built. Restart with "
+                "--no-enable-prefix-caching."
+            )
+        if speculative_config.num_speculative_tokens > self.max_num_speculative_tokens:
+            raise NotImplementedError(
+                "Native MTP head "
+                f"{self.model_type!r} supports at most "
+                f"{self.max_num_speculative_tokens} speculative "
+                f"token(s), got num_speculative_tokens="
+                f"{speculative_config.num_speculative_tokens}."
+            )
+        if context.vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise NotImplementedError(
+                "Native MTP speculative decoding on Metal does not support "
+                "pipeline parallelism: a non-last pipeline stage does not produce "
+                "the target final hidden states the MTP head consumes. Run with "
+                "pipeline_parallel_size=1."
+            )
+
+        from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import Glm4MoeLiteMTPHeadLoader
+        from vllm_metal.v1.mtp_proposer import NativeMTPProposer
+
+        return NativeMTPProposer.build(
+            speculative_config=speculative_config,
+            controller=context.controller,
+            loader=Glm4MoeLiteMTPHeadLoader(),
+            model_type=self.model_type,
+            target_config=context.target_config,
+        )
+
+
+NativeMTPHeadRegistry.register(Glm4MoeLiteMTPHead())

--- a/vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp.py
+++ b/vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp.py
@@ -1,0 +1,879 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-4.7-Flash native MTP head: MLX model, weight transform, loader, metadata.
+
+The ``glm4_moe_lite`` (GLM-4.7-Flash) family ships a single trained nextn layer
+(``model.layers.<num_hidden_layers>.*``) that predicts one extra token. This
+module runs that layer as a tiny standalone MLX model over the "slot stream":
+
+    slot_p = eh_proj([enorm(embed(t_{p+1})), hnorm(h_p)])
+
+where ``h_p`` is the target's post-final-norm hidden state. One stock mlx_lm
+``Glm4MoeLiteDecoderLayer`` forward over the appended slots, then the shared
+head norm + untied lm_head, yields one greedy draft token.
+
+The checkpoint this model loads is the flat, post-``sanitize`` layout emitted by
+the mlx-vlm ``glm4_moe_lite_mtp`` drafter split; that split and
+``convert_nextn_weights`` share the transform so there is one source of truth.
+
+The :class:`~vllm_metal.v1.mtp_heads.NativeMTPHead` that registers this head
+imports its model and loader lazily, so ``import vllm_metal.v1.mtp_heads`` stays
+free of mlx / mlx_lm.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, fields
+from json import JSONDecodeError, loads
+from numbers import Integral, Real
+from pathlib import Path
+from threading import Lock
+from typing import Any, ClassVar
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+from mlx_lm.models.base import BaseModelArgs, create_attention_mask
+from mlx_lm.models.glm4_moe_lite import Glm4MoeLiteDecoderLayer
+from mlx_lm.models.glm4_moe_lite import ModelArgs as Glm4MoeLiteBackboneArgs
+from vllm.logger import init_logger
+
+from vllm_metal.v1.mlx_lm_paths import mlx_lm_compatible_model_path
+
+logger = init_logger(__name__)
+
+GLM4_MOE_LITE_MTP_MODEL_TYPE = "glm4_moe_lite_mtp"
+GLM4_MOE_LITE_MTP_NUM_NEXTN = 1
+GLM4_MOE_LITE_TARGET_MODEL_TYPE = "glm4_moe_lite"
+
+# The head ships as a hosted, revision-pinned drafter checkpoint; error messages
+# point users at those repos (or at the mlx-vlm split tool for a custom source
+# revision or quantization).
+HOSTED_HEAD_REPOS = (
+    "samithaj/GLM-4.7-Flash-MTP-4bit",
+    "samithaj/GLM-4.7-Flash-MTP-bf16",
+)
+SPLIT_TOOL = "python -m mlx_vlm.speculative.drafters.glm4_moe_lite_mtp.split"
+_HEAD_SOURCE_HINT = (
+    f"Use a hosted GLM-4.7-Flash MTP head ({HOSTED_HEAD_REPOS[0]} or "
+    f"{HOSTED_HEAD_REPOS[1]}), or split your own with '{SPLIT_TOOL}'."
+)
+
+_HEAD_DOWNLOAD_ALLOW_PATTERNS = [
+    "config.json",
+    "*.safetensors",
+    "*.safetensors.index.json",
+]
+
+# Flat-layout prefixes shared by the model tree and the weight transform below.
+_MTP_ATTN_PREFIX = "model.mtp_block.self_attn"
+_MTP_MLP_PREFIX = "model.mtp_block.mlp"
+
+# Compat / target hyperparameters that must match between the extracted head and
+# the target model for the shared MLA + embedding math to be valid.
+_COMPAT_FIELDS = (
+    "hidden_size",
+    "vocab_size",
+    "kv_lora_rank",
+    "qk_rope_head_dim",
+    "qk_nope_head_dim",
+    "v_head_dim",
+    "num_attention_heads",
+    "rope_theta",
+    "rms_norm_eps",
+)
+
+
+@dataclass
+class Glm4MoeLiteMTPArgs(BaseModelArgs):
+    """MLX model args for the extracted GLM-4.7-Flash nextn head checkpoint.
+
+    Mirrors the field set that ``mlx_lm.models.glm4_moe_lite.ModelArgs`` needs to
+    build one decoder layer, plus the MTP-specific ``model_type`` /
+    ``num_nextn_predict_layers`` contract. ``num_hidden_layers`` is ``0`` for the
+    standalone head (the backbone is stripped); the head builds exactly one
+    ``mtp_block`` regardless.
+    """
+
+    model_type: str = GLM4_MOE_LITE_MTP_MODEL_TYPE
+    vocab_size: int = 154880
+    hidden_size: int = 2048
+    intermediate_size: int = 10240
+    moe_intermediate_size: int = 1536
+    num_hidden_layers: int = 0
+    num_attention_heads: int = 20
+    num_key_value_heads: int = 20
+    n_shared_experts: int | None = 1
+    n_routed_experts: int = 64
+    routed_scaling_factor: float = 1.8
+    kv_lora_rank: int = 512
+    q_lora_rank: int | None = 768
+    qk_rope_head_dim: int = 64
+    qk_nope_head_dim: int = 192
+    v_head_dim: int = 256
+    topk_method: str = "noaux_tc"
+    scoring_func: str = "sigmoid"
+    norm_topk_prob: bool = True
+    n_group: int = 1
+    topk_group: int = 1
+    num_experts_per_tok: int = 4
+    moe_layer_freq: int = 1
+    first_k_dense_replace: int = 1
+    max_position_embeddings: int = 202752
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 1_000_000.0
+    rope_scaling: dict[str, Any] | None = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    partial_rotary_factor: float = 1.0
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = GLM4_MOE_LITE_MTP_NUM_NEXTN
+    quantization: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.model_type != GLM4_MOE_LITE_MTP_MODEL_TYPE:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires "
+                f"model_type={GLM4_MOE_LITE_MTP_MODEL_TYPE!r}, got "
+                f"{self.model_type!r}"
+            )
+        if self.num_nextn_predict_layers != GLM4_MOE_LITE_MTP_NUM_NEXTN:
+            raise ValueError(
+                "Glm4MoeLiteMTP head only supports "
+                f"num_nextn_predict_layers={GLM4_MOE_LITE_MTP_NUM_NEXTN}, got "
+                f"{self.num_nextn_predict_layers!r}"
+            )
+        for name in ("hidden_size", "vocab_size", "num_attention_heads"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(
+                    f"Glm4MoeLiteMTP head {name} must be a positive int, got {value!r}"
+                )
+        if not self.n_routed_experts or self.n_routed_experts <= 0:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires n_routed_experts > 0 to build the "
+                f"MoE mtp_block, got {self.n_routed_experts!r}"
+            )
+        # The head builds exactly one decoder layer at
+        # layer_idx=first_k_dense_replace and needs it to be the MoE variant
+        # (the trained nextn layer is MoE). Stock Glm4MoeLiteDecoderLayer selects
+        # MoE only when layer_idx >= first_k_dense_replace AND
+        # layer_idx % moe_layer_freq == 0; the first is trivially true here, so
+        # validate the second (and guard the modulo against a zero freq).
+        if (
+            not isinstance(self.moe_layer_freq, int)
+            or isinstance(self.moe_layer_freq, bool)
+            or self.moe_layer_freq <= 0
+        ):
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires moe_layer_freq to be a positive "
+                f"int, got {self.moe_layer_freq!r}"
+            )
+        if self.first_k_dense_replace % self.moe_layer_freq != 0:
+            raise ValueError(
+                "Glm4MoeLiteMTP head builds its mtp_block at "
+                f"layer_idx=first_k_dense_replace={self.first_k_dense_replace}, "
+                "but stock Glm4MoeLiteDecoderLayer only makes that an MoE layer "
+                "when layer_idx % moe_layer_freq == 0 "
+                f"(moe_layer_freq={self.moe_layer_freq}). The extracted nextn "
+                "layer is MoE, so first_k_dense_replace must be divisible by "
+                "moe_layer_freq."
+            )
+        if self.quantization is not None and not isinstance(self.quantization, Mapping):
+            raise ValueError(
+                "Glm4MoeLiteMTP head quantization must be a mapping, got "
+                f"{type(self.quantization).__name__}"
+            )
+
+    @classmethod
+    def from_dict(cls, params: Mapping[str, Any]) -> Glm4MoeLiteMTPArgs:
+        """Build args from the drafter-split config, reading the nested shape.
+
+        The head's shape lives in the nested ``text_config``; the top level
+        carries only the head identity (``model_type``), ``quantization``, and
+        ``block_size``. Merge the nested config in with the top level winning for
+        the fields it owns, so the shape is read from the checkpoint rather than
+        silently falling back to this class's GLM-4.7-Flash defaults.
+        """
+        merged = dict(params)
+        text_config = merged.pop("text_config", None)
+        if text_config is not None:
+            if not isinstance(text_config, Mapping):
+                raise ValueError(
+                    "Glm4MoeLiteMTP head text_config must be a mapping, got "
+                    f"{type(text_config).__name__}"
+                )
+            merged = {**text_config, **merged}
+        return super().from_dict(merged)
+
+    def backbone_args(self) -> Glm4MoeLiteBackboneArgs:
+        """Build the stock mlx_lm backbone args used to construct ``mtp_block``.
+
+        The nextn layer is architecturally a ``glm4_moe_lite`` decoder layer, so
+        the stock ``ModelArgs`` drives its construction. ``model_type`` is reset
+        to the backbone type (``from_dict`` drops MTP-only fields).
+        """
+        data = {f.name: getattr(self, f.name) for f in fields(self)}
+        data["model_type"] = GLM4_MOE_LITE_TARGET_MODEL_TYPE
+        return Glm4MoeLiteBackboneArgs.from_dict(data)
+
+
+def _split_kv_b_proj(weights: dict[str, Any], args: Glm4MoeLiteMTPArgs) -> None:
+    """Split the fused ``kv_b_proj`` into absorbed ``embed_q`` / ``unembed_out``.
+
+    Adapts ``mlx_lm.models.glm4_moe_lite.Model.sanitize`` to the single
+    ``mtp_block`` prefix. No-op when the weights are already in the post-split
+    (absorbed) layout.
+    """
+    prefix = _MTP_ATTN_PREFIX
+    weight_key = f"{prefix}.kv_b_proj.weight"
+    if weight_key not in weights:
+        return
+
+    quantized = f"{prefix}.kv_b_proj.scales" in weights
+    v = weights.pop(weight_key)
+    head_dim = args.qk_nope_head_dim + args.v_head_dim
+
+    bits = group_size = 0
+    if quantized:
+        dims = args.kv_lora_rank
+        scales = weights.pop(f"{prefix}.kv_b_proj.scales")
+        biases = weights.pop(f"{prefix}.kv_b_proj.biases")
+        # Infer bits/group_size from the packed weight and scale shapes, exactly
+        # as the stock sanitize does.
+        bits = (v.shape[-1] * 32) // dims
+        group_size = dims // scales.shape[-1]
+        v = mx.dequantize(v, scales, biases, bits=bits, group_size=group_size)
+
+    num_heads = args.num_attention_heads
+    v = v.reshape(num_heads, head_dim, -1)
+    wk = mx.contiguous(v[:, : args.qk_nope_head_dim, :].swapaxes(-1, -2))
+    wv = mx.contiguous(v[:, args.qk_nope_head_dim :, :])
+    if quantized:
+        wk, wk_scales, wk_biases = mx.quantize(wk, bits=bits, group_size=group_size)
+        wv, wv_scales, wv_biases = mx.quantize(wv, bits=bits, group_size=group_size)
+        weights[f"{prefix}.embed_q.scales"] = wk_scales
+        weights[f"{prefix}.unembed_out.scales"] = wv_scales
+        weights[f"{prefix}.embed_q.biases"] = wk_biases
+        weights[f"{prefix}.unembed_out.biases"] = wv_biases
+    weights[f"{prefix}.embed_q.weight"] = wk
+    weights[f"{prefix}.unembed_out.weight"] = wv
+
+
+def _stack_experts(weights: dict[str, Any], args: Glm4MoeLiteMTPArgs) -> None:
+    """Stack per-expert MoE tensors into the ``switch_mlp`` layout.
+
+    Adapts the expert-stacking half of the stock sanitize to the single
+    ``mtp_block`` prefix. No-op when already stacked.
+    """
+    prefix = _MTP_MLP_PREFIX
+    n_experts = args.n_routed_experts
+    for proj in ("gate_proj", "down_proj", "up_proj"):
+        for suffix in ("weight", "scales", "biases"):
+            first = f"{prefix}.experts.0.{proj}.{suffix}"
+            if first not in weights:
+                continue
+            expert_keys = [
+                f"{prefix}.experts.{e}.{proj}.{suffix}" for e in range(n_experts)
+            ]
+            # Pre-validate so a checkpoint with fewer experts than the config's
+            # ``n_routed_experts`` fails with a descriptive error rather than a
+            # bare KeyError leaking from the pop below.
+            for e, key in enumerate(expert_keys):
+                if key not in weights:
+                    raise ValueError(
+                        f"Glm4MoeLiteMTP head checkpoint is missing expert {e} "
+                        f"tensor {key!r}: config n_routed_experts={n_experts} "
+                        f"expects experts 0..{n_experts - 1} for "
+                        f"{prefix}.experts.<e>.{proj}.{suffix} to stack into "
+                        f"switch_mlp. {_HEAD_SOURCE_HINT}"
+                    )
+            to_join = [weights.pop(key) for key in expert_keys]
+            weights[f"{prefix}.switch_mlp.{proj}.{suffix}"] = mx.stack(to_join)
+
+
+def convert_nextn_weights(
+    weights: Mapping[str, Any],
+    args: Glm4MoeLiteMTPArgs,
+) -> dict[str, Any]:
+    """Rewrite flat nextn weights into the module tree the head loads.
+
+    Idempotent: applies the absorbed-MLA ``kv_b_proj`` split and MoE expert
+    stacking only when the pre-split / unstacked tensors are present. Shared by
+    the mlx-vlm drafter split (which pre-applies it so the shipped checkpoint is
+    post-``sanitize``) and by ``Glm4MoeLiteMTPModel.sanitize`` (which tolerates
+    either layout).
+    """
+    out = dict(weights)
+    _split_kv_b_proj(out, args)
+    _stack_experts(out, args)
+    return out
+
+
+class _Glm4MoeLiteMTPInner(nn.Module):
+    """The ``model.*`` subtree matching the flat extracted checkpoint layout."""
+
+    def __init__(
+        self,
+        args: Glm4MoeLiteMTPArgs,
+        backbone: Glm4MoeLiteBackboneArgs,
+    ) -> None:
+        super().__init__()
+        hidden = args.hidden_size
+        eps = args.rms_norm_eps
+        self.embed_tokens = nn.Embedding(args.vocab_size, hidden)
+        self.enorm = nn.RMSNorm(hidden, eps=eps)
+        self.hnorm = nn.RMSNorm(hidden, eps=eps)
+        self.eh_proj = nn.Linear(2 * hidden, hidden, bias=False)
+        # layer_idx == first_k_dense_replace forces the MoE MLP (use_moe=True),
+        # matching the trained nextn layer.
+        self.mtp_block = Glm4MoeLiteDecoderLayer(
+            backbone,
+            layer_idx=backbone.first_k_dense_replace,
+        )
+        self.shared_head_norm = nn.RMSNorm(hidden, eps=eps)
+
+
+class Glm4MoeLiteMTPModel(nn.Module):
+    """MLX module matching the extracted GLM-4.7-Flash nextn head checkpoint."""
+
+    def __init__(self, args: Glm4MoeLiteMTPArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.hidden_size = args.hidden_size
+        backbone = args.backbone_args()
+        self.model = _Glm4MoeLiteMTPInner(args, backbone)
+        # Head is NOT tied; the extracted checkpoint ships a dedicated lm_head
+        # (from the trained ``shared_head.head``).
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def build_slot_inputs(
+        self,
+        token_ids: mx.array,
+        hidden_rows: mx.array,
+        first_position: int,
+    ) -> mx.array:
+        """Project ``[embed(t_{p+1}), h_p]`` into one input row per slot.
+
+        ``token_ids`` are the tokens whose embeddings feed each slot (target
+        tokens shifted left by one). ``hidden_rows`` are the matching target
+        post-final-norm hidden states. Embedding rows at absolute position 0 are
+        zeroed (upstream ``inputs_embeds[positions == 0] = 0``), which is why
+        ``first_position`` (the absolute position of row 0) is required.
+        """
+        token_ids = mx.array(token_ids)
+        if token_ids.ndim != 1:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs expects 1-D token_ids "
+                f"[num_slots], got shape {tuple(token_ids.shape)}"
+            )
+        if hidden_rows.ndim != 2:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs expects 2-D hidden_rows "
+                f"[num_slots, hidden], got shape {tuple(hidden_rows.shape)}"
+            )
+        num_slots = token_ids.shape[0]
+        if hidden_rows.shape[0] != num_slots:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs token/hidden row count "
+                f"mismatch: token_ids={num_slots}, hidden_rows={hidden_rows.shape[0]}"
+            )
+        if hidden_rows.shape[1] != self.hidden_size:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs hidden_rows last dim must be "
+                f"{self.hidden_size}, got {hidden_rows.shape[1]}"
+            )
+
+        emb = self.model.embed_tokens(token_ids)
+        positions = first_position + mx.arange(num_slots)
+        keep = (positions != 0)[:, None].astype(emb.dtype)
+        emb = emb * keep
+        combined = mx.concatenate(
+            [self.model.enorm(emb), self.model.hnorm(hidden_rows)],
+            axis=-1,
+        )
+        return self.model.eh_proj(combined)
+
+    def forward_slots(
+        self,
+        x: mx.array,
+        cache: Any,
+        *,
+        expected_offset: int | None = None,
+    ) -> mx.array:
+        """Run one stock decoder-layer forward over ``x`` with an appending cache.
+
+        ``x`` is ``[num_slots, hidden]``; the slab index == sequence position ==
+        RoPE offset, so stock mlx_lm attention is correct. Returns the
+        post-shared-head-norm hidden states ``[num_slots, hidden]``.
+
+        The slot stream carries two independent position anchors: the caller's
+        ``first_position`` passed to :meth:`build_slot_inputs` (which zeroes the
+        absolute-position-0 embedding), and the ``cache.offset`` that drives
+        RoPE / causal masking here. They must agree for the row at ``x[0]``.
+        Pass ``expected_offset`` (typically the same ``first_position``) to
+        assert the cache is positioned where the caller thinks it is; when it
+        differs from the cache's ``offset``, this fails loud instead of silently
+        drafting at the wrong position. Omitted by default so existing callers
+        stay unaffected.
+        """
+        if x.ndim != 2:
+            raise ValueError(
+                "Glm4MoeLiteMTP forward_slots expects 2-D x [num_slots, hidden], "
+                f"got shape {tuple(x.shape)}"
+            )
+        if expected_offset is not None and cache.offset != expected_offset:
+            raise ValueError(
+                "Glm4MoeLiteMTP forward_slots cache offset "
+                f"{cache.offset} does not match expected_offset "
+                f"{expected_offset}: the slot position anchor "
+                "(first_position in build_slot_inputs) and the cache's RoPE "
+                "offset have diverged."
+            )
+        h = x[None]
+        mask = create_attention_mask(h, cache, return_array=True)
+        h = self.model.mtp_block(h, mask, cache)
+        h = self.model.shared_head_norm(h)
+        return h[0]
+
+    def compute_logits(self, hidden: mx.array) -> mx.array:
+        """Project post-norm hidden states through the untied lm_head."""
+        return self.lm_head(hidden)
+
+    def sanitize(self, weights: Mapping[str, Any]) -> dict[str, Any]:
+        """Accept pre- or post-split attention and (un)stacked expert layouts."""
+        return convert_nextn_weights(weights, self.args)
+
+    @property
+    def cast_predicate(self):  # noqa: ANN201
+        """Keep ``e_score_correction_bias`` at its source dtype during casts.
+
+        Mirrors ``mlx_lm.models.glm4_moe_lite.Model.cast_predicate``: the
+        noaux_tc router correction bias is fp32 in the source shard and must
+        stay fp32 (vLLM keeps the noaux_tc bias fp32). An mlx_lm convert that
+        honors this predicate will not down-cast that tensor with the rest of
+        the weights.
+        """
+
+        def predicate(weight_key: str) -> bool:
+            return "e_score_correction_bias" not in weight_key
+
+        return predicate
+
+
+@dataclass(frozen=True, slots=True)
+class Glm4MoeLiteMTPHeadMetadata:
+    """Validated shape of a GLM-4.7-Flash nextn (MTP) head checkpoint."""
+
+    model_type: str
+    architectures: tuple[str, ...]
+    hidden_size: int
+    vocab_size: int
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    qk_nope_head_dim: int
+    v_head_dim: int
+    num_attention_heads: int
+    rope_theta: float
+    rms_norm_eps: float
+    num_nextn_predict_layers: int
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> Glm4MoeLiteMTPHeadMetadata:
+        model_type = _config_value(config, "model_type")
+        if model_type != GLM4_MOE_LITE_MTP_MODEL_TYPE:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires "
+                f"model_type={GLM4_MOE_LITE_MTP_MODEL_TYPE!r}, got "
+                f"{model_type!r}. {_HEAD_SOURCE_HINT}"
+            )
+
+        # The drafter split nests the source model config under ``text_config``;
+        # the head's shape fields live there. The top-level ``model_type`` above is
+        # the guard that this is the head, not the raw target repo
+        # (``glm4_moe_lite``). Require the nested schema rather than tolerating a
+        # flat checkpoint, so a malformed head is rejected at its own boundary.
+        text = _config_value(config, "text_config")
+        if not isinstance(text, Mapping):
+            raise ValueError(
+                "Glm4MoeLiteMTP head config must nest the source model config "
+                f"under 'text_config' (the drafter-split schema). {_HEAD_SOURCE_HINT}"
+            )
+
+        num_nextn = _required_int(text, "num_nextn_predict_layers")
+        if num_nextn != GLM4_MOE_LITE_MTP_NUM_NEXTN:
+            raise ValueError(
+                "Glm4MoeLiteMTP head only supports "
+                f"num_nextn_predict_layers={GLM4_MOE_LITE_MTP_NUM_NEXTN}, got "
+                f"{num_nextn}"
+            )
+
+        block_size = _required_int(config, "block_size")
+        if block_size != num_nextn + 1:
+            raise ValueError(
+                "Glm4MoeLiteMTP head block_size must be "
+                f"num_nextn_predict_layers+1={num_nextn + 1}, got {block_size}"
+            )
+
+        return cls(
+            model_type=str(model_type),
+            architectures=_architectures(text),
+            hidden_size=_required_positive_int(text, "hidden_size"),
+            vocab_size=_required_positive_int(text, "vocab_size"),
+            kv_lora_rank=_required_positive_int(text, "kv_lora_rank"),
+            qk_rope_head_dim=_required_positive_int(text, "qk_rope_head_dim"),
+            qk_nope_head_dim=_required_positive_int(text, "qk_nope_head_dim"),
+            v_head_dim=_required_positive_int(text, "v_head_dim"),
+            num_attention_heads=_required_positive_int(text, "num_attention_heads"),
+            rope_theta=_required_positive_float(text, "rope_theta"),
+            rms_norm_eps=_required_positive_float(text, "rms_norm_eps"),
+            num_nextn_predict_layers=num_nextn,
+        )
+
+    def validate_compatible_with(self, target_config: Mapping[str, Any]) -> None:
+        """Fail loud when the head and target disagree on shared hyperparameters."""
+        target = _text_config(target_config)
+        self._validate_target_model_type(target_config, target)
+        for name in _COMPAT_FIELDS:
+            head_value = getattr(self, name)
+            target_value = _config_value(target, name)
+            if target_value is None:
+                raise ValueError(
+                    "Glm4MoeLiteMTP target model is missing "
+                    f"{name!r} required to validate head compatibility"
+                )
+            if not _values_match(head_value, target_value):
+                raise ValueError(
+                    f"Glm4MoeLiteMTP head {name} must match target {name}: "
+                    f"head={head_value!r}, target={target_value!r}"
+                )
+
+    @staticmethod
+    def _validate_target_model_type(
+        target_config: Any,
+        target_text_config: Any,
+    ) -> None:
+        """Reject a target whose ``model_type`` is not the GLM MoE-lite backbone.
+
+        The head's absorbed-MLA + embedding math is only valid over a
+        ``glm4_moe_lite`` target; accept the ``model_type`` at the top level of
+        the target config or inside its resolved text config.
+        """
+        model_types = {
+            model_type
+            for model_type in (
+                _config_value(target_config, "model_type"),
+                _config_value(target_text_config, "model_type"),
+            )
+            if model_type is not None
+        }
+        if not model_types:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires a "
+                f"{GLM4_MOE_LITE_TARGET_MODEL_TYPE!r} target model, got "
+                "model_type=None"
+            )
+        unknown = sorted(
+            str(model_type)
+            for model_type in model_types
+            if model_type != GLM4_MOE_LITE_TARGET_MODEL_TYPE
+        )
+        if unknown:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires a "
+                f"{GLM4_MOE_LITE_TARGET_MODEL_TYPE!r} target model, got "
+                f"model_type={unknown[0]!r}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Glm4MoeLiteMTPHeadSource:
+    """Resolved head checkpoint source from a vLLM speculative config."""
+
+    model_name: str
+    revision: str | None
+
+    @classmethod
+    def from_speculative_config(
+        cls,
+        speculative_config: Any,
+    ) -> Glm4MoeLiteMTPHeadSource:
+        draft_model_config = speculative_config.draft_model_config
+        return cls(
+            model_name=draft_model_config.model,
+            revision=draft_model_config.revision,
+        )
+
+    def resolve(
+        self,
+        model_path_resolver: Callable[[str], str],
+    ) -> Glm4MoeLiteMTPHeadSource:
+        return Glm4MoeLiteMTPHeadSource(
+            model_name=model_path_resolver(self.model_name),
+            revision=self.revision,
+        )
+
+    @property
+    def cache_key(self) -> tuple[str, str | None]:
+        return (self.model_name, self.revision)
+
+
+@dataclass(frozen=True, slots=True)
+class Glm4MoeLiteMTPHeadRuntime:
+    """A loaded head model plus its validated metadata."""
+
+    model_name: str
+    model: Any
+    metadata: Glm4MoeLiteMTPHeadMetadata
+
+
+class Glm4MoeLiteMTPHeadLoader:
+    """Loads and validates an extracted GLM-4.7-Flash nextn head."""
+
+    _CACHE: ClassVar[dict[tuple[str, str | None], Glm4MoeLiteMTPHeadRuntime]] = {}
+    _CACHE_LOCK: ClassVar[Lock] = Lock()
+
+    def __init__(
+        self,
+        *,
+        load_model_fn: Callable[..., tuple[Any, dict[str, Any]]] | None = None,
+        download_fn: Callable[[str, str | None], Path] | None = None,
+        model_path_resolver: Callable[[str], str] | None = None,
+    ) -> None:
+        self._load_model = load_model_fn
+        self._download = download_fn
+        self._model_path_resolver = model_path_resolver
+
+    def load_if_needed(
+        self,
+        *,
+        speculative_config: Any,
+        target_config: Mapping[str, Any],
+    ) -> Glm4MoeLiteMTPHeadRuntime:
+        """Load the head for this speculative config, reusing the cross-instance cache."""
+        source = Glm4MoeLiteMTPHeadSource.from_speculative_config(speculative_config)
+        if self._model_path_resolver is not None:
+            source = source.resolve(self._model_path_resolver)
+
+        cached = self._cached_runtime(source)
+        if cached is not None:
+            cached.metadata.validate_compatible_with(target_config)
+            logger.info("GLM4 MTP head loaded from cache: %s", source.model_name)
+            return cached
+
+        return self._load_uncached(source, target_config)
+
+    def _load_uncached(
+        self,
+        source: Glm4MoeLiteMTPHeadSource,
+        target_config: Mapping[str, Any],
+    ) -> Glm4MoeLiteMTPHeadRuntime:
+        logger.info("Loading GLM4 MTP head: %s", source.model_name)
+        start_time = time.time()
+        model_path = self._download_model(source)
+        self._preflight_config(model_path, target_config)
+        model, head_config = self._load_head_model(model_path)
+        metadata = self._metadata_from_config(head_config, target_config)
+        self._assert_head_tensors(model)
+        runtime = Glm4MoeLiteMTPHeadRuntime(
+            model_name=source.model_name,
+            model=model,
+            metadata=metadata,
+        )
+        with self._CACHE_LOCK:
+            self._CACHE[source.cache_key] = runtime
+        logger.info(
+            "GLM4 MTP head loaded in %.2fs: %s",
+            time.time() - start_time,
+            source.model_name,
+        )
+        return runtime
+
+    def _cached_runtime(
+        self,
+        source: Glm4MoeLiteMTPHeadSource,
+    ) -> Glm4MoeLiteMTPHeadRuntime | None:
+        with self._CACHE_LOCK:
+            return self._CACHE.get(source.cache_key)
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clear the process-level head cache."""
+        with cls._CACHE_LOCK:
+            cls._CACHE.clear()
+
+    def _preflight_config(
+        self,
+        model_path: Path,
+        target_config: Mapping[str, Any],
+    ) -> None:
+        head_config = self._read_config_file(model_path)
+        if head_config is None and self._load_model is None:
+            raise ValueError(
+                "GLM4 MTP head model path must contain config.json: "
+                f"{model_path}. {_HEAD_SOURCE_HINT}"
+            )
+        if head_config is not None:
+            self._metadata_from_config(head_config, target_config)
+
+    def _metadata_from_config(
+        self,
+        head_config: Mapping[str, Any],
+        target_config: Mapping[str, Any],
+    ) -> Glm4MoeLiteMTPHeadMetadata:
+        self._reject_custom_model_file(head_config)
+        metadata = Glm4MoeLiteMTPHeadMetadata.from_config(head_config)
+        metadata.validate_compatible_with(target_config)
+        return metadata
+
+    def _load_head_model(self, model_path: Path) -> tuple[Any, dict[str, Any]]:
+        if self._load_model is None:
+            from mlx_lm.utils import load_model as load_model_fn
+        else:
+            load_model_fn = self._load_model
+
+        with mlx_lm_compatible_model_path(model_path) as compatible_model_path:
+            return load_model_fn(
+                compatible_model_path,
+                lazy=False,
+                strict=True,
+                get_model_classes=self._get_model_classes,
+            )
+
+    def _download_model(self, source: Glm4MoeLiteMTPHeadSource) -> Path:
+        if self._download is not None:
+            return Path(self._download(source.model_name, source.revision))
+
+        model_path = Path(source.model_name)
+        if model_path.exists():
+            return model_path
+
+        from huggingface_hub import snapshot_download
+
+        return Path(
+            snapshot_download(
+                source.model_name,
+                revision=source.revision,
+                allow_patterns=_HEAD_DOWNLOAD_ALLOW_PATTERNS,
+            )
+        )
+
+    @staticmethod
+    def _assert_head_tensors(model: Any) -> None:
+        params = dict(tree_flatten(model.parameters()))
+        for key, source in (
+            ("lm_head.weight", "shared_head.head"),
+            ("model.embed_tokens.weight", "the dedicated nextn embedding"),
+        ):
+            if key not in params:
+                raise ValueError(
+                    f"GLM4 MTP head checkpoint is missing {key!r} (from {source}). "
+                    f"{_HEAD_SOURCE_HINT}"
+                )
+
+    @staticmethod
+    def _read_config_file(model_path: Path) -> dict[str, Any] | None:
+        config_path = model_path / "config.json"
+        if not config_path.exists():
+            return None
+        try:
+            config = loads(config_path.read_text(encoding="utf-8"))
+        except JSONDecodeError as exc:
+            raise ValueError(
+                f"GLM4 MTP head config.json is not valid JSON: {config_path}"
+            ) from exc
+        if not isinstance(config, dict):
+            raise ValueError("GLM4 MTP head config.json must contain an object")
+        return config
+
+    @staticmethod
+    def _reject_custom_model_file(config: Mapping[str, Any]) -> None:
+        if "model_file" in config:
+            model_file = config["model_file"]
+            raise ValueError(
+                "GLM4 MTP head loader uses built-in Metal model classes and does "
+                f"not support custom model_file={model_file!r}"
+            )
+
+    @staticmethod
+    def _get_model_classes(
+        config: dict[str, Any],
+    ) -> tuple[type[Any], type[Any]]:
+        if config.get("model_type") != GLM4_MOE_LITE_MTP_MODEL_TYPE:
+            model_type = config.get("model_type")
+            architectures = config.get("architectures")
+            raise ValueError(
+                "GLM4 MTP head loader only supports "
+                f"{GLM4_MOE_LITE_MTP_MODEL_TYPE!r} configs, got "
+                f"model_type={model_type!r}, architectures={architectures!r}. "
+                f"{_HEAD_SOURCE_HINT}"
+            )
+        return Glm4MoeLiteMTPModel, Glm4MoeLiteMTPArgs
+
+
+def _text_config(config: Any | None) -> Any | None:
+    if config is None:
+        return None
+    get_text_config = getattr(config, "get_text_config", None)
+    if callable(get_text_config):
+        return get_text_config()
+    return _config_value(config, "text_config", config)
+
+
+def _config_value(config: Any, key: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _values_match(head_value: Any, target_value: Any) -> bool:
+    if isinstance(head_value, Real) and isinstance(target_value, Real):
+        return bool(
+            abs(float(head_value) - float(target_value))
+            <= 1e-9 * max(1.0, abs(float(head_value)))
+        )
+    return head_value == target_value
+
+
+def _required_int(config: Mapping[str, Any], key: str) -> int:
+    value = _config_value(config, key)
+    if value is None:
+        raise ValueError(f"GLM4 MTP head config is missing {key}")
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"GLM4 MTP head {key} must be an integer, got {value!r}")
+    return int(value)
+
+
+def _required_positive_int(config: Mapping[str, Any], key: str) -> int:
+    value = _required_int(config, key)
+    if value <= 0:
+        raise ValueError(f"GLM4 MTP head {key} must be positive, got {value}")
+    return value
+
+
+def _required_positive_float(config: Mapping[str, Any], key: str) -> float:
+    value = _config_value(config, key)
+    if value is None:
+        raise ValueError(f"GLM4 MTP head config is missing {key}")
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"GLM4 MTP head {key} must be a number, got {value!r}")
+    if float(value) <= 0.0:
+        raise ValueError(f"GLM4 MTP head {key} must be positive, got {value}")
+    return float(value)
+
+
+def _architectures(config: Mapping[str, Any]) -> tuple[str, ...]:
+    value = _config_value(config, "architectures", ()) or ()
+    if isinstance(value, str):
+        raise ValueError("GLM4 MTP head architectures must be a non-string sequence")
+    try:
+        names = tuple(value)
+    except TypeError as exc:
+        raise ValueError("GLM4 MTP head architectures must be a sequence") from exc
+    if any(not isinstance(name, str) for name in names):
+        raise ValueError("GLM4 MTP head architectures entries must be strings")
+    return names

--- a/vllm_metal/v1/mtp_heads/registry.py
+++ b/vllm_metal/v1/mtp_heads/registry.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MTP head registry keyed by draft ``model_type``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+    from vllm_metal.v1.proposer import MetalProposer
+    from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMTPBuildContext:
+    """Inputs a native MTP head uses to build its proposer."""
+
+    speculative_config: Any
+    controller: SpeculativeDecodeController
+    vllm_config: VllmConfig
+    target_config: Any
+
+
+class NativeMTPHead(Protocol):
+    """Native MTP head that owns validation and proposer construction."""
+
+    model_type: str
+
+    def build_proposer(self, context: NativeMTPBuildContext) -> MetalProposer: ...
+
+
+class NativeMTPHeadRegistry:
+    """Registry for native MTP head implementations."""
+
+    _heads: ClassVar[dict[str, NativeMTPHead]] = {}
+
+    @classmethod
+    def register(cls, head: NativeMTPHead) -> None:
+        cls._heads[head.model_type] = head
+
+    @classmethod
+    def find(cls, speculative_config: Any) -> NativeMTPHead | None:
+        model_type = cls._draft_model_type(speculative_config)
+        return cls._heads.get(model_type)
+
+    @classmethod
+    def registered_types(cls) -> list[str]:
+        return sorted(cls._heads)
+
+    @classmethod
+    def unsupported_message(cls, speculative_config: Any) -> str:
+        model_type = cls._draft_model_type(speculative_config)
+        return (
+            f"No MTP head on Metal for draft model_type {model_type!r} "
+            f"(registered native heads: {cls.registered_types()}; plus "
+            "Gemma4 MTP via the in-model assistant)."
+        )
+
+    @staticmethod
+    def _draft_model_type(speculative_config: Any) -> str:
+        return speculative_config.draft_model_config.hf_config.model_type
+
+
+__all__ = [
+    "NativeMTPBuildContext",
+    "NativeMTPHead",
+    "NativeMTPHeadRegistry",
+]

--- a/vllm_metal/v1/mtp_proposer.py
+++ b/vllm_metal/v1/mtp_proposer.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MTP-head speculative-decoding proposer for the Metal paged path.
+
+Runs a registered native MTP head (first: GLM-4.7-Flash's ``glm4_moe_lite_mtp``)
+as a tiny autoregressive 1-layer model over the target's "slot stream". Slot
+``p`` is::
+
+    slot_p = eh_proj([enorm(embed(t_{p+1})), hnorm(h_p)])
+
+where ``h_p`` is the target's post-final-norm hidden state at position ``p`` and
+``t_{p+1}`` is the token committed at position ``p+1``. One stock decoder-layer
+forward over a request's newly committed slots both **ingests** (the layer's
+compressed MLA latent lands in a proposer-owned per-request KV slab as a side
+effect of attention) and **drafts** (the last slot's output -> shared-head norm
+-> lm_head -> argmax = one draft token).
+
+The slab rewind/hole/accepted-rows-only discipline keeps each request's KV
+history consistent across scheduler preemption-recompute. The proposer reuses the
+runner's existing ``target_hidden_states`` (no aux-hidden-state machinery) and the
+KV slab holds the head layer's own MLA latent (different k/v feature dims).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import mlx.core as mx
+from mlx_lm.models.cache import create_attention_mask as _cache_create_attention_mask
+from vllm.logger import init_logger
+from vllm.v1.outputs import DraftTokenIds
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from vllm_metal.v1.proposer import ProposeContext
+    from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+logger = init_logger(__name__)
+
+# Slab growth quantum (positions), mirroring mlx_lm's KVCache.step.
+_SLAB_STEP = 256
+
+
+class MTPSlab:
+    """Per-request growable KV history for the head's single MLA layer.
+
+    Exposes the mlx_lm KV-cache protocol the stock ``Glm4MoeLiteDecoderLayer``
+    attention drives: ``.offset``, ``update_and_fetch(kv_latent, k_pe)`` and
+    ``make_mask`` (so ``create_attention_mask`` produces an offset-aware causal
+    mask over the appended history). Keys/values carry **different** feature dims
+    (GLM MLA: 512 compressed latent vs 64 rope) which the update handles by
+    reading each dim from the first append rather than assuming they match.
+
+    Slab index == absolute sequence position == RoPE offset, which is exactly
+    what makes the stock attention correct. ``update_and_fetch`` follows the
+    mlx_lm ``KVCache`` slice-assignment growth pattern (grow in ``_SLAB_STEP``
+    quanta, write in place); ``truncate_to`` supports scheduler
+    preemption-recompute rewinds.
+    """
+
+    __slots__ = ("keys", "offset", "values")
+
+    def __init__(self) -> None:
+        self.keys: mx.array | None = None
+        self.values: mx.array | None = None
+        self.offset = 0
+
+    def update_and_fetch(
+        self, keys: mx.array, values: mx.array
+    ) -> tuple[mx.array, mx.array]:
+        """Append ``[B, n, T, *]`` k/v at ``offset`` and return the full history.
+
+        Ported from ``mlx_lm.models.cache.KVCache.update_and_fetch``; the only
+        substantive difference is that keys (compressed latent) and values (rope)
+        have distinct last dims, which the stock implementation already reads
+        independently (``k_head_dim`` vs ``v_head_dim``), so the pattern carries
+        over unchanged. Feature dims and dtype are therefore inferred from the
+        first append — nothing is hardcoded.
+        """
+        prev = self.offset
+        num_new = keys.shape[2]
+        if self.keys is None or (prev + num_new) > self.keys.shape[2]:
+            batch, n_kv_heads, _, k_head_dim = keys.shape
+            v_head_dim = values.shape[3]
+            n_steps = (_SLAB_STEP + num_new - 1) // _SLAB_STEP
+            k_shape = (batch, n_kv_heads, n_steps * _SLAB_STEP, k_head_dim)
+            v_shape = (batch, n_kv_heads, n_steps * _SLAB_STEP, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                if prev % _SLAB_STEP != 0:
+                    self.keys = self.keys[..., :prev, :]
+                    self.values = self.values[..., :prev, :]
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
+        self.offset += num_new
+        self.keys[..., prev : self.offset, :] = keys
+        self.values[..., prev : self.offset, :] = values
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
+    def make_mask(self, *args: Any, **kwargs: Any) -> Any:
+        """Offset-aware causal mask, mirroring ``mlx_lm.KVCache.make_mask``.
+
+        Called by ``create_attention_mask`` before ``update_and_fetch`` runs, so
+        ``self.offset`` is the pre-append offset and the mask covers the ``N`` new
+        query rows attending over ``offset + N`` keys.
+        """
+        return _cache_create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def truncate_to(self, position: int) -> None:
+        """Rewind the valid length to absolute ``position`` (a preemption redo).
+
+        Only lowers the offset (the underlying buffers are kept; stale rows are
+        overwritten on the next append and never read, since fetches slice to
+        ``offset``). A forward move would fabricate unobserved positions, so it is
+        rejected.
+        """
+        if position < 0:
+            raise ValueError(f"truncate_to position must be non-negative: {position}")
+        if position > self.offset:
+            raise ValueError(
+                f"truncate_to cannot advance the slab: position {position} > "
+                f"offset {self.offset}"
+            )
+        self.offset = position
+
+
+class _SlotBatch:
+    """A request's contiguous slot stream to ingest this step.
+
+    ``tokens``/``hidden_rows`` are the per-slot embedding token and target hidden
+    state; ``first_position`` is the absolute sequence position of the first slot
+    (positions are contiguous). ``draft`` marks whether the last slot's output is
+    read out as this step's single draft token (decode + final-prefill slots
+    draft; intermediate-chunk ingest does not).
+    """
+
+    __slots__ = ("draft", "first_position", "hidden_rows", "req_id", "slab", "tokens")
+
+    def __init__(
+        self,
+        *,
+        req_id: str,
+        first_position: int,
+        tokens: list[int],
+        hidden_rows: list[mx.array],
+        draft: bool,
+        slab: MTPSlab,
+    ) -> None:
+        self.req_id = req_id
+        self.first_position = first_position
+        self.tokens = tokens
+        self.hidden_rows = hidden_rows
+        self.draft = draft
+        self.slab = slab
+
+
+class NativeMTPProposer:
+    """:class:`vllm_metal.v1.proposer.MetalProposer` for native MTP heads."""
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        controller: SpeculativeDecodeController,
+    ) -> None:
+        self._model = model
+        self._controller = controller
+        # The slab infers its k/v dtype and feature dims from the first append,
+        # so nothing here needs the target's kv dtype to size them.
+        self._slabs: dict[str, MTPSlab] = {}
+        # req_id -> (position, hidden) for an intermediate prefill chunk's last
+        # row, whose next token is unknown until the following chunk runs. Its
+        # hidden state exists only in the step that produced it, so it is carried
+        # forward and prepended to the next batch.
+        self._pending_last_hidden: dict[str, tuple[int, mx.array]] = {}
+
+    # -- construction ----------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        speculative_config: Any,
+        controller: SpeculativeDecodeController,
+        loader: Any,
+        model_type: str,
+        target_config: Mapping[str, Any],
+    ) -> NativeMTPProposer:
+        """Load the head via ``loader`` and build the proposer over it."""
+        runtime = loader.load_if_needed(
+            speculative_config=speculative_config,
+            target_config=target_config,
+        )
+        logger.info(
+            "Native MTP proposer ready: head=%s (%s)",
+            model_type,
+            runtime.model_name,
+        )
+        return cls(model=runtime.model, controller=controller)
+
+    # -- MetalProposer protocol -------------------------------------------------
+
+    def needs_target_hidden_states(
+        self,
+        decode_segments: Any,
+        *,
+        has_final_prefill: bool,
+    ) -> bool:
+        # The slot stream projects one input row from EVERY committed token's
+        # target hidden state — including intermediate prefill chunks, whose
+        # hidden states exist only in the step that ran them. So always collect.
+        return True
+
+    def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        self._prune_finished(ctx.finished_req_ids)
+
+        if ctx.target_hidden_states is None:
+            # The runner collects target hidden states on every paged text
+            # forward while this drafter is installed; their absence means the
+            # batch ran an execution path native MTP does not support
+            # (multimodal / pipeline-parallel forward). Fail loud rather than
+            # silently never drafting.
+            raise RuntimeError(
+                "Native MTP drafting requires target hidden states, but none "
+                "were collected this step; the current execution path "
+                "(multimodal or pipeline-parallel forward) does not support "
+                "native MTP speculative decoding."
+            )
+
+        hidden = ctx.target_hidden_states
+        batches = self._collect_slot_batches(ctx, hidden)
+        if not batches:
+            return None
+
+        # Zero scheduled spec tokens suppresses drafting but not ingest:
+        # committed slots must still land so the slabs stay contiguous for when
+        # speculation re-enables.
+        draft_enabled = ctx.num_speculative_tokens > 0
+
+        draft_req_ids: list[str] = []
+        draft_tokens: list[mx.array] = []
+        touched: list[MTPSlab] = []
+        for batch in batches:
+            x = self._model.build_slot_inputs(
+                mx.array(batch.tokens, dtype=mx.int32),
+                mx.stack(batch.hidden_rows),
+                batch.first_position,
+            )
+            out = self._model.forward_slots(
+                x, batch.slab, expected_offset=batch.first_position
+            )
+            touched.append(batch.slab)
+            if draft_enabled and batch.draft:
+                logits = self._model.compute_logits(out[-1:])
+                draft_req_ids.append(batch.req_id)
+                draft_tokens.append(mx.argmax(logits, axis=-1))
+
+        draft_matrix = mx.stack(draft_tokens) if draft_tokens else None
+
+        # One eval over every touched slab array + the carried pending hiddens +
+        # the stacked drafts: slabs updated for ingest-only requests (intermediate
+        # prefill chunks) must not accumulate a lazy graph across steps, and the
+        # pending hidden must be materialized before this step's
+        # target_hidden_states is discarded (laziness discipline, one sync).
+        eval_targets: list[mx.array] = [
+            slab.keys for slab in touched if slab.keys is not None
+        ]
+        eval_targets.extend(slab.values for slab in touched if slab.values is not None)
+        eval_targets.extend(h for _, h in self._pending_last_hidden.values())
+        if draft_matrix is not None:
+            eval_targets.append(draft_matrix)
+        if eval_targets:
+            mx.eval(*eval_targets)
+
+        if draft_matrix is None:
+            return None
+        rows: list[list[int]] = draft_matrix.reshape(len(draft_req_ids), -1).tolist()  # type: ignore[assignment]
+        return DraftTokenIds(req_ids=draft_req_ids, draft_token_ids=rows)
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        # Drop the per-request slab (freeing its k/v arrays) and any deferred
+        # pending row on eviction/preemption, so a waiting request does not pin
+        # the slab; a resumed request rebuilds its slab from position 0 during
+        # recompute (release-don't-hold, mirroring the runtime's recurrent-state
+        # release in #489).
+        for req_id in req_ids:
+            self._slabs.pop(req_id, None)
+            self._pending_last_hidden.pop(req_id, None)
+
+    # -- slot batching ----------------------------------------------------------
+
+    def _collect_slot_batches(
+        self, ctx: ProposeContext, hidden: mx.array
+    ) -> list[_SlotBatch]:
+        """Build each greedy-eligible request's contiguous slot batch."""
+        batches: list[_SlotBatch] = []
+        seen: set[str] = set()
+
+        for (req_id, state), segment, sampled_ids in zip(
+            ctx.decode_reqs,
+            ctx.decode_segments,
+            ctx.decode_token_ids,
+            strict=True,
+        ):
+            accepted = len(sampled_ids)
+            if accepted == 0:
+                continue
+            if not self._controller.can_draft_greedy(
+                req_id, state, logitsprocs=ctx.logitsprocs
+            ):
+                continue
+            # Committed rows 0..accepted-1 only — rejected draft rows never enter.
+            # Slot at position cache_start_pos+j embeds sampled_ids[j] (the token
+            # committed at position+1) over hidden row start_row+j.
+            hidden_rows = [hidden[segment.start_row + j] for j in range(accepted)]
+            slab = self._align_slab(req_id, segment.cache_start_pos)
+            batches.append(
+                _SlotBatch(
+                    req_id=req_id,
+                    first_position=segment.cache_start_pos,
+                    tokens=list(sampled_ids[:accepted]),
+                    hidden_rows=hidden_rows,
+                    draft=True,
+                    slab=slab,
+                )
+            )
+            seen.add(req_id)
+
+        for i, prefill in enumerate(ctx.prefill_reqs):
+            req_id = prefill.req_id
+            if req_id in seen:
+                continue
+            result_mode = ctx.prefill_result_modes[i]
+            state = ctx.request_states.get(req_id)
+            greedy_state = (
+                state
+                if state is not None
+                else SimpleNamespace(
+                    sampling_params=prefill.sampling_params, generated_tokens=0
+                )
+            )
+            if not self._controller.can_draft_greedy(
+                req_id, greedy_state, logitsprocs=ctx.logitsprocs
+            ):
+                continue
+            batch = self._prefill_batch(ctx, i, prefill, result_mode, hidden)
+            if batch is not None:
+                batches.append(batch)
+            seen.add(req_id)
+
+        return batches
+
+    def _prefill_batch(
+        self,
+        ctx: ProposeContext,
+        index: int,
+        prefill: Any,
+        result_mode: str,
+        hidden: mx.array,
+    ) -> _SlotBatch | None:
+        """Slot batch for one prefill chunk, deferring an intermediate last row.
+
+        A chunk of ``n`` tokens at positions ``s..s+n-1`` yields ``n`` slots; slot
+        ``s+j`` embeds the token committed at ``s+j+1``. For rows ``0..n-2`` that
+        is the next token *within* the chunk. The last row's next token is either
+        this step's sampled token (final chunk) or unknown (intermediate chunk),
+        in which case its hidden state is deferred to ``_pending_last_hidden`` and
+        the slot is emitted next step, once the following chunk supplies the
+        token.
+        """
+        req_id = prefill.req_id
+        token_ids = list(prefill.token_ids)
+        num_rows = len(token_ids)
+        row_start = ctx.cu_seqlens[ctx.num_decode_segments + index]
+        start_pos = prefill.start_pos
+        is_intermediate = result_mode == "intermediate"
+        slab_offset = self._slabs[req_id].offset if req_id in self._slabs else 0
+
+        first_position = start_pos
+        tokens: list[int] = []
+        hidden_rows: list[mx.array] = []
+
+        # A pending row from this request's previous (intermediate) chunk sits one
+        # position before this chunk; its next token is this chunk's first token.
+        # Prepend it only when it is contiguous with both the slab tail and this
+        # chunk (i.e. no intervening preemption); any other pending is stale.
+        pending = self._pending_last_hidden.pop(req_id, None)
+        if (
+            pending is not None
+            and num_rows > 0
+            and pending[0] == start_pos - 1
+            and pending[0] == slab_offset
+        ):
+            first_position = pending[0]
+            tokens.append(token_ids[0])
+            hidden_rows.append(pending[1][0])
+
+        ready_rows = num_rows - 1 if is_intermediate else num_rows
+        for j in range(ready_rows):
+            tokens.append(
+                token_ids[j + 1] if j < num_rows - 1 else ctx.prefill_token_ids[index]
+            )
+            hidden_rows.append(hidden[row_start + j])
+
+        # Align the slab (truncate on a rewind, fail loud on a hole) BEFORE
+        # recording this chunk's deferred row, so a recompute that both rewinds
+        # and defers keeps the freshly-deferred row.
+        slab = self._align_slab(req_id, first_position)
+
+        if is_intermediate and num_rows > 0:
+            # Defer the last row: carry a materialized copy of its hidden state so
+            # it survives past this step's target_hidden_states.
+            last_hidden = mx.array(hidden[row_start + num_rows - 1])[None]
+            self._pending_last_hidden[req_id] = (start_pos + num_rows - 1, last_hidden)
+
+        if not tokens:
+            # Purely deferred single-row intermediate chunk with no pending: only
+            # the slab (aligned above) needs to exist for the next step.
+            return None
+
+        return _SlotBatch(
+            req_id=req_id,
+            first_position=first_position,
+            tokens=tokens,
+            hidden_rows=hidden_rows,
+            draft=not is_intermediate,
+            slab=slab,
+        )
+
+    # -- slab bookkeeping -------------------------------------------------------
+
+    def _align_slab(self, req_id: str, first_position: int) -> MTPSlab:
+        """Return the request's slab positioned at ``first_position``.
+
+        ``first_position < offset`` is a scheduler preemption-recompute: the same
+        committed tokens are re-forwarded, so truncating and re-ingesting rebuilds
+        the identical slab. ``first_position > offset`` is a hole — target hidden
+        states for the gap were never observed and cannot be repaired — so fail
+        loud. Any stale deferred (pending) row is resolved by the caller before
+        this runs, so alignment never touches ``_pending_last_hidden``.
+        """
+        slab = self._slabs.get(req_id)
+        if slab is None:
+            slab = MTPSlab()
+            self._slabs[req_id] = slab
+
+        if first_position < slab.offset:
+            logger.info(
+                "Native MTP slab for request %s rewound from %d to %d "
+                "(scheduler recompute); re-ingesting.",
+                req_id,
+                slab.offset,
+                first_position,
+            )
+            slab.truncate_to(first_position)
+        elif first_position > slab.offset:
+            raise RuntimeError(
+                f"Native MTP slab for request {req_id!r} has a hole: next slot is "
+                f"at position {first_position} but only {slab.offset} positions "
+                "were ingested. Target hidden states for the gap were never "
+                "observed."
+            )
+        return slab
+
+    def _prune_finished(self, finished_req_ids: set[str]) -> None:
+        for req_id in finished_req_ids:
+            self._slabs.pop(req_id, None)
+            self._pending_last_hidden.pop(req_id, None)
+
+
+__all__ = [
+    "MTPSlab",
+    "NativeMTPProposer",
+]

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -147,6 +147,11 @@ class NgramProposer:
         # N-gram matches token ids only; it never reads the target's hidden states.
         return False
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # N-gram drafts from the per-step token history it is handed; it holds no
+        # per-request state to release.
+        del req_ids
+
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         # Bookkeeping runs unconditionally, before the num_speculative_tokens
         # check: a step with drafting disabled still needs finished ids

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -63,11 +63,7 @@ class ProposeContext:
 
 
 class MetalProposer(Protocol):
-    """Uniform drafting seam.
-
-    Implementations: :class:`Gemma4MTPProposer`, and (draft-model SD) a
-    ``DraftModelProposer``.
-    """
+    """Uniform drafting seam."""
 
     def needs_target_hidden_states(
         self,
@@ -80,6 +76,16 @@ class MetalProposer(Protocol):
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         """Return per-request draft tokens for the next step, or ``None``."""
+        ...
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        """Release any per-request drafter state for these evicted/preempted ids.
+
+        Called from the runner's lifecycle reconcile on eviction, preemption, and
+        resume. A proposer that pins a bounded per-request resource (a KV slab,
+        draft cache blocks) must release it here rather than hold it while the
+        request waits; a stateless proposer is a no-op.
+        """
         ...
 
 
@@ -105,6 +111,11 @@ class Gemma4MTPProposer:
         # decode and final-prefill rows; intermediate prefill chunks never
         # sample, so they cannot seed a draft.
         return bool(decode_segments) or has_final_prefill
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The assistant reads the target's paged KV (released by the runtime);
+        # the proposer holds no per-request state of its own.
+        del req_ids
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         if ctx.num_speculative_tokens <= 0:


### PR DESCRIPTION
Native MTP speculative decoding for GLM-4.7-Flash, reopened fresh against current
main as invited when #484/#485 were closed. GLM-4.7-Flash ships one trained nextn
(MTP) layer inside the target checkpoint (`num_nextn_predict_layers: 1`); this runs
it as a native drafter on the paged path — one decoder-layer forward over the
target's post-final-norm hidden states proposes one draft token, keeping only the
head's own compressed MLA latent per request (~1.2 KB/token). It reads none of the
target's paged KV, needs no second block allocator, and drafts without a separate
draft-model prompt prefill during the normal path.

The head loads from a hosted MLX checkpoint split from a pinned target revision
(`samithaj/GLM-4.7-Flash-MTP-4bit` / `-bf16`), produced with the
`glm4_moe_lite_mtp` split tool proposed in Blaizzy/mlx-vlm#1570 — the upstream
artifact contract laid out in #482. There is no per-user extraction step. Pin the
head `revision` in `speculative_config` for reproducible runs.

What's here:
- A class-owned `NativeMTPHeadRegistry` keyed on the draft `model_type`, and
  `Glm4MoeLiteMTPHead`, which owns its validation and builds its proposer.
- The MLX head model + hosted-checkpoint loader. The drafter split nests the
  source config under `text_config` and leaves the head's architecture / nextn
  depth out of the top level, so the compat shim promotes both before vLLM's MTP
  override runs (and the promoted config survives pickling into vLLM's spawned
  engine workers), and the head's config/args parsing reads the shape from the
  nested `text_config` rather than falling back to defaults.
- `NativeMTPProposer` / `MTPSlab`, which releases its per-request KV slab on
  eviction/preemption/resume through a new `MetalProposer.release_requests` seam,
  rebuilding it during scheduler recompute (with rewind/hole checks) rather than
  pinning it while a request waits.
- `model_runner.install_drafter` dispatch for non-Gemma4 `method="mtp"` configs.

Changed vs the earlier stack (#484/#485): the hosted loader replaces the in-repo
per-user extraction tool (deleted), and the whole thing is a single integration PR
rather than a seam-split series, per the reopen-fresh request.

Constraints: greedy only (`temperature=0`), `num_speculative_tokens=1`, synchronous
scheduling (`--no-async-scheduling`), the paged text path, prefix caching off
(`--no-enable-prefix-caching`), and no pipeline parallelism — each rejected at
startup / proposer construction rather than surfacing mid-run.

Tests: `pytest -m "not slow" tests/` — 1591 passed / 15 skipped / 46 deselected
(under vLLM 0.25.1 + MLX 0.32.0, this branch). `ruff check` / `format --check`
clean on all touched files.

Benchmarks (M3 Max, GLM-4.7-Flash-4bit target + 4-bit hosted head, both
revision-pinned and recorded in the JSONs; greedy, bs1, 8 distinct prompts run
serialized x 256 tokens): SD on vs off raises end-to-end output-token
throughput by **~10%** (66.1 vs 59.8 tok/s, interleaved A/B processes with
cooldowns on an idle machine; 1.06-1.13x across all idle-machine pairings) at
**0.770** acceptance measured over the timed runs only (889/1155 post-warmup
draft tokens; identical across runs under greedy). An earlier version of this
paragraph claimed 1.35x — that paired an SD run against a baseline depressed
by steady background load (which passes an intra-run drift gate); interleaved
A/B runs corrected it. Lossless verified against a no-SD batch-shape control:
SD divergences fall in the same class as the 4-bit MLA target's intrinsic
batch-shape wobble. The earlier measurement in #482 (~1.40x at ~0.91
acceptance) used a different prompt set, token budget, and MLX/vLLM versions,
so the two are not directly comparable; single-prompt acceptance varies
substantially by prompt (0.71-0.83 observed). With K=1 at 0.77 acceptance the
no-overhead ceiling is 1.77x; the gap is per-step draft + verify overhead (the
2-token verify step runs the target's quantized matmuls at M=2 well below
2-token efficiency), which is kernel follow-up territory, not head quality.
Benchmark JSONs are linked in the first comment (token_ids trimmed).
