### PR TITLE
Share LoRA slot logic between LoRA and QLoRA

### DIFF
--- a/tests/test_qlora.py
+++ b/tests/test_qlora.py
@@ -170,13 +170,6 @@ def test_can_wrap_qlora_rejects_non_unary_quantized_projection() -> None:
 # MLXQuantizedLinearWithLoRA wrapper
 
 
-def test_qlora_wrapper_infers_dims_from_quantized_linear() -> None:
-    ql = _make_quantized_linear(128, 64)
-    w = MLXQuantizedLinearWithLoRA(ql, max_loras=2, max_lora_rank=4, dtype=mx.float32)
-    assert w.input_size == 128
-    assert w.output_size == 64
-
-
 def test_qlora_wrapper_preserves_quantized_projection_surface() -> None:
     ql = _make_quantized_linear(128, 64, bias=True)
     w = MLXQuantizedLinearWithLoRA(ql, max_loras=2, max_lora_rank=4, dtype=mx.float32)
@@ -197,24 +190,12 @@ def test_qlora_wrapper_preserves_quantized_projection_surface() -> None:
     assert "bias" not in wrapped_param_names
 
 
-@pytest.mark.parametrize(
-    "lora_a_shape,lora_b_shape,err_match",
-    [
-        ((2, 99), (64, 2), "QLoRA weight shape mismatch"),  # in_dim mismatch
-        ((5, 128), (64, 5), "exceeds max_lora_rank"),  # rank > max
-        ((2, 3, 1), (64, 2), "must be 2-D"),  # A not 2-D
-        ((2, 128), (64, 2, 1), "must be 2-D"),  # B not 2-D
-        ((2, 128), (64, 3), "does not match B rank"),  # A rank != B rank
-    ],
-)
-def test_qlora_wrapper_rejects_bad_weights(
-    lora_a_shape, lora_b_shape, err_match
-) -> None:
+def test_qlora_wrapper_uses_shared_weight_validation_label() -> None:
     ql = _make_quantized_linear(128, 64)
     w = MLXQuantizedLinearWithLoRA(ql, max_loras=1, max_lora_rank=4, dtype=mx.float32)
-    a = mx.array(np.ones(lora_a_shape, dtype=np.float32))
-    b = mx.array(np.ones(lora_b_shape, dtype=np.float32))
-    with pytest.raises(ValueError, match=err_match):
+    a = mx.array(np.ones((2, 99), dtype=np.float32))
+    b = mx.array(np.ones((64, 2), dtype=np.float32))
+    with pytest.raises(ValueError, match="QLoRA weight shape mismatch"):
         w.set_lora(0, a, b)
 
 

--- a/vllm_metal/v1/lora/layers.py
+++ b/vllm_metal/v1/lora/layers.py
@@ -50,65 +50,67 @@ def _infer_qlora_dims(module: Any) -> tuple[int, int]:
     return in_dim, out_dim
 
 
-class MLXLinearWithLoRA(nn.Module):
+class _LoRALinearBase(nn.Module):
+    _lora_name = "LoRA"
+
     def __init__(
-        self, base_layer: nn.Linear, max_loras: int, max_lora_rank: int, dtype: mx.Dtype
-    ):
+        self,
+        base_layer: Any,
+        input_size: int,
+        output_size: int,
+        max_loras: int,
+        max_lora_rank: int,
+        dtype: mx.Dtype,
+    ) -> None:
         super().__init__()
         self.base_layer = base_layer
         self.max_loras, self.max_lora_rank = max_loras, max_lora_rank
-        out, in_ = base_layer.weight.shape[-2:]
-        self.input_size, self.output_size = int(in_), int(out)
-        # +1 trailing slot is the null slot (see punica_wrapper).
-        slots = max_loras + 1
-        self.lora_a_stacked = mx.zeros((slots, max_lora_rank, self.input_size), dtype)
-        self.lora_b_stacked = mx.zeros((slots, self.output_size, max_lora_rank), dtype)
+        self.input_size, self.output_size = input_size, output_size
+        slots = max_loras + 1  # Trailing null slot; see punica_wrapper.
+        self.lora_a_stacked = mx.zeros((slots, max_lora_rank, input_size), dtype)
+        self.lora_b_stacked = mx.zeros((slots, output_size, max_lora_rank), dtype)
         self.punica_wrapper: PunicaWrapperMLX | None = None
+
+    def set_mapping(self, punica_wrapper: PunicaWrapperMLX) -> None:
+        self.punica_wrapper = punica_wrapper
 
     @property
     def weight(self) -> mx.array:
         return self.base_layer.weight
 
-    @weight.setter
-    def weight(self, value: mx.array) -> None:
-        self.base_layer.weight = value
-
     @property
     def bias(self) -> mx.array:
         return self.base_layer.bias
