### PR TITLE
[Spec Decode] Dspark

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -1,15 +1,15 @@
 # Speculative Decoding
 
-vllm-metal supports three speculative decoding methods on the paged attention
+vllm-metal supports four speculative decoding methods on the paged attention
 path. All require synchronous scheduling and greedy sampling.
 
-| | MTP | Draft Model | N-gram |
-|---|---|---|---|
-| `--speculative-config` method | `mtp` | `draft_model` | `ngram` |
-| Target models | Gemma4 (paged) | Any paged-attention model | Any paged-attention model |
-| Draft source | MTP assistant checkpoint (reads target KV cache) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
-| `num_speculative_tokens` | 1 | Configurable (3–5 typical) | Configurable (3–5 typical) |
-| Extra memory | None (reads target KV cache) | Second un-budgeted KV cache | None |
+| | MTP | DSpark | Draft Model | N-gram |
+|---|---|---|---|---|
+| `--speculative-config` method | `mtp` | `dspark` / `draft_model` | `draft_model` | `ngram` |
+| Target models | Gemma4 (paged) | Qwen3 4B/8B/14B (needs a matched drafter) | Any paged-attention model | Any paged-attention model |
+| Draft source | MTP assistant checkpoint (reads target KV cache) | DeepSeek EAGLE3+Markov drafter (consumes target hidden states) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
+| `num_speculative_tokens` | 1 | 2 (recommended) | Configurable (3–5 typical) | Configurable (3–5 typical) |
+| Extra memory | None (reads target KV cache) | Draft weights + small proposer-owned context KV | Second un-budgeted KV cache | None |
 
 All three methods:
 
@@ -142,6 +142,71 @@ from RedHatAI/speculator_benchmarks:
 - **Single-stream:** 1.36–1.48x TPOT improvement (K=3–5).
 - **Batched (concurrency 32):** K=3 gives +11% throughput; K=5 turns
   net-negative as draft compute exceeds the savings.
