### PR TITLE
Add vLLM-backed MHA KV cache layout

### DIFF
--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -7,9 +7,18 @@ from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
+import torch
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+    SlidingWindowSpec,
+)
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
 from vllm_metal.attention.runtime.mha import (
     MHAPagedAttentionRuntime,
 )
@@ -238,3 +247,87 @@ class TestCachePolicyPerLayerBytes:
             match="TurboQuant with per-layer KV shapes is not yet supported",
         ):
             runner.get_kv_cache_spec()
+
+
+class TestMHAKVCacheLayout:
+    """vLLM-managed standard-MHA cache layout contracts."""
+
+    @staticmethod
+    def _mixed_mha_config() -> tuple[KVCacheConfig, tuple[str, ...]]:
+        full = FullAttentionSpec(
+            block_size=32,
+            num_kv_heads=4,
+            head_size=512,
+            dtype=torch.bfloat16,
+        )
+        sliding = SlidingWindowSpec(
+            block_size=16,
+            num_kv_heads=16,
+            head_size=256,
+            dtype=torch.bfloat16,
+            sliding_window=1024,
+        )
+        names = tuple(f"layers.{index}.self_attn" for index in range(4))
+        groups = [
+            KVCacheGroupSpec([names[0], names[2]], full),
+            KVCacheGroupSpec([names[1], names[3]], sliding),
+        ]
+        assert full.page_size_bytes == sliding.page_size_bytes
+        size = full.page_size_bytes * 3
+        config = KVCacheConfig(
+            num_blocks=3,
+            kv_cache_tensors=[
+                KVCacheTensor(size=size, shared_by=[names[0], names[1]]),
+                KVCacheTensor(size=size, shared_by=[names[2], names[3]]),
+            ],
+            kv_cache_groups=groups,
+        )
+        return config, names
+
+    def test_translates_upstream_slots_and_groups(self) -> None:
+        config, names = self._mixed_mha_config()
+
+        layout = MHAKVCacheLayout.from_config(config, names)
+
+        assert layout.group_block_sizes == (32, 16)
+        assert layout.slot_layers == ((0, 1), (2, 3))
+        assert [layer.tensor_index for layer in layout.layers] == [0, 0, 1, 1]
+        assert [layer.group_index for layer in layout.layers] == [0, 1, 0, 1]
+        assert [layer.sliding_window for layer in layout.layers] == [-1, 1024, -1, 1024]
+        assert layout.total_bytes == sum(
+            tensor.size for tensor in config.kv_cache_tensors
+        )
+
+    def test_allocates_shared_slots_from_layout(self) -> None:
+        config, names = self._mixed_mha_config()
+        layout = MHAKVCacheLayout.from_config(config, names)
+
+        cache = MetalPagedKVCache.from_layout(layout, mx.bfloat16)
+
+        assert cache.key_caches[0].shape == (3, 32, 4, 512)
+        assert cache.key_caches[1].shape == (3, 16, 16, 256)
+        assert cache.group_index_for_layer(1) == 1
+        assert cache.block_size_for_layer(1) == 16
+
+    def test_rebind_updates_every_layer_sharing_the_slot(self) -> None:
+        config, names = self._mixed_mha_config()
+        cache = MetalPagedKVCache.from_layout(
+            MHAKVCacheLayout.from_config(config, names), mx.bfloat16
+        )
+
+        new_key = cache.key_caches[1] + mx.array(1, dtype=mx.bfloat16)
+        new_value = cache.value_caches[1] + mx.array(2, dtype=mx.bfloat16)
+
+        cache.replace_layer_cache(1, new_key, new_value)
+
+        assert mx.all(cache.key_caches[1].reshape(-1) == new_key.reshape(-1)).item()
+        assert mx.all(cache.value_caches[1].reshape(-1) == new_value.reshape(-1)).item()
+        assert mx.all(cache.key_caches[0].reshape(-1) == new_key.reshape(-1)).item()
+        assert mx.all(cache.value_caches[0].reshape(-1) == new_value.reshape(-1)).item()
+
+    def test_rejects_packed_upstream_tensors(self) -> None:
+        config, names = self._mixed_mha_config()
+        config.kv_cache_tensors[0].block_stride = 256
+
+        with pytest.raises(NotImplementedError, match="offset and block_stride"):
+            MHAKVCacheLayout.from_config(config, names)

