### PR TITLE
[Spec Decode] Add the GLM-4.7-Flash MTP head model and checkpoint loader

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -7,6 +7,7 @@ import builtins
 import importlib.util
 import json
 import os
+import pickle
 import sys
 from types import ModuleType
 
@@ -90,6 +91,65 @@ def _write_gemma4_assistant_config(path) -> None:
         },
         "tie_word_embeddings": True,
         "use_ordered_embeddings": True,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm4_moe_lite_mtp_config(path) -> None:
+    # The literal hosted-checkpoint schema emitted by the mlx-vlm drafter split:
+    # a top-level glm4_moe_lite_mtp with NO top-level architectures, the source
+    # model config nested under text_config (which carries architectures, the
+    # shape fields, and num_nextn_predict_layers).
+    config = {
+        "block_size": 2,
+        "model_type": "glm4_moe_lite_mtp",
+        "quantization": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "quantization_config": {"group_size": 64, "bits": 4, "mode": "affine"},
+        "text_config": {
+            "architectures": ["Glm4MoeLiteForCausalLM"],
+            "model_type": "glm4_moe_lite",
+            "hidden_size": 2048,
+            "vocab_size": 154880,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64,
+            "qk_nope_head_dim": 192,
+            "v_head_dim": 256,
+            "num_attention_heads": 20,
+            "num_key_value_heads": 20,
+            "n_routed_experts": 64,
+            "n_shared_experts": 1,
+            "moe_intermediate_size": 1536,
+            "intermediate_size": 10240,
+            "first_k_dense_replace": 1,
+            "num_hidden_layers": 47,
+            "num_nextn_predict_layers": 1,
+            "rope_theta": 1000000.0,
+            "rms_norm_eps": 1e-5,
+            "tie_word_embeddings": False,
+        },
+        "tie_word_embeddings": False,
+    }
+    (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+def _write_glm4_moe_lite_target_config(path) -> None:
+    # A minimal raw glm4_moe_lite target config (the checkpoint the head drafts
+    # for), enough for a download-free target ModelConfig.
+    config = {
+        "architectures": ["Glm4MoeLiteForCausalLM"],
+        "model_type": "glm4_moe_lite",
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "num_key_value_heads": 20,
+        "num_hidden_layers": 47,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+        "max_position_embeddings": 4096,
     }
     (path / "config.json").write_text(json.dumps(config), encoding="utf-8")
 
@@ -282,10 +342,170 @@ class TestGemma4MTPConfigCompatPatch:
             "_patch_mlx_lm_gemma4_kv_shared_sanitize",
             lambda: calls.append("gemma4_kv"),
         )
+        # Stub the GLM MTP config patch too, so this unrelated test does not run
+        # the real one (which would register glm4_moe_lite_mtp with AutoConfig).
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_glm4_moe_lite_mtp_config_loading",
+            lambda: calls.append("glm4_mtp"),
+        )
 
         compat.apply_compat_patches()
 
-        assert calls == ["bytelevel", "qwen35_fp8", "gemma4_kv"]
+        assert calls == ["glm4_mtp", "bytelevel", "qwen35_fp8", "gemma4_kv"]
+
+
+class TestGlm4MoeLiteMTPConfigCompatPatch:
+    def test_transformers_autoconfig_loads_raw_glm4_moe_lite_mtp_config(
+        self,
+        tmp_path,
+    ) -> None:
+        from transformers import AutoConfig
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        assert config.model_type == "glm4_moe_lite_mtp"
+        # architectures and the nextn depth are promoted out of the nested
+        # text_config so vLLM's top-level-keyed MTP override can run.
+        assert config.architectures == ["Glm4MoeLiteForCausalLM"]
+        assert config.num_nextn_predict_layers == 1
+        assert config.get_text_config().model_type == "glm4_moe_lite"
+        assert config.get_text_config().num_hidden_layers == 47
+        assert config.get_text_config().hidden_size == 2048
+
+    def test_compat_config_survives_pickle_round_trip(self, tmp_path) -> None:
+        # vLLM's spawn-based EngineCore pickles the draft config into the worker
+        # process, so the promoted head config must round-trip through pickle
+        # (a closure-scoped config class cannot, and fails only in the real
+        # engine, not in-process config tests).
+        from transformers import AutoConfig
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+        config = AutoConfig.from_pretrained(tmp_path)
+
+        restored = pickle.loads(pickle.dumps(config))
+
+        assert restored.model_type == "glm4_moe_lite_mtp"
+        assert restored.architectures == ["Glm4MoeLiteForCausalLM"]
+        assert restored.num_nextn_predict_layers == 1
+        assert restored.get_text_config().model_type == "glm4_moe_lite"
+        assert restored.get_text_config().num_hidden_layers == 47
+
+    def test_vllm_get_config_applies_existing_glm4_moe_lite_mtp_override(
+        self,
+        tmp_path,
+    ) -> None:
+        from vllm.config.speculative import SpeculativeConfig
+        from vllm.transformers_utils.config import get_config
+
+        _write_glm4_moe_lite_mtp_config(tmp_path)
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        config = get_config(
+            tmp_path,
+            trust_remote_code=False,
+            hf_overrides_fn=SpeculativeConfig.hf_config_override,
+        )
+
+        # vLLM's override normalizes the promoted top-level config into the MTP
+        # wrapper form (this is the front door that crashed on the raw hosted
+        # config before the shim promoted architectures + nextn depth).
+        assert config.model_type == "glm4_moe_lite_mtp"
+        assert config.architectures == ["Glm4MoeLiteMTPModel"]
+        assert config.num_hidden_layers == 0
+        assert config.n_predict == 1
+
+    def test_speculative_config_builds_from_hosted_head(self, tmp_path) -> None:
+        from vllm.config import ModelConfig, ParallelConfig
+        from vllm.config.speculative import SpeculativeConfig
+
+        compat._patch_vllm_glm4_moe_lite_mtp_config_loading()
+
+        target_dir = tmp_path / "target"
+        target_dir.mkdir()
+        _write_glm4_moe_lite_target_config(target_dir)
+        draft_dir = tmp_path / "draft"
+        draft_dir.mkdir()
+        _write_glm4_moe_lite_mtp_config(draft_dir)
+
+        target = ModelConfig(
+            model=str(target_dir),
+            tokenizer=str(target_dir),
+            trust_remote_code=False,
+            dtype="bfloat16",
+            seed=0,
+            skip_tokenizer_init=True,
+        )
+        spec = SpeculativeConfig(
+            target_model_config=target,
+            target_parallel_config=ParallelConfig(),
+            method="mtp",
+            model=str(draft_dir),
+            num_speculative_tokens=1,
+        )
+
+        assert spec.method == "mtp"
+        assert spec.num_speculative_tokens == 1
+        draft_hf = spec.draft_model_config.hf_config
+        assert draft_hf.model_type == "glm4_moe_lite_mtp"
+        assert draft_hf.architectures == ["Glm4MoeLiteMTPModel"]
+        assert draft_hf.n_predict == 1
+
+    def test_missing_glm4_config_module_does_not_stop_other_patches(
+        self,
+        monkeypatch,
+    ) -> None:
+        calls: list[str] = []
+
+        monkeypatch.setattr(compat, "_APPLIED", False)
+        monkeypatch.setattr(
+            compat,
+            "_transformers_knows_glm4_moe_lite_mtp",
+            lambda _auto_config: False,
+        )
+
+        def _raise_missing_glm4_config():
+            raise ModuleNotFoundError(
+                "No module named 'transformers.models.glm4_moe_lite'"
+            )
+
+        monkeypatch.setattr(
+            compat,
+            "_glm4_moe_lite_mtp_config_class",
+            _raise_missing_glm4_config,
+        )
+        # Stub the surrounding patches so only the caught behavior of the GLM
+        # config patch is exercised.
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_gemma4_mtp_config_loading",
+            lambda: calls.append("gemma4_mtp"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_vllm_bytelevel_tokenizer_loading",
+            lambda: calls.append("bytelevel"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_qwen35_fp8_sanitize",
+            lambda: calls.append("qwen35_fp8"),
+        )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_gemma4_kv_shared_sanitize",
+            lambda: calls.append("gemma4_kv"),
+        )
+
+        # The GLM patch swallows the missing-module import error and returns, so
+        # every other patch still runs.
+        compat.apply_compat_patches()
+
+        assert calls == ["gemma4_mtp", "bytelevel", "qwen35_fp8", "gemma4_kv"]
 
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the draft-model proposer's draft KV block pool.
+
+A stub draft model returns logits of the right shape, so the block allocator and
+the release path run through ``propose`` without loading any weights.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_metal.attention.context import OffsetCache, get_context
+from vllm_metal.v1.draft_model_proposer import DraftModelProposer
+from vllm_metal.v1.model_runner import RequestState
+from vllm_metal.v1.proposer import ProposeContext
+from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+BLOCK_SIZE = 16
+NUM_BLOCKS = 2
+VOCAB_SIZE = 8
+# Long enough that one request plus its drafted position spans the whole pool.
+PROMPT_LEN = 20
+
+
+class _StubDraftModel:
+    """mlx_lm-shaped draft model: logits per input token, recorded block tables."""
+
+    def __init__(self) -> None:
+        self.block_tables: list[list[list[int]]] = []
+
+    def __call__(self, input_ids: mx.array, *, cache: list[OffsetCache]) -> mx.array:
+        ctx = get_context()
+        assert ctx is not None
+        self.block_tables.append([list(block_ids) for block_ids in ctx.block_tables])
+        return mx.zeros((1, int(input_ids.shape[1]), VOCAB_SIZE), dtype=mx.float32)
+
+
+def _proposer(model: _StubDraftModel) -> DraftModelProposer:
+    return DraftModelProposer(
+        model=model,
+        block_size=BLOCK_SIZE,
+        num_blocks=NUM_BLOCKS,
+        num_layers=1,
+        controller=SpeculativeDecodeController(),
+        extract_logits=lambda output: output,
+    )
+
+
+def _request_state() -> RequestState:
+    return RequestState(
+        token_ids=list(range(PROMPT_LEN)),
+        prompt_len=PROMPT_LEN,
+        cache=[],
+        sampling_params=SamplingParams(temperature=0.0),
+    )
+
+
+def _context(
+    req_id: str,
+    state: RequestState,
+    request_states: dict[str, RequestState],
+) -> ProposeContext:
+    return ProposeContext(
+        target_hidden_states=None,
+        decode_reqs=[(req_id, state)],
+        decode_segments=[],
+        decode_token_ids=[[state.token_ids[-1]]],
+        prefill_reqs=[],
+        prefill_token_ids=[],
+        prefill_result_modes=[],
+        request_states=request_states,
+        cu_seqlens=[],
+        num_decode_segments=1,
+        num_speculative_tokens=1,
+        logitsprocs=None,
+        finished_req_ids=set(),
+    )
+
+
+def _drafting_blocks(model: _StubDraftModel, forward_index: int) -> set[int]:
+    (block_ids,) = model.block_tables[forward_index]
+    return set(block_ids)
+
+
+def test_release_requests_returns_draft_blocks_to_the_free_pool() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    waiting, resumed = _request_state(), _request_state()
+    # A preempted request keeps its RequestState, so the finished-request sweep
+    # inside propose() never reclaims its blocks.
+    request_states = {"waiting": waiting, "resumed": resumed}
+
+    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+    pool = _drafting_blocks(model, 0)
+    assert len(pool) == NUM_BLOCKS
+
+    proposer.release_requests({"waiting"})
+
+    drafts = proposer.propose(_context("resumed", resumed, request_states))
+
+    assert drafts is not None
+    assert list(drafts.req_ids) == ["resumed"]
+    assert _drafting_blocks(model, 1) == pool
+
+
+def test_draft_blocks_stay_pinned_without_release() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    waiting, resumed = _request_state(), _request_state()
+    request_states = {"waiting": waiting, "resumed": resumed}
+
+    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+
+    with pytest.raises(RuntimeError) as excinfo:
+        proposer.propose(_context("resumed", resumed, request_states))
+
+    assert "'resumed'" in str(excinfo.value)
+    # Allocation fails before any draft forward runs.
+    assert len(model.block_tables) == 1

