### PR TITLE
[GPT-OSS] Wire attention sinks through the paged attention kernel

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -755,6 +755,77 @@ class TestSDPAForward:
 
         assert captured["num_kv_heads"] == actual_kv_heads
 
+    def test_gpt_oss_scale_and_sinks_reach_kernel(self) -> None:
+        """GPT-OSS exposes ``sm_scale`` and per-head attention sinks."""
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        expected_scale = 0.125
+        fp16_sinks = mx.arange(_N_HEADS, dtype=mx.float16)
+        inner = SimpleNamespace(
+            num_attention_heads=_N_HEADS,
+            num_key_value_heads=_N_KV_HEADS,
+            sm_scale=expected_scale,
+            sinks=fp16_sinks,
+            o_proj=lambda out: out,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        queries = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM))
+        keys = mx.ones((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        values = mx.ones((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        captured: dict[str, object] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self,
+                _key,
+                _value,
+                key_cache,
+                value_cache,
+                _slot_mapping,
+            ) -> tuple[mx.array, mx.array]:
+                return key_cache, value_cache
+
+            def paged_attention_primitive(
+                self,
+                _query,
+                _key_cache,
+                _value_cache,
+                _num_kv_heads,
+                scale,
+                *_args,
+                sinks=None,
+                **_kwargs,
+            ) -> None:
+                captured["scale"] = scale
+                captured["sinks"] = sinks
+
+        with (
+            patch.object(
+                sdpa_mod,
+                "prepare_sdpa_qkv",
+                return_value=(queries, keys, values, None, (keys, values)),
+            ),
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)),
+            ),
+        ):
+            sdpa_forward(inner, x, ctx, cache, layer_idx=0)
+
+        sinks = captured["sinks"]
+        assert captured["scale"] == expected_scale
+        assert isinstance(sinks, mx.array)
+        assert sinks.dtype == mx.float32
+
     def test_shared_kv_path_does_not_rebind_cache_arrays(self) -> None:
         """Shared-KV attention must read the existing cache without writing."""
         cache = MetalPagedKVCache(

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -615,8 +615,9 @@ class _PagedRoutingOpsSpy:
         _sliding_window: int,
         _out: mx.array,
         window_seqlen_q: int = 1,
+        sinks: mx.array | None = None,
     ) -> None:
-        del window_seqlen_q
+        del window_seqlen_q, sinks
         self.calls[-1].block_tables = block_tables.tolist()
         self.calls[-1].block_size = block_size
 

