### PR TITLE
Publish stable wheels to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,66 @@
+name: Publish to PyPI
+
+# Manual, unlike release.yml's per-push dev wheels: a PyPI version can only be
+# uploaded once, so publishing on every merge would burn version numbers.
+# Publishes whatever version pyproject.toml holds — bump it first.
+#
+# Needs a one-time Trusted Publisher registration; see docs/releasing.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
+
+jobs:
+  build:
+    name: Build macOS arm64 wheel
+    # macOS runner: the wheel bundles compiled .metallib shaders.
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build wheel
+        run: ./scripts/build.sh
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*.whl
+          if-no-files-found: error
+
+  publish:
+    name: Publish to ${{ inputs.target }}
+    needs: build
+    # Linux despite the macOS wheel: gh-action-pypi-publish is a container action.
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target }}
+    permissions:
+      id-token: write # mint the OIDC token for Trusted Publishing
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to TestPyPI
+        if: ${{ inputs.target == 'testpypi' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: ${{ inputs.target == 'pypi' }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,67 @@
+# Releasing
+
+vllm-metal ships on two channels:
+
+| Channel | Trigger | Version | Destination |
+| --- | --- | --- | --- |
+| **Dev** | every push to `main` (`release.yml`) | `0.3.0.devTIMESTAMP` | [GitHub Releases](https://github.com/vllm-project/vllm-metal/releases) |
+| **Stable** | manual (`publish-pypi.yml`) | `[project].version` from `pyproject.toml` | [PyPI](https://pypi.org/project/vllm-metal/) |
+
+This mirrors upstream vLLM, which publishes stable wheels to PyPI and per-commit
+dev wheels to its own `wheels.vllm.ai` index. Both channels build the same wheel
+via `build_wheel` in `scripts/lib.sh`, so the native `_paged_ops.so` + `.metallib`
+shaders are always bundled and end users never compile.
+
+## One-time setup (PyPI project owner)
+
+Stable publishing uses **PyPI Trusted Publishing (OIDC)** — no API token is
+stored in the repo. A maintainer with owner rights on the PyPI `vllm-metal`
+project needs to do this once, on **both** PyPI and TestPyPI:
+
+1. **Register the trusted publisher.** On the project's *Publishing* settings
+   (e.g. <https://pypi.org/manage/project/vllm-metal/settings/publishing/>), add
+   a new *GitHub* pending/existing publisher with:
+
+   | Field | Value |
+   | --- | --- |
+   | Owner | `vllm-project` |
+   | Repository | `vllm-metal` |
+   | Workflow name | `publish-pypi.yml` |
+   | Environment | `pypi` (on PyPI) / `testpypi` (on TestPyPI) |
+
+   Repeat on <https://test.pypi.org/> with environment `testpypi`.
+
+2. **Create the GitHub Environments** `pypi` and `testpypi`
+   (repo *Settings → Environments*). Optionally add required reviewers on `pypi`
+   so a human approves each production upload.
+
+That's all the maintainer action needed — no secrets, nothing to rotate.
+
+## Cutting a stable release
+
+1. Bump `version` in `pyproject.toml` (the current PyPI release is stale at
+   `0.1.0`; the first publish off this workflow is `0.3.0`). Land it on `main`.
+2. **Rehearse on TestPyPI:** *Actions → Publish to PyPI → Run workflow*, target
+   `testpypi`. Confirm the wheel uploads and
+   `pip install -i https://test.pypi.org/simple/ vllm-metal` resolves the wheel.
+3. **Publish:** run the workflow again with target `pypi`.
+
+Each version can be uploaded only once; bump the version for any re-publish.
+
+## Known limitation — `pip install vllm-metal` is not yet self-contained
+
+Publishing the plugin to PyPI does **not** by itself make a bare
+`pip install vllm-metal` a working install. vllm-metal deliberately does not
+declare a hard `vllm` dependency, because **vLLM ships no macOS wheel on PyPI**
+(across all its versions PyPI has only manylinux wheels + an sdist, and the sdist
+pins NVIDIA-only deps that make it unsatisfiable on macOS). The only macOS `vllm`
+wheel exists as a GitHub *release asset* — which `install.sh` pins by URL, but
+which cannot go into a PyPI package's dependency metadata (PyPI forbids
+direct-URL deps).
+
+So today the supported install is still `install.sh` (which fetches vLLM core
+and the plugin as prebuilt wheels — zero compile). Turning
+`pip install vllm-metal` into a complete one-command install needs an **upstream**
+change: vLLM must publish its macOS arm64 wheel to PyPI as part of its release
+pipeline. Only then can vllm-metal flip `vllm` to a hard pinned dependency. This
+is tracked in [#436](https://github.com/vllm-project/vllm-metal/issues/436).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,11 @@ version = "0.3.0"
 description = "vLLM hardware plugin for Apple Silicon - unifies MLX and PyTorch under a single lowering path"
 readme = "README.md"
 license = {text = "Apache-2.0"}
-requires-python = ">=3.12,<3.14"
+# 3.12 only: the native extensions are version-specific (not abi3) and vLLM's
+# own macOS wheel is cp312, so there is nothing to pair a cp313 build with.
+# Claiming 3.13 here turns "requires Python 3.12" into a confusing
+# "no matching distribution" for anyone on a newer default interpreter.
+requires-python = ">=3.12,<3.13"
 authors = [
     {name = "vLLM Community"}
 ]
@@ -21,7 +25,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Build entrypoint for the PyPI channel. Separate from release.sh because that
+# one dev-stamps the version and cuts a GitHub release; here the wheel in dist/
+# keeps pyproject.toml's version and the workflow uploads it.
+main() {
+  set -eu -o pipefail
+
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  # shellcheck source=lib.sh disable=SC1091
+  source "${script_dir}/lib.sh"
+
+  setup_dev_env
+  build_wheel
+}
+
+main "$@"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -172,7 +172,10 @@ build_wheel() {
   build_native_artifacts
 
   section "Building wheel"
-  uv build
+  # --wheel: never produce an sdist. Publishing one would let pip fall back to a
+  # source build on any platform we ship no wheel for, which needs the Metal
+  # toolchain — the compile-on-install this project exists to avoid.
+  uv build --wheel
 
   local wheels=(dist/*.whl)
   if [ ! -f "${wheels[0]}" ]; then

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -163,3 +163,21 @@ for _name in METALLIB_NAMES:
 
   success "Wheel bundles all native artifacts"
 }
+
+# Build the wheel into dist/ and fail unless it bundles the native artifacts.
+# Needs setup_dev_env first, and builds whatever version pyproject.toml holds —
+# release.sh dev-stamps it beforehand, build.sh leaves it alone.
+build_wheel() {
+  ensure_metal_toolchain
+  build_native_artifacts
+
+  section "Building wheel"
+  uv build
+
+  local wheels=(dist/*.whl)
+  if [ ! -f "${wheels[0]}" ]; then
+    error "No wheel found in dist/ after uv build."
+    return 1
+  fi
+  verify_wheel_artifacts "${wheels[0]}"
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,13 +11,6 @@ main() {
 
   setup_dev_env
 
-  # Build the prebuilt native extension (.so) and the three precompiled
-  # .metallib shader libraries into vllm_metal/metal/ before `uv build`, so the
-  # wheel ships them (via the maturin `include` directive) and end users never
-  # invoke clang++ or `xcrun metal` at runtime.
-  ensure_metal_toolchain
-  build_native_artifacts
-
   local base_version version
   base_version=$(get_version)
   # Per-commit dev version, e.g. 0.3.0.dev20260603184500 — unique and PEP 440.
@@ -29,19 +22,7 @@ main() {
   # dynamic. The runner checkout is ephemeral, so the committed file is untouched.
   sed -i '' -E "s/^version = .*/version = \"${version}\"/" pyproject.toml
 
-  section "Building wheel"
-  uv build
-
-  # Guard: never publish a wheel that doesn't actually bundle the prebuilt
-  # native artifacts (maturin `include`). Abort here — before the tag and
-  # release — rather than ship a wheel that fails with "Prebuilt native
-  # extension not found" on the user's first run.
-  local wheels=(dist/*.whl)
-  if [ ! -f "${wheels[0]}" ]; then
-    error "No wheel found in dist/ after uv build."
-    exit 1
-  fi
-  verify_wheel_artifacts "${wheels[0]}"
+  build_wheel
 
   local tag
   tag="v${version}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -147,25 +147,10 @@ main() {
   setup_dev_env
 
   if [ "$(uname)" == "Darwin" ]; then
-    # Build the native artifacts (.so + .metallib) into the package tree before
-    # install.sh's `uv pip install .`, so the wheel bundles them (maturin
-    # `include`) and CI exercises the prebuilt path users get, like release.sh.
-    ensure_metal_toolchain
-    build_native_artifacts
-
-    # Shift-left the release wheel guard. The pytest run below imports the source
-    # tree, which shadows the installed wheel, so a maturin `include` regression
-    # (artifacts silently dropped from the wheel) would pass CI here and only
-    # surface when release.sh runs on main. Build the wheel and assert it bundles
-    # the prebuilt artifacts now — the same check release.sh runs before publish.
-    section "Building wheel"
-    uv build
-    local wheels=(dist/*.whl)
-    if [ ! -f "${wheels[0]}" ]; then
-      error "No wheel found in dist/ after uv build."
-      exit 1
-    fi
-    verify_wheel_artifacts "${wheels[0]}"
+    # Build before install.sh so CI exercises the prebuilt path users get. The
+    # pytest run below imports the source tree, shadowing the installed wheel, so
+    # a maturin `include` regression would otherwise surface only at release.
+    build_wheel
 
     installs
     # shellcheck source=/dev/null


### PR DESCRIPTION
Last step toward `pip install vllm-metal` (#436 Step 3). Adds a PyPI publish path for the plugin; the wheel itself already needs no compiler since #423 and #508.

**Remaining blockers, all upstream in vLLM:**

- vLLM publishes no macOS wheel to PyPI — only manylinux wheels and an sdist.
- That sdist doesn't even resolve on macOS: it pins `pynvvideocodec`, which is NVIDIA-only.
- The macOS vLLM wheel exists only as a GitHub release asset, and PyPI forbids direct-URL dependencies, so `install.sh`'s pin can't move into package metadata.
- So vllm-metal still can't declare a hard `vllm` dependency; users install vLLM core separately until upstream publishes a macOS wheel to PyPI.
- vLLM's macOS wheel is cp312-only, so we can't offer newer Python either even though mlx already ships cp310–cp314.

**Handled here:** our PyPI project is stale at `0.1.0` and nothing publishes to it. `requires-python` also claimed 3.13 while only a cp312 wheel exists, which turned "requires Python 3.12" into a confusing "no matching distribution" for anyone on a default 3.13/3.14 interpreter — now tightened to match the artifacts. Builds are wheel-only, so pip can never fall back to a source build that would need the Metal toolchain.

**Proposed release mechanism**

Two channels, both building the same wheel via a shared `build_wheel` in `scripts/lib.sh`. `release.yml` keeps pushing per-commit `0.3.0.devTIMESTAMP` wheels to GitHub Releases on every merge to main. The new `publish-pypi.yml` is manual: it builds the release-versioned wheel on macOS, then uploads it with PyPI Trusted Publishing (OIDC, no stored token), targeting TestPyPI or PyPI as chosen at dispatch so a release can be rehearsed first. Manual because a PyPI version can only be uploaded once, so publishing on every merge would burn version numbers. Setup steps are in `docs/releasing.md`.

@mgoin this needs a one-time Trusted Publisher registration on the PyPI `vllm-metal` project (fields in `docs/releasing.md`) before it can be rehearsed on TestPyPI.
