### PR TITLE
Cap apache-tvm-ffi below the xgrammar ABI break

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ dependencies = [
     "mlx==0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
+    # Temporary cap: xgrammar's prebuilt wheels are compiled against a specific
+    # apache-tvm-ffi C++ ABI but declare only `apache-tvm-ffi>=0.1.9`, so a
+    # clean install resolves 0.1.13 and segfaults inside
+    # `xgrammar::__TVMFFIStaticInitFunc0()` before vLLM starts (#569).  We never
+    # import tvm-ffi; this bounds the resolver only.
+    # TODO: remove once xgrammar bounds its own apache-tvm-ffi range.
+    "apache-tvm-ffi>=0.1.9,<0.1.13; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights


### PR DESCRIPTION
A clean install segfaults before vLLM starts. `apache-tvm-ffi` published 0.1.13, xgrammar's prebuilt wheels are compiled against an older tvm-ffi C++ ABI, and xgrammar declares only `apache-tvm-ffi>=0.1.9`, so the resolver takes 0.1.13 and `import xgrammar` dies in `xgrammar::__TVMFFIStaticInitFunc0()`. Reported in #569.

This does not come from our dependency chain. Installing just the vLLM wheel, which is what `install.sh` does first, already lands 0.1.13, and `import xgrammar` segfaults right there, before vllm-metal is installed at all. `VLLM_PLUGINS=` does not help either, so nothing on the Metal path is involved. The cap bounds the resolver and nothing else, the same way we already bound llguidance, fastapi, and starlette without importing any of them.

Evidence from a fresh venv on an M1 Ultra 128GB. After the vLLM wheel alone, `import xgrammar` exits 139. Installing our dependency set on top downgrades tvm-ffi 0.1.13 to 0.1.12, and both `import xgrammar` and `vllm --help` then exit 0. Putting 0.1.13 back in that same venv brings the segfault straight back.

The version that matters is tvm-ffi, not xgrammar. 0.2.3 and 0.2.4 both crash on 0.1.13 and both work on 0.1.12, so the xgrammar 0.2.4 upgrade suggested in the issue thread does not fix it on its own, and 0.2.5 has no cp312 macOS arm64 wheel on PyPI. Scoped to macOS arm64 because that is where I verified it. Removing the cap is gated on xgrammar bounding its own range.
