### PR TITLE
Simplify Gemma4 MTP metadata handling

### DIFF
--- a/tests/test_gemma4_mtp_assistant.py
+++ b/tests/test_gemma4_mtp_assistant.py
@@ -327,11 +327,13 @@ def test_validate_accepts_assistant_layer_types_tail_matching_target_non_shared_
 def test_validate_rejects_layer_types_not_tail_matching_target_non_shared_layers() -> (
     None
 ):
+    text_config = _assistant_config()["text_config"]
+    assert isinstance(text_config, dict)
     with pytest.raises(ValueError, match="tail-match"):
         _validate_assistant_config(
             _assistant_config(
                 text_config={
-                    **_assistant_config()["text_config"],
+                    **text_config,
                     "num_hidden_layers": 1,
                     "layer_types": ["full_attention"],
                 }
@@ -352,6 +354,14 @@ def test_validate_rejects_assistant_with_more_layers_than_target_non_shared() ->
         _validate_assistant_config(
             _assistant_config(),
             target_model_args=_target_args(num_kv_shared_layers=3),
+        )
+
+
+def test_validate_rejects_non_gemma4_target_model_type() -> None:
+    with pytest.raises(ValueError, match="requires a Gemma4 target model"):
+        _validate_assistant_config(
+            _assistant_config(),
+            target_model_args=_target_args(model_type="qwen3"),
         )
 
 

--- a/tests/test_gemma4_mtp_assistant.py
+++ b/tests/test_gemma4_mtp_assistant.py
@@ -355,6 +355,14 @@ def test_validate_rejects_assistant_with_more_layers_than_target_non_shared() ->
         )
 
 
+def test_validate_rejects_target_kv_shared_layers_past_layer_count() -> None:
+    with pytest.raises(ValueError, match="leave at least one non-shared KV layer"):
+        _validate_assistant_config(
+            _assistant_config(),
+            target_model_args=_target_args(num_kv_shared_layers=5),
+        )
+
+
 def test_validate_rejects_malformed_assistant_layer_types() -> None:
     text_config = _assistant_config()["text_config"]
     assert isinstance(text_config, dict)

--- a/tests/test_gemma4_mtp_assistant.py
+++ b/tests/test_gemma4_mtp_assistant.py
@@ -283,6 +283,19 @@ def test_validate_rejects_ordered_embedding_top_k_above_centroids() -> None:
         )
 
 
+def test_validate_ignores_ordered_embedding_fields_when_disabled() -> None:
+    metadata = _validate_assistant_config(
+        _assistant_config(
+            use_ordered_embeddings=False,
+            num_centroids=0,
+            centroid_intermediate_top_k=0,
+        ),
+        target_model_args=_target_args(),
+    )
+
+    assert metadata.use_ordered_embeddings is False
+
+
 def test_validate_rejects_bool_assistant_config_values() -> None:
     text_config = _assistant_config()["text_config"]
     assert isinstance(text_config, dict)

--- a/tests/test_gemma4_mtp_assistant.py
+++ b/tests/test_gemma4_mtp_assistant.py
@@ -79,13 +79,9 @@ def _target_args(**overrides: object) -> dict[str, object]:
 def _validate_assistant_config(
     assistant_config: Any,
     *,
-    target_hf_config: Any | None,
     target_model_args: Mapping[str, Any],
 ) -> Gemma4MTPAssistantMetadata:
-    target_metadata = Gemma4MTPTargetMetadata.from_configs(
-        target_hf_config=target_hf_config,
-        target_model_args=target_model_args,
-    )
+    target_metadata = Gemma4MTPTargetMetadata.from_model_args(target_model_args)
     if isinstance(assistant_config, Gemma4MTPAssistantMetadata):
         metadata = assistant_config
     else:
@@ -105,14 +101,6 @@ def _speculative_config(*, hf_config: object | None = None) -> SimpleNamespace:
         revision=None,
         draft_model_config=draft_config,
     )
-
-
-class _ConfigWithTextAccessor:
-    def __init__(self, text_config: object) -> None:
-        self._text_config = text_config
-
-    def get_text_config(self) -> object:
-        return self._text_config
 
 
 @pytest.mark.parametrize("model_type", sorted(GEMMA4_MTP_DRAFT_MODEL_TYPES))
