### PR TITLE
[Spec Decode] Register the GLM-4.7-Flash MTP head config for vLLM

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -7,6 +7,7 @@ import builtins
 import importlib.util
 import json
 import os
+import pickle
 import sys
 from types import ModuleType
 
@@ -90,6 +91,65 @@ def _write_gemma4_assistant_config(path) -> None:
         },
         "tie_word_embeddings": True,
         "use_ordered_embeddings": True,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm4_moe_lite_mtp_config(path) -> None:
+    # The literal hosted-checkpoint schema emitted by the mlx-vlm drafter split:
+    # a top-level glm4_moe_lite_mtp with NO top-level architectures, the source
+    # model config nested under text_config (which carries architectures, the
+    # shape fields, and num_nextn_predict_layers).
+    config = {
+        "block_size": 2,
+        "model_type": "glm4_moe_lite_mtp",
+        "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "quantization_config": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "text_config": {
+            "architectures": ["Glm4MoeLiteForCausalLM"],
+            "model_type": "glm4_moe_lite",
+            "hidden_size": 2048,
+            "vocab_size": 154880,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64,
+            "qk_nope_head_dim": 192,
+            "v_head_dim": 256,
+            "num_attention_heads": 20,
+            "num_key_value_heads": 20,
+            "n_routed_experts": 64,
+            "n_shared_experts": 1,
+            "moe_intermediate_size": 1536,
+            "intermediate_size": 10240,
+            "first_k_dense_replace": 1,
+            "num_hidden_layers": 47,
+            "num_nextn_predict_layers": 1,
+            "rope_theta": 1000000.0,
+            "rms_norm_eps": 1e-5,
+            "tie_word_embeddings": False,
+        },
+        "tie_word_embeddings": False,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm4_moe_lite_target_config(path) -> None:
+    # A minimal raw glm4_moe_lite target config (the checkpoint the head drafts
+    # for), enough for a download-free target ModelConfig.
+    config = {
+        "architectures": ["Glm4MoeLiteForCausalLM"],
+        "model_type": "glm4_moe_lite",
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "num_key_value_heads": 20,
+        "num_hidden_layers": 47,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+        "max_position_embeddings": 4096,
     }
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
@@ -282,10 +342,170 @@ class TestGemma4MTPConfigCompatPatch:
             "_patch_mlx_lm_gemma4_kv_shared_sanitize",
             lambda: calls.append("gemma4_kv"),
         )
+        # Stub the GLM MTP config patch too, so this unrelated test does not run
+        # the real one (which would register glm4_moe_lite_mtp with AutoConfig).
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_glm4_moe_lite_mtp_config_loading",
+            lambda: calls.append("glm4_mtp"),
+        )
 
         compat.apply_compat_patches()
 
