### PR TITLE
Remove custom Metal debug config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,6 @@
 | `VLLM_METAL_MEMORY_FRACTION` | `auto` | Metal memory budget mode; see [Paged KV vs MLX KV Memory Settings](#paged-kv-vs-mlx-kv-memory-settings) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
-| `VLLM_METAL_DEBUG` | `0` | Enable debug logging |
 | `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` uses the compatibility allowlist; `multimodal-native` disables overrides |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,7 +31,6 @@ class TestMetalConfig:
         assert config.memory_fraction == AUTO_MEMORY_FRACTION
         assert config.is_auto_memory is True
         assert config.mlx_device == "gpu"
-        assert config.debug is False
         assert config.use_paged_attention is True
         assert config.multimodal_mode == "auto"
 
@@ -39,7 +38,6 @@ class TestMetalConfig:
         """Test configuration from environment variables."""
         monkeypatch.setenv("VLLM_METAL_MEMORY_FRACTION", "0.75")
         monkeypatch.setenv("VLLM_MLX_DEVICE", "cpu")
-        monkeypatch.setenv("VLLM_METAL_DEBUG", "1")
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
 
@@ -47,7 +45,6 @@ class TestMetalConfig:
 
         assert config.memory_fraction == 0.75
         assert config.mlx_device == "cpu"
-        assert config.debug is True
         assert config.multimodal_mode == "multimodal-native"
 
     def test_paged_attention_can_be_disabled(self, monkeypatch) -> None:
@@ -109,7 +106,6 @@ class TestMetalConfig:
             MetalConfig(
                 memory_fraction=0.7,
                 mlx_device="gpu",
-                debug=False,
                 use_paged_attention=False,
             )
 
@@ -118,7 +114,6 @@ class TestMetalConfig:
             MetalConfig(
                 memory_fraction=1.5,
                 mlx_device="gpu",
-                debug=False,
                 use_paged_attention=True,
             )
 
@@ -128,7 +123,6 @@ class TestMetalConfig:
                 MetalConfig(
                     memory_fraction=fraction,
                     mlx_device="gpu",
-                    debug=False,
                     use_paged_attention=True,
                 )
 
@@ -145,7 +139,6 @@ class TestMetalConfig:
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 use_paged_attention=True,
                 multimodal_mode=mode,  # type: ignore[arg-type]
             )
@@ -156,7 +149,6 @@ class TestMetalConfig:
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 use_paged_attention=False,
                 turboquant=True,
                 k_quant="uint8",
@@ -168,7 +160,6 @@ class TestMetalConfig:
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 use_paged_attention=True,
                 turboquant=True,
                 k_quant="fp16",
@@ -180,7 +171,6 @@ class TestMetalConfig:
             MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 use_paged_attention=True,
                 turboquant=True,
                 k_quant="q8_0",

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -135,7 +135,6 @@ def _make_lifecycle(
 ) -> tuple[ModelLifecycle, object]:
     runner = make_stub_runner(
         model_args=model_args,
-        metal_config=SimpleNamespace(debug=False),
         model_config=model_config or _runner_model_config(),
     )
     lifecycle = ModelLifecycle(runner, runner._model_adapter)
@@ -218,7 +217,6 @@ class TestModelLifecycle:
                 return True
 
         runner = make_stub_runner(
-            metal_config=SimpleNamespace(debug=False),
             model_config=_runner_model_config(
                 hf_config=hf_config,
                 is_multimodal_model=True,
@@ -255,7 +253,6 @@ class TestModelLifecycle:
 
         def _lazy_for(pp: PipelineGroup | None) -> bool:
             runner = make_stub_runner(
-                metal_config=SimpleNamespace(debug=False),
                 model_config=_runner_model_config(),
                 pp=pp,
             )

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -291,7 +291,6 @@ class TestCachePolicyPerLayerBytes:
             lambda: MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 turboquant=True,
             ),
         )
@@ -420,7 +419,6 @@ class TestMHAKVCacheLayout:
             lambda: MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 turboquant=False,
             ),
         )
@@ -465,7 +463,6 @@ class TestMHAKVCacheLayout:
             lambda: MetalConfig(
                 memory_fraction=AUTO_MEMORY_FRACTION,
                 mlx_device="gpu",
-                debug=False,
                 turboquant=False,
             ),
         )
