### PR TITLE
Trust loaded model config shapes

### DIFF
--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -42,42 +42,6 @@ def _reset_env(monkeypatch: pytest.MonkeyPatch):
     reset_config()
 
 
-class _BaseSlotTextConfig:
-    __slots__ = ("vocab_size", "num_hidden_layers", "num_attention_heads")
-
-    def __init__(
-        self,
-        *,
-        vocab_size: int,
-        num_hidden_layers: int,
-        num_attention_heads: int,
-    ) -> None:
-        self.vocab_size = vocab_size
-        self.num_hidden_layers = num_hidden_layers
-        self.num_attention_heads = num_attention_heads
-
-
-class _SlotTextConfig(_BaseSlotTextConfig):
-    __slots__ = ("num_key_value_heads", "hidden_size")
-
-    def __init__(
-        self,
-        *,
-        vocab_size: int,
-        num_hidden_layers: int,
-        num_attention_heads: int,
-        num_key_value_heads: int,
-        hidden_size: int,
-    ) -> None:
-        super().__init__(
-            vocab_size=vocab_size,
-            num_hidden_layers=num_hidden_layers,
-            num_attention_heads=num_attention_heads,
-        )
-        self.num_key_value_heads = num_key_value_heads
-        self.hidden_size = hidden_size
-
-
 def _runner_model_config(**overrides: object) -> object:
     values = {
         "model": "stub-model",
@@ -756,33 +720,6 @@ class TestModelLifecycle:
         assert runner.model_args["model_type"] == "gemma4"
         assert runner.model_args["vocab_size"] == _TEXT_MODEL_ARGS["vocab_size"]
 
-    def test_load_extracts_vlm_text_config_with_inherited_slots(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        _stub_generation_model(
-            monkeypatch,
-            config=SimpleNamespace(
-                text_config=_SlotTextConfig(
-                    **_TEXT_MODEL_ARGS,
-                )
-            ),
-            is_vlm=True,
-        )
-        lifecycle, runner = _make_lifecycle(
-            model_config=_runner_model_config(
-                is_multimodal_model=True,
-            )
-        )
-
-        lifecycle.load()
-
-        assert runner._is_vlm is True
-        assert runner.model_args["vocab_size"] == 32000
-        assert runner.model_args["hidden_size"] == 4096
-        assert runner.num_layers == 32
-        assert runner.head_dim == 128
-
     def test_load_stt_model_loads_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake_model = SimpleNamespace(
             create_runtime_adapter=lambda model_name: (object(), model_name)
@@ -887,7 +824,9 @@ class TestModelLifecycle:
             assert len(mlx_lm_load_calls) == 1
             # The generic path must NOT pass ``model_config`` (which is
             # reserved for the AWQ owner's normalized quant config kwargs).
-            assert "model_config" not in mlx_lm_load_calls[0]["kwargs"]
+            kwargs = mlx_lm_load_calls[0]["kwargs"]
+            assert isinstance(kwargs, dict)
+            assert "model_config" not in kwargs
 
     def test_load_routes_gguf_to_owner_on_quantization_detection(
         self,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -456,7 +456,7 @@ class ModelLifecycle:
         # its keys onto the top level so every key sits in one flat dict.
         model_args = getattr(model, "args", None)
         if model_args is not None:
-            model_values = self._config_to_mapping(model_args, label="model.args")
+            model_values = self._config_to_mapping(model_args)
         else:
             config = getattr(model, "config", None)
             if config is None:
@@ -465,12 +465,9 @@ class ModelLifecycle:
                     ".config attribute."
                 )
 
-            config_values = self._config_to_mapping(config, label="config")
+            config_values = self._config_to_mapping(config)
             if is_vlm and "text_config" in config_values:
-                model_values = self._config_to_mapping(
-                    config_values["text_config"],
-                    label="text_config",
-                )
+                model_values = self._config_to_mapping(config_values["text_config"])
             else:
                 model_values = config_values
 
@@ -479,42 +476,12 @@ class ModelLifecycle:
             return model_values
 
         merged_values = dict(model_values)
-        text_values = self._config_to_mapping(text_config, label="text_config")
+        text_values = self._config_to_mapping(text_config)
         for key, value in text_values.items():
             merged_values.setdefault(key, value)
         return merged_values
 
-    def _config_to_mapping(self, config: Any, *, label: str) -> dict[str, Any]:
-        missing = object()
-
+    def _config_to_mapping(self, config: Any) -> dict[str, Any]:
         if isinstance(config, Mapping):
             return dict(config)
-
-        to_dict = getattr(config, "to_dict", None)
-        if callable(to_dict):
-            values = to_dict()
-            if isinstance(values, Mapping):
-                return dict(values)
-            raise TypeError(f"{label}.to_dict() must return a mapping.")
-
-        instance_dict = getattr(config, "__dict__", None)
-        if instance_dict is not None:
-            return dict(instance_dict)
-
-        slot_values: dict[str, Any] = {}
-        for cls in type(config).__mro__:
-            slots = cls.__dict__.get("__slots__", ())
-            if isinstance(slots, str):
-                slots = (slots,)
-            for name in slots:
-                if not isinstance(name, str) or name.startswith("__"):
-                    continue
-                value = getattr(config, name, missing)
-                if value is not missing:
-                    slot_values[name] = value
-        if slot_values:
-            return slot_values
-
-        raise TypeError(
-            f"{label} must expose a mapping, to_dict(), __dict__, or __slots__."
-        )
+        return dict(vars(config))


### PR DESCRIPTION
This PR is:

- To remove the generic model-config scanner from the lifecycle load path.
- To trust loaded MLX/HF config objects as mapping or normal object-backed configs.
- To delete the synthetic inherited-slots test that only proved the scanner.

Note:

The real load paths still cover `.args`, `.config`, and nested `text_config` flattening. This just removes support for config shapes that current loaders do not produce.