### PR TITLE
Remove old text-only compat mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
-| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` / `text-only-compat` use the compatibility allowlist; `multimodal-native` disables overrides |
+| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` uses the compatibility allowlist; `multimodal-native` disables overrides |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |
 | `VLLM_METAL_GDN_LAZY_KERNELS` | `1` | Enable lazy GDN kernels for eligible hybrid batches. Set to `0` to force the eager conv / C++ recurrent fallback path. |
@@ -22,7 +22,6 @@
 ## Multimodal Serve Modes
 
 - `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
-- `text-only-compat`: use the same compatibility allowlist as `auto`.
 - `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
 
 ## Speculative Decoding

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,18 +145,8 @@ class TestMetalConfig:
         assert config.k_quant == "q8_0"
         assert config.v_quant == "q3_0"
 
-    def test_text_only_compat_mode_is_accepted(self) -> None:
-        config = MetalConfig(
-            memory_fraction=AUTO_MEMORY_FRACTION,
-            use_mlx=True,
-            mlx_device="gpu",
-            debug=False,
-            use_paged_attention=True,
-            multimodal_mode="text-only-compat",
-        )
-        assert config.multimodal_mode == "text-only-compat"
-
-    def test_invalid_multimodal_mode_rejected(self) -> None:
+    @pytest.mark.parametrize("mode", ["text-only-compat", "vlm"])
+    def test_invalid_multimodal_mode_rejected(self, mode: str) -> None:
         with pytest.raises(ValueError, match="Invalid VLLM_METAL_MULTIMODAL_MODE"):
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
@@ -164,7 +154,7 @@ class TestMetalConfig:
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=True,
-                multimodal_mode="vlm",  # type: ignore[arg-type]
+                multimodal_mode=mode,  # type: ignore[arg-type]
             )
 
     def test_turboquant_requires_paged_attention(self) -> None:

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -70,32 +70,6 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
 
