### PR TITLE
[Bugfix] Count padded mamba pages in the non-paged admission estimate

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -34,6 +34,7 @@ def make_stub_runner(
 
     defaults: dict[str, Any] = {
         "vllm_config": SimpleNamespace(speculative_config=None),
+        "cache_config": SimpleNamespace(mamba_page_size_padded=None),
         "model_config": SimpleNamespace(
             runner_type="generate", get_head_size=lambda: 128
         ),

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -162,6 +162,39 @@ class TestOneSequenceKvBytes:
         linear_bytes = 3 * (conv_bytes + recurrent_bytes)
         assert result == sdpa_bytes + linear_bytes
 
+    def test_hybrid_uses_padded_mamba_page_size_when_set(self) -> None:
+        # vLLM checks admission against the reported MambaSpec, whose page
+        # size is padded to align with attention pages. The one-sequence
+        # estimate must count the padded pages, or admission of a max-length
+        # sequence falls short by the padding on every linear layer.
+        padded_page = 4096
+        model_runner = make_stub_runner(
+            model_args={"full_attention_interval": 2},
+            num_sdpa_layers=8,
+            num_kv_heads=4,
+            head_dim=256,
+            kv_cache_dtype=mx.float16,
+            linear_conv_kernel_dim=3,
+            linear_conv_dim=5,
+            linear_num_v_heads=2,
+            linear_value_head_dim=7,
+            linear_key_head_dim=11,
+            num_linear_layers=3,
+            cache_config=SimpleNamespace(mamba_page_size_padded=padded_page),
+        )
+        worker = _make_worker(model_runner, use_paged_attention=False)
+        worker.model_config = SimpleNamespace(max_model_len=2048)
+        worker.vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=16)
+        )
+
+        # Act
+        result = MetalWorker._one_sequence_kv_bytes(worker)
+
+        # Assert — SDPA bytes + padded linear pages (not raw state bytes)
+        sdpa_bytes = 2 * 8 * 2048 * 4 * 256 * 2
+        assert result == sdpa_bytes + 3 * padded_page
+
     def test_linear_cache_bytes_uses_float32_recurrent(self) -> None:
         runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
         runner.model_args = {"full_attention_interval": 2}

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -656,8 +656,23 @@ class ModelCachePolicy:
             self._kv_factor() * aligned_tokens * dtype_size * self._kv_layer_size_sum()
         )
         if self._runner.is_hybrid:
-            return sdpa_kv_bytes + self.linear_cache_bytes_per_slot()
+            return sdpa_kv_bytes + self._linear_spec_bytes_per_slot()
         return sdpa_kv_bytes
+
+    def _linear_spec_bytes_per_slot(self) -> int:
+        """Per-slot linear-state bytes as the reported MambaSpec charges them.
+
+        vLLM admits against the specs this worker reports, and the linear
+        MambaSpec carries ``mamba_page_size_padded`` — an unpadded estimate
+        falls short of that requirement by the padding margin.
+        """
+        # Mirrors MambaSpec.max_memory_usage_bytes with zero speculative
+        # blocks and mamba_cache_mode "none"; if vLLM's defaults change,
+        # this mirror must follow.
+        padded = self._runner.cache_config.mamba_page_size_padded
+        if padded is not None:
+            return self._runner.num_linear_layers * padded
+        return self.linear_cache_bytes_per_slot()
 
     def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionRuntime:
         config = get_config()


### PR DESCRIPTION
On the MLX (non-paged) path, hybrid GDN models fail admission at any `--max-model-len`: startup dies with "X GiB KV cache is needed, which is larger than the available X GiB". The #571 reporter hit this too when trying the non-paged path as a control. Same estimate-vs-requirement principle as #505: the worker reports one max-length sequence using the raw linear-state bytes, but vLLM checks against the `MambaSpec` we report, which carries `mamba_page_size_padded`, so the budget always lands one padding margin short.

The fix makes the estimate count what the spec charges: when `cache_config.mamba_page_size_padded` is set, linear layers are priced at the padded page; otherwise, the raw bytes as before. Attention layers were already aligned.

Before, on main, `VLLM_METAL_USE_PAGED_ATTENTION=0 VLLM_METAL_MEMORY_FRACTION=auto vllm serve mlx-community/Qwen3.6-35B-A3B-4bit --max-model-len 8192` fails with "0.22 GiB is needed, which is larger than the available 0.22 GiB". With this change, the same command boots and generates correctly. Two tests pin the padded and non-hybrid cases.