+
+---
+
+## DSpark
+
+DSpark is DeepSeek's EAGLE-family speculative-decoding drafter. A small
+backbone cross-attends over the *target's* fused intermediate-layer hidden
+states (selected by the drafter's `target_layer_ids`), proposes a 7-token
+block, and applies a rank-256 Markov head for previous-token correction. The
+target verifies every token, so output is greedy-identical up to
+floating-point tie-breaking.
+
+A DSpark drafter is **trained per target** — it consumes that target's
+hidden states and predicts that target's continuations, so it only works for
+models with a published matched drafter:
+
+| Target | DSpark drafter |
+| --- | --- |
+| `mlx-community/Qwen3-4B-4bit` (or any quant) | `deepseek-ai/dspark_qwen3_4b_block7` |
+| `mlx-community/Qwen3-8B-8bit` (or any quant) | `deepseek-ai/dspark_qwen3_8b_block7` |
+| `mlx-community/Qwen3-14B-8bit` (or any quant) | `deepseek-ai/dspark_qwen3_14b_block7` |
+
+For targets without a matched DSpark drafter, use [N-gram](#n-gram)
+(model-agnostic) instead.
+
+### Serve
+
+```bash
+# DSpark requires the V1 model runner — Metal has no Triton, and vLLM 0.25.1's
+# native DSpark path forces Model Runner V2, which errors without it.
+VLLM_USE_V2_MODEL_RUNNER=0 \
+VLLM_METAL_MEMORY_FRACTION=0.8 \
+vllm serve mlx-community/Qwen3-4B-4bit \
+  --max-model-len 2048 \
+  --max-num-seqs 1 \
+  --no-async-scheduling \
+  --speculative-config '{"method":"draft_model","model":"deepseek-ai/dspark_qwen3_4b_block7","num_speculative_tokens":2}'
+```
+
+The drafter can be an HF repo id or a local path. `num_speculative_tokens=2`
+is the measured optimum on Apple Silicon (the verify cost grows with each
+accepted token, so longer blocks rarely pay).
+
+Confirm speculative decoding is active: the server log shows
+`DSpark drafter loaded for speculative decoding: <model> (block_size=7,
+target_layer_ids=[...])`, and the periodic `SpecDecoding metrics ... Avg
+Draft acceptance rate` reflects the live acceptance.
+
+### Characteristics
+
+- **Greedy only**, like every Metal spec-decode method.
+- **Prefix-caching compatible.** DSpark re-runs a tapped target forward to
+  seed the drafter context at first draft, so it does not require
+  `--no-enable-prefix-caching`.
+- **Per-request drafting in v1.** Each request's drafter context is drafted
+  independently; a batched drafter forward is a follow-up.
+
+### Limitations
+
+- **Per-target drafters.** No drafter is published for Llama, Mistral, Phi, or
+  other families — DSpark cannot accelerate them. Use N-gram for those.
+- **Floating-point tie-breaking.** On near-ties the multi-token verify
+  forward may flip an argmax the single-token baseline would not, so output
+  is greedy-*identical up to fp ties*, not bit-identical on every prompt.
+- **Drafter context grows with generation length** in v1 (no eviction yet).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ include = ["vllm_metal/metal/*.metallib", "vllm_metal/metal/_paged_ops*.so"]
 [tool.ruff]
 line-length = 88
 target-version = "py312"
-exclude = ["extern", ".venv*", "test_vllm.py", "target"]
+exclude = ["extern", ".venv*", "test_vllm.py", "target", "vllm_metal/v1/dspark"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "C4"]

--- a/sonnet.txt
+++ b/sonnet.txt
@@ -1,0 +1,518 @@
+FROM fairest creatures we desire increase,
+That thereby beauty's rose might never die,
+But as the riper should by time decease,
+His tender heir might bear his memory:
+But thou, contracted to thine own bright eyes,
+Feed'st thy light'st flame with self-substantial fuel,
+Making a famine where abundance lies,
+Thyself thy foe, to thy sweet self too cruel.
+Thou that art now the world's fresh ornament
+And only herald to the gaudy spring,
+Within thine own bud buriest thy content
+And, tender churl, makest waste in niggarding.
+Pity the world, or else this glutton be,
+To eat the world's due, by the grave and thee.
+When forty winters shall beseige thy brow,
+And dig deep trenches in thy beauty's field,
+Thy youth's proud livery, so gazed on now,
+Will be a tatter'd weed, of small worth held:
+Then being ask'd where all thy beauty lies,
+Where all the treasure of thy lusty days,
+To say, within thine own deep-sunken eyes,
+Were an all-eating shame and thriftless praise.
+How much more praise deserved thy beauty's use,
+If thou couldst answer 'This fair child of mine
+Shall sum my count and make my old excuse,'
+Proving his beauty by succession thine!
+This were to be new made when thou art old,
+And see thy blood warm when thou feel'st it cold.
+Look in thy glass, and tell the face thou viewest
+Now is the time that face should form another;
+Whose fresh repair if now thou not renewest,
+Thou dost beguile the world, unbless some mother.
+For where is she so fair whose unear'd womb
+Disdains the tillage of thy husbandry?
+Or who is he so fond will be the tomb
+Of his self-love, to stop posterity?
+Thou art thy mother's glass, and she in thee
+Calls back the lovely April of her prime:
+So thou through windows of thine age shall see
+Despite of wrinkles this thy golden time.
+But if thou live, remember'd not to be,
+Die single, and thine image dies with thee.
+Unthrifty loveliness, why dost thou spend
+Upon thyself thy beauty's legacy?
+Nature's bequest gives nothing but doth lend,
+And being frank she lends to those are free.
+Then, beauteous niggard, why dost thou abuse
+The bounteous largess given thee to give?
+Profitless usurer, why dost thou use
+So great a sum of sums, yet canst not live?
+For having traffic with thyself alone,
+Thou of thyself thy sweet self dost deceive.
+Then how, when nature calls thee to be gone,
+What acceptable audit canst thou leave?
+Thy unused beauty must be tomb'd with thee,
+Which, used, lives th' executor to be.
+Those hours, that with gentle work did frame
+The lovely gaze where every eye doth dwell,
+Will play the tyrants to the very same
+And that unfair which fairly doth excel:
+For never-resting time leads summer on
+To hideous winter and confounds him there;
+Sap cheque'd with frost and lusty leaves quite gone,
+Beauty o'ersnow'd and bareness every where:
+Then, were not summer's distillation left,
+A liquid prisoner pent in walls of glass,
+Beauty's effect with beauty were bereft,
+Nor it nor no remembrance what it was:
+But flowers distill'd though they with winter meet,
+Leese but their show; their substance still lives sweet.
+Then let not winter's ragged hand deface
+In thee thy summer, ere thou be distill'd:
+Make sweet some vial; treasure thou some place
+With beauty's treasure, ere it be self-kill'd.
+That use is not forbidden usury,
+Which happies those that pay the willing loan;
+That's for thyself to breed another thee,
+Or ten times happier, be it ten for one;
+Ten times thyself were happier than thou art,
+If ten of thine ten times refigured thee:
+Then what could death do, if thou shouldst depart,
+Leaving thee living in posterity?
+Be not self-will'd, for thou art much too fair
+To be death's conquest and make worms thine heir.
+Lo! in the orient when the gracious light
+Lifts up his burning head, each under eye
+Doth homage to his new-appearing sight,
+Serving with looks his sacred majesty;
+And having climb'd the steep-up heavenly hill,
+Resembling strong youth in his middle age,
+yet mortal looks adore his beauty still,
+Attending on his golden pilgrimage;
+But when from highmost pitch, with weary car,
+Like feeble age, he reeleth from the day,
+The eyes, 'fore duteous, now converted are
+From his low tract and look another way:
+So thou, thyself out-going in thy noon,
+Unlook'd on diest, unless thou get a son.
+Music to hear, why hear'st thou music sadly?
+Sweets with sweets war not, joy delights in joy.
+Why lovest thou that which thou receivest not gladly,
+Or else receivest with pleasure thine annoy?
+If the true concord of well-tuned sounds,
+By unions married, do offend thine ear,
+They do but sweetly chide thee, who confounds
+In singleness the parts that thou shouldst bear.
+Mark how one string, sweet husband to another,
+Strikes each in each by mutual ordering,
+Resembling sire and child and happy mother
+Who all in one, one pleasing note do sing:
+Whose speechless song, being many, seeming one,
+Sings this to thee: 'thou single wilt prove none.'
+Is it for fear to wet a widow's eye
+That thou consumest thyself in single life?
+Ah! if thou issueless shalt hap to die.
+The world will wail thee, like a makeless wife;
+The world will be thy widow and still weep
+That thou no form of thee hast left behind,
+When every private widow well may keep
+By children's eyes her husband's shape in mind.
+Look, what an unthrift in the world doth spend
+Shifts but his place, for still the world enjoys it;
+But beauty's waste hath in the world an end,
+And kept unused, the user so destroys it.
+No love toward others in that bosom sits
+That on himself such murderous shame commits.
+For shame! deny that thou bear'st love to any,
+Who for thyself art so unprovident.
+Grant, if thou wilt, thou art beloved of many,
+But that thou none lovest is most evident;
+For thou art so possess'd with murderous hate
+That 'gainst thyself thou stick'st not to conspire.
+Seeking that beauteous roof to ruinate
+Which to repair should be thy chief desire.
+O, change thy thought, that I may change my mind!
+Shall hate be fairer lodged than gentle love?
+Be, as thy presence is, gracious and kind,
+Or to thyself at least kind-hearted prove:
+Make thee another self, for love of me,
+That beauty still may live in thine or thee.
+As fast as thou shalt wane, so fast thou growest
+In one of thine, from that which thou departest;
+And that fresh blood which youngly thou bestowest
+Thou mayst call thine when thou from youth convertest.
+Herein lives wisdom, beauty and increase:
+Without this, folly, age and cold decay:
+If all were minded so, the times should cease
+And threescore year would make the world away.
+Let those whom Nature hath not made for store,
+Harsh featureless and rude, barrenly perish:
+Look, whom she best endow'd she gave the more;
+Which bounteous gift thou shouldst in bounty cherish:
+She carved thee for her seal, and meant thereby
+Thou shouldst print more, not let that copy die.
+When I do count the clock that tells the time,
+And see the brave day sunk in hideous night;
+When I behold the violet past prime,
+And sable curls all silver'd o'er with white;
+When lofty trees I see barren of leaves
+Which erst from heat did canopy the herd,
+And summer's green all girded up in sheaves
+Borne on the bier with white and bristly beard,
+Then of thy beauty do I question make,
+That thou among the wastes of time must go,
+Since sweets and beauties do themselves forsake
+And die as fast as they see others grow;
+And nothing 'gainst Time's scythe can make defence
+Save breed, to brave him when he takes thee hence.
+O, that you were yourself! but, love, you are
+No longer yours than you yourself here live:
+Against this coming end you should prepare,
+And your sweet semblance to some other give.
+So should that beauty which you hold in lease
+Find no determination: then you were
+Yourself again after yourself's decease,
+When your sweet issue your sweet form should bear.
+Who lets so fair a house fall to decay,
+Which husbandry in honour might uphold
+Against the stormy gusts of winter's day
+And barren rage of death's eternal cold?
+O, none but unthrifts! Dear my love, you know
+You had a father: let your son say so.
+Not from the stars do I my judgment pluck;
+And yet methinks I have astronomy,
+But not to tell of good or evil luck,
+Of plagues, of dearths, or seasons' quality;
+Nor can I fortune to brief minutes tell,
+Pointing to each his thunder, rain and wind,
+Or say with princes if it shall go well,
+By oft predict that I in heaven find:
+But from thine eyes my knowledge I derive,
+And, constant stars, in them I read such art
+As truth and beauty shall together thrive,
+If from thyself to store thou wouldst convert;
+Or else of thee this I prognosticate:
+Thy end is truth's and beauty's doom and date.
+When I consider every thing that grows
+Holds in perfection but a little moment,
+That this huge stage presenteth nought but shows
+Whereon the stars in secret influence comment;
+When I perceive that men as plants increase,
+Cheered and cheque'd even by the self-same sky,
+Vaunt in their youthful sap, at height decrease,
+And wear their brave state out of memory;
+Then the conceit of this inconstant stay
+Sets you most rich in youth before my sight,
+Where wasteful Time debateth with Decay,
+To change your day of youth to sullied night;
+And all in war with Time for love of you,
+As he takes from you, I engraft you new.
+But wherefore do not you a mightier way
+Make war upon this bloody tyrant, Time?
+And fortify yourself in your decay
+With means more blessed than my barren rhyme?
+Now stand you on the top of happy hours,
+And many maiden gardens yet unset
+With virtuous wish would bear your living flowers,
+Much liker than your painted counterfeit:
+So should the lines of life that life repair,
+Which this, Time's pencil, or my pupil pen,
+Neither in inward worth nor outward fair,
+Can make you live yourself in eyes of men.
+To give away yourself keeps yourself still,
+And you must live, drawn by your own sweet skill.
+Who will believe my verse in time to come,
+If it were fill'd with your most high deserts?
+Though yet, heaven knows, it is but as a tomb
+Which hides your life and shows not half your parts.
+If I could write the beauty of your eyes
+And in fresh numbers number all your graces,
+The age to come would say 'This poet lies:
+Such heavenly touches ne'er touch'd earthly faces.'
+So should my papers yellow'd with their age
+Be scorn'd like old men of less truth than tongue,
+And your true rights be term'd a poet's rage
+And stretched metre of an antique song:
+But were some child of yours alive that time,
+You should live twice; in it and in my rhyme.
+Shall I compare thee to a summer's day?
+Thou art more lovely and more temperate:
+Rough winds do shake the darling buds of May,
+And summer's lease hath all too short a date:
+Sometime too hot the eye of heaven shines,
+And often is his gold complexion dimm'd;
+And every fair from fair sometime declines,
+By chance or nature's changing course untrimm'd;
+But thy eternal summer shall not fade
+Nor lose possession of that fair thou owest;
+Nor shall Death brag thou wander'st in his shade,
+When in eternal lines to time thou growest:
+So long as men can breathe or eyes can see,
+So long lives this and this gives life to thee.
+Devouring Time, blunt thou the lion's paws,
+And make the earth devour her own sweet brood;
+Pluck the keen teeth from the fierce tiger's jaws,
+And burn the long-lived phoenix in her blood;
+Make glad and sorry seasons as thou fleets,
+And do whate'er thou wilt, swift-footed Time,
+To the wide world and all her fading sweets;
+But I forbid thee one most heinous crime:
+O, carve not with thy hours my love's fair brow,
+Nor draw no lines there with thine antique pen;
+Him in thy course untainted do allow
+For beauty's pattern to succeeding men.
+Yet, do thy worst, old Time: despite thy wrong,
+My love shall in my verse ever live young.
+A woman's face with Nature's own hand painted
+Hast thou, the master-mistress of my passion;
+A woman's gentle heart, but not acquainted
+With shifting change, as is false women's fashion;
+An eye more bright than theirs, less false in rolling,
+Gilding the object whereupon it gazeth;
+A man in hue, all 'hues' in his controlling,
+Much steals men's eyes and women's souls amazeth.
+And for a woman wert thou first created;
+Till Nature, as she wrought thee, fell a-doting,
+And by addition me of thee defeated,
+By adding one thing to my purpose nothing.
+But since she prick'd thee out for women's pleasure,
+Mine be thy love and thy love's use their treasure.
+So is it not with me as with that Muse
+Stirr'd by a painted beauty to his verse,
+Who heaven itself for ornament doth use
+And every fair with his fair doth rehearse
+Making a couplement of proud compare,
+With sun and moon, with earth and sea's rich gems,
+With April's first-born flowers, and all things rare
+That heaven's air in this huge rondure hems.
+O' let me, true in love, but truly write,
+And then believe me, my love is as fair
+As any mother's child, though not so bright
+As those gold candles fix'd in heaven's air:
+Let them say more than like of hearsay well;
+I will not praise that purpose not to sell.
+My glass shall not persuade me I am old,
+So long as youth and thou are of one date;
+But when in thee time's furrows I behold,
+Then look I death my days should expiate.
+For all that beauty that doth cover thee
+Is but the seemly raiment of my heart,
+Which in thy breast doth live, as thine in me:
+How can I then be elder than thou art?
+O, therefore, love, be of thyself so wary
+As I, not for myself, but for thee will;
+Bearing thy heart, which I will keep so chary
+As tender nurse her babe from faring ill.
+Presume not on thy heart when mine is slain;
+Thou gavest me thine, not to give back again.
+As an unperfect actor on the stage
+Who with his fear is put besides his part,
+Or some fierce thing replete with too much rage,
+Whose strength's abundance weakens his own heart.
+So I, for fear of trust, forget to say
+The perfect ceremony of love's rite,
+And in mine own love's strength seem to decay,
+O'ercharged with burden of mine own love's might.
+O, let my books be then the eloquence
+And dumb presagers of my speaking breast,
+Who plead for love and look for recompense
+More than that tongue that more hath more express'd.
+O, learn to read what silent love hath writ:
+To hear with eyes belongs to love's fine wit.
+Mine eye hath play'd the painter and hath stell'd
+Thy beauty's form in table of my heart;
+My body is the frame wherein 'tis held,
+And perspective it is the painter's art.
+For through the painter must you see his skill,
+To find where your true image pictured lies;
+Which in my bosom's shop is hanging still,
+That hath his windows glazed with thine eyes.
+Now see what good turns eyes for eyes have done:
+Mine eyes have drawn thy shape, and thine for me
+Are windows to my breast, where-through the sun
+Delights to peep, to gaze therein on thee;
+Yet eyes this cunning want to grace their art;
+They draw but what they see, know not the heart.
+Let those who are in favour with their stars
+Of public honour and proud titles boast,
+Whilst I, whom fortune of such triumph bars,
+Unlook'd for joy in that I honour most.
+Great princes' favourites their fair leaves spread
+But as the marigold at the sun's eye,
+And in themselves their pride lies buried,
+For at a frown they in their glory die.
+The painful warrior famoused for fight,
+After a thousand victories once foil'd,
+Is from the book of honour razed quite,
+And all the rest forgot for which he toil'd:
+Then happy I, that love and am beloved
+Where I may not remove nor be removed.
+Lord of my love, to whom in vassalage
+Thy merit hath my duty strongly knit,
+To thee I send this written embassage,
+To witness duty, not to show my wit:
+Duty so great, which wit so poor as mine
+May make seem bare, in wanting words to show it,
+But that I hope some good conceit of thine
+In thy soul's thought, all naked, will bestow it;
+Till whatsoever star that guides my moving
+Points on me graciously with fair aspect
+And puts apparel on my tatter'd loving,
+To show me worthy of thy sweet respect:
+Then may I dare to boast how I do love thee;
+Till then not show my head where thou mayst prove me.
+Weary with toil, I haste me to my bed,
+The dear repose for limbs with travel tired;
+But then begins a journey in my head,
+To work my mind, when body's work's expired:
+For then my thoughts, from far where I abide,
+Intend a zealous pilgrimage to thee,
+And keep my drooping eyelids open wide,
+Looking on darkness which the blind do see
+Save that my soul's imaginary sight
+Presents thy shadow to my sightless view,
+Which, like a jewel hung in ghastly night,
+Makes black night beauteous and her old face new.
+Lo! thus, by day my limbs, by night my mind,
+For thee and for myself no quiet find.
+How can I then return in happy plight,
+That am debarr'd the benefit of rest?
+When day's oppression is not eased by night,
+But day by night, and night by day, oppress'd?
+And each, though enemies to either's reign,
+Do in consent shake hands to torture me;
+The one by toil, the other to complain
+How far I toil, still farther off from thee.
+I tell the day, to please them thou art bright
+And dost him grace when clouds do blot the heaven:
+So flatter I the swart-complexion'd night,
+When sparkling stars twire not thou gild'st the even.
+But day doth daily draw my sorrows longer
+And night doth nightly make grief's strength seem stronger.
+When, in disgrace with fortune and men's eyes,
+I all alone beweep my outcast state
+And trouble deal heaven with my bootless cries
+And look upon myself and curse my fate,
+Wishing me like to one more rich in hope,
+Featured like him, like him with friends possess'd,
+Desiring this man's art and that man's scope,
+With what I most enjoy contented least;
+Yet in these thoughts myself almost despising,
+Haply I think on thee, and then my state,
+Like to the lark at break of day arising
+From sullen earth, sings hymns at heaven's gate;
+For thy sweet love remember'd such wealth brings
+That then I scorn to change my state with kings.
+When to the sessions of sweet silent thought
+I summon up remembrance of things past,
+I sigh the lack of many a thing I sought,
+And with old woes new wail my dear time's waste:
+Then can I drown an eye, unused to flow,
+For precious friends hid in death's dateless night,
+And weep afresh love's long since cancell'd woe,
+And moan the expense of many a vanish'd sight:
+Then can I grieve at grievances foregone,
+And heavily from woe to woe tell o'er
+The sad account of fore-bemoaned moan,
+Which I new pay as if not paid before.
+But if the while I think on thee, dear friend,
+All losses are restored and sorrows end.
+Thy bosom is endeared with all hearts,
+Which I by lacking have supposed dead,
+And there reigns love and all love's loving parts,
+And all those friends which I thought buried.
+How many a holy and obsequious tear
+Hath dear religious love stol'n from mine eye
+As interest of the dead, which now appear
+But things removed that hidden in thee lie!
+Thou art the grave where buried love doth live,
+Hung with the trophies of my lovers gone,
+Who all their parts of me to thee did give;
+That due of many now is thine alone:
+Their images I loved I view in thee,
+And thou, all they, hast all the all of me.
+If thou survive my well-contented day,
+When that churl Death my bones with dust shall cover,
+And shalt by fortune once more re-survey
+These poor rude lines of thy deceased lover,
+Compare them with the bettering of the time,
+And though they be outstripp'd by every pen,
+Reserve them for my love, not for their rhyme,
+Exceeded by the height of happier men.
+O, then vouchsafe me but this loving thought:
+'Had my friend's Muse grown with this growing age,
+A dearer birth than this his love had brought,
+To march in ranks of better equipage:
+But since he died and poets better prove,
+Theirs for their style I'll read, his for his love.'
+Full many a glorious morning have I seen
+Flatter the mountain-tops with sovereign eye,
+Kissing with golden face the meadows green,
+Gilding pale streams with heavenly alchemy;
+Anon permit the basest clouds to ride
+With ugly rack on his celestial face,
+And from the forlorn world his visage hide,
+Stealing unseen to west with this disgrace:
+Even so my sun one early morn did shine
+With all triumphant splendor on my brow;
+But out, alack! he was but one hour mine;
+The region cloud hath mask'd him from me now.
+Yet him for this my love no whit disdaineth;
+Suns of the world may stain when heaven's sun staineth.
+Why didst thou promise such a beauteous day,
+And make me travel forth without my cloak,
+To let base clouds o'ertake me in my way,
+Hiding thy bravery in their rotten smoke?
+'Tis not enough that through the cloud thou break,
+To dry the rain on my storm-beaten face,
+For no man well of such a salve can speak
+That heals the wound and cures not the disgrace:
+Nor can thy shame give physic to my grief;
+Though thou repent, yet I have still the loss:
+The offender's sorrow lends but weak relief
+To him that bears the strong offence's cross.
+Ah! but those tears are pearl which thy love sheds,
+And they are rich and ransom all ill deeds.
+No more be grieved at that which thou hast done:
+Roses have thorns, and silver fountains mud;
+Clouds and eclipses stain both moon and sun,
+And loathsome canker lives in sweetest bud.
+All men make faults, and even I in this,
+Authorizing thy trespass with compare,
+Myself corrupting, salving thy amiss,
+Excusing thy sins more than thy sins are;
+For to thy sensual fault I bring in sense--
+Thy adverse party is thy advocate--
+And 'gainst myself a lawful plea commence:
+Such civil war is in my love and hate
+That I an accessary needs must be
+To that sweet thief which sourly robs from me.
+Let me confess that we two must be twain,
+Although our undivided loves are one:
+So shall those blots that do with me remain
+Without thy help by me be borne alone.
+In our two loves there is but one respect,
+Though in our lives a separable spite,
+Which though it alter not love's sole effect,
+Yet doth it steal sweet hours from love's delight.
+I may not evermore acknowledge thee,
+Lest my bewailed guilt should do thee shame,
+Nor thou with public kindness honour me,
+Unless thou take that honour from thy name:
+But do not so; I love thee in such sort
+As, thou being mine, mine is thy good report.
+As a decrepit father takes delight
+To see his active child do deeds of youth,
+So I, made lame by fortune's dearest spite,
+Take all my comfort of thy worth and truth.
+For whether beauty, birth, or wealth, or wit,
+Or any of these all, or all, or more,
+Entitled in thy parts do crowned sit,
+I make my love engrafted to this store:
+So then I am not lame, poor, nor despised,
+Whilst that this shadow doth such substance give
+That I in thy abundance am sufficed
+And by a part of all thy glory live.
+Look, what is best, that best I wish in thee:
+This wish I have; then ten times happy me!

--- a/tests/test_dspark_proposer.py
+++ b/tests/test_dspark_proposer.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model-free unit tests for the DSpark speculative-decoding proposer.
+
+A ``SimpleNamespace`` stub drafter + a stub controller drive ``propose`` through
+the real lifecycle (prompt seeding at first draft, segment-row context growth,
+the ``n_cached == committed_len - 1`` invariant, eligibility gating, pruning).
+No MLX model is loaded — ``run_backbone_with_capture`` is monkeypatched out so
+``_seed_prompt`` needs no real backbone.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+pytest.importorskip("vllm", reason="vllm not installed")
+
+import vllm_metal.v1.dspark_proposer as dspark_mod  # noqa: E402
+from vllm_metal.v1.dspark_proposer import DSparkProposer  # noqa: E402
+from vllm_metal.v1.proposer import ProposeContext  # noqa: E402
+from vllm_metal.v1.spec_decode import SpeculativeDecodeController  # noqa: E402
+
+TARGET_LAYER_IDS = [1, 9, 17, 25, 33]
+BLOCK_SIZE = 7
+MASK_TOKEN_ID = 151669
+
+
+def _cfg() -> SimpleNamespace:
+    return SimpleNamespace(
+        target_layer_ids=TARGET_LAYER_IDS,
+        block_size=BLOCK_SIZE,
+        mask_token_id=MASK_TOKEN_ID,
+    )
+
+
+def _stub_drafter() -> MagicMock:
+    """A fake drafter that records calls + returns a `cap`-length 1-D block."""
+    d = MagicMock()
+    # sample_block -> array of length `cap` (all zeros) so [int(t) ...] works.
+    d.sample_block.side_effect = lambda base_logits, first_prev_token: mx.zeros(
+        (base_logits.shape[0] or 1,), dtype=mx.int32
+    )
+    d.embed.return_value = mx.zeros((1, BLOCK_SIZE, 4))
+    d.backbone.return_value = mx.zeros((1, BLOCK_SIZE, 4))
+    d.compute_logits.return_value = mx.zeros((1, BLOCK_SIZE, 3))
+    d.markov_head = None  # no Markov in model-free tests
+    d.confidence_head = None  # no confidence truncation in model-free tests
+    d.make_ctx_cache.return_value = [object() for _ in range(5)]
+    # update_context records (ctx_offset, n_rows) per call.
+    updates: list[tuple[int, int]] = []
+    d._updates = updates
+
+    def _update(fused, ctx_offset, ctx_caches):
+        updates.append((int(ctx_offset), int(fused.shape[1])))
+
+    d.update_context.side_effect = _update
+    return d
+
+
+def _proposer(drafter: MagicMock | None = None) -> DSparkProposer:
+    return DSparkProposer(
+        drafter=drafter or _stub_drafter(),
+        config=_cfg(),
+        runner=SimpleNamespace(
+            _model_adapter=SimpleNamespace(_target_backbone=lambda model: None),
+            _forward_model=object(),
+        ),
+        controller=SpeculativeDecodeController(),
+    )
+
+
+def _segment(
+    req_id: str,
+    *,
+    start_row: int = 0,
+    num_query_tokens: int = 3,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        req_id=req_id,
+        start_row=start_row,
+        num_query_tokens=num_query_tokens,
+    )
+
+
+def _state(token_ids: list[int]) -> SimpleNamespace:
+    # sampling_params(temperature=0) satisfies _validate_greedy_sampling.
+    return SimpleNamespace(
+        token_ids=list(token_ids),
+        sampling_params=SamplingParams(temperature=0.0),
+    )
+
+
+def _context(
+    *,
+    decode_reqs: list[tuple[str, SimpleNamespace]],
+    decode_segments: list[SimpleNamespace],
+    target_hidden_states: mx.array | None,
+    request_states: dict[str, SimpleNamespace] | None = None,
+    num_speculative_tokens: int = 2,
+    eligible: list | None = None,
+) -> ProposeContext:
+    """A ProposeContext whose controller.draft_eligible_requests returns `eligible`
+    (default: all decode_reqs)."""
+    ctx = ProposeContext(
+        target_hidden_states=target_hidden_states,
+        decode_reqs=decode_reqs,
+        decode_segments=decode_segments,
+        decode_token_ids=[[s.token_ids[-1]] for _, s in decode_reqs],
+        prefill_reqs=[],
+        prefill_token_ids=[],
+        prefill_result_modes=[],
+        request_states=request_states or dict(decode_reqs),
+        cu_seqlens=[],
+        num_decode_segments=len(decode_segments),
+        num_speculative_tokens=num_speculative_tokens,
+        logitsprocs=None,
+    )
+    elig = eligible if eligible is not None else list(decode_reqs)
+    ctx_ctrl = SpeculativeDecodeController()
+    ctx_ctrl.draft_eligible_requests = lambda *a, **k: elig  # type: ignore[assignment]
+    return ctx
+
+
+# -- needs_target_hidden_states + capture_layer_ids --------------------------
+
+
+class TestDSparkProtocol:
+    def test_capture_layer_ids_from_config(self) -> None:
+        p = _proposer()
+        assert p.capture_layer_ids == TARGET_LAYER_IDS
+
+    @pytest.mark.parametrize(
+        "segments, expected",
+        [
+            ([], False),
+            ([_segment("r0")], True),
+            ([_segment("r0"), _segment("r1")], True),
+        ],
+    )
+    def test_needs_target_hidden_states(self, segments: list, expected: bool) -> None:
+        p = _proposer()
+        assert (
+            p.needs_target_hidden_states(segments, has_final_prefill=False) is expected
+        )
+
+
+# -- propose gating ----------------------------------------------------------
+
+
+class TestDSparkProposeGating:
+    def test_returns_none_when_no_spec_tokens(self) -> None:
+        p = _proposer()
+        ctx = _context(
+            decode_reqs=[("r0", _state([1, 2, 3]))],
+            decode_segments=[_segment("r0")],
+            target_hidden_states=mx.zeros((1, 4)),
+            num_speculative_tokens=0,
+        )
+        assert p.propose(ctx) is None
+
+    def test_returns_none_when_no_hidden_states(self) -> None:
+        p = _proposer()
+        ctx = _context(
+            decode_reqs=[("r0", _state([1, 2, 3]))],
+            decode_segments=[_segment("r0")],
+            target_hidden_states=None,
+        )
+        assert p.propose(ctx) is None
+
+    def test_returns_none_when_no_eligible(self, monkeypatch) -> None:
+        p = _proposer()
+        monkeypatch.setattr(
+            p._controller,
+            "draft_eligible_requests",
+            lambda *a, **k: [],
+        )
+        ctx = _context(
+            decode_reqs=[("r0", _state([1, 2, 3]))],
+            decode_segments=[_segment("r0")],
+            target_hidden_states=mx.zeros((1, 4)),
+        )
+        assert p.propose(ctx) is None
+
+    def test_skips_request_without_segment(self) -> None:
+        # A decode request absent from decode_segments AND not in prefill_reqs
+        # is skipped — it will be picked up when it appears in a decode
+        # segment.  Prefill-finalizing requests (those in ctx.prefill_reqs)
+        # without a segment ARE seeded (tested separately).
+        p = _proposer()
+        state = _state([1, 2, 3])
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[],  # no segment for r0
+            target_hidden_states=mx.zeros((1, 4)),
+        )
+        assert p.propose(ctx) is None
+
+    def test_seeds_prefill_finalizing_from_stashed_hidden(self) -> None:
+        """A request in prefill_reqs with no decode segment is seeded
+        from the stashed prefill fused hidden (no extra forward)."""
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        state = _state([10, 20, 30, 40, 50])  # prompt + 1 sampled token
+        # Simulate stashed prefill hidden.
+        p._pending_seed["r0"] = mx.zeros((4, 8))  # 4 prompt tokens -> n_cached=4
+        ctx = ProposeContext(
+            target_hidden_states=mx.zeros((4, 8)),  # 4 prefill rows
+            decode_reqs=[],
+            decode_segments=[],
+            decode_token_ids=[],
+            prefill_reqs=[
+                SimpleNamespace(
+                    req_id="r0",
+                    token_ids=[10, 20, 30, 40],
+                    prompt_len=4,
+                    block_ids=[],
+                    start_pos=0,
+                )
+            ],
+            prefill_token_ids=[50],
+            prefill_result_modes=["new_final"],
+            request_states={"r0": state},
+            cu_seqlens=[0, 4],  # 1 prefill of 4 tokens
+            num_decode_segments=0,
+            num_speculative_tokens=2,
+            logitsprocs=None,
+        )
+        from unittest.mock import patch
+
+        with patch.object(
+            p._controller,
+            "draft_eligible_requests",
+            return_value=[("r0", state)],
+        ):
+            out = p.propose(ctx)
+        assert out is not None
+        assert out.req_ids == ["r0"]
+        # Seeded from stashed hidden: n_cached = 4 (prompt_len), ctx_caches created.
+        assert p._n_cached["r0"] == 4
+        assert "r0" in p._ctx_caches
+        # update_context called once with ctx_offset=0, 4 rows.
+        assert drafter._updates == [(0, 4)]
+
+    def test_prefill_stash_uses_correct_cu_index(self) -> None:
+        """The prefill stash must skip past decode entries in cu_seqlens.
+
+        cu_seqlens = [0, decode_0, …, decode_total, prefill_0, …].
+        When decode segments are present, indexing by prefill position
+        without the decode offset grabs wrong (decode) rows.
+        """
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        # 3 decode segments (1+3+1 = 5 decode rows), 1 prefill request (4 rows).
+        decode_segs = [
+            _segment("d0", start_row=0, num_query_tokens=1),
+            _segment("d1", start_row=1, num_query_tokens=3),
+            _segment("d2", start_row=4, num_query_tokens=1),
+        ]
+        decode_reqs = [
+            ("d0", _state([1, 2])),
+            ("d1", _state([3, 4, 5, 6])),
+            ("d2", _state([7, 8])),
+        ]
+        for s in decode_reqs:
+            s[1].generated_tokens = 1
+        # Prefill request: 4 tokens, final chunk.
+        prefill_state = _state([100, 200, 300, 400, 500])
+        # target_hidden_states: 5 decode rows + 4 prefill rows = 9 rows.
+        # Each row has its index as its value so we can identify extracted rows.
+        hidden = mx.arange(9 * 8, dtype=mx.float32).reshape(9, 8)
+        # cu_seqlens: [0, 1, 4, 5, 9]
+        cu = [0, 1, 4, 5, 9]
+        from unittest.mock import patch
+
+        with patch.object(
+            p._controller,
+            "draft_eligible_requests",
+            return_value=decode_reqs,
+        ):
+            ctx = ProposeContext(
+                target_hidden_states=hidden,
+                decode_reqs=decode_reqs,
+                decode_segments=decode_segs,
+                decode_token_ids=[[s[1].token_ids[-1]] for s in decode_reqs],
+                prefill_reqs=[
+                    SimpleNamespace(
+                        req_id="p0",
+                        token_ids=[100, 200, 300, 400],
+                        prompt_len=4,  # final chunk
+                        block_ids=[],
+                        start_pos=0,
+                    )
+                ],
+                prefill_token_ids=[500],
+                prefill_result_modes=["new_final"],
+                request_states={"p0": prefill_state, **dict(decode_reqs)},
+                cu_seqlens=cu,
+                num_decode_segments=len(decode_segs),
+                num_speculative_tokens=2,
+                logitsprocs=None,
+            )
+            p.propose(ctx)
+        # Stashed hidden should be rows [5:9] (the 4 prefill rows, not rows [0:1]).
+        stashed = p._pending_seed.get("p0")
+        assert stashed is not None, "prefill hidden was not stashed"
+        assert stashed.shape[0] == 4, f"expected 4 rows, got {stashed.shape[0]}"
+        assert mx.array_equal(stashed, hidden[5:9]), "stashed wrong rows — cu index bug"
+
+    def test_caps_batch_draft_at_max_drafts_per_step(self) -> None:
+        """When eligible > _max_drafts_per_step, only the first N are drafted."""
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        p._max_drafts_per_step = 3
+        states = {}
+        segments = []
+        decode_reqs = []
+        for k in range(10):
+            rid = f"r{k}"
+            st = _state(list(range(k * 10 + 1, k * 10 + 6)))
+            states[rid] = st
+            segments.append(_segment(rid, start_row=k, num_query_tokens=1))
+            decode_reqs.append((rid, st))
+            p._ctx_caches[rid] = [object()]
+            p._n_cached[rid] = 4
+
+        ctx = _context(
+            decode_reqs=decode_reqs,
+            decode_segments=segments,
+            target_hidden_states=mx.zeros((10, 8)),
+            request_states=states,
+        )
+        out = p.propose(ctx)
+        assert out is not None
+        # The cap limits plans to 3; req_ids reflects this.
+        # (draft_token_ids count may differ with stub drafter fixed shapes.)
+        assert len(out.req_ids) == 3
+
+    def test_cap_not_exceeded_when_under_limit(self) -> None:
+        """When plans < _max_drafts_per_step, none are truncated."""
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        p._max_drafts_per_step = 10
+        state = _state([1, 2, 3])
+        p._ctx_caches["r0"] = [object()]
+        p._n_cached["r0"] = 2
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[_segment("r0", num_query_tokens=1)],
+            target_hidden_states=mx.zeros((1, 8)),
+        )
+        out = p.propose(ctx)
+        assert out is not None
+        assert len(out.req_ids) == 1
+
+
+# -- lifecycle invariant -----------------------------------------------------
+
+
+class TestDSparkLifecycle:
+    def test_first_call_seeds_prompt_via_extra_forward(self, monkeypatch) -> None:
+        """First draft: _seed_prompt runs the tapped forward (monkeypatched) and
+        sets n_cached = committed_len - 1; no segment-row growth yet."""
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        # committed_len = 5 -> prompt is token_ids[:-1] (4 tokens) -> n_cached = 4.
+        state = _state([10, 20, 30, 40, 50])
+        captured = {}
+
+        def _fake_capture(backbone, ids, *, cache, layer_ids):
+            captured["ids"] = ids.tolist()
+            captured["layer_ids"] = list(layer_ids)
+            return mx.zeros((1, 1, 1)), mx.zeros((1, len(ids[0]), len(layer_ids) * 4))
+
+        monkeypatch.setattr(dspark_mod, "run_backbone_with_capture", _fake_capture)
+        # Give _seed_prompt a real-ish backbone (the stub runner returns None).
+        p._runner._model_adapter._target_backbone = lambda model: SimpleNamespace(
+            layers=[object()] * 36
+        )
+
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[_segment("r0", num_query_tokens=3)],
+            target_hidden_states=mx.zeros((3, 8)),
+        )
+        out = p.propose(ctx)
+        assert out is not None
+        assert out.req_ids == ["r0"]
+        assert captured["layer_ids"] == TARGET_LAYER_IDS
+        # prompt seeded with token_ids[:-1] (4 tokens); n_cached = 4.
+        assert captured["ids"] == [[10, 20, 30, 40]]
+        assert p._n_cached["r0"] == 4  # committed_len(5) - 1
+        # seed update_context called once with ctx_offset=0, 4 rows.
+        assert drafter._updates == [(0, 4)]
+
+    def test_later_call_grows_context_from_segment_rows(self, monkeypatch) -> None:
+        """Second draft: ingests (committed_len - 1 - n_cached) segment rows,
+        preserving n_cached == committed_len - 1; no re-seed."""
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        # Pretend the prompt was already seeded (n_cached = 4, committed_len = 5).
+        p._ctx_caches["r0"] = [object()]
+        p._n_cached["r0"] = 4
+
+        # Now committed_len = 7 (2 newly-committed since the seed): grow by 2.
+        state = _state([10, 20, 30, 40, 50, 60, 70])
+        seg = _segment("r0", num_query_tokens=3)  # rows 0..2 of the fused tensor
+        hidden = mx.zeros((3, 8))  # 3 rows, k*H
+
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[seg],
+            target_hidden_states=hidden,
+        )
+        out = p.propose(ctx)
+        assert out is not None
+        # Grew by (7 - 1) - 4 = 2 rows at offset 4 -> n_cached = 6 (= committed_len - 1).
+        assert drafter._updates == [(4, 2)]
+        assert p._n_cached["r0"] == 6
+
+    def test_no_growth_when_context_already_current(self) -> None:
+        """If n_cached == committed_len - 1 already, no ingest."""
+        drafter = _stub_drafter()
+        p = _proposer(drafter)
+        p._ctx_caches["r0"] = [object()]
+        p._n_cached["r0"] = 4
+        state = _state([10, 20, 30, 40, 50])  # committed_len - 1 == 4 == n_cached
+        ctx = _context(
+            decode_reqs=[("r0", state)],
+            decode_segments=[_segment("r0", num_query_tokens=3)],
+            target_hidden_states=mx.zeros((3, 8)),
+        )
+        p.propose(ctx)
+        assert drafter._updates == []  # no growth, but a block was still drafted
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+class TestDSparkHelpers:
+    def test_segment_rows_slices_first_count(self) -> None:
+        p = _proposer()
+        seg = _segment("r0", start_row=2, num_query_tokens=5)
+        hidden = mx.arange(7 * 3, dtype=mx.float32).reshape(7, 3)
+        out = p._segment_rows(hidden, seg, count=3)
+        assert out is not None
+        assert out.shape == (1, 3, 3)  # [1, count, k*H]
+        assert mx.array_equal(out[0], hidden[2:5])
+
+    def test_segment_rows_none_when_count_exceeds_segment(self) -> None:
+        p = _proposer()
+        seg = _segment("r0", start_row=0, num_query_tokens=2)
+        hidden = mx.zeros((2, 3))
+        assert p._segment_rows(hidden, seg, count=5) is None
+
+    def test_prune_finished_drops_state(self) -> None:
+        p = _proposer()
+        p._ctx_caches["keep"] = [object()]
+        p._n_cached["keep"] = 3
+        p._ctx_caches["drop"] = [object()]
+        p._n_cached["drop"] = 5
+        p._prune_finished({"keep": _state([1, 2, 3])})
+        assert "keep" in p._ctx_caches
+        assert "drop" not in p._ctx_caches
+        assert p._n_cached.get("drop") is None

