### PR TITLE
Pin ruff and format profiling doc for 0.16

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -49,9 +49,9 @@ llm = LLM(
     },
 )
 
-llm.start_profile(profile_prefix="my_run")        # → start_capture
+llm.start_profile(profile_prefix="my_run")  # → start_capture
 out = llm.generate(["Hello"], SamplingParams(max_tokens=8))
-llm.stop_profile()                                # → stop_capture
+llm.stop_profile()  # → stop_capture
 
 # Trace lands at /tmp/metal-trace/my_run_dp0_pp0_tp0.gputrace
 ```
@@ -118,6 +118,7 @@ vllm serve Qwen/Qwen3-0.6B \
 ```python
 # Or, equivalent offline-LLM form. Bound capture work with max_tokens.
 from vllm import LLM, SamplingParams
+
 llm = LLM(
     model="Qwen/Qwen3-0.6B",
     profiler_config={"profiler": "torch", "torch_profiler_dir": "/tmp/metal-trace"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ stt = [
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=0.21.0",
-    "ruff>=0.1.0",
+    "ruff==0.16.0",
     "mypy>=1.19.1",
     "gguf>=0.17.0",
 ]


### PR DESCRIPTION
ruff 0.16.0 came out yesterday and started formatting Python code blocks in markdown, so every lint run now fails on docs/profiling.md (CI installs latest ruff). First hit on #534; main and the other open PRs will hit it on their next run.

Reformats that one file and pins ruff to 0.16.0 in the dev extra, so future ruff upgrades are a deliberate bump.