-
-    @bias.setter
-    def bias(self, value: mx.array) -> None:
-        self.base_layer.bias = value
-
-    def set_mapping(self, punica_wrapper: PunicaWrapperMLX) -> None:
-        self.punica_wrapper = punica_wrapper
 
     def prepare_lora_weights(
         self, slot: int, lora_a: mx.array, lora_b: mx.array
     ) -> tuple[mx.array, mx.array]:
         if lora_a.ndim != 2 or lora_b.ndim != 2:
             raise ValueError(
-                f"LoRA weight shape mismatch for slot {slot}: A and B must be "
-                f"2-D, got A.ndim={lora_a.ndim}, B.ndim={lora_b.ndim} "
+                f"{self._lora_name} weight shape mismatch for slot {slot}: "
+                f"A and B must be 2-D, got A.ndim={lora_a.ndim}, "
+                f"B.ndim={lora_b.ndim} "
                 "(expected A=(rank, in), B=(out, rank))"
             )
         rank, in_ = int(lora_a.shape[0]), int(lora_a.shape[1])
         out, b_rank = int(lora_b.shape[0]), int(lora_b.shape[1])
         if b_rank != rank:
             raise ValueError(
-                f"LoRA weight shape mismatch for slot {slot}: A rank {rank} "
-                f"(A=({rank},{in_})) does not match B rank {b_rank} "
-                f"(B=({out},{b_rank})); A=(rank, in), B=(out, rank)"
+                f"{self._lora_name} weight shape mismatch for slot {slot}: "
+                f"A rank {rank} (A=({rank},{in_})) does not match "
+                f"B rank {b_rank} (B=({out},{b_rank})); "
+                "A=(rank, in), B=(out, rank)"
             )
         if (in_, out) != (self.input_size, self.output_size):
             raise ValueError(
-                f"LoRA weight shape mismatch for slot {slot}: A=({rank},{in_}), "
-                f"B=({out},{rank}); expected in={self.input_size}, out={self.output_size}"
+                f"{self._lora_name} weight shape mismatch for slot {slot}: "
+                f"A=({rank},{in_}), B=({out},{rank}); expected "
+                f"in={self.input_size}, out={self.output_size}"
             )
         if rank > self.max_lora_rank:
             raise ValueError(
-                f"LoRA rank {rank} exceeds max_lora_rank {self.max_lora_rank}"
+                f"{self._lora_name} rank {rank} exceeds "
+                f"max_lora_rank {self.max_lora_rank}"
             )
         a = mx.zeros_like(self.lora_a_stacked[slot])
         b = mx.zeros_like(self.lora_b_stacked[slot])
@@ -117,8 +119,8 @@ class MLXLinearWithLoRA(nn.Module):
         return a, b
 
     def set_lora(self, slot: int, lora_a: mx.array, lora_b: mx.array) -> None:
-        a, b = self.prepare_lora_weights(slot, lora_a, lora_b)
-        self.set_prepared_lora(slot, a, b)
+        prepared = self.prepare_lora_weights(slot, lora_a, lora_b)
+        self.set_prepared_lora(slot, *prepared)
 
     def set_prepared_lora(self, slot: int, lora_a: mx.array, lora_b: mx.array) -> None:
         self.lora_a_stacked[slot], self.lora_b_stacked[slot] = lora_a, lora_b
@@ -126,6 +128,29 @@ class MLXLinearWithLoRA(nn.Module):
     def reset_lora(self, slot: int) -> None:
         self.lora_a_stacked[slot] = mx.zeros_like(self.lora_a_stacked[slot])
         self.lora_b_stacked[slot] = mx.zeros_like(self.lora_b_stacked[slot])
+
+
+class MLXLinearWithLoRA(_LoRALinearBase):
+    def __init__(
+        self, base_layer: nn.Linear, max_loras: int, max_lora_rank: int, dtype: mx.Dtype
+    ) -> None:
+        out, in_ = base_layer.weight.shape[-2:]
+        super().__init__(
+            base_layer,
+            int(in_),
+            int(out),
+            max_loras,
+            max_lora_rank,
+            dtype,
+        )
+
+    @_LoRALinearBase.weight.setter
+    def weight(self, value: mx.array) -> None:
+        self.base_layer.weight = value
+
+    @_LoRALinearBase.bias.setter
+    def bias(self, value: mx.array) -> None:
+        self.base_layer.bias = value
 
     def __call__(self, x: mx.array) -> mx.array:
         y = self.base_layer(x)
@@ -145,31 +170,25 @@ class MLXLinearWithLoRA(nn.Module):
         return out if out is y else out.reshape(shape)
 
 
