### PR TITLE
[Doc] Update README news section with v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 ---
 *Latest News* 🔥
 
+- [2026/07] We released the new version v0.3.0! Now with improved performance and stability.
 - [2026/04] We released the new version v0.2.0! Unified paged varlen Metal kernel is now the default attention backend. 83x TTFT, 3.6x throughput compared to v0.1.0.
 
 ---


### PR DESCRIPTION
## Summary

The README news section references the v0.2.0 release from April 2026. This updates it to mention the latest v0.3.0 release from July 2026.

## Changes

- Added v0.3.0 release announcement to the Latest News section
- Preserved the v0.2.0 news entry for historical reference

## Testing

Verified by grep:
```
grep -n "v0.3.0" README.md
```