### PR TITLE
Re-pin Qwen3.5 golden to current MLX

### DIFF
--- a/tests/test_qwen35_smoke.py
+++ b/tests/test_qwen35_smoke.py
@@ -34,10 +34,11 @@ PROMPTS = [
 
 # fmt: off
 # Golden token IDs from MLX inline cache, greedy decoding (Qwen3.5-0.8B).
+# Environment: mlx 0.32.0, mlx-lm 0.31.3
 GOLDEN_MLX = {
     "The capital of France is":                     [11751, 13, 198, 760, 6511, 314, 9338, 369, 11751, 13],
     "The weather today is not":                     [1603, 13, 198, 760, 8831, 3242, 369, 524, 1603, 13],
-    "One plus one equals":                          [1330, 13, 198, 3833, 5346, 799, 16327, 1330, 13, 198],
+    "One plus one equals":                          [220, 17, 13, 198, 3833, 5346, 799, 16327, 220, 17],
     "The largest planet in our solar system is":    [279, 7806, 13, 271, 248068, 271, 248069, 271, 332, 2665],
     "Water boils at a temperature of":              [220, 16, 15, 15, 29922, 13, 1368, 264, 1637, 369],
 }


### PR DESCRIPTION
tests/test_qwen35_smoke.py has been failing on `One plus one equals` and nobody noticed, because it is `@pytest.mark.slow` and CI only runs `pytest -m "not slow"`. The golden was last regenerated in #463, and three dependency bumps have landed since (#501 MLX 0.32, #506 vLLM 0.25.1, #559 vLLM 0.26) without touching it.

I tried to pin down which one moved the output and could not, so here is what I ruled out. Reinstalling vLLM 0.25.1 and re-running at #506 still fails. Downgrading MLX to 0.31.2 on current main, with the native extension rebuilt against it, still fails. It is not hardware either: an M1 Ultra 128GB and an M2 Ultra 192GB produce byte-identical output on all five prompts, and both disagree with the stored value on this one.

What settles it is that mlx_lm now produces `[220, 17, 13, 198, 3833, 5346, 799, 16327, 220, 17]` for this prompt, the same tokens vLLM produces. The reference and the engine agree, and the stored golden matches neither. So this re-pins the one stale value per the #202 precedent instead of adding a tolerance, which would keep alive a value nothing in the current stack produces. The other four prompts are unchanged.