--- a/tests/test_glm4_moe_lite_mtp_head.py
+++ b/tests/test_glm4_moe_lite_mtp_head.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for GLM-4.7-Flash native MTP head loading and validation contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import (
+    GLM4_MOE_LITE_MTP_MODEL_TYPE,
+    GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+    Glm4MoeLiteMTPHeadLoader,
+    Glm4MoeLiteMTPHeadMetadata,
+)
+from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp_model import (
+    Glm4MoeLiteMTPArgs,
+    Glm4MoeLiteMTPModel,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_head_cache():
+    Glm4MoeLiteMTPHeadLoader.clear_cache()
+    yield
+    Glm4MoeLiteMTPHeadLoader.clear_cache()
+
+
+# Identity lives at the top level; the source model config is nested under
+# ``text_config`` (the hosted drafter-split schema). Overrides route to the top
+# level for these keys, else into ``text_config``.
+_TOP_LEVEL_KEYS = frozenset(
+    {"model_type", "block_size", "tie_word_embeddings", "model_file"}
+)
+
+
+def _head_config(**overrides: object) -> dict[str, object]:
+    """A hosted GLM-4.7-Flash MTP head config (drafter-split ``text_config`` schema)."""
+    text: dict[str, object] = {
+        "architectures": ["Glm4MoeLiteForCausalLM"],
+        "model_type": GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+        "num_hidden_layers": 47,
+        "num_nextn_predict_layers": 1,
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+    }
+    config: dict[str, object] = {
+        "model_type": GLM4_MOE_LITE_MTP_MODEL_TYPE,
+        "block_size": 2,
+        "tie_word_embeddings": False,
+    }
+    for key, value in overrides.items():
+        target = config if key in _TOP_LEVEL_KEYS else text
+        target[key] = value
+    config["text_config"] = text
+    return config
+
+
+def _target_config(**overrides: object) -> dict[str, object]:
+    config: dict[str, object] = {
+        "model_type": "glm4_moe_lite",
+        "hidden_size": 2048,
+        "vocab_size": 154880,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 64,
+        "qk_nope_head_dim": 192,
+        "v_head_dim": 256,
+        "num_attention_heads": 20,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+    }
+    config.update(overrides)
+    return config
+
+
+def _speculative_config(*, model: str = "/head") -> SimpleNamespace:
+    return SimpleNamespace(
+        draft_model_config=SimpleNamespace(model=model, revision=None),
+    )
+
+
+def _fake_head_model(*, missing: tuple[str, ...] = ()) -> object:
+    params: dict[str, object] = {
+        "lm_head": {"weight": mx.zeros((1,))},
+        "model": {"embed_tokens": {"weight": mx.zeros((1,))}},
+    }
+    if "lm_head.weight" in missing:
+        params["lm_head"] = {}
+    if "model.embed_tokens.weight" in missing:
+        params["model"] = {}
+
+    class _FakeModel:
+        def parameters(self) -> dict[str, object]:
+            return params
+
+    return _FakeModel()
+
+
+# --------------------------------------------------------------------------
+# Metadata parsing
+# --------------------------------------------------------------------------
+
+
+def test_from_config_parses_valid_head() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    assert metadata.model_type == GLM4_MOE_LITE_MTP_MODEL_TYPE
+    assert metadata.architectures == ("Glm4MoeLiteForCausalLM",)
+    assert metadata.hidden_size == 2048
+    assert metadata.vocab_size == 154880
+    assert metadata.kv_lora_rank == 512
+    assert metadata.num_nextn_predict_layers == 1
+
+
+def test_from_config_rejects_missing_text_config() -> None:
+    config = _head_config()
+    del config["text_config"]
+
+    with pytest.raises(ValueError, match="text_config"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(config)
+
+
+def test_from_config_rejects_missing_num_nextn() -> None:
+    config = _head_config()
+    del config["text_config"]["num_nextn_predict_layers"]
+
+    with pytest.raises(ValueError, match="num_nextn_predict_layers"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(config)
+
+
+def test_from_config_rejects_missing_block_size() -> None:
+    config = _head_config()
+    del config["block_size"]
+
+    with pytest.raises(ValueError, match="block_size"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(config)
+
+
+def test_from_config_rejects_wrong_model_type() -> None:
+    with pytest.raises(ValueError, match="got 'glm4_moe_lite'"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(model_type="glm4_moe_lite"))
+
+
+def test_from_config_rejects_bad_num_nextn() -> None:
+    with pytest.raises(ValueError, match="num_nextn_predict_layers=1"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(num_nextn_predict_layers=2))
+
+
+def test_from_config_rejects_inconsistent_block_size() -> None:
+    # block_size must equal num_nextn_predict_layers + 1 (the drafter-split
+    # schema's MTP-depth field); an inconsistent value fails loud.
+    with pytest.raises(ValueError, match="block_size must be"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(block_size=3))
+
+
+def test_from_config_rejects_non_integer_field() -> None:
+    with pytest.raises(ValueError, match="hidden_size must be positive"):
+        Glm4MoeLiteMTPHeadMetadata.from_config(_head_config(hidden_size=0))
+
+
+# --------------------------------------------------------------------------
+# Target compatibility
+# --------------------------------------------------------------------------
+
+
+def test_validate_compatible_accepts_match() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    metadata.validate_compatible_with(_target_config())
+
+
+def test_validate_compatible_reads_nested_text_config() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    metadata.validate_compatible_with({"text_config": _target_config()})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("hidden_size", 4096),
+        ("vocab_size", 32000),
+        ("kv_lora_rank", 256),
+        ("qk_rope_head_dim", 32),
+        ("qk_nope_head_dim", 128),
+        ("v_head_dim", 128),
+        ("num_attention_heads", 32),
+        ("rope_theta", 500000.0),
+        ("rms_norm_eps", 1e-6),
+    ],
+)
+def test_validate_compatible_rejects_each_field_mismatch(
+    field: str,
+    value: object,
+) -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    with pytest.raises(ValueError, match=f"head {field} must match target {field}"):
+        metadata.validate_compatible_with(_target_config(**{field: value}))
+
+
+def test_validate_compatible_reports_both_values() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    with pytest.raises(ValueError, match="head=2048, target=4096"):
+        metadata.validate_compatible_with(_target_config(hidden_size=4096))
+
+
+def test_validate_compatible_rejects_missing_target_field() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+    target = _target_config()
+    del target["kv_lora_rank"]
+
+    with pytest.raises(ValueError, match="missing 'kv_lora_rank'"):
+        metadata.validate_compatible_with(target)
+
+
+def test_validate_compatible_rejects_wrong_target_model_type() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+
+    with pytest.raises(
+        ValueError, match="requires a 'glm4_moe_lite' target model"
+    ) as excinfo:
+        metadata.validate_compatible_with(_target_config(model_type="llama"))
+    assert "model_type='llama'" in str(excinfo.value)
+
+
+def test_validate_compatible_rejects_missing_target_model_type() -> None:
+    metadata = Glm4MoeLiteMTPHeadMetadata.from_config(_head_config())
+    target = _target_config()
+    del target["model_type"]
+
+    with pytest.raises(ValueError, match="model_type=None"):
+        metadata.validate_compatible_with(target)
+
+
+# --------------------------------------------------------------------------
+# Loader
+# --------------------------------------------------------------------------
+
+
+def test_get_model_classes_returns_head_classes() -> None:
+    model_cls, args_cls = Glm4MoeLiteMTPHeadLoader._get_model_classes(_head_config())
+
+    assert model_cls is Glm4MoeLiteMTPModel
+    assert args_cls is Glm4MoeLiteMTPArgs
+
+
+def test_get_model_classes_rejects_wrong_model_type() -> None:
+    with pytest.raises(ValueError, match="mlx_vlm") as excinfo:
+        Glm4MoeLiteMTPHeadLoader._get_model_classes(
+            _head_config(model_type="glm4_moe_lite")
+        )
+    # Points users at the alternative head sources, not a deleted local script.
+    assert "GLM-4.7-Flash-MTP" in str(excinfo.value)
+
+
+def test_loader_loads_and_validates_with_injected_fakes() -> None:
+    load_calls: list[dict[str, object]] = []
+    download_calls: list[tuple[str, str | None]] = []
+    fake_model = _fake_head_model()
+
+    def _load_model(model_path: object, *args: object, **kwargs: object):
+        load_calls.append({"path": model_path, "kwargs": kwargs})
+        get_model_classes = kwargs["get_model_classes"]
+        assert callable(get_model_classes)
+        assert get_model_classes(_head_config()) == (
+            Glm4MoeLiteMTPModel,
+            Glm4MoeLiteMTPArgs,
+        )
+        return fake_model, _head_config()
+
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=_load_model,
+        download_fn=lambda name, rev: download_calls.append((name, rev)) or Path(name),
+    )
+
+    runtime = loader.load_if_needed(
+        speculative_config=_speculative_config(),
+        target_config=_target_config(),
+    )
+
+    assert runtime.model is fake_model
+    assert runtime.metadata.hidden_size == 2048
+    assert download_calls == [("/head", None)]
+    assert load_calls[0]["kwargs"]["strict"] is True
+
+
+def test_loader_caches_runtime_and_revalidates_target() -> None:
+    load_calls = 0
+
+    def _load_model(*args: object, **kwargs: object):
+        nonlocal load_calls
+        load_calls += 1
+        return _fake_head_model(), _head_config()
+
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=_load_model,
+        download_fn=lambda name, rev: Path(name),
+        model_path_resolver=lambda name: name,
+    )
+
+    first = loader.load_if_needed(
+        speculative_config=_speculative_config(),
+        target_config=_target_config(),
+    )
+    second = loader.load_if_needed(
+        speculative_config=_speculative_config(),
+        target_config=_target_config(),
+    )
+
+    assert first is second
+    assert load_calls == 1
+
+    with pytest.raises(ValueError, match="head hidden_size must match"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(hidden_size=4096),
+        )
+    assert load_calls == 1
+
+
+def test_loader_keeps_revisions_in_separate_cache_slots() -> None:
+    load_calls = 0
+    download_calls: list[tuple[str, str | None]] = []
+
+    def _load_model(*args: object, **kwargs: object):
+        nonlocal load_calls
+        load_calls += 1
+        return _fake_head_model(), _head_config()
+
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=_load_model,
+        download_fn=lambda name, rev: download_calls.append((name, rev)) or Path(name),
+        model_path_resolver=lambda name: name,
+    )
+    spec_a = _speculative_config()
+    spec_a.revision = "rev-a"
+    spec_a.draft_model_config.revision = "rev-a"
+    spec_b = _speculative_config()
+    spec_b.revision = "rev-b"
+    spec_b.draft_model_config.revision = "rev-b"
+
+    first = loader.load_if_needed(
+        speculative_config=spec_a, target_config=_target_config()
+    )
+    again = loader.load_if_needed(
+        speculative_config=spec_a, target_config=_target_config()
+    )
+    other = loader.load_if_needed(
+        speculative_config=spec_b, target_config=_target_config()
+    )
+
+    assert first is again
+    assert first is not other
+    assert load_calls == 2
+    assert download_calls == [("/head", "rev-a"), ("/head", "rev-b")]
+
+
+def test_loader_rejects_custom_model_file_before_load(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(
+        json.dumps(_head_config(model_file="modeling_glm.py"))
+    )
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="custom model_file"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_loader_rejects_raw_target_repo_config(tmp_path: Path) -> None:
+    # Pointing at the raw GLM-4.7-Flash target repo (top-level
+    # model_type=glm4_moe_lite) is rejected before load: only the MTP head, whose
+    # top-level model_type is glm4_moe_lite_mtp, is a valid source.
+    (tmp_path / "config.json").write_text(json.dumps(_target_config()))
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="glm4_moe_lite_mtp") as excinfo:
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+    assert "mlx_vlm" in str(excinfo.value)
+
+
+def test_loader_prevalidates_config_file_before_load(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text(json.dumps(_head_config(hidden_size=4096)))
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="head hidden_size must match"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_default_loader_rejects_missing_config_before_load(tmp_path: Path) -> None:
+    loader = Glm4MoeLiteMTPHeadLoader(
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="must contain config.json"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_loader_rejects_invalid_json_config(tmp_path: Path) -> None:
+    (tmp_path / "config.json").write_text("{", encoding="utf-8")
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: pytest.fail("load_model called"),
+        download_fn=lambda name, rev: tmp_path,
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+@pytest.mark.parametrize("missing", ["lm_head.weight", "model.embed_tokens.weight"])
+def test_loader_asserts_head_tensors_present(missing: str) -> None:
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: (
+            _fake_head_model(missing=(missing,)),
+            _head_config(),
+        ),
+        download_fn=lambda name, rev: Path(name),
+        model_path_resolver=lambda name: name,
+    )
+
+    with pytest.raises(ValueError, match=f"missing {missing!r}"):
+        loader.load_if_needed(
+            speculative_config=_speculative_config(),
+            target_config=_target_config(),
+        )
+
+
+def test_default_loader_snapshot_allow_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    huggingface_hub = pytest.importorskip("huggingface_hub")
+    (tmp_path / "config.json").write_text(json.dumps(_head_config()))
+    (tmp_path / "model.safetensors").write_text("", encoding="utf-8")
+    snapshot_calls: list[dict[str, object]] = []
+
+    def _snapshot_download(*args: object, **kwargs: object) -> str:
+        snapshot_calls.append({"args": args, "kwargs": kwargs})
+        return str(tmp_path)
+
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", _snapshot_download)
+    spec = _speculative_config(model="zai-org/GLM-4.7-Flash-mtp-head")
+    loader = Glm4MoeLiteMTPHeadLoader(
+        load_model_fn=lambda *a, **k: (_fake_head_model(), _head_config()),
+    )
+
+    loader.load_if_needed(speculative_config=spec, target_config=_target_config())
+
+    assert snapshot_calls == [
+        {
+            "args": ("zai-org/GLM-4.7-Flash-mtp-head",),
+            "kwargs": {
+                "revision": None,
+                "allow_patterns": [
+                    "config.json",
+                    "*.safetensors",
+                    "*.safetensors.index.json",
+                ],
+            },
+        }
+    ]
+
+
+def test_default_loader_loads_real_head_from_disk(tmp_path: Path) -> None:
+    # Load-bearing positive path: a real on-disk head checkpoint flows through the
+    # default loader + mlx_lm.load_model, validates against a matching target, and
+    # produces finite logits. Small dims are nested under text_config (the hosted
+    # drafter-split schema); from_dict promotes them to build the tiny model.
+    from mlx.utils import tree_flatten
+    from mlx_lm.models.cache import KVCache
+
+    dims: dict[str, object] = {
+        "vocab_size": 32,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "moe_intermediate_size": 32,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "n_shared_experts": 1,
+        "n_routed_experts": 4,
+        "kv_lora_rank": 16,
+        "q_lora_rank": 32,
+        "qk_rope_head_dim": 8,
+        "qk_nope_head_dim": 16,
+        "v_head_dim": 16,
+        "num_experts_per_tok": 2,
+        "first_k_dense_replace": 1,
+        "moe_layer_freq": 1,
+        "rope_theta": 1000000.0,
+        "rms_norm_eps": 1e-5,
+    }
+
+    mx.random.seed(0)
+    model = Glm4MoeLiteMTPModel(Glm4MoeLiteMTPArgs(**dims))
+    mx.eval(model.parameters())
+    mx.save_safetensors(
+        str(tmp_path / "model.safetensors"), dict(tree_flatten(model.parameters()))
+    )
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": GLM4_MOE_LITE_MTP_MODEL_TYPE,
+                "block_size": 2,
+                "text_config": {
+                    "model_type": GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+                    "architectures": ["Glm4MoeLiteForCausalLM"],
+                    "num_hidden_layers": 47,
+                    "num_nextn_predict_layers": 1,
+                    **dims,
+                },
+            }
+        )
+    )
+    target = _target_config(
+        hidden_size=64,
+        vocab_size=32,
+        kv_lora_rank=16,
+        qk_rope_head_dim=8,
+        qk_nope_head_dim=16,
+        v_head_dim=16,
+        num_attention_heads=4,
+    )
+
+    loader = Glm4MoeLiteMTPHeadLoader(model_path_resolver=lambda name: name)
+    runtime = loader.load_if_needed(
+        speculative_config=_speculative_config(model=str(tmp_path)),
+        target_config=target,
+    )
+
+    assert isinstance(runtime.model, Glm4MoeLiteMTPModel)
+    assert runtime.metadata.hidden_size == 64
+    assert runtime.metadata.num_nextn_predict_layers == 1
+
+    x = runtime.model.build_slot_inputs(mx.array([1, 2, 3]), mx.zeros((3, 64)), 0)
+    logits = runtime.model.compute_logits(runtime.model.forward_slots(x, KVCache()))
+    mx.eval(logits)
+    assert tuple(logits.shape) == (3, 32)
+    assert bool(mx.all(mx.isfinite(logits)))

