### PR TITLE
[Bugfix] Route MLX-quantized VL wrappers to the text backbone

### DIFF
--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -54,6 +54,98 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is True
 
+    @pytest.mark.parametrize("bits", [4, 8])
+    @pytest.mark.parametrize(
+        ("model_type", "architecture"),
+        [
+            # The real pair of the motivating checkpoints
+            # (Qwen3.6-35B-A3B MLX 4-bit, issue #571).
+            ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+            ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
+        ],
+    )
+    def test_mlx_quant_conditional_generation_uses_auto_override(
+        self, model_type: str, architecture: str, bits: int
+    ) -> None:
+        hf_config = SimpleNamespace(
+            model_type=model_type,
+            architectures=[architecture],
+            quantization={"group_size": 64, "bits": bits, "mode": "affine"},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is True
+
+    @pytest.mark.parametrize(
+        ("model_type", "architecture"),
+        [
+            # The flagship native-multimodal checkpoint family
+            # (mlx-community Qwen3-VL MLX conversions carry the same
+            # top-level quantization dict) must keep the native path.
+            ("qwen3_vl", "Qwen3VLForConditionalGeneration"),
+            # A natively-adapted Qwen3.5 VL wrapper keeps image serving.
+            ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+            # An arbitrary non-allowlisted multimodal model.
+            ("llava", "LlavaForConditionalGeneration"),
+        ],
+    )
+    def test_mlx_quant_natively_adapted_arch_skips_auto_override(
+        self, model_type: str, architecture: str
+    ) -> None:
+        hf_config = SimpleNamespace(
+            model_type=model_type,
+            architectures=[architecture],
+            quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
+    def test_multimodal_native_mode_disables_mlx_quant_override(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
+        reset_config()
+
+        hf_config = SimpleNamespace(
+            model_type="qwen3_6",
+            architectures=["Qwen3_6MoeForConditionalGeneration"],
+            quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
+    def test_omitted_quantization_key_skips_auto_override(self) -> None:
+        # The common dense-checkpoint case: no `quantization` key at all.
+        hf_config = SimpleNamespace(
+            model_type="qwen3_6",
+            architectures=["Qwen3_6ForConditionalGeneration"],
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
+    def test_non_dict_quantization_value_skips_auto_override(self) -> None:
+        hf_config = SimpleNamespace(
+            model_type="qwen3_6",
+            architectures=["Qwen3_6ForConditionalGeneration"],
+            quantization="int4",
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
+    def test_quantization_dict_without_bits_skips_auto_override(self) -> None:
+        hf_config = SimpleNamespace(
+            model_type="qwen3_6",
+            architectures=["Qwen3_6ForConditionalGeneration"],
+            quantization={"group_size": 64},
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
+
     def test_qwen35_non_fp8_conditional_generation_skips_auto_override(self) -> None:
         hf_config = SimpleNamespace(
             model_type="qwen3_5",
@@ -302,6 +394,20 @@ class TestNormalizeModelConfig:
                 model_type="qwen3_5",
                 architectures=["Qwen3_5ForConditionalGeneration"],
                 quantization_config={"quant_method": "fp8"},
+            ),
+        )
+
+        DefaultModelAdapter().normalize_model_config(model_config)
+
+        assert model_config.multimodal_config is None
+
+    def test_clears_multimodal_config_for_mlx_quant_moe_in_auto_mode(self) -> None:
+        model_config = SimpleNamespace(
+            multimodal_config=SimpleNamespace(language_model_only=False),
+            hf_config=SimpleNamespace(
+                model_type="qwen3_5_moe",
+                architectures=["Qwen3_5MoeForConditionalGeneration"],
+                quantization={"group_size": 64, "bits": 4, "mode": "affine"},
             ),
         )
 

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -196,6 +196,18 @@ _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES: frozenset[str] = frozenset(
         "Qwen3_6MoeForConditionalGeneration",
     }
 )
+# MLX-quantized wrappers are only force-texted when no native multimodal
+# adapter covers the architecture (see _QWEN3_VL_ARCHITECTURES):
+# Qwen3_5ForConditionalGeneration has one, so its MLX checkpoints keep the
+# native path and image serving; the rest would run the bare language model
+# with unset mrope state and generate garbled output.
+_MLX_QUANT_TEXT_BACKBONE_ARCHITECTURES: frozenset[str] = frozenset(
+    {
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_6ForConditionalGeneration",
+        "Qwen3_6MoeForConditionalGeneration",
+    }
+)
 _QWEN3_VL_MODEL_TYPES: frozenset[str] = frozenset({"qwen3_5", "qwen3_vl"})
 _QWEN3_VL_ARCHITECTURES: frozenset[str] = frozenset(
     {
@@ -224,9 +236,13 @@ class DefaultModelAdapter(ModelAdapter):
         override once mlx_vlm Gemma4 parity is fixed upstream.
 
         Qwen3.5/Qwen3.6 conditional-generation wrappers: these configs are
-        marked multimodal even when served text-only. Route them through
-        mlx_lm's qwen3_5 text loader so FP8 `*_weight_scale_inv` tensors are
-        consumed correctly instead of failing inside mlx_vlm.load().
+        marked multimodal even when served text-only, and both quantized
+        families diverge under mlx_vlm.load() — FP8 fails on
+        `*_weight_scale_inv` tensors, while MLX affine checkpoints load but,
+        for architectures with no native multimodal adapter, run the bare
+        language model with unset mrope state and generate garbled output.
+        Both route through the mlx_lm text loader instead; MLX-quant
+        wrappers covered by a native adapter keep the multimodal path.
         """
         if hf_config is None:
             return False
@@ -246,7 +262,17 @@ class DefaultModelAdapter(ModelAdapter):
             quant_method = quantization_config.get("quant_method")
         else:
             quant_method = getattr(quantization_config, "quant_method", None)
-        return quant_method == "fp8"
+        if quant_method == "fp8":
+            return True
+        # MLX affine checkpoints carry a top-level `quantization` dict; only
+        # architectures without a native multimodal adapter are force-texted
+        # (see _MLX_QUANT_TEXT_BACKBONE_ARCHITECTURES).
+        if not any(
+            arch in _MLX_QUANT_TEXT_BACKBONE_ARCHITECTURES for arch in architectures
+        ):
+            return False
+        mlx_quantization = getattr(hf_config, "quantization", None)
+        return isinstance(mlx_quantization, dict) and "bits" in mlx_quantization
 
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether the current serve mode should use the text-only path.


### PR DESCRIPTION
Fixes #571. MLX-quantized Qwen3.5/3.6 MoE checkpoints load fine but generate garbage, while the same checkpoint works under `mlx_lm`. The config is marked multimodal, so the load goes through `mlx_vlm` and the runner ends up driving the language model with mrope state that never gets set. The fp8 checkpoints already get force-routed to the `mlx_lm` text loader; the MLX affine ones slipped past that gate.

This PR makes the same override match MLX quantization dicts, but only for architectures that have no native multimodal adapter, so MLX-quantized Qwen3.5 VL and Qwen3-VL keep image serving.

Verified with #571's repro on `lmstudio-community/Qwen3.6-35B-A3B-MLX-4bit`: main produces token soup, with this change the greedy output matches `mlx_lm` on the same snapshot for all 120 generated tokens. `mlx-community/Qwen3.6-35B-A3B-4bit` behaves the same. Added ten tests for the predicate truth table. The AWQ MoE load failure from #571 is a separate problem.
