### PR TITLE
[GGUF] Add MLX-native Q4_1 support

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -69,12 +69,16 @@ vllm-metal's GGUF engine integration sets `quantization=gguf` from the file
 [vllm-gguf-plugin](https://github.com/vllm-project/vllm-gguf-plugin)). A
 `.gguf` carries weights only, so it pairs with a companion config dir
 (`--tokenizer`) and needs the `gguf` extra; the weights stay MLX-native
-quantized (Q8_0/Q4_0, not a dense fallback). Scope is dense
+quantized (Q8_0/Q4_0/Q4_1, not a dense fallback). Scope is dense
 `qwen2`/`qwen3`/`llama`/`mistral` (mistral converts under the llama GGUF arch)
-with per-tensor `Q8_0`/`Q4_0`; K-quants, `Q4_1`, fused-QKV, MoE, SSM/hybrid,
-vision, and remote `repo:quant` are rejected with a clear error. Verified
-end-to-end on Qwen3-0.6B, Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3
-Q8_0 ([#415](https://github.com/vllm-project/vllm-metal/issues/415)).
+with per-tensor `Q8_0`/`Q4_0`/`Q4_1`; K-quants, fused-QKV, MoE, SSM/hybrid,
+vision, and remote `repo:quant` are rejected with a clear error. The narrow
+exception is an unused tied `output.weight`: MLX may briefly materialize an
+unsupported qtype such as Q6_K as FP16 before the loader discards it. Preflight
+limits that transient table to 512 MiB. Verified end-to-end on Qwen3-0.6B Q4_1
+and on Qwen3-0.6B,
+Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
+([#415](https://github.com/vllm-project/vllm-metal/issues/415)).
 
 | Model | Support | Attention Kernel | Automatic Prefix Cache | Example checkpoint |
 | --- | --- | --- | --- | --- |

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -9,6 +9,7 @@ completeness, and fail-fast rejection of unsupported files.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import mlx.core as mx
@@ -18,6 +19,7 @@ import pytest
 
 gguf = pytest.importorskip("gguf")
 
+import vllm_metal.gguf.loader as gguf_loader  # noqa: E402
 from vllm_metal.gguf.adapter import GGUFModelAdapter  # noqa: E402
 from vllm_metal.gguf.loader import GGUFLoadError, GGUFModelLoader  # noqa: E402
 from vllm_metal.gguf.mlx_native import GGUFMLXQuantizedTensor  # noqa: E402
@@ -63,6 +65,8 @@ def _dense_tensor_specs(config: dict, *, has_qk_norm: bool, with_bias: bool) -> 
     """Return ``{gguf_name: (kind, shape)}`` for a dense decoder GGUF.
 
     ``kind`` is ``"q"`` (quantized weight) or ``"f"`` (F32 plain weight/bias).
+    Tests may inject ``"q6_k"`` zero blocks for unsupported-qtype coverage;
+    gguf-py can dequantize Q6_K but does not implement its quantizer.
     """
     d = _dims(config)
     specs: dict[str, tuple[str, tuple[int, ...]]] = {
@@ -106,7 +110,16 @@ def _write_gguf(
     for name, (kind, shape) in {**specs, **(inject or {})}.items():
         data = rng.standard_normal(shape).astype(np.float32)
         qtype = (quant_overrides or {}).get(name)
-        if kind == "q" or qtype is not None:
+        if kind == "q6_k":
+            block_size, type_size = gguf.GGML_QUANT_SIZES[QT.Q6_K]
+            assert shape[-1] % block_size == 0
+            packed_shape = (
+                *shape[:-1],
+                shape[-1] // block_size * type_size,
+            )
+            raw = np.zeros(packed_shape, dtype=np.uint8)
+            writer.add_tensor(name, raw, raw_shape=raw.shape, raw_dtype=QT.Q6_K)
+        elif kind == "q" or qtype is not None:
             raw_dtype = qtype or quant_type
             quant_input = data.reshape(1, -1) if data.ndim == 1 else data
             raw = gguf.quants.quantize(quant_input, raw_dtype)
@@ -174,7 +187,7 @@ def _assert_forward_vocab_shape(model: nn.Module) -> None:
     assert out.shape == (1, 3, 256)
 
 
-@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
+@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0, QT.Q4_1])
 @pytest.mark.parametrize(
     ("model_type", "has_qk_norm", "needs_tokenizer"),
     [("qwen3", True, False), ("llama", False, True)],
@@ -198,24 +211,72 @@ def test_loads_dense_model_installs_wrappers(
     _assert_forward_vocab_shape(model)
 
 
-def test_skips_tie_redundant_output(tmp_path):
-    # Tied config but the GGUF still carries a redundant Q8_0 output.weight.
-    d = _dims(_tiny_config("qwen3"))
+def test_skips_tie_redundant_output(tmp_path, monkeypatch, caplog):
+    # Tied config but the GGUF still carries a redundant output.weight in an
+    # otherwise unsupported qtype. It is unused and must not block the model.
+    config_overrides = {
+        "hidden_size": 256,
+        "intermediate_size": 256,
+        "head_dim": 64,
+    }
+    d = _dims(_tiny_config("qwen3", **config_overrides))
     gguf_path, cfg_dir = _build_dense_fixture(
         tmp_path,
         "qwen3",
+        config_overrides=config_overrides,
         has_qk_norm=True,
-        inject={"output.weight": ("q", (d["vocab"], d["h"]))},
+        inject={"output.weight": ("q6_k", (d["vocab"], d["h"]))},
     )
+    clear_cache_calls = 0
+    original_clear_cache = gguf_loader.mx.clear_cache
+
+    def track_clear_cache():
+        nonlocal clear_cache_calls
+        clear_cache_calls += 1
+        original_clear_cache()
+
+    monkeypatch.setattr(gguf_loader.mx, "clear_cache", track_clear_cache)
     # Must NOT raise (the redundant output is tie-skipped, not unmapped-failed).
-    model, _ = GGUFModelLoader(
-        gguf_path,
-        config_dir=cfg_dir,
-        target_dtype=mx.float32,
-    ).load()
+    with caplog.at_level(logging.INFO, logger=gguf_loader.__name__):
+        model, _ = GGUFModelLoader(
+            gguf_path,
+            config_dir=cfg_dir,
+            target_dtype=mx.float32,
+        ).load()
     assert not hasattr(model, "lm_head")
     # The tied head runs through the GGUFEmbedding's as_linear.
     assert _gguf_module_histogram(model).get("GGUFEmbedding") == 1
+    assert clear_cache_calls == 1
+    assert f"qtype={QT.Q6_K.name}" in caplog.text
+    assert f"fallback_bytes={d['vocab'] * d['h'] * 2}" in caplog.text
+
+
+def test_rejects_tied_output_above_dense_fallback_limit(tmp_path, monkeypatch):
+    config_overrides = {
+        "hidden_size": 256,
+        "intermediate_size": 256,
+        "head_dim": 64,
+    }
+    d = _dims(_tiny_config("qwen3", **config_overrides))
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "qwen3",
+        config_overrides=config_overrides,
+        has_qk_norm=True,
+        inject={"output.weight": ("q6_k", (d["vocab"], d["h"]))},
+    )
+    monkeypatch.setattr(gguf_loader, "_MAX_TIED_OUTPUT_FALLBACK_BYTES", 1)
+
+    def fail_mx_load(*args, **kwargs):
+        raise AssertionError("memory safety preflight must run before mx.load")
+
+    monkeypatch.setattr(gguf_loader.mx, "load", fail_mx_load)
+    with pytest.raises(GGUFLoadError, match="transient FP16 allocation"):
+        GGUFModelLoader(
+            gguf_path,
+            config_dir=cfg_dir,
+            target_dtype=mx.float32,
+        ).load()
 
 
 @pytest.mark.parametrize(
@@ -318,7 +379,7 @@ def _write_minimal_tokenizer(config_dir: str, vocab_size: int) -> None:
     )
 
 
-@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
+@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0, QT.Q4_1])
 def test_quantized_llama_qk_are_row_unpermuted(tmp_path, quant_type):
     # The main quantized-path behavior: installed q/k GGUFLinear tensors carry the
     # RoPE-un-permuted quantized weight, not the raw (llama.cpp-permuted) one.
@@ -704,16 +765,45 @@ def test_rejects_vision_tensor(tmp_path):
         ).load()
 
 
-def test_rejects_unsupported_qtype(tmp_path):
+def test_rejects_unsupported_qtype_before_model_allocation(tmp_path, monkeypatch):
     gguf_path, cfg_dir = _build_dense_fixture(
         tmp_path,
         "qwen3",
         has_qk_norm=True,
-        quant_overrides={"blk.0.ffn_up.weight": QT.Q4_1},
+        quant_overrides={"blk.0.ffn_up.weight": QT.Q5_0},
     )
+
+    def fail_load_model(*args, **kwargs):
+        raise AssertionError("qtype preflight must run before load_model")
+
+    monkeypatch.setattr(gguf_loader, "load_model", fail_load_model)
     with pytest.raises(
         GGUFLoadError,
-        match="Unsupported qtype Q4_1 on mapped weight 'blk.0.ffn_up.weight'",
+        match="Unsupported qtype Q5_0 on mapped weight 'blk.0.ffn_up.weight'",
+    ):
+        GGUFModelLoader(
+            gguf_path,
+            config_dir=cfg_dir,
+            target_dtype=mx.float32,
+        ).load()
+
+
+def test_rejects_unsupported_untied_output_before_mx_load(tmp_path, monkeypatch):
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path,
+        "qwen3",
+        config_overrides={"tie_word_embeddings": False},
+        has_qk_norm=True,
+        quant_overrides={"output.weight": QT.Q5_0},
+    )
+
+    def fail_mx_load(*args, **kwargs):
+        raise AssertionError("deferred output preflight must run before mx.load")
+
+    monkeypatch.setattr(gguf_loader.mx, "load", fail_mx_load)
+    with pytest.raises(
+        GGUFLoadError,
+        match="Unsupported qtype Q5_0 on mapped weight 'output.weight'",
     ):
         GGUFModelLoader(
             gguf_path,

--- a/tests/test_gguf_mlx_native.py
+++ b/tests/test_gguf_mlx_native.py
@@ -24,7 +24,11 @@ from vllm_metal.gguf.mlx_native import (  # noqa: E402
 
 GGMLQuantizationType = gguf.GGMLQuantizationType
 
-NATIVE_QTYPES = [GGMLQuantizationType.Q8_0, GGMLQuantizationType.Q4_0]
+NATIVE_QTYPES = [
+    GGMLQuantizationType.Q8_0,
+    GGMLQuantizationType.Q4_0,
+    GGMLQuantizationType.Q4_1,
+]
 
 
 def _write_quantized_gguf(path, weight: np.ndarray, qtype) -> dict[str, mx.array]:
@@ -162,18 +166,6 @@ def test_accepts_int_qweight_type(tmp_path):
     assert rebuilt.qweight_type is GGMLQuantizationType.Q8_0
 
 
-def test_rejects_q4_1_with_mlx_bug_reference(tmp_path):
-    weight = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
-    arrays = _write_quantized_gguf(
-        tmp_path / "q4_1.gguf", weight, GGMLQuantizationType.Q4_1
-    )
-    with pytest.raises(ValueError, match="ml-explore/mlx#3664"):
-        GGUFMLXQuantizedTensor.from_mx_load(
-            arrays, "w.weight", GGMLQuantizationType.Q4_1
-        )
-    assert GGMLQuantizationType.Q4_1 not in MLX_NATIVE_GGUF_TYPES
-
-
 def test_rejects_unsupported_qtype():
     with pytest.raises(ValueError, match="Unsupported GGUF quantization type"):
         GGUFMLXQuantizedTensor(
@@ -285,11 +277,10 @@ def test_embedding_empty_ids(tmp_path, qtype):
 # --- Real-file parity (opt-in: needs local GGUF files) ------------------------
 #
 # Set VLLM_METAL_TEST_GGUF_PATHS to a comma-separated list of real .gguf files
-# (e.g. a Q8_0 and a Q4_0 model) to run these. They prove the representation and
-# primitives hold on real checkpoints — every MLX-native tensor constructs, with
-# matmul/embedding parity vs the gguf-py dequantize oracle and a quantized-vs-
-# dense memory comparison. Each file is checked for whichever native qtypes it
-# contains, so pointing at a Q4_0 file gives real Q4_0 coverage.
+# to run these. They prove the representation and primitives hold on real
+# checkpoints — every MLX-native tensor constructs, with matmul/embedding parity
+# vs the gguf-py dequantize oracle and a quantized-vs-dense memory comparison.
+# Each file is checked for whichever native qtypes it contains.
 
 _REAL_GGUF_PATHS = [
     p.strip()
@@ -382,8 +373,8 @@ def test_real_file_memory_below_dense(path):
         quantized += qt.qweight.nbytes + qt.scales.nbytes + qt.biases.nbytes
         dense_f16 += qt.out_features * qt.in_features * 2
 
-    # Per weight: Q8_0 ~1.125 bytes, Q4_0 ~0.625 (packed + f16 scale/bias) vs 2
-    # for dense f16, so any native mix stays well under 0.6x dense.
+    # Per weight: Q8_0 ~1.125 bytes, Q4_0/Q4_1 ~0.625 (packed + f16
+    # scale/bias) vs 2 for dense f16, so any native mix stays below 0.6x dense.
     assert quantized < dense_f16 * 0.6
 
 

--- a/tests/test_gguf_serve_golden.py
+++ b/tests/test_gguf_serve_golden.py
@@ -6,7 +6,7 @@ checks, parameterized over the supported GGUF model families:
 
 - ``test_gguf_greedy_matches_committed_golden`` pins the first ``N`` token ids
   to a committed golden sequence — a deterministic regression guard for the
-  served Q8_0 model.
+  served quantized model.
 - ``test_gguf_greedy_matches_dense_reference_prefix`` asserts the leading
   tokens match an ``mlx_lm`` dense reference of the same checkpoint (loaded at
   its native dtype), proving the quantized model decodes the same
@@ -26,7 +26,8 @@ checkpoints, not synthetic fixtures). Run a family with its env trio, e.g.::
     VLLM_METAL_TEST_GGUF_DENSE_PATH=<...Qwen3-0.6B dir> \\
     pytest tests/test_gguf_serve_golden.py -m slow
 
-(llama uses ``VLLM_METAL_TEST_GGUF_LLAMA_*`` and mistral
+(Qwen3 Q4_1 uses ``VLLM_METAL_TEST_GGUF_Q41_*``, llama uses
+``VLLM_METAL_TEST_GGUF_LLAMA_*``, and mistral uses
 ``VLLM_METAL_TEST_GGUF_MISTRAL_*`` for the same trio.)
 """
 
@@ -46,7 +47,7 @@ from mlx_lm import load as mlx_lm_load  # noqa: E402
 
 from vllm_metal.gguf.loader import GGUFModelLoader  # noqa: E402
 
-_PROMPT = "The capital of France is"
+_DEFAULT_PROMPT = "The capital of France is"
 _N = 16
 
 
@@ -55,6 +56,8 @@ class _GoldenCase:
     """One GGUF family's committed golden material and env-gated local paths."""
 
     label: str
+    quantization: str
+    prompt: str
     gguf_env: str
     tokenizer_env: str
     dense_env: str
@@ -69,6 +72,8 @@ _CASES = [
     # safely inside that agreement.
     _GoldenCase(
         label="qwen3",
+        quantization="Q8_0",
+        prompt=_DEFAULT_PROMPT,
         gguf_env="VLLM_METAL_TEST_GGUF_SERVE_PATH",
         tokenizer_env="VLLM_METAL_TEST_GGUF_TOKENIZER_PATH",
         dense_env="VLLM_METAL_TEST_GGUF_DENSE_PATH",
@@ -93,12 +98,46 @@ _CASES = [
         dense_agree_prefix=8,
         target_dtype=mx.bfloat16,
     ),
+    # Qwen_Qwen3-0.6B-Q4_1.gguf: all 16 ids match the dense reference for this
+    # high-confidence factual sequence. The file has a tied, redundant Q6_K
+    # output.weight; the loader correctly skips it and uses the Q4_1 embedding
+    # table as the tied output projection.
+    _GoldenCase(
+        label="qwen3-q4_1",
+        quantization="Q4_1",
+        prompt="The capital of France is Paris. The capital of Germany is",
+        gguf_env="VLLM_METAL_TEST_GGUF_Q41_SERVE_PATH",
+        tokenizer_env="VLLM_METAL_TEST_GGUF_Q41_TOKENIZER_PATH",
+        dense_env="VLLM_METAL_TEST_GGUF_Q41_DENSE_PATH",
+        golden_ids=(
+            19846,
+            13,
+            576,
+            6722,
+            315,
+            15344,
+            374,
+            21718,
+            13,
+            576,
+            6722,
+            315,
+            6323,
+            374,
+            26194,
+            13,
+        ),
+        dense_agree_prefix=16,
+        target_dtype=mx.bfloat16,
+    ),
     # Llama-3.2-1B-Instruct-Q8_0.gguf: agreement through index 12, divergence
     # at 13. Without the llama.cpp q/k RoPE row-un-permutation this prefix
     # agreement is only 1 token (attention is broken), so this pins the fix
     # end-to-end.
     _GoldenCase(
         label="llama",
+        quantization="Q8_0",
+        prompt=_DEFAULT_PROMPT,
         gguf_env="VLLM_METAL_TEST_GGUF_LLAMA_SERVE_PATH",
         tokenizer_env="VLLM_METAL_TEST_GGUF_LLAMA_TOKENIZER_PATH",
         dense_env="VLLM_METAL_TEST_GGUF_LLAMA_DENSE_PATH",
@@ -130,6 +169,8 @@ _CASES = [
     # All 16 ids match the dense reference inside the window.
     _GoldenCase(
         label="mistral",
+        quantization="Q8_0",
+        prompt=_DEFAULT_PROMPT,
         gguf_env="VLLM_METAL_TEST_GGUF_MISTRAL_SERVE_PATH",
         tokenizer_env="VLLM_METAL_TEST_GGUF_MISTRAL_TOKENIZER_PATH",
         dense_env="VLLM_METAL_TEST_GGUF_MISTRAL_DENSE_PATH",
@@ -188,7 +229,7 @@ def test_gguf_greedy_matches_committed_golden(case: _GoldenCase) -> None:
         gguf_path, config_dir=tokenizer_dir, target_dtype=case.target_dtype
     ).load()
 
-    ids = _greedy_token_ids(model, tokenizer, _PROMPT, _N)
+    ids = _greedy_token_ids(model, tokenizer, case.prompt, _N)
     assert ids == list(case.golden_ids)
 
 
@@ -201,7 +242,7 @@ def test_gguf_greedy_matches_dense_reference_prefix(case: _GoldenCase) -> None:
 
     dense_model, dense_tokenizer = mlx_lm_load(dense_dir)
     dense_ids = _greedy_token_ids(
-        dense_model, dense_tokenizer, _PROMPT, case.dense_agree_prefix
+        dense_model, dense_tokenizer, case.prompt, case.dense_agree_prefix
     )
     del dense_model
     mx.clear_cache()
@@ -210,11 +251,11 @@ def test_gguf_greedy_matches_dense_reference_prefix(case: _GoldenCase) -> None:
         gguf_path, config_dir=tokenizer_dir, target_dtype=case.target_dtype
     ).load()
     gguf_ids = _greedy_token_ids(
-        gguf_model, gguf_tokenizer, _PROMPT, case.dense_agree_prefix
+        gguf_model, gguf_tokenizer, case.prompt, case.dense_agree_prefix
     )
 
     assert gguf_ids == dense_ids, (
-        f"{case.label} Q8_0 GGUF greedy prefix must match the dense mlx_lm "
-        f"reference (gguf={gguf_ids}, dense={dense_ids})"
+        f"{case.label} {case.quantization} GGUF greedy prefix must match the "
+        f"dense mlx_lm reference (gguf={gguf_ids}, dense={dense_ids})"
     )
     assert gguf_ids == list(case.golden_ids)[: case.dense_agree_prefix]

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX-native local GGUF loader for dense Q8_0/Q4_0 decoder checkpoints."""
+"""MLX-native local GGUF loader for dense Q8_0/Q4_0/Q4_1 checkpoints."""
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -26,9 +27,20 @@ from vllm_metal.gguf.wrappers import GGUFEmbedding, GGUFLinear
 
 __all__ = ["GGUFLoadError", "GGUFModelLoader"]
 
+logger = logging.getLogger(__name__)
+
 _WEIGHT_SUFFIX = ".weight"
 _BIAS_SUFFIX = ".bias"
 _NUM_LAYERS_KEYS = ("num_hidden_layers", "n_layers", "num_layers", "n_layer")
+_MAX_TIED_OUTPUT_FALLBACK_BYTES = 512 * 1024 * 1024
+_PLAIN_GGUF_TYPES = frozenset(
+    {
+        gguf.GGMLQuantizationType.F32,
+        gguf.GGMLQuantizationType.F16,
+        gguf.GGMLQuantizationType.BF16,
+    }
+)
+_ALLOWED_WEIGHT_TYPES = frozenset(MLX_NATIVE_GGUF_TYPES) | _PLAIN_GGUF_TYPES
 
 
 GGUFWrapper = GGUFLinear | GGUFEmbedding
@@ -55,7 +67,7 @@ class GGUFModelLoader:
     """Load a dense GGUF checkpoint into its mlx-lm model.
 
     Args:
-        gguf_path: Path to a local ``.gguf`` file (dense decoder, Q8_0/Q4_0).
+        gguf_path: Path to a local ``.gguf`` file (dense, Q8_0/Q4_0/Q4_1).
         config_dir: Companion HF config source that defines the mlx-lm skeleton.
         tokenizer_dir: Companion tokenizer source. Defaults to ``config_dir``.
         target_dtype: Compute dtype for dequantized embedding rows / activations.
@@ -95,6 +107,7 @@ class GGUFModelLoader:
         # Build the mlx-lm skeleton through the public upstream loader path.
         model, _ = load_model(self._config_dir, strict=False, model_config=config)
         tied = bool(getattr(model.args, "tie_word_embeddings", False))
+        self._preflight_deferred_output(reader, tied=tied)
 
         # Derive the GGUF->MLX name translation from the live model structure.
         adapter = GGUFModelAdapter.from_model(
@@ -139,12 +152,6 @@ class GGUFModelLoader:
 
     def _preflight(self, reader: Any) -> None:
         """Reject out-of-scope tensors / qtypes from the reader, before ``mx.load``."""
-        plain_types = {
-            gguf.GGMLQuantizationType.F32,
-            gguf.GGMLQuantizationType.F16,
-            gguf.GGMLQuantizationType.BF16,
-        }
-        allowed_weight_types = set(MLX_NATIVE_GGUF_TYPES) | plain_types
         for tensor in reader.tensors:
             name = tensor.name
             if any(
@@ -154,19 +161,59 @@ class GGUFModelLoader:
                     f"Out-of-scope GGUF tensor {name!r} (fused-QKV/SSM/MoE/vision) "
                     "is not supported by the dense GGUF loader."
                 )
+            if name == "output.weight":
+                continue
             if (
                 name.endswith(_WEIGHT_SUFFIX)
-                and tensor.tensor_type not in allowed_weight_types
+                and tensor.tensor_type not in _ALLOWED_WEIGHT_TYPES
             ):
                 raise GGUFLoadError(
                     f"Unsupported qtype {tensor.tensor_type.name} on mapped weight "
-                    f"{name!r}; only Q8_0/Q4_0 (and plain F32/F16/BF16) are supported."
+                    f"{name!r}; only Q8_0/Q4_0/Q4_1 (and plain F32/F16/BF16) "
+                    "are supported."
                 )
-            if name.endswith(_BIAS_SUFFIX) and tensor.tensor_type not in plain_types:
+            if (
+                name.endswith(_BIAS_SUFFIX)
+                and tensor.tensor_type not in _PLAIN_GGUF_TYPES
+            ):
                 raise GGUFLoadError(
                     f"Unsupported qtype {tensor.tensor_type.name} on bias {name!r}; "
                     "additive biases must be plain F32/F16/BF16."
                 )
+
+    def _preflight_deferred_output(self, reader: Any, *, tied: bool) -> None:
+        """Validate ``output.weight`` after the live model resolves weight tying."""
+        output = next(
+            (tensor for tensor in reader.tensors if tensor.name == "output.weight"),
+            None,
+        )
+        if output is None or output.tensor_type in _ALLOWED_WEIGHT_TYPES:
+            return
+        if not tied:
+            raise GGUFLoadError(
+                f"Unsupported qtype {output.tensor_type.name} on mapped weight "
+                "'output.weight'; only Q8_0/Q4_0/Q4_1 (and plain "
+                "F32/F16/BF16) are supported."
+            )
+
+        # MLX currently converts unsupported GGUF qtypes to FP16 before returning
+        # from mx.load. The tied output is redundant and immediately discarded,
+        # but cap that unavoidable transient allocation so a large vocabulary
+        # cannot cause an unbounded memory spike.
+        fallback_bytes = int(output.n_elements) * 2
+        if fallback_bytes > _MAX_TIED_OUTPUT_FALLBACK_BYTES:
+            raise GGUFLoadError(
+                f"Tied redundant output.weight uses {output.tensor_type.name}, "
+                f"which requires a {fallback_bytes}-byte transient FP16 allocation "
+                f"during mx.load; the safety limit is "
+                f"{_MAX_TIED_OUTPUT_FALLBACK_BYTES} bytes."
+            )
+        logger.info(
+            "MLX will transiently materialize tied output.weight as FP16 before "
+            "discard: qtype=%s, fallback_bytes=%d",
+            output.tensor_type.name,
+            fallback_bytes,
+        )
 
     def _partition(
         self,
@@ -177,6 +224,11 @@ class GGUFModelLoader:
     ) -> _PartitionedTensors:
         """Route each GGUF tensor to quant-install / plain-load / bias-side-map."""
         arrays = mx.load(str(self._gguf_path))
+        if tied:
+            skipped_output = arrays.pop("output.weight", None)
+            if skipped_output is not None:
+                del skipped_output
+                mx.clear_cache()
         quant: dict[str, GGUFMLXQuantizedTensor] = {}
         plain: dict[str, mx.array] = {}
         biases: dict[str, mx.array] = {}
@@ -185,6 +237,8 @@ class GGUFModelLoader:
             translated = adapter.translate(name)
             if translated is None:
                 continue
+            if tied and translated == "lm_head.weight":
+                continue  # tie-redundant output table; the tied head uses as_linear
 
             suffix = _BIAS_SUFFIX if name.endswith(_BIAS_SUFFIX) else _WEIGHT_SUFFIX
             module_path = translated[: -len(suffix)]
@@ -192,8 +246,6 @@ class GGUFModelLoader:
             try:
                 current = self._resolve_path(model, module_path)
             except (AttributeError, KeyError, IndexError) as exc:
-                if tied and translated == "lm_head.weight":
-                    continue  # tie-redundant output table; the tied head uses as_linear
                 raise GGUFLoadError(
                     f"GGUF tensor {name!r} maps to {translated!r} but module "
                     f"{module_path!r} is absent from the model."

--- a/vllm_metal/gguf/mlx_native.py
+++ b/vllm_metal/gguf/mlx_native.py
@@ -1,19 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """MLX-native quantized GGUF tensors that compute with their packed weights.
 
-MLX's GGUF loader (``mx.load``) repacks Q8_0 and Q4_0 weights into the affine,
-group-32 representation that ``mx.quantized_matmul`` already consumes: a
-``uint32`` packed ``qweight`` alongside ``float16`` ``scales`` and ``biases``.
-``GGUFMLXQuantizedTensor`` wraps that triple in an explicit, validated contract
-and exposes :meth:`~GGUFMLXQuantizedTensor.matmul` /
+MLX's GGUF loader (``mx.load``) repacks Q8_0, Q4_0, and Q4_1 weights into the
+affine, group-32 representation that ``mx.quantized_matmul`` already consumes:
+a ``uint32`` packed ``qweight`` alongside ``float16`` ``scales`` and
+``biases``. ``GGUFMLXQuantizedTensor`` wraps that triple in an explicit,
+validated contract and exposes :meth:`~GGUFMLXQuantizedTensor.matmul` /
 :meth:`~GGUFMLXQuantizedTensor.embedding`, which run on the packed weights so
 supported weights never get expanded into a dense copy.
 
-Q4_1 is deliberately not supported here. MLX's repack mis-decodes Q4_1 blocks
-(it skips a 2-byte block header where Q4_1 uses 4), so ``mx.load`` returns
-corrupted Q4_1 weights. Fix tracked upstream at ml-explore/mlx#3664; Q4_1 can
-join once a fixed MLX release is in our supported range. K-quants and other
-qtypes MLX does not repack natively are out of scope for this path.
+K-quants and other qtypes MLX does not repack natively are out of scope for
+this path.
 """
 
 from __future__ import annotations
@@ -32,11 +29,11 @@ except ImportError as exc:  # pragma: no cover - exercised only without the extr
 
 GGMLQuantizationType = gguf.GGMLQuantizationType
 
-# qtypes MLX repacks into its affine representation (see module docstring for
-# why Q4_1 is excluded despite being a 4-bit standard qtype).
+# qtypes MLX repacks into its affine representation.
 _BITS: dict[GGMLQuantizationType, int] = {
     GGMLQuantizationType.Q8_0: 8,
     GGMLQuantizationType.Q4_0: 4,
+    GGMLQuantizationType.Q4_1: 4,
 }
 MLX_NATIVE_GGUF_TYPES = frozenset(_BITS)
 
@@ -59,7 +56,7 @@ class GGUFMLXQuantizedTensor:
     * ``qweight_type`` — a ``gguf.GGMLQuantizationType`` in
       :data:`MLX_NATIVE_GGUF_TYPES`.
     * logical weight is ``(out_features, in_features)``; :attr:`group_size` is 32;
-      :attr:`bits` is 8 for Q8_0, 4 for Q4_0.
+      :attr:`bits` is 8 for Q8_0, 4 for Q4_0/Q4_1.
     * activations: :meth:`matmul` accepts float16/bfloat16/float32 ``x`` and
       returns ``x``'s dtype; :meth:`embedding` returns an explicit ``output_dtype``.
 
@@ -90,15 +87,6 @@ class GGUFMLXQuantizedTensor:
         if qweight_type in MLX_NATIVE_GGUF_TYPES:
             return qweight_type
         supported = ", ".join(t.name for t in _BITS)
-        if qweight_type == GGMLQuantizationType.Q4_1:
-            # Remove this special case once a fixed MLX release (ml-explore/mlx#3664)
-            # is our lower bound and Q4_1 can be added to _BITS.
-            raise ValueError(
-                "GGUF Q4_1 is not supported on the MLX-native path: MLX's GGUF "
-                "repack mis-decodes Q4_1 blocks and returns corrupted weights "
-                "(ml-explore/mlx#3664). "
-                f"Supported MLX-native qtypes: {supported}."
-            )
         raise ValueError(
             f"Unsupported GGUF quantization type for the MLX-native path: "
             f"{qweight_type.name}. Supported MLX-native qtypes: {supported}."


### PR DESCRIPTION
## Summary

- enable GGUF Q4_1 in the existing MLX-native affine representation now that
  vllm-metal pins MLX 0.32.0, which contains the upstream Q4_1 repack fix
- extend tensor, wrapper, and loader coverage so Q4_1 runs through the same
  dequantization-oracle and model-install paths as Q8_0/Q4_0
- admit an unsupported `output.weight` only when the live model ties word
  embeddings; bound MLX's transient FP16 fallback to 512 MiB, then discard it
  and clear the cache (real Qwen3 Q4_1 files commonly carry an unused Q6_K table)
- preserve fail-fast preflight before model allocation for every non-output
  tensor, then validate the deferred output once the live tie flag is known
- add an opt-in real Qwen3-0.6B Q4_1 golden-token/dense-prefix case and update
  the supported-model documentation

This follows up on #415 and ml-explore/mlx#3664.

## Why this is not a duplicate

I checked the #415 comments and searched open PRs for both `415 in:body` and
`Q4_1 GGUF` on July 24, 2026. Both PR searches returned no results. This change
is limited to the Q4_1 follow-up described in the issue; it does not add new
custom kernels or expand support to K-quants.

## Validation

- `.venv-vllm-metal/bin/python -m pytest tests/test_gguf_mlx_native.py tests/test_gguf_wrappers.py tests/test_gguf_loader.py tests/test_gguf_serve_golden.py -q`
  - `117 passed, 13 skipped`
- real `bartowski/Qwen_Qwen3-0.6B-GGUF` `Qwen_Qwen3-0.6B-Q4_1.gguf`
  (`sha256:459dad8b75080ce0c96ba2ed7514887f942bd9739c40aad0923ba324c34fb25e`)
  - real tensor construction, linear oracle, embedding oracle, and memory:
    `4 passed, 1 skipped`
  - committed greedy golden and dense-reference prefix (16/16 tokens):
    `2 passed`
- `.venv-vllm-metal/bin/python tools/gguf_serve_smoke.py <Q4_1.gguf> --tokenizer <Qwen3-0.6B>`
  - `/health` returned 200
  - `/v1/completions` returned 200
  - continuation contained `Paris`
- `.venv-vllm-metal/bin/python -m pytest -m "not slow" tests/ -q`
  - `1630 passed, 15 skipped, 48 deselected`
- `.venv-vllm-metal/bin/ruff check .`
  - passed
- `.venv-vllm-metal/bin/ruff format --check .`
  - `230 files already formatted`
- `.venv-vllm-metal/bin/mypy vllm_metal`
  - `Success: no issues found in 105 source files`

## AI assistance

OpenAI Codex was used to help implement, test, and prepare this change. Before
marking this draft ready for review, I will personally review every changed
line and remain responsible for explaining and defending the implementation.