--- a/vllm_metal/attention/caches/kv_cache.py
+++ b/vllm_metal/attention/caches/kv_cache.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import mlx.core as mx
 from vllm.logger import init_logger
 
+from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
 from vllm_metal.attention.caches.turboquant import (
     BLOCK_SIZE,
     FWHT_SUPPORTED_HEAD_DIMS,
@@ -56,6 +57,7 @@ class MetalPagedKVCache:
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
         sliding_window_per_layer: list[int] | None = None,
+        layout: MHAKVCacheLayout | None = None,
     ) -> None:
         self.num_layers = num_layers
         self.num_kv_heads = num_kv_heads
@@ -66,6 +68,10 @@ class MetalPagedKVCache:
         self.turboquant = turboquant
         self.k_quant = k_quant
         self.v_quant = v_quant
+        self._layout = layout
+
+        if layout is not None and turboquant:
+            raise ValueError("layout-backed KV caches do not support TurboQuant")
 
         if turboquant:
             if k_quant is None or k_quant not in QUANT_PARAMS:
@@ -142,32 +148,15 @@ class MetalPagedKVCache:
         self.key_scale_caches: list[mx.array] = []
         self.value_scale_caches: list[mx.array] = []
         self.key_zero_caches: list[mx.array] = []  # asymmetric K zero_point
+        self._key_slots: list[mx.array] = []
+        self._value_slots: list[mx.array] = []
         if not turboquant:
-            for i in range(num_layers):
-                shape = (
-                    num_blocks,
-                    block_size,
-                    self.kv_heads_per_layer[i],
-                    self.head_dim_per_layer[i],
-                )
-                self.key_caches.append(mx.zeros(shape, dtype=dtype))
-                self.value_caches.append(mx.zeros(shape, dtype=dtype))
-            mx.eval(*self.key_caches, *self.value_caches)
-
-            # Log KV cache memory usage
-            kv_bytes = (
-                num_layers
-                * num_blocks
-                * block_size
-                * num_kv_heads
-                * head_dim
-                * 2
-                * self._dtype_size(dtype)
-            )
-            logger.info(
-                f"KV cache: {kv_bytes / 1e6:.1f} MB "
-                f"({num_layers} layers, {num_blocks} blocks, {block_size} tokens/block)"
-            )
+            if layout is None:
+                self._allocate_dense_caches(dtype)
+                self._log_dense_cache(dtype)
+            else:
+                self._allocate_layout_caches(layout, dtype)
+                self._log_layout_cache(layout)
         else:
             for _ in range(num_layers):
                 self.key_caches.append(
@@ -228,6 +217,112 @@ class MetalPagedKVCache:
                 f"(K: {self.k_bits}b->{self.k_packed_dim}d, V: {self.v_bits}b->{self.v_packed_dim}d, "
                 f"vs {fp16_equivalent / 1e6:.1f} MB fp16, {compression:.2f}x compression)"
             )
