### PR TITLE
[Spec Decode] Release drafter state for evicted, preempted, and resumed requests

### DIFF
--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the draft-model proposer's draft KV block pool.
+
+A stub draft model returns logits of the right shape, so the block allocator and
+the release path run through ``propose`` without loading any weights.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_metal.attention.context import OffsetCache, get_context
+from vllm_metal.v1.draft_model_proposer import DraftModelProposer
+from vllm_metal.v1.model_runner import RequestState
+from vllm_metal.v1.proposer import ProposeContext
+from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+BLOCK_SIZE = 16
+NUM_BLOCKS = 2
+VOCAB_SIZE = 8
+# Long enough that one request plus its drafted position spans the whole pool.
+PROMPT_LEN = 20
+
+
+class _StubDraftModel:
+    """mlx_lm-shaped draft model: logits per input token, recorded block tables."""
+
+    def __init__(self) -> None:
+        self.block_tables: list[list[list[int]]] = []
+
+    def __call__(self, input_ids: mx.array, *, cache: list[OffsetCache]) -> mx.array:
+        ctx = get_context()
+        assert ctx is not None
+        self.block_tables.append([list(block_ids) for block_ids in ctx.block_tables])
+        return mx.zeros((1, int(input_ids.shape[1]), VOCAB_SIZE), dtype=mx.float32)
+
+
+def _proposer(model: _StubDraftModel) -> DraftModelProposer:
+    return DraftModelProposer(
+        model=model,
+        block_size=BLOCK_SIZE,
+        num_blocks=NUM_BLOCKS,
+        num_layers=1,
+        controller=SpeculativeDecodeController(),
+        extract_logits=lambda output: output,
+    )
+
+
+def _request_state() -> RequestState:
+    return RequestState(
+        token_ids=list(range(PROMPT_LEN)),
+        prompt_len=PROMPT_LEN,
+        cache=[],
+        sampling_params=SamplingParams(temperature=0.0),
+    )
+
+
+def _context(
+    req_id: str,
+    state: RequestState,
+    request_states: dict[str, RequestState],
+) -> ProposeContext:
+    return ProposeContext(
+        target_hidden_states=None,
+        decode_reqs=[(req_id, state)],
+        decode_segments=[],
+        decode_token_ids=[[state.token_ids[-1]]],
+        prefill_reqs=[],
+        prefill_token_ids=[],
+        prefill_result_modes=[],
+        request_states=request_states,
+        cu_seqlens=[],
+        num_decode_segments=1,
+        num_speculative_tokens=1,
+        logitsprocs=None,
+        finished_req_ids=set(),
+    )
+
+
+def _drafting_blocks(model: _StubDraftModel, forward_index: int) -> set[int]:
+    (block_ids,) = model.block_tables[forward_index]
+    return set(block_ids)
+
+
+def test_release_requests_returns_draft_blocks_to_the_free_pool() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    waiting, resumed = _request_state(), _request_state()
+    # A preempted request keeps its RequestState, so the finished-request sweep
+    # inside propose() never reclaims its blocks.
+    request_states = {"waiting": waiting, "resumed": resumed}
+
+    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+    pool = _drafting_blocks(model, 0)
+    assert len(pool) == NUM_BLOCKS
+
+    proposer.release_requests({"waiting"})
+
+    drafts = proposer.propose(_context("resumed", resumed, request_states))
+
+    assert drafts is not None
+    assert list(drafts.req_ids) == ["resumed"]
+    assert _drafting_blocks(model, 1) == pool
+
+
+def test_draft_blocks_stay_pinned_without_release() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    waiting, resumed = _request_state(), _request_state()
+    request_states = {"waiting": waiting, "resumed": resumed}
+
+    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        proposer.propose(_context("resumed", resumed, request_states))
+
+    assert "'resumed'" in str(excinfo.value)
+    # Allocation fails before any draft forward runs.
+    assert len(model.block_tables) == 1

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -85,6 +85,35 @@ def test_gemma4_mtp_config_installs_gemma4_proposer() -> None:
     assert isinstance(runner._drafter, Gemma4MTPProposer)
 
 
+class TestDrafterReleaseOnLifecycle:
+    def test_reconcile_releases_drafter_state_for_invalidated_requests(self) -> None:
+        released: list[set[str]] = []
+
+        class _RecordingDrafter:
+            def needs_target_hidden_states(self, *args, **kwargs) -> bool:
+                return False
+
+            def propose(self, ctx) -> None:
+                return None
+
+            def release_requests(self, req_ids: set[str]) -> None:
+                released.append(set(req_ids))
+
+        runner = make_stub_runner(tokenizer=object())
+        runner._drafter = _RecordingDrafter()
+
+        # Eviction + preemption + resume all invalidate the drafter's per-request
+        # state, mirroring the runtime recurrent-state release path.
+        runner._reconcile_request_lifecycle(
+            {"done"},
+            preempted_req_ids={"paused"},
+            resumed_req_ids={"back"},
+            materialize_runtime_state=False,
+        )
+
+        assert released == [{"done", "paused", "back"}]
+
+
 class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -207,6 +207,17 @@ class DraftModelProposer:
             draft_token_ids=[[int(token) for token in row] for row in rows],
         )
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # Return a preempted/evicted request's draft KV blocks to the free pool
+        # and drop its committed-length bookkeeping, so it does not pin draft
+        # cache while it waits; a resumed request re-ingests from the paged
+        # context. Mirrors _prune_finished for an explicit lifecycle set.
+        for req_id in req_ids:
+            blocks = self._req_blocks.pop(req_id, None)
+            if blocks is not None:
+                self._free_blocks.extend(blocks)
+            self._draft_seq_lens.pop(req_id, None)
+
     # -- internals -----------------------------------------------------------
 
     def _prune_finished(self, request_states: Any) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -2208,14 +2208,22 @@ class MetalModelRunner:
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
 