--- a/tests/test_glm4_moe_lite_mtp_model.py
+++ b/tests/test_glm4_moe_lite_mtp_model.py
@@ -1,0 +1,670 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Numeric parity tests for the GLM-4.7-Flash native MTP head MLX model.
+
+A self-contained numpy reference implements the upstream nextn math (enorm /
+hnorm / eh_proj concat, position-0 embedding zeroing, absorbed-MLA attention with
+traditional RoPE, noaux_tc sigmoid gating with e_score_correction_bias, shared
+expert add, shared_head norm + head readout). The MLX head must match it within
+fp32 tolerance, incremental slab forwards must equal a single multi-row forward
+and a recompute-from-scratch, and ``convert_nextn_weights`` must produce the exact
+module tree the model loads under a strict ``load_weights``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx.utils import tree_unflatten
+from mlx_lm.models.cache import KVCache
+
+from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp_model import (
+    Glm4MoeLiteMTPArgs,
+    Glm4MoeLiteMTPModel,
+    convert_nextn_weights,
+)
+
+# Tiny dims (plan): hidden 64, kv_lora_rank 16, qk_rope 8, qk_nope 16, v_head 16,
+# 4 experts top-2, n_group 1, topk_group 1, vocab 32. q_lora_rank set so the
+# q_a_proj/q_a_layernorm/q_b_proj path (as in the real GLM-4.7-Flash) is exercised.
+H = 64
+NH = 4
+QL = 32
+KVL = 16
+ROPE = 8
+NOPE = 16
+VH = 16
+NROUT = 4
+NSHR = 1
+TOPK = 2
+MOEI = 32
+VOCAB = 32
+SCALE_F = 1.5
+EPS = 1e-5
+THETA = 1_000_000.0
+QHD = NOPE + ROPE
+
+
+def _args() -> Glm4MoeLiteMTPArgs:
+    return Glm4MoeLiteMTPArgs(
+        vocab_size=VOCAB,
+        hidden_size=H,
+        intermediate_size=128,
+        moe_intermediate_size=MOEI,
+        num_attention_heads=NH,
+        num_key_value_heads=NH,
+        n_shared_experts=NSHR,
+        n_routed_experts=NROUT,
+        kv_lora_rank=KVL,
+        q_lora_rank=QL,
+        qk_rope_head_dim=ROPE,
+        qk_nope_head_dim=NOPE,
+        v_head_dim=VH,
+        num_experts_per_tok=TOPK,
+        n_group=1,
+        topk_group=1,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+        routed_scaling_factor=SCALE_F,
+        rms_norm_eps=EPS,
+        rope_theta=THETA,
+        norm_topk_prob=True,
+    )
+
+
+def _random_flat_weights(rng: np.random.Generator) -> dict[str, np.ndarray]:
+    def rnd(*shape: int) -> np.ndarray:
+        return (rng.standard_normal(shape) * 0.1).astype(np.float32)
+
+    def norm(*shape: int) -> np.ndarray:
+        return (1.0 + rnd(*shape)).astype(np.float32)
+
+    weights: dict[str, np.ndarray] = {
+        "model.embed_tokens.weight": rnd(VOCAB, H),
+        "model.enorm.weight": norm(H),
+        "model.hnorm.weight": norm(H),
+        "model.eh_proj.weight": rnd(H, 2 * H),
+        "model.mtp_block.input_layernorm.weight": norm(H),
+        "model.mtp_block.post_attention_layernorm.weight": norm(H),
+        "model.mtp_block.self_attn.q_a_proj.weight": rnd(QL, H),
+        "model.mtp_block.self_attn.q_a_layernorm.weight": norm(QL),
+        "model.mtp_block.self_attn.q_b_proj.weight": rnd(NH * QHD, QL),
+        "model.mtp_block.self_attn.kv_a_proj_with_mqa.weight": rnd(KVL + ROPE, H),
+        "model.mtp_block.self_attn.kv_a_layernorm.weight": norm(KVL),
+        "model.mtp_block.self_attn.kv_b_proj.weight": rnd(NH * (NOPE + VH), KVL),
+        "model.mtp_block.self_attn.o_proj.weight": rnd(H, NH * VH),
+        "model.mtp_block.mlp.gate.weight": rnd(NROUT, H),
+        "model.mtp_block.mlp.gate.e_score_correction_bias": rnd(NROUT),
+        "model.mtp_block.mlp.shared_experts.gate_proj.weight": rnd(MOEI, H),
+        "model.mtp_block.mlp.shared_experts.up_proj.weight": rnd(MOEI, H),
+        "model.mtp_block.mlp.shared_experts.down_proj.weight": rnd(H, MOEI),
+        "model.shared_head_norm.weight": norm(H),
+        "lm_head.weight": rnd(VOCAB, H),
+    }
+    for e in range(NROUT):
+        weights[f"model.mtp_block.mlp.experts.{e}.gate_proj.weight"] = rnd(MOEI, H)
+        weights[f"model.mtp_block.mlp.experts.{e}.up_proj.weight"] = rnd(MOEI, H)
+        weights[f"model.mtp_block.mlp.experts.{e}.down_proj.weight"] = rnd(H, MOEI)
+    return weights
+
+
+def _rms(x: np.ndarray, w: np.ndarray) -> np.ndarray:
+    return (x / np.sqrt((x**2).mean(-1, keepdims=True) + EPS)) * w
+
+
+def _rope_traditional(x: np.ndarray, pos: np.ndarray) -> np.ndarray:
+    # x: (T, num_heads, ROPE) — interleaved-pair rotation (mlx traditional=True).
+    d = x.shape[-1]
+    half = d // 2
+    inv = THETA ** (-(2 * np.arange(half)) / d)
+    ang = np.outer(pos, inv)
+    cos = np.cos(ang)[:, None, :]
+    sin = np.sin(ang)[:, None, :]
+    x0 = x[..., 0::2]
+    x1 = x[..., 1::2]
+    out = np.empty_like(x)
+    out[..., 0::2] = x0 * cos - x1 * sin
+    out[..., 1::2] = x0 * sin + x1 * cos
+    return out
+
+
+def _silu(x: np.ndarray) -> np.ndarray:
+    return x / (1.0 + np.exp(-x))
+
+
+def _reference_forward(
+    weights: dict[str, np.ndarray],
+    token_ids: np.ndarray,
+    hidden_rows: np.ndarray,
+    first_position: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    def w(name: str) -> np.ndarray:
+        return weights[name]
+
+    num_slots = len(token_ids)
+    positions = first_position + np.arange(num_slots)
+
+    emb = w("model.embed_tokens.weight")[token_ids]
+    emb = emb * (positions != 0)[:, None]
+    fused = np.concatenate(
+        [
+            _rms(emb, w("model.enorm.weight")),
+            _rms(hidden_rows, w("model.hnorm.weight")),
+        ],
+        axis=-1,
+    )
+    x = fused @ w("model.eh_proj.weight").T
+
+    # --- absorbed MLA attention (un-absorbed reference form) ---
+    residual = x
+    xin = _rms(x, w("model.mtp_block.input_layernorm.weight"))
+    qa = _rms(
+        xin @ w("model.mtp_block.self_attn.q_a_proj.weight").T,
+        w("model.mtp_block.self_attn.q_a_layernorm.weight"),
+    )
+    q = (qa @ w("model.mtp_block.self_attn.q_b_proj.weight").T).reshape(
+        num_slots, NH, QHD
+    )
+    q_nope, q_pe = q[..., :NOPE], q[..., NOPE:]
+    compressed = xin @ w("model.mtp_block.self_attn.kv_a_proj_with_mqa.weight").T
+    kv_c, k_pe = compressed[:, :KVL], compressed[:, KVL:]
+    kv_latent = _rms(kv_c, w("model.mtp_block.self_attn.kv_a_layernorm.weight"))
+
+    q_pe = _rope_traditional(q_pe, positions)
+    k_pe = _rope_traditional(k_pe[:, None, :], positions)[:, 0, :]
+
+    kv_b = (kv_latent @ w("model.mtp_block.self_attn.kv_b_proj.weight").T).reshape(
+        num_slots, NH, NOPE + VH
+    )
+    k_nope, value = kv_b[..., :NOPE], kv_b[..., NOPE:]
+    k_pe_heads = np.broadcast_to(k_pe[:, None, :], (num_slots, NH, ROPE))
+    keys = np.concatenate([k_nope, k_pe_heads], axis=-1)
+    queries = np.concatenate([q_nope, q_pe], axis=-1)
+
+    scale = QHD**-0.5
+    causal = np.triu(np.ones((num_slots, num_slots), dtype=bool), 1)
+    head_outs = []
+    for h in range(NH):
+        scores = (queries[:, h, :] @ keys[:, h, :].T) * scale
+        scores = np.where(causal, -np.inf, scores)
+        scores = scores - scores.max(-1, keepdims=True)
+        probs = np.exp(scores)
+        probs = probs / probs.sum(-1, keepdims=True)
+        head_outs.append(probs @ value[:, h, :])
+    attn = np.concatenate(head_outs, axis=-1)
+    attn_out = attn @ w("model.mtp_block.self_attn.o_proj.weight").T
+    hidden = residual + attn_out
+
+    # --- MoE (noaux_tc sigmoid gating + shared expert) ---
+    residual = hidden
+    xmlp = _rms(hidden, w("model.mtp_block.post_attention_layernorm.weight"))
+    gates = xmlp @ w("model.mtp_block.mlp.gate.weight").T
+    sig = 1.0 / (1.0 + np.exp(-gates))
+    biased = sig + w("model.mtp_block.mlp.gate.e_score_correction_bias")
+
+    routed = np.zeros((num_slots, H), dtype=np.float32)
+    for t in range(num_slots):
+        idx = np.argsort(-biased[t])[:TOPK]
+        weight = sig[t, idx].copy()
+        weight = weight / (weight.sum() + 1e-20)
+        weight = weight * SCALE_F
+        acc = np.zeros(H, dtype=np.float32)
+        for k, e in enumerate(idx):
+            gate = xmlp[t] @ w(f"model.mtp_block.mlp.experts.{e}.gate_proj.weight").T
+            up = xmlp[t] @ w(f"model.mtp_block.mlp.experts.{e}.up_proj.weight").T
+            expert = (_silu(gate) * up) @ w(
+                f"model.mtp_block.mlp.experts.{e}.down_proj.weight"
+            ).T
+            acc += weight[k] * expert
+        routed[t] = acc
+
+    shared_gate = xmlp @ w("model.mtp_block.mlp.shared_experts.gate_proj.weight").T
+    shared_up = xmlp @ w("model.mtp_block.mlp.shared_experts.up_proj.weight").T
+    shared = (_silu(shared_gate) * shared_up) @ w(
+        "model.mtp_block.mlp.shared_experts.down_proj.weight"
+    ).T
+    hidden = residual + routed + shared
+
+    out_hidden = _rms(hidden, w("model.shared_head_norm.weight"))
+    logits = out_hidden @ w("lm_head.weight").T
+    return out_hidden, logits
+
+
+def _build_model(
+    weights: dict[str, np.ndarray],
+) -> Glm4MoeLiteMTPModel:
+    model = Glm4MoeLiteMTPModel(_args())
+    converted = convert_nextn_weights(
+        {k: mx.array(v) for k, v in weights.items()},
+        model.args,
+    )
+    model.update(tree_unflatten(list(converted.items())))
+    mx.eval(model.parameters())
+    return model
+
+
+@pytest.fixture()
+def fixture():  # noqa: ANN201
+    rng = np.random.default_rng(1234)
+    weights = _random_flat_weights(rng)
+    model = _build_model(weights)
+    token_ids = rng.integers(0, VOCAB, size=6).astype(np.int32)
+    hidden_rows = (rng.standard_normal((6, H)) * 0.5).astype(np.float32)
+    return model, weights, token_ids, hidden_rows
+
+
+def test_forward_matches_numpy_reference(fixture) -> None:  # noqa: ANN001
+    model, weights, token_ids, hidden_rows = fixture
+
+    cache = KVCache()
+    x = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    hidden = model.forward_slots(x, cache)
+    logits = model.compute_logits(hidden)
+    mx.eval(hidden, logits)
+
+    ref_hidden, ref_logits = _reference_forward(weights, token_ids, hidden_rows, 0)
+
+    assert np.allclose(np.array(hidden), ref_hidden, atol=2e-4, rtol=2e-4)
+    assert np.allclose(np.array(logits), ref_logits, atol=2e-4, rtol=2e-4)
+    assert (
+        np.array(mx.argmax(logits, axis=-1)).tolist() == ref_logits.argmax(-1).tolist()
+    )
+
+
+def test_position_zero_embedding_is_masked(fixture) -> None:  # noqa: ANN001
+    model, weights, token_ids, hidden_rows = fixture
+
+    # Row at absolute position 0 must ignore its token embedding: swapping the
+    # position-0 token cannot change the slot input.
+    x0 = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    swapped = token_ids.copy()
+    swapped[0] = (int(swapped[0]) + 7) % VOCAB
+    x1 = model.build_slot_inputs(mx.array(swapped), mx.array(hidden_rows), 0)
+    mx.eval(x0, x1)
+    assert np.allclose(np.array(x0[0]), np.array(x1[0]), atol=1e-6)
+
+    # But with a non-zero first_position, row 0 is a real position and does use
+    # its embedding.
+    x2 = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 3)
+    x3 = model.build_slot_inputs(mx.array(swapped), mx.array(hidden_rows), 3)
+    mx.eval(x2, x3)
+    assert not np.allclose(np.array(x2[0]), np.array(x3[0]), atol=1e-6)
+
+
+def test_incremental_slots_equal_full_forward(fixture) -> None:  # noqa: ANN001
+    model, _weights, token_ids, hidden_rows = fixture
+    num_slots = len(token_ids)
+
+    full_cache = KVCache()
+    x_full = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    full = model.forward_slots(x_full, full_cache, expected_offset=0)
+    mx.eval(full)
+    full_np = np.array(full)
+
+    inc_cache = KVCache()
+    rows = []
+    for i in range(num_slots):
+        xi = model.build_slot_inputs(
+            mx.array(token_ids[i : i + 1]),
+            mx.array(hidden_rows[i : i + 1]),
+            i,
+        )
+        # The cache offset and the caller's first_position must agree per slot.
+        hi = model.forward_slots(xi, inc_cache, expected_offset=i)
+        mx.eval(hi)
+        rows.append(np.array(hi))
+    incremental = np.concatenate(rows, axis=0)
+
+    assert incremental.shape == full_np.shape
+    assert np.allclose(incremental, full_np, atol=2e-4, rtol=2e-4)
+    assert inc_cache.offset == num_slots
+
+
+def test_split_prefill_then_decode_equals_full(fixture) -> None:  # noqa: ANN001
+    model, _weights, token_ids, hidden_rows = fixture
+    num_slots = len(token_ids)
+
+    x_full = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    full = model.forward_slots(x_full, KVCache())
+    mx.eval(full)
+    full_np = np.array(full)
+
+    # Prefill the first `split` rows in one shot, then feed the remainder one at
+    # a time, mirroring a decode-after-prefill sequence.
+    split = 4
+    cache = KVCache()
+    x_prefill = model.build_slot_inputs(
+        mx.array(token_ids[:split]), mx.array(hidden_rows[:split]), 0
+    )
+    prefill = model.forward_slots(x_prefill, cache, expected_offset=0)
+    mx.eval(prefill)
+    rows = [np.array(prefill)]
+    for i in range(split, num_slots):
+        xi = model.build_slot_inputs(
+            mx.array(token_ids[i : i + 1]),
+            mx.array(hidden_rows[i : i + 1]),
+            i,
+        )
+        hi = model.forward_slots(xi, cache, expected_offset=i)
+        mx.eval(hi)
+        rows.append(np.array(hi))
+    combined = np.concatenate(rows, axis=0)
+
+    assert np.allclose(combined, full_np, atol=2e-4, rtol=2e-4)
+
+
+def test_convert_nextn_weights_round_trips_into_model() -> None:
+    rng = np.random.default_rng(7)
+    weights = _random_flat_weights(rng)
+    model = Glm4MoeLiteMTPModel(_args())
+
+    converted = convert_nextn_weights(
+        {k: mx.array(v) for k, v in weights.items()},
+        model.args,
+    )
+
+    # The transformed weights must be exactly the module tree — strict load
+    # rejects any missing or extra key.
+    model.load_weights(list(converted.items()), strict=True)
+
+    # kv_b_proj is consumed; embed_q / unembed_out are produced with the right
+    # absorbed shapes; experts are stacked into switch_mlp.
+    assert "model.mtp_block.self_attn.kv_b_proj.weight" not in converted
+    assert converted["model.mtp_block.self_attn.embed_q.weight"].shape == (
+        NH,
+        KVL,
+        NOPE,
+    )
+    assert converted["model.mtp_block.self_attn.unembed_out.weight"].shape == (
+        NH,
+        VH,
+        KVL,
+    )
+    assert converted["model.mtp_block.mlp.switch_mlp.gate_proj.weight"].shape == (
+        NROUT,
+        MOEI,
+        H,
+    )
+    assert "model.mtp_block.mlp.experts.0.gate_proj.weight" not in converted
+
+
+def test_convert_nextn_weights_is_idempotent() -> None:
+    rng = np.random.default_rng(9)
+    weights = _random_flat_weights(rng)
+    args = _args()
+
+    once = convert_nextn_weights({k: mx.array(v) for k, v in weights.items()}, args)
+    twice = convert_nextn_weights(once, args)
+
+    assert set(once) == set(twice)
+    for key in once:
+        assert np.array_equal(np.array(once[key]), np.array(twice[key]))
+
+
+def test_convert_nextn_weights_reports_missing_expert() -> None:
+    # A checkpoint with fewer experts than n_routed_experts must fail with a
+    # descriptive error (naming the first missing expert + a head source),
+    # not a bare KeyError leaking from the stacking pop.
+    rng = np.random.default_rng(3)
+    weights = _random_flat_weights(rng)
+    args = _args()
+    dropped = f"model.mtp_block.mlp.experts.{NROUT - 1}.gate_proj.weight"
+    del weights[dropped]
+
+    with pytest.raises(ValueError) as excinfo:
+        convert_nextn_weights({k: mx.array(v) for k, v in weights.items()}, args)
+
+    message = str(excinfo.value)
+    assert f"missing expert {NROUT - 1}" in message
+    assert dropped in message
+    assert f"n_routed_experts={NROUT}" in message
+    assert "mlx_vlm" in message
+
+
+def test_from_dict_reads_nested_text_config_not_defaults() -> None:
+    # The hosted drafter-split schema nests the shape under text_config with the
+    # head identity at the top level. from_dict must read the nested (non-default)
+    # dims -- tiny values distinct from this class's GLM-4.7-Flash field defaults
+    # -- rather than silently building the head with the defaults.
+    config = {
+        "model_type": "glm4_moe_lite_mtp",
+        "block_size": 2,
+        "quantization": {"group_size": 32, "bits": 4},
+        "text_config": {
+            "model_type": "glm4_moe_lite",
+            "hidden_size": 128,
+            "vocab_size": 1024,
+            "num_attention_heads": 4,
+            "kv_lora_rank": 32,
+            "num_nextn_predict_layers": 1,
+        },
+    }
+
+    args = Glm4MoeLiteMTPArgs.from_dict(config)
+
+    assert args.model_type == "glm4_moe_lite_mtp"
+    assert args.hidden_size == 128
+    assert args.vocab_size == 1024
+    assert args.num_attention_heads == 4
+    assert args.kv_lora_rank == 32
+    assert args.quantization == {"group_size": 32, "bits": 4}
+
+
+def test_from_dict_rejects_non_mapping_text_config() -> None:
+    with pytest.raises(ValueError, match="text_config must be a mapping"):
+        Glm4MoeLiteMTPArgs.from_dict(
+            {"model_type": "glm4_moe_lite_mtp", "text_config": "nope"}
+        )
+
+
+def test_forward_slots_expected_offset_guards_against_desync(fixture) -> None:  # noqa: ANN001
+    model, _weights, token_ids, hidden_rows = fixture
+
+    cache = KVCache()
+    x = model.build_slot_inputs(mx.array(token_ids), mx.array(hidden_rows), 0)
+    # Fresh cache is at offset 0 — matching expected_offset passes.
+    first = model.forward_slots(x, cache, expected_offset=0)
+    mx.eval(first)
+    assert cache.offset == len(token_ids)
+
+    # Re-using the now-advanced cache while still claiming offset 0 is a
+    # position anchor desync and must fail loud.
+    x2 = model.build_slot_inputs(mx.array(token_ids[:1]), mx.array(hidden_rows[:1]), 0)
+    with pytest.raises(ValueError, match="does not match expected_offset"):
+        model.forward_slots(x2, cache, expected_offset=0)
+
+
+# ---------------------------------------------------------------------------
+# Args validation
+# ---------------------------------------------------------------------------
+
+
+def test_args_reject_wrong_model_type() -> None:
+    with pytest.raises(ValueError, match="model_type"):
+        Glm4MoeLiteMTPArgs(model_type="glm4_moe_lite")
+
+
+def test_args_reject_bad_num_nextn() -> None:
+    with pytest.raises(ValueError, match="num_nextn_predict_layers"):
+        Glm4MoeLiteMTPArgs(num_nextn_predict_layers=2)
+
+
+def test_args_reject_layer_idx_that_would_not_be_moe() -> None:
+    # first_k_dense_replace=1 (default) is not divisible by moe_layer_freq=2, so
+    # stock Glm4MoeLiteDecoderLayer would build a *dense* mtp_block, not the MoE
+    # the trained nextn head requires. Fail fast rather than mis-build.
+    with pytest.raises(ValueError, match="must be divisible by"):
+        Glm4MoeLiteMTPArgs(moe_layer_freq=2)
+
+
+def test_args_accept_layer_idx_divisible_by_moe_layer_freq() -> None:
+    # first_k_dense_replace=2 is divisible by moe_layer_freq=2 -> MoE layer.
+    args = Glm4MoeLiteMTPArgs(first_k_dense_replace=2, moe_layer_freq=2)
+
+    assert args.first_k_dense_replace == 2
+    assert args.moe_layer_freq == 2
+
+
+def test_args_reject_non_positive_moe_layer_freq() -> None:
+    with pytest.raises(ValueError, match="moe_layer_freq to be a positive"):
+        Glm4MoeLiteMTPArgs(moe_layer_freq=0)
+
+
+def test_args_from_dict_ignores_extra_config_keys() -> None:
+    args = Glm4MoeLiteMTPArgs.from_dict(
+        {
+            "model_type": "glm4_moe_lite_mtp",
+            "block_size": 2,
+            "unrelated": 123,
+            "text_config": {
+                "model_type": "glm4_moe_lite",
+                "hidden_size": 2048,
+                "num_nextn_predict_layers": 1,
+            },
+        }
+    )
+
+    assert args.model_type == "glm4_moe_lite_mtp"
+    assert args.hidden_size == 2048
+    backbone = args.backbone_args()
+    assert backbone.model_type == "glm4_moe_lite"
+    assert backbone.hidden_size == 2048
+
+
+# ---------------------------------------------------------------------------
+# Quantized weight transform (convert_nextn_weights on a 4-bit checkpoint)
+# ---------------------------------------------------------------------------
+
+# mx.quantize requires group_size in {32, 64, 128} and the quantized last dim
+# divisible by it, so the quantized fixture uses coarser dims than the fp32
+# tests above.
+QH = 32  # hidden / head dims (all multiples of the group size)
+QNH = 2  # attention heads
+QKVL = 32  # kv_lora_rank
+QNOPE = 32  # qk_nope_head_dim
+QVH = 32  # v_head_dim
+QNROUT = 2  # routed experts
+QMOEI = 32  # moe intermediate
+QBITS = 4
+QGROUP = 32
+
+
+def _quant_args() -> Glm4MoeLiteMTPArgs:
+    return Glm4MoeLiteMTPArgs(
+        vocab_size=64,
+        hidden_size=QH,
+        intermediate_size=64,
+        moe_intermediate_size=QMOEI,
+        num_attention_heads=QNH,
+        num_key_value_heads=QNH,
+        n_shared_experts=1,
+        n_routed_experts=QNROUT,
+        kv_lora_rank=QKVL,
+        q_lora_rank=QH,
+        qk_rope_head_dim=QGROUP,
+        qk_nope_head_dim=QNOPE,
+        v_head_dim=QVH,
+        num_experts_per_tok=1,
+        first_k_dense_replace=1,
+        moe_layer_freq=1,
+    )
+
+
+def _quantize(w: np.ndarray) -> tuple[mx.array, mx.array, mx.array]:
+    q, s, b = mx.quantize(mx.array(w), bits=QBITS, group_size=QGROUP)
+    mx.eval(q, s, b)
+    return q, s, b
+
+
+def _dequant(q: mx.array, s: mx.array, b: mx.array) -> np.ndarray:
+    d = mx.dequantize(q, s, b, bits=QBITS, group_size=QGROUP)
+    mx.eval(d)
+    return np.array(d)
+
+
+def test_convert_nextn_weights_quantized_kv_b_proj_round_trips() -> None:
+    rng = np.random.default_rng(11)
+    prefix = "model.mtp_block.self_attn"
+    # kv_b_proj: (num_heads * (qk_nope + v_head), kv_lora_rank).
+    kv_b_fp32 = (rng.standard_normal((QNH * (QNOPE + QVH), QKVL)) * 0.1).astype(
+        np.float32
+    )
+    q, s, b = _quantize(kv_b_fp32)
+    weights = {
+        f"{prefix}.kv_b_proj.weight": q,
+        f"{prefix}.kv_b_proj.scales": s,
+        f"{prefix}.kv_b_proj.biases": b,
+    }
+
+    out = convert_nextn_weights(weights, _quant_args())
+
+    # Fused kv_b_proj is consumed; absorbed embed_q / unembed_out appear with
+    # quantized triplets.
+    assert f"{prefix}.kv_b_proj.weight" not in out
+    for name in ("embed_q", "unembed_out"):
+        for suffix in ("weight", "scales", "biases"):
+            assert f"{prefix}.{name}.{suffix}" in out
+    assert out[f"{prefix}.embed_q.weight"].shape[0] == QNH
+    assert out[f"{prefix}.unembed_out.weight"].shape[0] == QNH
+
+    # Numeric round-trip: reproduce the reference by splitting the *unquantized*
+    # weights and quantizing, then compare dequantized values (4-bit tolerance).
+    v = kv_b_fp32.reshape(QNH, QNOPE + QVH, QKVL)
+    wk_ref = np.ascontiguousarray(v[:, :QNOPE, :].swapaxes(-1, -2))
+    wv_ref = np.ascontiguousarray(v[:, QNOPE:, :])
+    ek = _dequant(*_quantize(wk_ref))
+    ev = _dequant(*_quantize(wv_ref))
+    got_ek = _dequant(
+        out[f"{prefix}.embed_q.weight"],
+        out[f"{prefix}.embed_q.scales"],
+        out[f"{prefix}.embed_q.biases"],
+    )
+    got_ev = _dequant(
+        out[f"{prefix}.unembed_out.weight"],
+        out[f"{prefix}.unembed_out.scales"],
+        out[f"{prefix}.unembed_out.biases"],
+    )
+    # The convert path quantizes -> dequantizes -> splits -> re-quantizes (two
+    # 4-bit rounds) vs the reference's single round on the exact fp32 split, so
+    # compare dequantized values within a 4-bit-appropriate tolerance.
+    assert np.allclose(got_ek, ek, atol=0.08)
+    assert np.allclose(got_ev, ev, atol=0.08)
+
+
+def test_convert_nextn_weights_stacks_quantized_experts() -> None:
+    rng = np.random.default_rng(13)
+    prefix = "model.mtp_block.mlp"
+    per_expert: dict[str, mx.array] = {}
+    expected: dict[str, list[tuple[mx.array, mx.array, mx.array]]] = {
+        "gate_proj": [],
+        "up_proj": [],
+        "down_proj": [],
+    }
+    shapes = {
+        "gate_proj": (QMOEI, QH),
+        "up_proj": (QMOEI, QH),
+        "down_proj": (QH, QMOEI),
+    }
+    for e in range(QNROUT):
+        for proj, shape in shapes.items():
+            w = (rng.standard_normal(shape) * 0.1).astype(np.float32)
+            q, s, b = _quantize(w)
+            per_expert[f"{prefix}.experts.{e}.{proj}.weight"] = q
+            per_expert[f"{prefix}.experts.{e}.{proj}.scales"] = s
+            per_expert[f"{prefix}.experts.{e}.{proj}.biases"] = b
+            expected[proj].append((q, s, b))
+
+    out = convert_nextn_weights(per_expert, _quant_args())
+
+    for proj in ("gate_proj", "up_proj", "down_proj"):
+        # Per-expert keys are consumed.
+        assert f"{prefix}.experts.0.{proj}.weight" not in out
+        for si, suffix in enumerate(("weight", "scales", "biases")):
+            stacked = out[f"{prefix}.switch_mlp.{proj}.{suffix}"]
+            assert stacked.shape[0] == QNROUT
+            # Stacking preserves each expert's quantized tensor exactly (no
+            # dequant): row e equals expert e's tensor.
+            for e in range(QNROUT):
+                np.testing.assert_array_equal(
+                    np.array(stacked[e]), np.array(expected[proj][e][si])
+                )

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -85,6 +85,35 @@ def test_gemma4_mtp_config_installs_gemma4_proposer() -> None:
     assert isinstance(runner._drafter, Gemma4MTPProposer)
 
 