--- a/tests/test_hidden_state_tap.py
+++ b/tests/test_hidden_state_tap.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the reusable hidden-state layer tap (DSpark prep)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+pytest.importorskip("vllm", reason="vllm not installed")
+
+from vllm_metal.v1.hidden_state_tap import (
+    capture_layer_hidden_states,
+    run_backbone_with_capture,
+)
+
+
+class _Id:
+    """Callable identity (stands in for norm)."""
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x
+
+
+class _Embed:
+    """Stand-in for embed_tokens: [B, T] ids -> [B, T, 1] (hidden dim of 1)."""
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        return ids[..., None]
+
+
+class _AddLayer:
+    """Fake transformer layer: adds its index to the residual stream."""
+
+    def __init__(self, i: int) -> None:
+        self.i = i
+
+    def __call__(self, h: mx.array, mask, cache) -> mx.array:  # noqa: ANN001
+        return h + self.i
+
+
+def _toy_backbone(num_layers: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        embed_tokens=_Embed(),
+        layers=[_AddLayer(i) for i in range(num_layers)],
+        norm=_Id(),
+    )
+
+
+# --- capture_layer_hidden_states (fused-only view) ---
+
+
+def test_capture_requires_at_least_one_layer() -> None:
+    backbone = _toy_backbone(3)
+    with pytest.raises(ValueError):
+        capture_layer_hidden_states(
+            backbone, mx.array([[1.0, 2.0, 3.0]]), cache=[None] * 3, layer_ids=[]
+        )
+
+
+def test_capture_fuses_requested_layers_in_order() -> None:
+    # embed: ids -> ids[...,None]; layer i adds i to the running residual, so
+    # after layer i the residual is ids + sum(0..i). Capturing [0, 2] fuses the
+    # residual after layer 0 (ids+0) and after layer 2 (ids+0+1+2 = ids+3).
+    backbone = _toy_backbone(3)
+    ids = mx.array([[1.0, 2.0, 3.0]])  # [1, 3]
+    out = capture_layer_hidden_states(backbone, ids, cache=[None] * 3, layer_ids=[0, 2])
+    mx.eval(out)
+    assert out.shape == (1, 3, 2)  # [batch, tokens, len(layer_ids) * hidden(=1)]
+    expected = mx.concatenate([ids[..., None], (ids + 3)[..., None]], axis=-1)
+    assert mx.array_equal(out, expected)
+
+
+def test_capture_single_last_layer_matches_full_residual() -> None:
+    # Capturing only the last layer reproduces the body's own final residual
+    # (the pre-norm stream) — the fidelity invariant the drafter relies on.
+    backbone = _toy_backbone(4)
+    ids = mx.array([[1.0, 2.0, 3.0]])
+    out = capture_layer_hidden_states(backbone, ids, cache=[None] * 4, layer_ids=[3])
+    final = (ids + 0 + 1 + 2 + 3)[..., None]  # residual after all 4 layers
+    mx.eval(out)
+    assert out.shape == (1, 3, 1)
+    assert mx.array_equal(out, final)
+
+
+def test_capture_rejects_out_of_range_layer() -> None:
+    backbone = _toy_backbone(3)
+    with pytest.raises(IndexError):
+        capture_layer_hidden_states(
+            backbone, mx.array([[1.0, 2.0]]), cache=[None] * 3, layer_ids=[5]
+        )
+
+
+# --- run_backbone_with_capture (final + fused from one traversal) ---
+
+
+def test_run_backbone_returns_final_post_norm_and_fused() -> None:
+    # One traversal must yield BOTH the post-norm final hidden (for target logits)
+    # and the fused intermediate captures (for the drafter) — the integrated path
+    # can't afford a second forward.
+    backbone = _toy_backbone(3)
+    ids = mx.array([[1.0, 2.0, 3.0]])
+    final, fused = run_backbone_with_capture(
+        backbone, ids, cache=[None] * 3, layer_ids=[0, 2]
+    )
+    mx.eval(final, fused)
+    # final = post-norm residual after ALL layers = ids + 0+1+2 = ids+3
+    assert mx.array_equal(final, (ids + 3)[..., None])
+    # fused = residuals after layer 0 (ids+0) and layer 2 (ids+3)
+    assert mx.array_equal(
+        fused, mx.concatenate([ids[..., None], (ids + 3)[..., None]], axis=-1)
+    )
+
+
+# --- target_forward wiring (capture_layer_ids routing) ---
+
+
+def test_target_forward_capture_routes_through_helper(monkeypatch) -> None:
+    """capture_layer_ids=[...] routes through run_backbone_with_capture and
+    returns its fused output as hidden_states plus logits from
+    _compute_target_logits (computed from the same forward's final hidden)."""
+    import vllm_metal.v1.model_adapter as ma
+
+    adapter = ma.DefaultModelAdapter()
+    toy = _toy_backbone(3)
+    monkeypatch.setattr(adapter, "_target_backbone", lambda model: toy)
+    sentinel_logits = mx.full((1, 2, 3), 7.0)
+    monkeypatch.setattr(
+        adapter, "_compute_target_logits", lambda model, h: sentinel_logits
+    )
+
+    seen: dict = {}
+    fused_sentinel = mx.full((1, 2, 4), 9.0)  # [1, tokens, len(layer_ids) * hidden]
+
+    def _spy(backbone, ids, *, cache, layer_ids):
+        seen["layer_ids"] = list(layer_ids)
+        seen["backbone_is_toy"] = backbone is toy
+        return mx.zeros((1, 2, 1)), fused_sentinel  # final, fused
+
+    monkeypatch.setattr(ma, "run_backbone_with_capture", _spy)
+
+    out = adapter.target_forward(
+        object(), mx.array([[1.0, 2.0]]), cache=[None] * 3, capture_layer_ids=[0, 2]
+    )
+
+    assert seen["layer_ids"] == [0, 2]
+    assert seen["backbone_is_toy"]
+    assert mx.array_equal(out.logits, sentinel_logits)
+    assert out.hidden_states.shape == (2, 4)  # fused [1,2,4] flattened
+    assert mx.array_equal(out.hidden_states, mx.full((2, 4), 9.0))
+
+
+def test_target_forward_none_path_does_not_capture(monkeypatch) -> None:
+    """capture_layer_ids=None must take the existing forward path: the helper is
+    never called, and _forward_target_hidden_states runs as before."""
+    import vllm_metal.v1.model_adapter as ma
+
+    adapter = ma.DefaultModelAdapter()
+    capture_calls = {"n": 0}
+    monkeypatch.setattr(
+        ma,
+        "run_backbone_with_capture",
+        lambda *a, **k: capture_calls.__setitem__("n", capture_calls["n"] + 1),
+    )
+    fwd_calls = {"n": 0}
+
+    def _fwd_spy(self, model, input_ids, *, cache):
+        fwd_calls["n"] += 1
+        return mx.zeros((1, 2, 1))
+
+    monkeypatch.setattr(
+        ma.DefaultModelAdapter, "_forward_target_hidden_states", _fwd_spy
+    )
+    monkeypatch.setattr(
+        adapter, "_compute_target_logits", lambda model, h: mx.zeros((1, 2, 3))
+    )
+
+    adapter.target_forward(
+        object(),
+        mx.array([[1.0, 2.0]]),
+        cache=[None] * 3,
+        collect_hidden_states=True,
+        capture_layer_ids=None,
+    )
+
+    assert capture_calls["n"] == 0
+    assert fwd_calls["n"] == 1

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -341,7 +341,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -397,7 +397,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         def fake_prepare_unified(decode_info, prefill_info, block_size):
             captured["decode_info"] = decode_info
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache, collect_hidden_states
             captured["input_ids"] = input_ids.tolist()
             return mr.TargetModelForwardOutput(
@@ -442,7 +442,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -544,7 +544,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -592,7 +592,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -649,7 +649,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_size
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
@@ -1772,7 +1772,7 @@ class TestV1MetalModelRunnerGDNLifecycle:
 
         captured: dict[str, object] = {}
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(input_ids, *, cache, collect_hidden_states, **kwargs):
             del cache, collect_hidden_states
             ctx = mr.get_context()
             assert ctx is not None

--- a/tools/check_sd_lossless.py
+++ b/tools/check_sd_lossless.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify speculative decoding is lossless under greedy sampling (Metal).
+
+Greedy SD must produce token-identical output to greedy non-SD: the verifier
+accepts a draft token iff it equals the target argmax, so any divergence means
+the verification forward (or the draft/KV plumbing behind it) is wrong. This
+exercises the whole spec-decode stack end to end — including the attention
+kernel's multi-token verify windows — with no golden files to maintain.
+
+Each engine runs in its own subprocess (clean Metal state between configs).
+
+vLLM 0.25.1's native DSpark path forces Model Runner V2 (needs Triton), which
+Metal lacks — so the SD engine here pins VLLM_USE_V2_MODEL_RUNNER=0, under
+which vllm-metal builds its own DSparkProposer. The base engine is identical.
+
+Usage:
+  python tools/check_sd_lossless.py                         # Qwen3-0.6B self-draft K=3
+  python tools/check_sd_lossless.py --method dspark \\
+      --model mlx-community/Qwen3-4B-4bit \\
+      --draft /path/to/dspark_qwen3_4b_block7 -k 2
+  python tools/check_sd_lossless.py --method ngram --model Qwen/Qwen3-0.6B -k 3
+  python tools/check_sd_lossless.py --method dflash \\
+      --model Qwen/Qwen3-8B --draft RedHatAI/Qwen3-8B-speculator.dflash -k 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+PROMPTS = [
+    "The capital of France is",
+    "One plus one equals",
+    "Water boils at a temperature of",
+    "The largest planet in our solar system is",
+    "In Python, a list comprehension is",
+    "The theory of relativity states that",
+    "A binary search tree is a data structure where",
+    "Photosynthesis is the process by which",
+    "The French Revolution began in",
+    "To reverse a linked list, you",
+    "The speed of light in a vacuum is",
+    "Machine learning models are trained by",
+]
+
+_WORKER = r"""
+import json, sys, time
+from vllm import LLM, SamplingParams
+
+cfg = json.load(open(sys.argv[1]))
+llm = LLM(
+    model=cfg["model"],
+    max_model_len=cfg["max_model_len"],
+    enable_prefix_caching=False,
+    speculative_config=cfg["speculative_config"],
+    # Both engines run synchronous scheduling: SD on Metal requires it, and
+    # keeping the base engine identical isolates the SD stack as the only
+    # variable in the token-identity comparison.
+    async_scheduling=False,
+    disable_log_stats=False,  # keep spec-decode acceptance counters available
+)
+params = SamplingParams(temperature=0.0, max_tokens=cfg["max_tokens"], ignore_eos=True)
+start = time.perf_counter()
+outputs = llm.generate(cfg["prompts"], params)
+elapsed = time.perf_counter() - start
+result = {o.prompt: list(o.outputs[0].token_ids) for o in outputs}
+gen_tokens = sum(len(v) for v in result.values())
+stats = {"gen_tokens": gen_tokens, "elapsed_s": round(elapsed, 2),
+         "tok_per_s": round(gen_tokens / elapsed, 2)}
+try:
+    for metric in llm.get_metrics():
+        if "spec_decode" in metric.name:
+            key = metric.name.split(":")[-1]
+            value = getattr(metric, "value", None)
+            if value is None:
+                value = getattr(metric, "values", None)
+            stats[key] = value
+except Exception as exc:  # pragma: no cover - metrics API drift
+    stats["metrics_error"] = repr(exc)
+json.dump({"tokens": result, "stats": stats}, open(cfg["out"], "w"))
+"""
+
+
+def run_engine(args, spec_config: dict | None, out_path: str) -> dict[str, list[int]]:
+    cfg = {
+        "model": args.model,
+        "max_model_len": args.max_model_len,
+        "max_tokens": args.max_tokens,
+        "prompts": PROMPTS[: args.num_prompts],
+        "speculative_config": spec_config,
+        "out": out_path,
+    }
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(cfg, f)
+        cfg_path = f.name
+    env = os.environ.copy()
+    env.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    env.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")  # Metal has no Triton
+    env.setdefault("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+    env.setdefault("VLLM_METAL_MEMORY_FRACTION", args.memory_fraction)
+    label = json.dumps(spec_config) if spec_config else "no-SD"
+    print(f"[check_sd_lossless] running engine: {label}", flush=True)
+    subprocess.run(
+        [sys.executable, "-c", _WORKER, cfg_path],
+        env=env,
+        check=True,
+    )
+    return json.load(open(out_path))
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    p.add_argument("--draft", default="Qwen/Qwen3-0.6B")
+    p.add_argument(
+        "--method",
+        default="draft_model",
+        choices=["draft_model", "dspark", "dflash", "ngram", "mtp"],
+    )
+    p.add_argument("-k", "--num-speculative-tokens", type=int, default=3)
+    p.add_argument("--max-tokens", type=int, default=64)
+    p.add_argument("--num-prompts", type=int, default=len(PROMPTS))
+    p.add_argument("--max-model-len", type=int, default=512)
+    p.add_argument("--memory-fraction", default="0.35")
+    args = p.parse_args()
+
+    spec = {
+        "method": args.method,
+        "model": args.draft,
+        "num_speculative_tokens": args.num_speculative_tokens,
+    }
+    with tempfile.TemporaryDirectory() as td:
+        base_result = run_engine(args, None, os.path.join(td, "base.json"))
+        sd_result = run_engine(args, spec, os.path.join(td, "sd.json"))
+    base, sd = base_result["tokens"], sd_result["tokens"]
+    print(f"[stats] base: {json.dumps(base_result['stats'])}")
+    print(f"[stats] sd:   {json.dumps(sd_result['stats'])}")
+
+    mismatches = 0
+    for prompt in base:
+        if base[prompt] != sd.get(prompt):
+            mismatches += 1
+            b, s = base[prompt], sd.get(prompt) or []
+            div = next(
+                (i for i, (x, y) in enumerate(zip(b, s, strict=False)) if x != y),
+                min(len(b), len(s)),
+            )
+            print(f"MISMATCH @ token {div}: {prompt!r}")
+            print(f"  base[{div}:{div + 5}] = {b[div : div + 5]}")
+            print(f"  sd  [{div}:{div + 5}] = {s[div : div + 5]}")
+    if mismatches:
+        print(f"FAIL: {mismatches}/{len(base)} prompts diverged — SD is NOT lossless")
+        return 1
+    print(
+        f"PASS: {len(base)} prompts x {args.max_tokens} tokens are token-identical "
+        f"(greedy, method={args.method}, K={args.num_speculative_tokens})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/vllm_metal/v1/dspark/__init__.py
+++ b/vllm_metal/v1/dspark/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DSpark speculative-decoding drafter.
+
+Vendored from ARahim3/mlx-dspark (MIT) with attribution — see NOTICE.
+Faithful port of the DeepSpec inference path for the Qwen3 / Gemma-4 families.
+"""

--- a/vllm_metal/v1/dspark/config.py
+++ b/vllm_metal/v1/dspark/config.py
@@ -1,0 +1,235 @@
+"""DSpark drafter config — loaded from the HF checkpoint's config.json.
+
+Supports two drafter families with a shared inference path:
+  - gemma4  (gemma4_text): k_eq_v attention, v_norm, partial/proportional rope,
+            sandwich norms + layer_scalar, gelu-tanh MLP, logit softcap.
+  - qwen3   (qwen3):       standard GQA (separate v_proj, no v_norm), default rope,
+            Llama-style 2-norm layer, silu MLP, no softcap. Also covers qwen3_5-flavored
+            backbones (model_type qwen3_5, e.g. Ornith drafters) via two config-driven
+            knobs: gated_q_proj (q_proj emits [q ‖ gate], attn out × sigmoid(gate)) and
+            rope_dims (partial rotary).
+Only the fields the MLX inference path needs are pulled out.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class DSparkConfig:
+    family: str = "gemma4"             # "gemma4" | "qwen3"
+
+    # core dims
+    hidden_size: int = 3840
+    vocab_size: int = 262144
+    num_hidden_layers: int = 5
+    intermediate_size: int = 15360
+    rms_norm_eps: float = 1e-6
+
+    # attention
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    num_global_key_value_heads: int = 1
+    head_dim: int = 256
+    global_head_dim: int = 512
+    attention_k_eq_v: bool = True
+    attention_bias: bool = False
+
+    # rope
+    rope_theta: float = 1_000_000.0
+    partial_rotary_factor: float = 0.25
+    rope_type: str = "proportional"
+    # qwen3_5 drafters rope only the first rope_dims of head_dim (partial rotary);
+    # None = full head_dim (all other families).
+    rope_dims: int | None = None
+
+    # qwen3_5 gated attention: q_proj emits [q ‖ gate] per head (2× out-features),
+    # attention output is multiplied by sigmoid(gate) before o_proj.
+    gated_q_proj: bool = False
+
+    # qwen3_5 stores every RMSNorm weight as an additive offset from one (Gemma-style
+    # (1+w)·x̂ — the reference vLLM patches call this offset_rms_norm). load_drafter adds
+    # 1.0 to all RMSNorm weights at load so plain nn.RMSNorm modules compute the right
+    # thing. Applying them un-offset multiplies the context fusion by ~0 and silently
+    # collapses acceptance to ~1.25 (measured; d0 15% → 90% with the offset).
+    offset_rms_norm: bool = False
+
+    # dspark specifics
+    block_size: int = 7
+    mask_token_id: int = 4
+    target_layer_ids: list[int] = field(default_factory=lambda: [5, 17, 29, 41, 46])
+    num_target_layers: int = 48
+
+    # markov + confidence
+    markov_rank: int = 256
+    markov_head_type: str = "vanilla"
+    enable_confidence_head: bool = True
+    confidence_head_with_markov: bool = True
+
+    # GIDD log-SNR conditioning (PrismML Bonsai drafters; absent from DeepSpec's).
+    # At inference the per-position pattern is fixed — anchor (block pos 0) at
+    # max_log_snr, every masked position at min_log_snr — so the resulting additive
+    # embedding is a constant per block position (see model.LogSnrEmbed).
+    log_snr_conditioning: bool = False
+    min_log_snr: float = -9.0
+    max_log_snr: float = 9.0
+
+    # logits
+    final_logit_softcapping: float | None = 30.0
+    pad_token_id: int = 0
+
+    # ---- family-derived knobs (set in from_json) ----
+    mlp_activation: str = "gelu_tanh"   # "gelu_tanh" | "silu"
+    norm_style: str = "gemma"           # "gemma" (sandwich+scalar) | "qwen" (llama 2-norm)
+    use_v_norm: bool = True             # gemma: RMSNormNoScale v_norm; qwen: none
+    attention_scaling: float | None = None  # None -> 1/sqrt(attn_head_dim)
+
+    @property
+    def attn_head_dim(self) -> int:
+        """Head dim used by the drafter's own attention."""
+        return self.global_head_dim if self.family == "gemma4" else self.head_dim
+
+    @property
+    def n_kv_heads(self) -> int:
+        if self.family == "gemma4" and self.attention_k_eq_v:
+            return self.num_global_key_value_heads
+        return self.num_key_value_heads
+
+    @property
+    def scaling(self) -> float:
+        if self.attention_scaling is not None:
+            return self.attention_scaling
+        return self.attn_head_dim ** -0.5 if self.family == "qwen3" else 1.0
+
+    @property
+    def rope_parameters(self) -> dict:
+        return {"rope_type": self.rope_type, "partial_rotary_factor": self.partial_rotary_factor}
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "DSparkConfig":
+        with open(path) as f:
+            c = json.load(f)
+        mt = c.get("model_type", "")
+
+        # Reject the known-incompatible checkpoint packagings with a specific message before
+        # family detection — a vLLM-speculators drafter says model_type "qwen3" too, and would
+        # otherwise die a few lines down with an unhelpful KeyError.
+        if "speculators_config" in c or "speculators_model_type" in c:
+            raise ValueError(
+                f"{path}: this checkpoint is in the vLLM 'speculators' format "
+                f"(speculators_config present), which mlx-dspark cannot load yet — it uses a "
+                f"different config schema (aux_hidden_state_layer_ids, transformer_layer_config, "
+                f"draft_vocab_size). Use a DeepSpec-native standalone drafter "
+                f"(e.g. deepseek-ai/dspark_*_block7), or open an issue: "
+                f"https://github.com/ARahim3/mlx-dspark/issues"
+            )
+        if "block_size" not in c and any(k.startswith("dspark_") for k in c):
+            raise ValueError(
+                f"{path}: this looks like a full target model with an embedded DSpark drafter "
+                f"(dspark_* fields in the target config, e.g. DeepSeek-V4-*-DSpark), not a "
+                f"standalone drafter checkpoint. mlx-dspark loads standalone DeepSpec drafters "
+                f"(e.g. deepseek-ai/dspark_*_block7)."
+            )
+
+        if "qwen3" in mt:
+            family = "qwen3"
+        elif "gemma4" in mt:
+            family = "gemma4"
+        else:
+            raise ValueError(
+                f"{path}: unsupported drafter family (model_type={mt!r}). Supported drafter "
+                f"backbones: qwen3, gemma4 (gemma4_text). Drafter-free speculation works with "
+                f"any target via --mode lookup / --mode auto; for a new drafter family, open an "
+                f"issue: https://github.com/ARahim3/mlx-dspark/issues"
+            )
+
+        required = ("hidden_size", "vocab_size", "num_hidden_layers", "intermediate_size",
+                    "num_attention_heads", "block_size", "mask_token_id", "target_layer_ids")
+        missing = [k for k in required if k not in c]
+        if missing:
+            raise ValueError(
+                f"{path}: config is missing required DeepSpec drafter fields {missing} — this "
+                f"does not look like a DeepSpec-format DSpark drafter checkpoint."
+            )
+
+        if family == "qwen3":
+            rp = c.get("rope_parameters") or {}
+            head_dim = c.get("head_dim", c["hidden_size"] // c["num_attention_heads"])
+            # qwen3_5-flavored backbones (e.g. Ornith drafters) declare gated q_proj and
+            # partial rotary in the same DeepSpec layout; plain qwen3 configs carry neither,
+            # so both knobs default to the classic behavior. The config's mrope fields are a
+            # text-only no-op (equal position ids collapse mrope to standard rope — mlx-lm's
+            # own qwen3_5 text module does the same).
+            gated_q = bool(c.get("enable_qwen35_gated_q_proj", False))
+            rope_dims = int(head_dim * float(rp.get("partial_rotary_factor", 1.0)))
+            # qwen3_5 house style: norm weights stored offset-from-one (see field docs).
+            offset_norms = mt == "qwen3_5"
+            if c.get("log_snr_conditioning"):
+                lo, hi = c.get("min_log_snr"), c.get("max_log_snr")
+                if lo is None or hi is None or not (float(hi) > float(lo)):
+                    raise ValueError(
+                        f"{path}: log_snr_conditioning is enabled but min/max_log_snr are "
+                        f"missing or not ordered (min={lo!r}, max={hi!r}) — the featurization "
+                        f"divides by (max - min), so a drafter converted without them would "
+                        f"draft from silently-wrong embeddings."
+                    )
+            return cls(
+                family="qwen3",
+                hidden_size=c["hidden_size"], vocab_size=c["vocab_size"],
+                num_hidden_layers=c["num_hidden_layers"],
+                intermediate_size=c["intermediate_size"],
+                rms_norm_eps=c.get("rms_norm_eps", 1e-6),
+                num_attention_heads=c["num_attention_heads"],
+                num_key_value_heads=c.get("num_key_value_heads", 8),
+                head_dim=head_dim,
+                attention_k_eq_v=False, attention_bias=c.get("attention_bias", False),
+                rope_theta=rp.get("rope_theta", c.get("rope_theta", 1_000_000.0)),
+                rope_type="default",
+                rope_dims=(rope_dims if rope_dims != head_dim else None),
+                gated_q_proj=gated_q,
+                offset_rms_norm=offset_norms,
+                block_size=c["block_size"], mask_token_id=c["mask_token_id"],
+                target_layer_ids=list(c["target_layer_ids"]),
+                num_target_layers=c.get("num_target_layers", 36),
+                markov_rank=c.get("markov_rank", 256),
+                markov_head_type=c.get("markov_head_type", "vanilla"),
+                enable_confidence_head=c.get("enable_confidence_head", True),
+                confidence_head_with_markov=c.get("confidence_head_with_markov", True),
+                final_logit_softcapping=c.get("final_logit_softcapping", None),
+                pad_token_id=c.get("pad_token_id") or 0,
+                mlp_activation="silu", norm_style="qwen", use_v_norm=False,
+                log_snr_conditioning=bool(c.get("log_snr_conditioning", False)),
+                min_log_snr=float(c.get("min_log_snr", -9.0)),
+                max_log_snr=float(c.get("max_log_snr", 9.0)),
+            )
+
+        rope = (c.get("rope_parameters") or {}).get("full_attention", {}) or {}
+        return cls(
+            family="gemma4",
+            hidden_size=c["hidden_size"], vocab_size=c["vocab_size"],
+            num_hidden_layers=c["num_hidden_layers"],
+            intermediate_size=c["intermediate_size"],
+            rms_norm_eps=c.get("rms_norm_eps", 1e-6),
+            num_attention_heads=c["num_attention_heads"],
+            num_key_value_heads=c.get("num_key_value_heads", 8),
+            num_global_key_value_heads=c.get("num_global_key_value_heads", 1),
+            head_dim=c.get("head_dim", 256), global_head_dim=c.get("global_head_dim", 512),
+            attention_k_eq_v=c.get("attention_k_eq_v", True),
+            attention_bias=c.get("attention_bias", False),
+            rope_theta=rope.get("rope_theta", 1_000_000.0),
+            partial_rotary_factor=rope.get("partial_rotary_factor", 0.25),
+            rope_type=rope.get("rope_type", "proportional"),
+            block_size=c["block_size"], mask_token_id=c["mask_token_id"],
+            target_layer_ids=list(c["target_layer_ids"]),
+            num_target_layers=c.get("num_target_layers", 48),
+            markov_rank=c.get("markov_rank", 256),
+            markov_head_type=c.get("markov_head_type", "vanilla"),
+            enable_confidence_head=c.get("enable_confidence_head", True),
+            confidence_head_with_markov=c.get("confidence_head_with_markov", True),
+            final_logit_softcapping=c.get("final_logit_softcapping", 30.0),
+            pad_token_id=c.get("pad_token_id", 0),
+            mlp_activation="gelu_tanh", norm_style="gemma", use_v_norm=True,
+        )

--- a/vllm_metal/v1/dspark/loader.py
+++ b/vllm_metal/v1/dspark/loader.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DSpark drafter checkpoint loader.
+
+Adapted from ARahim3/mlx-dspark ``load.py`` (MIT) — vendored here so vllm-metal
+has no runtime dependency on the standalone library. Only the drafter loader is
+ported: the target model is loaded by vllm-metal's own model lifecycle.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from huggingface_hub import snapshot_download
+
+from .config import DSparkConfig
+from .model import DSparkDrafter
+
+
+def _resolve(repo_or_path: str) -> str:
+    if os.path.isdir(repo_or_path):
+        return repo_or_path
+    return snapshot_download(repo_or_path)
+
+
+def _flatten_params(module) -> list[tuple[str, Any]]:
+    from mlx.utils import tree_flatten
+
+    params = tree_flatten(module.parameters())
+    assert isinstance(params, list)  # Module.parameters() is a dict -> list of pairs
+    return params
+
+
+def load_drafter(
+    repo_or_path: str,
+    *,
+    quantize: bool = True,
+    bits: int = 4,
+    group_size: int = 64,
+    strict: bool = True,
+) -> tuple[DSparkDrafter, DSparkConfig]:
+    """Load a DeepSpec-native standalone DSpark drafter. Returns ``(drafter, config)``.
+
+    Weights load 1:1 by tensor name (``strict=True``); a name mismatch raises
+    instead of silently loading a partial drafter (which would draft with
+    near-zero acceptance). 4-bit quantized by default — the drafter runs every
+    round, so quantizing it is what makes speculation a net win on Apple Silicon.
+    Output correctness is unaffected (the target verifies every token).
+    """
+    path = _resolve(repo_or_path)
+    config = DSparkConfig.from_json(os.path.join(path, "config.json"))
+    drafter = DSparkDrafter(config)
+
+    weights: dict[str, mx.array] = {}
+    for st in glob.glob(os.path.join(path, "*.safetensors")):
+        weights.update(mx.load(st))
+
+    model_keys = {k for k, _ in _flatten_params(drafter)}
+    ckpt_keys = set(weights.keys())
+    missing = sorted(model_keys - ckpt_keys)
+    unexpected = sorted(ckpt_keys - model_keys)
+    if missing or unexpected:
+        detail = ""
+        if missing:
+            detail += f"\n  missing in checkpoint ({len(missing)}): {missing[:8]}"
+        if unexpected:
+            detail += f"\n  unexpected in checkpoint ({len(unexpected)}): {unexpected[:8]}"
+        if strict:
+            raise ValueError(
+                f"{repo_or_path}: drafter tensor names don't match a DeepSpec-format "
+                f"DSpark drafter — the checkpoint may be a different packaging or "
+                f"variant (e.g. vLLM 'speculators' format).{detail}"
+            )
+        print(f"[load_drafter] WARNING key mismatch:{detail}")
+
+    drafter.load_weights(list(weights.items()), strict=not (missing or unexpected))
+
+    if quantize:
+        nn.quantize(drafter, group_size=group_size, bits=bits)
+
+    mx.eval(drafter.parameters())
+    return drafter, config
+
+
+def is_dspark_drafter(draft_model_config: object) -> bool:
+    """True if a draft-model config points at a DeepSpec DSpark drafter checkpoint.
+
+    Distinguishing fields vs an ordinary Qwen3/Gemma-4 target: the drafter's
+    ``config.json`` carries ``block_size`` and ``target_layer_ids``.
+    """
+    hf_config = getattr(draft_model_config, "hf_config", None)
+    if hf_config is None:
+        return False
+    return (
+        getattr(hf_config, "block_size", None) is not None
+        and getattr(hf_config, "target_layer_ids", None) is not None
+    )

--- a/vllm_metal/v1/dspark/model.py
+++ b/vllm_metal/v1/dspark/model.py
@@ -1,0 +1,382 @@
+"""DSpark drafter in MLX — Gemma-4 and Qwen3 families.
+
+Faithful port of the DeepSpec inference path. The EAGLE-style cross-attention is shared:
+Q comes from the draft block, K/V from concat([fused_target_context, block]), with the
+context K/V cached per layer (CtxCache). Family differences (norm layout, rope, MLP act,
+v handling, logit softcap) are config-driven. Module attribute names match the HF
+checkpoints so weights load 1:1.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+try:  # mlx-vlm <= 0.6.4
+    from mlx_vlm.models.gemma4.rope_utils import initialize_rope
+except ImportError:  # mlx-vlm >= 0.6.5 consolidated per-family rope utils
+    from mlx_vlm.models.rope_utils import initialize_rope
+
+from .config import DSparkConfig
+
+
+class RMSNormNoScale(nn.Module):
+    """RMSNorm with no learnable weight (Gemma-4 v_norm)."""
+
+    def __init__(self, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, None, self.eps)
+
+
+def _act(name: str):
+    return nn.silu if name == "silu" else nn.gelu_approx
+
+
+class MLP(nn.Module):
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        h, i = config.hidden_size, config.intermediate_size
+        self.gate_proj = nn.Linear(h, i, bias=False)
+        self.up_proj = nn.Linear(h, i, bias=False)
+        self.down_proj = nn.Linear(i, h, bias=False)
+        self.act = _act(config.mlp_activation)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(self.act(self.gate_proj(x)) * self.up_proj(x))
+
+
+class CtxCache:
+    """Per-layer cache of the target context's projected K/V (roped K, normed/raw V).
+
+    Append-only (the drafter context only ever grows with *committed* tokens — it is
+    never trimmed/rolled back, unlike the target KV cache). A preallocated growing buffer
+    (mlx-lm KVCache style) was tried to avoid the O(n²) realloc, but measured 0.99× at
+    ≤600 tokens — the realloc is negligible at realistic lengths and the scatter overhead
+    is not. Plain concatenate is simpler and as fast here."""
+
+    __slots__ = ("k", "v")
+
+    def __init__(self):
+        self.k = None
+        self.v = None
+
+    def append(self, k: mx.array, v: mx.array) -> None:
+        if self.k is None:
+            self.k, self.v = k, v
+        else:
+            self.k = mx.concatenate([self.k, k], axis=2)
+            self.v = mx.concatenate([self.v, v], axis=2)
+
+    def trim_to(self, length: int) -> None:
+        """Keep only the first ``length`` context positions (seq axis) — used by prefix
+        caching to roll the drafter context back to a shared prefix. The retained K was
+        roped at its absolute position, so it stays valid after the trim."""
+        if self.k is not None and length < self.k.shape[2]:
+            self.k = self.k[:, :, :length, :]
+            self.v = self.v[:, :, :length, :]
+
+    @property
+    def length(self) -> int:
+        return 0 if self.k is None else self.k.shape[2]
+
+
+class DSparkAttention(nn.Module):
+    """Cross-attention: Q from the draft block, K/V from [target_context, block]."""
+
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.attn_head_dim
+        self.k_eq_v = config.attention_k_eq_v
+        self.n_kv_heads = config.n_kv_heads
+        self.scale = config.scaling
+        self.use_v_norm = config.use_v_norm
+        self.gated = config.gated_q_proj
+
+        h = config.hidden_size
+        b = config.attention_bias
+        # gated (qwen3_5): q_proj emits [q ‖ gate] interleaved per head (2× out-features),
+        # split per head like mlx-lm's Qwen3NextAttention so the checkpoint loads 1:1.
+        self.q_proj = nn.Linear(h, self.n_heads * self.head_dim * (2 if self.gated else 1), bias=b)
+        self.k_proj = nn.Linear(h, self.n_kv_heads * self.head_dim, bias=b)
+        if not self.k_eq_v:
+            self.v_proj = nn.Linear(h, self.n_kv_heads * self.head_dim, bias=b)
+        self.o_proj = nn.Linear(self.n_heads * self.head_dim, h, bias=b)
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        if self.use_v_norm:
+            self.v_norm = RMSNormNoScale(eps=config.rms_norm_eps)
+
+        self.rope = initialize_rope(
+            dims=config.rope_dims or self.head_dim, base=config.rope_theta,
+            traditional=False, scaling_config=config.rope_parameters,
+        )
+
+    def _kv(self, x: mx.array):
+        """Project x -> (roped+normed K, V). k_eq_v shares k_proj for V."""
+        B, S, _ = x.shape
+        kp = self.k_proj(x).reshape(B, S, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.k_norm(kp)
+        if self.k_eq_v:
+            v = self.v_norm(kp)
+        else:
+            v = self.v_proj(x).reshape(B, S, self.n_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+            if self.use_v_norm:
+                v = self.v_norm(v)
+        return k, v
+
+    def update_ctx(self, fused_new: mx.array, ctx_offset: int, cache: CtxCache) -> None:
+        k, v = self._kv(fused_new)
+        cache.append(self.rope(k, offset=ctx_offset), v)   # V is not roped
+
+    def attend(self, hidden: mx.array, block_offset, cache, mask=None) -> mx.array:
+        """``block_offset`` may be an int (single sequence) or a per-row ``[B]`` array (batched
+        drafting — rows sit at different context lengths). ``mask`` is None for the single-seq
+        path (block attends the whole context + all block positions) or a ``[B, 1, k, Lctx+k]``
+        boolean mask that hides each row's context padding when ``cache.k/v`` are a batched buffer."""
+        B, q_len, _ = hidden.shape
+        q = self.q_proj(hidden).reshape(B, q_len, self.n_heads, -1)
+        gate = None
+        if self.gated:
+            q, gate = mx.split(q, 2, axis=-1)          # per-head [q ‖ gate]
+            gate = gate.reshape(B, q_len, -1)          # gate is NOT q-normed (qwen3_5 semantics)
+        q = self.rope(self.q_norm(q).transpose(0, 2, 1, 3), offset=block_offset)
+
+        k_blk, v_blk = self._kv(hidden)
+        k_blk = self.rope(k_blk, offset=block_offset)
+        k = mx.concatenate([cache.k, k_blk], axis=2)
+        v = mx.concatenate([cache.v, v_blk], axis=2)
+
+        # SDPA does GQA/MQA head broadcast internally — pass the n_kv-head K/V straight through.
+        # The old code tiled K/V up to full heads (`_repeat_kv`, n_rep=4 Qwen / 16 Gemma) across the
+        # *whole* context cache every round: O(n_rep · ctx_len) of pure wasted memory traffic that
+        # grows with depth. On cheap-verify targets (Qwen-class), where the drafter is the dominant
+        # share of each round, that made long-context drafting collapse to net-negative past a few
+        # thousand tokens (measured 0.6× at 8k on Qwen3-4B); removing it restores a flat ~1.6× out
+        # to 12k+. On expensive-verify targets (Gemma-12B) the drafter is a small fraction, so it was
+        # already amortized — neutral there. Bit-for-bit identical output (same math, no redundant
+        # tiling), strictly less work on every target.
+        out = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
+        out = out.transpose(0, 2, 1, 3).reshape(B, q_len, -1)
+        if gate is not None:
+            out = out * mx.sigmoid(gate)
+        return self.o_proj(out)
+
+
+class DSparkDecoderLayer(nn.Module):
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        eps = config.rms_norm_eps
+        self.norm_style = config.norm_style
+        self.self_attn = DSparkAttention(config)
+        self.mlp = MLP(config)
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=eps)
+        self.post_attention_layernorm = nn.RMSNorm(config.hidden_size, eps=eps)
+        if self.norm_style == "gemma":
+            self.pre_feedforward_layernorm = nn.RMSNorm(config.hidden_size, eps=eps)
+            self.post_feedforward_layernorm = nn.RMSNorm(config.hidden_size, eps=eps)
+            self.layer_scalar = mx.ones((1,))
+
+    def __call__(self, hidden, block_offset, cache, mask=None):
+        if self.norm_style == "gemma":
+            residual = hidden
+            h = self.input_layernorm(hidden)
+            h = self.self_attn.attend(h, block_offset, cache, mask)
+            h = self.post_attention_layernorm(h)
+            h = residual + h
+            residual = h
+            h = self.pre_feedforward_layernorm(h)
+            h = self.mlp(h)
+            h = self.post_feedforward_layernorm(h)
+            h = residual + h
+            return h * self.layer_scalar
+        # qwen / llama 2-norm
+        residual = hidden
+        h = self.input_layernorm(hidden)
+        h = self.self_attn.attend(h, block_offset, cache, mask)
+        h = residual + h
+        residual = h
+        h = self.post_attention_layernorm(h)
+        h = self.mlp(h)
+        return residual + h
+
+
+class VanillaMarkov(nn.Module):
+    """Rank-256 previous-token correction: logits += w2(w1[prev_token])."""
+
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        self.markov_w1 = nn.Embedding(config.vocab_size, config.markov_rank)
+        self.markov_w2 = nn.Linear(config.markov_rank, config.vocab_size, bias=False)
+
+    def prev_embeddings(self, token_ids: mx.array) -> mx.array:
+        return self.markov_w1(token_ids)
+
+    def step_bias(self, token_ids: mx.array) -> mx.array:
+        return self.markov_w2(self.markov_w1(token_ids))
+
+
+class ConfidenceHead(nn.Module):
+    def __init__(self, input_dim: int):
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1)
+
+    def __call__(self, features: mx.array) -> mx.array:
+        return self.proj(features).squeeze(-1)
+
+
+LOG_SNR_FREQS = 128  # sinusoidal feature count of the GIDD LogSnrEmbed (fixed by training)
+
+
+def log_snr_features(block_size: int, min_log_snr: float, max_log_snr: float) -> mx.array:
+    """``[block_size, 128]`` sinusoidal features for the fixed inference-time log-SNR
+    pattern (PrismML dspark.cpp): the anchor at block position 0 is "clean" (max_log_snr),
+    every masked position is "fully noised" (min_log_snr); each value maps to
+    ``t = (snr - min) / (max - min) * 1000`` and is featurized as
+    ``[sin(t·f_i), cos(t·f_i)]`` with ``f_i = 10000^(-i/64)`` — the sin half first,
+    matching the reference layout exactly."""
+    import math
+
+    half = LOG_SNR_FREQS // 2
+    pos = mx.arange(block_size)
+    log_snr = mx.where(pos == 0, max_log_snr, min_log_snr).astype(mx.float32)
+    t = (log_snr - min_log_snr) / (max_log_snr - min_log_snr) * 1000.0
+    freq = mx.exp(-math.log(10000.0) * mx.arange(half).astype(mx.float32) / half)
+    angle = t[:, None] * freq[None, :]
+    return mx.concatenate([mx.sin(angle), mx.cos(angle)], axis=-1)
+
+
+class LogSnrEmbed(nn.Module):
+    """GIDD log-SNR conditioning MLP (Bonsai drafters): 128 sinusoidal features →
+    fc1 → silu → fc2 → an additive embedding on the draft block. Since the inference
+    pattern is a pure function of the block position, the drafter caches the resulting
+    ``[1, block_size, H]`` addend after the first call."""
+
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(LOG_SNR_FREQS, config.hidden_size)
+        self.fc2 = nn.Linear(config.hidden_size, config.hidden_size)
+
+    def __call__(self, feat: mx.array) -> mx.array:
+        return self.fc2(nn.silu(self.fc1(feat)))
+
+
+class DSparkDrafter(nn.Module):
+    def __init__(self, config: DSparkConfig):
+        super().__init__()
+        self.config = config
+        self.block_size = config.block_size
+        self.mask_token_id = config.mask_token_id
+        self.embed_scale = (float(config.hidden_size) ** 0.5) if config.family == "gemma4" else 1.0
+        self.softcap = config.final_logit_softcapping
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.fc = nn.Linear(
+            len(config.target_layer_ids) * config.hidden_size, config.hidden_size, bias=False
+        )
+        self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layers = [DSparkDecoderLayer(config) for _ in range(config.num_hidden_layers)]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        self.markov_head = VanillaMarkov(config) if config.markov_rank > 0 else None
+        self.confidence_head = None
+        if config.enable_confidence_head:
+            in_dim = config.hidden_size + (config.markov_rank if config.confidence_head_with_markov else 0)
+            self.confidence_head = ConfidenceHead(in_dim)
+        self.log_snr_embed = LogSnrEmbed(config) if config.log_snr_conditioning else None
+        self._snr_addend = None       # lazily-built [1, block_size, H] constant
+
+    def embed(self, ids: mx.array) -> mx.array:
+        e = self.embed_tokens(ids) * self.embed_scale
+        if self.log_snr_embed is not None:
+            if self._snr_addend is None:
+                feat = log_snr_features(
+                    self.block_size, self.config.min_log_snr, self.config.max_log_snr)
+                self._snr_addend = self.log_snr_embed(feat.astype(e.dtype))[None]
+            # ids is the draft block ([1, block_size]); slicing keeps shorter probes valid.
+            e = e + self._snr_addend[:, : e.shape[1], :]
+        return e
+
+    def fuse_target(self, target_hidden_cat: mx.array) -> mx.array:
+        return self.hidden_norm(self.fc(target_hidden_cat))
+
+    def make_ctx_cache(self) -> list[CtxCache]:
+        return [CtxCache() for _ in self.layers]
+
+    def update_context(self, target_hidden_cat, ctx_offset, ctx_caches) -> None:
+        fused = self.fuse_target(target_hidden_cat)
+        for layer, cache in zip(self.layers, ctx_caches):
+            layer.self_attn.update_ctx(fused, ctx_offset, cache)
+
+    def backbone(self, noise_embedding, block_offset, ctx_caches, mask=None) -> mx.array:
+        h = noise_embedding
+        for layer, cache in zip(self.layers, ctx_caches):
+            h = layer(h, block_offset, cache, mask)
+        return self.norm(h)
+
+    def compute_logits(self, hidden: mx.array) -> mx.array:
+        logits = self.lm_head(hidden)
+        if self.softcap is not None:
+            logits = mx.tanh(logits / self.softcap) * self.softcap
+        return logits
+
+    def sample_block(self, base_logits: mx.array, first_prev_token: int) -> mx.array:
+        k = base_logits.shape[0]
+        if self.markov_head is None:
+            return mx.argmax(base_logits, axis=-1)
+        tokens = []
+        prev = mx.array([first_prev_token])
+        for i in range(k):
+            step = base_logits[i] + self.markov_head.step_bias(prev)[0]
+            nxt = mx.argmax(step, axis=-1, keepdims=True)
+            tokens.append(nxt)
+            prev = nxt
+        return mx.concatenate(tokens)
+
+    def sample_block_probs(self, base_logits: mx.array, first_prev_token: int,
+                           temperature: float, top_p: float = 1.0,
+                           top_k: int = 0) -> tuple[mx.array, mx.array]:
+        """Temperature draft for speculative *sampling*: sample each block position from
+        its (temperature-scaled, optionally top-p/top-k truncated) distribution and return
+        ``(tokens [k], probs [k, V])``. ``probs[i]`` is the draft distribution q_i that token
+        i was sampled from — the verifier needs it for the accept test ``min(1, p_i/q_i)`` and
+        residual resampling. Truncating q here (same top-p/top-k as the target) keeps
+        acceptance from collapsing when a client asks for nucleus sampling; losslessness comes
+        from the *target* side (see ``_spec_sample_accept``). Sequential because the Markov
+        bias for position i depends on the token sampled at i-1."""
+        from .sampling import sample_probs, truncate_probs
+
+        k = base_logits.shape[0]
+        inv_t = 1.0 / temperature
+        tokens, probs = [], []
+        prev = mx.array([first_prev_token])
+        for i in range(k):
+            logits = base_logits[i]
+            if self.markov_head is not None:
+                logits = logits + self.markov_head.step_bias(prev)[0]
+            q = truncate_probs(mx.softmax(logits * inv_t, axis=-1), top_p, top_k)
+            probs.append(q)
+            nxt = sample_probs(q).reshape(1)
+            tokens.append(nxt)
+            prev = nxt
+        return mx.concatenate(tokens), mx.stack(probs, axis=0)
+
+    def confidence_logits(self, block_hidden, prev_token_ids):
+        if self.confidence_head is None:
+            return None
+        if self.config.confidence_head_with_markov:
+            feats = mx.concatenate(
+                [block_hidden, self.markov_head.prev_embeddings(prev_token_ids)], axis=-1
+            )
+        else:
+            feats = block_hidden
+        return self.confidence_head(feats)
+
+
+# Backwards-compatible alias
+Gemma4DSparkDrafter = DSparkDrafter

--- a/vllm_metal/v1/dspark_proposer.py
+++ b/vllm_metal/v1/dspark_proposer.py
@@ -1,0 +1,484 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DSpark (DeepSeek EAGLE3+Markov) speculative-decoding proposer for Metal.
+
+DSpark is an EAGLE-family drafter: a small backbone that cross-attends over the
+*target's* fused hidden states (captured from a selection of target layers),
+plus a rank-256 Markov head + optional confidence head. Unlike Gemma4 MTP
+(which shares the target KV), DSpark keeps its **own** per-layer context KV
+(:class:`CtxCache`) that grows with the committed tokens — so the proposer is
+stateful per request, closer to :class:`DraftModelProposer` in shape but
+consuming target hidden states (EAGLE-style) instead of running autoregressively.
+
+Lifecycle (per request), mirroring the reference implementation:
+
+- **First draft** (``n_cached == 0``): seed the drafter context with the prompt's
+  fused hidden, using the prefill's captured rows when available (non-chunked
+  prefill) or re-running a tapped forward otherwise.
+- **Each later draft**: ingest the newly-committed positions' fused hidden from
+  this step's decode segment, then draft a block.
+
+Batched drafter forward: context update stays per-request (cheap), but the
+drafter backbone runs **once** across all eligible requests with a batched
+mask (matching the reference implementation's batch_engine). This eliminates
+the per-request loop that dominated concurrent workloads.
+
+The context invariant is ``n_cached == committed_len - 1`` (context holds every
+committed token except the current pending, which seeds the draft block).
+
+Greedy only (matches the shared :meth:`verify_greedy` verifier).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+from vllm.logger import init_logger
+from vllm.v1.outputs import DraftTokenIds
+
+from vllm_metal.v1.dspark.loader import DSparkConfig, DSparkDrafter
+from vllm_metal.v1.hidden_state_tap import run_backbone_with_capture
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from vllm_metal.v1.model_runner import MetalModelRunner, RequestState
+    from vllm_metal.v1.proposer import ProposeContext
+    from vllm_metal.v1.spec_decode import (
+        PagedDecodeSegment,
+        SpeculativeDecodeController,
+    )
+
+logger = init_logger(__name__)
+
+
+def _ctx_block_mask(ctx_lens: list[int], n_block: int) -> mx.array:
+    """Boolean ``[B, 1, K, Lmax+K]`` mask for batched drafter cross-attention.
+
+    Every block position attends its row's valid context (columns ``< lens[b]``)
+    plus ALL block positions (columns ``>= Lmax``, bidirectional) — matching the
+    single-seq full-attention path (``mask=None``) exactly per row. Ported from
+    the reference implementation's ``_ctx_block_mask``.
+    """
+    num_reqs = len(ctx_lens)
+    max_ctx = max(ctx_lens)
+    lens_arr = mx.array(ctx_lens, dtype=mx.int32)[:, None, None, None]  # [B,1,1,1]
+    j = mx.arange(max_ctx + n_block, dtype=mx.int32)[
+        None, None, None, :
+    ]  # [1,1,1,Lmax+K]
+    m = (j >= max_ctx) | (j < lens_arr)  # block region OR valid context
+    return mx.broadcast_to(m, (num_reqs, 1, n_block, max_ctx + n_block))
+
+
+@dataclass
+class _DraftPlan:
+    req_id: str
+    pending: int
+    n_cached: int
+    ctx_caches: list | None  # None means needs seeding
+    cap: int
+    prompt_ids: list[int] | None = None  # for batched seeding
+
+
+class DSparkProposer:
+    """:class:`vllm_metal.v1.proposer.MetalProposer` backed by a DSpark drafter."""
+
+    def __init__(
+        self,
+        *,
+        drafter: DSparkDrafter,
+        config: DSparkConfig,
+        runner: MetalModelRunner,
+        controller: SpeculativeDecodeController,
+    ) -> None:
+        self._drafter = drafter
+        self._config = config
+        self._runner = runner
+        self._controller = controller
+        self.capture_layer_ids: list[int] = list(config.target_layer_ids)
+        self._block_size = int(config.block_size)
+        self._mask_token_id = int(config.mask_token_id)
+        self._ctx_caches: dict[str, list] = {}
+        self._n_cached: dict[str, int] = {}
+        self._pending_seed: dict[str, mx.array] = {}  # prefill fused hidden
+        # Per-step draft cap: batched drafter attention is O(B·ctx_len·K).
+        # Drafting every eligible request every step saturates the GPU on
+        # concurrent workloads.  A moderate cap keeps per-step latency low
+        # while still covering the requests the scheduler can verify.
+        self._max_drafts_per_step: int = 32
+
+    # -- MetalProposer protocol -----------------------------------------
+
+    def needs_target_hidden_states(
+        self,
+        decode_segments: Sequence[PagedDecodeSegment],
+        *,
+        has_final_prefill: bool,
+    ) -> bool:
+        # Decode-only: capture fused hidden each step for context growth.
+        # Prefill uses the fast backbone() path (no capture overhead).
+        # New-request prompt seeding is done via _seed_prompts_batched —
+        # one batched forward instead of 100 serial _seed_prompt calls.
+        return bool(decode_segments)
+
+    def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        num_speculative_tokens = ctx.num_speculative_tokens
+
+        # Stash prefill fused hidden for new requests BEFORE eligibility
+        # (the stash must run at the prefill step, even though there are
+        # no decode segments to draft from yet). Eliminates the duplicate
+        # full-prompt forward — the TTFT tax.
+        if ctx.prefill_reqs and ctx.target_hidden_states is not None:
+            cu = ctx.cu_seqlens
+            num_decode = ctx.num_decode_segments
+            for i, pr in enumerate(ctx.prefill_reqs):
+                if pr.prompt_len is not None:  # final chunk
+                    # cu_seqlens = [0, decode_0, …, decode_total, prefill_0, …]
+                    # Skip past the decode entries to index the prefill rows.
+                    start = cu[num_decode + i]
+                    end = cu[num_decode + i + 1]
+                    self._pending_seed[pr.req_id] = ctx.target_hidden_states[start:end]
+
+        if num_speculative_tokens <= 0:
+            return None
+
+        self._prune_finished(ctx.request_states)
+        eligible = self._controller.draft_eligible_requests(
+            ctx.decode_reqs,
+            ctx.decode_token_ids,
+            ctx.prefill_reqs,
+            ctx.prefill_result_modes,
+            ctx.request_states,
+            logitsprocs=ctx.logitsprocs,
+        )
+        if not eligible:
+            logger.warning(
+                "DSpark: propose() — eligible=0 (decode_segments=%d, decode_reqs=%d)",
+                len(ctx.decode_segments),
+                len(ctx.decode_reqs),
+            )
+            return None
+
+        segment_by_id = {seg.req_id: seg for seg in ctx.decode_segments}
+        _base_cap = min(num_speculative_tokens, self._block_size)
+
+        # Phase 1: per-request context update (seeding + growth — cheap).
+        plans: list[_DraftPlan] = []
+        # Prefill-finalizing requests (those in ctx.prefill_reqs that are
+        # eligible) don't yet have decode segments.  Identify them by
+        # req_id so we can seed their drafter context now.  We cannot use
+        # generated_tokens==0 because _sample_paged_batch sets it to 1 in
+        # the same step, before propose() runs.
+        prefill_req_ids = {pr.req_id for pr in ctx.prefill_reqs}
+        for req_id, state in eligible:
+            segment = segment_by_id.get(req_id)
+            if segment is None:
+                # Request not yet in decode_segments.  Only seed genuinely
+                # new (prefill-finalizing) requests here; decode requests
+                # that happen to be absent from this batch are skipped —
+                # they will be picked up when they appear in a decode
+                # segment.  Use the stashed prefill hidden when available
+                # (captured at the top of propose — no extra forward);
+                # fall back to batched prompt seeding only for chunked
+                # prefill where no stashed hidden exists.
+                if req_id in prefill_req_ids:
+                    fused_prefill = self._pending_seed.pop(req_id, None)
+                    if fused_prefill is not None:
+                        p_len = fused_prefill.shape[0]
+                        ctx_caches = self._drafter.make_ctx_cache()
+                        self._drafter.update_context(
+                            fused_prefill[None, :, :],
+                            ctx_offset=0,
+                            ctx_caches=ctx_caches,
+                        )
+                        self._ctx_caches[req_id] = ctx_caches
+                        self._n_cached[req_id] = p_len
+                        token_ids = state.token_ids
+                        if token_ids:
+                            plans.append(
+                                _DraftPlan(
+                                    req_id,
+                                    int(token_ids[-1]),
+                                    p_len,
+                                    ctx_caches,
+                                    _base_cap,
+                                )
+                            )
+                    else:
+                        token_ids = state.token_ids
+                        if token_ids:
+                            plans.append(
+                                _DraftPlan(
+                                    req_id,
+                                    int(token_ids[-1]),
+                                    0,
+                                    None,  # seeded below by _seed_prompts_batched
+                                    _base_cap,
+                                    prompt_ids=list(token_ids[:-1]),
+                                )
+                            )
+                continue
+            plan = self._ensure_context(ctx, state, segment, _base_cap)
+            if plan is not None:
+                plans.append(plan)
+
+        if not plans:
+            logger.warning(
+                "DSpark: propose() — %d eligible, 0 plans (all skipped)",
+                len(eligible),
+            )
+            return None
+
+        # Seed new requests in one batched target forward (one weight-read).
+        self._seed_prompts_batched(plans)
+
+        # Drop plans that weren't seeded (empty ctx_caches).
+        plans = [p for p in plans if p.ctx_caches is not None]
+        if not plans:
+            return None
+
+        # Phase 2: batched backbone forward — one call across all requests.
+        # Cap the batch size: batched attention over many large contexts
+        # saturates the GPU and drags per-step latency past the breakeven
+        # point on concurrent workloads.  Context ingestion (Phase 1) still
+        # runs for every eligible request so caches stay current.
+        if len(plans) > self._max_drafts_per_step:
+            plans = plans[: self._max_drafts_per_step]
+        req_ids, draft_rows = self._batch_draft(plans)
+        if not req_ids:
+            logger.warning("DSpark: _batch_draft returned empty (plans=%d)", len(plans))
+            return None
+        logger.info(
+            "DSpark: propose() — %d eligible, %d plans, %d drafted",
+            len(eligible),
+            len(plans),
+            len(req_ids),
+        )
+        return DraftTokenIds(req_ids=req_ids, draft_token_ids=draft_rows)
+
+    # -- context management (per-request, cheap) --------------------------
+
+    def _ensure_context(
+        self,
+        ctx: ProposeContext,
+        state: RequestState,
+        segment: PagedDecodeSegment,
+        cap: int,
+    ) -> _DraftPlan | None:
+        req_id = segment.req_id
+        token_ids = state.token_ids
+        committed_len = len(token_ids)
+        if committed_len < 1:
+            return None
+        pending = int(token_ids[-1])
+
+        ctx_caches = self._ctx_caches.get(req_id)
+        if ctx_caches is not None:
+            new_to_ingest = (committed_len - 1) - self._n_cached[req_id]
+            if new_to_ingest > 0:
+                # Cap at the rows actually available in this step's segment.
+                # When the scheduler skips a request for several steps the
+                # hidden states for those skipped positions are already lost,
+                # but capping lets the request stay in the draft pool rather
+                # than permanently dropping it (the Markov head still works
+                # with a partial context — the missing positions represent
+                # tokens whose hidden states were never captured).
+                take = min(new_to_ingest, segment.num_query_tokens)
+                fused = self._segment_rows(ctx.target_hidden_states, segment, take)
+                if fused is None:
+                    return None
+                self._drafter.update_context(
+                    fused,
+                    ctx_offset=self._n_cached[req_id],
+                    ctx_caches=ctx_caches,
+                )
+                self._n_cached[req_id] += take
+            elif new_to_ingest < 0:
+                logger.warning(
+                    "DSpark: req %s n_cached=%d > committed_len-1=%d; resetting",
+                    req_id,
+                    self._n_cached[req_id],
+                    committed_len - 1,
+                )
+                self._n_cached[req_id] = committed_len - 1
+        else:
+            # New request: try stashed prefill hidden first (captured during
+            # the prefill forward — no duplicate forward). Fall back to
+            # batched seeding (re-run backbone) only for chunked prefill.
+            fused_prefill = self._pending_seed.pop(req_id, None)
+            if fused_prefill is not None:
+                p_len = fused_prefill.shape[0]
+                ctx_caches = self._drafter.make_ctx_cache()
+                self._drafter.update_context(
+                    fused_prefill[None, :, :],
+                    ctx_offset=0,
+                    ctx_caches=ctx_caches,
+                )
+                self._ctx_caches[req_id] = ctx_caches
+                self._n_cached[req_id] = p_len
+            # If no stashed prefill, prompt_ids marks for batched seeding.
+        return _DraftPlan(
+            req_id,
+            pending,
+            self._n_cached.get(req_id, 0),
+            ctx_caches,
+            cap,
+            prompt_ids=list(token_ids[:-1]) if ctx_caches is None else None,
+        )
+
+    # -- batched forward (one backbone call) -----------------------------
+
+    def _batch_draft(
+        self, plans: list[_DraftPlan]
+    ) -> tuple[list[str], list[list[int]]]:
+        num_reqs = len(plans)
+        block_sz = self._block_size
+
+        # Batched noise [num_reqs, block_sz, H].
+        block_ids_list = [
+            [p.pending] + [self._mask_token_id] * (block_sz - 1) for p in plans
+        ]
+        noise = self._drafter.embed(mx.array(block_ids_list))
+
+        # Batched block offsets [num_reqs].
+        offsets = [p.n_cached for p in plans]
+        off_arr = mx.array(offsets, dtype=mx.int32)
+
+        # Per-layer batched K/V from per-request CtxCache.
+        n_layers = len(self._drafter.layers)
+        batched_ctx = []
+        for layer_idx in range(n_layers):
+            lens = [p.ctx_caches[layer_idx].length for p in plans]
+            max_len = max(lens) if max(lens) > 0 else 1
+            ref = plans[0].ctx_caches[layer_idx]
+            n_heads_k = ref.k.shape[1]
+            dim_k, dim_v = ref.k.shape[3], ref.v.shape[3]
+            keys = mx.zeros((num_reqs, n_heads_k, max_len, dim_k), dtype=ref.k.dtype)
+            vals = mx.zeros((num_reqs, n_heads_k, max_len, dim_v), dtype=ref.v.dtype)
+            for b, p in enumerate(plans):
+                ctx_len_b = lens[b]
+                if ctx_len_b > 0:
+                    keys[b : b + 1, :, :ctx_len_b, :] = p.ctx_caches[layer_idx].k
+                    vals[b : b + 1, :, :ctx_len_b, :] = p.ctx_caches[layer_idx].v
+            batched_ctx.append(SimpleNamespace(k=keys, v=vals))
+
+        # Batched mask.
+        mask = _ctx_block_mask(offsets, block_sz)
+
+        # One backbone forward.
+        batched_hidden = self._drafter.backbone(
+            noise, off_arr, batched_ctx, mask=mask
+        )  # [B, K, H]
+
+        # Batched logits + greedy drafting (vectorized across rows).
+        cap = plans[0].cap
+        head_hidden = batched_hidden[:, :cap, :]  # [B, cap, H]
+        base_logits = self._drafter.compute_logits(head_hidden)  # [B, cap, V]
+        all_pending = mx.array([p.pending for p in plans])
+        if self._drafter.markov_head is not None:
+            # Markov head: sequential over cap positions, vectorized across rows.
+            prev = all_pending
+            drafts = []
+            for i in range(cap):
+                step = base_logits[:, i, :] + self._drafter.markov_head.step_bias(prev)
+                nxt = mx.argmax(step, axis=-1)
+                drafts.append(nxt)
+                prev = nxt
+            draft_arr = mx.stack(drafts, axis=1)  # [B, cap]
+        else:
+            draft_arr = mx.argmax(base_logits, axis=-1)  # [B, cap]
+        mx.eval(draft_arr)
+        rows = draft_arr.tolist()
+        return (
+            [p.req_id for p in plans],
+            [list(r) for r in rows],
+        )
+
+    # -- helpers ---------------------------------------------------------
+
+    def _segment_rows(
+        self,
+        target_hidden_states: mx.array,
+        segment: PagedDecodeSegment,
+        count: int,
+    ) -> mx.array | None:
+        start = segment.start_row
+        if start + count > segment.start_row + segment.num_query_tokens:
+            return None
+        if start + count > target_hidden_states.shape[0]:
+            return None
+        rows = target_hidden_states[start : start + count]
+        if rows.shape[0] != count:
+            return None
+        return rows[None, :, :]  # [1, count, k*H]
+
+    def _seed_prompts_batched(self, plans: list[_DraftPlan]) -> None:
+        """Seed ALL new requests in one batched target forward."""
+        seed = [(idx, p) for idx, p in enumerate(plans) if p.ctx_caches is None]
+        if not seed:
+            return
+        body = self._runner._model_adapter._target_backbone(self._runner._forward_model)
+        if body is None:
+            for _, p in seed:
+                self._seed_prompt(p.req_id, p.prompt_ids)
+                p.ctx_caches = self._ctx_caches.get(p.req_id)
+                p.n_cached = self._n_cached.get(p.req_id, 0)
+            return
+        n_layers = len(body.layers)
+        max_len = max(len(p.prompt_ids) for _, p in seed) if seed else 0
+        batched_ids = []
+        for _, p in seed:
+            pad = max_len - len(p.prompt_ids)
+            batched_ids.append(list(p.prompt_ids) + [0] * pad)
+        _, fused = run_backbone_with_capture(
+            body,
+            mx.array(batched_ids),
+            cache=[None] * n_layers,
+            layer_ids=self.capture_layer_ids,
+        )
+        for batch_pos, (_, p) in enumerate(seed):
+            p_len = len(p.prompt_ids)
+            ctx_caches = self._drafter.make_ctx_cache()
+            self._drafter.update_context(
+                fused[batch_pos : batch_pos + 1, :p_len, :],
+                ctx_offset=0,
+                ctx_caches=ctx_caches,
+            )
+            self._ctx_caches[p.req_id] = ctx_caches
+            self._n_cached[p.req_id] = p_len
+            p.ctx_caches = ctx_caches
+            p.n_cached = p_len
+
+    def _seed_prompt(self, req_id: str, prompt_ids: Sequence[int]) -> bool:
+        if not prompt_ids:
+            ctx_caches = self._drafter.make_ctx_cache()
+            self._ctx_caches[req_id] = ctx_caches
+            self._n_cached[req_id] = 0
+            return True
+        body = self._runner._model_adapter._target_backbone(self._runner._forward_model)
+        if body is None:
+            logger.warning(
+                "DSpark: cannot seed prompt — target has no `.model` backbone"
+            )
+            return False
+        ids = mx.array([list(prompt_ids)])
+        _, fused = run_backbone_with_capture(
+            body,
+            ids,
+            cache=[None] * len(body.layers),
+            layer_ids=self.capture_layer_ids,
+        )
+        ctx_caches = self._drafter.make_ctx_cache()
+        self._drafter.update_context(fused, ctx_offset=0, ctx_caches=ctx_caches)
+        self._ctx_caches[req_id] = ctx_caches
+        self._n_cached[req_id] = int(len(prompt_ids))
+        return True
+
+    def _prune_finished(self, request_states: Mapping[str, RequestState]) -> None:
+        for req_id in list(self._ctx_caches.keys()):
+            if req_id not in request_states:
+                self._ctx_caches.pop(req_id, None)
+                self._n_cached.pop(req_id, None)
+                self._pending_seed.pop(req_id, None)

--- a/vllm_metal/v1/hidden_state_tap.py
+++ b/vllm_metal/v1/hidden_state_tap.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reusable hidden-state tap: capture a target backbone's residual stream after
+an arbitrary selection of layers and fuse them.
+
+Both the existing Gemma4 MTP path (last layer) and DSpark (several specific
+intermediate layers) become users of this one helper. Mirrors the explicit
+transformer-layer traversal used by the reference implementation: embed,
+mask, loop over layers calling ``layer(h, mask, c)``, apply the final norm,
+and capture the residual after each requested index (concatenated along the
+feature axis).
+
+``run_backbone_with_capture`` returns BOTH the post-norm final hidden (so the
+target's own logits can be computed from the same forward — the integrated path
+cannot afford a second pass) and the fused intermediate captures (for the
+drafter). ``capture_layer_hidden_states`` is a fused-only view over it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+from mlx_lm.models.base import create_attention_mask
+
+
+def run_backbone_with_capture(
+    backbone: Any,
+    input_ids: mx.array,
+    *,
+    cache: Any,
+    layer_ids: list[int],
+) -> tuple[mx.array, mx.array]:
+    """Run ``backbone``'s full layer loop, returning final + fused residuals.
+
+    Args:
+        backbone: an MLX transformer body exposing ``embed_tokens``, ``layers``,
+            and ``norm`` — i.e. what ``_target_backbone`` returns
+            (``text_model(model).model``).
+        input_ids: ``[batch, tokens]``.
+        cache: per-layer cache list, passed straight through to each layer. The
+            paged KV routing for patched models happens inside the attention via
+            the active step context, not via this arg.
+        layer_ids: 0-indexed layer positions to capture; residuals are fused in
+            this order along the feature axis.
+
+    Returns:
+        ``(final, fused)`` where ``final`` is the post-norm hidden after the last
+        layer (suitable for the target lm_head) and ``fused`` is
+        ``[batch, tokens, len(layer_ids) * hidden]``.
+    """
+    if not layer_ids:
+        raise ValueError("run_backbone_with_capture requires at least one layer_id")
+    layers = backbone.layers
+    if any(i < 0 or i >= len(layers) for i in layer_ids):
+        raise IndexError(
+            f"layer_ids {layer_ids} out of range for backbone with {len(layers)} layers"
+        )
+
+    tapset = set(layer_ids)
+    h = backbone.embed_tokens(input_ids)
+    # Match the body's own mask creation; patched attention reads paged KV from
+    # the active step context regardless of this arg.
+    mask = create_attention_mask(h, cache[0] if cache else None)
+    captured: list[mx.array] = []
+    for i, (layer, c) in enumerate(zip(layers, cache, strict=True)):
+        h = layer(h, mask, c)
+        if i in tapset:
+            captured.append(h)
+    final = backbone.norm(h)
+    fused = mx.concatenate(captured, axis=-1)
+    return final, fused
+
+
+def capture_layer_hidden_states(
+    backbone: Any,
+    input_ids: mx.array,
+    *,
+    cache: Any,
+    layer_ids: list[int],
+) -> mx.array:
+    """Fused-only view over :func:`run_backbone_with_capture`.
+
+    Returns ``[batch, tokens, len(layer_ids) * hidden]`` — just the fused
+    intermediate residuals, for callers (e.g. the M0 sanity harness) that feed
+    a drafter without needing the target's own logits.
+    """
+    _, fused = run_backbone_with_capture(
+        backbone, input_ids, cache=cache, layer_ids=layer_ids
+    )
+    return fused

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 import mlx.core as mx
 from vllm.logger import init_logger
 
+from vllm_metal.v1.hidden_state_tap import run_backbone_with_capture
+
 if TYPE_CHECKING:
     from vllm.config import ModelConfig
 
@@ -137,6 +139,7 @@ class ModelAdapter(Protocol):
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        capture_layer_ids: list[int] | None = None,
     ) -> TargetModelForwardOutput:
         """Run the target text model and optionally retain target hidden states."""
 
@@ -336,8 +339,33 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        capture_layer_ids: list[int] | None = None,
     ) -> TargetModelForwardOutput:
