### PR TITLE
Bump vLLM to 0.26.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,7 +165,7 @@ EOF
     exit 1
   fi
 
-  local vllm_v="0.25.1"
+  local vllm_v="0.26.0"
   local url_base="https://github.com/vllm-project/vllm/releases/download"
   local filename="vllm-$vllm_v.tar.gz"
   local vllm_tmp_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
-    # Keep aligned with vLLM 0.25.1's Transformers lower bound.
+    # Keep aligned with vLLM 0.26.0's Transformers lower bound.
     # Temporary cap: transformers 5.13.0 (released 2026-07-03) breaks MLX Metal
     # availability inside the vLLM process on GitHub's macOS runner VMs, so
     # platform resolution falls back to CPU. Verified A/B on the same runner:
@@ -53,7 +53,7 @@ dependencies = [
     # Core utilities
     "numpy>=1.24.0",
     "psutil>=5.9.0",
-    # Keep aligned with vLLM 0.25.1's FastAPI/Starlette bounds. vLLM caps fastapi
+    # Keep aligned with vLLM 0.26.0's FastAPI/Starlette bounds. vLLM caps fastapi
     # itself (requirements/common.txt): 0.133.0 is the first release supporting
     # Starlette 1.0, and <0.137.0 avoids the FastAPI 0.137 route-tree change that
     # breaks its handler overrides. The earlier prometheus crash (vllm#45597) is

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -245,8 +245,8 @@ class TestTurboQuantHybridAlignment:
         "cache_kwargs,hash_consumer",
         [
             ({"block_size": 64}, False),
-            ({"block_size": 64, "hash_block_size": 64}, True),
-            ({"hash_block_size": 64}, True),
+            ({"block_size": 64, "prefix_match_unit": 64}, True),
+            ({"prefix_match_unit": 64}, True),
         ],
         ids=["user_block", "user_block_and_hash", "hash_only"],
     )
@@ -279,9 +279,9 @@ class TestTurboQuantHybridAlignment:
         assert {group.kv_cache_spec.page_size_bytes for group in groups} == {
             cache_config.block_size * self._TQ_PAGE_1_TOKEN
         }
-        if cache_config.hash_block_size is None:
+        if cache_config.prefix_match_unit is None:
             assert hash_block_size == scheduler_block_size
         else:
-            assert cache_config.block_size % cache_config.hash_block_size == 0
-            assert scheduler_block_size % cache_config.hash_block_size == 0
-            assert hash_block_size == cache_config.hash_block_size
+            assert cache_config.block_size % cache_config.prefix_match_unit == 0
+            assert scheduler_block_size % cache_config.prefix_match_unit == 0
+            assert hash_block_size == cache_config.prefix_match_unit

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -582,7 +582,7 @@ class TestMetalPoolingFailFast:
 
     @pytest.mark.parametrize(
         "task",
-        ["score", "token_embed", "token_classify", "plugin"],
+        ["token_embed", "token_classify", "plugin"],
     )
     def test_unsupported_pooling_tasks_fail_fast(self, task: str) -> None:
         runner = _make_runner()

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -820,7 +820,7 @@ class MetalPlatform(Platform):
         user_block_size = (
             cache_config.block_size if cache_config.user_specified_block_size else None
         )
-        hash_block_size = cache_config.hash_block_size
+        hash_block_size = cache_config.prefix_match_unit
         super().update_block_size_for_backend(vllm_config)
 
         cls._realign_hybrid_block_size_for_turboquant(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -789,7 +789,7 @@ class WorkerCachePlanner:
         1. Numeric VLLM_METAL_MEMORY_FRACTION, for example 0.6, wins.
         2. Otherwise, VLLM_METAL_MEMORY_FRACTION=auto uses the user-provided
            --gpu-memory-utilization value.
-        3. If the user did not provide --gpu-memory-utilization, vLLM 0.25.1
+        3. If the user did not provide --gpu-memory-utilization, vLLM 0.26.0
            supplies its default value, 0.92.
         """
         metal_config = self._worker.metal_config


### PR DESCRIPTION
vLLM 0.26.0 renamed `CacheConfig.hash_block_size` to `prefix_match_unit`, and we read that field unconditionally in `MetalPlatform.update_block_size_for_backend`, so every `vllm serve` died with an `AttributeError` at engine init. This PR moves `install.sh:168` to 0.26.0, fixes that read, and updates the two tests that touch the renamed field or build the removed score pooling task. Nothing else in the release reaches us, and no shim or cap discharges.

`vllm bench serve`, Qwen3-0.6B, sonnet, 100 prompts, `--request-rate inf --temperature 0 --ignore-eos --seed 0`, two server sessions per arm on the same machine. Both arms completed 100 requests with 54256 input and 15000 generated tokens.

| Metric | vLLM 0.25.1 | vLLM 0.26.0 | Delta |
|---|---:|---:|---:|
| Output tok/s | 1053.60 | 1054.51 | +0.1% |
| Total tok/s | 4864.52 | 4868.76 | +0.1% |
| Mean TTFT (ms) | 4250.10 | 4326.08 | +1.8% |
| P99 TTFT (ms) | 5558.97 | 5605.81 | +0.8% |
| Mean TPOT (ms) | 66.66 | 66.16 | -0.8% |
| P99 TPOT (ms) | 77.86 | 77.59 | -0.3% |
| Duration (s) | 14.24 | 14.22 | -0.1% |