### PR TITLE
Re-ensure the ByteLevel tokenizer patch after vLLM finishes importing

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -127,7 +127,7 @@ class TestByteLevelTokenizerCompatPatch:
         from transformers.tokenization_utils_tokenizers import TokenizersBackend
 
         _write_mismatched_bytelevel_tokenizer_repo(tmp_path)
-        compat._patch_vllm_bytelevel_tokenizer_loading()
+        compat.ensure_vllm_bytelevel_tokenizer_patch()
 
         tokenizer = tokenizer_registry.get_tokenizer(tmp_path, tokenizer_mode="hf")
         decoded = tokenizer.decode([0, 1])
@@ -269,7 +269,7 @@ class TestGemma4MTPConfigCompatPatch:
         )
         monkeypatch.setattr(
             compat,
-            "_patch_vllm_bytelevel_tokenizer_loading",
+            "ensure_vllm_bytelevel_tokenizer_patch",
             lambda: calls.append("bytelevel"),
         )
         monkeypatch.setattr(

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -246,7 +246,7 @@ class TestGemma4MTPConfigCompatPatch:
         assert config.text_config.num_kv_shared_layers == 0
         assert get_hf_text_config(config).model_type == "gemma4_text"
 
-    def test_missing_gemma4_config_module_does_not_stop_other_patches(
+    def test_registration_time_failures_do_not_stop_other_patches(
         self,
         monkeypatch,
     ) -> None:
@@ -267,10 +267,15 @@ class TestGemma4MTPConfigCompatPatch:
             "_gemma4_assistant_config_class",
             _raise_missing_gemma4_config,
         )
+
+        def _raise_bytelevel_import_error() -> None:
+            calls.append("bytelevel")
+            raise ImportError("partial vLLM import")
+
         monkeypatch.setattr(
             compat,
             "ensure_vllm_bytelevel_tokenizer_patch",
-            lambda: calls.append("bytelevel"),
+            _raise_bytelevel_import_error,
         )
         monkeypatch.setattr(
             compat,

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -135,6 +135,82 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
+    def test_check_and_update_config_reensures_bytelevel_tokenizer_patch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plugin activation can never install the ByteLevel tokenizer patch.
+
+        ``_register()`` runs from inside ``vllm.utils.torch_utils``'s own
+        import -- its module-level ``PIN_MEMORY = is_pin_memory_available()``
+        is what resolves the platform -- so ``import vllm.tokenizers`` reaches
+        a partially initialized ``torch_utils`` and raises. The patch is
+        skipped every time. Without this post-import re-ensure, the fix from
+        #337/#342 never installs and ByteLevel pieces leak into served text.
+        """
+        import vllm.tokenizers.registry as tokenizer_registry
+
+        sentinel = "_vllm_metal_bytelevel_decoder_patch"
+
+        # Register both rebindings with monkeypatch so teardown restores them,
+        # then clear the sentinel to simulate a freshly registered process.
+        monkeypatch.setattr(
+            tokenizer_registry,
+            "get_tokenizer",
+            tokenizer_registry.get_tokenizer,
+        )
+        monkeypatch.setattr(
+            tokenizer_registry,
+            "cached_get_tokenizer",
+            tokenizer_registry.cached_get_tokenizer,
+        )
+        # setattr (not delattr) so teardown restores a previously-absent
+        # sentinel by deleting it, instead of leaving it set for later tests.
+        monkeypatch.setattr(tokenizer_registry, sentinel, False, raising=False)
+        assert not getattr(tokenizer_registry, sentinel, False)
+
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        reset_config()
+        try:
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    pipeline_parallel_size=1,
+                    tensor_parallel_size=1,
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    kv_cache_dtype_skip_layers=[],
+                    block_size=None,
+                ),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
+                    is_hybrid=False,
+                ),
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+                speculative_config=None,
+                lora_config=None,
+            )
+
+            MetalPlatform.check_and_update_config(vllm_config)
+
+            assert getattr(tokenizer_registry, sentinel, False), (
+                "check_and_update_config must re-ensure the ByteLevel tokenizer "
+                "patch; plugin registration alone always skips it"
+            )
+        finally:
+            reset_config()
+
     def test_check_and_update_config_rejects_pipeline_ring_port_overflow(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -14,7 +14,7 @@ from vllm.v1.attention.selector import AttentionSelectorConfig
 from vllm.v1.core.kv_cache_utils import get_kv_cache_configs
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
-from vllm_metal.compat import ensure_vllm_auto_fit_null_block_patch
+import vllm_metal.compat as compat
 from vllm_metal.config import reset_config
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
@@ -135,81 +135,20 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
-    def test_check_and_update_config_reensures_bytelevel_tokenizer_patch(
+    def test_check_and_update_config_fails_if_bytelevel_retry_fails(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Plugin activation can never install the ByteLevel tokenizer patch.
+        def _raise_import_error() -> None:
+            raise ImportError("tokenizer registry unavailable")
 
-        ``_register()`` runs from inside ``vllm.utils.torch_utils``'s own
-        import -- its module-level ``PIN_MEMORY = is_pin_memory_available()``
-        is what resolves the platform -- so ``import vllm.tokenizers`` reaches
-        a partially initialized ``torch_utils`` and raises. The patch is
-        skipped every time. Without this post-import re-ensure, the fix from
-        #337/#342 never installs and ByteLevel pieces leak into served text.
-        """
-        import vllm.tokenizers.registry as tokenizer_registry
-
-        sentinel = "_vllm_metal_bytelevel_decoder_patch"
-
-        # Register both rebindings with monkeypatch so teardown restores them,
-        # then clear the sentinel to simulate a freshly registered process.
         monkeypatch.setattr(
-            tokenizer_registry,
-            "get_tokenizer",
-            tokenizer_registry.get_tokenizer,
+            compat,
+            "ensure_vllm_bytelevel_tokenizer_patch",
+            _raise_import_error,
         )
-        monkeypatch.setattr(
-            tokenizer_registry,
-            "cached_get_tokenizer",
-            tokenizer_registry.cached_get_tokenizer,
-        )
-        # setattr (not delattr) so teardown restores a previously-absent
-        # sentinel by deleting it, instead of leaving it set for later tests.
-        monkeypatch.setattr(tokenizer_registry, sentinel, False, raising=False)
-        assert not getattr(tokenizer_registry, sentinel, False)
 
-        self._patch_stt_resolution(monkeypatch, is_stt=False)
-        reset_config()
-        try:
-            vllm_config = SimpleNamespace(
-                parallel_config=SimpleNamespace(
-                    worker_cls="auto",
-                    distributed_executor_backend="auto",
-                    pipeline_parallel_size=1,
-                    tensor_parallel_size=1,
-                    disable_custom_all_reduce=False,
-                ),
-                cache_config=SimpleNamespace(
-                    kv_cache_dtype_skip_layers=[],
-                    block_size=None,
-                ),
-                model_config=SimpleNamespace(
-                    model="test-model",
-                    disable_cascade_attn=False,
-                    tokenizer=None,
-                    max_model_len=32768,
-                    multimodal_config=None,
-                    hf_config=SimpleNamespace(model_type="qwen3"),
-                    is_hybrid=False,
-                ),
-                scheduler_config=SimpleNamespace(
-                    async_scheduling=False,
-                    enable_chunked_prefill=True,
-                    max_num_batched_tokens=2048,
-                    max_num_scheduled_tokens=None,
-                ),
-                speculative_config=None,
-                lora_config=None,
-            )
-
-            MetalPlatform.check_and_update_config(vllm_config)
-
-            assert getattr(tokenizer_registry, sentinel, False), (
-                "check_and_update_config must re-ensure the ByteLevel tokenizer "
-                "patch; plugin registration alone always skips it"
-            )
-        finally:
-            reset_config()
+        with pytest.raises(ImportError, match="tokenizer registry unavailable"):
+            MetalPlatform.check_and_update_config(SimpleNamespace())
 
     def test_check_and_update_config_rejects_pipeline_ring_port_overflow(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1700,7 +1639,7 @@ class TestAutoFitMaxModelLenChain:
         """The null-block auto-fit patch (compat.py) is part of the contract
         under test; ensure it directly because plugin activation can skip it
         while vLLM is partially imported."""
-        ensure_vllm_auto_fit_null_block_patch()
+        compat.ensure_vllm_auto_fit_null_block_patch()
 
     _BLOCK_SIZE = 16
     # 16 tokens x (50 x 16 x 256 + 10 x 4 x 512) heads*dims x K/V x bf16 —

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -28,7 +28,7 @@ def apply_compat_patches() -> None:
         return
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
-    _patch_vllm_bytelevel_tokenizer_loading()
+    ensure_vllm_bytelevel_tokenizer_patch()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_mlx_lm_gemma4_kv_shared_sanitize()
@@ -488,7 +488,7 @@ def _maybe_load_bytelevel_tokenizers_backend(
     return tokenizer
 
 
-def _patch_vllm_bytelevel_tokenizer_loading() -> None:
+def ensure_vllm_bytelevel_tokenizer_patch() -> None:
     """Use TokenizersBackend at vLLM's serving tokenizer boundary when needed.
 
     Some MLX-community Qwen/DeepSeek redistributions ship a ByteLevel
@@ -496,16 +496,20 @@ def _patch_vllm_bytelevel_tokenizer_loading() -> None:
     transformers versions instantiate a Llama/SentencePiece-style decoder.
     That decoder leaves ByteLevel token pieces such as "\u0120" and "\u010a"
     in served text.
+
+    Idempotent and safe to call repeatedly: plugin activation runs while vLLM
+    is still partially initialized, so the import below always fails there
+    (``vllm.tokenizers`` reaches ``vllm.utils.torch_utils``, which is mid-import
+    because its own module-level ``PIN_MEMORY = is_pin_memory_available()`` is
+    what resolves the platform and loads this plugin). So
+    ``MetalPlatform.check_and_update_config`` re-ensures it after vLLM is fully
+    imported, before the serving tokenizer is built.
     """
     try:
         import vllm.tokenizers.registry as tokenizer_registry
         from vllm.tokenizers.protocol import TokenizerLike
     except ImportError as exc:
-        logger.warning(
-            "Could not install vLLM ByteLevel tokenizer compatibility patch "
-            "because vLLM tokenizer registry is unavailable: %s",
-            exc,
-        )
+        logger.debug("Skipping vLLM ByteLevel tokenizer patch: %s", exc)
         return
 
     sentinel = "_vllm_metal_bytelevel_decoder_patch"

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -28,11 +28,19 @@ def apply_compat_patches() -> None:
         return
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
-    ensure_vllm_bytelevel_tokenizer_patch()
+    _apply_bytelevel_patch_during_registration()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_mlx_lm_gemma4_kv_shared_sanitize()
     _patch_transformers_exaone4_config()
+
+
+def _apply_bytelevel_patch_during_registration() -> None:
+    """Best-effort install while vLLM may still be partially imported."""
+    try:
+        ensure_vllm_bytelevel_tokenizer_patch()
+    except ImportError as exc:
+        logger.debug("Deferring vLLM ByteLevel tokenizer patch: %s", exc)
 
 
 def ensure_vllm_auto_fit_null_block_patch() -> None:
@@ -497,20 +505,12 @@ def ensure_vllm_bytelevel_tokenizer_patch() -> None:
     That decoder leaves ByteLevel token pieces such as "\u0120" and "\u010a"
     in served text.
 
-    Idempotent and safe to call repeatedly: plugin activation runs while vLLM
-    is still partially initialized, so the import below always fails there
-    (``vllm.tokenizers`` reaches ``vllm.utils.torch_utils``, which is mid-import
-    because its own module-level ``PIN_MEMORY = is_pin_memory_available()`` is
-    what resolves the platform and loads this plugin). So
-    ``MetalPlatform.check_and_update_config`` re-ensures it after vLLM is fully
-    imported, before the serving tokenizer is built.
+    Idempotent and safe to call repeatedly. Plugin activation may run while vLLM
+    is partially initialized, so ``apply_compat_patches`` defers import failure
+    and ``MetalPlatform.check_and_update_config`` retries after vLLM imports.
     """
-    try:
-        import vllm.tokenizers.registry as tokenizer_registry
-        from vllm.tokenizers.protocol import TokenizerLike
-    except ImportError as exc:
-        logger.debug("Skipping vLLM ByteLevel tokenizer patch: %s", exc)
-        return
+    import vllm.tokenizers.registry as tokenizer_registry
+    from vllm.tokenizers.protocol import TokenizerLike
 
     sentinel = "_vllm_metal_bytelevel_decoder_patch"
     if getattr(tokenizer_registry, sentinel, False):

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -334,10 +334,7 @@ class MetalPlatform(Platform):
         """
         from vllm_metal.compat import ensure_vllm_bytelevel_tokenizer_patch
 
-        # Runs after vLLM is fully imported, in every process that builds a
-        # config, and before the serving tokenizer is created: the reliable
-        # spot to (re-)install the ByteLevel tokenizer patch that plugin
-        # activation always skips mid-import.
+        # Retry after vLLM is fully imported, before serving tokenizers are built.
         ensure_vllm_bytelevel_tokenizer_patch()
 
         config = get_config()

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -332,6 +332,14 @@ class MetalPlatform(Platform):
         Args:
             vllm_config: vLLM configuration object
         """
+        from vllm_metal.compat import ensure_vllm_bytelevel_tokenizer_patch
+
+        # Runs after vLLM is fully imported, in every process that builds a
+        # config, and before the serving tokenizer is created: the reliable
+        # spot to (re-)install the ByteLevel tokenizer patch that plugin
+        # activation always skips mid-import.
+        ensure_vllm_bytelevel_tokenizer_patch()
+
         config = get_config()
         parallel_config = vllm_config.parallel_config
         model_config = vllm_config.model_config


### PR DESCRIPTION
Fixes #548.

The ByteLevel tokenizer compatibility patch from #337, refined in #342, has never installed. Not in a corner case, not on some transformers versions. Never, in any real `vllm serve`. So the `Ġ` and `Ċ` pieces that #336 was filed about have been leaking into served text this whole time for the affected MLX-community Qwen and DeepSeek repos.

The patch body itself is fine. It just never runs.

## Why it always fails

Plugin registration is triggered from inside `vllm.utils.torch_utils`'s own import. Its module-level `PIN_MEMORY = is_pin_memory_available()` is what resolves `current_platform`, which loads this plugin, which calls `apply_compat_patches()`:

```
vllm/env_override.py:90            from vllm.utils.torch_utils import ...
 └─ vllm/utils/torch_utils.py:72   PIN_MEMORY = is_pin_memory_available()
    └─ vllm/utils/platform_utils.py:44   from vllm.platforms import current_platform
       └─ vllm/platforms/__init__.py:219 resolve_current_platform_cls_qualname()
          └─ vllm_metal/__init__.py:117  _register()
             └─ vllm_metal/compat.py:31  apply_compat_patches()
```

The patch then does `import vllm.tokenizers.registry`, which reaches back into that half-built module:

```
vllm/tokenizers/__init__.py:4          from .hf import maybe_make_thread_pool
vllm/tokenizers/hf.py:11               from vllm.transformers_utils.config import ...
vllm/transformers_utils/config.py:34   from vllm.utils.torch_utils import common_broadcastable_dtype
```

`common_broadcastable_dtype` is defined at `torch_utils.py:255`, well below the line 72 that started all of this. ImportError, every time. The `except` branch logged a warning and returned, and nothing ever retried.

Checking the sentinel after full platform activation:

```
$ python -c "
import vllm, vllm.platforms as P
P.current_platform
import vllm.tokenizers.registry as reg
print(getattr(reg, '_vllm_metal_bytelevel_decoder_patch', False))"
False
```

It is the only one of the six patches in `apply_compat_patches()` that fails. The other five install cleanly, which is probably why the warning on every startup never got a second look.

## Why CI stayed green

`tests/test_compat.py` calls the patch function directly, and the `apply_compat_patches` test replaces it with a lambda that only records that it was called. The patch body is well covered. Its installation through the real registration path was not covered at all, so the suite happily stayed green while the patch was dead.

## The fix

This is the same hazard `ensure_vllm_auto_fit_null_block_patch` already documents in its own docstring, and #513 solved it there with a re-ensure hook. This does the same thing for the ByteLevel patch rather than inventing a second mechanism:

- Renamed to `ensure_vllm_bytelevel_tokenizer_patch`, matching the sibling's `ensure_*` naming that signals "safe to call repeatedly". It was already idempotent via its sentinel.
- Re-ensured from `MetalPlatform.check_and_update_config`.
- The registration-time ImportError drops from `logger.warning` to `logger.debug`. With a re-ensure hook it is expected and benign at that point, and it was firing on every startup.

The patch body is untouched.

## On the hook choice

`check_and_update_config` rather than `update_block_size_for_backend`, which is where #513 put the sibling. vLLM calls `check_and_update_config` from `VllmConfig.__post_init__`, so it runs after vLLM is fully imported and in every process that builds a config. That matters here because the serving tokenizer is built in the front end process, via `renderers/registry.py:83` to `cached_tokenizer_from_config` to `cached_get_tokenizer`, which the KV sizing hook never reaches.

Worth noting for review: the patch rebinds both `get_tokenizer` and `cached_get_tokenizer`. That second rebinding is load bearing, because `cached_tokenizer_from_config` resolves `cached_get_tokenizer` as a module global at call time.

## Testing

New test in `tests/test_platform.py` asserts the sentinel is set on `vllm.tokenizers.registry` after `check_and_update_config`, which is the coverage gap that let this ship. I verified it fails with the `platform.py` hook reverted and passes with it, rather than just assuming it would.

`tests/test_compat.py` and `tests/test_platform.py`: 90 passed, 13 skipped. `ruff check`, `ruff format --check`, and `mypy vllm_metal` are clean.

To confirm this is not merely a flag flipping from False to True, here is the repo's own fixture (`_write_mismatched_bytelevel_tokenizer_repo`) driven through `get_tokenizer` in the state a real server is actually in:

```
patch installed at this point: False
decoded (UNPATCHED): 'ĠHelloĊ'      <- the #336 symptom
decoded (PATCHED):   ' Hello\n'
```

Reproduced against vLLM 0.25.1, the version `install.sh` pins. The same ordering holds on 0.24.0 (72/255 vs 71/254), so this is not specific to the pinned release.
