### PR TITLE
Fix Gemma4 mixed KV cache planning

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+import mlx.core as mx
 import torch
 
 import vllm_metal.v1.model_runner as mr
@@ -87,3 +88,85 @@ def make_stub_runner(
         runner._vocab_size = _model_args["vocab_size"]
 
     return runner
+
+
+def make_gemma4_mixed_mha_runner(
+    num_layers: int,
+    sliding_kv_heads: int,
+    full_kv_heads: int,
+    max_model_len: int = 16,
+    original_max_model_len: int | None = 16,
+    max_in_flight_tokens: int = 16,
+    disable_hybrid_manager: bool = False,
+    num_gpu_blocks_override: int | None = None,
+) -> mr.MetalModelRunner:
+    """Create a Gemma4 mixed sliding/full MHA runner stub."""
+    layer_types = [
+        "full_attention" if (index + 1) % 6 == 0 else "sliding_attention"
+        for index in range(num_layers)
+    ]
+    model_args = {
+        "global_head_dim": 512,
+        "num_global_key_value_heads": full_kv_heads,
+        "sliding_window": 1024,
+        "layer_types": layer_types,
+    }
+    adapter = DefaultModelAdapter()
+    per_layer = adapter.build_per_layer_kv_shapes(
+        model_args,
+        num_layers=num_layers,
+        num_kv_heads=sliding_kv_heads,
+        head_dim=256,
+    )
+    sliding_windows = adapter.build_sliding_window_per_layer(
+        model_args,
+        num_layers=num_layers,
+    )
+    assert per_layer is not None
+    assert sliding_windows is not None
+    kv_heads_per_layer, head_dim_per_layer = per_layer
+    cache_config = SimpleNamespace(
+        block_size=16,
+        gpu_memory_utilization=1.0,
+        num_gpu_blocks_override=num_gpu_blocks_override,
+        kv_cache_memory_bytes=None,
+        enable_prefix_caching=False,
+        prefix_match_unit=None,
+    )
+    scheduler_config = SimpleNamespace(
+        max_num_batched_tokens=max_in_flight_tokens,
+        disable_hybrid_kv_cache_manager=disable_hybrid_manager,
+    )
+    vllm_config = SimpleNamespace(
+        speculative_config=None,
+        max_in_flight_tokens=max_in_flight_tokens,
+        model_config=SimpleNamespace(
+            max_model_len=max_model_len,
+            original_max_model_len=original_max_model_len,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+        ),
+        scheduler_config=scheduler_config,
+        cache_config=cache_config,
+        kv_transfer_config=None,
+    )
+    return make_stub_runner(
+        model_args=model_args,
+        num_layers=num_layers,
+        num_kv_cache_layers=num_layers,
+        num_kv_heads=sliding_kv_heads,
+        head_dim=512,
+        kv_cache_dtype=mx.bfloat16,
+        cache_config=cache_config,
+        scheduler_config=scheduler_config,
+        vllm_config=vllm_config,
+        model=SimpleNamespace(
+            layers=[SimpleNamespace(self_attn=object()) for _ in range(num_layers)]
+        ),
+        _model_adapter=adapter,
+        kv_heads_per_layer=kv_heads_per_layer,
+        head_dim_per_layer=head_dim_per_layer,
+        sliding_window_per_layer=sliding_windows,
+    )

--- a/tests/test_kv_cache_spec_capacity.py
+++ b/tests/test_kv_cache_spec_capacity.py
@@ -23,7 +23,15 @@ def _engine_blocks(specs: dict, metal_per_block: int) -> int:
     return available // get_uniform_page_size(list(specs.values())) // len(specs)
 
 
-def _policy(*, num_layers, is_mla=False, yoco=None, num_kv_heads=4, head_dim=256):
+def _policy(
+    *,
+    num_layers,
+    is_mla=False,
+    yoco=None,
+    num_kv_heads=4,
+    head_dim=256,
+    sliding_window_per_layer=None,
+):
     # ``is_mla``/``is_hybrid`` are derived from the model config, not settable.
     model_args = {"kv_lora_rank": head_dim} if is_mla else {}
     runner = make_stub_runner(
@@ -36,6 +44,7 @@ def _policy(*, num_layers, is_mla=False, yoco=None, num_kv_heads=4, head_dim=256
         cache_config=SimpleNamespace(block_size=BLOCK_SIZE),
         kv_heads_per_layer=None,
         head_dim_per_layer=None,
+        sliding_window_per_layer=sliding_window_per_layer,
     )
     return runner._cache_policy
 
@@ -56,10 +65,15 @@ def test_mla_spec_matches_single_latent_cache() -> None:
 def test_yoco_shared_layers_get_no_spec() -> None:
     """Only the layers that own a cache may appear in the spec."""
     layers, owned = 35, 15
-    policy = _policy(num_layers=layers, yoco=(owned, list(range(owned))))
+    policy = _policy(
+        num_layers=layers,
+        yoco=(owned, list(range(owned))),
+        sliding_window_per_layer=[512] * owned,
+    )
     specs = policy.get_kv_cache_spec()
 
     assert len(specs) == owned
+    assert all(type(s) is FullAttentionSpec for s in specs.values())
 
     metal_per_block = 2 * BLOCK_SIZE * DTYPE.itemsize * owned * 4 * 256
     assert _engine_blocks(specs, metal_per_block) == POOL_BLOCKS

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -23,10 +23,13 @@ from vllm.v1.kv_cache_interface import (
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
+from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
 from vllm_metal.attention.runtime.mha import (
     MHAPagedAttentionRuntime,
 )
 from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
+from vllm_metal.v1.cache_policy import WorkerCachePlanner
+from vllm_metal.v1.model_adapter import DefaultModelAdapter
 
 
 def vllm_config_for_kv_grouping() -> VllmConfig:
@@ -459,6 +462,126 @@ class TestMHAKVCacheLayout:
         assert backend.kv_cache is original_cache
         assert runner._paged_scheduler_group_indices == (0,)
         assert runner._paged_group_block_sizes == (16,)
+
+    @pytest.mark.parametrize(
+        ("num_layers", "sliding_kv_heads", "full_kv_heads", "expected_slots"),
+        (
+            (60, 16, 4, 10),
+            (30, 8, 2, 5),
+        ),
+    )
+    def test_cache_policy_initializes_gemma4_grouped_layout_from_budget(
+        self,
+        monkeypatch,
+        num_layers: int,
+        sliding_kv_heads: int,
+        full_kv_heads: int,
+        expected_slots: int,
+    ) -> None:
+        layer_types = [
+            "full_attention" if (index + 1) % 6 == 0 else "sliding_attention"
+            for index in range(num_layers)
+        ]
+        model_args = {
+            "global_head_dim": 512,
+            "num_global_key_value_heads": full_kv_heads,
+            "sliding_window": 1024,
+            "layer_types": layer_types,
+        }
+        adapter = DefaultModelAdapter()
+        per_layer = adapter.build_per_layer_kv_shapes(
+            model_args,
+            num_layers=num_layers,
+            num_kv_heads=sliding_kv_heads,
+            head_dim=256,
+        )
+        sliding_windows = adapter.build_sliding_window_per_layer(
+            model_args,
+            num_layers=num_layers,
+        )
+        assert per_layer is not None
+        assert sliding_windows is not None
+        kv_heads_per_layer, head_dim_per_layer = per_layer
+        runner = make_stub_runner(
+            model_args=model_args,
+            num_layers=num_layers,
+            num_kv_cache_layers=num_layers,
+            num_kv_heads=sliding_kv_heads,
+            head_dim=512,
+            kv_cache_dtype=mx.bfloat16,
+            cache_config=SimpleNamespace(block_size=16),
+            vllm_config=SimpleNamespace(
+                speculative_config=None,
+                cache_config=SimpleNamespace(
+                    block_size=16,
+                    gpu_memory_utilization=1.0,
+                ),
+            ),
+            model=SimpleNamespace(
+                layers=[SimpleNamespace(self_attn=object()) for _ in range(num_layers)]
+            ),
+            _model_adapter=adapter,
+            kv_heads_per_layer=kv_heads_per_layer,
+            head_dim_per_layer=head_dim_per_layer,
+            sliding_window_per_layer=sliding_windows,
+        )
+        metal_config = MetalConfig(
+            memory_fraction=1.0,
+            use_mlx=True,
+            mlx_device="gpu",
+            debug=False,
+            turboquant=False,
+        )
+        monkeypatch.setattr(
+            "vllm_metal.v1.cache_policy.get_config",
+            lambda: metal_config,
+        )
+        dense_block_bytes = runner.get_cache_block_size_bytes()
+        worker = SimpleNamespace(
+            model_runner=runner,
+            metal_config=metal_config,
+            vllm_config=runner.vllm_config,
+            get_cache_block_size_bytes=runner.get_cache_block_size_bytes,
+        )
+        planner = WorkerCachePlanner(worker)
+        monkeypatch.setattr(runner, "profile_run", lambda: 0)
+        monkeypatch.setattr(planner, "get_model_memory_usage", lambda: 0)
+        monkeypatch.setattr(planner, "_metal_limit_bytes", lambda: dense_block_bytes)
+
+        available = planner.determine_available_memory()
+
+        specs = runner.get_kv_cache_spec()
+        groups = get_kv_cache_groups(vllm_config_for_kv_grouping(), specs)
+        config = get_kv_cache_config_from_groups(
+            vllm_config_for_kv_grouping(),
+            groups,
+            available,
+        )
+
+        assert runner.paged_attention_runtime is None
+        assert available // dense_block_bytes == 1
+        assert type(specs["layers.0.self_attn"]) is SlidingWindowSpec
+        assert type(specs["layers.5.self_attn"]) is FullAttentionSpec
+        assert len(groups) == 6
+        assert config.num_blocks > 1
+        assert len(config.kv_cache_tensors) == expected_slots
+
+        runner.initialize_kv_cache(config)
+
+        backend = runner.paged_attention_runtime
+        assert isinstance(backend, MHAPagedAttentionRuntime)
+        assert backend.num_blocks() == config.num_blocks
+        assert runner._paged_scheduler_group_indices == (0, 1, 2, 3, 4, 5)
+        assert runner._paged_group_block_sizes == (16, 16, 16, 16, 16, 32)
+        assert backend.kv_cache.group_index_for_layer(5) == 5
+        assert backend.kv_cache.block_size_for_layer(5) == 32
+        assert backend.kv_cache.sliding_window_per_layer[0] == 1024
+        assert backend.kv_cache.sliding_window_per_layer[5] == -1
+        assert len(backend.kv_cache.key_caches) == num_layers
+        assert all(
+            isinstance(layer.self_attn, SDPAPagedAttentionWrapper)
+            for layer in runner.model.layers
+        )
 
     def test_rebind_updates_every_layer_sharing_the_slot(self) -> None:
         config, names = self._mixed_mha_config()

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -11,6 +11,7 @@ import torch
 from vllm.config import VllmConfig
 from vllm.v1.core.kv_cache_utils import (
     get_kv_cache_config_from_groups,
+    get_kv_cache_configs,
     get_kv_cache_groups,
 )
 from vllm.v1.kv_cache_interface import (
@@ -27,7 +28,11 @@ from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
 from vllm_metal.attention.runtime.mha import (
     MHAPagedAttentionRuntime,
 )
-from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
+from vllm_metal.config import (
+    AUTO_MEMORY_FRACTION,
+    PAGED_ATTENTION_MIN_BLOCKS,
+    MetalConfig,
+)
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
 from vllm_metal.v1.model_adapter import DefaultModelAdapter
 
@@ -309,6 +314,84 @@ class TestCachePolicyPerLayerBytes:
 class TestMHAKVCacheLayout:
     """vLLM-managed standard-MHA cache layout contracts."""
 
+    def gemma4_mixed_runner(
+        self,
+        *,
+        num_layers: int,
+        sliding_kv_heads: int,
+        full_kv_heads: int,
+        disable_hybrid_manager: bool = False,
+        num_gpu_blocks_override: int | None = None,
+    ):
+        layer_types = [
+            "full_attention" if (index + 1) % 6 == 0 else "sliding_attention"
+            for index in range(num_layers)
+        ]
+        model_args = {
+            "global_head_dim": 512,
+            "num_global_key_value_heads": full_kv_heads,
+            "sliding_window": 1024,
+            "layer_types": layer_types,
+        }
+        adapter = DefaultModelAdapter()
+        per_layer = adapter.build_per_layer_kv_shapes(
+            model_args,
+            num_layers=num_layers,
+            num_kv_heads=sliding_kv_heads,
+            head_dim=256,
+        )
+        sliding_windows = adapter.build_sliding_window_per_layer(
+            model_args,
+            num_layers=num_layers,
+        )
+        assert per_layer is not None
+        assert sliding_windows is not None
+        kv_heads_per_layer, head_dim_per_layer = per_layer
+        cache_config = SimpleNamespace(
+            block_size=16,
+            gpu_memory_utilization=1.0,
+            num_gpu_blocks_override=num_gpu_blocks_override,
+            kv_cache_memory_bytes=None,
+            enable_prefix_caching=False,
+            prefix_match_unit=None,
+        )
+        scheduler_config = SimpleNamespace(
+            disable_hybrid_kv_cache_manager=disable_hybrid_manager,
+        )
+        vllm_config = SimpleNamespace(
+            speculative_config=None,
+            max_in_flight_tokens=16,
+            model_config=SimpleNamespace(
+                max_model_len=16,
+                original_max_model_len=16,
+            ),
+            parallel_config=SimpleNamespace(
+                decode_context_parallel_size=1,
+                prefill_context_parallel_size=1,
+            ),
+            scheduler_config=scheduler_config,
+            cache_config=cache_config,
+            kv_transfer_config=None,
+        )
+        return make_stub_runner(
+            model_args=model_args,
+            num_layers=num_layers,
+            num_kv_cache_layers=num_layers,
+            num_kv_heads=sliding_kv_heads,
+            head_dim=512,
+            kv_cache_dtype=mx.bfloat16,
+            cache_config=cache_config,
+            scheduler_config=scheduler_config,
+            vllm_config=vllm_config,
+            model=SimpleNamespace(
+                layers=[SimpleNamespace(self_attn=object()) for _ in range(num_layers)]
+            ),
+            _model_adapter=adapter,
+            kv_heads_per_layer=kv_heads_per_layer,
+            head_dim_per_layer=head_dim_per_layer,
+            sliding_window_per_layer=sliding_windows,
+        )
+
     def _mixed_mha_config(self) -> tuple[KVCacheConfig, tuple[str, ...]]:
         names = tuple(f"layers.{index}.self_attn" for index in range(4))
         specs = {
@@ -478,52 +561,75 @@ class TestMHAKVCacheLayout:
         full_kv_heads: int,
         expected_slots: int,
     ) -> None:
-        layer_types = [
-            "full_attention" if (index + 1) % 6 == 0 else "sliding_attention"
-            for index in range(num_layers)
-        ]
-        model_args = {
-            "global_head_dim": 512,
-            "num_global_key_value_heads": full_kv_heads,
-            "sliding_window": 1024,
-            "layer_types": layer_types,
-        }
-        adapter = DefaultModelAdapter()
-        per_layer = adapter.build_per_layer_kv_shapes(
-            model_args,
+        runner = self.gemma4_mixed_runner(
             num_layers=num_layers,
-            num_kv_heads=sliding_kv_heads,
-            head_dim=256,
+            sliding_kv_heads=sliding_kv_heads,
+            full_kv_heads=full_kv_heads,
         )
-        sliding_windows = adapter.build_sliding_window_per_layer(
-            model_args,
-            num_layers=num_layers,
+        metal_config = MetalConfig(
+            memory_fraction=1.0,
+            use_mlx=True,
+            mlx_device="gpu",
+            debug=False,
+            turboquant=False,
         )
-        assert per_layer is not None
-        assert sliding_windows is not None
-        kv_heads_per_layer, head_dim_per_layer = per_layer
-        runner = make_stub_runner(
-            model_args=model_args,
-            num_layers=num_layers,
-            num_kv_cache_layers=num_layers,
-            num_kv_heads=sliding_kv_heads,
-            head_dim=512,
-            kv_cache_dtype=mx.bfloat16,
-            cache_config=SimpleNamespace(block_size=16),
-            vllm_config=SimpleNamespace(
-                speculative_config=None,
-                cache_config=SimpleNamespace(
-                    block_size=16,
-                    gpu_memory_utilization=1.0,
-                ),
-            ),
-            model=SimpleNamespace(
-                layers=[SimpleNamespace(self_attn=object()) for _ in range(num_layers)]
-            ),
-            _model_adapter=adapter,
-            kv_heads_per_layer=kv_heads_per_layer,
-            head_dim_per_layer=head_dim_per_layer,
-            sliding_window_per_layer=sliding_windows,
+        monkeypatch.setattr(
+            "vllm_metal.v1.cache_policy.get_config",
+            lambda: metal_config,
+        )
+        reported_dense_blocks = 2
+        dense_block_bytes = runner.get_cache_block_size_bytes()
+        worker = SimpleNamespace(
+            model_runner=runner,
+            metal_config=metal_config,
+            vllm_config=runner.vllm_config,
+            get_cache_block_size_bytes=runner.get_cache_block_size_bytes,
+        )
+        planner = WorkerCachePlanner(worker)
+        monkeypatch.setattr(runner, "profile_run", lambda: 0)
+        monkeypatch.setattr(planner, "get_model_memory_usage", lambda: 0)
+        monkeypatch.setattr(
+            planner,
+            "_metal_limit_bytes",
+            lambda: dense_block_bytes * reported_dense_blocks,
+        )
+
+        available = planner.determine_available_memory()
+
+        specs = runner.get_kv_cache_spec()
+        config = get_kv_cache_configs(runner.vllm_config, [specs], [available])[0]
+
+        assert runner.paged_attention_runtime is None
+        assert available // dense_block_bytes == reported_dense_blocks
+        assert type(specs["layers.0.self_attn"]) is SlidingWindowSpec
+        assert type(specs["layers.5.self_attn"]) is FullAttentionSpec
+        assert len(config.kv_cache_groups) == 6
+        assert config.num_blocks > reported_dense_blocks
+        assert len(config.kv_cache_tensors) == expected_slots
+
+        runner.initialize_kv_cache(config)
+
+        backend = runner.paged_attention_runtime
+        assert isinstance(backend, MHAPagedAttentionRuntime)
+        assert backend.num_blocks() == config.num_blocks
+        assert runner._paged_scheduler_group_indices == (0, 1, 2, 3, 4, 5)
+        assert runner._paged_group_block_sizes == (16, 16, 16, 16, 16, 32)
+        assert backend.kv_cache.group_index_for_layer(5) == 5
+        assert backend.kv_cache.block_size_for_layer(5) == 32
+        assert backend.kv_cache.sliding_window_per_layer[0] == 1024
+        assert backend.kv_cache.sliding_window_per_layer[5] == -1
+        assert len(backend.kv_cache.key_caches) == num_layers
+        assert all(
+            isinstance(layer.self_attn, SDPAPagedAttentionWrapper)
+            for layer in runner.model.layers
+        )
+
+    def test_disabled_hybrid_manager_stays_on_dense_path(self, monkeypatch) -> None:
+        runner = self.gemma4_mixed_runner(
+            num_layers=60,
+            sliding_kv_heads=16,
+            full_kv_heads=4,
+            disable_hybrid_manager=True,
         )
         metal_config = MetalConfig(
             memory_fraction=1.0,
@@ -546,42 +652,63 @@ class TestMHAKVCacheLayout:
         planner = WorkerCachePlanner(worker)
         monkeypatch.setattr(runner, "profile_run", lambda: 0)
         monkeypatch.setattr(planner, "get_model_memory_usage", lambda: 0)
-        monkeypatch.setattr(planner, "_metal_limit_bytes", lambda: dense_block_bytes)
+        monkeypatch.setattr(
+            planner,
+            "_metal_limit_bytes",
+            lambda: dense_block_bytes * PAGED_ATTENTION_MIN_BLOCKS,
+        )
 
         available = planner.determine_available_memory()
-
         specs = runner.get_kv_cache_spec()
-        groups = get_kv_cache_groups(vllm_config_for_kv_grouping(), specs)
-        config = get_kv_cache_config_from_groups(
-            vllm_config_for_kv_grouping(),
-            groups,
-            available,
-        )
-
-        assert runner.paged_attention_runtime is None
-        assert available // dense_block_bytes == 1
-        assert type(specs["layers.0.self_attn"]) is SlidingWindowSpec
-        assert type(specs["layers.5.self_attn"]) is FullAttentionSpec
-        assert len(groups) == 6
-        assert config.num_blocks > 1
-        assert len(config.kv_cache_tensors) == expected_slots
-
+        config = get_kv_cache_configs(runner.vllm_config, [specs], [available])[0]
         runner.initialize_kv_cache(config)
 
-        backend = runner.paged_attention_runtime
-        assert isinstance(backend, MHAPagedAttentionRuntime)
-        assert backend.num_blocks() == config.num_blocks
-        assert runner._paged_scheduler_group_indices == (0, 1, 2, 3, 4, 5)
-        assert runner._paged_group_block_sizes == (16, 16, 16, 16, 16, 32)
-        assert backend.kv_cache.group_index_for_layer(5) == 5
-        assert backend.kv_cache.block_size_for_layer(5) == 32
-        assert backend.kv_cache.sliding_window_per_layer[0] == 1024
-        assert backend.kv_cache.sliding_window_per_layer[5] == -1
-        assert len(backend.kv_cache.key_caches) == num_layers
-        assert all(
-            isinstance(layer.self_attn, SDPAPagedAttentionWrapper)
-            for layer in runner.model.layers
+        assert all(type(spec) is FullAttentionSpec for spec in specs.values())
+        assert runner._paged_scheduler_group_indices == (0,)
+        assert runner.paged_attention_runtime is not None
+        assert runner.paged_attention_runtime.num_blocks() == config.num_blocks
+
+    def test_block_override_uses_existing_capacity_guard(self, monkeypatch) -> None:
+        runner = self.gemma4_mixed_runner(
+            num_layers=60,
+            sliding_kv_heads=16,
+            full_kv_heads=4,
+            num_gpu_blocks_override=100,
         )
+        metal_config = MetalConfig(
+            memory_fraction=1.0,
+            use_mlx=True,
+            mlx_device="gpu",
+            debug=False,
+            turboquant=False,
+        )
+        monkeypatch.setattr(
+            "vllm_metal.v1.cache_policy.get_config",
+            lambda: metal_config,
+        )
+        dense_block_bytes = runner.get_cache_block_size_bytes()
+        worker = SimpleNamespace(
+            model_runner=runner,
+            metal_config=metal_config,
+            vllm_config=runner.vllm_config,
+            get_cache_block_size_bytes=runner.get_cache_block_size_bytes,
+        )
+        planner = WorkerCachePlanner(worker)
+        monkeypatch.setattr(runner, "profile_run", lambda: 0)
+        monkeypatch.setattr(planner, "get_model_memory_usage", lambda: 0)
+        monkeypatch.setattr(
+            planner,
+            "_metal_limit_bytes",
+            lambda: dense_block_bytes * PAGED_ATTENTION_MIN_BLOCKS,
+        )
+
+        available = planner.determine_available_memory()
+        specs = runner.get_kv_cache_spec()
+        config = get_kv_cache_configs(runner.vllm_config, [specs], [available])[0]
+
+        assert config.num_blocks == 100
+        with pytest.raises(ValueError, match="Engine KV cache config requests 100"):
+            runner.initialize_kv_cache(config)
 
     def test_rebind_updates_every_layer_sharing_the_slot(self) -> None:
         config, names = self._mixed_mha_config()

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -21,7 +21,7 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 
-from tests.stub_runner import make_stub_runner
+from tests.stub_runner import make_gemma4_mixed_mha_runner, make_stub_runner
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
 from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
@@ -34,7 +34,6 @@ from vllm_metal.config import (
     MetalConfig,
 )
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
-from vllm_metal.v1.model_adapter import DefaultModelAdapter
 
 
 def vllm_config_for_kv_grouping() -> VllmConfig:
@@ -323,73 +322,12 @@ class TestMHAKVCacheLayout:
         disable_hybrid_manager: bool = False,
         num_gpu_blocks_override: int | None = None,
     ):
-        layer_types = [
-            "full_attention" if (index + 1) % 6 == 0 else "sliding_attention"
-            for index in range(num_layers)
-        ]
-        model_args = {
-            "global_head_dim": 512,
-            "num_global_key_value_heads": full_kv_heads,
-            "sliding_window": 1024,
-            "layer_types": layer_types,
-        }
-        adapter = DefaultModelAdapter()
-        per_layer = adapter.build_per_layer_kv_shapes(
-            model_args,
+        return make_gemma4_mixed_mha_runner(
             num_layers=num_layers,
-            num_kv_heads=sliding_kv_heads,
-            head_dim=256,
-        )
-        sliding_windows = adapter.build_sliding_window_per_layer(
-            model_args,
-            num_layers=num_layers,
-        )
-        assert per_layer is not None
-        assert sliding_windows is not None
-        kv_heads_per_layer, head_dim_per_layer = per_layer
-        cache_config = SimpleNamespace(
-            block_size=16,
-            gpu_memory_utilization=1.0,
+            sliding_kv_heads=sliding_kv_heads,
+            full_kv_heads=full_kv_heads,
+            disable_hybrid_manager=disable_hybrid_manager,
             num_gpu_blocks_override=num_gpu_blocks_override,
-            kv_cache_memory_bytes=None,
-            enable_prefix_caching=False,
-            prefix_match_unit=None,
-        )
-        scheduler_config = SimpleNamespace(
-            disable_hybrid_kv_cache_manager=disable_hybrid_manager,
-        )
-        vllm_config = SimpleNamespace(
-            speculative_config=None,
-            max_in_flight_tokens=16,
-            model_config=SimpleNamespace(
-                max_model_len=16,
-                original_max_model_len=16,
-            ),
-            parallel_config=SimpleNamespace(
-                decode_context_parallel_size=1,
-                prefill_context_parallel_size=1,
-            ),
-            scheduler_config=scheduler_config,
-            cache_config=cache_config,
-            kv_transfer_config=None,
-        )
-        return make_stub_runner(
-            model_args=model_args,
-            num_layers=num_layers,
-            num_kv_cache_layers=num_layers,
-            num_kv_heads=sliding_kv_heads,
-            head_dim=512,
-            kv_cache_dtype=mx.bfloat16,
-            cache_config=cache_config,
-            scheduler_config=scheduler_config,
-            vllm_config=vllm_config,
-            model=SimpleNamespace(
-                layers=[SimpleNamespace(self_attn=object()) for _ in range(num_layers)]
-            ),
-            _model_adapter=adapter,
-            kv_heads_per_layer=kv_heads_per_layer,
-            head_dim_per_layer=head_dim_per_layer,
-            sliding_window_per_layer=sliding_windows,
         )
 
     def _mixed_mha_config(self) -> tuple[KVCacheConfig, tuple[str, ...]]:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -8,13 +8,21 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
-from vllm.config import ParallelConfig
+from vllm.config import ParallelConfig, VllmConfig
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
-from vllm.v1.core.kv_cache_utils import get_kv_cache_configs
-from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
+from vllm.v1.core.kv_cache_utils import (
+    get_kv_cache_capacity,
+    get_kv_cache_configs,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
 
 import vllm_metal.compat as compat
+from tests.stub_runner import make_gemma4_mixed_mha_runner
 from vllm_metal.config import reset_config
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
@@ -1576,15 +1584,15 @@ class TestKvBudgetBytes:
 class TestAutoFitMaxModelLenChain:
     """The -1 sentinel drives the Metal null-block auto-fit contract.
 
-    Builds the gemma-4-31B KV shape (the all-FullAttentionSpec specs vllm-metal
-    emits today: 50 sliding-shaped 16x256 layers + 10 global-shaped 4x512
-    layers) and runs vLLM's ``get_kv_cache_configs`` against fixed synthetic
-    memory budgets. These tests do not re-test upstream's fitting algorithm;
-    they only check Metal's null-block reservation and too-small-pool failure.
+    Builds the gemma-4-31B mixed-MHA KV shape and runs vLLM's
+    ``get_kv_cache_configs`` against fixed synthetic memory budgets. These
+    tests do not re-test upstream's fitting algorithm; they check Metal's
+    null-block reservation, too-small-pool failure, and current mixed-layout
+    budget shape for issue #505.
     """
 
     _NUM_LAYERS = 60
-    _FULL_EVERY = 6  # gemma-4's 5:1 sliding:full layer pattern
+    _MAX_BATCH_TOKENS = 2048
 
     @pytest.fixture(autouse=True)
     def _ensure_compat_patches(self) -> None:
@@ -1593,46 +1601,24 @@ class TestAutoFitMaxModelLenChain:
         while vLLM is partially imported."""
         compat.ensure_vllm_auto_fit_null_block_patch()
 
-    _BLOCK_SIZE = 16
     # 16 tokens x (50 x 16 x 256 + 10 x 4 x 512) heads*dims x K/V x bf16 —
     # equals the packed per-block bytes the Metal pool reports.
     _PACKED_BLOCK_BYTES = 14_417_920
     _DERIVED_MAX_LEN = 262_144
+    _FULL_CONTEXT_BUDGET_BYTES = int(22.5 * 1024**3)
 
-    @classmethod
-    def _specs(cls) -> dict[str, KVCacheSpec]:
-        """Fresh specs per call: upstream grouping mutates specs in place."""
-        specs: dict[str, KVCacheSpec] = {}
-        for i in range(cls._NUM_LAYERS):
-            is_full = (i + 1) % cls._FULL_EVERY == 0
-            specs[f"layers.{i}.self_attn"] = FullAttentionSpec(
-                block_size=cls._BLOCK_SIZE,
-                num_kv_heads=4 if is_full else 16,
-                head_size=512 if is_full else 256,
-                dtype=torch.bfloat16,
-            )
-        return specs
-
-    @classmethod
-    def _vllm_config(cls, *, original_max_model_len: int | None) -> SimpleNamespace:
-        return SimpleNamespace(
-            model_config=SimpleNamespace(
-                max_model_len=cls._DERIVED_MAX_LEN,
-                original_max_model_len=original_max_model_len,
-            ),
-            parallel_config=SimpleNamespace(
-                decode_context_parallel_size=1,
-                prefill_context_parallel_size=1,
-            ),
-            scheduler_config=SimpleNamespace(
-                max_num_batched_tokens=2048,
-                disable_hybrid_kv_cache_manager=False,
-            ),
-            cache_config=SimpleNamespace(
-                num_gpu_blocks_override=None,
-                kv_cache_memory_bytes=None,
-            ),
+    def gemma4_config_and_specs(
+        self, *, original_max_model_len: int | None
+    ) -> tuple[VllmConfig, dict[str, KVCacheSpec]]:
+        runner = make_gemma4_mixed_mha_runner(
+            num_layers=self._NUM_LAYERS,
+            sliding_kv_heads=16,
+            full_kv_heads=4,
+            max_model_len=self._DERIVED_MAX_LEN,
+            original_max_model_len=original_max_model_len,
+            max_in_flight_tokens=self._MAX_BATCH_TOKENS,
         )
+        return runner.vllm_config, runner.get_kv_cache_spec()
 
     def test_reduced_length_reserves_the_null_block(self) -> None:
         """The fitted length must never need the whole pool: BlockPool keeps
@@ -1640,16 +1626,45 @@ class TestAutoFitMaxModelLenChain:
         would otherwise starve in the scheduler forever."""
         num_pool_blocks = 1500
         available = num_pool_blocks * self._PACKED_BLOCK_BYTES
-        vllm_config = self._vllm_config(original_max_model_len=-1)
+        vllm_config, specs = self.gemma4_config_and_specs(original_max_model_len=-1)
 
-        get_kv_cache_configs(vllm_config, [self._specs()], [available])
+        config = get_kv_cache_configs(vllm_config, [specs], [available])[0]
 
-        resolved_blocks = -(-vllm_config.model_config.max_model_len // self._BLOCK_SIZE)
-        assert resolved_blocks == num_pool_blocks - 1
+        capacity, _ = get_kv_cache_capacity(vllm_config, config)
+        assert vllm_config.model_config.max_model_len < self._DERIVED_MAX_LEN
+        assert capacity > vllm_config.model_config.max_model_len
+
+    def test_mixed_layout_keeps_full_context_under_sufficient_budget(self) -> None:
+        available = self._FULL_CONTEXT_BUDGET_BYTES
+        vllm_config, specs = self.gemma4_config_and_specs(
+            original_max_model_len=self._DERIVED_MAX_LEN
+        )
+
+        config = get_kv_cache_configs(vllm_config, [specs], [available])[0]
+
+        full_groups = [
+            group
+            for group in config.kv_cache_groups
+            if type(group.kv_cache_spec) is FullAttentionSpec
+        ]
+        sliding_groups = [
+            group
+            for group in config.kv_cache_groups
+            if type(group.kv_cache_spec) is SlidingWindowSpec
+        ]
+        assert len(sliding_groups) == 5
+        assert len(full_groups) == 1
+        assert sum(len(group.layer_names) for group in sliding_groups) == 50
+        assert sum(len(group.layer_names) for group in full_groups) == 10
+        assert len(config.kv_cache_tensors) == 10
+        capacity, _ = get_kv_cache_capacity(vllm_config, config)
+        assert vllm_config.model_config.max_model_len == self._DERIVED_MAX_LEN
+        assert capacity >= self._DERIVED_MAX_LEN
+        assert sum(tensor.size for tensor in config.kv_cache_tensors) <= available
 
     def test_insufficient_memory_for_one_block_raises(self) -> None:
         available = self._PACKED_BLOCK_BYTES - 1
-        vllm_config = self._vllm_config(original_max_model_len=-1)
+        vllm_config, specs = self.gemma4_config_and_specs(original_max_model_len=-1)
 
         with pytest.raises(ValueError, match="Cannot auto-fit max_model_len"):
-            get_kv_cache_configs(vllm_config, [self._specs()], [available])
+            get_kv_cache_configs(vllm_config, [specs], [available])

--- a/vllm_metal/attention/runtime/mha.py
+++ b/vllm_metal/attention/runtime/mha.py
@@ -69,8 +69,7 @@ class MHAPagedAttentionRuntime(PagedAttentionRuntimeBase):
         )
 
     def adopt_layout(self, layout: MHAKVCacheLayout) -> None:
-        """Replace the legacy dense cache with vLLM's grouped MHA layout."""
-        self._require_initialized("adopt_layout")
+        """Use vLLM's grouped MHA layout as the runtime KV cache."""
         if self._turboquant:
             raise NotImplementedError(
                 "layout-backed MHA runtime does not support TurboQuant"

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -15,6 +15,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheSpec,
     MLAAttentionSpec,
+    SlidingWindowSpec,
 )
 
 from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
@@ -264,11 +265,36 @@ class ModelCachePolicy:
 
     def scheduler_memory_reporting_mode(
         self, *, paged_attention_enabled: bool
-    ) -> Literal["paged_attention_capacity", "single_sequence_estimate"]:
+    ) -> Literal[
+        "paged_attention_capacity",
+        "paged_attention_mha_layout_budget",
+        "single_sequence_estimate",
+    ]:
         """Return which scheduler memory-reporting mode worker should use."""
         if paged_attention_enabled:
+            if self._uses_deferred_mha_layout():
+                return "paged_attention_mha_layout_budget"
             return "paged_attention_capacity"
         return "single_sequence_estimate"
+
+    def _uses_deferred_mha_layout(self) -> bool:
+        """Return whether vLLM's grouped MHA config must own allocation."""
+        kv_heads = self._runner.kv_heads_per_layer
+        head_dims = self._runner.head_dim_per_layer
+        sliding_windows = self._runner.sliding_window_per_layer
+        return (
+            kv_heads is not None
+            and head_dims is not None
+            and sliding_windows is not None
+            and self._runner._yoco_cache_mapping is None
+            and not self._runner.is_hybrid
+            and not self._runner.is_mla
+            and not self._use_turboquant(get_config())
+            and self._runner.vllm_config.speculative_config is None
+            and self._runner._gemma4_mtp_assistant is None
+            and any(window >= 0 for window in sliding_windows)
+            and any(window < 0 for window in sliding_windows)
+        )
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Build the scheduler-visible KV cache specification."""
@@ -289,6 +315,7 @@ class ModelCachePolicy:
         if self._runner._yoco_cache_mapping is not None:
             num_spec_layers, _ = self._runner._yoco_cache_mapping
         specs: dict[str, KVCacheSpec] = {}
+        use_deferred_mha_layout = self._uses_deferred_mha_layout()
         for layer_idx in range(num_spec_layers):
             if (
                 self._runner.is_hybrid
@@ -322,17 +349,55 @@ class ModelCachePolicy:
                 # the 2x K/V factor in ``real_page_size_bytes``, so describing
                 # MLA with it makes the engine halve the block count it plans
                 # against relative to the pool actually allocated.
-                spec_cls = (
-                    MLAAttentionSpec if self._runner.is_mla else FullAttentionSpec
-                )
-                specs[layer_name] = spec_cls(
-                    block_size=block_size,
-                    num_kv_heads=kv_heads[layer_idx],
-                    head_size=head_dims[layer_idx],
-                    dtype=torch_dtype,
-                )
+                if self._runner.is_mla:
+                    specs[layer_name] = MLAAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=kv_heads[layer_idx],
+                        head_size=head_dims[layer_idx],
+                        dtype=torch_dtype,
+                    )
+                elif use_deferred_mha_layout:
+                    specs[layer_name] = self._build_mha_attention_spec(
+                        layer_idx=layer_idx,
+                        block_size=block_size,
+                        num_kv_heads=kv_heads[layer_idx],
+                        head_dim=head_dims[layer_idx],
+                        torch_dtype=torch_dtype,
+                    )
+                else:
+                    specs[layer_name] = FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=kv_heads[layer_idx],
+                        head_size=head_dims[layer_idx],
+                        dtype=torch_dtype,
+                    )
 
         return specs
+
+    def _build_mha_attention_spec(
+        self,
+        layer_idx: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_dim: int,
+        torch_dtype: torch.dtype,
+    ) -> FullAttentionSpec | SlidingWindowSpec:
+        """Build the scheduler spec for one standard MHA cache layer."""
+        sliding_windows = self._runner.sliding_window_per_layer
+        if sliding_windows is not None and sliding_windows[layer_idx] >= 0:
+            return SlidingWindowSpec(
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+                head_size=head_dim,
+                dtype=torch_dtype,
+                sliding_window=sliding_windows[layer_idx],
+            )
+        return FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_dim,
+            dtype=torch_dtype,
+        )
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """Accept engine KV cache config for API compatibility.
@@ -346,6 +411,19 @@ class ModelCachePolicy:
         adopt its grouping before serving.
         """
         runtime = self._runner.paged_attention_runtime
+        if self._uses_deferred_mha_layout():
+            if runtime is not None:
+                raise RuntimeError(
+                    "deferred MHA layout path must not preallocate paged KV cache"
+                )
+            self._initialize_deferred_mha_layout(kv_cache_config)
+            logger.info(
+                "KV cache config received: %d grouped blocks "
+                "(MLX layout initialized from vLLM config)",
+                kv_cache_config.num_blocks,
+            )
+            return
+
         if runtime is not None and kv_cache_config.num_blocks > runtime.num_blocks():
             raise ValueError(
                 f"Engine KV cache config requests {kv_cache_config.num_blocks} "
@@ -360,6 +438,17 @@ class ModelCachePolicy:
         logger.info(
             "KV cache config received: %d blocks (MLX manages cache internally)",
             kv_cache_config.num_blocks,
+        )
+
+    def _initialize_deferred_mha_layout(self, kv_cache_config: KVCacheConfig) -> None:
+        model_layer_names = self._mha_model_layer_names()
+        layout = MHAKVCacheLayout.from_config(kv_cache_config, model_layer_names)
+        runtime = self._build_mha_backend(block_size=layout.group_block_sizes[0])
+        runtime.adopt_layout(layout)
+        runtime.patch_model(self._runner.model)
+        self._runner.install_paged_attention_runtime(
+            runtime,
+            block_size=layout.group_block_sizes[0],
         )
 
     def _adopt_scheduler_groups(
@@ -802,6 +891,19 @@ class WorkerCachePlanner:
             )
             return available
 
+        if mode == "paged_attention_mha_layout_budget":
+            overhead = self._worker.model_runner.profile_run()
+            plan = self._paged_attention_plan(
+                overhead=overhead,
+                require_min_blocks=False,
+            )
+            logger.info(
+                "Mixed MHA paged attention: reporting %.2f GB KV budget; "
+                "runtime allocation deferred until vLLM KVCacheConfig",
+                plan.kv_budget / 1e9,
+            )
+            return plan.kv_budget
+
         available = self._worker._one_sequence_kv_bytes()
         logger.info(
             "MLX path: reporting %.2f GB for scheduler admission control "
@@ -821,7 +923,9 @@ class WorkerCachePlanner:
         """Return Metal-memory budget before hybrid GDN reservation."""
         return int(metal_limit * fraction) - model_memory - overhead
 
-    def _paged_attention_plan(self, *, overhead: int) -> _PagedAttentionPlan:
+    def _paged_attention_plan(
+        self, *, overhead: int, require_min_blocks: bool = True
+    ) -> _PagedAttentionPlan:
         block_size = self._worker.vllm_config.cache_config.block_size
         fraction = self._memory_fraction()
         metal_limit = self._metal_limit_bytes()
@@ -849,17 +953,22 @@ class WorkerCachePlanner:
             kv_budget=kv_budget,
             num_blocks=max(0, kv_budget // per_block_bytes),
         )
-        self._validate_paged_attention_plan(plan)
+        self._validate_paged_attention_plan(
+            plan,
+            require_min_blocks=require_min_blocks,
+        )
         return plan
 
-    def _validate_paged_attention_plan(self, plan: _PagedAttentionPlan) -> None:
+    def _validate_paged_attention_plan(
+        self, plan: _PagedAttentionPlan, *, require_min_blocks: bool
+    ) -> None:
         if plan.kv_budget <= 0:
             raise ValueError(
                 "Paged attention: not enough Metal memory for KV cache. "
                 f"{plan.format_breakdown()}. {plan.format_mitigations()}"
             )
 
-        if plan.num_blocks < PAGED_ATTENTION_MIN_BLOCKS:
+        if require_min_blocks and plan.num_blocks < PAGED_ATTENTION_MIN_BLOCKS:
             raise ValueError(
                 "Paged attention: computed num_blocks too low "
                 f"({plan.num_blocks} < minimum {PAGED_ATTENTION_MIN_BLOCKS}). "

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -282,6 +282,7 @@ class ModelCachePolicy:
         kv_heads = self._runner.kv_heads_per_layer
         head_dims = self._runner.head_dim_per_layer
         sliding_windows = self._runner.sliding_window_per_layer
+        vllm_config = self._runner.vllm_config
         return (
             kv_heads is not None
             and head_dims is not None
@@ -292,6 +293,8 @@ class ModelCachePolicy:
             and not self._use_turboquant(get_config())
             and self._runner.vllm_config.speculative_config is None
             and self._runner._gemma4_mtp_assistant is None
+            and not vllm_config.scheduler_config.disable_hybrid_kv_cache_manager
+            and vllm_config.cache_config.num_gpu_blocks_override is None
             and any(window >= 0 for window in sliding_windows)
             and any(window < 0 for window in sliding_windows)
         )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -117,6 +117,7 @@ logger = init_logger(__name__)
 SchedulerMemoryReportingMode: TypeAlias = Literal[
     "stt_nominal",
     "paged_attention_capacity",
+    "paged_attention_mha_layout_budget",
     "single_sequence_estimate",
 ]
 


### PR DESCRIPTION
This PR is:

- To emit Gemma4 full/sliding MHA KV specs instead of charging every layer as full attention.
- To let vLLM build the authoritative grouped `KVCacheConfig` before Metal allocates cache tensors.
- To initialize Metal paged attention from the returned grouped layout.
- To keep unsupported modes on the existing dense path.

This fixes issue #505 overcharge where Gemma4 31B's 50 sliding layers and 10 full-attention layers were all planned as full attention. Metal now trusts vLLM's grouped cache contract and only translates the returned layout into Metal cache tensors.

Note:

@ricky-chaoju could you test this on the real Gemma4 hardware path after this PR is up? The local tests cover the config/startup path, but the final proof should be a real 26B/31B long-context serve.