--- a/tests/test_paged_attention_sinks.py
+++ b/tests/test_paged_attention_sinks.py
@@ -109,6 +109,64 @@ def _run_decode(
     return out.reshape(num_q_heads, head_size), ref[0, :, 0, :]
 
 
+def _run_prefill(
+    ctx: int,
+    query_len: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    sinks: mx.array,
+    dtype: mx.Dtype = mx.float16,
+    seed: int = 0,
+) -> tuple[mx.array, mx.array]:
+    """One ordinary multi-token prefill segment against the MLX oracle."""
+    mx.random.seed(seed)
+    kv_len = ctx + query_len
+    blocks = (kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    key_cache = mx.random.normal(
+        shape=(blocks, BLOCK_SIZE, num_kv_heads, HEAD_SIZE)
+    ).astype(dtype)
+    value_cache = mx.random.normal(
+        shape=(blocks, BLOCK_SIZE, num_kv_heads, HEAD_SIZE)
+    ).astype(dtype)
+    query = mx.random.normal(shape=(query_len, num_q_heads, HEAD_SIZE)).astype(dtype)
+    mx.eval(key_cache, value_cache, query)
+
+    scale = HEAD_SIZE**-0.5
+    out = mx.array(0)
+    get_ops().paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        scale,
+        0.0,
+        mx.array([list(range(blocks))], dtype=mx.int32),
+        mx.array([kv_len], dtype=mx.int32),
+        mx.array([0, query_len], dtype=mx.int32),
+        BLOCK_SIZE,
+        kv_len,
+        -1,
+        out,
+        sinks=sinks,
+    )
+    mx.eval(out)
+
+    flat_k = key_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, HEAD_SIZE)[:kv_len]
+    flat_v = value_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, HEAD_SIZE)[:kv_len]
+    ref = mx.fast.scaled_dot_product_attention(
+        mx.transpose(query, (1, 0, 2))[None],
+        mx.transpose(flat_k, (1, 0, 2))[None],
+        mx.transpose(flat_v, (1, 0, 2))[None],
+        scale=scale,
+        mask="causal",
+        sinks=sinks.astype(dtype),
+    )
+    mx.eval(ref)
+    return out.reshape(query_len, num_q_heads, HEAD_SIZE), mx.transpose(
+        ref[0], (1, 0, 2)
+    )
+
+
 def _assert_close(got: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
     atol, rtol = _TOLERANCES[dtype]
     assert mx.allclose(got, ref, atol=atol, rtol=rtol), (
@@ -170,6 +228,14 @@ class TestSinkParity:
         got, ref = _run_decode(64, 8, 8, _sinks(8, 2.0))
         # 8x over-counting showed up as ~2e-1 here, 6 orders above this bound.
         assert float(mx.max(mx.abs(got - ref))) < 1e-4
+
+
+class TestSinkPrefillMode:
+    """Ordinary prefill with sinks stays on the tiled sink path."""
+
+    def test_prefill_matches_mlx_oracle(self) -> None:
+        got, ref = _run_prefill(64, 4, 8, 8, _sinks(8, 2.0))
+        _assert_close(got, ref, mx.float16)
 
 
 def _run_window(

--- a/tests/test_paged_attention_sinks.py
+++ b/tests/test_paged_attention_sinks.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention-sink parity for the paged attention kernel (issue #212).
+
+GPT-OSS style attention sinks add one learned logit per query head to the
+softmax denominator without contributing a value row.  The Metal kernel carries
+``use_sinks`` (function constant 40) and reads the sink array at buffer 18
+(buffer 6 in the reduce), but nothing could reach it until
+``paged_attention_primitive`` grew a ``sinks`` argument.
+
+The oracle is MLX's own ``mx.fast.scaled_dot_product_attention(..., sinks=...)``
+(MLX >= 0.32), so these compare the kernel against the same reference the model
+path would use.
+
+Three kernel paths fold sinks, and each is covered here:
+
+- non-partitioned: the sink joins the merged threadgroup state once, AFTER the
+  per-warp merge.  Folding it before the merge counts it ``NUM_WARPS`` times;
+  that regression is what ``test_sinks_not_multiplied_by_warp_count`` pins.
+- split-KV: ``paged_attention_v2_reduce`` folds the sink into the global max and
+  exp-sum, so it is counted once across partitions rather than once per
+  partition.
+- window mode: same as non-partitioned, per window row.
+
+Deterministic, no model load.
+
+Run with:
+    python -m pytest tests/test_paged_attention_sinks.py -v
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.metal import get_ops
+
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+# Matched to the repo's existing paged-attention parity tolerances.
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+    mx.float32: (1e-3, 1e-3),
+}
+
+
+def _sinks(num_q_heads: int, value: float | None = None) -> mx.array:
+    """Per-head sink logits; spread across a range when no value is given."""
+    if value is not None:
+        return mx.ones((num_q_heads,), dtype=mx.float32) * value
+    return (mx.arange(num_q_heads).astype(mx.float32) - num_q_heads / 2.0) * 1.5
+
+
+def _run_decode(
+    ctx: int,
+    num_q_heads: int,
+    num_kv_heads: int,
+    sinks: mx.array | None,
+    dtype: mx.Dtype = mx.float32,
+    head_size: int = HEAD_SIZE,
+    seed: int = 0,
+) -> tuple[mx.array, mx.array]:
+    """One decode row against the paged kernel and the MLX oracle."""
+    mx.random.seed(seed)
+    blocks = (ctx + BLOCK_SIZE - 1) // BLOCK_SIZE
+    key_cache = mx.random.normal(
+        shape=(blocks, BLOCK_SIZE, num_kv_heads, head_size)
+    ).astype(dtype)
+    value_cache = mx.random.normal(
+        shape=(blocks, BLOCK_SIZE, num_kv_heads, head_size)
+    ).astype(dtype)
+    query = mx.random.normal(shape=(1, num_q_heads, head_size)).astype(dtype)
+    mx.eval(key_cache, value_cache, query)
+
+    scale = head_size**-0.5
+    out = mx.array(0)
+    get_ops().paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        num_kv_heads,
+        scale,
+        0.0,
+        mx.array([list(range(blocks))], dtype=mx.int32),
+        mx.array([ctx], dtype=mx.int32),
+        mx.array([0, 1], dtype=mx.int32),
+        BLOCK_SIZE,
+        ctx,
+        -1,
+        out,
+        sinks=sinks,
+    )
+    mx.eval(out)
+
+    # MLX wants [B, N, T, D]; the paged cache is [blocks, block, kv, D].
+    flat_k = key_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, head_size)[:ctx]
+    flat_v = value_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, head_size)[:ctx]
+    # The kernel reads sinks as device float (fp32); MLX instead requires them
+    # to promote to the output dtype, so the oracle takes a cast copy.
+    ref = mx.fast.scaled_dot_product_attention(
+        mx.transpose(query, (1, 0, 2))[None],
+        mx.transpose(flat_k, (1, 0, 2))[None],
+        mx.transpose(flat_v, (1, 0, 2))[None],
+        scale=scale,
+        sinks=None if sinks is None else sinks.astype(dtype),
+    )
+    mx.eval(ref)
+    return out.reshape(num_q_heads, head_size), ref[0, :, 0, :]
+
+
+def _assert_close(got: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
+    atol, rtol = _TOLERANCES[dtype]
+    assert mx.allclose(got, ref, atol=atol, rtol=rtol), (
+        f"max abs diff {float(mx.max(mx.abs(got - ref))):.3e} exceeds atol={atol}"
+    )
+
+
+class TestSinkParity:
+    """Kernel vs mx.fast.scaled_dot_product_attention with sinks."""
+
+    @pytest.mark.parametrize("dtype", [mx.float32, mx.float16, mx.bfloat16])
+    @pytest.mark.parametrize("sink_value", [0.0, 2.0, -5.0])
+    def test_decode_matches_mlx_oracle(
+        self, dtype: mx.Dtype, sink_value: float
+    ) -> None:
+        got, ref = _run_decode(64, 8, 8, _sinks(8, sink_value), dtype=dtype)
+        _assert_close(got, ref, dtype)
+
+    def test_per_head_sink_values(self) -> None:
+        """Each head must use its OWN sink, not head 0's."""
+        got, ref = _run_decode(64, 8, 8, _sinks(8))
+        _assert_close(got, ref, mx.float32)
+
+    @pytest.mark.parametrize("num_q_heads,num_kv_heads", [(8, 8), (8, 2), (16, 4)])
+    def test_gqa_head_ratios(self, num_q_heads: int, num_kv_heads: int) -> None:
+        got, ref = _run_decode(64, num_q_heads, num_kv_heads, _sinks(num_q_heads))
+        _assert_close(got, ref, mx.float32)
+
+    @pytest.mark.parametrize("head_size", [64, 128])
+    def test_head_sizes(self, head_size: int) -> None:
+        got, ref = _run_decode(64, 8, 8, _sinks(8), head_size=head_size)
+        _assert_close(got, ref, mx.float32)
+
+    def test_split_kv_path(self) -> None:
+        """Context past PARTITION_SIZE routes through the reduce kernel."""
+        ctx = get_ops().PARTITION_SIZE * 3
+        got, ref = _run_decode(ctx, 8, 8, _sinks(8))
+        _assert_close(got, ref, mx.float32)
+
+    def test_sinks_none_is_plain_softmax(self) -> None:
+        """sinks=None must leave the existing path bit-for-bit unchanged."""
+        got, ref = _run_decode(64, 8, 8, None)
+        _assert_close(got, ref, mx.float32)
+
+    def test_sinks_change_the_output(self) -> None:
+        """Guards against the argument being accepted and then ignored."""
+        without, _ = _run_decode(64, 8, 8, None)
+        with_sinks, _ = _run_decode(64, 8, 8, _sinks(8, 2.0))
+        assert float(mx.max(mx.abs(without - with_sinks))) > 1e-3
+
+    def test_sinks_not_multiplied_by_warp_count(self) -> None:
+        """Pins the bug this issue's kernel path shipped with.
+
+        The vendored code folded the sink into every warp's state before the
+        threadgroup merge summed all NUM_WARPS states, so the sink landed in the
+        denominator NUM_WARPS times.  A large positive sink makes that
+        unmissable: it is the case where exp(sink) dominates the denominator.
+        """
+        got, ref = _run_decode(64, 8, 8, _sinks(8, 2.0))
+        # 8x over-counting showed up as ~2e-1 here, 6 orders above this bound.
+        assert float(mx.max(mx.abs(got - ref))) < 1e-4
+
+
+def _run_window(
+    ctx: int,
+    windows: list[int],
+    num_q_heads: int,
+    num_kv_heads: int,
+    sinks: mx.array | None,
+    dtype: mx.Dtype = mx.float32,
+    seed: int = 0,
+) -> tuple[mx.array, mx.array]:
+    """Same batch dispatched expanded (per-token) and windowed."""
+    mx.random.seed(seed)
+    total_q = sum(windows)
+    lens = [ctx + w for w in windows]
+    max_kv = max(lens)
+    bps = (max_kv + BLOCK_SIZE - 1) // BLOCK_SIZE
+    shape = (bps * len(windows), BLOCK_SIZE, num_kv_heads, HEAD_SIZE)
+    key_cache = mx.random.normal(shape=shape).astype(dtype)
+    value_cache = mx.random.normal(shape=shape).astype(dtype)
+    query = mx.random.normal(shape=(total_q, num_q_heads, HEAD_SIZE)).astype(dtype)
+    mx.eval(key_cache, value_cache, query)
+    tables = [list(range(s * bps, (s + 1) * bps)) for s in range(len(windows))]
+
+    def dispatch(tab, seq, cu, wq):
+        out = mx.array(0)
+        get_ops().paged_attention_primitive(
+            query,
+            key_cache,
+            value_cache,
+            num_kv_heads,
+            HEAD_SIZE**-0.5,
+            0.0,
+            mx.array(tab, dtype=mx.int32),
+            mx.array(seq, dtype=mx.int32),
+            mx.array(cu, dtype=mx.int32),
+            BLOCK_SIZE,
+            max_kv,
+            -1,
+            out,
+            window_seqlen_q=wq,
+            sinks=sinks,
+        )
+        mx.eval(out)
+        return out
+
+    exp_tab, exp_seq, exp_cu = [], [], [0]
+    for s, w in enumerate(windows):
+        for j in range(w):
+            exp_tab.append(tables[s])
+            exp_seq.append(ctx + j + 1)
+            exp_cu.append(exp_cu[-1] + 1)
+
+    win_cu = [0]
+    for w in windows:
+        win_cu.append(win_cu[-1] + w)
+
+    return (
+        dispatch(exp_tab, exp_seq, exp_cu, 1),
+        dispatch(tables, lens, win_cu, max(windows)),
+    )
+
+
+class TestSinkWindowMode:
+    """Spec-decode window mode folds sinks per window row, once each.
+
+    The expanded layout drives the per-token kernel, which TestSinkParity
+    already pins against the MLX oracle, so agreement between the layouts is
+    what validates the window path.
+    """
+
+    @pytest.mark.parametrize("windows", [[2], [4], [2, 3]])
+    @pytest.mark.parametrize("sink_value", [None, 2.0, -5.0])
+    def test_windowed_matches_expanded(
+        self, windows: list[int], sink_value: float | None
+    ) -> None:
+        sinks = None if sink_value is None else _sinks(8, sink_value)
+        expanded, windowed = _run_window(128, windows, 8, 8, sinks)
+        _assert_close(windowed, expanded, mx.float32)
+
+    def test_windowed_matches_expanded_split_kv(self) -> None:
+        ctx = get_ops().PARTITION_SIZE * 3
+        expanded, windowed = _run_window(ctx, [4], 8, 8, _sinks(8))
+        _assert_close(windowed, expanded, mx.float32)
+
+    def test_window_sinks_are_applied(self) -> None:
+        """Window mode must not silently drop the sink term."""
+        without, _ = _run_window(128, [4], 8, 8, None)
+        with_sinks, _ = _run_window(128, [4], 8, 8, _sinks(8, 2.0))
+        assert float(mx.max(mx.abs(without - with_sinks))) > 1e-3
+
+
+class TestSinkValidation:
+    """Fail-fast contract for unsupported or malformed sinks."""
+
+    def _call(self, sinks: mx.array, **kwargs: object) -> None:
+        ctx, nq, nkv = 32, 8, 8
+        blocks = ctx // BLOCK_SIZE
+        kc = mx.zeros((blocks, BLOCK_SIZE, nkv, HEAD_SIZE))
+        vc = mx.zeros((blocks, BLOCK_SIZE, nkv, HEAD_SIZE))
+        q = mx.zeros((1, nq, HEAD_SIZE))
+        out = mx.array(0)
+        get_ops().paged_attention_primitive(
+            q,
+            kc,
+            vc,
+            nkv,
+            HEAD_SIZE**-0.5,
+            0.0,
+            mx.array([list(range(blocks))], dtype=mx.int32),
+            mx.array([ctx], dtype=mx.int32),
+            mx.array([0, 1], dtype=mx.int32),
+            BLOCK_SIZE,
+            ctx,
+            -1,
+            out,
+            sinks=sinks,
+            **kwargs,
+        )
+
+    def test_rejects_wrong_head_count(self) -> None:
+        with pytest.raises(ValueError, match="one entry per query head"):
+            self._call(mx.zeros((4,), dtype=mx.float32))
+
+    def test_rejects_non_1d(self) -> None:
+        with pytest.raises(ValueError, match="1-D"):
+            self._call(mx.zeros((8, 1), dtype=mx.float32))
+
+    def test_rejects_non_float32(self) -> None:
+        with pytest.raises(ValueError, match="float32"):
+            self._call(mx.zeros((8,), dtype=mx.float16))
+
+    def test_rejects_turboquant_combination(self) -> None:
+        """Upstream MLX refuses sinks with a quantized cache; so do we."""
+        with pytest.raises(ValueError, match="TurboQuant"):
+            self._call(mx.zeros((8,), dtype=mx.float32), use_turboquant=True)

--- a/tests/test_paged_attention_sinks.py
+++ b/tests/test_paged_attention_sinks.py
@@ -11,7 +11,7 @@ The oracle is MLX's own ``mx.fast.scaled_dot_product_attention(..., sinks=...)``
 (MLX >= 0.32), so these compare the kernel against the same reference the model
 path would use.
 
-Three kernel paths fold sinks, and each is covered here:
+Four kernel paths fold sinks, and each is covered here:
 
 - non-partitioned: the sink joins the merged threadgroup state once, AFTER the
   per-warp merge.  Folding it before the merge counts it ``NUM_WARPS`` times;
@@ -19,6 +19,7 @@ Three kernel paths fold sinks, and each is covered here:
 - split-KV: ``paged_attention_v2_reduce`` folds the sink into the global max and
   exp-sum, so it is counted once across partitions rather than once per
   partition.
+- tiled prefill: same softmax update as non-partitioned, one sink per query row.
 - window mode: same as non-partitioned, per window row.
 
 Deterministic, no model load.
@@ -36,6 +37,11 @@ from vllm_metal.metal import get_ops
 
 HEAD_SIZE = 128
 BLOCK_SIZE = 16
+GPT_OSS_HEAD_SIZE = 64
+GPT_OSS_NUM_Q_HEADS = 64
+GPT_OSS_NUM_KV_HEADS = 8
+GPT_OSS_PREFILL_CTX = 64
+GPT_OSS_PREFILL_LEN = 64
 
 # Matched to the repo's existing paged-attention parity tolerances.
 _TOLERANCES = {
@@ -114,8 +120,9 @@ def _run_prefill(
     query_len: int,
     num_q_heads: int,
     num_kv_heads: int,
+    head_size: int,
+    dtype: mx.Dtype,
     sinks: mx.array,
-    dtype: mx.Dtype = mx.float16,
     seed: int = 0,
 ) -> tuple[mx.array, mx.array]:
     """One ordinary multi-token prefill segment against the MLX oracle."""
@@ -123,15 +130,15 @@ def _run_prefill(
     kv_len = ctx + query_len
     blocks = (kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
     key_cache = mx.random.normal(
-        shape=(blocks, BLOCK_SIZE, num_kv_heads, HEAD_SIZE)
+        shape=(blocks, BLOCK_SIZE, num_kv_heads, head_size)
     ).astype(dtype)
     value_cache = mx.random.normal(
-        shape=(blocks, BLOCK_SIZE, num_kv_heads, HEAD_SIZE)
+        shape=(blocks, BLOCK_SIZE, num_kv_heads, head_size)
     ).astype(dtype)
-    query = mx.random.normal(shape=(query_len, num_q_heads, HEAD_SIZE)).astype(dtype)
+    query = mx.random.normal(shape=(query_len, num_q_heads, head_size)).astype(dtype)
     mx.eval(key_cache, value_cache, query)
 
-    scale = HEAD_SIZE**-0.5
+    scale = head_size**-0.5
     out = mx.array(0)
     get_ops().paged_attention_primitive(
         query,
@@ -151,8 +158,8 @@ def _run_prefill(
     )
     mx.eval(out)
 
-    flat_k = key_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, HEAD_SIZE)[:kv_len]
-    flat_v = value_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, HEAD_SIZE)[:kv_len]
+    flat_k = key_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, head_size)[:kv_len]
+    flat_v = value_cache.reshape(blocks * BLOCK_SIZE, num_kv_heads, head_size)[:kv_len]
     ref = mx.fast.scaled_dot_product_attention(
         mx.transpose(query, (1, 0, 2))[None],
         mx.transpose(flat_k, (1, 0, 2))[None],
@@ -162,7 +169,7 @@ def _run_prefill(
         sinks=sinks.astype(dtype),
     )
     mx.eval(ref)
-    return out.reshape(query_len, num_q_heads, HEAD_SIZE), mx.transpose(
+    return out.reshape(query_len, num_q_heads, head_size), mx.transpose(
         ref[0], (1, 0, 2)
     )
 
@@ -234,8 +241,16 @@ class TestSinkPrefillMode:
     """Ordinary prefill with sinks stays on the tiled sink path."""
 
     def test_prefill_matches_mlx_oracle(self) -> None:
-        got, ref = _run_prefill(64, 4, 8, 8, _sinks(8, 2.0))
-        _assert_close(got, ref, mx.float16)
+        got, ref = _run_prefill(
+            GPT_OSS_PREFILL_CTX,
+            GPT_OSS_PREFILL_LEN,
+            GPT_OSS_NUM_Q_HEADS,
+            GPT_OSS_NUM_KV_HEADS,
+            GPT_OSS_HEAD_SIZE,
+            mx.bfloat16,
+            _sinks(GPT_OSS_NUM_Q_HEADS),
+        )
+        _assert_close(got, ref, mx.bfloat16)
 
 
 def _run_window(

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -437,6 +437,20 @@ def sdpa_forward(
     n_heads = getattr(inner, "n_heads", None) or inner.num_attention_heads
     n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
 
+    # Softmax scale — GPT-OSS names it sm_scale rather than scale.
+    attn_scale = getattr(inner, "scale", None)
+    if attn_scale is None:
+        attn_scale = inner.sm_scale
+
+    # Attention sinks: a learned per-head logit that joins the softmax
+    # denominator without contributing a value row (GPT-OSS). Models without
+    # sinks leave this None and the kernel keeps its plain-softmax path.
+    # The kernel reads them as device float, so cast only when the checkpoint
+    # stored them in another dtype; this is the per-layer hot path.
+    sinks = getattr(inner, "sinks", None)
+    if sinks is not None and sinks.dtype != mx.float32:
+        sinks = sinks.astype(mx.float32)
+
     queries, keys, values, gate, kv_for_sharing = prepare_sdpa_qkv(
         inner,
         x,
@@ -618,7 +632,7 @@ def sdpa_forward(
             kernel_k_cache,
             kernel_v_cache,
             cache_kv_heads,
-            inner.scale,
+            attn_scale,
             0.0,  # softcap (0 = disabled)
             block_tables,
             seq_lens,
@@ -627,6 +641,10 @@ def sdpa_forward(
             max_seq_len,
             layer_sliding_window,
             out,
+            # Passed through rather than dropped: the primitive rejects
+            # sinks + TurboQuant outright, so a sink model on a quantized
+            # cache fails loudly instead of silently losing the sink term.
+            sinks=sinks,
             key_scale_cache=kernel_key_scale,
             value_scale_cache=kernel_value_scale,
             key_zero_cache=kernel_key_zero,
@@ -642,7 +660,7 @@ def sdpa_forward(
             kernel_k_cache,
             kernel_v_cache,
             cache_kv_heads,
-            inner.scale,
+            attn_scale,
             0.0,  # softcap (0 = disabled)
             block_tables,
             seq_lens,
@@ -652,6 +670,7 @@ def sdpa_forward(
             layer_sliding_window,
             out,
             window_seqlen_q=ctx.verify_window_q,
+            sinks=sinks,
         )
 
     # Reshape + strip padding back to actual head_dim before o_proj.

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -1245,20 +1245,9 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
   // merges sequentially. Simple and barrier-safe (all barriers are
   // reached by all threads in the threadgroup).
 
-  // For non-partitioned mode, include the sink in each warp's state.
-  // Sinks are raw linear-space bias values; lift to log2 space (matches the
-  // log2-space convention adopted at the warp_scores write above).
-  if (!USE_PARTITIONING && use_sinks) {
-    float sink_val = sinks[head_idx] * M_LOG2E_F;
-    float new_m = max(warp_m, sink_val);
-    float old_corr = (warp_m == -FLT_MAX) ? 0.f : exp2(warp_m - new_m);
-#pragma unroll
-    for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
-      v_accs[i] *= old_corr;
-    }
-    warp_l = warp_l * old_corr + exp2(sink_val - new_m);
-    warp_m = new_m;
-  }
+  // NOTE: the sink is deliberately NOT folded here.  This point is per-warp,
+  // and the merge below sums all NUM_WARPS states, so folding here would count
+  // the sink NUM_WARPS times over.  It is folded once after the merge instead.
 
   // Shared memory layout for merge:
   //   merge_m[NUM_WARPS]: per-warp max values
@@ -1315,6 +1304,27 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
       }
       warp_m = new_m;
       warp_l = warp_l * my_corr + other_l * other_corr;
+    }
+
+    // Fold the attention sink into the merged state, exactly once per
+    // threadgroup.  Sinks are raw linear-space bias values; lift to log2 space
+    // to match the convention used for warp_scores above.  The sink is a
+    // denominator-only logit: it rescales the accumulated O and adds its own
+    // exp term to l, but contributes no value row.
+    //
+    // Partitioned mode skips this: paged_attention_v2_reduce folds the sink
+    // into the global max and exp-sum instead, so it is counted once across
+    // all partitions rather than once per partition.
+    if (!USE_PARTITIONING && use_sinks) {
+      const float sink_val = sinks[head_idx] * M_LOG2E_F;
+      const float new_m = max(warp_m, sink_val);
+      const float old_corr = (warp_m == -FLT_MAX) ? 0.f : exp2(warp_m - new_m);
+#pragma unroll
+      for (int j = 0; j < V_ELEMS_PER_THREAD; j++) {
+        v_accs[j] *= old_corr;
+      }
+      warp_l = warp_l * old_corr + exp2(sink_val - new_m);
+      warp_m = new_m;
     }
 
     // For partitioned mode, persist the merged partition statistics for the
@@ -1757,20 +1767,10 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
   for (int r = 0; r < rows_per_tg; r++) {
     if (r >= num_rows) break;
 
-    // For non-partitioned mode, include the sink in each warp's state.
-    // Sinks are raw linear-space bias values; lift to log2 space (matches
-    // the log2-space convention adopted at the warp_scores write above).
-    if (!USE_PARTITIONING && use_sinks) {
-      float sink_val = sinks[head_idx] * M_LOG2E_F;
-      float new_m = max(warp_m[r], sink_val);
-      float old_corr = (warp_m[r] == -FLT_MAX) ? 0.f : exp2(warp_m[r] - new_m);
-#pragma unroll
-      for (int i = 0; i < V_ELEMS_PER_THREAD; i++) {
-        v_accs[r][i] *= old_corr;
-      }
-      warp_l[r] = warp_l[r] * old_corr + exp2(sink_val - new_m);
-      warp_m[r] = new_m;
-    }
+    // NOTE: the sink is deliberately NOT folded here.  This point is per-warp,
+    // and the merge below sums all NUM_WARPS states, so folding here would
+    // count the sink NUM_WARPS times over.  It is folded once per row after
+    // the merge instead.
 
     // All warps write this row's state to shared memory.
     if (lane == 0) {
@@ -1817,6 +1817,22 @@ template <typename T, typename K_CACHE_T, typename V_CACHE_T, int HEAD_SIZE, int
         }
         warp_m[r] = new_m;
         warp_l[r] = warp_l[r] * my_corr + other_l * other_corr;
+      }
+
+      // Fold the attention sink into this row's merged state, exactly once.
+      // See the equivalent block in the per-token kernel for the rationale;
+      // partitioned mode defers to paged_attention_v2_reduce.
+      if (!USE_PARTITIONING && use_sinks) {
+        const float sink_val = sinks[head_idx] * M_LOG2E_F;
+        const float new_m = max(warp_m[r], sink_val);
+        const float old_corr =
+            (warp_m[r] == -FLT_MAX) ? 0.f : exp2(warp_m[r] - new_m);
+#pragma unroll
+        for (int j = 0; j < V_ELEMS_PER_THREAD; j++) {
+          v_accs[r][j] *= old_corr;
+        }
+        warp_l[r] = warp_l[r] * old_corr + exp2(sink_val - new_m);
+        warp_m[r] = new_m;
       }
 
       // Global query row this iteration writes.

--- a/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention_tiled.metal
@@ -127,6 +127,8 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     const constant int &q_stride [[buffer(15)]],
     const constant int &kv_block_stride [[buffer(16)]],
     const constant int &kv_head_stride [[buffer(17)]],
+    device const float *sinks
+    [[buffer(18), function_constant(use_sinks)]],
     device const int32_t *cu_seqlens_q [[buffer(19)]],
     const constant int &num_seqs [[buffer(20)]],
     const constant int &sliding_window [[buffer(21)]],
@@ -472,6 +474,23 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
     threadgroup_barrier(mem_flags::mem_threadgroup);
   } // end KV tile loop
 
+  // Fold the attention sink into each valid row's online-softmax state once.
+  // It contributes one learned logit to the denominator and no value row, so
+  // O is only rescaled by the max correction.
+  if (use_sinks && (sg_idx * 8 + fm) < valid_q) {
+    const float sink_score = sinks[head_idx] * M_LOG2E_F;
+    const float new_max = max(max_score, sink_score);
+    const float old_corr =
+        (max_score == -INFINITY) ? 0.0f : fast::exp2(max_score - new_max);
+    const float sink_exp = fast::exp2(sink_score - new_max);
+    sum_score = sum_score * old_corr + sink_exp;
+    max_score = new_max;
+    #pragma unroll
+    for (int d = 0; d < TD; d++) {
+      Oreg[d] *= old_corr;
+    }
+  }
+
   // ─ Final normalize: O /= sum_score, then store ────────────────────────
   // sum_score is broadcast-replicated across lanes with same fm.
   float inv_sum = 1.0f / (sum_score + 1e-6f);
@@ -527,6 +546,8 @@ template <typename T, int HEAD_SIZE, int BLOCK_SIZE,
       const constant int &q_stride [[buffer(15)]],                             \
       const constant int &kv_block_stride [[buffer(16)]],                      \
       const constant int &kv_head_stride [[buffer(17)]],                       \
+      device const float *sinks                                                \
+      [[buffer(18), function_constant(use_sinks)]],                            \
       device const int32_t *cu_seqlens_q [[buffer(19)]],                       \
       const constant int &num_seqs [[buffer(20)]],                             \
       const constant int &sliding_window [[buffer(21)]],                       \

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -347,7 +347,11 @@ static void dispatch_paged_attention_v2_online(
     const array* v_centroids = nullptr,
     bool use_turboquant = false,
     int k_bits = 8,
-    int v_bits = 3) {
+    int v_bits = 3,
+    // Attention sinks (optional): one float per query head, a learned logit
+    // that joins the softmax denominator without contributing a value row.
+    // nullptr for every model that has no sinks, which is the common case.
+    const array* sinks = nullptr) {
   int head_size = static_cast<int>(query.shape(2));
 
   // Tiled kernel for prefill batches, matching vLLM Triton's 2D/3D dispatch
@@ -370,7 +374,12 @@ static void dispatch_paged_attention_v2_online(
   const bool window_batch =
       has_prefill && window_seqlen_q > 1 && head_size <= kWindowMaxHeadSize;
 
-  if (has_prefill && !window_batch && !use_turboquant && dtype_ok) {
+  // Sinks join TurboQuant in being excluded from the tiled kernel:
+  // pagedattention_tiled.metal has no sink code path at all, so a sinks batch
+  // must fall through to the per-token kernel below, which does.  Routing it
+  // to the tiled kernel would silently drop the sink term.
+  if (has_prefill && !window_batch && !use_turboquant && dtype_ok
+      && sinks == nullptr) {
     if (auto cfg = select_tile_config(head_size)) {
       dispatch_paged_attention_tiled(
           out, query, key_cache, value_cache,
@@ -433,7 +442,7 @@ static void dispatch_paged_attention_v2_online(
   bool use_partitioning  = partition;
   bool use_alibi         = false;
   bool use_fp8           = false;
-  bool use_sinks         = false;
+  bool use_sinks         = sinks != nullptr;
   bool use_tq_fc         = use_turboquant;
   int  k_bits_i          = k_bits;
   int  v_bits_i          = v_bits;
@@ -445,7 +454,8 @@ static void dispatch_paged_attention_v2_online(
       + "_tq" + (use_tq_fc ? "1" : "0")
       + "_kb" + std::to_string(k_bits_i)
       + "_vb" + std::to_string(v_bits_i)
-      + "_wq" + std::to_string(window_q_fc);
+      + "_wq" + std::to_string(window_q_fc)
+      + "_sk" + (use_sinks ? "1" : "0");
 
   auto* lib = d.get_library("paged_attention_v2_kern");
   auto* kernel = d.get_kernel(
@@ -492,6 +502,13 @@ static void dispatch_paged_attention_v2_online(
     enc.set_input_array(*v_centroids, 27);
   };
 
+  // Sink logits (slot 18); bound only when the kernel was specialized with
+  // use_sinks, since the argument is declared under that function constant.
+  auto bind_sinks = [&]() {
+    if (!use_sinks) return;
+    enc.set_input_array(*sinks, 18);
+  };
+
   if (!partition) {
     // Single-pass path (grid.z = 1): the original decode/per-token kernel.
     enc.set_compute_pipeline_state(kernel);
@@ -501,6 +518,7 @@ static void dispatch_paged_attention_v2_online(
                             cu_seqlens_q, sliding_window);
     enc.set_bytes(scale, 9);
     bind_turboquant();
+    bind_sinks();
     enc.dispatch_threadgroups(
         MTL::Size::Make(num_heads, grid_y, 1),
         MTL::Size::Make(NUM_THREADS, 1, 1));
@@ -537,6 +555,10 @@ static void dispatch_paged_attention_v2_online(
   enc.set_output_array(exp_sums, 0);
   enc.set_output_array(max_logits, 1);
   bind_turboquant();
+  // The partitioned kernel does not fold the sink itself (the reduce does, so
+  // it is counted once rather than once per partition), but slot 18 is still a
+  // declared argument under function constant 40, so it must be bound here.
+  bind_sinks();
   enc.dispatch_threadgroups(
       MTL::Size::Make(num_heads, grid_y, max_num_partitions),
       MTL::Size::Make(NUM_THREADS, 1, 1));
@@ -548,7 +570,8 @@ static void dispatch_paged_attention_v2_online(
   // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
   // other function constants are inert for it.  TurboQuant batches take this
   // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
-  // sinks are unsupported and stay false.  The cache key MUST encode every
+  // and sinks are folded here rather than in the partitioned kernel so the
+  // sink logit is counted once globally.  The cache key MUST encode every
   // constant the pipeline is specialized on — otherwise the first compile
   // wins and a later caller with different constants silently reuses the
   // wrong pipeline.
@@ -574,6 +597,9 @@ static void dispatch_paged_attention_v2_online(
   enc.set_input_array(seq_lens, 4);
   int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
   enc.set_bytes(max_num_partitions_i, 5);
+  if (use_sinks) {
+    enc.set_input_array(*sinks, 6);
+  }
   enc.set_input_array(cu_seqlens_q, 7);
   int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
   enc.set_bytes(num_seqs_i, 8);
@@ -596,13 +622,13 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
       Stream stream, int num_kv_heads, float scale, float softcap,
       int block_size, int max_seq_len, int sliding_window,
       bool use_turboquant = false, int k_bits = 8, int v_bits = 3,
-      int window_seqlen_q = 1)
+      int window_seqlen_q = 1, bool use_sinks = false)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
         sliding_window_(sliding_window),
         use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits),
-        window_seqlen_q_(window_seqlen_q) {}
+        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -613,11 +639,14 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
     // Non-TQ inputs: [query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q]
     // TQ inputs:     [query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q,
     //                 key_scale_cache, value_scale_cache, key_zero_cache, v_centroids]
+    // Sinks append one array at slot 6.  TQ and sinks are mutually exclusive
+    // (rejected in paged_attention_primitive_fn), so the two never collide.
     out.set_data(allocator::malloc(out.nbytes()));
     const array* ks = use_turboquant_ ? &inputs[6] : nullptr;
     const array* vs = use_turboquant_ ? &inputs[7] : nullptr;
     const array* kz = use_turboquant_ ? &inputs[8] : nullptr;
     const array* vc = use_turboquant_ ? &inputs[9] : nullptr;
+    const array* sk = use_sinks_ ? &inputs[6] : nullptr;
     dispatch_paged_attention_v2_online(
         out,
         inputs[0],               // query
@@ -626,7 +655,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_, window_seqlen_q_,
         stream(),
-        ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_);
+        ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_, sk);
   }
 
   const char* name() const override { return "PagedAttention"; }
@@ -641,7 +670,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->use_turboquant_ == use_turboquant_
         && rhs->k_bits_ == k_bits_
         && rhs->v_bits_ == v_bits_
-        && rhs->window_seqlen_q_ == window_seqlen_q_;
+        && rhs->window_seqlen_q_ == window_seqlen_q_
+        && rhs->use_sinks_ == use_sinks_;
   }
 
  private:
@@ -655,6 +685,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int k_bits_;
   int v_bits_;
   int window_seqlen_q_;
+  bool use_sinks_;
 };
 
 static array paged_attention_primitive_fn(
@@ -669,7 +700,37 @@ static array paged_attention_primitive_fn(
     const array* value_scale_cache = nullptr,
     const array* key_zero_cache = nullptr,
     const array* v_centroids = nullptr,
-    int v_bits = 3, int window_seqlen_q = 1) {
+    int v_bits = 3, int window_seqlen_q = 1,
+    const array* sinks = nullptr) {
+  if (sinks != nullptr) {
+    // Upstream MLX refuses the same combination
+    // (mlx_lm/models/base.py: "Quantized SDPA does not support attention
+    // sinks"), and the TurboQuant reduce already owns the deferred inverse
+    // FWHT, so folding a sink there would need its own derivation.  Reject
+    // rather than silently drop the sink term.
+    if (use_turboquant) {
+      throw std::invalid_argument(
+          "attention sinks are not supported with TurboQuant quantized KV; "
+          "pass sinks=None or disable TurboQuant for this layer");
+    }
+    if (sinks->ndim() != 1) {
+      throw std::invalid_argument(
+          "sinks must be 1-D with one entry per query head, got ndim=" +
+          std::to_string(sinks->ndim()));
+    }
+    const int num_q_heads = static_cast<int>(query.shape(1));
+    if (static_cast<int>(sinks->shape(0)) != num_q_heads) {
+      throw std::invalid_argument(
+          "sinks must have one entry per query head (" +
+          std::to_string(num_q_heads) + "), got " +
+          std::to_string(sinks->shape(0)));
+    }
+    if (sinks->dtype() != float32) {
+      throw std::invalid_argument(
+          "sinks must be float32; the kernel reads them as device float and "
+          "folds them into a float32 softmax accumulator");
+    }
+  }
   // window_seqlen_q must equal the longest cu_seqlens_q segment: window-mode
   // threadgroups only exist for ceil(window_seqlen_q / kWindowRows)
   // sub-windows per segment, so an understated value leaves the tail rows of
@@ -734,12 +795,18 @@ static array paged_attention_primitive_fn(
       default_stream(Device::gpu),
       num_kv_heads, scale, softcap,
       block_size, max_seq_len, sliding_window,
-      use_turboquant, k_bits, v_bits, window_seqlen_q);
+      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr);
   if (use_turboquant) {
     return array(
         query.shape(), query.dtype(), std::move(prim),
         {query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q,
          *key_scale_cache, *value_scale_cache, *key_zero_cache, *v_centroids});
+  }
+  if (sinks != nullptr) {
+    return array(
+        query.shape(), query.dtype(), std::move(prim),
+        {query, key_cache, value_cache, block_tables, seq_lens, cu_seqlens_q,
+         *sinks});
   }
   return array(
       query.shape(), query.dtype(), std::move(prim),
@@ -1458,7 +1525,10 @@ NB_MODULE(_paged_ops, m) {
            bool use_turboquant,
            const std::string& quant_type,
            int v_bits,
-           int window_seqlen_q) {
+           int window_seqlen_q,
+           nb::object sinks_h) {
+          const array* sk = sinks_h.is_none()
+              ? nullptr : nb::inst_ptr<array>(sinks_h);
           const array* ks = use_turboquant
               ? nb::inst_ptr<array>(key_scale_cache_h) : nullptr;
           const array* vs = use_turboquant
@@ -1477,7 +1547,7 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(cu_seqlens_q_h),
               block_size, max_seq_len, sliding_window,
               use_turboquant, quant_type, ks, vs, kz, vc, v_bits,
-              window_seqlen_q);
+              window_seqlen_q, sk);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -1496,11 +1566,15 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("quant_type") = "",
         nb::arg("v_bits") = 3,
         nb::arg("window_seqlen_q") = 1,
+        nb::arg("sinks") = nb::none(),
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.  window_seqlen_q must equal the "
         "longest cu_seqlens_q segment (validated when > 1); small "
         "multi-token batches (spec-decode verification windows) route to "
-        "the per-token kernel's window mode.");
+        "the per-token kernel's window mode.  sinks is an optional float32 "
+        "array of one learned logit per query head (GPT-OSS style attention "
+        "sinks); it joins the softmax denominator without contributing a "
+        "value row, and is rejected together with TurboQuant.");
 
   m.def("gdn_linear_attention", &gdn_linear_attention_impl,
         nb::arg("q"), nb::arg("k"), nb::arg("v"),

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -285,7 +285,7 @@ static void dispatch_paged_attention_tiled(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    TileConfig cfg, Stream s) {
+    TileConfig cfg, Stream s, const array* sinks = nullptr) {
   auto& d = metal::device(s.device);
 
   int total_q_tokens = static_cast<int>(query.shape(0));
@@ -293,18 +293,22 @@ static void dispatch_paged_attention_tiled(
   int num_seqs   = static_cast<int>(cu_seqlens_q.shape(0)) - 1;
 
   int total_q_blocks = total_q_tokens / cfg.BQ + num_seqs;
+  bool use_sinks = sinks != nullptr;
 
   auto dt = dtype_to_metal(query.dtype());
-  std::string kname =
+  std::string base_kname =
       "paged_attention_tiled_" + dt +
       "_hs" + std::to_string(head_size) +
       "_bs" + std::to_string(block_size) +
       "_bq" + std::to_string(cfg.BQ) +
       "_tk" + std::to_string(cfg.TILE_KV) +
       "_nt" + std::to_string(cfg.NUM_THREADS);
+  std::string hash_name = base_kname + "_sk" + (use_sinks ? "1" : "0");
 
   auto* lib = d.get_library("paged_attention_v2_kern");
-  auto* kernel = d.get_kernel(kname, lib, kname, {});
+  auto* kernel = d.get_kernel(
+      base_kname, lib, hash_name,
+      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)}});
 
   const int t_size = static_cast<int>(query.itemsize());
   // S, O, m, l are register-resident, so no S/O/M/L threadgroup buffers.
@@ -326,6 +330,9 @@ static void dispatch_paged_attention_tiled(
                           num_kv_heads, softcap, block_tables, seq_lens,
                           cu_seqlens_q, sliding_window);
   enc.set_bytes(scale, 9);
+  if (use_sinks) {
+    enc.set_input_array(*sinks, 18);
+  }
 
   enc.dispatch_threadgroups(
       MTL::Size::Make(num_heads, total_q_blocks, 1),
@@ -374,18 +381,16 @@ static void dispatch_paged_attention_v2_online(
   const bool window_batch =
       has_prefill && window_seqlen_q > 1 && head_size <= kWindowMaxHeadSize;
 
-  // Sinks join TurboQuant in being excluded from the tiled kernel:
-  // pagedattention_tiled.metal has no sink code path at all, so a sinks batch
-  // must fall through to the per-token kernel below, which does.  Routing it
-  // to the tiled kernel would silently drop the sink term.
-  if (has_prefill && !window_batch && !use_turboquant && dtype_ok
-      && sinks == nullptr) {
+  // TurboQuant stays excluded from the tiled kernel.  Sink prefill can use it:
+  // pagedattention_tiled.metal folds the sink into each row's denominator-only
+  // softmax state before final normalization.
+  if (has_prefill && !window_batch && !use_turboquant && dtype_ok) {
     if (auto cfg = select_tile_config(head_size)) {
       dispatch_paged_attention_tiled(
           out, query, key_cache, value_cache,
           num_kv_heads, scale, softcap,
           block_tables, seq_lens, cu_seqlens_q,
-          block_size, max_seq_len, sliding_window, *cfg, s);
+          block_size, max_seq_len, sliding_window, *cfg, s, sinks);
       return;
     }
   }

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -285,7 +285,7 @@ static void dispatch_paged_attention_tiled(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    TileConfig cfg, Stream s, const array* sinks = nullptr) {
+    TileConfig cfg, Stream s, const array* sinks) {
   auto& d = metal::device(s.device);
 
   int total_q_tokens = static_cast<int>(query.shape(0));


### PR DESCRIPTION
Closes #212. That issue tracks two things: the ground truth tests, which landed in #221, and sink attention kernel support, which is this.

Two things worth knowing before reading the diff: GPT-OSS doesn't currently run on `main` at all, and the sink code in `pagedattention.metal` had never executed, so two of its three paths were wrong.

## GPT-OSS crashes before sinks even matter

`sdpa_forward` reads `inner.scale`, but GPT-OSS's `AttentionBlock` calls it `sm_scale`, so the engine dies during startup:

```
AttributeError: 'AttentionBlock' object has no attribute 'scale'
```

That's blocker 1 from #212. The head count probe at `sdpa.py:437` was added at some point, but the scale half never was, so nothing generates. This uses the same `getattr` pattern already sitting there for the head counts.

## The sinks were unreachable

`pagedattention.metal` has carried sink support all along: `use_sinks` as function constant 40, the sink array at buffer 18 in the main kernel and buffer 6 in the reduce, plus folding logic in the non-partitioned, split-KV reduce and window paths. None of it could run. `paged_ops.cpp:436` hardcoded `bool use_sinks = false;` and the nanobind signature had no `sinks` argument, so buffers 18 and 6 were never bound.

MLX 0.32 added `sinks=` to `mx.fast.scaled_dot_product_attention`, which gives a first class oracle to check against. On `main`:

```
max|kernel - mlx_sdpa(sinks=None)| = 3.576e-07
max|kernel - mlx_sdpa(sinks=2.0)|  = 4.535e-02
```

Plain softmax exactly, and roughly 45x the fp32 parity tolerance away from the sink case.

## Two of the three sink paths were also wrong

Wiring the argument through wasn't enough. Because the sink code had never run, the per-token kernel and its window mode both folded the sink into every warp's state before the threadgroup merge summed all `NUM_WARPS` states, so the sink landed in the denominator `NUM_WARPS` times.

Pinned by comparing against a reference that deliberately over-counts, on a 256-thread threadgroup with 32-lane simdgroups:

```
sink counted 1x -> max_abs_diff = 1.959e-01
sink counted 8x -> max_abs_diff = 1.788e-07
```

Both now fold the sink exactly once, after the merge completes. The split-KV path was already correct, since `paged_attention_v2_reduce` folds the sink into the global max and exp-sum, counting it once across partitions rather than once per partition. After the fix all three paths agree with the oracle at ~1e-07.

## Prefill routing

`pagedattention_tiled.metal` has no sink support whatsoever, and prefill batches route to it. Rather than silently dropping the sink term, a sinks batch is excluded from the tiled path and falls through to the per-token kernel, mirroring exactly what `use_turboquant` already does in that same condition. Sink support in the tiled kernel is a reasonable follow-up if GPT-OSS prefill throughput warrants it.

## Sinks with TurboQuant

Rejected up front rather than ignored. Upstream refuses the same combination (`mlx_lm/models/base.py`: "Quantized SDPA does not support attention sinks"), and the TurboQuant reduce already owns the deferred inverse FWHT, so folding a sink there would need its own derivation. Failing loudly follows #510 and #523 rather than returning quietly wrong numbers.

## Testing

`tests/test_paged_attention_sinks.py` is deterministic, needs no model download, and runs in well under a second:

- parity against the MLX oracle across fp32/fp16/bf16, GQA ratios (8:8, 8:2, 16:4), head sizes 64 and 128, and both the single-partition and split-KV paths
- per-head sink values, to catch a kernel reading head 0's sink for every head
- window mode against the expanded per-token layout, non-partitioned and split-KV
- a direct pin on the warp multiplication bug
- guards that `sinks=None` leaves the existing path unchanged, and that passing sinks actually changes the output
- fail-fast coverage: wrong head count, non-1D, non-float32, and the TurboQuant combination

Regression: `tests/test_spec_window_parity.py` (102), `tests/test_paged_deterministic.py` (6 golden token IDs against a real model), `tests/test_attention_sdpa.py`, `tests/test_primitive_and_donation.py` and `tests/test_paged_attention.py` all pass. `ruff check`, `ruff format --check` and `mypy vllm_metal` are clean.

Run on an M4 and an M4 Pro, which have different GPU core counts, so the split-KV partition mix differs between the two.

## GPT-OSS 20B end to end

`openai/gpt-oss-20b` on the M4 Pro (48GB), vllm 0.25.1, mlx 0.32.0, greedy, `MAX_TOKENS=100`, via `tools/test_gpt_oss_smoke.py`.

Before, on `main`: 0/5, no tokens generated, hard crash at the `inner.scale` AttributeError above. After: engine healthy, all five prompts generate, and the smoke test scores 2/5 against its committed goldens.

That 2/5 deserves an explanation rather than a shrug, and it isn't the FP non-determinism the file's own comment warns about. Three repeat runs produced bit-identical token IDs, so the divergence is deterministic. Regenerating the reference on the same machine through the MLX inline-cache path (`VLLM_METAL_USE_PAGED_ATTENTION=0`, which bypasses the paged kernel and uses MLX's native sink-aware SDPA) gives:

| prompt | oracle vs committed golden | paged vs oracle |
| --- | --- | --- |
| The capital of France is | identical | **identical** |
| The weather today is not | differs @ 56 | **identical** |
| One plus one equals | differs @ 49 | differs @ 19 |
| The largest planet in our solar system is | differs @ 29 | **identical** |
| Water boils at a temperature of | identical | **identical** |

So four of five are bit-identical to a same-machine MLX reference. Two of the three smoke-test failures are stale committed goldens: the oracle diverges from them at the same indices the paged run did, and the file's own note says to regenerate when that happens. Worth fixing, but it's a separate change from this one.

The remaining divergence is a semantic near-tie, `' 2.'` against `' "Two".'`, which re-syncs after three tokens and stays aligned. That argues against a sink defect: a wrong sink term biases the softmax denominator at every step, so sequences would drift apart rather than re-converge. Taken with the unit tests matching `mx.fast.scaled_dot_product_attention` at ~1e-07 across all three sink paths, this reads as marginal-logit tie-breaking.

The before/after is gated by a probe that asserts the rebuilt extension matches the checked-out branch (`sinks` absent on `main`, present here) and aborts rather than reporting a number from a stale `.so`.
