### PR TITLE
[Perf] Build kernel format paged metadata once per forward, not per layer

### DIFF
--- a/tests/test_block_size_translation.py
+++ b/tests/test_block_size_translation.py
@@ -10,9 +10,16 @@ from __future__ import annotations
 
 import pytest
 
+from vllm_metal.attention.context import (
+    clear_context,
+    get_context,
+    prepare_grouped,
+    prepare_unified,
+)
 from vllm_metal.attention.impls.sdpa import (
     _KERNEL_BLOCK_SIZES,
     _build_block_tables,
+    _kernel_metadata,
     _pick_kernel_block_size,
 )
 
@@ -92,3 +99,69 @@ class TestBuildBlockTables:
         bt, kbs = _build_block_tables([], 544)
         assert bt.shape == (0, 0)
         assert kbs == 544
+
+
+class TestKernelMetadataMemo:
+    """Per-forward memo of kernel-format metadata (_kernel_metadata).
+
+    The paged context lives for exactly one forward pass and its list
+    metadata is identical for every layer of a KV group, so the converted
+    mx arrays are built once per (group, cache block size) and reused by
+    the remaining layers instead of being rebuilt per layer.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_context(self):
+        yield
+        clear_context()
+
+    def _fresh_ctx(self, block_ids, seq_len, num_tokens):
+        prepare_unified([(block_ids, seq_len, num_tokens)], [], 16)
+        return get_context()
+
+    def test_returns_same_objects_within_one_context(self):
+        ctx = self._fresh_ctx([0, 1, 2], 40, 4)
+        first = _kernel_metadata(ctx, 0, ctx.slot_mapping, ctx.block_tables, 16)
+        second = _kernel_metadata(ctx, 0, ctx.slot_mapping, ctx.block_tables, 16)
+        assert second is first
+
+    def test_matches_direct_conversion(self):
+        ctx = self._fresh_ctx([0, 1, 2], 40, 4)
+        meta = _kernel_metadata(ctx, 0, ctx.slot_mapping, ctx.block_tables, 16)
+        direct_bt, direct_bs = _build_block_tables(ctx.block_tables, 16)
+        assert meta.block_tables.tolist() == direct_bt.tolist()
+        assert meta.block_size == direct_bs
+        assert meta.slot_mapping.tolist() == ctx.slot_mapping
+        assert meta.seq_lens.tolist() == ctx.context_lens
+        assert meta.cu_seqlens_q.tolist() == ctx.cu_seqlens
+
+    def test_new_context_is_not_served_stale_arrays(self):
+        ctx1 = self._fresh_ctx([0, 1, 2], 40, 4)
+        stale = _kernel_metadata(ctx1, 0, ctx1.slot_mapping, ctx1.block_tables, 16)
+        ctx2 = self._fresh_ctx([7, 8], 16, 1)
+        fresh = _kernel_metadata(ctx2, 0, ctx2.slot_mapping, ctx2.block_tables, 16)
+        assert fresh is not stale
+        assert fresh.block_tables.tolist() == [[7, 8]]
+
+    def test_cache_keys_by_block_size(self):
+        ctx = self._fresh_ctx([0, 1, 2], 32, 2)
+        m16 = _kernel_metadata(ctx, 0, ctx.slot_mapping, ctx.block_tables, 16)
+        m32 = _kernel_metadata(ctx, 0, ctx.slot_mapping, ctx.block_tables, 32)
+        assert m32 is not m16
+        assert m32.block_size == 32
+        assert _kernel_metadata(ctx, 0, ctx.slot_mapping, ctx.block_tables, 16) is m16
+
+    def test_cache_keys_by_group_with_equal_block_size(self):
+        # Two scheduler groups with the SAME cache block size: only the
+        # group index separates their memo entries.  Guards the key against
+        # ever being reduced to cache_block_size alone, which would serve
+        # group 0's tables to group 1 on hybrid models.
+        prepare_grouped([(([10, 11], [77, 78]), 24)], [], (16, 16))
+        ctx = get_context()
+        g0 = ctx.kv_groups[0]
+        g1 = ctx.kv_groups[1]
+        m0 = _kernel_metadata(ctx, 0, g0.slot_mapping, g0.block_tables, 16)
+        m1 = _kernel_metadata(ctx, 1, g1.slot_mapping, g1.block_tables, 16)
+        assert m1 is not m0
+        assert m0.block_tables.tolist() == [[10, 11]]
+        assert m1.block_tables.tolist() == [[77, 78]]

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -84,6 +84,14 @@ class PagedAttentionContext:
     # ``slot_mapping`` / ``block_tables`` above mirror group zero for the
     # legacy single-group path.
     kv_groups: tuple[PagedKVGroupContext, ...] | None = None
+    # Kernel-format metadata memo, keyed by (KV group index, cache block
+    # size).  The context lives for exactly one forward pass, so entries
+    # never go stale; every layer of a group reuses the first layer's
+    # conversion instead of re-serializing the Python lists above (see
+    # ``impls.sdpa._kernel_metadata``).
+    kernel_metadata_cache: dict[tuple[int | None, int], Any] = field(
+        default_factory=dict
+    )
 
 
 def set_context(ctx: PagedAttentionContext) -> None:

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -28,6 +28,8 @@ All operations use MLX arrays end-to-end — no PyTorch MPS bridge.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -157,6 +159,54 @@ def _build_block_tables(
         bt_arr.shape[0], -1
     )
     return expanded, kernel_bs
+
+
+@dataclass(frozen=True, eq=False)
+class _KernelMetadata:
+    """Kernel-format copies of the per-forward paged metadata.
+
+    ``eq=False``: the generated ``__eq__`` would compare mx arrays, which
+    raises on ``bool()``; identity comparison is the only meaningful one.
+    """
+
+    slot_mapping: mx.array
+    seq_lens: mx.array
+    cu_seqlens_q: mx.array
+    block_tables: mx.array
+    block_size: int
+
+
+def _kernel_metadata(
+    ctx: PagedAttentionContext,
+    group_index: int | None,
+    raw_slot_mapping: list[int],
+    raw_block_tables: list[list[int]],
+    cache_block_size: int,
+) -> _KernelMetadata:
+    """Kernel-format metadata for one KV group, built once per forward.
+
+    The paged context is fixed for the duration of one forward pass and
+    every layer of a KV group needs the same converted arrays, so the
+    conversion runs on the group's first layer and is cached on the
+    context; the remaining layers reuse it instead of re-serializing
+    O(rows × blocks) Python lists per layer.  The context dies with the
+    forward, so entries can never go stale.
+    """
+    key = (group_index, cache_block_size)
+    meta = ctx.kernel_metadata_cache.get(key)
+    if meta is None:
+        block_tables, kernel_block_size = _build_block_tables(
+            raw_block_tables, cache_block_size
+        )
+        meta = _KernelMetadata(
+            slot_mapping=mx.array(raw_slot_mapping, dtype=mx.int64),
+            seq_lens=mx.array(ctx.context_lens, dtype=mx.int32),
+            cu_seqlens_q=mx.array(ctx.cu_seqlens, dtype=mx.int32),
+            block_tables=block_tables,
+            block_size=kernel_block_size,
+        )
+        ctx.kernel_metadata_cache[key] = meta
+    return meta
 
 
 # === Q/K/V preparation (YOCO, K-eq-V, v_norm variants) ===
@@ -477,20 +527,26 @@ def sdpa_forward(
     k_3d = mx.contiguous(keys[0].transpose(1, 0, 2).astype(kv_cache.dtype))
     v_3d = mx.contiguous(values[0].transpose(1, 0, 2).astype(kv_cache.dtype))
 
-    slot_mapping = mx.array(raw_slot_mapping, dtype=mx.int64)
-    seq_lens = mx.array(ctx.context_lens, dtype=mx.int32)
-    cu_seqlens_q = mx.array(ctx.cu_seqlens, dtype=mx.int32)
-    max_seq_len = max(ctx.context_lens)
-
-    # --- Block tables (with hybrid block-size translation) ---
+    # --- Kernel-format metadata (memoized per forward) ---
+    # Converted on the group's first layer and reused by the rest (see
+    # _kernel_metadata).  Includes the hybrid block-size translation:
     # vLLM may inflate block_size (e.g. 544) to align attention pages with
-    # mamba pages in hybrid models.  The Metal kernel only supports small
-    # block sizes (8, 16, 32).  _build_block_tables handles the translation:
-    # it expands each vLLM block into multiple kernel blocks and returns the
-    # kernel-compatible block_size.  The cache is reshaped to match (zero-copy).
-    block_tables, kernel_block_size = _build_block_tables(
-        raw_block_tables, cache_block_size
+    # mamba pages in hybrid models, while the Metal kernel only supports
+    # small block sizes (8, 16, 32); _build_block_tables expands each vLLM
+    # block into multiple kernel blocks and returns the kernel-compatible
+    # block_size.  The cache is reshaped to match (zero-copy).
+    meta = _kernel_metadata(
+        ctx,
+        None if ctx.kv_groups is None else group_index,
+        raw_slot_mapping,
+        raw_block_tables,
+        cache_block_size,
     )
+    slot_mapping = meta.slot_mapping
+    seq_lens = meta.seq_lens
+    cu_seqlens_q = meta.cu_seqlens_q
+    block_tables, kernel_block_size = meta.block_tables, meta.block_size
+    max_seq_len = max(ctx.context_lens)
 
     if shared_kv is not None or read_existing_kv:
         # YOCO shared layer / MTP read-existing layer: the authoritative K/V


### PR DESCRIPTION
`sdpa_forward` reserializes the context's Python metadata lists into mx arrays on every layer: `slot_mapping`, `context_lens`, `cu_seqlens`, and the padded block tables. All of them are invariant within one forward pass, so every layer after the first repeats identical work. The block table conversion is O(rows x blocks) pure Python, and the waste grows with batch size, speculation width, and context length.

Isolated numbers on a 16 core M4 Pro (median of 60 reps, calling the real `_build_block_tables` from main): 16 us per call at rows=4, blocks=512, which is a single stream K=3 verify batch at 8k context. The cost grows linearly to about 500 us per call at rows=128 (concurrency 32 with K=3 expanded verify at 8k) and about 2.1 ms at rows=128, blocks=2048 (the same at 32k). Multiplied by 28 to 36 layers that is roughly 0.6 ms per step single stream and 18 ms per step at the concurrency 32 shape. That is the same envelope where the verify window kernel (#534, #560) earns its win, so the two compose.

This PR builds the converted arrays once per forward pass and KV group and reuses them across layers: a small memo dict on `PagedAttentionContext` keyed by (group index, cache block size), populated by the first layer of a group. The context lives for exactly one forward pass and nothing mutates its metadata lists after `prepare_grouped` installs it (checked across the callers, including YOCO, which swaps in its own reduced context), so entries cannot go stale and no invalidation logic is needed.

Verification on the engine (0.6B draft pair, CONC=4, K=3, vLLM 0.26.0, interleaved A/B, 3 runs per side): generated token ids are bitwise identical in all six runs, so the change is semantically a no op. Throughput at this small shape is parity within run to run noise (medians 69.1 vs 68.7 tok/s). I am deliberately not claiming an engine speedup from that data: the isolated scaling above is the sizing argument, and the shapes where it reaches double digit milliseconds per step need more memory than my 24 GB box can host.

The same per layer pattern exists in the MLA wrapper's per request slow path (`impls/mla.py`); left untouched here since that path is the documented fallback. Happy to follow up if there is interest.

Tests: `TestKernelMetadataMemo` pins reuse within one context, bitwise agreement with direct conversion, fresh context isolation, key independence by block size, and key independence by group at equal block size (guards hybrid models against a key regression). Full attention suites pass on vLLM 0.26.0; the one red test on my box fails identically on clean main, so it is unrelated.