+
+    def _allocate_dense_caches(self, dtype: mx.Dtype) -> None:
+        """Allocate one independent K/V pair for each logical layer."""
+        for i in range(self.num_layers):
+            shape = (
+                self.num_blocks,
+                self.block_size,
+                self.kv_heads_per_layer[i],
+                self.head_dim_per_layer[i],
+            )
+            self.key_caches.append(mx.zeros(shape, dtype=dtype))
+            self.value_caches.append(mx.zeros(shape, dtype=dtype))
+        mx.eval(*self.key_caches, *self.value_caches)
+
+    def _allocate_layout_caches(
+        self, layout: MHAKVCacheLayout, dtype: mx.Dtype
+    ) -> None:
+        """Allocate shared physical K/V slots and per-layer logical views."""
+        for slot_layers in layout.slot_layers:
+            shape = layout.layers[slot_layers[0]].cache_shape(self.num_blocks)
+            self._key_slots.append(mx.zeros(shape, dtype=dtype))
+            self._value_slots.append(mx.zeros(shape, dtype=dtype))
+        mx.eval(*self._key_slots, *self._value_slots)
+
+        for layer in layout.layers:
+            self.key_caches.append(
+                self._key_slots[layer.tensor_index].reshape(
+                    layer.cache_shape(self.num_blocks)
+                )
+            )
+            self.value_caches.append(
+                self._value_slots[layer.tensor_index].reshape(
+                    layer.cache_shape(self.num_blocks)
+                )
+            )
+
+    def _log_dense_cache(self, dtype: mx.Dtype) -> None:
+        kv_bytes = (
+            self.num_layers
+            * self.num_blocks
+            * self.block_size
+            * self.num_kv_heads
+            * self.head_dim
+            * 2
+            * self._dtype_size(dtype)
+        )
+        logger.info(
+            f"KV cache: {kv_bytes / 1e6:.1f} MB "
+            f"({self.num_layers} layers, {self.num_blocks} blocks, "
+            f"{self.block_size} tokens/block)"
+        )
+
+    def _log_layout_cache(self, layout: MHAKVCacheLayout) -> None:
+        logger.info(
+            f"KV cache: {layout.total_bytes / 1e6:.1f} MB "
+            f"({len(layout.slot_layers)} physical slots across "
+            f"{len(layout.group_block_sizes)} groups, {self.num_blocks} blocks)"
+        )
+
+    @classmethod
+    def from_layout(
+        cls, layout: MHAKVCacheLayout, dtype: mx.Dtype
+    ) -> MetalPagedKVCache:
+        """Allocate one physical K/V pair for every upstream tensor slot."""
+        first_layer = layout.layers[0]
+        return cls(
+            num_layers=len(layout.layers),
+            num_kv_heads=first_layer.num_kv_heads,
+            head_dim=first_layer.head_dim,
+            num_blocks=layout.num_blocks,
+            block_size=first_layer.block_size,
+            dtype=dtype,
+            kv_heads_per_layer=[layer.num_kv_heads for layer in layout.layers],
+            head_dim_per_layer=[layer.head_dim for layer in layout.layers],
+            sliding_window_per_layer=[layer.sliding_window for layer in layout.layers],
+            layout=layout,
+        )
+
+    def group_index_for_layer(self, layer_idx: int) -> int:
+        """Return the vLLM cache-group index for ``layer_idx``."""
+        return 0 if self._layout is None else self._layout.layers[layer_idx].group_index
+
+    def block_size_for_layer(self, layer_idx: int) -> int:
+        """Return the vLLM page size for ``layer_idx``."""
+        return (
+            self.block_size
+            if self._layout is None
+            else self._layout.layers[layer_idx].block_size
+        )
+
+    def replace_layer_cache(
+        self, layer_idx: int, key_cache: mx.array, value_cache: mx.array
+    ) -> None:
+        """Rebind a native primitive result and every layer sharing its slot."""
+        if self._layout is None:
+            self.key_caches[layer_idx] = key_cache
+            self.value_caches[layer_idx] = value_cache
+            return
+
+        slot = self._layout.layers[layer_idx].tensor_index
+        self._key_slots[slot] = key_cache
+        self._value_slots[slot] = value_cache
+        for shared_layer in self._layout.slot_layers[slot]:
+            shape = self._layout.layers[shared_layer].cache_shape(self.num_blocks)
+            self.key_caches[shared_layer] = key_cache.reshape(shape)
+            self.value_caches[shared_layer] = value_cache.reshape(shape)
 
     _DTYPE_SIZES = {
         mx.float16: 2,

--- a/vllm_metal/attention/caches/mha_layout.py
+++ b/vllm_metal/attention/caches/mha_layout.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Immutable Metal layout translated from vLLM's standard MHA cache DTOs.
+
+vLLM owns KV-cache grouping and capacity planning. This module only validates
+and translates the resulting ``KVCacheConfig`` for the standard mixed
+full/sliding-window MHA path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheTensor,
+    SlidingWindowSpec,
+)
+
+NO_SLIDING_WINDOW = -1
+StandardMHASpec: TypeAlias = FullAttentionSpec | SlidingWindowSpec
+
+
+@dataclass(frozen=True, slots=True)
+class MHAGroupLayout:
+    """vLLM cache-group specs and layer-to-group mapping."""
+
+    specs: tuple[StandardMHASpec, ...]
+    layer_indices: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class MHATensorLayout:
+    """vLLM physical tensor slots and layer-to-slot mapping."""
+
+    layer_indices: dict[str, int]
+    slot_layers: tuple[tuple[int, ...], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MHALayerKVLayout:
+    """KV-cache shape and vLLM mapping for one model layer."""
+
+    tensor_index: int
+    group_index: int
+    block_size: int
+    num_kv_heads: int
+    head_dim: int
+    sliding_window: int
+
+    def cache_shape(self, num_blocks: int) -> tuple[int, int, int, int]:
+        """Return the key or value cache shape for ``num_blocks`` pages."""
+        return (num_blocks, self.block_size, self.num_kv_heads, self.head_dim)
+
+
+@dataclass(frozen=True, slots=True)
+class MHAKVCacheLayout:
+    """Immutable standard-MHA cache layout derived from vLLM's DTOs."""
+
+    num_blocks: int
+    tensor_sizes: tuple[int, ...]
+    layers: tuple[MHALayerKVLayout, ...]
+    group_block_sizes: tuple[int, ...]
+    slot_layers: tuple[tuple[int, ...], ...]
+
+    @property
+    def total_bytes(self) -> int:
+        """Return the aggregate storage vLLM allocated for KV tensors."""
+        return sum(self.tensor_sizes)
+
+    @classmethod
+    def from_config(
+        cls, config: KVCacheConfig, model_layer_names: tuple[str, ...]
+    ) -> MHAKVCacheLayout:
+        """Translate a standard mixed-MHA ``KVCacheConfig`` without regrouping.
+
+        ``model_layer_names`` is the runner's ordered attention-layer sequence.
+        Each layer must occur exactly once in vLLM's group and tensor mappings.
+        """
+        return MHAKVCacheLayoutTranslator(config, model_layer_names).translate()
+
+
+@dataclass(frozen=True, slots=True)
+class MHAKVCacheLayoutTranslator:
+    """Translate vLLM's standard-MHA KV cache config into Metal's layout DTO."""
+
+    config: KVCacheConfig
+    model_layer_names: tuple[str, ...]
+
+    def translate(self) -> MHAKVCacheLayout:
+        """Translate without changing vLLM's grouping."""
+        group_layout = self._group_layout()
+        self._require_model_layers(group_layout.layer_indices, "group")
+
+        tensor_layout = self._tensor_layout(group_layout)
+        self._require_model_layers(tensor_layout.layer_indices, "tensor")
+
+        return MHAKVCacheLayout(
+            num_blocks=self.config.num_blocks,
+            tensor_sizes=tuple(tensor.size for tensor in self.config.kv_cache_tensors),
+            layers=self._layer_layouts(group_layout, tensor_layout),
+            group_block_sizes=tuple(spec.block_size for spec in group_layout.specs),
+            slot_layers=tensor_layout.slot_layers,
+        )
+
+    @property
+    def _model_layer_indices(self) -> dict[str, int]:
+        return {name: index for index, name in enumerate(self.model_layer_names)}
+
+    def _group_layout(self) -> MHAGroupLayout:
+        specs: list[StandardMHASpec] = []
+        layer_indices: dict[str, int] = {}
+        for group_index, group in enumerate(self.config.kv_cache_groups):
+            spec = group.kv_cache_spec
+            if not isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
+                raise NotImplementedError(
+                    "standard MHA layout requires FullAttentionSpec or "
+                    "SlidingWindowSpec groups"
+                )
+            if spec.head_size_v != spec.head_size:
+                raise NotImplementedError(
+                    "standard MHA layout requires matching key and value head sizes"
+                )
+
+            specs.append(spec)
+            for layer_name in group.layer_names:
+                layer_indices[layer_name] = group_index
+        return MHAGroupLayout(specs=tuple(specs), layer_indices=layer_indices)
+
+    def _tensor_layout(self, group_layout: MHAGroupLayout) -> MHATensorLayout:
+        layer_indices: dict[str, int] = {}
+        slot_layers: list[tuple[int, ...]] = []
+        model_layer_indices = self._model_layer_indices
+
+        for tensor_index, tensor in enumerate(self.config.kv_cache_tensors):
+            if tensor.offset != 0 or tensor.block_stride != 0:
+                raise NotImplementedError(
+                    "standard MHA layout does not support KV tensors with "
+                    "offset and block_stride"
+                )
+
+            tensor_layer_indices: list[int] = []
+            for layer_name in tensor.shared_by:
+                group_index = group_layout.layer_indices[layer_name]
+                group_spec = group_layout.specs[group_index]
+                self._require_tensor_size(tensor, tensor_index, group_spec, layer_name)
+                layer_indices[layer_name] = tensor_index
+                tensor_layer_indices.append(model_layer_indices[layer_name])
+            slot_layers.append(tuple(tensor_layer_indices))
+
+        return MHATensorLayout(
+            layer_indices=layer_indices,
+            slot_layers=tuple(slot_layers),
+        )
+
+    def _layer_layouts(
+        self,
+        group_layout: MHAGroupLayout,
+        tensor_layout: MHATensorLayout,
+    ) -> tuple[MHALayerKVLayout, ...]:
+        return tuple(
+            self._layer_layout(layer_name, group_layout, tensor_layout)
+            for layer_name in self.model_layer_names
+        )
+
+    def _layer_layout(
+        self,
+        layer_name: str,
+        group_layout: MHAGroupLayout,
+        tensor_layout: MHATensorLayout,
+    ) -> MHALayerKVLayout:
+        group_index = group_layout.layer_indices[layer_name]
+        spec = group_layout.specs[group_index]
+        return MHALayerKVLayout(
+            tensor_index=tensor_layout.layer_indices[layer_name],
+            group_index=group_index,
+            block_size=spec.block_size,
+            num_kv_heads=spec.num_kv_heads,
+            head_dim=spec.head_size,
+            sliding_window=(
+                spec.sliding_window
+                if isinstance(spec, SlidingWindowSpec)
+                else NO_SLIDING_WINDOW
+            ),
+        )
+
+    def _require_model_layers(self, layer_mapping: dict[str, int], source: str) -> None:
+        if set(layer_mapping) != set(self.model_layer_names):
+            raise ValueError(
+                f"{source} layer mapping must contain the same layers as "
+                "model_layer_names"
+            )
+
+    def _require_tensor_size(
+        self,
+        tensor: KVCacheTensor,
+        tensor_index: int,
+        group_spec: StandardMHASpec,
+        layer_name: str,
+    ) -> None:
+        expected_size = self.config.num_blocks * group_spec.page_size_bytes
+        if tensor.size != expected_size:
+            raise ValueError(
+                f"KV cache tensor {tensor_index} size {tensor.size} does not "
+                f"match {self.config.num_blocks} blocks of "
+                f"{group_spec.page_size_bytes} bytes for layer {layer_name!r}"
+            )


### PR DESCRIPTION
This PR is:

- To add a Metal layout object for standard MHA KV cache.
- To translate vLLM’s `KVCacheConfig` into Metal’s per-layer cache layout.
- To let `MetalPagedKVCache` allocate shared KV slots from that layout.

Note: this is PR 1 of 3 for #505. Gemma-style mixed full/sliding MHA needs to use the cache groups and tensor slots from vLLM. Without that, Metal can keep treating the cache as one flat shape. This PR only adds the layout and allocation path. It does not change runtime routing yet.

I will submit two follow-up PRs:

- Carry grouped paged-KV metadata through the MHA runtime path.
- Use this layout for Gemma-style full/sliding MHA cache.