+        invalidated = set(evicted_req_ids)
+        if preempted_req_ids:
+            invalidated.update(preempted_req_ids)
+        if resumed_req_ids:
+            invalidated.update(resumed_req_ids)
+
+        # A drafter that pins a bounded per-request resource (draft cache blocks)
+        # releases it on the same events as the runtime's recurrent state: a
+        # waiting or preempted request must not keep holding the resource, and a
+        # resumed request re-acquires it during recompute.
+        if invalidated and self._drafter is not None:
+            self._drafter.release_requests(invalidated)
+
         if runtime is not None:
-            runtime_invalidated = set(evicted_req_ids)
-            if preempted_req_ids:
-                runtime_invalidated.update(preempted_req_ids)
-            if resumed_req_ids:
-                runtime_invalidated.update(resumed_req_ids)
-            if runtime_invalidated:
-                runtime.release_requests(runtime_invalidated)
+            if invalidated:
+                runtime.release_requests(invalidated)
             if materialize_runtime_state:
                 runtime.materialize_pending_state()
 

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -147,6 +147,12 @@ class NgramProposer:
         # N-gram matches token ids only; it never reads the target's hidden states.
         return False
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The miss-streak throttle is per-request bookkeeping, not a bounded
+        # resource: a preempted request keeps its counters across resume, and
+        # they are dropped when its id finishes.
+        del req_ids
+
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         # Bookkeeping runs unconditionally, before the num_speculative_tokens
         # check: a step with drafting disabled still needs finished ids

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -63,11 +63,7 @@ class ProposeContext:
 
 
 class MetalProposer(Protocol):
-    """Uniform drafting seam.
-
-    Implementations: :class:`Gemma4MTPProposer`, and (draft-model SD) a
-    ``DraftModelProposer``.
-    """
+    """Uniform drafting seam."""
 
     def needs_target_hidden_states(
         self,
@@ -80,6 +76,16 @@ class MetalProposer(Protocol):
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         """Return per-request draft tokens for the next step, or ``None``."""
+        ...
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        """Release any per-request drafter state for these evicted/preempted ids.
+
+        Called from the runner's lifecycle reconcile on eviction, preemption, and
+        resume. A proposer that pins a bounded per-request resource (draft cache
+        blocks) must release it here rather than hold it while the request waits;
+        a stateless proposer is a no-op.
+        """
         ...
 
 
@@ -105,6 +111,11 @@ class Gemma4MTPProposer:
         # decode and final-prefill rows; intermediate prefill chunks never
         # sample, so they cannot seed a draft.
         return bool(decode_segments) or has_final_prefill
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The assistant reads the target's paged KV (released by the runtime);
+        # the proposer holds no per-request state of its own.
+        del req_ids
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         if ctx.num_speculative_tokens <= 0:


### PR DESCRIPTION
The runner's lifecycle reconcile released the paged runtime's recurrent state for evicted, preempted, and resumed requests, but the drafter's own per-request state was never released. A request that stops running keeps pinning a bounded drafter resource for as long as it waits.

I added `release_requests` to the `MetalProposer` seam and call it from `_reconcile_request_lifecycle` on the same invalidation set the runtime already uses (evicted + preempted + resumed). `DraftModelProposer` returns the request's draft KV blocks to its free pool and drops its committed-length bookkeeping, so a waiting request no longer holds draft cache; a resumed request re-ingests from the paged context and draws fresh blocks. The n-gram and Gemma4 proposers pin no bounded resource, so they are no-ops.

The pinning is real rather than theoretical: a preempted request keeps its `RequestState`, so `DraftModelProposer._prune_finished` never reclaims its blocks — only an explicit release can.

Tests:

- `tests/test_draft_model_proposer.py::test_release_requests_returns_draft_blocks_to_the_free_pool` drives allocation through `propose()` with a stub draft model until the block pool is drained, releases the waiting request, and asserts the next request is handed the same block ids. `test_draft_blocks_stay_pinned_without_release` is the paired negative: without the release the allocator fails before any draft forward runs.
- `tests/test_v1_model_runner_generate.py::TestDrafterReleaseOnLifecycle` covers the runner side — the drafter receives the union of evicted, preempted, and resumed ids.

`pytest -m "not slow" tests/` — 1622 passed, 15 skipped, 46 deselected.

This is the first of a small series splitting #535 as requested: the drafter release seam (here), the hosted-config front door, the GLM-4.7-Flash MTP head model and loader, the runtime path that runs it as a drafter (carrying a download-free engine-level test), and the benchmark helper with docs.