@@ -135,7 +123,6 @@ def test_validate_rejects_unknown_assistant_model_type_with_known_architecture()
     with pytest.raises(ValueError, match="model_type='unknown'"):
         _validate_assistant_config(
             _assistant_config(model_type="unknown"),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -149,7 +136,6 @@ def test_detection_ignores_malformed_non_gemma_architectures() -> None:
 def test_validate_accepts_matching_assistant_config() -> None:
     metadata = _validate_assistant_config(
         _assistant_config(),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -162,149 +148,16 @@ def test_validate_accepts_matching_assistant_config() -> None:
 def test_validate_records_tie_word_embeddings_contract() -> None:
     metadata = _validate_assistant_config(
         _assistant_config(tie_word_embeddings=False),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
     assert metadata.tie_word_embeddings is False
 
 
-def test_validate_accepts_target_metadata_from_hf_text_config() -> None:
-    target_hf_config = SimpleNamespace(
-        text_config=SimpleNamespace(
-            model_type="gemma4_text",
-            vocab_size=262144,
-            hidden_size=1536,
-            num_hidden_layers=4,
-            num_kv_shared_layers=0,
-            layer_types=[
-                "sliding_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    metadata = _validate_assistant_config(
-        _assistant_config(),
-        target_hf_config=target_hf_config,
-        target_model_args={
-            "vocab_size": 262144,
-            "hidden_size": 1536,
-        },
-    )
-
-    assert metadata.backbone_hidden_size == 1536
-
-
-def test_validate_rejects_mismatched_target_vocab_sources() -> None:
-    target_hf_config = SimpleNamespace(
-        text_config=SimpleNamespace(
-            model_type="gemma4_text",
-            vocab_size=32000,
-            hidden_size=1536,
-            num_hidden_layers=4,
-            num_kv_shared_layers=0,
-            layer_types=[
-                "sliding_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    with pytest.raises(ValueError, match="vocab_size metadata mismatch"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=target_hf_config,
-            target_model_args=_target_args(),
-        )
-
-
-def test_validate_rejects_mismatched_target_layer_type_sources() -> None:
-    target_hf_config = SimpleNamespace(
-        text_config=SimpleNamespace(
-            model_type="gemma4_text",
-            vocab_size=262144,
-            hidden_size=1536,
-            num_hidden_layers=4,
-            num_kv_shared_layers=0,
-            layer_types=[
-                "full_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    with pytest.raises(ValueError, match="layer_types metadata mismatch"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=target_hf_config,
-            target_model_args=_target_args(),
-        )
-
-
-def test_validate_rejects_mismatched_target_kv_shared_sources() -> None:
-    target_hf_config = SimpleNamespace(
-        text_config=SimpleNamespace(
-            model_type="gemma4_text",
-            vocab_size=262144,
-            hidden_size=1536,
-            num_hidden_layers=4,
-            num_kv_shared_layers=1,
-            layer_types=[
-                "sliding_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    with pytest.raises(ValueError, match="num_kv_shared_layers metadata mismatch"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=target_hf_config,
-            target_model_args=_target_args(),
-        )
-
-
 def test_validate_accepts_top_level_gemma4_target_model_type() -> None:
     metadata = _validate_assistant_config(
         _assistant_config(),
-        target_hf_config=None,
         target_model_args=_target_args(model_type="gemma4"),
-    )
-
-    assert metadata.backbone_hidden_size == 1536
-
-
-def test_validate_accepts_target_metadata_from_get_text_config() -> None:
-    target_hf_config = _ConfigWithTextAccessor(
-        SimpleNamespace(
-            model_type="gemma4_text",
-            num_hidden_layers=4,
-            num_kv_shared_layers=0,
-            layer_types=[
-                "sliding_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    metadata = _validate_assistant_config(
-        _assistant_config(),
-        target_hf_config=target_hf_config,
-        target_model_args={
-            "vocab_size": 262144,
-            "hidden_size": 1536,
-        },
     )
 
     assert metadata.backbone_hidden_size == 1536
@@ -314,7 +167,6 @@ def test_validate_rejects_vocab_mismatch() -> None:
     with pytest.raises(ValueError, match="vocab size must match"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(vocab_size=32000),
         )
 
@@ -323,7 +175,6 @@ def test_validate_rejects_assistant_top_level_vocab_mismatch() -> None:
     with pytest.raises(ValueError, match="vocab_size metadata mismatch"):
         _validate_assistant_config(
             _assistant_config(vocab_size=32000),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -332,7 +183,6 @@ def test_validate_rejects_non_positive_target_size() -> None:
     with pytest.raises(ValueError, match="target model hidden_size must be positive"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(hidden_size=0),
         )
 
@@ -341,7 +191,6 @@ def test_validate_rejects_backbone_hidden_size_mismatch() -> None:
     with pytest.raises(ValueError, match="backbone hidden size must match"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(hidden_size=2048),
         )
 
@@ -363,7 +212,6 @@ def test_validate_rejects_non_positive_assistant_text_sizes(
     with pytest.raises(ValueError, match=f"assistant {field} must be positive"):
         _validate_assistant_config(
             _assistant_config(text_config={**text_config, field: value}),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -375,7 +223,6 @@ def test_validate_rejects_non_positive_assistant_backbone_hidden_size() -> None:
     ):
         _validate_assistant_config(
             _assistant_config(backbone_hidden_size=0),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -387,7 +234,6 @@ def test_validate_rejects_non_integer_assistant_config_values(
     with pytest.raises(ValueError, match="assistant n_predict must be an integer"):
         _validate_assistant_config(
             _assistant_config(n_predict=value),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -401,7 +247,6 @@ def test_validate_rejects_non_integer_assistant_mask_config_values(
     with pytest.raises(ValueError, match=f"assistant {field} must be an integer"):
         _validate_assistant_config(
             _assistant_config(**{field: value}),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -413,7 +258,6 @@ def test_validate_rejects_non_positive_assistant_mask_config_values(
     with pytest.raises(ValueError, match=f"assistant {field} must be positive"):
         _validate_assistant_config(
             _assistant_config(**{field: 0}),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -427,7 +271,6 @@ def test_validate_rejects_ordered_embedding_vocab_centroid_mismatch() -> None:
                 num_centroids=64,
                 text_config={**text_config, "vocab_size": 262143},
             ),
-            target_hf_config=None,
             target_model_args=_target_args(vocab_size=262143),
         )
 
@@ -436,7 +279,6 @@ def test_validate_rejects_ordered_embedding_top_k_above_centroids() -> None:
     with pytest.raises(ValueError, match="centroid_intermediate_top_k must be <="):
         _validate_assistant_config(
             _assistant_config(num_centroids=8, centroid_intermediate_top_k=9),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -447,7 +289,6 @@ def test_validate_rejects_bool_assistant_config_values() -> None:
     with pytest.raises(ValueError, match="assistant hidden_size must be an integer"):
         _validate_assistant_config(
             _assistant_config(text_config={**text_config, "hidden_size": True}),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -457,7 +298,6 @@ def test_validate_rejects_non_bool_assistant_config_values(field: str) -> None:
     with pytest.raises(ValueError, match=f"assistant {field} must be a boolean"):
         _validate_assistant_config(
             _assistant_config(**{field: "false"}),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -466,30 +306,6 @@ def test_validate_rejects_non_gemma4_target_model_type() -> None:
     with pytest.raises(ValueError, match="Gemma4 target"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
-            target_model_args=_target_args(model_type="llama"),
-        )
-
-
-def test_validate_rejects_mismatched_target_model_type_sources() -> None:
-    target_hf_config = SimpleNamespace(
-        text_config=SimpleNamespace(
-            model_type="gemma4_text",
-            num_hidden_layers=4,
-            num_kv_shared_layers=0,
-            layer_types=[
-                "sliding_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    with pytest.raises(ValueError, match="model_type='llama'"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=target_hf_config,
             target_model_args=_target_args(model_type="llama"),
         )
 
@@ -498,7 +314,6 @@ def test_validate_rejects_missing_target_model_type() -> None:
     with pytest.raises(ValueError, match="model_type=None"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args={
                 "vocab_size": 262144,
                 "hidden_size": 1536,
@@ -518,7 +333,6 @@ def test_validate_accepts_assistant_layer_types_tail_matching_target_non_shared_
 ):
     metadata = _validate_assistant_config(
         _assistant_config(),
-        target_hf_config=None,
         target_model_args=_target_args(
             num_hidden_layers=6,
             layer_types=[
@@ -552,7 +366,6 @@ def test_validate_rejects_layer_types_not_tail_matching_target_non_shared_layers
                     "layer_types": ["full_attention"],
                 }
             ),
-            target_hf_config=None,
             target_model_args=_target_args(
                 layer_types=[
                     "sliding_attention",
@@ -568,7 +381,6 @@ def test_validate_rejects_assistant_with_more_layers_than_target_non_shared() ->
     with pytest.raises(ValueError, match="more layers"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(num_kv_shared_layers=3),
         )
 
@@ -577,7 +389,6 @@ def test_validate_rejects_target_layer_types_length_mismatch() -> None:
     with pytest.raises(ValueError, match="layer_types must match num_hidden_layers"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(
                 num_hidden_layers=5,
                 layer_types=[
@@ -590,62 +401,11 @@ def test_validate_rejects_target_layer_types_length_mismatch() -> None:
         )
 
 
-def test_validate_rejects_mismatched_target_num_hidden_layer_sources() -> None:
-    target_hf_config = SimpleNamespace(
-        text_config=SimpleNamespace(
-            model_type="gemma4_text",
-            vocab_size=262144,
-            hidden_size=1536,
-            num_hidden_layers=5,
-            num_kv_shared_layers=0,
-            layer_types=[
-                "sliding_attention",
-                "sliding_attention",
-                "sliding_attention",
-                "full_attention",
-            ],
-        )
-    )
-
-    with pytest.raises(ValueError, match="num_hidden_layers metadata mismatch"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=target_hf_config,
-            target_model_args=_target_args(),
-        )
-
-
 def test_validate_rejects_target_with_no_non_shared_kv_layers() -> None:
     with pytest.raises(ValueError, match="leave at least one non-shared KV layer"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(num_kv_shared_layers=4),
-        )
-
-
-def test_validate_rejects_string_target_layer_types() -> None:
-    with pytest.raises(ValueError, match="layer_types must be a non-string sequence"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=None,
-            target_model_args=_target_args(layer_types="full_attention"),
-        )
-
-
-def test_validate_rejects_non_string_target_layer_type_entries() -> None:
-    with pytest.raises(ValueError, match="layer_types entries must be strings"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=None,
-            target_model_args=_target_args(
-                layer_types=[
-                    "sliding_attention",
-                    1,
-                    "sliding_attention",
-                    "full_attention",
-                ],
-            ),
         )
 
 
@@ -653,7 +413,6 @@ def test_validate_rejects_unknown_target_layer_types() -> None:
     with pytest.raises(ValueError, match="Unsupported Gemma4 MTP target layer types"):
         _validate_assistant_config(
             _assistant_config(),
-            target_hf_config=None,
             target_model_args=_target_args(
                 layer_types=[
                     "sliding_attention",
@@ -662,18 +421,6 @@ def test_validate_rejects_unknown_target_layer_types() -> None:
                     "full_attention",
                 ],
             ),
-        )
-
-
-def test_validate_rejects_non_integer_target_config_values() -> None:
-    with pytest.raises(
-        ValueError,
-        match="target model num_kv_shared_layers must be an integer",
-    ):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_hf_config=None,
-            target_model_args=_target_args(num_kv_shared_layers="0"),
         )
 
 
@@ -690,7 +437,6 @@ def test_validate_rejects_malformed_assistant_layer_types() -> None:
     with pytest.raises(ValueError, match="layer_types must match num_hidden_layers"):
         _validate_assistant_config(
             config,
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -703,7 +449,6 @@ def test_validate_rejects_string_assistant_layer_types() -> None:
             _assistant_config(
                 text_config={**text_config, "layer_types": "full_attention"}
             ),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -724,7 +469,6 @@ def test_validate_rejects_non_string_assistant_layer_type_entries() -> None:
                     ],
                 }
             ),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -733,7 +477,6 @@ def test_validate_rejects_mapped_config_with_unsupported_n_predict() -> None:
     with pytest.raises(ValueError, match="n_predict=1"):
         _validate_assistant_config(
             _assistant_config(model_type="gemma4_mtp", n_predict=2),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -742,7 +485,6 @@ def test_validate_rejects_malformed_assistant_architectures() -> None:
     with pytest.raises(ValueError, match="architectures must be a sequence"):
         _validate_assistant_config(
             _assistant_config(architectures=1),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -754,7 +496,6 @@ def test_validate_rejects_string_assistant_architectures() -> None:
     ):
         _validate_assistant_config(
             _assistant_config(architectures="Gemma4AssistantForCausalLM"),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -763,7 +504,6 @@ def test_validate_rejects_non_string_assistant_architecture_entries() -> None:
     with pytest.raises(ValueError, match="architectures entries must be strings"):
         _validate_assistant_config(
             _assistant_config(architectures=[1]),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -772,7 +512,6 @@ def test_validate_rejects_missing_gemma4_mtp_architecture() -> None:
     with pytest.raises(ValueError, match="requires a Gemma4 MTP architecture"):
         _validate_assistant_config(
             _assistant_config(architectures=["OtherModel"]),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -800,7 +539,6 @@ def test_loader_uses_custom_mlx_model_classes_and_validates_runtime() -> None:
 
     runtime = loader.load_if_needed(
         speculative_config=_speculative_config(),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -843,7 +581,6 @@ def test_loader_wraps_local_custom_shards_for_mlx_lm(
 
     loader.load_if_needed(
         speculative_config=_speculative_config(),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -885,7 +622,6 @@ def test_default_loader_downloads_custom_named_safetensors_shards(
 
     loader.load_if_needed(
         speculative_config=spec_config,
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -924,7 +660,6 @@ def test_loader_revalidates_cached_runtime_against_target() -> None:
 
     runtime = loader.load_if_needed(
         speculative_config=_speculative_config(),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
     assert runtime is not None
@@ -932,7 +667,6 @@ def test_loader_revalidates_cached_runtime_against_target() -> None:
     with pytest.raises(ValueError, match="backbone hidden size must match"):
         loader.load_if_needed(
             speculative_config=_speculative_config(),
-            target_hf_config=None,
             target_model_args=_target_args(hidden_size=2048),
         )
     assert load_model_calls == 1
@@ -946,7 +680,6 @@ def test_loader_skips_non_gemma4_mtp_speculative_config() -> None:
 
     runtime = loader.load_if_needed(
         speculative_config=SimpleNamespace(method="draft_model"),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -964,7 +697,6 @@ def test_loader_skips_non_gemma4_mtp_without_resolving_model() -> None:
         speculative_config=_speculative_config(
             hf_config=SimpleNamespace(model_type="deepseek_mtp")
         ),
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -988,7 +720,6 @@ def test_loader_rejects_custom_model_file_before_load(
     with pytest.raises(ValueError, match="custom model_file"):
         loader.load_if_needed(
             speculative_config=_speculative_config(),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -1005,7 +736,6 @@ def test_loader_rejects_postload_custom_model_file() -> None:
     with pytest.raises(ValueError, match="custom model_file"):
         loader.load_if_needed(
             speculative_config=_speculative_config(),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -1025,7 +755,6 @@ def test_loader_prevalidates_config_file_before_load(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="assistant hidden_size must be an integer"):
         loader.load_if_needed(
             speculative_config=_speculative_config(),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -1039,7 +768,6 @@ def test_default_loader_rejects_missing_config_before_load(tmp_path: Path) -> No
     with pytest.raises(ValueError, match="must contain config.json"):
         loader.load_if_needed(
             speculative_config=_speculative_config(),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -1055,7 +783,6 @@ def test_loader_rejects_invalid_json_config_before_load(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="config.json is not valid JSON"):
         loader.load_if_needed(
             speculative_config=_speculative_config(),
-            target_hf_config=None,
             target_model_args=_target_args(),
         )
 
@@ -1085,17 +812,14 @@ def test_loader_passes_revision_and_keeps_cache_keys_separate() -> None:
 
     first = loader.load_if_needed(
         speculative_config=spec_a,
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
     second = loader.load_if_needed(
         speculative_config=spec_a,
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
     third = loader.load_if_needed(
         speculative_config=spec_b,
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 
@@ -1121,7 +845,6 @@ def test_loader_prefers_resolved_draft_model_revision() -> None:
 
     loader.load_if_needed(
         speculative_config=spec,
-        target_hf_config=None,
         target_model_args=_target_args(),
     )
 

--- a/tests/test_gemma4_mtp_assistant.py
+++ b/tests/test_gemma4_mtp_assistant.py
@@ -154,15 +154,6 @@ def test_validate_records_tie_word_embeddings_contract() -> None:
     assert metadata.tie_word_embeddings is False
 
 
-def test_validate_accepts_top_level_gemma4_target_model_type() -> None:
-    metadata = _validate_assistant_config(
-        _assistant_config(),
-        target_model_args=_target_args(model_type="gemma4"),
-    )
-
-    assert metadata.backbone_hidden_size == 1536
-
-
 def test_validate_rejects_vocab_mismatch() -> None:
     with pytest.raises(ValueError, match="vocab size must match"):
         _validate_assistant_config(
@@ -176,14 +167,6 @@ def test_validate_rejects_assistant_top_level_vocab_mismatch() -> None:
         _validate_assistant_config(
             _assistant_config(vocab_size=32000),
             target_model_args=_target_args(),
-        )
-
-
-def test_validate_rejects_non_positive_target_size() -> None:
-    with pytest.raises(ValueError, match="target model hidden_size must be positive"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_model_args=_target_args(hidden_size=0),
         )
 
 
@@ -315,32 +298,6 @@ def test_validate_rejects_non_bool_assistant_config_values(field: str) -> None:
         )
 
 
-def test_validate_rejects_non_gemma4_target_model_type() -> None:
-    with pytest.raises(ValueError, match="Gemma4 target"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_model_args=_target_args(model_type="llama"),
-        )
-
-
-def test_validate_rejects_missing_target_model_type() -> None:
-    with pytest.raises(ValueError, match="model_type=None"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_model_args={
-                "vocab_size": 262144,
-                "hidden_size": 1536,
-                "num_kv_shared_layers": 0,
-                "layer_types": [
-                    "sliding_attention",
-                    "sliding_attention",
-                    "sliding_attention",
-                    "full_attention",
-                ],
-            },
-        )
-
-
 def test_validate_accepts_assistant_layer_types_tail_matching_target_non_shared_layers() -> (
     None
 ):
@@ -395,45 +352,6 @@ def test_validate_rejects_assistant_with_more_layers_than_target_non_shared() ->
         _validate_assistant_config(
             _assistant_config(),
             target_model_args=_target_args(num_kv_shared_layers=3),
-        )
-
-
-def test_validate_rejects_target_layer_types_length_mismatch() -> None:
-    with pytest.raises(ValueError, match="layer_types must match num_hidden_layers"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_model_args=_target_args(
-                num_hidden_layers=5,
-                layer_types=[
-                    "sliding_attention",
-                    "sliding_attention",
-                    "sliding_attention",
-                    "full_attention",
-                ],
-            ),
-        )
-
-
-def test_validate_rejects_target_with_no_non_shared_kv_layers() -> None:
-    with pytest.raises(ValueError, match="leave at least one non-shared KV layer"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_model_args=_target_args(num_kv_shared_layers=4),
-        )
-
-
-def test_validate_rejects_unknown_target_layer_types() -> None:
-    with pytest.raises(ValueError, match="Unsupported Gemma4 MTP target layer types"):
-        _validate_assistant_config(
-            _assistant_config(),
-            target_model_args=_target_args(
-                layer_types=[
-                    "sliding_attention",
-                    "unknown_attention",
-                    "sliding_attention",
-                    "full_attention",
-                ],
-            ),
         )
 
 

--- a/tests/test_gemma4_mtp_kv_sharing.py
+++ b/tests/test_gemma4_mtp_kv_sharing.py
@@ -497,22 +497,7 @@ def test_cache_policy_installs_gemma4_mtp_kv_sharing() -> None:
         "full_attention",
     ]
     runner = make_stub_runner(
-        model_args={
-            "vocab_size": 262144,
-            "hidden_size": 1536,
-        },
-        model_config=SimpleNamespace(
-            hf_config=SimpleNamespace(
-                text_config=SimpleNamespace(
-                    model_type="gemma4_text",
-                    vocab_size=262144,
-                    hidden_size=1536,
-                    num_hidden_layers=3,
-                    num_kv_shared_layers=0,
-                    layer_types=layer_types,
-                )
-            )
-        ),
+        model_args=_target_args(layer_types),
         _gemma4_mtp_assistant=_AssistantRuntime(),
     )
 

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -673,6 +673,7 @@ class TestModelLifecycle:
             "model_type": "gemma4_text",
             "vocab_size": 32000,
             "hidden_size": 4096,
+            "num_hidden_layers": 1,
             "num_kv_shared_layers": 0,
             "layer_types": ["full_attention"],
         }
@@ -683,12 +684,10 @@ class TestModelLifecycle:
 
         first = loader.load_if_needed(
             speculative_config=spec_config,
-            target_hf_config=None,
             target_model_args=target_args,
         )
         second = loader.load_if_needed(
             speculative_config=spec_config,
-            target_hf_config=None,
             target_model_args=target_args,
         )
         assert first is second
@@ -698,7 +697,6 @@ class TestModelLifecycle:
 
         third = loader.load_if_needed(
             speculative_config=spec_config,
-            target_hf_config=None,
             target_model_args=target_args,
         )
         assert third is not first

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -622,9 +622,8 @@ class ModelCachePolicy:
                 "Gemma4 MTP assistant KV sharing requires the MHA paged "
                 "attention backend on Metal."
             )
-        target_metadata = Gemma4MTPTargetMetadata.from_configs(
-            target_hf_config=self._runner.model_config.hf_config,
-            target_model_args=self._runner.model_args,
+        target_metadata = Gemma4MTPTargetMetadata.from_model_args(
+            self._runner.model_args
         )
         self._runner._gemma4_mtp_assistant = assistant.with_target_kv_sharing(
             target_metadata=target_metadata,

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -30,6 +30,7 @@ GEMMA4_MTP_DRAFT_MODEL_TYPES = frozenset({"gemma4_assistant", "gemma4_mtp"})
 GEMMA4_MTP_DRAFT_ARCHITECTURES = frozenset(
     {"Gemma4AssistantForCausalLM", "Gemma4MTPModel"}
 )
+GEMMA4_TARGET_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
 GEMMA4_MTP_TEXT_MODEL_TYPE = "gemma4_text"
 GEMMA4_MTP_VALID_LAYER_TYPES = frozenset({"sliding_attention", "full_attention"})
 
@@ -492,6 +493,12 @@ class Gemma4MTPTargetMetadata:
         cls,
         target_model_args: Mapping[str, Any],
     ) -> Gemma4MTPTargetMetadata:
+        model_type = target_model_args.get("model_type")
+        if model_type not in GEMMA4_TARGET_MODEL_TYPES:
+            raise ValueError(
+                "Gemma4 MTP assistant requires a Gemma4 target model, "
+                f"got model_type={model_type!r}"
+            )
         layer_types = target_model_args["layer_types"]
         num_kv_shared_layers = target_model_args.get("num_kv_shared_layers", 0)
         if not 0 <= num_kv_shared_layers < len(layer_types):

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -494,6 +494,11 @@ class Gemma4MTPTargetMetadata:
     ) -> Gemma4MTPTargetMetadata:
         layer_types = target_model_args["layer_types"]
         num_kv_shared_layers = target_model_args.get("num_kv_shared_layers", 0)
+        if not 0 <= num_kv_shared_layers < len(layer_types):
+            raise ValueError(
+                "Gemma4 target num_kv_shared_layers must leave at least one "
+                "non-shared KV layer"
+            )
         num_non_shared = len(layer_types) - num_kv_shared_layers
         return cls(
             vocab_size=target_model_args["vocab_size"],

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -560,11 +560,111 @@ class Gemma4MTPAssistantMetadata:
     @classmethod
     def is_assistant_config(cls, config: Any | None) -> bool:
         """Accept raw assistant configs and upstream vLLM's wrapper config."""
-        return _Gemma4MTPAssistantConfigParser._is_assistant_config(config)
+        if config is None:
+            return False
+        model_type = _config_value(config, "model_type")
+        if model_type in GEMMA4_MTP_DRAFT_MODEL_TYPES:
+            return True
+        return any(
+            arch in GEMMA4_MTP_DRAFT_ARCHITECTURES
+            for arch in cls._architectures(config, strict=False)
+        )
 
     @classmethod
     def from_config(cls, config: Any) -> Gemma4MTPAssistantMetadata:
-        return _Gemma4MTPAssistantConfigParser().parse(config)
+        model_type = _config_value(config, "model_type")
+        if model_type not in GEMMA4_MTP_DRAFT_MODEL_TYPES:
+            raise ValueError(
+                "Gemma4 MTP assistant requires a gemma4_assistant or gemma4_mtp "
+                f"config, got model_type={model_type!r}"
+            )
+
+        text_config = _text_config(config)
+        text_model_type = _config_value(text_config, "model_type")
+        if text_model_type != GEMMA4_MTP_TEXT_MODEL_TYPE:
+            raise ValueError(
+                "Gemma4 MTP assistant text_config.model_type must be "
+                f"{GEMMA4_MTP_TEXT_MODEL_TYPE!r}, got {text_model_type!r}"
+            )
+
+        vocab_size = cls._required_positive_int(
+            text_config,
+            "vocab_size",
+            context="assistant",
+        )
+        top_level_vocab_size = cls._optional_int(
+            config,
+            "vocab_size",
+            context="assistant",
+        )
+        if top_level_vocab_size is not None and top_level_vocab_size <= 0:
+            raise ValueError(
+                f"assistant vocab_size must be positive, got {top_level_vocab_size}"
+            )
+        if top_level_vocab_size is not None and top_level_vocab_size != vocab_size:
+            raise ValueError(
+                "Gemma4 MTP assistant vocab_size metadata mismatch: "
+                f"top-level={top_level_vocab_size}, text_config={vocab_size}"
+            )
+
+        hidden_size = cls._required_positive_int(
+            text_config,
+            "hidden_size",
+            context="assistant",
+        )
+        backbone_hidden_size = cls._required_positive_int(
+            config,
+            "backbone_hidden_size",
+            context="assistant",
+        )
+        num_hidden_layers = cls._required_positive_int(
+            text_config,
+            "num_hidden_layers",
+            context="assistant",
+        )
+        layer_types = cls._required_layer_types(text_config, num_hidden_layers)
+        architectures = cls._architectures(config, strict=True)
+        if not any(arch in GEMMA4_MTP_DRAFT_ARCHITECTURES for arch in architectures):
+            raise ValueError(
+                "Gemma4 MTP assistant requires a Gemma4 MTP architecture, got "
+                f"architectures={architectures!r}"
+            )
+
+        n_predict = cls._optional_int(config, "n_predict", context="assistant")
+        if n_predict is not None and n_predict != GEMMA4_MTP_N_PREDICT:
+            raise ValueError(
+                "Gemma4 MTP assistant config must use "
+                f"n_predict={GEMMA4_MTP_N_PREDICT}, got {n_predict!r}"
+            )
+        tie_word_embeddings = cls._optional_bool(
+            config,
+            "tie_word_embeddings",
+            context="assistant",
+            default=True,
+        )
+        use_ordered_embeddings = cls._optional_bool(
+            config,
+            "use_ordered_embeddings",
+            context="assistant",
+            default=False,
+        )
+        cls._validate_ordered_embedding_config(
+            config,
+            vocab_size=vocab_size,
+            use_ordered_embeddings=use_ordered_embeddings,
+        )
+
+        return cls(
+            model_type=str(model_type),
+            architectures=architectures,
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            backbone_hidden_size=backbone_hidden_size,
+            tie_word_embeddings=tie_word_embeddings,
+            num_hidden_layers=num_hidden_layers,
+            layer_types=layer_types,
+            use_ordered_embeddings=use_ordered_embeddings,
+        )
 
     def validate_compatible_with(self, target: Gemma4MTPTargetMetadata) -> None:
         if self.vocab_size != target.vocab_size:
@@ -595,122 +695,9 @@ class Gemma4MTPAssistantMetadata:
                 f"target_tail_layer_types={target_tail}"
             )
 
-
-class _Gemma4MTPAssistantConfigParser:
-    """Parse the Gemma4 MTP assistant checkpoint contract."""
-
-    @staticmethod
-    def _is_assistant_config(config: Any | None) -> bool:
-        if config is None:
-            return False
-        model_type = _config_value(config, "model_type")
-        if model_type in GEMMA4_MTP_DRAFT_MODEL_TYPES:
-            return True
-        return any(
-            arch in GEMMA4_MTP_DRAFT_ARCHITECTURES
-            for arch in _Gemma4MTPAssistantConfigParser._architectures(
-                config,
-                strict=False,
-            )
-        )
-
-    def parse(self, config: Any) -> Gemma4MTPAssistantMetadata:
-        model_type = _config_value(config, "model_type")
-        if model_type not in GEMMA4_MTP_DRAFT_MODEL_TYPES:
-            raise ValueError(
-                "Gemma4 MTP assistant requires a gemma4_assistant or gemma4_mtp "
-                f"config, got model_type={model_type!r}"
-            )
-
-        text_config = _text_config(config)
-        text_model_type = _config_value(text_config, "model_type")
-        if text_model_type != GEMMA4_MTP_TEXT_MODEL_TYPE:
-            raise ValueError(
-                "Gemma4 MTP assistant text_config.model_type must be "
-                f"{GEMMA4_MTP_TEXT_MODEL_TYPE!r}, got {text_model_type!r}"
-            )
-
-        vocab_size = self._required_positive_int(
-            text_config,
-            "vocab_size",
-            context="assistant",
-        )
-        top_level_vocab_size = self._optional_int(
-            config,
-            "vocab_size",
-            context="assistant",
-        )
-        if top_level_vocab_size is not None and top_level_vocab_size <= 0:
-            raise ValueError(
-                f"assistant vocab_size must be positive, got {top_level_vocab_size}"
-            )
-        if top_level_vocab_size is not None and top_level_vocab_size != vocab_size:
-            raise ValueError(
-                "Gemma4 MTP assistant vocab_size metadata mismatch: "
-                f"top-level={top_level_vocab_size}, text_config={vocab_size}"
-            )
-
-        hidden_size = self._required_positive_int(
-            text_config,
-            "hidden_size",
-            context="assistant",
-        )
-        backbone_hidden_size = self._required_positive_int(
-            config,
-            "backbone_hidden_size",
-            context="assistant",
-        )
-        num_hidden_layers = self._required_positive_int(
-            text_config,
-            "num_hidden_layers",
-            context="assistant",
-        )
-        layer_types = self._required_layer_types(text_config, num_hidden_layers)
-        architectures = self._architectures(config, strict=True)
-        if not any(arch in GEMMA4_MTP_DRAFT_ARCHITECTURES for arch in architectures):
-            raise ValueError(
-                "Gemma4 MTP assistant requires a Gemma4 MTP architecture, got "
-                f"architectures={architectures!r}"
-            )
-
-        n_predict = self._optional_int(config, "n_predict", context="assistant")
-        if n_predict is not None and n_predict != GEMMA4_MTP_N_PREDICT:
-            raise ValueError(
-                "Gemma4 MTP assistant config must use "
-                f"n_predict={GEMMA4_MTP_N_PREDICT}, got {n_predict!r}"
-            )
-        tie_word_embeddings = self._optional_bool(
-            config,
-            "tie_word_embeddings",
-            context="assistant",
-            default=True,
-        )
-        use_ordered_embeddings = self._optional_bool(
-            config,
-            "use_ordered_embeddings",
-            context="assistant",
-            default=False,
-        )
-        self._validate_ordered_embedding_config(
-            config,
-            vocab_size=vocab_size,
-            use_ordered_embeddings=use_ordered_embeddings,
-        )
-
-        return Gemma4MTPAssistantMetadata(
-            model_type=str(model_type),
-            architectures=architectures,
-            vocab_size=vocab_size,
-            hidden_size=hidden_size,
-            backbone_hidden_size=backbone_hidden_size,
-            tie_word_embeddings=tie_word_embeddings,
-            num_hidden_layers=num_hidden_layers,
-            layer_types=layer_types,
-            use_ordered_embeddings=use_ordered_embeddings,
-        )
-
-    @staticmethod
+    @classmethod
     def _validate_ordered_embedding_config(
+        cls,
         config: Any,
         *,
         vocab_size: int,
@@ -719,12 +706,12 @@ class _Gemma4MTPAssistantConfigParser:
         if not use_ordered_embeddings:
             return
 
-        num_centroids = _Gemma4MTPAssistantConfigParser._optional_int(
+        num_centroids = cls._optional_int(
             config,
             "num_centroids",
             context="assistant",
         )
-        centroid_intermediate_top_k = _Gemma4MTPAssistantConfigParser._optional_int(
+        centroid_intermediate_top_k = cls._optional_int(
             config,
             "centroid_intermediate_top_k",
             context="assistant",
@@ -759,9 +746,11 @@ class _Gemma4MTPAssistantConfigParser:
                 f"{centroid_intermediate_top_k}, num_centroids={num_centroids}"
             )
 
-    @staticmethod
-    def _required_layer_types(config: Any, num_hidden_layers: int) -> tuple[str, ...]:
-        layer_types = _Gemma4MTPAssistantConfigParser._sequence_field(
+    @classmethod
+    def _required_layer_types(
+        cls, config: Any, num_hidden_layers: int
+    ) -> tuple[str, ...]:
+        layer_types = cls._sequence_field(
             config,
             "layer_types",
         )
@@ -776,44 +765,46 @@ class _Gemma4MTPAssistantConfigParser:
             raise ValueError(f"Unsupported Gemma4 MTP assistant layer types: {unknown}")
         return layer_types
 
-    @staticmethod
-    def _required_int(config: Any, key: str, *, context: str) -> int:
+    @classmethod
+    def _required_int(cls, config: Any, key: str, *, context: str) -> int:
         value = _config_value(config, key)
         if value is None:
             raise ValueError(f"Missing {context} {key}")
-        return _Gemma4MTPAssistantConfigParser._coerce_int(
+        return cls._coerce_int(
             value,
             key=key,
             context=context,
         )
 
-    @staticmethod
-    def _optional_int(config: Any, key: str, *, context: str) -> int | None:
+    @classmethod
+    def _optional_int(cls, config: Any, key: str, *, context: str) -> int | None:
         value = _config_value(config, key)
         if value is None:
             return None
-        return _Gemma4MTPAssistantConfigParser._coerce_int(
+        return cls._coerce_int(
             value,
             key=key,
             context=context,
         )
 
-    @staticmethod
-    def _optional_bool(config: Any, key: str, *, context: str, default: bool) -> bool:
+    @classmethod
+    def _optional_bool(
+        cls, config: Any, key: str, *, context: str, default: bool
+    ) -> bool:
         value = _config_value(config, key, default)
         if not isinstance(value, bool):
             raise ValueError(f"{context} {key} must be a boolean, got {value!r}")
         return value
 
-    @staticmethod
-    def _coerce_int(value: Any, *, key: str, context: str) -> int:
+    @classmethod
+    def _coerce_int(cls, value: Any, *, key: str, context: str) -> int:
         if isinstance(value, bool) or not isinstance(value, Integral):
             raise ValueError(f"{context} {key} must be an integer, got {value!r}")
         return int(value)
 
-    @staticmethod
-    def _required_positive_int(config: Any, key: str, *, context: str) -> int:
-        value = _Gemma4MTPAssistantConfigParser._required_int(
+    @classmethod
+    def _required_positive_int(cls, config: Any, key: str, *, context: str) -> int:
+        value = cls._required_int(
             config,
             key,
             context=context,
@@ -822,8 +813,8 @@ class _Gemma4MTPAssistantConfigParser:
             raise ValueError(f"{context} {key} must be positive, got {value}")
         return value
 
-    @staticmethod
-    def _architectures(config: Any, *, strict: bool) -> tuple[str, ...]:
+    @classmethod
+    def _architectures(cls, config: Any, *, strict: bool) -> tuple[str, ...]:
         architectures = _config_value(config, "architectures", ()) or ()
         if isinstance(architectures, str):
             if strict:
@@ -844,8 +835,8 @@ class _Gemma4MTPAssistantConfigParser:
             names.append(arch)
         return tuple(names)
 
-    @staticmethod
-    def _sequence_field(config: Any, key: str) -> tuple[str, ...]:
+    @classmethod
+    def _sequence_field(cls, config: Any, key: str) -> tuple[str, ...]:
         value = _config_value(config, key, ()) or ()
         if isinstance(value, str):
             raise ValueError(f"{key} must be a non-string sequence")

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -30,7 +30,6 @@ GEMMA4_MTP_DRAFT_MODEL_TYPES = frozenset({"gemma4_assistant", "gemma4_mtp"})
 GEMMA4_MTP_DRAFT_ARCHITECTURES = frozenset(
     {"Gemma4AssistantForCausalLM", "Gemma4MTPModel"}
 )
-GEMMA4_TARGET_MODEL_TYPES = frozenset({"gemma4", "gemma4_text"})
 GEMMA4_MTP_TEXT_MODEL_TYPE = "gemma4_text"
 GEMMA4_MTP_VALID_LAYER_TYPES = frozenset({"sliding_attention", "full_attention"})
 
@@ -482,7 +481,7 @@ class Gemma4MTPAssistantSource:
 
 @dataclass(frozen=True, slots=True)
 class Gemma4MTPTargetMetadata:
-    """Validated target model metadata needed by Gemma4 MTP."""
+    """Target model metadata needed by Gemma4 MTP."""
 
     vocab_size: int
     hidden_size: int
@@ -493,53 +492,13 @@ class Gemma4MTPTargetMetadata:
         cls,
         target_model_args: Mapping[str, Any],
     ) -> Gemma4MTPTargetMetadata:
-        model_type = target_model_args.get("model_type")
-        if model_type not in GEMMA4_TARGET_MODEL_TYPES:
-            raise ValueError(
-                "Gemma4 MTP assistant requires a Gemma4 target model, "
-                f"got model_type={model_type!r}"
-            )
-
-        vocab_size = int(target_model_args["vocab_size"])
-        if vocab_size <= 0:
-            raise ValueError(
-                f"target model vocab_size must be positive, got {vocab_size}"
-            )
-        hidden_size = int(target_model_args["hidden_size"])
-        if hidden_size <= 0:
-            raise ValueError(
-                f"target model hidden_size must be positive, got {hidden_size}"
-            )
-        layer_types = tuple(target_model_args["layer_types"])
-        if not layer_types:
-            raise ValueError("Gemma4 MTP target model must expose layer_types")
-        unknown_layer_types = sorted(set(layer_types) - GEMMA4_MTP_VALID_LAYER_TYPES)
-        if unknown_layer_types:
-            raise ValueError(
-                f"Unsupported Gemma4 MTP target layer types: {unknown_layer_types}"
-            )
-
-        num_hidden_layers = int(target_model_args["num_hidden_layers"])
-        if len(layer_types) != num_hidden_layers:
-            raise ValueError(
-                "Gemma4 MTP target layer_types must match num_hidden_layers: "
-                f"len(layer_types)={len(layer_types)}, "
-                f"num_hidden_layers={num_hidden_layers}"
-            )
-
-        num_kv_shared_layers = int(target_model_args.get("num_kv_shared_layers", 0))
-        if num_kv_shared_layers < 0 or num_kv_shared_layers >= len(layer_types):
-            raise ValueError(
-                "Gemma4 MTP target num_kv_shared_layers must leave at least one "
-                f"non-shared KV layer: num_kv_shared_layers={num_kv_shared_layers}, "
-                f"num_layers={len(layer_types)}"
-            )
-
+        layer_types = target_model_args["layer_types"]
+        num_kv_shared_layers = target_model_args.get("num_kv_shared_layers", 0)
         num_non_shared = len(layer_types) - num_kv_shared_layers
         return cls(
-            vocab_size=vocab_size,
-            hidden_size=hidden_size,
-            non_shared_layer_types=layer_types[:num_non_shared],
+            vocab_size=target_model_args["vocab_size"],
+            hidden_size=target_model_args["hidden_size"],
+            non_shared_layer_types=tuple(layer_types[:num_non_shared]),
         )
 
 

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -55,7 +55,10 @@ class Gemma4MTPAssistantRuntime:
     model: Any
     metadata: Gemma4MTPAssistantMetadata
     kv_sharing: Gemma4MTPKVSharingBinding | None = None
-    forward_ready: bool = False
+
+    @property
+    def forward_ready(self) -> bool:
+        return self.kv_sharing is not None
 
     @property
     def kv_sharing_plan(self) -> Gemma4MTPKVSharingPlan | None:
@@ -87,7 +90,6 @@ class Gemma4MTPAssistantRuntime:
                 block_size=block_size,
                 group_block_sizes=group_block_sizes,
             ),
-            forward_ready=hasattr(self.model, "draft_token_ids"),
         )
 
     def propose_draft_token_ids(
@@ -102,8 +104,6 @@ class Gemma4MTPAssistantRuntime:
             return []
         if self.kv_sharing is None:
             raise RuntimeError("Gemma4 MTP assistant requires target KV sharing")
-        if not self.forward_ready:
-            raise RuntimeError("Gemma4 MTP assistant forward is not ready")
 
         if len(target_hidden_states.shape) == 3:
             if target_hidden_states.shape[0] != 1:
@@ -499,26 +499,17 @@ class Gemma4MTPTargetMetadata:
                 "Gemma4 MTP assistant requires a Gemma4 target model, "
                 f"got model_type={model_type!r}"
             )
-        return cls(
-            vocab_size=cls._required_positive_int("vocab_size", target_model_args),
-            hidden_size=cls._required_positive_int("hidden_size", target_model_args),
-            non_shared_layer_types=cls._non_shared_layer_types(target_model_args),
-        )
 
-    @staticmethod
-    def _required_positive_int(
-        key: str,
-        target_model_args: Mapping[str, Any],
-    ) -> int:
-        value = int(target_model_args[key])
-        if value <= 0:
-            raise ValueError(f"target model {key} must be positive, got {value}")
-        return value
-
-    @staticmethod
-    def _non_shared_layer_types(
-        target_model_args: Mapping[str, Any],
-    ) -> tuple[str, ...]:
+        vocab_size = int(target_model_args["vocab_size"])
+        if vocab_size <= 0:
+            raise ValueError(
+                f"target model vocab_size must be positive, got {vocab_size}"
+            )
+        hidden_size = int(target_model_args["hidden_size"])
+        if hidden_size <= 0:
+            raise ValueError(
+                f"target model hidden_size must be positive, got {hidden_size}"
+            )
         layer_types = tuple(target_model_args["layer_types"])
         if not layer_types:
             raise ValueError("Gemma4 MTP target model must expose layer_types")
@@ -545,7 +536,11 @@ class Gemma4MTPTargetMetadata:
             )
 
         num_non_shared = len(layer_types) - num_kv_shared_layers
-        return layer_types[:num_non_shared]
+        return cls(
+            vocab_size=vocab_size,
+            hidden_size=hidden_size,
+            non_shared_layer_types=layer_types[:num_non_shared],
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -635,11 +635,15 @@ class _Gemma4MTPAssistantConfigParser:
             "vocab_size",
             context="assistant",
         )
-        top_level_vocab_size = self._optional_positive_int(
+        top_level_vocab_size = self._optional_int(
             config,
             "vocab_size",
             context="assistant",
         )
+        if top_level_vocab_size is not None and top_level_vocab_size <= 0:
+            raise ValueError(
+                f"assistant vocab_size must be positive, got {top_level_vocab_size}"
+            )
         if top_level_vocab_size is not None and top_level_vocab_size != vocab_size:
             raise ValueError(
                 "Gemma4 MTP assistant vocab_size metadata mismatch: "
@@ -712,21 +716,19 @@ class _Gemma4MTPAssistantConfigParser:
         vocab_size: int,
         use_ordered_embeddings: bool,
     ) -> None:
-        num_centroids = _Gemma4MTPAssistantConfigParser._optional_positive_int(
+        if not use_ordered_embeddings:
+            return
+
+        num_centroids = _Gemma4MTPAssistantConfigParser._optional_int(
             config,
             "num_centroids",
             context="assistant",
         )
-        centroid_intermediate_top_k = (
-            _Gemma4MTPAssistantConfigParser._optional_positive_int(
-                config,
-                "centroid_intermediate_top_k",
-                context="assistant",
-            )
+        centroid_intermediate_top_k = _Gemma4MTPAssistantConfigParser._optional_int(
+            config,
+            "centroid_intermediate_top_k",
+            context="assistant",
         )
-        if not use_ordered_embeddings:
-            return
-
         num_centroids = (
             GEMMA4_MTP_DEFAULT_NUM_CENTROIDS if num_centroids is None else num_centroids
         )
@@ -735,6 +737,15 @@ class _Gemma4MTPAssistantConfigParser:
             if centroid_intermediate_top_k is None
             else centroid_intermediate_top_k
         )
+        if num_centroids <= 0:
+            raise ValueError(
+                f"assistant num_centroids must be positive, got {num_centroids}"
+            )
+        if centroid_intermediate_top_k <= 0:
+            raise ValueError(
+                "assistant centroid_intermediate_top_k must be positive, "
+                f"got {centroid_intermediate_top_k}"
+            )
         if vocab_size % num_centroids != 0:
             raise ValueError(
                 "Gemma4 MTP assistant vocab_size must be divisible by "
@@ -786,19 +797,6 @@ class _Gemma4MTPAssistantConfigParser:
             key=key,
             context=context,
         )
-
-    @staticmethod
-    def _optional_positive_int(config: Any, key: str, *, context: str) -> int | None:
-        value = _Gemma4MTPAssistantConfigParser._optional_int(
-            config,
-            key,
-            context=context,
-        )
-        if value is None:
-            return None
-        if value <= 0:
-            raise ValueError(f"{context} {key} must be positive, got {value}")
-        return value
 
     @staticmethod
     def _optional_bool(config: Any, key: str, *, context: str, default: bool) -> bool:

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -257,7 +257,6 @@ class Gemma4MTPAssistantLoader:
         self,
         *,
         speculative_config: Any | None,
-        target_hf_config: Any | None,
         target_model_args: Mapping[str, Any],
     ) -> Gemma4MTPAssistantRuntime | None:
         """Load the Gemma4 MTP assistant configured for this target model."""
@@ -267,10 +266,7 @@ class Gemma4MTPAssistantLoader:
         source = Gemma4MTPAssistantSource.from_speculative_config(speculative_config)
         if self._model_path_resolver is not None:
             source = source.resolve(self._model_path_resolver)
-        target_metadata = Gemma4MTPTargetMetadata.from_configs(
-            target_hf_config=target_hf_config,
-            target_model_args=target_model_args,
-        )
+        target_metadata = Gemma4MTPTargetMetadata.from_model_args(target_model_args)
 
         cached = self._cached_runtime(source)
         if cached is not None:
@@ -493,81 +489,37 @@ class Gemma4MTPTargetMetadata:
     non_shared_layer_types: tuple[str, ...]
 
     @classmethod
-    def from_configs(
+    def from_model_args(
         cls,
-        *,
-        target_hf_config: Any | None,
         target_model_args: Mapping[str, Any],
     ) -> Gemma4MTPTargetMetadata:
-        target_text_config = _text_config(target_hf_config)
-        cls._validate_model_types(target_text_config, target_model_args)
+        model_type = target_model_args.get("model_type")
+        if model_type not in GEMMA4_TARGET_MODEL_TYPES:
+            raise ValueError(
+                "Gemma4 MTP assistant requires a Gemma4 target model, "
+                f"got model_type={model_type!r}"
+            )
         return cls(
-            vocab_size=cls._required_positive_int(
-                "vocab_size",
-                target_text_config,
-                target_model_args,
-            ),
-            hidden_size=cls._required_positive_int(
-                "hidden_size",
-                target_text_config,
-                target_model_args,
-            ),
-            non_shared_layer_types=cls._non_shared_layer_types(
-                target_text_config,
-                target_model_args,
-            ),
+            vocab_size=cls._required_positive_int("vocab_size", target_model_args),
+            hidden_size=cls._required_positive_int("hidden_size", target_model_args),
+            non_shared_layer_types=cls._non_shared_layer_types(target_model_args),
         )
 
     @staticmethod
-    def _validate_model_types(
-        target_text_config: Any | None,
-        target_model_args: Mapping[str, Any],
-    ) -> None:
-        model_types = {
-            model_type
-            for model_type in (
-                _config_value(target_text_config, "model_type"),
-                target_model_args.get("model_type"),
-            )
-            if model_type is not None
-        }
-        if not model_types:
-            raise ValueError(
-                "Gemma4 MTP assistant requires a Gemma4 target model, "
-                "got model_type=None"
-            )
-        unknown_model_types = sorted(model_types - GEMMA4_TARGET_MODEL_TYPES)
-        if unknown_model_types:
-            raise ValueError(
-                "Gemma4 MTP assistant requires a Gemma4 target model, got "
-                f"model_type={unknown_model_types[0]!r}"
-            )
-
-    @classmethod
     def _required_positive_int(
-        cls,
         key: str,
-        target_text_config: Any | None,
         target_model_args: Mapping[str, Any],
     ) -> int:
-        value = cls._matching_optional_int(key, target_text_config, target_model_args)
-        if value is None:
-            raise ValueError(f"Missing target model {key}")
+        value = int(target_model_args[key])
         if value <= 0:
             raise ValueError(f"target model {key} must be positive, got {value}")
         return value
 
-    @classmethod
+    @staticmethod
     def _non_shared_layer_types(
-        cls,
-        target_text_config: Any | None,
         target_model_args: Mapping[str, Any],
     ) -> tuple[str, ...]:
-        layer_types = cls._matching_sequence(
-            "layer_types",
-            target_text_config,
-            target_model_args,
-        )
+        layer_types = tuple(target_model_args["layer_types"])
         if not layer_types:
             raise ValueError("Gemma4 MTP target model must expose layer_types")
         unknown_layer_types = sorted(set(layer_types) - GEMMA4_MTP_VALID_LAYER_TYPES)
@@ -576,25 +528,15 @@ class Gemma4MTPTargetMetadata:
                 f"Unsupported Gemma4 MTP target layer types: {unknown_layer_types}"
             )
 
-        num_hidden_layers = cls._matching_optional_int(
-            "num_hidden_layers",
-            target_text_config,
-            target_model_args,
-        )
-        if num_hidden_layers is not None and len(layer_types) != num_hidden_layers:
+        num_hidden_layers = int(target_model_args["num_hidden_layers"])
+        if len(layer_types) != num_hidden_layers:
             raise ValueError(
                 "Gemma4 MTP target layer_types must match num_hidden_layers: "
                 f"len(layer_types)={len(layer_types)}, "
                 f"num_hidden_layers={num_hidden_layers}"
             )
 
-        num_kv_shared_layers = cls._matching_optional_int(
-            "num_kv_shared_layers",
-            target_text_config,
-            target_model_args,
-        )
-        if num_kv_shared_layers is None:
-            num_kv_shared_layers = 0
+        num_kv_shared_layers = int(target_model_args.get("num_kv_shared_layers", 0))
         if num_kv_shared_layers < 0 or num_kv_shared_layers >= len(layer_types):
             raise ValueError(
                 "Gemma4 MTP target num_kv_shared_layers must leave at least one "
@@ -604,84 +546,6 @@ class Gemma4MTPTargetMetadata:
 
         num_non_shared = len(layer_types) - num_kv_shared_layers
         return layer_types[:num_non_shared]
-
-    @classmethod
-    def _matching_optional_int(
-        cls,
-        key: str,
-        target_text_config: Any | None,
-        target_model_args: Mapping[str, Any],
-    ) -> int | None:
-        return cls._matching_value(
-            key,
-            target_text_config,
-            target_model_args,
-            parse=cls._optional_int,
-        )
-
-    @classmethod
-    def _matching_sequence(
-        cls,
-        key: str,
-        target_text_config: Any | None,
-        target_model_args: Mapping[str, Any],
-    ) -> tuple[str, ...]:
-        return (
-            cls._matching_value(
-                key,
-                target_text_config,
-                target_model_args,
-                parse=cls._sequence_field,
-            )
-            or ()
-        )
-
-    @staticmethod
-    def _matching_value[T](
-        key: str,
-        target_text_config: Any | None,
-        target_model_args: Mapping[str, Any],
-        *,
-        parse: Callable[[Any, str], T],
-    ) -> T | None:
-        sources: list[tuple[str, T]] = []
-        if key in target_model_args and target_model_args.get(key) is not None:
-            sources.append(("target_model_args", parse(target_model_args, key)))
-        if _config_value(target_text_config, key) is not None:
-            sources.append(
-                ("target_hf_config.text_config", parse(target_text_config, key))
-            )
-        if not sources:
-            return None
-
-        _, value = sources[0]
-        for label, other in sources[1:]:
-            if other != value:
-                raise ValueError(
-                    f"Gemma4 MTP target {key} metadata mismatch: "
-                    f"{sources[0][0]}={value}, {label}={other}"
-                )
-        return value
-
-    @staticmethod
-    def _optional_int(config: Any, key: str) -> int | None:
-        value = _config_value(config, key)
-        if value is None:
-            return None
-        if isinstance(value, bool) or not isinstance(value, Integral):
-            raise ValueError(f"target model {key} must be an integer, got {value!r}")
-        return int(value)
-
-    @staticmethod
-    def _sequence_field(config: Any, key: str) -> tuple[str, ...]:
-        value = _config_value(config, key, ()) or ()
-        if isinstance(value, str):
-            raise ValueError(f"{key} must be a non-string sequence")
-        if not isinstance(value, Sequence):
-            raise ValueError(f"{key} must be a sequence")
-        if any(not isinstance(item, str) for item in value):
-            raise ValueError(f"{key} entries must be strings")
-        return tuple(value)
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -444,7 +444,6 @@ class ModelLifecycle:
         runner._gemma4_mtp_assistant = None
         gemma4_mtp_assistant = Gemma4MTPAssistantLoader().load_if_needed(
             speculative_config=runner.vllm_config.speculative_config,
-            target_hf_config=request.hf_config,
             target_model_args=model_args,
         )
         runner.kv_cache_dtype = request.target_dtype


### PR DESCRIPTION
This PR is:

- To use loaded MLX model args as the source of truth for Gemma4 MTP target metadata.
- To keep strict validation on the assistant checkpoint config.
- To remove duplicate HF-vs-MLX target metadata checks and mismatch-only tests.
- To simplify Gemma4 MTP runtime state and parsing code.

The target model is already loaded before MTP is wired, so we should trust its loaded args instead of reconciling them again with HF config. The assistant config is still external JSON, so it keeps the strict validation boundary.