+class TestDrafterReleaseOnLifecycle:
+    def test_reconcile_releases_drafter_state_for_invalidated_requests(self) -> None:
+        released: list[set[str]] = []
+
+        class _RecordingDrafter:
+            def needs_target_hidden_states(self, *args, **kwargs) -> bool:
+                return False
+
+            def propose(self, ctx) -> None:
+                return None
+
+            def release_requests(self, req_ids: set[str]) -> None:
+                released.append(set(req_ids))
+
+        runner = make_stub_runner(tokenizer=object())
+        runner._drafter = _RecordingDrafter()
+
+        # Eviction + preemption + resume all invalidate the drafter's per-request
+        # state, mirroring the runtime recurrent-state release path.
+        runner._reconcile_request_lifecycle(
+            {"done"},
+            preempted_req_ids={"paused"},
+            resumed_req_ids={"back"},
+            materialize_runtime_state=False,
+        )
+
+        assert released == [{"done", "paused", "back"}]
+
+
 class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -15,6 +15,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from transformers.configuration_utils import PretrainedConfig
+
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
@@ -28,6 +30,7 @@ def apply_compat_patches() -> None:
         return
     _APPLIED = True
     _patch_vllm_gemma4_mtp_config_loading()
+    _patch_vllm_glm4_moe_lite_mtp_config_loading()
     _patch_vllm_bytelevel_tokenizer_loading()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