-    def test_text_only_compat_mode_forces_allowlisted_text_backbone(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-
-        hf_config = SimpleNamespace(
-            model_type="qwen3_6",
-            architectures=["Qwen3_6MoeForConditionalGeneration"],
-            quantization_config={"quant_method": "fp8"},
-        )
-        adapter = DefaultModelAdapter()
-        result = adapter.should_force_text_backbone(hf_config)
-        assert result is True
-
-    def test_text_only_compat_mode_does_not_force_generic_vlm(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-
-        hf_config = SimpleNamespace(model_type="phi3_v")
-        adapter = DefaultModelAdapter()
-        result = adapter.should_force_text_backbone(hf_config)
-        assert result is False
-
     def test_multimodal_native_mode_disables_auto_override(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
         reset_config()
@@ -335,39 +309,6 @@ class TestNormalizeModelConfig:
 
         assert model_config.multimodal_config is None
 
-    def test_text_only_compat_mode_clears_multimodal_for_allowlisted_vlm(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-
-        model_config = SimpleNamespace(
-            multimodal_config=SimpleNamespace(language_model_only=False),
-            hf_config=SimpleNamespace(
-                model_type="qwen3_6",
-                architectures=["Qwen3_6ForConditionalGeneration"],
-                quantization_config={"quant_method": "fp8"},
-            ),
-        )
-
-        DefaultModelAdapter().normalize_model_config(model_config)
-
-        assert model_config.multimodal_config is None
-
-    def test_text_only_compat_mode_preserves_generic_vlm(self, monkeypatch) -> None:
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-
-        sentinel = SimpleNamespace(language_model_only=False)
-        model_config = SimpleNamespace(
-            multimodal_config=sentinel,
-            hf_config=SimpleNamespace(model_type="phi3_v"),
-        )
-
-        DefaultModelAdapter().normalize_model_config(model_config)
-
-        assert model_config.multimodal_config is sentinel
-
     def test_preserves_multimodal_config_for_other_models(self) -> None:
         sentinel = SimpleNamespace(language_model_only=False)
         model_config = SimpleNamespace(
@@ -408,22 +349,6 @@ class TestNormalizeModelConfig:
         DefaultModelAdapter().normalize_model_config(model_config)
 
         assert model_config.multimodal_config is None
-
-    def test_text_only_compat_mode_preserves_missing_hf_config(
-        self, monkeypatch
-    ) -> None:
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-
-        sentinel = SimpleNamespace(language_model_only=False)
-        model_config = SimpleNamespace(
-            multimodal_config=sentinel,
-            hf_config=None,
-        )
-
-        DefaultModelAdapter().normalize_model_config(model_config)
-
-        assert model_config.multimodal_config is sentinel
 
 
 class TestTextModel:

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -510,32 +510,9 @@ class TestModelLifecycle:
         assert runner.tokenizer is vlm_tokenizer
         assert runner._is_vlm is True
 
-    def test_load_text_only_compat_mode_keeps_generic_vlm_native(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-        _stub_generation_model(
-            monkeypatch,
-            config=SimpleNamespace(text_config=_text_config()),
-            is_vlm=True,
-        )
-        lifecycle, runner = _make_lifecycle(
-            model_config=_runner_model_config(
-                hf_config=SimpleNamespace(model_type="phi3_v"),
-                is_multimodal_model=True,
-            )
-        )
-
-        lifecycle.load()
-
-        assert runner._is_vlm is True
-
     @pytest.mark.slow
-    def test_load_text_only_compat_real_qwen_fp8_checkpoint(
+    def test_load_auto_mode_real_qwen_fp8_checkpoint(
         self,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         model_path = os.environ.get("VLLM_METAL_QWEN_FP8_COMPAT_MODEL_PATH")
         if not model_path:
@@ -547,8 +524,6 @@ class TestModelLifecycle:
 
         from vllm_metal.compat import _patch_mlx_lm_qwen35_fp8_sanitize
 
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
         Gemma4MTPAssistantLoader.clear_cache()
         _patch_mlx_lm_qwen35_fp8_sanitize()
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1484,54 +1484,6 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
-    def test_check_and_update_config_text_only_compat_preserves_generic_vlm(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        self._patch_stt_resolution(monkeypatch, is_stt=False)
-        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
-        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only-compat")
-        reset_config()
-        try:
-            sentinel = SimpleNamespace(language_model_only=False)
-            model_config = SimpleNamespace(
-                model="test-model",
-                disable_cascade_attn=False,
-                tokenizer=None,
-                max_model_len=128,
-                multimodal_config=sentinel,
-                hf_config=SimpleNamespace(model_type="phi3_v"),
-                is_hybrid=False,
-            )
-            vllm_config = SimpleNamespace(
-                speculative_config=None,
-                parallel_config=SimpleNamespace(
-                    worker_cls="auto",
-                    distributed_executor_backend="auto",
-                    pipeline_parallel_size=1,
-                    tensor_parallel_size=1,
-                    disable_custom_all_reduce=False,
-                ),
-                cache_config=SimpleNamespace(
-                    kv_cache_dtype_skip_layers=[],
-                    block_size=None,
-                    enable_prefix_caching=False,
-                ),
-                model_config=model_config,
-                scheduler_config=SimpleNamespace(
-                    async_scheduling=False,
-                    enable_chunked_prefill=True,
-                    max_num_batched_tokens=2048,
-                    max_num_scheduled_tokens=None,
-                ),
-            )
-
-            MetalPlatform.check_and_update_config(vllm_config)
-
-            assert model_config.multimodal_config is sentinel
-
-        finally:
-            reset_config()
-
     def test_synchronize_runs_mlx_barrier(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -24,9 +24,9 @@ TURBOQUANT_VALID_V_QUANTS: frozenset[str] = frozenset(
     {"q2_0", "q3_0", "q4_0", "q5_0", "q8_0"}
 )
 
-MultimodalMode = Literal["auto", "text-only-compat", "multimodal-native"]
+MultimodalMode = Literal["auto", "multimodal-native"]
 VALID_MULTIMODAL_MODES: frozenset[MultimodalMode] = frozenset(
-    {"auto", "text-only-compat", "multimodal-native"}
+    {"auto", "multimodal-native"}
 )
 
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -53,8 +53,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the
     #   text-only compatibility path.
-    # - "text-only-compat": force known-safe multimodal checkpoints onto the
-    #   text-only compatibility path.
     # - "multimodal-native": keep native multimodal loading enabled.
     "VLLM_METAL_MULTIMODAL_MODE": lambda: os.getenv(
         "VLLM_METAL_MULTIMODAL_MODE", "auto"

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -251,8 +251,8 @@ class DefaultModelAdapter(ModelAdapter):
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether the current serve mode should use the text-only path.
 
-        ``multimodal-native`` disables compatibility overrides. ``auto`` and
-        ``text-only-compat`` share the same compatibility allowlist.
+        ``multimodal-native`` disables compatibility overrides. ``auto`` uses
+        the compatibility allowlist.
         """
         multimodal_mode = self._multimodal_mode()
         if multimodal_mode == "multimodal-native":


### PR DESCRIPTION
This PR is:

- To remove the old `text-only-compat` multimodal mode.
- To keep `auto` as the normal compatibility mode.
- To keep `multimodal-native` for testing native multimodal loading.
- To delete duplicate tests for the old alias.

`text-only-compat` no longer had its own behavior. It did the same thing as `auto`, so keeping both made the config and tests harder to read.

Note: `VLLM_METAL_MULTIMODAL_MODE=text-only-compat` no longer works. Use `auto` or unset the env var instead.