### PR TITLE
[Bugfix] Validate VLLM_MLX_DEVICE instead of silently falling back to CPU

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,3 +206,32 @@ class TestMetalConfig:
                 k_quant="q8_0",
                 v_quant="fp16",
             )
+
+    def test_invalid_mlx_device_rejected(self) -> None:
+        """An unknown mlx_device must fail fast, not silently fall back to CPU."""
+        for device in ["mps", "cuda", "gpuu", ""]:
+            with pytest.raises(ValueError, match="Invalid VLLM_MLX_DEVICE"):
+                MetalConfig(
+                    memory_fraction=AUTO_MEMORY_FRACTION,
+                    use_mlx=True,
+                    mlx_device=device,  # type: ignore[arg-type]
+                    debug=False,
+                    use_paged_attention=True,
+                )
+
+    def test_mlx_device_from_env_normalizes_case(self, monkeypatch) -> None:
+        """'GPU' / ' gpu ' / 'CPU' from the environment normalize to canonical values."""
+        for value, expected in [("GPU", "gpu"), (" gpu ", "gpu"), ("CPU", "cpu")]:
+            reset_config()
+            monkeypatch.setenv("VLLM_MLX_DEVICE", value)
+
+            config = MetalConfig.from_env()
+
+            assert config.mlx_device == expected
+
+    def test_invalid_mlx_device_from_env_rejected(self, monkeypatch) -> None:
+        """A wrong backend name in the environment is rejected, not silently CPU-routed."""
+        monkeypatch.setenv("VLLM_MLX_DEVICE", "cuda")
+
+        with pytest.raises(ValueError, match="Invalid VLLM_MLX_DEVICE"):
+            MetalConfig.from_env()

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -29,6 +29,9 @@ VALID_MULTIMODAL_MODES: frozenset[MultimodalMode] = frozenset(
     {"auto", "text-only-compat", "multimodal-native"}
 )
 
+MLXDevice = Literal["gpu", "cpu"]
+VALID_MLX_DEVICES: frozenset[MLXDevice] = frozenset({"gpu", "cpu"})
+
 
 @dataclass
 class MetalConfig:
@@ -36,7 +39,7 @@ class MetalConfig:
 
     memory_fraction: float  # -1.0 selects the active backend's auto policy
     use_mlx: bool
-    mlx_device: Literal["gpu", "cpu"]
+    mlx_device: MLXDevice
     debug: bool
     use_paged_attention: bool = True
     multimodal_mode: MultimodalMode = "auto"
@@ -59,6 +62,13 @@ class MetalConfig:
                     f"Invalid VLLM_METAL_MEMORY_FRACTION={self.memory_fraction}. "
                     "Must be a finite value in (0, 1] when paged attention is enabled."
                 )
+
+        if self.mlx_device not in VALID_MLX_DEVICES:
+            available = ", ".join(sorted(VALID_MLX_DEVICES))
+            raise ValueError(
+                f"Invalid VLLM_MLX_DEVICE={self.mlx_device!r}. "
+                f"Available devices: {available}."
+            )
 
         if self.multimodal_mode not in VALID_MULTIMODAL_MODES:
             available = ", ".join(sorted(VALID_MULTIMODAL_MODES))
@@ -115,7 +125,7 @@ class MetalConfig:
         return cls(
             memory_fraction=memory_fraction,
             use_mlx=envs.VLLM_METAL_USE_MLX,
-            mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
+            mlx_device=envs.VLLM_MLX_DEVICE.strip().lower(),  # type: ignore[arg-type]
             debug=envs.VLLM_METAL_DEBUG,
             use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
             multimodal_mode=envs.VLLM_METAL_MULTIMODAL_MODE,  # type: ignore[arg-type]


### PR DESCRIPTION
### Summary

`MetalConfig` validates `memory_fraction`, `multimodal_mode`, and the TurboQuant quant types, but **`mlx_device` receives no validation** — even though it is typed `Literal["gpu", "cpu"]`.

`from_env()` passes the raw `VLLM_MLX_DEVICE` string straight through (`# type: ignore[arg-type]`), and both consumers treat anything that isn't exactly `"gpu"` as CPU:

```python
# vllm_metal/v1/worker.py  and  vllm_metal/platform.py
device_type = mx.DeviceType.gpu if config.mlx_device == "gpu" else mx.DeviceType.cpu
```

So a typo or wrong backend name (`GPU`, `gpuu`, `mps`, `cuda`) **silently routes the entire engine onto the MLX CPU device** — a large, unannounced performance regression on Apple Silicon, with no error or warning. This is the one config option that doesn't follow the file's fail-fast convention.

### Change

- Add `VALID_MLX_DEVICES` and validate `mlx_device` in `MetalConfig.__post_init__`, raising a clear `ValueError` consistent with the existing `memory_fraction` / `multimodal_mode` messages.
- Normalize the env value with `.strip().lower()` in `from_env()` — mirrors the existing `.lower()` handling of `VLLM_METAL_MEMORY_FRACTION=auto`, so `GPU` / ` gpu ` work while genuinely-wrong values fail fast.
- Add tests: invalid device rejected (direct construction + from env) and case normalization.

### Testing

```
pytest tests/test_config.py   # 20 passed
ruff check vllm_metal/config.py tests/test_config.py   # All checks passed!
```

No behavior change for valid `"gpu"`/`"cpu"` configs; wrong values now fail fast instead of silently degrading to CPU.