@@ -289,6 +292,117 @@ def _patch_vllm_gemma4_mtp_config_loading() -> None:
     # override runs.
     AutoConfig.register("gemma4_assistant", config_cls, exist_ok=True)
     logger.debug("Registered Gemma4 assistant config compatibility")
+
+
+@lru_cache(maxsize=1)
+def _glm4_moe_lite_config_cls() -> type[Any]:
+    """The base Transformers config the nextn head nests under ``text_config``.
+
+    Imported lazily so a Transformers release without ``glm4_moe_lite`` raises
+    here (caught by the caller) rather than at module import.
+    """
+    from transformers.models.glm4_moe_lite.configuration_glm4_moe_lite import (
+        Glm4MoeLiteConfig,
+    )
+
+    return Glm4MoeLiteConfig
+
+
+class Glm4MoeLiteMTPCompatConfig(PretrainedConfig):
+    """Transformers config for the GLM-4.7-Flash nextn head.
+
+    The mlx-vlm drafter split nests the source model config under ``text_config``
+    and leaves the head's own ``architectures`` / ``num_nextn_predict_layers`` out
+    of the top level. vLLM's MTP override keys on the top-level ``architectures[0]``
+    (``Glm4MoeLiteForCausalLM``) and ``num_nextn_predict_layers`` to normalize the
+    draft into ``Glm4MoeLiteMTPModel`` (``num_hidden_layers=0``, ``n_predict=1``),
+    so promote both from the nested config before that override runs.
+
+    Defined at module scope (not a closure) so vLLM's spawn-based EngineCore can
+    pickle a config instance by qualified name into the worker process.
+    """
+
+    model_type = "glm4_moe_lite_mtp"
+
+    def __init__(self, text_config: Any | None = None, **kwargs: Any) -> None:
+        base = _glm4_moe_lite_config_cls()
+        if text_config is None:
+            self.text_config = base()
+        elif isinstance(text_config, base):
+            self.text_config = text_config
+        elif isinstance(text_config, Mapping):
+            self.text_config = base(**text_config)
+        else:
+            self.text_config = text_config
+        kwargs.setdefault(
+            "architectures", getattr(self.text_config, "architectures", None)
+        )
+        if "num_nextn_predict_layers" not in kwargs:
+            nextn = getattr(self.text_config, "num_nextn_predict_layers", None)
+            if nextn is not None:
+                kwargs["num_nextn_predict_layers"] = nextn
+        super().__init__(**kwargs)
+
+    def get_text_config(self, decoder: bool = False) -> Any:
+        return self.text_config
+
+
+def _glm4_moe_lite_mtp_config_class() -> type[Any]:
+    """Return the GLM-4.7-Flash nextn head config, wiring its nested
+    ``text_config`` sub-config. Raises if the pinned Transformers lacks
+    ``glm4_moe_lite`` (caught by the caller).
+    """
+    Glm4MoeLiteMTPCompatConfig.sub_configs = {
+        "text_config": _glm4_moe_lite_config_cls()
+    }
+    return Glm4MoeLiteMTPCompatConfig
+
+
+def _transformers_knows_glm4_moe_lite_mtp(auto_config: Any) -> bool:
+    try:
+        auto_config.for_model("glm4_moe_lite_mtp")
+    except ValueError:
+        return False
+    return True
+
+
+def _patch_vllm_glm4_moe_lite_mtp_config_loading() -> None:
+    """Register the GLM-4.7-Flash ``glm4_moe_lite_mtp`` draft config for the pin.
+
+    vLLM normalizes a ``Glm4MoeLiteForCausalLM`` draft config into the
+    ``glm4_moe_lite_mtp`` MTP wrapper (``num_hidden_layers=0``,
+    ``n_predict=num_nextn_predict_layers``), but the pinned Transformers release
+    has no ``glm4_moe_lite_mtp`` AutoConfig entry, so parsing the head
+    checkpoint's ``model_type`` fails before that override runs. The shim covers
+    config parsing only and never constructs a model. Mirrors
+    ``_patch_vllm_gemma4_mtp_config_loading``.
+    """
+    try:
+        from transformers import AutoConfig
+    except ImportError as exc:
+        logger.warning(
+            "Could not install GLM4 MoE-lite MTP config compatibility patch: %s",
+            exc,
+        )
+        return
+
+    if _transformers_knows_glm4_moe_lite_mtp(AutoConfig):
+        return
+
+    try:
+        config_cls = _glm4_moe_lite_mtp_config_class()
+    except ImportError as exc:
+        logger.warning(
+            "Could not install GLM4 MoE-lite MTP config compatibility patch "
+            "because Glm4MoeLite config classes are unavailable: %s",
+            exc,
+        )
+        return
+
+    # TODO: remove once the supported dependency stack parses raw
+    # ``model_type=glm4_moe_lite_mtp`` configs before vLLM's MTP override runs.
+    AutoConfig.register("glm4_moe_lite_mtp", config_cls, exist_ok=True)
+    logger.debug("Registered GLM4 MoE-lite MTP config compatibility")
 
 
 def _decoder_tree_contains_type(value: Any, decoder_type: str) -> bool:

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -207,6 +207,17 @@ class DraftModelProposer:
             draft_token_ids=[[int(token) for token in row] for row in rows],
         )
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # Return a preempted/evicted request's draft KV blocks to the free pool
+        # and drop its committed-length bookkeeping, so it does not pin draft
+        # cache while it waits; a resumed request re-ingests from the paged
+        # context. Mirrors _prune_finished for an explicit lifecycle set.
+        for req_id in req_ids:
+            blocks = self._req_blocks.pop(req_id, None)
+            if blocks is not None:
+                self._free_blocks.extend(blocks)
+            self._draft_seq_lens.pop(req_id, None)
+
     # -- internals -----------------------------------------------------------
 
     def _prune_finished(self, request_states: Any) -> None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -2208,14 +2208,22 @@ class MetalModelRunner:
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
 
+        invalidated = set(evicted_req_ids)
+        if preempted_req_ids:
+            invalidated.update(preempted_req_ids)
+        if resumed_req_ids:
+            invalidated.update(resumed_req_ids)
+
+        # A drafter that pins a bounded per-request resource (draft cache blocks)
+        # releases it on the same events as the runtime's recurrent state: a
+        # waiting or preempted request must not keep holding the resource, and a
+        # resumed request re-acquires it during recompute.
+        if invalidated and self._drafter is not None:
+            self._drafter.release_requests(invalidated)
+
         if runtime is not None:
-            runtime_invalidated = set(evicted_req_ids)
-            if preempted_req_ids:
-                runtime_invalidated.update(preempted_req_ids)
-            if resumed_req_ids:
-                runtime_invalidated.update(resumed_req_ids)
-            if runtime_invalidated:
-                runtime.release_requests(runtime_invalidated)
+            if invalidated:
+                runtime.release_requests(invalidated)
             if materialize_runtime_state:
                 runtime.materialize_pending_state()
 