@@ -504,7 +501,6 @@ class TestMHAKVCacheLayout:
         metal_config = MetalConfig(
             memory_fraction=1.0,
             mlx_device="gpu",
-            debug=False,
             turboquant=False,
         )
         monkeypatch.setattr(
@@ -568,7 +564,6 @@ class TestMHAKVCacheLayout:
         metal_config = MetalConfig(
             memory_fraction=1.0,
             mlx_device="gpu",
-            debug=False,
             turboquant=False,
         )
         monkeypatch.setattr(
@@ -611,7 +606,6 @@ class TestMHAKVCacheLayout:
         metal_config = MetalConfig(
             memory_fraction=1.0,
             mlx_device="gpu",
-            debug=False,
             turboquant=False,
         )
         monkeypatch.setattr(

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -67,7 +67,6 @@ def _tq_config() -> MetalConfig:
     return MetalConfig(
         memory_fraction=-1.0,
         mlx_device="gpu",
-        debug=False,
         use_paged_attention=True,
         turboquant=True,
         k_quant=K_QUANT,

--- a/tools/repro_block_exhaustion.py
+++ b/tools/repro_block_exhaustion.py
@@ -12,7 +12,6 @@ import os
 
 os.environ.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.12")
 os.environ.setdefault("VLLM_METAL_USE_PAGED_ATTENTION", "1")
-os.environ.setdefault("VLLM_METAL_DEBUG", "1")
 os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
 os.environ.setdefault("VLLM_LOGGING_LEVEL", "DEBUG")
 

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -36,7 +36,6 @@ class MetalConfig:
 
     memory_fraction: float  # -1.0 selects the active backend's auto policy
     mlx_device: Literal["gpu", "cpu"]
-    debug: bool
     use_paged_attention: bool = True
     multimodal_mode: MultimodalMode = "auto"
     turboquant: bool = False  # Enable TurboQuant KV cache compression
@@ -114,7 +113,6 @@ class MetalConfig:
         return cls(
             memory_fraction=memory_fraction,
             mlx_device=envs.VLLM_MLX_DEVICE,  # type: ignore[arg-type]
-            debug=envs.VLLM_METAL_DEBUG,
             use_paged_attention=envs.VLLM_METAL_USE_PAGED_ATTENTION,
             multimodal_mode=envs.VLLM_METAL_MULTIMODAL_MODE,  # type: ignore[arg-type]
         )

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     VLLM_METAL_MEMORY_FRACTION: str = "auto"
     VLLM_MLX_DEVICE: str = "gpu"
-    VLLM_METAL_DEBUG: bool = False
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
     VLLM_METAL_MULTIMODAL_MODE: str = "auto"
     VLLM_METAL_MODELSCOPE_CACHE: str | None = None
@@ -41,8 +40,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # MLX device type: "gpu" (default) or "cpu".
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
-    # Enable verbose debug logging (default False).
-    "VLLM_METAL_DEBUG": lambda: os.getenv("VLLM_METAL_DEBUG", "0") == "1",
     # Use native Metal paged attention (default True).
     "VLLM_METAL_USE_PAGED_ATTENTION": lambda: (
         os.getenv("VLLM_METAL_USE_PAGED_ATTENTION", "1") == "1"

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -353,8 +353,7 @@ class MetalPlatform(Platform):
                 f"k_quant={config.k_quant}, v_quant={config.v_quant}"
             )
 
-        if config.debug:
-            logger.info(f"Metal config: {config}")
+        logger.debug("Metal config: %s", config)
 
         # Set worker class for Metal
         if parallel_config.worker_cls == "auto":

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -309,8 +309,7 @@ class ModelLifecycle:
         # Dimension resolution reads model_args immediately after this phase.
         runner.model_args = loaded_model.model_args
         runner._vocab_size = int(loaded_model.model_args["vocab_size"])
-        if runner.metal_config.debug:
-            logger.info("Model args: %s", loaded_model.model_args)
+        logger.debug("Model args: %s", loaded_model.model_args)
 
     def _install_runner_attention_dims(self, args: dict[str, Any]) -> int | None:
         """Install runner-wide attention dims and return the default head_dim."""


### PR DESCRIPTION
This PR is:

- To remove the repo-specific `VLLM_METAL_DEBUG` setting.
- To use normal debug logging for Metal config and model-args dumps.
- To reduce config, env, docs, and test plumbing that did not affect runtime behavior.

Note: `VLLM_METAL_DEBUG` no longer works. Use `VLLM_LOGGING_LEVEL=DEBUG` to show the Metal config and model-args debug logs.
