### PR TITLE
Trim duplicate GGUF parity tests

### DIFF
--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -168,11 +168,25 @@ def _gguf_module_histogram(model: nn.Module) -> dict[str, int]:
     return counts
 
 
+def _assert_forward_vocab_shape(model: nn.Module) -> None:
+    out = model(mx.array([[1, 2, 3]]))
+    mx.eval(out)
+    assert out.shape == (1, 3, 256)
+
+
 @pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
-def test_loads_dense_qwen3_installs_wrappers(tmp_path, quant_type):
+@pytest.mark.parametrize(
+    ("model_type", "has_qk_norm", "needs_tokenizer"),
+    [("qwen3", True, False), ("llama", False, True)],
+)
+def test_loads_dense_model_installs_wrappers(
+    tmp_path, quant_type, model_type, has_qk_norm, needs_tokenizer
+):
     gguf_path, cfg_dir = _build_dense_fixture(
-        tmp_path, "qwen3", has_qk_norm=True, quant_type=quant_type
+        tmp_path, model_type, has_qk_norm=has_qk_norm, quant_type=quant_type
     )
+    if needs_tokenizer:
+        _write_minimal_tokenizer(cfg_dir, 256)
     model, _ = GGUFModelLoader(
         gguf_path,
         config_dir=cfg_dir,
@@ -181,9 +195,7 @@ def test_loads_dense_qwen3_installs_wrappers(tmp_path, quant_type):
     hist = _gguf_module_histogram(model)
     assert hist.get("GGUFEmbedding") == 1
     assert hist.get("GGUFLinear") == 2 * 7
-    out = model(mx.array([[1, 2, 3]]))
-    mx.eval(out)
-    assert out.shape == (1, 3, 256)
+    _assert_forward_vocab_shape(model)
 
 
 def test_skips_tie_redundant_output(tmp_path):
@@ -206,19 +218,27 @@ def test_skips_tie_redundant_output(tmp_path):
     assert _gguf_module_histogram(model).get("GGUFEmbedding") == 1
 
 
-def test_skips_tie_redundant_output_when_config_omits_tie_flag(tmp_path):
-    d = _dims(_tiny_config("qwen2"))
+@pytest.mark.parametrize(
+    ("model_type", "has_qk_norm", "with_bias", "needs_tokenizer"),
+    [("qwen2", False, True, False), ("llama", False, False, True)],
+)
+def test_skips_tie_redundant_output_when_config_omits_tie_flag(
+    tmp_path, model_type, has_qk_norm, with_bias, needs_tokenizer
+):
+    d = _dims(_tiny_config(model_type))
     gguf_path, cfg_dir = _build_dense_fixture(
         tmp_path,
-        "qwen2",
-        has_qk_norm=False,
-        with_bias=True,
+        model_type,
+        has_qk_norm=has_qk_norm,
+        with_bias=with_bias,
         inject={"output.weight": ("q", (d["vocab"], d["h"]))},
     )
     config_path = Path(cfg_dir) / "config.json"
     config = json.loads(config_path.read_text())
     config.pop("tie_word_embeddings")
     config_path.write_text(json.dumps(config))
+    if needs_tokenizer:
+        _write_minimal_tokenizer(cfg_dir, 256)
 
     model, _ = GGUFModelLoader(
         gguf_path,
@@ -230,14 +250,22 @@ def test_skips_tie_redundant_output_when_config_omits_tie_flag(tmp_path):
     assert _gguf_module_histogram(model).get("GGUFEmbedding") == 1
 
 
-def test_untied_qwen2_attaches_bias_and_installs_lm_head(tmp_path):
+@pytest.mark.parametrize(
+    ("model_type", "has_qk_norm", "with_bias", "needs_tokenizer"),
+    [("qwen2", False, True, False), ("llama", False, False, True)],
+)
+def test_untied_model_installs_lm_head_and_bias_policy(
+    tmp_path, model_type, has_qk_norm, with_bias, needs_tokenizer
+):
     gguf_path, cfg_dir = _build_dense_fixture(
         tmp_path,
-        "qwen2",
+        model_type,
         config_overrides={"tie_word_embeddings": False},
-        has_qk_norm=False,
-        with_bias=True,
+        has_qk_norm=has_qk_norm,
+        with_bias=with_bias,
     )
+    if needs_tokenizer:
+        _write_minimal_tokenizer(cfg_dir, 256)
     model, _ = GGUFModelLoader(
         gguf_path,
         config_dir=cfg_dir,
@@ -246,11 +274,9 @@ def test_untied_qwen2_attaches_bias_and_installs_lm_head(tmp_path):
     # Assert through the model's own public structure, not loader internals.
     q_proj = model.model.layers[0].self_attn.q_proj
     assert isinstance(q_proj, GGUFLinear)
-    assert "bias" in q_proj  # F32 bias paired from the side-map
+    assert ("bias" in q_proj) is with_bias
     assert isinstance(model.lm_head, GGUFLinear)  # untied output -> real lm_head
-    out = model(mx.array([[1, 2, 3]]))
-    mx.eval(out)
-    assert out.shape[-1] == 256
+    _assert_forward_vocab_shape(model)
 
 
 def _write_minimal_tokenizer(config_dir: str, vocab_size: int) -> None:
@@ -290,26 +316,6 @@ def _write_minimal_tokenizer(config_dir: str, vocab_size: int) -> None:
     (dir_path / "tokenizer_config.json").write_text(
         json.dumps({"tokenizer_class": "PreTrainedTokenizerFast"})
     )
-
-
-@pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
-def test_loads_dense_llama_installs_wrappers(tmp_path, quant_type):
-    # llama: separate q/k/v, no q/k norm, no attention bias, tied embeddings.
-    gguf_path, cfg_dir = _build_dense_fixture(
-        tmp_path, "llama", has_qk_norm=False, quant_type=quant_type
-    )
-    _write_minimal_tokenizer(cfg_dir, 256)
-    model, _ = GGUFModelLoader(
-        gguf_path,
-        config_dir=cfg_dir,
-        target_dtype=mx.float32,
-    ).load()
-    hist = _gguf_module_histogram(model)
-    assert hist.get("GGUFEmbedding") == 1
-    assert hist.get("GGUFLinear") == 2 * 7
-    out = model(mx.array([[1, 2, 3]]))
-    mx.eval(out)
-    assert out.shape == (1, 3, 256)
 
 
 @pytest.mark.parametrize("quant_type", [QT.Q8_0, QT.Q4_0])
@@ -420,56 +426,6 @@ def test_resolve_arch_mismatch_names_raw_and_mapped_config_type():
         "(maps to GGUF arch 'llama'); the .gguf and config_dir describe "
         "different models."
     )
-
-
-def test_untied_llama_installs_lm_head(tmp_path):
-    # The 8B-shaped path: untied output, no biases (llama attention_bias=False).
-    gguf_path, cfg_dir = _build_dense_fixture(
-        tmp_path,
-        "llama",
-        config_overrides={"tie_word_embeddings": False},
-        has_qk_norm=False,
-        with_bias=False,
-    )
-    _write_minimal_tokenizer(cfg_dir, 256)
-    model, _ = GGUFModelLoader(
-        gguf_path,
-        config_dir=cfg_dir,
-        target_dtype=mx.float32,
-    ).load()
-    q_proj = model.model.layers[0].self_attn.q_proj
-    assert isinstance(q_proj, GGUFLinear)
-    assert "bias" not in q_proj  # llama q/k/v are bias-free
-    assert isinstance(model.lm_head, GGUFLinear)  # untied output -> real lm_head
-    out = model(mx.array([[1, 2, 3]]))
-    mx.eval(out)
-    assert out.shape[-1] == 256
-
-
-def test_llama_skips_tie_redundant_output_when_config_omits_tie_flag(tmp_path):
-    # Omitted-tie branch for the new arch: the loader must read the resolved
-    # model.args tie flag (llama default True), not a config.get default.
-    d = _dims(_tiny_config("llama"))
-    gguf_path, cfg_dir = _build_dense_fixture(
-        tmp_path,
-        "llama",
-        has_qk_norm=False,
-        inject={"output.weight": ("q", (d["vocab"], d["h"]))},
-    )
-    config_path = Path(cfg_dir) / "config.json"
-    config = json.loads(config_path.read_text())
-    config.pop("tie_word_embeddings")
-    config_path.write_text(json.dumps(config))
-    _write_minimal_tokenizer(cfg_dir, 256)
-
-    model, _ = GGUFModelLoader(
-        gguf_path,
-        config_dir=cfg_dir,
-        target_dtype=mx.float32,
-    ).load()
-
-    assert not hasattr(model, "lm_head")
-    assert _gguf_module_histogram(model).get("GGUFEmbedding") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gguf_wrappers.py
+++ b/tests/test_gguf_wrappers.py
@@ -1,196 +1,132 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the GGUF-aware Linear/Embedding wrappers.
 
-Wrappers are exercised around the REAL tensor (built from a gguf/mx.load fixture
-like the PR-1 tests), with parity checked against ``gguf.quants.dequantize`` — no
-SimpleNamespace/MagicMock tensor fakes. The wrapper modules are nn.Modules, so
-this suite needs MLX (it won't collect on a machine without a Metal device).
+The native tensor suite owns quantized numerical parity. These wrapper tests
+only cover the nn.Module surface and delegation that wrappers add.
 """
 
 from __future__ import annotations
 
 import mlx.core as mx
-import numpy as np
 import pytest
 from mlx.utils import tree_flatten
 
-gguf = pytest.importorskip("gguf")
-
-from vllm_metal.gguf.mlx_native import GGUFMLXQuantizedTensor  # noqa: E402
-from vllm_metal.gguf.wrappers import GGUFEmbedding, GGUFLinear  # noqa: E402
-
-GGMLQuantizationType = gguf.GGMLQuantizationType
-
-NATIVE_QTYPES = [GGMLQuantizationType.Q8_0, GGMLQuantizationType.Q4_0]
+from vllm_metal.gguf.wrappers import GGUFEmbedding, GGUFLinear
 
 
-def _write_quantized_gguf(path, weight: np.ndarray, qtype) -> dict[str, mx.array]:
-    raw = gguf.quants.quantize(weight, qtype)
-    writer = gguf.GGUFWriter(str(path), "llama")
-    writer.add_tensor("w.weight", raw, raw_shape=raw.shape, raw_dtype=qtype)
-    writer.write_header_to_file()
-    writer.write_kv_data_to_file()
-    writer.write_tensors_to_file()
-    writer.close()
-    return mx.load(str(path))
+class _RecordingTensor:
+    def __init__(self, *, out_features: int = 4, in_features: int = 3) -> None:
+        self.out_features = out_features
+        self.in_features = in_features
+        self.qweight = mx.zeros((out_features, 1), dtype=mx.uint32)
+        self.scales = mx.zeros((out_features, 1), dtype=mx.float16)
+        self.biases = mx.zeros((out_features, 1), dtype=mx.float16)
+        self.matmul_inputs: list[mx.array] = []
+        self.embedding_inputs: list[tuple[mx.array, mx.Dtype]] = []
+        self.eval_calls = 0
+
+    def matmul(self, x: mx.array) -> mx.array:
+        self.matmul_inputs.append(x)
+        return mx.ones((*x.shape[:-1], self.out_features), dtype=x.dtype)
+
+    def embedding(self, ids: mx.array, output_dtype: mx.Dtype) -> mx.array:
+        self.embedding_inputs.append((ids, output_dtype))
+        return mx.ones((*ids.shape, self.in_features), dtype=output_dtype)
+
+    def eval_arrays(self) -> None:
+        self.eval_calls += 1
 
 
-def _make_tensor(tmp_path, qtype, shape=(64, 128)):
-    weight = np.random.default_rng(0).standard_normal(shape).astype(np.float32)
-    arrays = _write_quantized_gguf(tmp_path / f"{qtype.name}.gguf", weight, qtype)
-    qt = GGUFMLXQuantizedTensor.from_mx_load(arrays, "w.weight", qtype)
-    oracle = gguf.quants.dequantize(gguf.quants.quantize(weight, qtype), qtype).astype(
-        np.float32
-    )
-    return qt, oracle
+def test_quant_arrays_are_not_module_parameters():
+    tensor = _RecordingTensor()
+    bias = mx.zeros((tensor.out_features,), dtype=mx.float32)
 
-
-def test_quant_arrays_are_not_module_parameters(tmp_path):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
-    bias = mx.zeros((qt.out_features,), dtype=mx.float32)
-
-    # The packed quant arrays are owned by the tensor, not the Module, so a dtype
-    # cast / parameter sweep can't touch them.
-    assert dict(tree_flatten(GGUFLinear(qt).parameters())) == {}
-    emb = GGUFEmbedding(qt, output_dtype=mx.float16)
+    assert dict(tree_flatten(GGUFLinear(tensor).parameters())) == {}
+    emb = GGUFEmbedding(tensor, output_dtype=mx.float16)
     assert dict(tree_flatten(emb.parameters())) == {}
-    # Only the dense bias is a parameter, and freeze() leaves it non-trainable.
-    biased = GGUFLinear(qt, bias=bias)
+    biased = GGUFLinear(tensor, bias=bias)
     assert [k for k, _ in tree_flatten(biased.parameters())] == ["bias"]
     assert dict(tree_flatten(biased.trainable_parameters())) == {}
 
 
-@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_linear_matches_dense_oracle(tmp_path, qtype):
-    qt, oracle = _make_tensor(tmp_path, qtype)
-    layer = GGUFLinear(qt)
-    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
+def test_linear_delegates_matmul_and_adds_bias_at_output_dtype():
+    tensor = _RecordingTensor()
+    bias = mx.array([1.0, 2.0, 3.0, 4.0], dtype=mx.float32)
+    layer = GGUFLinear(tensor, bias=bias)
+    x = mx.zeros((2, tensor.in_features), dtype=mx.float16)
 
     out = layer(x)
-    expected = x @ mx.array(oracle).T
-    mx.eval(out, expected)
+    mx.eval(out)
 
-    ref_max = float(mx.max(mx.abs(expected)))
-    np.testing.assert_allclose(
-        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
-    )
-
-
-@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_linear_bias_is_a_real_post_matmul_add(tmp_path, qtype):
-    qt, _ = _make_tensor(tmp_path, qtype)
-    bias = mx.random.normal((qt.out_features,)).astype(mx.float32)
-    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
-
-    biased = GGUFLinear(qt, bias=bias)
-    plain = GGUFLinear(qt)
-    no_bias = plain(x)
-    with_bias = biased(x)
-    mx.eval(no_bias, with_bias)
-
-    assert "bias" in biased
-    assert "bias" not in plain
-    np.testing.assert_allclose(
-        np.array(with_bias), np.array(no_bias + bias), rtol=0, atol=1e-6
-    )
+    assert len(tensor.matmul_inputs) == 1
+    assert tensor.matmul_inputs[0] is x
+    assert out.dtype == mx.float16
+    assert out.shape == (2, tensor.out_features)
+    assert bool(mx.array_equal(out, mx.ones_like(out) + bias.astype(out.dtype)).item())
 
 
-@pytest.mark.parametrize("dtype", [mx.float32, mx.float16, mx.bfloat16])
-@pytest.mark.parametrize("with_bias", [False, True])
-def test_linear_output_dtype_follows_x(tmp_path, dtype, with_bias):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
-    # GGUF bias is float32; the wrapper must cast it so a bf16/f16 x stays bf16/f16.
-    bias = mx.zeros((qt.out_features,), dtype=mx.float32) if with_bias else None
-    layer = GGUFLinear(qt, bias=bias)
-    x = mx.random.normal((4, qt.in_features)).astype(dtype)
-
-    out = layer(x)
-
-    assert out.dtype == dtype
-    assert out.shape == (4, qt.out_features)
-
-
-def test_linear_rejects_bad_bias(tmp_path):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
+def test_linear_rejects_bad_bias():
+    tensor = _RecordingTensor()
     for bad in (
-        mx.zeros((1,), dtype=mx.float32),  # would broadcast
-        mx.zeros((), dtype=mx.float32),  # scalar
-        mx.zeros((qt.out_features - 1,), dtype=mx.float32),  # wrong length
-        mx.zeros((qt.out_features,), dtype=mx.int32),  # non-floating
+        mx.zeros((1,), dtype=mx.float32),
+        mx.zeros((), dtype=mx.float32),
+        mx.zeros((tensor.out_features - 1,), dtype=mx.float32),
+        mx.zeros((tensor.out_features,), dtype=mx.int32),
+        object(),
     ):
         with pytest.raises(ValueError, match="bias must be a floating mx.array"):
-            GGUFLinear(qt, bias=bad)
+            GGUFLinear(tensor, bias=bad)  # type: ignore[arg-type]
 
 
-def test_linear_extra_repr_shows_dims(tmp_path):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0, shape=(64, 128))
-    repr_str = repr(GGUFLinear(qt))
-    assert "input_dims=128" in repr_str
-    assert "output_dims=64" in repr_str
-    assert "bias=False" in repr_str
+def test_linear_surfaces_tensor_dims():
+    tensor = _RecordingTensor(out_features=64, in_features=128)
+    layer = GGUFLinear(tensor)
+
+    assert layer.out_features == 64
+    assert "input_dims=128" in repr(layer)
+    assert "output_dims=64" in repr(layer)
+    assert "bias=False" in repr(layer)
 
 
-def test_embedding_extra_repr_shows_dims(tmp_path):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0, shape=(64, 128))
-    # "out_features, in_features" in order, mirroring QuantizedEmbedding's repr.
-    assert "64, 128" in repr(GGUFEmbedding(qt, output_dtype=mx.float16))
+def test_embedding_delegates_gather_and_as_linear():
+    tensor = _RecordingTensor(out_features=10, in_features=6)
+    layer = GGUFEmbedding(tensor, output_dtype=mx.bfloat16)
+    ids = mx.array([[0, 1], [2, 3]], dtype=mx.int32)
+    x = mx.zeros((3, tensor.in_features), dtype=mx.float32)
+
+    gathered = layer(ids)
+    projected = layer.as_linear(x)
+    mx.eval(gathered, projected)
+
+    assert len(tensor.embedding_inputs) == 1
+    got_ids, got_dtype = tensor.embedding_inputs[0]
+    assert got_ids is ids
+    assert got_dtype == mx.bfloat16
+    assert len(tensor.matmul_inputs) == 1
+    assert tensor.matmul_inputs[0] is x
+    assert gathered.shape == (2, 2, tensor.in_features)
+    assert gathered.dtype == mx.bfloat16
+    assert projected.shape == (3, tensor.out_features)
+    assert projected.dtype == x.dtype
 
 
-@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_embedding_matches_dense_oracle(tmp_path, qtype):
-    qt, oracle = _make_tensor(tmp_path, qtype)
-    layer = GGUFEmbedding(qt, output_dtype=mx.float32)
-    ids = mx.array([[0, 5], [63, 0]], dtype=mx.int32)
-
-    out = layer(ids)
-    expected = mx.array(oracle)[ids]
-    mx.eval(out, expected)
-
-    assert out.shape == (2, 2, qt.in_features)
-    ref_max = float(mx.max(mx.abs(expected)))
-    np.testing.assert_allclose(
-        np.array(out), np.array(expected), rtol=0, atol=ref_max * 5e-3
-    )
-
-
-@pytest.mark.parametrize("qtype", NATIVE_QTYPES)
-def test_embedding_as_linear_matches_oracle(tmp_path, qtype):
-    # Tied lm_head: the embedding table is reused as the output projection.
-    qt, oracle = _make_tensor(tmp_path, qtype, shape=(100, 64))
-    layer = GGUFEmbedding(qt, output_dtype=mx.float32)
-    x = mx.random.normal((3, qt.in_features)).astype(mx.float32)
-
-    out = layer.as_linear(x)
-    expected = x @ mx.array(oracle).T
-    mx.eval(out, expected)
-
-    ref_max = float(mx.max(mx.abs(expected)))
-    np.testing.assert_allclose(
-        np.array(out), np.array(expected), rtol=0, atol=ref_max * 4e-6
-    )
-
-
-def test_embedding_output_dtype(tmp_path):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
-    out = GGUFEmbedding(qt, output_dtype=mx.bfloat16)(mx.array([0, 1], dtype=mx.int32))
-    assert out.dtype == mx.bfloat16
-
-
-def test_embedding_rejects_non_floating_output_dtype(tmp_path):
-    qt, _ = _make_tensor(tmp_path, GGMLQuantizationType.Q8_0)
-    # A non-floating output_dtype would silently truncate dequantized rows.
-    for bad in (mx.int32, mx.uint8, mx.int8):
+def test_embedding_rejects_non_floating_output_dtype():
+    tensor = _RecordingTensor()
+    for bad in (mx.int32, mx.uint8, mx.int8, object()):
         with pytest.raises(ValueError, match="output_dtype must be a floating"):
-            GGUFEmbedding(qt, output_dtype=bad)
+            GGUFEmbedding(tensor, output_dtype=bad)  # type: ignore[arg-type]
 
 
-def test_wrapper_never_sees_invalid_tensor(tmp_path):
-    # Q4_1 is rejected when the tensor is built — before any wrapper can exist.
-    weight = np.random.default_rng(0).standard_normal((32, 64)).astype(np.float32)
-    arrays = _write_quantized_gguf(
-        tmp_path / "q4_1.gguf", weight, GGMLQuantizationType.Q4_1
-    )
-    with pytest.raises(ValueError, match="ml-explore/mlx#3664"):
-        GGUFMLXQuantizedTensor.from_mx_load(
-            arrays, "w.weight", GGMLQuantizationType.Q4_1
-        )
+def test_embedding_extra_repr_shows_dims():
+    tensor = _RecordingTensor(out_features=64, in_features=128)
+
+    assert "64, 128" in repr(GGUFEmbedding(tensor, output_dtype=mx.float16))
+
+
+def test_eval_arrays_delegates_to_tensor():
+    tensor = _RecordingTensor()
+
+    GGUFLinear(tensor).eval_arrays()
+    GGUFEmbedding(tensor, output_dtype=mx.float16).eval_arrays()
+
+    assert tensor.eval_calls == 2


### PR DESCRIPTION
This PR is:

- To keep GGUF quantized math parity in the native tensor tests.
- To make GGUF wrapper tests cover only wrapper-owned module behavior.
- To share repeated Qwen/Llama loader cases through parameterized tests.

Note: `GGUFLinear` and `GGUFEmbedding` do not own quantized GGUF math; they delegate to the `GGUFTensor` contract. The native tensor tests still cover real GGUF files, MLX repack, qtype behavior, dense-oracle parity, unsupported Q4_1, and real generation. Loader tests still cover wrapper install, tied and untied heads, bias policy, q/k un-permutation, and fail-fast cases.