-        """Run the target model and return logits plus optional hidden states."""
+        """Run the target model and return logits plus optional hidden states.
+
+        ``capture_layer_ids`` (a non-empty list of layer indices) runs the body
+        forward while capturing the residual after each named layer and fusing
+        them into ``hidden_states``; the target's own logits are still computed
+        from the same forward's final hidden, so the integrated path needs only
+        one forward. ``None`` preserves the existing execution path with no
+        additional operations.
+        """
+        if capture_layer_ids:
+            backbone = self._target_backbone(model)
+            if backbone is None:
+                raise NotImplementedError(
+                    "capture_layer_ids requires a text model with a `.model` "
+                    "backbone; this model does not expose hidden states."
+                )
+            final, fused = run_backbone_with_capture(
+                backbone, input_ids, cache=cache, layer_ids=capture_layer_ids
+            )
+            logits = self._compute_target_logits(model, final)
+            return TargetModelForwardOutput(
+                logits=logits,
+                hidden_states=self._flatten_target_hidden_states(fused),
+            )
+
         if not collect_hidden_states:
             output = model(input_ids, cache=cache)
             return TargetModelForwardOutput(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -743,7 +743,6 @@ class MetalModelRunner:
                 drafter_cfg.target_layer_ids,
             )
         elif spec.uses_draft_model():