-        assert calls == ["bytelevel", "qwen35_fp8", "gemma4_kv"]
+        assert calls == ["glm4_mtp", "bytelevel", "qwen35_fp8", "gemma4_kv"]
+
+
+class TestGlm4MoeLiteMTPConfigCompatPatch:
+    def test_transformers_autoconfig_loads_raw_glm4_moe_lite_mtp_config(
+        self,
+        tmp_path,
+    ) -> None:
+        from transformers import AutoConfig
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        assert config.model_type == "glm4_moe_lite_mtp"
+        # architectures and the nextn depth are promoted out of the nested
+        # text_config so vLLM's top-level-keyed MTP override can run.
+        assert config.architectures == ["Glm4MoeLiteForCausalLM"]
+        assert config.num_nextn_predict_layers == 1
+        assert config.get_text_config().model_type == "glm4_moe_lite"
+        assert config.get_text_config().num_hidden_layers == 47
+        assert config.get_text_config().hidden_size == 2048
+
+    def test_compat_config_survives_pickle_round_trip(self, tmp_path) -> None:
+        # vLLM's spawn-based EngineCore pickles the draft config into the worker
+        # process, so the promoted head config must round-trip through pickle
+        # (a closure-scoped config class cannot, and fails only in the real
+        # engine, not in-process config tests).
+        from transformers import AutoConfig
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        restored = pickle.loads(pickle.dumps(config))
+
+        assert restored.model_type == "glm4_moe_lite_mtp"
+        assert restored.architectures == ["Glm4MoeLiteForCausalLM"]
+        assert restored.num_nextn_predict_layers == 1
+        assert restored.get_text_config().model_type == "glm4_moe_lite"
+        assert restored.get_text_config().num_hidden_layers == 47
+
+    def test_vllm_get_config_applies_existing_glm4_moe_lite_mtp_override(
+        self,
+        tmp_path,
+    ) -> None:
+        from vllm.config.speculative import SpeculativeConfig
+        from vllm.transformers_utils.config import get_config
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        config = get_config(
+            tmp_path,
+            trust_remote_code=False,
+            hf_overrides_fn=SpeculativeConfig.hf_config_override,
+        )
+
+        # vLLM's override normalizes the promoted top-level config into the MTP
+        # wrapper form (this is the front door that crashed on the raw hosted
+        # config before the shim promoted architectures + nextn depth).
+        assert config.model_type == "glm4_moe_lite_mtp"
+        assert config.architectures == ["Glm4MoeLiteMTPModel"]
+        assert config.num_hidden_layers == 0
+        assert config.n_predict == 1
+
+    def test_speculative_config_builds_from_hosted_head(self, tmp_path) -> None:
+        from vllm.config import ModelConfig, ParallelConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        _write_glm4_moe_lite_target_config(target_dir)
+        draft_dir = tmp_path / "draft"
+        draft_dir.mkdir()
+        _write_glm4_moe_lite_mtp_config(draft_dir)
+
+        target = ModelConfig(
+            model=str(target_dir),
+            tokenizer=str(target_dir),
+            trust_remote_code=False,
+            dtype="bfloat16",
+            seed=0,
+            skip_tokenizer_init=True,
+        )
+        spec = SpeculativeConfig(
+            target_model_config=target,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            model=str(draft_dir),
+            num_speculative_tokens=1,
+        )
+
+        assert spec.method == "mtp"
+        assert spec.num_speculative_tokens == 1
+        draft_hf = spec.draft_model_config.hf_config
+        assert draft_hf.model_type == "glm4_moe_lite_mtp"
+        assert draft_hf.architectures == ["Glm4MoeLiteMTPModel"]
+        assert draft_hf.n_predict == 1
+
+    def test_missing_glm4_config_module_does_not_stop_other_patches(
+        self,
+        monkeypatch,
+    ) -> None:
+        calls: list[str] = []
+
+        monkeypatch.setattr(compat, "_APPLIED", False)
+        monkeypatch.setattr(
+            compat,
+            "_transformers_knows_glm4_moe_lite_mtp",
+            lambda _auto_config: False,
+        )
+
+        def _raise_missing_glm4_config():
+            raise ModuleNotFoundError(
+                "No module named 'transformers.models.glm4_moe_lite'"
+            )
+
+        monkeypatch.setattr(
+            compat,
+            "_glm4_moe_lite_mtp_config_class",
+            _raise_missing_glm4_config,
+        )
+        # Stub the surrounding patches so only the caught behavior of the GLM
+        # config patch is exercised.
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_gemma4_mtp_config_loading",
+            lambda: calls.append("gemma4_mtp"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_bytelevel_tokenizer_loading",
+            lambda: calls.append("bytelevel"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_qwen35_fp8_sanitize",
+            lambda: calls.append("qwen35_fp8"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_gemma4_kv_shared_sanitize",
+            lambda: calls.append("gemma4_kv"),
+        )
+
+        # The GLM patch swallows the missing-module import error and returns, so
+        # every other patch still runs.
+        compat.apply_compat_patches()
+
+        assert calls == ["gemma4_mtp", "bytelevel", "qwen35_fp8", "gemma4_kv"]
 
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the draft-model proposer's draft KV block pool.
+
+A stub draft model returns logits of the right shape, so the block allocator and
+the release path run through ``propose`` without loading any weights.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_metal.attention.context import OffsetCache, get_context
+from vllm_metal.v1.draft_model_proposer import DraftModelProposer
+from vllm_metal.v1.model_runner import RequestState
+from vllm_metal.v1.proposer import ProposeContext
+from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+BLOCK_SIZE = 16
+NUM_BLOCKS = 2
+VOCAB_SIZE = 8
+# Long enough that one request plus its drafted position spans the whole pool.
+PROMPT_LEN = 20
+
+
+class _StubDraftModel:
+    """mlx_lm-shaped draft model: logits per input token, recorded block tables."""
+
+    def __init__(self) -> None:
+        self.block_tables: list[list[list[int]]] = []
+
+    def __call__(self, input_ids: mx.array, *, cache: list[OffsetCache]) -> mx.array:
+        ctx = get_context()
+        assert ctx is not None
+        self.block_tables.append([list(block_ids) for block_ids in ctx.block_tables])
+        return mx.zeros((1, int(input_ids.shape[1]), VOCAB_SIZE), dtype=mx.float32)
+
+
+def _proposer(model: _StubDraftModel) -> DraftModelProposer:
+    return DraftModelProposer(
+        model=model,
+        block_size=BLOCK_SIZE,
+        num_blocks=NUM_BLOCKS,
+        num_layers=1,
+        controller=SpeculativeDecodeController(),
+        extract_logits=lambda output: output,
+    )
+
+
+def _request_state() -> RequestState:
+    return RequestState(
+        token_ids=list(range(PROMPT_LEN)),
+        prompt_len=PROMPT_LEN,
+        cache=[],
+        sampling_params=SamplingParams(temperature=0.0),
+    )
+
+
+def _context(
+    req_id: str,
+    state: RequestState,
+    request_states: dict[str, RequestState],
+) -> ProposeContext:
+    return ProposeContext(
+        target_hidden_states=None,
+        decode_reqs=[(req_id, state)],
+        decode_segments=[],
+        decode_token_ids=[[state.token_ids[-1]]],
+        prefill_reqs=[],
+        prefill_token_ids=[],
+        prefill_result_modes=[],
+        request_states=request_states,
+        cu_seqlens=[],
+        num_decode_segments=1,
+        num_speculative_tokens=1,
+        logitsprocs=None,
+        finished_req_ids=set(),
+    )
+
+
+def _drafting_blocks(model: _StubDraftModel, forward_index: int) -> set[int]:
+    (block_ids,) = model.block_tables[forward_index]
+    return set(block_ids)
+
+
+def test_release_requests_returns_draft_blocks_to_the_free_pool() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    waiting, resumed = _request_state(), _request_state()
+    # A preempted request keeps its RequestState, so the finished-request sweep
+    # inside propose() never reclaims its blocks.
+    request_states = {"waiting": waiting, "resumed": resumed}
+
+    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+    pool = _drafting_blocks(model, 0)
+    assert len(pool) == NUM_BLOCKS
+
+    proposer.release_requests({"waiting"})
+
+    drafts = proposer.propose(_context("resumed", resumed, request_states))
+
+    assert drafts is not None
+    assert list(drafts.req_ids) == ["resumed"]
+    assert _drafting_blocks(model, 1) == pool
+
+
+def test_draft_blocks_stay_pinned_without_release() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    waiting, resumed = _request_state(), _request_state()
+    request_states = {"waiting": waiting, "resumed": resumed}
+
+    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        proposer.propose(_context("resumed", resumed, request_states))
+
+    assert "'resumed'" in str(excinfo.value)
+    # Allocation fails before any draft forward runs.
+    assert len(model.block_tables) == 1

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -85,6 +85,35 @@ def test_gemma4_mtp_config_installs_gemma4_proposer() -> None:
     assert isinstance(runner._drafter, Gemma4MTPProposer)
 
 
+class TestDrafterReleaseOnLifecycle:
+    def test_reconcile_releases_drafter_state_for_invalidated_requests(self) -> None:
+        released: list[set[str]] = []
+
+        class _RecordingDrafter:
+            def needs_target_hidden_states(self, *args, **kwargs) -> bool:
+                return False
+
+            def propose(self, ctx) -> None:
+                return None
+
+            def release_requests(self, req_ids: set[str]) -> None:
+                released.append(set(req_ids))
+
+        runner = make_stub_runner(tokenizer=object())
+        runner._drafter = _RecordingDrafter()
+
+        # Eviction + preemption + resume all invalidate the drafter's per-request
+        # state, mirroring the runtime recurrent-state release path.
+        runner._reconcile_request_lifecycle(
+            {"done"},
+            preempted_req_ids={"paused"},
+            resumed_req_ids={"back"},
+            materialize_runtime_state=False,
+        )
+
+        assert released == [{"done", "paused", "back"}]
+
+
 class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -15,6 +15,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from transformers.configuration_utils import PretrainedConfig
+
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
@@ -28,6 +30,7 @@ def apply_compat_patches() -> None:
         return
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
+    _patch_vllm_glm4_moe_lite_mtp_config_loading()
     _patch_vllm_bytelevel_tokenizer_loading()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
@@ -289,6 +292,117 @@ def _patch_vllm_gemma4_mtp_config_loading() -> None:
     # override runs.
     AutoConfig.register("gemma4_assistant", config_cls, exist_ok=True)
     logger.debug("Registered Gemma4 assistant config compatibility")
+
+
+@lru_cache(maxsize=1)
+def _glm4_moe_lite_config_cls() -> type[Any]:
+    """The base Transformers config the nextn head nests under ``text_config``.
+
+    Imported lazily so a Transformers release without ``glm4_moe_lite`` raises
+    here (caught by the caller) rather than at module import.
+    """
+    from transformers.models.glm4_moe_lite.configuration_glm4_moe_lite import (
+        Glm4MoeLiteConfig,
+    )
+
+    return Glm4MoeLiteConfig
+
+
+class Glm4MoeLiteMTPCompatConfig(PretrainedConfig):
+    """Transformers config for the GLM-4.7-Flash nextn head.
+
+    The mlx-vlm drafter split nests the source model config under ``text_config``
+    and leaves the head's own ``architectures`` / ``num_nextn_predict_layers`` out
+    of the top level. vLLM's MTP override keys on the top-level ``architectures[0]``
+    (``Glm4MoeLiteForCausalLM``) and ``num_nextn_predict_layers`` to normalize the
+    draft into ``Glm4MoeLiteMTPModel`` (``num_hidden_layers=0``, ``n_predict=1``),
+    so promote both from the nested config before that override runs.
+
+    Defined at module scope (not a closure) so vLLM's spawn-based EngineCore can
+    pickle a config instance by qualified name into the worker process.
+    """
+
+    model_type = "glm4_moe_lite_mtp"
+
+    def __init__(self, text_config: Any | None = None, **kwargs: Any) -> None:
+        base = _glm4_moe_lite_config_cls()
+        if text_config is None:
+            self.text_config = base()
+        elif isinstance(text_config, base):
+            self.text_config = text_config
+        elif isinstance(text_config, Mapping):
+            self.text_config = base(**text_config)
+        else:
+            self.text_config = text_config
+        kwargs.setdefault(
+            "architectures", getattr(self.text_config, "architectures", None)
+        )
+        if "num_nextn_predict_layers" not in kwargs:
+            nextn = getattr(self.text_config, "num_nextn_predict_layers", None)
+            if nextn is not None:
+                kwargs["num_nextn_predict_layers"] = nextn
+        super().__init__(**kwargs)
+
+    def get_text_config(self, decoder: bool = False) -> Any:
+        return self.text_config
+
+
+def _glm4_moe_lite_mtp_config_class() -> type[Any]:
+    """Return the GLM-4.7-Flash nextn head config, wiring its nested
+    ``text_config`` sub-config. Raises if the pinned Transformers lacks
+    ``glm4_moe_lite`` (caught by the caller).
+    """
+    Glm4MoeLiteMTPCompatConfig.sub_configs = {
+        "text_config": _glm4_moe_lite_config_cls()
+    }
+    return Glm4MoeLiteMTPCompatConfig
+
+
+def _transformers_knows_glm4_moe_lite_mtp(auto_config: Any) -> bool:
+    try:
+        auto_config.for_model("glm4_moe_lite_mtp")
+    except ValueError:
+        return False
+    return True
+
+
+def _patch_vllm_glm4_moe_lite_mtp_config_loading() -> None:
+    """Register the GLM-4.7-Flash ``glm4_moe_lite_mtp`` draft config for the pin.
+
+    vLLM normalizes a ``Glm4MoeLiteForCausalLM`` draft config into the
+    ``glm4_moe_lite_mtp`` MTP wrapper (``num_hidden_layers=0``,
+    ``n_predict=num_nextn_predict_layers``), but the pinned Transformers release
+    has no ``glm4_moe_lite_mtp`` AutoConfig entry, so parsing the head
+    checkpoint's ``model_type`` fails before that override runs. The shim covers
+    config parsing only and never constructs a model. Mirrors
+    ``_patch_vllm_gemma4_mtp_config_loading``.
+    """
+    try:
+        from transformers import AutoConfig
+    except ImportError as exc:
+        logger.warning(
+            "Could not install GLM4 MoE-lite MTP config compatibility patch: %s",
+            exc,
+        )
+        return
+
+    if _transformers_knows_glm4_moe_lite_mtp(AutoConfig):
+        return
+
+    try:
+        config_cls = _glm4_moe_lite_mtp_config_class()
+    except ImportError as exc:
+        logger.warning(
+            "Could not install GLM4 MoE-lite MTP config compatibility patch "
+            "because Glm4MoeLite config classes are unavailable: %s",
+            exc,
+        )
+        return
+
+    # TODO: remove once the supported dependency stack parses raw
+    # ``model_type=glm4_moe_lite_mtp`` configs before vLLM's MTP override runs.
+    AutoConfig.register("glm4_moe_lite_mtp", config_cls, exist_ok=True)
+    logger.debug("Registered GLM4 MoE-lite MTP config compatibility")
 
 
 def _decoder_tree_contains_type(value: Any, decoder_type: str) -> bool:

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -207,6 +207,17 @@ class DraftModelProposer:
             draft_token_ids=[[int(token) for token in row] for row in rows],
         )
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # Return a preempted/evicted request's draft KV blocks to the free pool
+        # and drop its committed-length bookkeeping, so it does not pin draft
+        # cache while it waits; a resumed request re-ingests from the paged
+        # context. Mirrors _prune_finished for an explicit lifecycle set.
+        for req_id in req_ids:
+            blocks = self._req_blocks.pop(req_id, None)
+            if blocks is not None:
+                self._free_blocks.extend(blocks)
+            self._draft_seq_lens.pop(req_id, None)
+
     # -- internals -----------------------------------------------------------
 
     def _prune_finished(self, request_states: Any) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -2208,14 +2208,22 @@ class MetalModelRunner:
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
 
+        invalidated = set(evicted_req_ids)
+        if preempted_req_ids:
+            invalidated.update(preempted_req_ids)
+        if resumed_req_ids:
+            invalidated.update(resumed_req_ids)
+
+        # A drafter that pins a bounded per-request resource (draft cache blocks)
+        # releases it on the same events as the runtime's recurrent state: a
+        # waiting or preempted request must not keep holding the resource, and a
+        # resumed request re-acquires it during recompute.
+        if invalidated and self._drafter is not None:
+            self._drafter.release_requests(invalidated)
+
         if runtime is not None:
-            runtime_invalidated = set(evicted_req_ids)
-            if preempted_req_ids:
-                runtime_invalidated.update(preempted_req_ids)
-            if resumed_req_ids:
-                runtime_invalidated.update(resumed_req_ids)
-            if runtime_invalidated:
-                runtime.release_requests(runtime_invalidated)
+            if invalidated:
+                runtime.release_requests(invalidated)
             if materialize_runtime_state:
                 runtime.materialize_pending_state()
 

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -147,6 +147,12 @@ class NgramProposer:
         # N-gram matches token ids only; it never reads the target's hidden states.
         return False
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The miss-streak throttle is per-request bookkeeping, not a bounded
+        # resource: a preempted request keeps its counters across resume, and
+        # they are dropped when its id finishes.
+        del req_ids
+
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         # Bookkeeping runs unconditionally, before the num_speculative_tokens
         # check: a step with drafting disabled still needs finished ids

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -63,11 +63,7 @@ class ProposeContext:
 
 
 class MetalProposer(Protocol):
-    """Uniform drafting seam.
-
-    Implementations: :class:`Gemma4MTPProposer`, and (draft-model SD) a
-    ``DraftModelProposer``.
-    """
+    """Uniform drafting seam."""
 
     def needs_target_hidden_states(
         self,
@@ -80,6 +76,16 @@ class MetalProposer(Protocol):
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         """Return per-request draft tokens for the next step, or ``None``."""
+        ...
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        """Release any per-request drafter state for these evicted/preempted ids.
+
+        Called from the runner's lifecycle reconcile on eviction, preemption, and
+        resume. A proposer that pins a bounded per-request resource (draft cache
+        blocks) must release it here rather than hold it while the request waits;
+        a stateless proposer is a no-op.
+        """
         ...
 
 
@@ -105,6 +111,11 @@ class Gemma4MTPProposer:
         # decode and final-prefill rows; intermediate prefill chunks never
         # sample, so they cannot seed a draft.
         return bool(decode_segments) or has_final_prefill
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The assistant reads the target's paged KV (released by the runtime);
+        # the proposer holds no per-request state of its own.
+        del req_ids
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         if ctx.num_speculative_tokens <= 0:


### PR DESCRIPTION
Second of the PRs split out of #535, stacked on #551 — that PR's commit shows up here until it merges.

The hosted GLM-4.7-Flash drafter checkpoint carries its identity at the top level (`model_type: glm4_moe_lite_mtp`) and nests the source model config under `text_config`, so `architectures` and `num_nextn_predict_layers` are not at the top level at all. vLLM already knows how to normalize such a draft into its MTP wrapper (`Glm4MoeLiteMTPModel`, `num_hidden_layers=0`, `n_predict=num_nextn_predict_layers`), but it keys that override on the top-level fields, and the pinned transformers has no AutoConfig entry for `glm4_moe_lite_mtp` — so the config load raises before the override ever runs.

I registered the config with `AutoConfig` and promoted `architectures` and `num_nextn_predict_layers` out of the nested `text_config`. This mirrors the existing `_patch_vllm_gemma4_mtp_config_loading` shim next to it and covers config parsing only; it never constructs a model.

The config class is module-scope rather than a closure so vLLM's spawn-based EngineCore can pickle a config instance by qualified name into the worker process. A closure-scoped class fails only in the real engine, never in an in-process config test, so `test_compat_config_survives_pickle_round_trip` covers that round trip explicitly.

Tests, in `tests/test_compat.py`:

- `test_vllm_get_config_applies_existing_glm4_moe_lite_mtp_override` — vLLM's own `get_config` front door, the call that crashed on the raw hosted config, now produces the normalized MTP wrapper.
- `test_speculative_config_builds_from_hosted_head` — a full `SpeculativeConfig` builds from the hosted head against a `glm4_moe_lite` target.
- `test_transformers_autoconfig_loads_raw_glm4_moe_lite_mtp_config`, `test_compat_config_survives_pickle_round_trip`, and `test_missing_glm4_config_module_does_not_stop_other_patches` cover the raw load, the pickle round trip, and a missing `glm4_moe_lite` module leaving the surrounding patches intact.

The one change outside the new code is `TestGemma4MTPConfigCompatPatch`: its expected patch-call list gains the new entry, and it stubs the new patch so an unrelated Gemma4 test does not register `glm4_moe_lite_mtp` with `AutoConfig` as a side effect.

Tests: `pytest -m "not slow" tests/` — 1627 passed, 15 skipped, 46 deselected. `scripts/lint.sh` clean.