-class MLXQuantizedLinearWithLoRA(nn.Module):
+class MLXQuantizedLinearWithLoRA(_LoRALinearBase):
+    _lora_name = "QLoRA"
+
     def __init__(
         self,
         base_layer: Any,
         max_loras: int,
         max_lora_rank: int,
         dtype: mx.Dtype,
-    ):
-        super().__init__()
-        self.base_layer = base_layer
-        self.max_loras, self.max_lora_rank = max_loras, max_lora_rank
-        self.input_size, self.output_size = _infer_qlora_dims(base_layer)
-        # +1 trailing slot is the null slot (see punica_wrapper).
-        slots = max_loras + 1
-        self.lora_a_stacked = mx.zeros((slots, max_lora_rank, self.input_size), dtype)
-        self.lora_b_stacked = mx.zeros((slots, self.output_size, max_lora_rank), dtype)
-        self.punica_wrapper: PunicaWrapperMLX | None = None
-
-    @property
-    def weight(self) -> mx.array:
-        return self.base_layer.weight
-
-    @property
-    def bias(self) -> mx.array:
-        return self.base_layer.bias
+    ) -> None:
+        input_size, output_size = _infer_qlora_dims(base_layer)
+        super().__init__(
+            base_layer,
+            input_size,
+            output_size,
+            max_loras,
+            max_lora_rank,
+            dtype,
+        )
 
     @property
     def in_features(self) -> int:
@@ -178,52 +197,6 @@ class MLXQuantizedLinearWithLoRA(nn.Module):
     @property
     def out_features(self) -> int:
         return self.output_size
-
-    def set_mapping(self, punica_wrapper: PunicaWrapperMLX) -> None:
-        self.punica_wrapper = punica_wrapper
-
-    def prepare_lora_weights(
-        self, slot: int, lora_a: mx.array, lora_b: mx.array
-    ) -> tuple[mx.array, mx.array]:
-        if lora_a.ndim != 2 or lora_b.ndim != 2:
-            raise ValueError(
-                f"QLoRA weight shape mismatch for slot {slot}: A and B must be "
-                f"2-D, got A.ndim={lora_a.ndim}, B.ndim={lora_b.ndim} "
-                "(expected A=(rank, in), B=(out, rank))"
-            )
-        rank, in_ = int(lora_a.shape[0]), int(lora_a.shape[1])
-        out, b_rank = int(lora_b.shape[0]), int(lora_b.shape[1])
-        if b_rank != rank:
-            raise ValueError(
-                f"QLoRA weight shape mismatch for slot {slot}: A rank {rank} "
-                f"(A=({rank},{in_})) does not match B rank {b_rank} "
-                f"(B=({out},{b_rank})); A=(rank, in), B=(out, rank)"
-            )
-        if (in_, out) != (self.input_size, self.output_size):
-            raise ValueError(
-                f"QLoRA weight shape mismatch for slot {slot}: A=({rank},{in_}), "
-                f"B=({out},{rank}); expected in={self.input_size}, out={self.output_size}"
-            )
-        if rank > self.max_lora_rank:
-            raise ValueError(
-                f"QLoRA rank {rank} exceeds max_lora_rank {self.max_lora_rank}"
-            )
-        a = mx.zeros_like(self.lora_a_stacked[slot])
-        b = mx.zeros_like(self.lora_b_stacked[slot])
-        a[:rank, :] = lora_a.astype(a.dtype)
-        b[:, :rank] = lora_b.astype(b.dtype)
-        return a, b
-
-    def set_lora(self, slot: int, lora_a: mx.array, lora_b: mx.array) -> None:
-        a, b = self.prepare_lora_weights(slot, lora_a, lora_b)
-        self.set_prepared_lora(slot, a, b)
-
-    def set_prepared_lora(self, slot: int, lora_a: mx.array, lora_b: mx.array) -> None:
-        self.lora_a_stacked[slot], self.lora_b_stacked[slot] = lora_a, lora_b
-
-    def reset_lora(self, slot: int) -> None:
-        self.lora_a_stacked[slot] = mx.zeros_like(self.lora_a_stacked[slot])
-        self.lora_b_stacked[slot] = mx.zeros_like(self.lora_b_stacked[slot])
 
     def __call__(self, x: mx.array) -> mx.array:
         # Quantized base forward — runs at the layer's native precision.


### PR DESCRIPTION
This PR is:

- To move shared LoRA/QLoRA slot setup, weight install, mapping, and reset logic into one base wrapper.
- To keep plain LoRA and QLoRA wrappers focused on their real differences.
- To remove duplicated QLoRA tests that now repeat the shared LoRA slot contract.

Validation:

Real offline LoRA smoke passed with base `Qwen/Qwen2.5-0.5B-Instruct` and LoRA `taronklm/Qwen2.5-0.5B-Instruct-lora-chatbot`.

The smoke loaded the real model, wrapped 168 LoRA modules, activated LoRA 1, and completed base-vs-LoRA generation. The outputs were close but not identical, which confirms the adapter path was active without breaking base generation.