-
             self._drafter = DraftModelProposer.build(
                 speculative_config=spec,
                 controller=self._spec_decode_controller,
@@ -763,7 +762,6 @@ class MetalModelRunner:
                     "Raise VLLM_METAL_MEMORY_FRACTION or lower --max-num-seqs."
                 )
         elif spec.method == "ngram":
-
             # N-gram drafts from token history alone — no model, no KV cache, so
             # num_blocks/block_size are unused here.
             self._drafter = NgramProposer.build(
@@ -1129,7 +1127,7 @@ class MetalModelRunner:
                 target_hidden_states = None
             else:
                 capture_layer_ids = (
-                    self._drafter.capture_layer_ids
+                    getattr(self._drafter, "capture_layer_ids", None)
                     if collect_target_hidden_states
                     else None
                 )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -68,6 +68,9 @@ from vllm_metal.v1.contiguous_cache import (
     _extract_kv_cache,
     _merge_kv_caches,
 )
+from vllm_metal.v1.draft_model_proposer import DraftModelProposer
+from vllm_metal.v1.dspark.loader import is_dspark_drafter, load_drafter
+from vllm_metal.v1.dspark_proposer import DSparkProposer
 from vllm_metal.v1.gemma4_mtp import (
     Gemma4MTPAssistantRuntime,
     Gemma4MTPAssistantSource,
@@ -81,6 +84,7 @@ from vllm_metal.v1.model_adapter import (
     TargetModelForwardOutput,
 )
 from vllm_metal.v1.model_lifecycle import ModelLifecycle
+from vllm_metal.v1.ngram_proposer import NgramProposer
 from vllm_metal.v1.pooling import (
     finish_paged_pooling_batch,
     forward_sequence_hidden_states,
@@ -568,12 +572,14 @@ class MetalModelRunner:
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        capture_layer_ids: list[int] | None = None,
     ) -> TargetModelForwardOutput:
         return self._model_adapter.target_forward(
             self._forward_model,
             input_ids,
             cache=cache,
             collect_hidden_states=collect_hidden_states,
+            capture_layer_ids=capture_layer_ids,
         )
 
     def _target_input_embeddings(self, input_ids: mx.array) -> mx.array:
@@ -710,10 +716,33 @@ class MetalModelRunner:
         spec = self.vllm_config.speculative_config
         if spec is None:
             return
+
         if Gemma4MTPAssistantSource.is_gemma4_mtp(spec):
             self._drafter = Gemma4MTPProposer(self)
+        elif spec.method == "dspark" or (
+            spec.uses_draft_model() and is_dspark_drafter(spec.draft_model_config)
+        ):
+            # vLLM resolves a Qwen3DSparkModel draft to method="dspark" and puts
+            # the drafter repo on `spec.model`; the draft_model path carries it on
+            # draft_model_config. Cover both.
+            drafter_repo = (
+                spec.model if spec.method == "dspark" else spec.draft_model_config.model
+            )
+            drafter_model, drafter_cfg = load_drafter(drafter_repo)
+            self._drafter = DSparkProposer(
+                drafter=drafter_model,
+                config=drafter_cfg,
+                runner=self,
+                controller=self._spec_decode_controller,
+            )
+            logger.info(
+                "DSpark drafter loaded for speculative decoding: %s "
+                "(block_size=%d, target_layer_ids=%s)",
+                drafter_repo,
+                drafter_cfg.block_size,
+                drafter_cfg.target_layer_ids,
+            )
         elif spec.uses_draft_model():
-            from vllm_metal.v1.draft_model_proposer import DraftModelProposer
 
             self._drafter = DraftModelProposer.build(
                 speculative_config=spec,
@@ -734,7 +763,6 @@ class MetalModelRunner:
                     "Raise VLLM_METAL_MEMORY_FRACTION or lower --max-num-seqs."
                 )
         elif spec.method == "ngram":
-            from vllm_metal.v1.ngram_proposer import NgramProposer
 
             # N-gram drafts from token history alone — no model, no KV cache, so
             # num_blocks/block_size are unused here.
@@ -1100,10 +1128,16 @@ class MetalModelRunner:
                     pp_send_handle = pipeline_send(stage_output, self.pp)
                 target_hidden_states = None
             else:
+                capture_layer_ids = (
+                    self._drafter.capture_layer_ids
+                    if collect_target_hidden_states
+                    else None
+                )
                 target_output = self._target_forward(
                     input_ids,
                     cache=offset_caches,
                     collect_hidden_states=collect_target_hidden_states,
+                    capture_layer_ids=capture_layer_ids,
                 )
                 logits = target_output.logits
                 target_hidden_states = target_output.hidden_states

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -63,6 +63,8 @@ class MetalProposer(Protocol):
     ``DraftModelProposer``.
     """
 
+    capture_layer_ids: list[int] | None
+
     def needs_target_hidden_states(
         self,
         decode_segments: Sequence[PagedDecodeSegment],
@@ -85,6 +87,11 @@ class Gemma4MTPProposer:
     after model load, so capturing it at construction time would pin the
     pre-sharing object.
     """
+
+    # Default to None: target_forward uses the existing collect_hidden_states
+    # path (single final layer). DSparkProposer overrides this with a non-empty
+    # list to trigger fused intermediate-layer capture.
+    capture_layer_ids: list[int] | None = None
 
     def __init__(self, runner: MetalModelRunner) -> None:
         self._runner = runner


### PR DESCRIPTION
# Dspark

CC: @WindChimeRan 

this pr contains the code related speculative decoding via a DSpark drafter (5-layer backbone + rank-256 Markov head) that cross-attends over fused target hidden states.

implementation reference: https://github.com/ARahim3/mlx-dspark

### How it works 

During prefill, hidden states from 5 target layers are captured, fused, and cached per request. Each decode step, the drafter runs one batched backbone forward over all active requests; the block attends bidirectionally to itself while cross attending over saved target context by producing a block of candidate tokens per request.
A Markov head corrects each position based on the previous prediction. The target verifies all candidates in one forward pass.

### Known issues

- Acceptance rate is stuck at ~35%
- num of speculative tokens is limited to 2 tk/step
- overall throughput at tks/ is much lower than baseline with benchmark at concurrent request (as well as single stream)

### Benchmark

#### Baseline
```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Benchmark duration (s):                  82.37
Total input tokens:                      54256
Total generated tokens:                  15000
Request throughput (req/s):              1.21
Output token throughput (tok/s):         182.10
Peak output token throughput (tok/s):    400.00
Peak concurrent requests:                100.00
Total token throughput (tok/s):          840.77
---------------Time to First Token----------------
Mean TTFT (ms):                          19977.99
Median TTFT (ms):                        19591.28
P50 TTFT (ms):                           19591.28
P99 TTFT (ms):                           35141.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          409.86
Median TPOT (ms):                        414.53
P50 TPOT (ms):                           414.53
P99 TPOT (ms):                           495.98
----------------End-to-end Latency----------------
Mean E2EL (ms):                          81046.61
Median E2EL (ms):                        81356.89
P50 E2EL (ms):                           81356.89
P99 E2EL (ms):                           82367.22
==================================================
```

#### Dspark

```
============ Serving Benchmark Result ============
Successful requests:                     100
Failed requests:                         0
Benchmark duration (s):                  143.67
Total input tokens:                      54256
Total generated tokens:                  15000
Request throughput (req/s):              0.70
Output token throughput (tok/s):         104.41
Peak output token throughput (tok/s):    200.00
Peak concurrent requests:                100.00
Total token throughput (tok/s):          482.06
---------------Time to First Token----------------
Mean TTFT (ms):                          23608.79
Median TTFT (ms):                        22791.84
P50 TTFT (ms):                           22791.84
P99 TTFT (ms):                           46843.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          637.39
Median TPOT (ms):                        657.74
P50 TPOT (ms):                           657.74
P99 TPOT (ms):                           753.27
----------------End-to-end Latency----------------
Mean E2EL (ms):                          118579.63
Median E2EL (ms):                        123820.01
P50 E2EL (ms):                           123820.01
P99 E2EL (ms):                           143659.68
---------------Speculative Decoding---------------
Acceptance rate (%):                     35.16
Acceptance length:                       1.70
Drafts:                                  4794
Draft tokens:                            9588
Accepted tokens:                         3371
Per-position acceptance (%):
  Position 0:                            46.35
  Position 1:                            23.97
==================================================
```


### How to reproduce

#### Server 
```
vllm bench serve --backend openai --base-url http://localhost:8000 \  
    --model mlx-community/Qwen3-4B-4bit --dataset-name sonnet --dataset-path sonnet.txt \
    --num-prompts 100 --request-rate inf --percentile-metrics ttft,tpot,e2el \
    --metric-percentiles 50,99 --temperature=0
```

#### Benchmark

```
vllm bench serve --backend openai --base-url http://localhost:8000 \                                   
    --model mlx-community/Qwen3-4B-4bit --dataset-name sonnet --dataset-path sonnet.txt \
    --num-prompts 100 --request-rate inf --percentile-metrics ttft,tpot,e2el \
    --metric-percentiles 50,99 --temperature=0
```