--- a/vllm_metal/v1/mtp_heads/__init__.py
+++ b/vllm_metal/v1/mtp_heads/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MTP head implementations."""

--- a/vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp.py
+++ b/vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM-4.7-Flash nextn (MTP) head loading, validation, and deployment metadata."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from json import JSONDecodeError, loads
+from numbers import Integral, Real
+from pathlib import Path
+from threading import Lock
+from typing import Any, ClassVar
+
+from vllm.logger import init_logger
+
+from vllm_metal.v1.mlx_lm_paths import mlx_lm_compatible_model_path
+
+logger = init_logger(__name__)
+
+GLM4_MOE_LITE_MTP_MODEL_TYPE = "glm4_moe_lite_mtp"
+GLM4_MOE_LITE_MTP_NUM_NEXTN = 1
+GLM4_MOE_LITE_TARGET_MODEL_TYPE = "glm4_moe_lite"
+
+# The head ships as a hosted, revision-pinned drafter checkpoint; error messages
+# point users at those repos (or at the mlx-vlm split tool for a custom source
+# revision or quantization).
+HOSTED_HEAD_REPOS = (
+    "samithaj/GLM-4.7-Flash-MTP-4bit",
+    "samithaj/GLM-4.7-Flash-MTP-bf16",
+)
+SPLIT_TOOL = "python -m mlx_vlm.speculative.drafters.glm4_moe_lite_mtp.split"
+HEAD_SOURCE_HINT = (
+    f"Use a hosted GLM-4.7-Flash MTP head ({HOSTED_HEAD_REPOS[0]} or "
+    f"{HOSTED_HEAD_REPOS[1]}), or split your own with '{SPLIT_TOOL}'."
+)
+
+_HEAD_DOWNLOAD_ALLOW_PATTERNS = [
+    "config.json",
+    "*.safetensors",
+    "*.safetensors.index.json",
+]
+
+# Compat / target hyperparameters that must match between the extracted head and
+# the target model for the shared MLA + embedding math to be valid.
+_COMPAT_FIELDS = (
+    "hidden_size",
+    "vocab_size",
+    "kv_lora_rank",
+    "qk_rope_head_dim",
+    "qk_nope_head_dim",
+    "v_head_dim",
+    "num_attention_heads",
+    "rope_theta",
+    "rms_norm_eps",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Glm4MoeLiteMTPHeadMetadata:
+    """Validated shape of a GLM-4.7-Flash nextn (MTP) head checkpoint."""
+
+    model_type: str
+    architectures: tuple[str, ...]
+    hidden_size: int
+    vocab_size: int
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    qk_nope_head_dim: int
+    v_head_dim: int
+    num_attention_heads: int
+    rope_theta: float
+    rms_norm_eps: float
+    num_nextn_predict_layers: int
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any]) -> Glm4MoeLiteMTPHeadMetadata:
+        model_type = _config_value(config, "model_type")
+        if model_type != GLM4_MOE_LITE_MTP_MODEL_TYPE:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires "
+                f"model_type={GLM4_MOE_LITE_MTP_MODEL_TYPE!r}, got "
+                f"{model_type!r}. {HEAD_SOURCE_HINT}"
+            )
+
+        # The drafter split nests the source model config under ``text_config``;
+        # the head's shape fields live there. The top-level ``model_type`` above is
+        # the guard that this is the head, not the raw target repo
+        # (``glm4_moe_lite``). Require the nested schema rather than tolerating a
+        # flat checkpoint, so a malformed head is rejected at its own boundary.
+        text = _config_value(config, "text_config")
+        if not isinstance(text, Mapping):
+            raise ValueError(
+                "Glm4MoeLiteMTP head config must nest the source model config "
+                f"under 'text_config' (the drafter-split schema). {HEAD_SOURCE_HINT}"
+            )
+
+        num_nextn = _required_int(text, "num_nextn_predict_layers")
+        if num_nextn != GLM4_MOE_LITE_MTP_NUM_NEXTN:
+            raise ValueError(
+                "Glm4MoeLiteMTP head only supports "
+                f"num_nextn_predict_layers={GLM4_MOE_LITE_MTP_NUM_NEXTN}, got "
+                f"{num_nextn}"
+            )
+
+        block_size = _required_int(config, "block_size")
+        if block_size != num_nextn + 1:
+            raise ValueError(
+                "Glm4MoeLiteMTP head block_size must be "
+                f"num_nextn_predict_layers+1={num_nextn + 1}, got {block_size}"
+            )
+
+        return cls(
+            model_type=str(model_type),
+            architectures=_architectures(text),
+            hidden_size=_required_positive_int(text, "hidden_size"),
+            vocab_size=_required_positive_int(text, "vocab_size"),
+            kv_lora_rank=_required_positive_int(text, "kv_lora_rank"),
+            qk_rope_head_dim=_required_positive_int(text, "qk_rope_head_dim"),
+            qk_nope_head_dim=_required_positive_int(text, "qk_nope_head_dim"),
+            v_head_dim=_required_positive_int(text, "v_head_dim"),
+            num_attention_heads=_required_positive_int(text, "num_attention_heads"),
+            rope_theta=_required_positive_float(text, "rope_theta"),
+            rms_norm_eps=_required_positive_float(text, "rms_norm_eps"),
+            num_nextn_predict_layers=num_nextn,
+        )
+
+    def validate_compatible_with(self, target_config: Mapping[str, Any]) -> None:
+        """Fail loud when the head and target disagree on shared hyperparameters."""
+        target = _text_config(target_config)
+        self._validate_target_model_type(target_config, target)
+        for name in _COMPAT_FIELDS:
+            head_value = getattr(self, name)
+            target_value = _config_value(target, name)
+            if target_value is None:
+                raise ValueError(
+                    "Glm4MoeLiteMTP target model is missing "
+                    f"{name!r} required to validate head compatibility"
+                )
+            if not _values_match(head_value, target_value):
+                raise ValueError(
+                    f"Glm4MoeLiteMTP head {name} must match target {name}: "
+                    f"head={head_value!r}, target={target_value!r}"
+                )
+
+    @staticmethod
+    def _validate_target_model_type(
+        target_config: Any,
+        target_text_config: Any,
+    ) -> None:
+        """Reject a target whose ``model_type`` is not the GLM MoE-lite backbone.
+
+        The head's absorbed-MLA + embedding math is only valid over a
+        ``glm4_moe_lite`` target; accept the ``model_type`` at the top level of
+        the target config or inside its resolved text config.
+        """
+        model_types = {
+            model_type
+            for model_type in (
+                _config_value(target_config, "model_type"),
+                _config_value(target_text_config, "model_type"),
+            )
+            if model_type is not None
+        }
+        if not model_types:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires a "
+                f"{GLM4_MOE_LITE_TARGET_MODEL_TYPE!r} target model, got "
+                "model_type=None"
+            )
+        unknown = sorted(
+            str(model_type)
+            for model_type in model_types
+            if model_type != GLM4_MOE_LITE_TARGET_MODEL_TYPE
+        )
+        if unknown:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires a "
+                f"{GLM4_MOE_LITE_TARGET_MODEL_TYPE!r} target model, got "
+                f"model_type={unknown[0]!r}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class Glm4MoeLiteMTPHeadSource:
+    """Resolved head checkpoint source from a vLLM speculative config."""
+
+    model_name: str
+    revision: str | None
+
+    @classmethod
+    def from_speculative_config(
+        cls,
+        speculative_config: Any,
+    ) -> Glm4MoeLiteMTPHeadSource:
+        draft_model_config = speculative_config.draft_model_config
+        return cls(
+            model_name=draft_model_config.model,
+            revision=draft_model_config.revision,
+        )
+
+    def resolve(
+        self,
+        model_path_resolver: Callable[[str], str],
+    ) -> Glm4MoeLiteMTPHeadSource:
+        return Glm4MoeLiteMTPHeadSource(
+            model_name=model_path_resolver(self.model_name),
+            revision=self.revision,
+        )
+
+    @property
+    def cache_key(self) -> tuple[str, str | None]:
+        return (self.model_name, self.revision)
+
+
+@dataclass(frozen=True, slots=True)
+class Glm4MoeLiteMTPHeadRuntime:
+    """A loaded head model plus its validated metadata."""
+
+    model_name: str
+    model: Any
+    metadata: Glm4MoeLiteMTPHeadMetadata
+
+
+class Glm4MoeLiteMTPHeadLoader:
+    """Loads and validates an extracted GLM-4.7-Flash nextn head."""
+
+    _CACHE: ClassVar[dict[tuple[str, str | None], Glm4MoeLiteMTPHeadRuntime]] = {}
+    _CACHE_LOCK: ClassVar[Lock] = Lock()
+
+    def __init__(
+        self,
+        *,
+        load_model_fn: Callable[..., tuple[Any, dict[str, Any]]] | None = None,
+        download_fn: Callable[[str, str | None], Path] | None = None,
+        model_path_resolver: Callable[[str], str] | None = None,
+    ) -> None:
+        self._load_model = load_model_fn
+        self._download = download_fn
+        self._model_path_resolver = model_path_resolver
+
+    def load_if_needed(
+        self,
+        *,
+        speculative_config: Any,
+        target_config: Mapping[str, Any],
+    ) -> Glm4MoeLiteMTPHeadRuntime:
+        """Load the head for this speculative config, reusing the cross-instance cache."""
+        source = Glm4MoeLiteMTPHeadSource.from_speculative_config(speculative_config)
+        if self._model_path_resolver is not None:
+            source = source.resolve(self._model_path_resolver)
+
+        cached = self._cached_runtime(source)
+        if cached is not None:
+            cached.metadata.validate_compatible_with(target_config)
+            logger.info("GLM4 MTP head loaded from cache: %s", source.model_name)
+            return cached
+
+        return self._load_uncached(source, target_config)
+
+    def _load_uncached(
+        self,
+        source: Glm4MoeLiteMTPHeadSource,
+        target_config: Mapping[str, Any],
+    ) -> Glm4MoeLiteMTPHeadRuntime:
+        logger.info("Loading GLM4 MTP head: %s", source.model_name)
+        start_time = time.time()
+        model_path = self._download_model(source)
+        self._preflight_config(model_path, target_config)
+        model, head_config = self._load_head_model(model_path)
+        metadata = self._metadata_from_config(head_config, target_config)
+        self._assert_head_tensors(model)
+        runtime = Glm4MoeLiteMTPHeadRuntime(
+            model_name=source.model_name,
+            model=model,
+            metadata=metadata,
+        )
+        with self._CACHE_LOCK:
+            self._CACHE[source.cache_key] = runtime
+        logger.info(
+            "GLM4 MTP head loaded in %.2fs: %s",
+            time.time() - start_time,
+            source.model_name,
+        )
+        return runtime
+
+    def _cached_runtime(
+        self,
+        source: Glm4MoeLiteMTPHeadSource,
+    ) -> Glm4MoeLiteMTPHeadRuntime | None:
+        with self._CACHE_LOCK:
+            return self._CACHE.get(source.cache_key)
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """Clear the process-level head cache."""
+        with cls._CACHE_LOCK:
+            cls._CACHE.clear()
+
+    def _preflight_config(
+        self,
+        model_path: Path,
+        target_config: Mapping[str, Any],
+    ) -> None:
+        head_config = self._read_config_file(model_path)
+        if head_config is None and self._load_model is None:
+            raise ValueError(
+                "GLM4 MTP head model path must contain config.json: "
+                f"{model_path}. {HEAD_SOURCE_HINT}"
+            )
+        if head_config is not None:
+            self._metadata_from_config(head_config, target_config)
+
+    def _metadata_from_config(
+        self,
+        head_config: Mapping[str, Any],
+        target_config: Mapping[str, Any],
+    ) -> Glm4MoeLiteMTPHeadMetadata:
+        self._reject_custom_model_file(head_config)
+        metadata = Glm4MoeLiteMTPHeadMetadata.from_config(head_config)
+        metadata.validate_compatible_with(target_config)
+        return metadata
+
+    def _load_head_model(self, model_path: Path) -> tuple[Any, dict[str, Any]]:
+        if self._load_model is None:
+            from mlx_lm.utils import load_model as load_model_fn
+        else:
+            load_model_fn = self._load_model
+
+        with mlx_lm_compatible_model_path(model_path) as compatible_model_path:
+            return load_model_fn(
+                compatible_model_path,
+                lazy=False,
+                strict=True,
+                get_model_classes=self._get_model_classes,
+            )
+
+    def _download_model(self, source: Glm4MoeLiteMTPHeadSource) -> Path:
+        if self._download is not None:
+            return Path(self._download(source.model_name, source.revision))
+
+        model_path = Path(source.model_name)
+        if model_path.exists():
+            return model_path
+
+        from huggingface_hub import snapshot_download
+
+        return Path(
+            snapshot_download(
+                source.model_name,
+                revision=source.revision,
+                allow_patterns=_HEAD_DOWNLOAD_ALLOW_PATTERNS,
+            )
+        )
+
+    @staticmethod
+    def _assert_head_tensors(model: Any) -> None:
+        from mlx.utils import tree_flatten
+
+        params = dict(tree_flatten(model.parameters()))
+        for key, source in (
+            ("lm_head.weight", "shared_head.head"),
+            ("model.embed_tokens.weight", "the dedicated nextn embedding"),
+        ):
+            if key not in params:
+                raise ValueError(
+                    f"GLM4 MTP head checkpoint is missing {key!r} (from {source}). "
+                    f"{HEAD_SOURCE_HINT}"
+                )
+
+    @staticmethod
+    def _read_config_file(model_path: Path) -> dict[str, Any] | None:
+        config_path = model_path / "config.json"
+        if not config_path.exists():
+            return None
+        try:
+            config = loads(config_path.read_text(encoding="utf-8"))
+        except JSONDecodeError as exc:
+            raise ValueError(
+                f"GLM4 MTP head config.json is not valid JSON: {config_path}"
+            ) from exc
+        if not isinstance(config, dict):
+            raise ValueError("GLM4 MTP head config.json must contain an object")
+        return config
+
+    @staticmethod
+    def _reject_custom_model_file(config: Mapping[str, Any]) -> None:
+        if "model_file" in config:
+            model_file = config["model_file"]
+            raise ValueError(
+                "GLM4 MTP head loader uses built-in Metal model classes and does "
+                f"not support custom model_file={model_file!r}"
+            )
+
+    @staticmethod
+    def _get_model_classes(
+        config: dict[str, Any],
+    ) -> tuple[type[Any], type[Any]]:
+        if config.get("model_type") != GLM4_MOE_LITE_MTP_MODEL_TYPE:
+            model_type = config.get("model_type")
+            architectures = config.get("architectures")
+            raise ValueError(
+                "GLM4 MTP head loader only supports "
+                f"{GLM4_MOE_LITE_MTP_MODEL_TYPE!r} configs, got "
+                f"model_type={model_type!r}, architectures={architectures!r}. "
+                f"{HEAD_SOURCE_HINT}"
+            )
+        from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp_model import (
+            Glm4MoeLiteMTPArgs,
+            Glm4MoeLiteMTPModel,
+        )
+
+        return Glm4MoeLiteMTPModel, Glm4MoeLiteMTPArgs
+
+
+def _text_config(config: Any | None) -> Any | None:
+    if config is None:
+        return None
+    get_text_config = getattr(config, "get_text_config", None)
+    if callable(get_text_config):
+        return get_text_config()
+    return _config_value(config, "text_config", config)
+
+
+def _config_value(config: Any, key: str, default: Any = None) -> Any:
+    if config is None:
+        return default
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def _values_match(head_value: Any, target_value: Any) -> bool:
+    if isinstance(head_value, Real) and isinstance(target_value, Real):
+        return bool(
+            abs(float(head_value) - float(target_value))
+            <= 1e-9 * max(1.0, abs(float(head_value)))
+        )
+    return head_value == target_value
+
+
+def _required_int(config: Mapping[str, Any], key: str) -> int:
+    value = _config_value(config, key)
+    if value is None:
+        raise ValueError(f"GLM4 MTP head config is missing {key}")
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"GLM4 MTP head {key} must be an integer, got {value!r}")
+    return int(value)
+
+
+def _required_positive_int(config: Mapping[str, Any], key: str) -> int:
+    value = _required_int(config, key)
+    if value <= 0:
+        raise ValueError(f"GLM4 MTP head {key} must be positive, got {value}")
+    return value
+
+
+def _required_positive_float(config: Mapping[str, Any], key: str) -> float:
+    value = _config_value(config, key)
+    if value is None:
+        raise ValueError(f"GLM4 MTP head config is missing {key}")
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError(f"GLM4 MTP head {key} must be a number, got {value!r}")
+    if float(value) <= 0.0:
+        raise ValueError(f"GLM4 MTP head {key} must be positive, got {value}")
+    return float(value)
+
+
+def _architectures(config: Mapping[str, Any]) -> tuple[str, ...]:
+    value = _config_value(config, "architectures", ()) or ()
+    if isinstance(value, str):
+        raise ValueError("GLM4 MTP head architectures must be a non-string sequence")
+    try:
+        names = tuple(value)
+    except TypeError as exc:
+        raise ValueError("GLM4 MTP head architectures must be a sequence") from exc
+    if any(not isinstance(name, str) for name in names):
+        raise ValueError("GLM4 MTP head architectures entries must be strings")
+    return names

--- a/vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp_model.py
+++ b/vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp_model.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX model classes and weight transform for the GLM-4.7-Flash nextn head.
+
+The ``glm4_moe_lite`` (GLM-4.7-Flash) family ships a single trained nextn layer
+(``model.layers.<num_hidden_layers>.*``) that predicts one extra token. This
+module runs that layer as a tiny standalone MLX model over the "slot stream":
+
+    slot_p = eh_proj([enorm(embed(t_{p+1})), hnorm(h_p)])
+
+where ``h_p`` is the target's post-final-norm hidden state. One stock mlx_lm
+``Glm4MoeLiteDecoderLayer`` forward over the appended slots, then the shared
+head norm + untied lm_head, yields one greedy draft token.
+
+The checkpoint this model loads is the flat, post-``sanitize`` layout emitted by
+the mlx-vlm ``glm4_moe_lite_mtp`` drafter split; that split and
+``convert_nextn_weights`` share the transform so there is one source of truth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, fields
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.base import BaseModelArgs, create_attention_mask
+from mlx_lm.models.glm4_moe_lite import Glm4MoeLiteDecoderLayer
+from mlx_lm.models.glm4_moe_lite import ModelArgs as Glm4MoeLiteBackboneArgs
+
+from vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp import (
+    GLM4_MOE_LITE_MTP_MODEL_TYPE,
+    GLM4_MOE_LITE_MTP_NUM_NEXTN,
+    GLM4_MOE_LITE_TARGET_MODEL_TYPE,
+    HEAD_SOURCE_HINT,
+)
+
+# Flat-layout prefixes shared by the model tree and the weight transform below.
+_MTP_ATTN_PREFIX = "model.mtp_block.self_attn"
+_MTP_MLP_PREFIX = "model.mtp_block.mlp"
+
+
+@dataclass
+class Glm4MoeLiteMTPArgs(BaseModelArgs):
+    """MLX model args for the extracted GLM-4.7-Flash nextn head checkpoint.
+
+    Mirrors the field set that ``mlx_lm.models.glm4_moe_lite.ModelArgs`` needs to
+    build one decoder layer, plus the MTP-specific ``model_type`` /
+    ``num_nextn_predict_layers`` contract. ``num_hidden_layers`` is ``0`` for the
+    standalone head (the backbone is stripped); the head builds exactly one
+    ``mtp_block`` regardless.
+    """
+
+    model_type: str = GLM4_MOE_LITE_MTP_MODEL_TYPE
+    vocab_size: int = 154880
+    hidden_size: int = 2048
+    intermediate_size: int = 10240
+    moe_intermediate_size: int = 1536
+    num_hidden_layers: int = 0
+    num_attention_heads: int = 20
+    num_key_value_heads: int = 20
+    n_shared_experts: int | None = 1
+    n_routed_experts: int = 64
+    routed_scaling_factor: float = 1.8
+    kv_lora_rank: int = 512
+    q_lora_rank: int | None = 768
+    qk_rope_head_dim: int = 64
+    qk_nope_head_dim: int = 192
+    v_head_dim: int = 256
+    topk_method: str = "noaux_tc"
+    scoring_func: str = "sigmoid"
+    norm_topk_prob: bool = True
+    n_group: int = 1
+    topk_group: int = 1
+    num_experts_per_tok: int = 4
+    moe_layer_freq: int = 1
+    first_k_dense_replace: int = 1
+    max_position_embeddings: int = 202752
+    rms_norm_eps: float = 1e-5
+    rope_theta: float = 1_000_000.0
+    rope_scaling: dict[str, Any] | None = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    partial_rotary_factor: float = 1.0
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = GLM4_MOE_LITE_MTP_NUM_NEXTN
+    quantization: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.model_type != GLM4_MOE_LITE_MTP_MODEL_TYPE:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires "
+                f"model_type={GLM4_MOE_LITE_MTP_MODEL_TYPE!r}, got "
+                f"{self.model_type!r}"
+            )
+        if self.num_nextn_predict_layers != GLM4_MOE_LITE_MTP_NUM_NEXTN:
+            raise ValueError(
+                "Glm4MoeLiteMTP head only supports "
+                f"num_nextn_predict_layers={GLM4_MOE_LITE_MTP_NUM_NEXTN}, got "
+                f"{self.num_nextn_predict_layers!r}"
+            )
+        for name in ("hidden_size", "vocab_size", "num_attention_heads"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(
+                    f"Glm4MoeLiteMTP head {name} must be a positive int, got {value!r}"
+                )
+        if not self.n_routed_experts or self.n_routed_experts <= 0:
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires n_routed_experts > 0 to build the "
+                f"MoE mtp_block, got {self.n_routed_experts!r}"
+            )
+        # The head builds exactly one decoder layer at
+        # layer_idx=first_k_dense_replace and needs it to be the MoE variant
+        # (the trained nextn layer is MoE). Stock Glm4MoeLiteDecoderLayer selects
+        # MoE only when layer_idx >= first_k_dense_replace AND
+        # layer_idx % moe_layer_freq == 0; the first is trivially true here, so
+        # validate the second (and guard the modulo against a zero freq).
+        if (
+            not isinstance(self.moe_layer_freq, int)
+            or isinstance(self.moe_layer_freq, bool)
+            or self.moe_layer_freq <= 0
+        ):
+            raise ValueError(
+                "Glm4MoeLiteMTP head requires moe_layer_freq to be a positive "
+                f"int, got {self.moe_layer_freq!r}"
+            )
+        if self.first_k_dense_replace % self.moe_layer_freq != 0:
+            raise ValueError(
+                "Glm4MoeLiteMTP head builds its mtp_block at "
+                f"layer_idx=first_k_dense_replace={self.first_k_dense_replace}, "
+                "but stock Glm4MoeLiteDecoderLayer only makes that an MoE layer "
+                "when layer_idx % moe_layer_freq == 0 "
+                f"(moe_layer_freq={self.moe_layer_freq}). The extracted nextn "
+                "layer is MoE, so first_k_dense_replace must be divisible by "
+                "moe_layer_freq."
+            )
+        if self.quantization is not None and not isinstance(self.quantization, Mapping):
+            raise ValueError(
+                "Glm4MoeLiteMTP head quantization must be a mapping, got "
+                f"{type(self.quantization).__name__}"
+            )
+
+    @classmethod
+    def from_dict(cls, params: Mapping[str, Any]) -> Glm4MoeLiteMTPArgs:
+        """Build args from the drafter-split config, reading the nested shape.
+
+        The head's shape lives in the nested ``text_config``; the top level
+        carries only the head identity (``model_type``), ``quantization``, and
+        ``block_size``. Merge the nested config in with the top level winning for
+        the fields it owns, so the shape is read from the checkpoint rather than
+        silently falling back to this class's GLM-4.7-Flash defaults.
+        """
+        merged = dict(params)
+        text_config = merged.pop("text_config", None)
+        if text_config is not None:
+            if not isinstance(text_config, Mapping):
+                raise ValueError(
+                    "Glm4MoeLiteMTP head text_config must be a mapping, got "
+                    f"{type(text_config).__name__}"
+                )
+            merged = {**text_config, **merged}
+        return super().from_dict(merged)
+
+    def backbone_args(self) -> Glm4MoeLiteBackboneArgs:
+        """Build the stock mlx_lm backbone args used to construct ``mtp_block``.
+
+        The nextn layer is architecturally a ``glm4_moe_lite`` decoder layer, so
+        the stock ``ModelArgs`` drives its construction. ``model_type`` is reset
+        to the backbone type (``from_dict`` drops MTP-only fields).
+        """
+        data = {f.name: getattr(self, f.name) for f in fields(self)}
+        data["model_type"] = GLM4_MOE_LITE_TARGET_MODEL_TYPE
+        return Glm4MoeLiteBackboneArgs.from_dict(data)
+
+
+def _split_kv_b_proj(weights: dict[str, Any], args: Glm4MoeLiteMTPArgs) -> None:
+    """Split the fused ``kv_b_proj`` into absorbed ``embed_q`` / ``unembed_out``.
+
+    Adapts ``mlx_lm.models.glm4_moe_lite.Model.sanitize`` to the single
+    ``mtp_block`` prefix. No-op when the weights are already in the post-split
+    (absorbed) layout.
+    """
+    prefix = _MTP_ATTN_PREFIX
+    weight_key = f"{prefix}.kv_b_proj.weight"
+    if weight_key not in weights:
+        return
+
+    quantized = f"{prefix}.kv_b_proj.scales" in weights
+    v = weights.pop(weight_key)
+    head_dim = args.qk_nope_head_dim + args.v_head_dim
+
+    bits = group_size = 0
+    if quantized:
+        dims = args.kv_lora_rank
+        scales = weights.pop(f"{prefix}.kv_b_proj.scales")
+        biases = weights.pop(f"{prefix}.kv_b_proj.biases")
+        # Infer bits/group_size from the packed weight and scale shapes, exactly
+        # as the stock sanitize does.
+        bits = (v.shape[-1] * 32) // dims
+        group_size = dims // scales.shape[-1]
+        v = mx.dequantize(v, scales, biases, bits=bits, group_size=group_size)
+
+    num_heads = args.num_attention_heads
+    v = v.reshape(num_heads, head_dim, -1)
+    wk = mx.contiguous(v[:, : args.qk_nope_head_dim, :].swapaxes(-1, -2))
+    wv = mx.contiguous(v[:, args.qk_nope_head_dim :, :])
+    if quantized:
+        wk, wk_scales, wk_biases = mx.quantize(wk, bits=bits, group_size=group_size)
+        wv, wv_scales, wv_biases = mx.quantize(wv, bits=bits, group_size=group_size)
+        weights[f"{prefix}.embed_q.scales"] = wk_scales
+        weights[f"{prefix}.unembed_out.scales"] = wv_scales
+        weights[f"{prefix}.embed_q.biases"] = wk_biases
+        weights[f"{prefix}.unembed_out.biases"] = wv_biases
+    weights[f"{prefix}.embed_q.weight"] = wk
+    weights[f"{prefix}.unembed_out.weight"] = wv
+
+
+def _stack_experts(weights: dict[str, Any], args: Glm4MoeLiteMTPArgs) -> None:
+    """Stack per-expert MoE tensors into the ``switch_mlp`` layout.
+
+    Adapts the expert-stacking half of the stock sanitize to the single
+    ``mtp_block`` prefix. No-op when already stacked.
+    """
+    prefix = _MTP_MLP_PREFIX
+    n_experts = args.n_routed_experts
+    for proj in ("gate_proj", "down_proj", "up_proj"):
+        for suffix in ("weight", "scales", "biases"):
+            first = f"{prefix}.experts.0.{proj}.{suffix}"
+            if first not in weights:
+                continue
+            expert_keys = [
+                f"{prefix}.experts.{e}.{proj}.{suffix}" for e in range(n_experts)
+            ]
+            # Pre-validate so a checkpoint with fewer experts than the config's
+            # ``n_routed_experts`` fails with a descriptive error rather than a
+            # bare KeyError leaking from the pop below.
+            for e, key in enumerate(expert_keys):
+                if key not in weights:
+                    raise ValueError(
+                        f"Glm4MoeLiteMTP head checkpoint is missing expert {e} "
+                        f"tensor {key!r}: config n_routed_experts={n_experts} "
+                        f"expects experts 0..{n_experts - 1} for "
+                        f"{prefix}.experts.<e>.{proj}.{suffix} to stack into "
+                        f"switch_mlp. {HEAD_SOURCE_HINT}"
+                    )
+            to_join = [weights.pop(key) for key in expert_keys]
+            weights[f"{prefix}.switch_mlp.{proj}.{suffix}"] = mx.stack(to_join)
+
+
+def convert_nextn_weights(
+    weights: Mapping[str, Any],
+    args: Glm4MoeLiteMTPArgs,
+) -> dict[str, Any]:
+    """Rewrite flat nextn weights into the module tree the head loads.
+
+    Idempotent: applies the absorbed-MLA ``kv_b_proj`` split and MoE expert
+    stacking only when the pre-split / unstacked tensors are present. Shared by
+    the mlx-vlm drafter split (which pre-applies it so the shipped checkpoint is
+    post-``sanitize``) and by ``Glm4MoeLiteMTPModel.sanitize`` (which tolerates
+    either layout).
+    """
+    out = dict(weights)
+    _split_kv_b_proj(out, args)
+    _stack_experts(out, args)
+    return out
+
+
+class _Glm4MoeLiteMTPInner(nn.Module):
+    """The ``model.*`` subtree matching the flat extracted checkpoint layout."""
+
+    def __init__(
+        self,
+        args: Glm4MoeLiteMTPArgs,
+        backbone: Glm4MoeLiteBackboneArgs,
+    ) -> None:
+        super().__init__()
+        hidden = args.hidden_size
+        eps = args.rms_norm_eps
+        self.embed_tokens = nn.Embedding(args.vocab_size, hidden)
+        self.enorm = nn.RMSNorm(hidden, eps=eps)
+        self.hnorm = nn.RMSNorm(hidden, eps=eps)
+        self.eh_proj = nn.Linear(2 * hidden, hidden, bias=False)
+        # layer_idx == first_k_dense_replace forces the MoE MLP (use_moe=True),
+        # matching the trained nextn layer.
+        self.mtp_block = Glm4MoeLiteDecoderLayer(
+            backbone,
+            layer_idx=backbone.first_k_dense_replace,
+        )
+        self.shared_head_norm = nn.RMSNorm(hidden, eps=eps)
+
+
+class Glm4MoeLiteMTPModel(nn.Module):
+    """MLX module matching the extracted GLM-4.7-Flash nextn head checkpoint."""
+
+    def __init__(self, args: Glm4MoeLiteMTPArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.hidden_size = args.hidden_size
+        backbone = args.backbone_args()
+        self.model = _Glm4MoeLiteMTPInner(args, backbone)
+        # Head is NOT tied; the extracted checkpoint ships a dedicated lm_head
+        # (from the trained ``shared_head.head``).
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def build_slot_inputs(
+        self,
+        token_ids: mx.array,
+        hidden_rows: mx.array,
+        first_position: int,
+    ) -> mx.array:
+        """Project ``[embed(t_{p+1}), h_p]`` into one input row per slot.
+
+        ``token_ids`` are the tokens whose embeddings feed each slot (target
+        tokens shifted left by one). ``hidden_rows`` are the matching target
+        post-final-norm hidden states. Embedding rows at absolute position 0 are
+        zeroed (upstream ``inputs_embeds[positions == 0] = 0``), which is why
+        ``first_position`` (the absolute position of row 0) is required.
+        """
+        token_ids = mx.array(token_ids)
+        if token_ids.ndim != 1:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs expects 1-D token_ids "
+                f"[num_slots], got shape {tuple(token_ids.shape)}"
+            )
+        if hidden_rows.ndim != 2:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs expects 2-D hidden_rows "
+                f"[num_slots, hidden], got shape {tuple(hidden_rows.shape)}"
+            )
+        num_slots = token_ids.shape[0]
+        if hidden_rows.shape[0] != num_slots:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs token/hidden row count "
+                f"mismatch: token_ids={num_slots}, hidden_rows={hidden_rows.shape[0]}"
+            )
+        if hidden_rows.shape[1] != self.hidden_size:
+            raise ValueError(
+                "Glm4MoeLiteMTP build_slot_inputs hidden_rows last dim must be "
+                f"{self.hidden_size}, got {hidden_rows.shape[1]}"
+            )
+
+        emb = self.model.embed_tokens(token_ids)
+        positions = first_position + mx.arange(num_slots)
+        keep = (positions != 0)[:, None].astype(emb.dtype)
+        emb = emb * keep
+        combined = mx.concatenate(
+            [self.model.enorm(emb), self.model.hnorm(hidden_rows)],
+            axis=-1,
+        )
+        return self.model.eh_proj(combined)
+
+    def forward_slots(
+        self,
+        x: mx.array,
+        cache: Any,
+        *,
+        expected_offset: int | None = None,
+    ) -> mx.array:
+        """Run one stock decoder-layer forward over ``x`` with an appending cache.
+
+        ``x`` is ``[num_slots, hidden]``; the slab index == sequence position ==
+        RoPE offset, so stock mlx_lm attention is correct. Returns the
+        post-shared-head-norm hidden states ``[num_slots, hidden]``.
+
+        The slot stream carries two independent position anchors: the caller's
+        ``first_position`` passed to :meth:`build_slot_inputs` (which zeroes the
+        absolute-position-0 embedding), and the ``cache.offset`` that drives
+        RoPE / causal masking here. They must agree for the row at ``x[0]``.
+        Pass ``expected_offset`` (typically the same ``first_position``) to
+        assert the cache is positioned where the caller thinks it is; when it
+        differs from the cache's ``offset``, this fails loud instead of silently
+        drafting at the wrong position.
+        """
+        if x.ndim != 2:
+            raise ValueError(
+                "Glm4MoeLiteMTP forward_slots expects 2-D x [num_slots, hidden], "
+                f"got shape {tuple(x.shape)}"
+            )
+        if expected_offset is not None and cache.offset != expected_offset:
+            raise ValueError(
+                "Glm4MoeLiteMTP forward_slots cache offset "
+                f"{cache.offset} does not match expected_offset "
+                f"{expected_offset}: the slot position anchor "
+                "(first_position in build_slot_inputs) and the cache's RoPE "
+                "offset have diverged."
+            )
+        h = x[None]
+        mask = create_attention_mask(h, cache, return_array=True)
+        h = self.model.mtp_block(h, mask, cache)
+        h = self.model.shared_head_norm(h)
+        return h[0]
+
+    def compute_logits(self, hidden: mx.array) -> mx.array:
+        """Project post-norm hidden states through the untied lm_head."""
+        return self.lm_head(hidden)
+
+    def sanitize(self, weights: Mapping[str, Any]) -> dict[str, Any]:
+        """Accept pre- or post-split attention and (un)stacked expert layouts."""
+        return convert_nextn_weights(weights, self.args)
+
+    @property
+    def cast_predicate(self):  # noqa: ANN201
+        """Keep ``e_score_correction_bias`` at its source dtype during casts.
+
+        Mirrors ``mlx_lm.models.glm4_moe_lite.Model.cast_predicate``: the
+        noaux_tc router correction bias is fp32 in the source shard and must
+        stay fp32 (vLLM keeps the noaux_tc bias fp32). An mlx_lm convert that
+        honors this predicate will not down-cast that tensor with the rest of
+        the weights.
+        """
+
+        def predicate(weight_key: str) -> bool:
+            return "e_score_correction_bias" not in weight_key
+
+        return predicate

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -147,6 +147,12 @@ class NgramProposer:
         # N-gram matches token ids only; it never reads the target's hidden states.
         return False
 
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The miss-streak throttle is per-request bookkeeping, not a bounded
+        # resource: a preempted request keeps its counters across resume, and
+        # they are dropped when its id finishes.
+        del req_ids
+
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         # Bookkeeping runs unconditionally, before the num_speculative_tokens
         # check: a step with drafting disabled still needs finished ids

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -63,11 +63,7 @@ class ProposeContext:
 
 
 class MetalProposer(Protocol):
-    """Uniform drafting seam.
-
-    Implementations: :class:`Gemma4MTPProposer`, and (draft-model SD) a
-    ``DraftModelProposer``.
-    """
+    """Uniform drafting seam."""
 
     def needs_target_hidden_states(
         self,
@@ -80,6 +76,16 @@ class MetalProposer(Protocol):
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         """Return per-request draft tokens for the next step, or ``None``."""
+        ...
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        """Release any per-request drafter state for these evicted/preempted ids.
+
+        Called from the runner's lifecycle reconcile on eviction, preemption, and
+        resume. A proposer that pins a bounded per-request resource (draft cache
+        blocks) must release it here rather than hold it while the request waits;
+        a stateless proposer is a no-op.
+        """
         ...
 
 
@@ -105,6 +111,11 @@ class Gemma4MTPProposer:
         # decode and final-prefill rows; intermediate prefill chunks never
         # sample, so they cannot seed a draft.
         return bool(decode_segments) or has_final_prefill
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        # The assistant reads the target's paged KV (released by the runtime);
+        # the proposer holds no per-request state of its own.
+        del req_ids
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         if ctx.num_speculative_tokens <= 0:


### PR DESCRIPTION
GLM-4.7-Flash (`glm4_moe_lite`) ships a single trained nextn layer that predicts one extra token. This adds the pieces needed to run that layer as a standalone MTP head — the MLX model, the checkpoint weight transform, and the loader — without wiring anything into the runtime.

`vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp_model.py`

- `Glm4MoeLiteMTPArgs` — model args for the extracted head. `from_dict` reads the shape out of the nested `text_config` of the drafter-split config rather than silently falling back to the GLM-4.7-Flash defaults, and rejects a `first_k_dense_replace` / `moe_layer_freq` pair that would build a dense `mtp_block` where the trained nextn layer is MoE.
- `Glm4MoeLiteMTPModel` — `build_slot_inputs` projects `[embed(t_{p+1}), h_p]` into one row per slot and zeroes the absolute-position-0 embedding; `forward_slots` runs one stock `Glm4MoeLiteDecoderLayer` over the slab and takes an optional `expected_offset` so a cache/position anchor desync fails loud instead of drafting at the wrong position; `compute_logits` reads out through the untied `lm_head`.
- `convert_nextn_weights` — the absorbed-MLA `kv_b_proj` split plus MoE expert stacking, idempotent so it accepts either the pre- or post-`sanitize` layout. The mlx-vlm drafter split applies the same transform, so there is one source of truth for the layout.

`vllm_metal/v1/mtp_heads/glm4_moe_lite_mtp.py`

- `Glm4MoeLiteMTPHeadMetadata` validates the head config against the drafter-split schema and fails loud when the head and target disagree on any shared MLA / embedding hyperparameter, or when the target is not a `glm4_moe_lite` backbone.
- `Glm4MoeLiteMTPHeadLoader` downloads (or reads from disk), preflights `config.json` before touching weights, loads through `mlx_lm.load_model` with the head's own model classes, asserts the checkpoint carries `lm_head.weight` and `model.embed_tokens.weight`, and caches per (model, revision).

The loader imports the MLX classes only inside `_get_model_classes`, so it stays importable without mlx / mlx_lm and config detection never constructs Metal-backed modules. Verified with mlx and mlx_lm blocked at the import-system level: `vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp` imports with zero mlx modules loaded, while `vllm_metal.v1.mtp_heads.glm4_moe_lite_mtp_model` fails on `mlx`.

The load-bearing test is `test_default_loader_loads_real_head_from_disk`: it writes a real safetensors checkpoint plus the hosted drafter-split `config.json`, loads it through the default loader path with no injected fakes, and checks the loaded model produces finite logits over a slot stream. `test_glm4_moe_lite_mtp_model.py` pins the forward against a self-contained numpy reference of the upstream nextn math (enorm/hnorm/eh_proj, position-0 masking, absorbed MLA with traditional RoPE, noaux_tc sigmoid gating, shared expert) and checks that incremental slab forwards equal a single multi-row forward.

Tests: `pytest -m "not slow" tests/` — 1682 passed, 15 skipped, 46 deselected.

Stacked on #553 (and #551 behind it); their commits show up in this diff until they merge.
