### PR TITLE
Remove dead MLX backend switch

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,6 @@
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `VLLM_METAL_MEMORY_FRACTION` | `auto` | Metal memory budget mode; see [Paged KV vs MLX KV Memory Settings](#paged-kv-vs-mlx-kv-memory-settings) |
-| `VLLM_METAL_USE_MLX` | `1` | Use MLX for compute (1=yes, 0=no) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_DEBUG` | `0` | Enable debug logging |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,6 @@ class TestMetalConfig:
 
         assert config.memory_fraction == AUTO_MEMORY_FRACTION
         assert config.is_auto_memory is True
-        assert config.use_mlx is True
         assert config.mlx_device == "gpu"
         assert config.debug is False
         assert config.use_paged_attention is True
@@ -39,7 +38,6 @@ class TestMetalConfig:
     def test_custom_config_from_env(self, monkeypatch) -> None:
         """Test configuration from environment variables."""
         monkeypatch.setenv("VLLM_METAL_MEMORY_FRACTION", "0.75")
-        monkeypatch.setenv("VLLM_METAL_USE_MLX", "0")
         monkeypatch.setenv("VLLM_MLX_DEVICE", "cpu")
         monkeypatch.setenv("VLLM_METAL_DEBUG", "1")
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
@@ -48,7 +46,6 @@ class TestMetalConfig:
         config = MetalConfig.from_env()
 
         assert config.memory_fraction == 0.75
-        assert config.use_mlx is False
         assert config.mlx_device == "cpu"
         assert config.debug is True
         assert config.multimodal_mode == "multimodal-native"
@@ -111,7 +108,6 @@ class TestMetalConfig:
         with pytest.raises(ValueError, match="only supported with paged attention"):
             MetalConfig(
                 memory_fraction=0.7,
-                use_mlx=False,
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=False,
@@ -121,7 +117,6 @@ class TestMetalConfig:
         with pytest.raises(ValueError, match="Invalid VLLM_METAL_MEMORY_FRACTION"):
             MetalConfig(
                 memory_fraction=1.5,
-                use_mlx=False,
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=True,
@@ -132,7 +127,6 @@ class TestMetalConfig:
             with pytest.raises(ValueError, match="Invalid VLLM_METAL_MEMORY_FRACTION"):
                 MetalConfig(
                     memory_fraction=fraction,
-                    use_mlx=False,
                     mlx_device="gpu",
                     debug=False,
                     use_paged_attention=True,
@@ -150,7 +144,6 @@ class TestMetalConfig:
         with pytest.raises(ValueError, match="Invalid VLLM_METAL_MULTIMODAL_MODE"):
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=True,
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=True,
@@ -162,7 +155,6 @@ class TestMetalConfig:
         with pytest.raises(ValueError, match="turboquant requires paged attention"):
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=False,
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=False,
@@ -175,7 +167,6 @@ class TestMetalConfig:
         with pytest.raises(ValueError, match="Invalid k_quant"):
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=False,
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=True,
@@ -188,7 +179,6 @@ class TestMetalConfig:
         with pytest.raises(ValueError, match="Invalid v_quant"):
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=False,
                 mlx_device="gpu",
                 debug=False,
                 use_paged_attention=True,

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -290,7 +290,6 @@ class TestCachePolicyPerLayerBytes:
             "vllm_metal.v1.cache_policy.get_config",
             lambda: MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=True,
                 mlx_device="gpu",
                 debug=False,
                 turboquant=True,
@@ -420,7 +419,6 @@ class TestMHAKVCacheLayout:
             "vllm_metal.v1.cache_policy.get_config",
             lambda: MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=True,
                 mlx_device="gpu",
                 debug=False,
                 turboquant=False,
@@ -466,7 +464,6 @@ class TestMHAKVCacheLayout:
             "vllm_metal.v1.cache_policy.get_config",
             lambda: MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
-                use_mlx=True,
                 mlx_device="gpu",
                 debug=False,
                 turboquant=False,
@@ -506,7 +503,6 @@ class TestMHAKVCacheLayout:
         )
         metal_config = MetalConfig(
             memory_fraction=1.0,
-            use_mlx=True,
             mlx_device="gpu",
             debug=False,
             turboquant=False,
@@ -571,7 +567,6 @@ class TestMHAKVCacheLayout:
         )
         metal_config = MetalConfig(
             memory_fraction=1.0,
-            use_mlx=True,
             mlx_device="gpu",
             debug=False,
             turboquant=False,
@@ -615,7 +610,6 @@ class TestMHAKVCacheLayout:
         )
         metal_config = MetalConfig(
             memory_fraction=1.0,
-            use_mlx=True,
             mlx_device="gpu",
             debug=False,
             turboquant=False,

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -66,7 +66,6 @@ def _hybrid_runner():
 def _tq_config() -> MetalConfig:
     return MetalConfig(
         memory_fraction=-1.0,
-        use_mlx=False,
         mlx_device="gpu",
         debug=False,
         use_paged_attention=True,

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -35,7 +35,6 @@ class MetalConfig:
     """Configuration for vLLM Metal plugin."""
 
     memory_fraction: float  # -1.0 selects the active backend's auto policy
-    use_mlx: bool
     mlx_device: Literal["gpu", "cpu"]
     debug: bool
     use_paged_attention: bool = True
@@ -114,7 +113,6 @@ class MetalConfig:
         # See MetalPlatform.check_and_update_config() for how it's applied.
         return cls(
             memory_fraction=memory_fraction,
-            use_mlx=envs.VLLM_METAL_USE_MLX,
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
             debug=envs.VLLM_METAL_DEBUG,
             use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     VLLM_METAL_MEMORY_FRACTION: str = "auto"
-    VLLM_METAL_USE_MLX: bool = True
     VLLM_MLX_DEVICE: str = "gpu"
     VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
@@ -40,8 +39,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MEMORY_FRACTION": lambda: os.getenv(
         "VLLM_METAL_MEMORY_FRACTION", "auto"
     ),
-    # Whether to use MLX as the compute backend (default True).
-    "VLLM_METAL_USE_MLX": lambda: os.getenv("VLLM_METAL_USE_MLX", "1") == "1",
     # MLX device type: "gpu" (default) or "cpu".
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
     # Enable verbose debug logging (default False).

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -175,13 +175,12 @@ class MetalPlatform(Platform):
             raise ValueError(msg)
 
         config = get_config()
-        if config.use_mlx:
-            import mlx.core as mx
+        import mlx.core as mx
 
-            device_type = (
-                mx.DeviceType.gpu if config.mlx_device == "gpu" else mx.DeviceType.cpu
-            )
-            mx.set_default_device(mx.Device(device_type))
+        device_type = (
+            mx.DeviceType.gpu if config.mlx_device == "gpu" else mx.DeviceType.cpu
+        )
+        mx.set_default_device(mx.Device(device_type))
 
     @classmethod
     def current_device(cls) -> int:

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -112,16 +112,14 @@ class MetalWorker(WorkerBase):
 
     def init_device(self) -> None:
         """Initialize the Metal device and distributed environment."""
-        # Set up MLX device
-        if self.metal_config.use_mlx:
-            device_type = (
-                mx.DeviceType.gpu
-                if self.metal_config.mlx_device == "gpu"
-                else mx.DeviceType.cpu
-            )
-            mx.set_default_device(mx.Device(device_type))
-            logger.info(f"MLX device set to: {mx.default_device()}")
-            set_wired_limit()
+        device_type = (
+            mx.DeviceType.gpu
+            if self.metal_config.mlx_device == "gpu"
+            else mx.DeviceType.cpu
+        )
+        mx.set_default_device(mx.Device(device_type))
+        logger.info(f"MLX device set to: {mx.default_device()}")
+        set_wired_limit()
 
         # Use MetalPlatform.get_torch_device() to properly support MPS when available.
         # This ensures consistency with the platform's device selection logic and


### PR DESCRIPTION
This PR is:

- To remove the unused `VLLM_METAL_USE_MLX` environment switch.
- To make MLX device initialization unconditional in the Metal worker and platform path.
- To keep `VLLM_MLX_DEVICE` as the only MLX device selector.

The old switch did not select another backend. Setting it to `0` only skipped required MLX initialization, while the runtime still depended on MLX. This removes the dead config surface and the related test scaffolding.
