### PR TITLE
Remove unused logits processor wiring

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -67,7 +67,6 @@ def make_stub_runner(
         "use_async_scheduling": True,
         "device": torch.device("cpu"),
         "_sampler": None,
-        "_logitsprocs": None,
         "_structured_output_applier": MetalStructuredOutputApplier(),
         "_lora": MetalLoRARuntime(),
         "_yoco_cache_mapping": None,

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -74,7 +74,6 @@ def _context(
         cu_seqlens=[],
         num_decode_segments=1,
         num_speculative_tokens=1,
-        logitsprocs=None,
         finished_req_ids=set(),
     )
 

--- a/tests/test_ngram_spec_decode.py
+++ b/tests/test_ngram_spec_decode.py
@@ -86,7 +86,6 @@ def _context(
         cu_seqlens=[],
         num_decode_segments=len(decode_reqs),
         num_speculative_tokens=num_speculative_tokens,
-        logitsprocs=None,
         finished_req_ids=finished_req_ids or set(),
     )
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -9,6 +9,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig
+from vllm.sampling_params import SamplingParams
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 from vllm.v1.core.kv_cache_utils import (
@@ -65,6 +66,23 @@ class TestMetalPlatform:
         MetalPlatform.set_device(torch.device("cpu", 0))  # index 0 -> ok
         with pytest.raises(ValueError, match="only supports device 0"):
             MetalPlatform.set_device(torch.device("cpu", 1))
+
+    @pytest.mark.parametrize(
+        ("sampling_params", "control"),
+        [
+            (SamplingParams(min_p=0.1), "min_p"),
+            (SamplingParams(logit_bias={1: 2.0}), "logit_bias"),
+            (SamplingParams(min_tokens=2), "min_tokens"),
+        ],
+        ids=["min-p", "logit-bias", "min-tokens"],
+    )
+    def test_validate_request_rejects_logits_processor_controls(
+        self,
+        sampling_params: SamplingParams,
+        control: str,
+    ) -> None:
+        with pytest.raises(NotImplementedError, match=control):
+            MetalPlatform.validate_request({}, sampling_params)
 
     def test_check_and_update_config_rejects_pipeline_with_tensor_parallel(
         self,

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -9,6 +9,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 from vllm.config import CacheConfig, ParallelConfig, VllmConfig
+from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
@@ -81,8 +82,9 @@ class TestMetalPlatform:
         sampling_params: SamplingParams,
         control: str,
     ) -> None:
-        with pytest.raises(NotImplementedError, match=control):
+        with pytest.raises(VLLMValidationError, match=control) as exc_info:
             MetalPlatform.validate_request({}, sampling_params)
+        assert exc_info.value.parameter == control
 
     def test_check_and_update_config_rejects_pipeline_with_tensor_parallel(
         self,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Metal sampling with vLLM Sampler integration."""
 
-from types import SimpleNamespace
-
 import mlx.core as mx
 import numpy as np
 import pytest
@@ -13,12 +11,7 @@ from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.engine import EngineCoreOutput, EngineCoreRequest, FinishReason
 from vllm.v1.engine.output_processor import OutputProcessor
 from vllm.v1.outputs import LogprobsLists
-from vllm.v1.sample.logits_processor import (
-    BatchUpdate,
-    LogitsProcessor,
-    LogitsProcessors,
-    build_logitsprocs,
-)
+from vllm.v1.sample.logits_processor import LogitsProcessors
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
@@ -311,17 +304,13 @@ class TestV1SeededSamplingGenerator:
 
 class TestV1SamplingBatch:
     @staticmethod
-    def _batch(
-        params_list: list[SamplingParams],
-        logitsprocs: LogitsProcessors | None = None,
-    ) -> SamplingBatch:
+    def _batch(params_list: list[SamplingParams]) -> SamplingBatch:
         return SamplingBatch(
             params_list,
             [[1]] * len(params_list),
             [[]] * len(params_list),
             vocab_size=VOCAB_SIZE,
             device=torch.device("cpu"),
-            logitsprocs=logitsprocs,
         )
 
     def test_can_use_native_greedy_requires_greedy_without_filters(self) -> None:
@@ -357,72 +346,6 @@ class TestV1SamplingBatch:
         bad_sp = SamplingParams(temperature=0.0)
         bad_sp._bad_words_token_ids = [[99]]
         assert not self._batch([bad_sp]).can_use_native_greedy()
-
-    def test_native_greedy_allows_dormant_builtin_logits_processors(self) -> None:
-        vllm_config = SimpleNamespace(
-            speculative_config=None,
-            scheduler_config=SimpleNamespace(max_num_seqs=4),
-        )
-        logitsprocs = build_logitsprocs(
-            vllm_config,
-            torch.device("cpu"),
-            is_pin_memory=False,
-            is_pooling_model=False,
-        )
-        batch = self._batch([SamplingParams(temperature=0.0)], logitsprocs)
-
-        assert batch.can_use_native_greedy()
-
-    @pytest.mark.parametrize(
-        ("logit_bias", "min_tokens"),
-        [
-            ({1: 5.0}, 0),
-            (None, 5),
-        ],
-        ids=["logit_bias", "min_tokens"],
-    )
-    def test_native_greedy_rejects_active_builtin_logits_processors(
-        self,
-        logit_bias: dict[int, float] | None,
-        min_tokens: int,
-    ) -> None:
-        vllm_config = SimpleNamespace(
-            speculative_config=None,
-            scheduler_config=SimpleNamespace(max_num_seqs=4),
-        )
-        logitsprocs = build_logitsprocs(
-            vllm_config,
-            torch.device("cpu"),
-            is_pin_memory=False,
-            is_pooling_model=False,
-        )
-        sampling_params = SamplingParams(
-            temperature=0.0,
-            logit_bias=logit_bias,
-            min_tokens=min_tokens,
-        )
-        batch = self._batch([sampling_params], logitsprocs)
-
-        assert not batch.can_use_native_greedy()
-
-    def test_native_greedy_rejects_unknown_non_argmax_processor(self) -> None:
-        class _UnknownNonArgmax(LogitsProcessor):
-            def __init__(self, *_args: object) -> None:
-                return None
-
-            def apply(self, logits: torch.Tensor) -> torch.Tensor:
-                return logits
-
-            def is_argmax_invariant(self) -> bool:
-                return False
-
-            def update_state(self, batch_update: BatchUpdate | None) -> None:
-                return None
-
-        logitsprocs = LogitsProcessors([_UnknownNonArgmax()])
-        batch = self._batch([SamplingParams(temperature=0.0)], logitsprocs)
-
-        assert not batch.can_use_native_greedy()
 
     def test_allowed_token_ids_constrains_greedy_sampling(self) -> None:
         """Greedy with allowed_token_ids must fall back and the constraint works."""
@@ -670,25 +593,6 @@ class TestV1SamplingBatch:
         assert completion_output.logprobs is not None
         assert completion_output.logprobs[0] is not None
         assert completion_output.logprobs[0][7].logprob == pytest.approx(-0.1)
-
-
-class TestV1SamplingMetadataLogitsProcessors:
-    @staticmethod
-    def _make_runner(vocab_size: int = 32) -> MetalModelRunner:
-        return make_stub_runner(model_args={"vocab_size": vocab_size})
-
-    def test_make_sampling_metadata_uses_runner_logitsprocs(self) -> None:
-        runner = self._make_runner()
-        expected_logitsprocs = LogitsProcessors()
-        runner._logitsprocs = expected_logitsprocs
-
-        metadata = runner._make_sampling_metadata(
-            sampling_params_list=[SamplingParams(temperature=0.0)],
-            prompt_token_id_lists=[[]],
-            output_token_id_lists=[[]],
-        )
-
-        assert metadata.logitsprocs is expected_logitsprocs
 
 
 class TestV1PenaltyTokenAccounting:

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -8,10 +8,8 @@ from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
-import torch
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
-from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
 
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPDraftSeed
 from vllm_metal.v1.spec_decode import (
@@ -26,18 +24,9 @@ def _state(token_ids: list[int], block_ids: list[int]) -> SimpleNamespace:
 
 def _request_state(
     temperature: float = 0.0,
-    *,
-    generated_tokens: int = 1,
-    min_tokens: int = 0,
-    stop_token_ids: list[int] | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
-        sampling_params=SamplingParams(
-            temperature=temperature,
-            min_tokens=min_tokens,
-            stop_token_ids=stop_token_ids,
-        ),
-        generated_tokens=generated_tokens,
+        sampling_params=SamplingParams(temperature=temperature),
     )
 
 
@@ -62,19 +51,6 @@ def _scheduler_output(
         finished_req_ids=set(),
         free_encoder_mm_hashes=[],
         num_invalid_spec_tokens=num_invalid_spec_tokens,
-    )
-
-
-def _spec_logitsprocs():
-    config = SimpleNamespace(
-        speculative_config=object(),
-        scheduler_config=SimpleNamespace(max_num_seqs=4),
-    )
-    return build_logitsprocs(
-        config,
-        torch.device("cpu"),
-        is_pin_memory=False,
-        is_pooling_model=False,
     )
 
 
@@ -210,7 +186,6 @@ class TestSpecDecodePolicy:
             (),
             paged_attention_enabled=False,
             is_hybrid=True,
-            logitsprocs=None,
         )
 
     def test_gemma4_mtp_rejects_async_scheduling(self) -> None:
@@ -220,7 +195,6 @@ class TestSpecDecodePolicy:
                 (),
                 paged_attention_enabled=True,
                 is_hybrid=False,
-                logitsprocs=None,
                 use_async_scheduling=True,
                 speculative_config=_gemma4_mtp_speculative_config(),
             )
@@ -232,7 +206,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=False,
                 is_hybrid=False,
-                logitsprocs=None,
             )
 
     def test_hybrid_scheduled_tokens_are_rejected(self) -> None:
@@ -242,7 +215,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=True,
-                logitsprocs=None,
             )
 
     def test_rejects_invalid_draft_token_sentinel(self) -> None:
@@ -252,7 +224,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=False,
-                logitsprocs=None,
             )
 
     def test_rejects_scheduler_invalid_spec_tokens(self) -> None:
@@ -265,7 +236,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=False,
-                logitsprocs=None,
             )
 
     def test_rejects_handoff_for_request_outside_decode_set(self) -> None:
@@ -275,7 +245,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=False,
-                logitsprocs=None,
             )
 
     def test_rejects_empty_handoff_for_request_outside_decode_set(self) -> None:
@@ -285,7 +254,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=False,
-                logitsprocs=None,
             )
 
     def test_rejects_mismatched_scheduler_token_accounting(self) -> None:
@@ -298,44 +266,6 @@ class TestSpecDecodePolicy:
                 [("r0", _request_state())],
                 paged_attention_enabled=True,
                 is_hybrid=False,
-                logitsprocs=None,
-            )
-
-    def test_allows_inactive_min_tokens_processor_from_speculative_config(self) -> None:
-        SpeculativeDecodeController().validate_supported(
-            _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
-            [
-                (
-                    "r0",
-                    _request_state(
-                        generated_tokens=2,
-                        min_tokens=1,
-                        stop_token_ids=[2],
-                    ),
-                )
-            ],
-            paged_attention_enabled=True,
-            is_hybrid=False,
-            logitsprocs=_spec_logitsprocs(),
-        )
-
-    def test_rejects_active_min_tokens_constraint(self) -> None:
-        with pytest.raises(NotImplementedError, match="active min_tokens"):
-            SpeculativeDecodeController().validate_supported(
-                _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
-                [
-                    (
-                        "r0",
-                        _request_state(
-                            generated_tokens=0,
-                            min_tokens=3,
-                            stop_token_ids=[2],
-                        ),
-                    )
-                ],
-                paged_attention_enabled=True,
-                is_hybrid=False,
-                logitsprocs=_spec_logitsprocs(),
             )
 
 
@@ -373,7 +303,6 @@ class TestGemma4MTPDraftSeeds:
             request_states={},
             cu_seqlens=[0, 2, 3],
             num_decode_segments=2,
-            logitsprocs=None,
         )
 
         assert seeds == (
@@ -413,7 +342,6 @@ class TestGemma4MTPDraftSeeds:
             },
             cu_seqlens=[0, 3, 5],
             num_decode_segments=0,
-            logitsprocs=None,
         )
 
         assert seeds == (
@@ -443,7 +371,6 @@ class TestVerifyGreedySpecDecode:
             _logits([7, 8, 9]),
             [("r0", _request_state())],
             (segment,),
-            logitsprocs=None,
         )
 
         assert output == [[7, 8, 9]]
@@ -463,7 +390,6 @@ class TestVerifyGreedySpecDecode:
             _logits([7, 5, 9]),
             [("r0", _request_state())],
             (segment,),
-            logitsprocs=None,
         )
 
         assert output == [[7, 5]]
@@ -484,30 +410,6 @@ class TestVerifyGreedySpecDecode:
                 _logits([7, 9]),
                 [("r0", _request_state(temperature=0.7))],
                 (segment,),
-                logitsprocs=None,
-            )
-
-    def test_rejects_logits_processors_that_can_change_argmax(self) -> None:
-        class _NonArgmaxProcessor:
-            def is_argmax_invariant(self) -> bool:
-                return False
-
-        with pytest.raises(NotImplementedError, match="logits processors"):
-            SpeculativeDecodeController().verify_greedy(
-                _logits([7, 9]),
-                [("r0", _request_state())],
-                (
-                    PagedDecodeSegment(
-                        req_id="r0",
-                        input_token_ids=(6, 7),
-                        start_row=0,
-                        num_query_tokens=2,
-                        draft_token_ids=(7,),
-                        cache_start_pos=1,
-                        block_ids=((0,),),
-                    ),
-                ),
-                logitsprocs=LogitsProcessors([_NonArgmaxProcessor()]),
             )
 
 
@@ -564,7 +466,6 @@ class TestSchedulerPaddedDrafts:
             [],
             paged_attention_enabled=True,
             is_hybrid=False,
-            logitsprocs=None,
         )
 
     def test_padded_drafts_reach_build_decode_segments_as_zero_drafts(self) -> None:

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1354,46 +1354,17 @@ class TestV1MetalModelRunnerExecuteModel:
     def _make_new_request(
         self,
         req_id: str = "new",
-        sampling_params: SamplingParams | None = None,
     ) -> NewRequestData:
         return NewRequestData(
             req_id=req_id,
             prompt_token_ids=[1],
             mm_features=[],
-            sampling_params=sampling_params or SamplingParams(),
+            sampling_params=SamplingParams(),
             pooling_params=None,
             block_ids=([0],),
             num_computed_tokens=0,
             lora_request=None,
         )
-
-    @pytest.mark.parametrize(
-        ("sampling_params", "control"),
-        [
-            (SamplingParams(min_p=0.1), "min_p"),
-            (SamplingParams(logit_bias={1: 2.0}), "logit_bias"),
-            (SamplingParams(min_tokens=2), "min_tokens"),
-        ],
-        ids=["min-p", "logit-bias", "min-tokens"],
-    )
-    def test_new_request_rejects_unsupported_logits_processor_controls(
-        self,
-        sampling_params: SamplingParams,
-        control: str,
-    ) -> None:
-        runner = self._make_runner()
-        runner._prefill_single = Mock(return_value=(1, [], None))
-        new_req = self._make_new_request(sampling_params=sampling_params)
-
-        with pytest.raises(NotImplementedError, match=control):
-            runner._handle_new_requests(
-                mr._ExecutionBatch(),
-                [new_req],
-                self._make_scheduler_output(scheduled_new_reqs=[new_req]),
-            )
-
-        runner._prefill_single.assert_not_called()
-        assert "new" not in runner._request_states
 
     def test_returns_empty_output_directly_for_empty_batch(self) -> None:
         runner = self._make_runner()

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 import mlx.core as mx
 import numpy as np
 import pytest
+import torch
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
@@ -117,6 +118,20 @@ class TestDrafterReleaseOnLifecycle:
 class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())
+
+    def test_init_rejects_configured_custom_logits_processors(self) -> None:
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                logits_processors=[object],
+                runner_type="generate",
+            ),
+            cache_config=SimpleNamespace(),
+            scheduler_config=SimpleNamespace(async_scheduling=False),
+            speculative_config=None,
+        )
+
+        with pytest.raises(NotImplementedError, match="custom logits processors"):
+            mr.MetalModelRunner(vllm_config, torch.device("cpu"))
 
     def test_warm_up_propagates_dummy_forward_failure(self) -> None:
         runner = self._make_runner()
@@ -1320,17 +1335,49 @@ class TestV1MetalModelRunnerExecuteModel:
             has_structured_output_requests=False,
         )
 
-    def _make_new_request(self, req_id: str = "new") -> NewRequestData:
+    def _make_new_request(
+        self,
+        req_id: str = "new",
+        sampling_params: SamplingParams | None = None,
+    ) -> NewRequestData:
         return NewRequestData(
             req_id=req_id,
             prompt_token_ids=[1],
             mm_features=[],
-            sampling_params=SamplingParams(),
+            sampling_params=sampling_params or SamplingParams(),
             pooling_params=None,
             block_ids=([0],),
             num_computed_tokens=0,
             lora_request=None,
         )
+
+    @pytest.mark.parametrize(
+        ("sampling_params", "control"),
+        [
+            (SamplingParams(min_p=0.1), "min_p"),
+            (SamplingParams(logit_bias={1: 2.0}), "logit_bias"),
+            (SamplingParams(min_tokens=2), "min_tokens"),
+        ],
+        ids=["min-p", "logit-bias", "min-tokens"],
+    )
+    def test_new_request_rejects_unsupported_logits_processor_controls(
+        self,
+        sampling_params: SamplingParams,
+        control: str,
+    ) -> None:
+        runner = self._make_runner()
+        runner._prefill_single = Mock(return_value=(1, [], None))
+        new_req = self._make_new_request(sampling_params=sampling_params)
+
+        with pytest.raises(NotImplementedError, match=control):
+            runner._handle_new_requests(
+                mr._ExecutionBatch(),
+                [new_req],
+                self._make_scheduler_output(scheduled_new_reqs=[new_req]),
+            )
+
+        runner._prefill_single.assert_not_called()
+        assert "new" not in runner._request_states
 
     def test_returns_empty_output_directly_for_empty_batch(self) -> None:
         runner = self._make_runner()

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -119,10 +119,26 @@ class TestV1MetalModelRunnerGenerate:
     def _make_runner(self) -> mr.MetalModelRunner:
         return make_stub_runner(tokenizer=object())
 
-    def test_init_rejects_configured_custom_logits_processors(self) -> None:
+    @pytest.mark.parametrize(
+        ("configured_processors", "installed_processors"),
+        [
+            ([object], ()),
+            (None, (object(),)),
+        ],
+        ids=["configured", "installed-plugin"],
+    )
+    def test_init_rejects_custom_logits_processors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        configured_processors: list[type] | None,
+        installed_processors: tuple[object, ...],
+    ) -> None:
+        monkeypatch.setattr(
+            mr, "entry_points", lambda **_: installed_processors, raising=False
+        )
         vllm_config = SimpleNamespace(
             model_config=SimpleNamespace(
-                logits_processors=[object],
+                logits_processors=configured_processors,
                 runner_type="generate",
             ),
             cache_config=SimpleNamespace(),

--- a/tools/test_ngram_spec_decode_e2e.py
+++ b/tools/test_ngram_spec_decode_e2e.py
@@ -143,12 +143,10 @@ def _generate_with_acceptance_counting(llm: LLM, prompt: str, max_tokens: int):
     original_verify = controller.verify_greedy
     counts = {"accepted": 0, "drafted": 0}
 
-    def counting_verify(logits, decode_reqs, decode_segments, *, logitsprocs):
+    def counting_verify(logits, decode_reqs, decode_segments):
         # Each verified row is (accepted drafts) + 1 trailing token (bonus on full
         # accept, else the target's correction), so accepted = len - 1.
-        result = original_verify(
-            logits, decode_reqs, decode_segments, logitsprocs=logitsprocs
-        )
+        result = original_verify(logits, decode_reqs, decode_segments)
         for segment, output_ids in zip(decode_segments, result, strict=True):
             counts["drafted"] += len(segment.draft_token_ids)
             counts["accepted"] += len(output_ids) - 1

--- a/tools/test_spec_decode_draft_model_e2e.py
+++ b/tools/test_spec_decode_draft_model_e2e.py
@@ -165,10 +165,8 @@ class TestDraftModelSpecDecode:
         # not the engine loop.
         real_mismatches: list[tuple[int, int, int, float]] = []
 
-        def tie_checking_verify(logits, decode_reqs, decode_segments, *, logitsprocs):
-            result = original_verify(
-                logits, decode_reqs, decode_segments, logitsprocs=logitsprocs
-            )
+        def tie_checking_verify(logits, decode_reqs, decode_segments):
+            result = original_verify(logits, decode_reqs, decode_segments)
             # verify stops at the first per-segment mismatch, so accepted =
             # len(output) - 1 locates the one rejected draft (if any).
             for segment, output_ids in zip(decode_segments, result, strict=True):

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import psutil
 import torch
 from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum
+from vllm.sampling_params import SamplingParams
 
 import vllm_metal.envs as envs
 from vllm_metal.config import get_config
@@ -218,6 +219,28 @@ class MetalPlatform(Platform):
         import mlx.core as mx
 
         mx.random.seed(seed)
+
+    @classmethod
+    def validate_request(cls, processed_inputs: object, params: object) -> None:
+        """Reject request options that Metal cannot apply correctly."""
+        if not isinstance(params, SamplingParams):
+            return
+
+        unsupported_controls = [
+            name
+            for name, enabled in (
+                ("min_p", params.min_p > 0.0),
+                ("logit_bias", bool(params.logit_bias)),
+                ("min_tokens", params.min_tokens > 0),
+            )
+            if enabled
+        ]
+        if unsupported_controls:
+            controls = ", ".join(unsupported_controls)
+            raise NotImplementedError(
+                "vllm-metal does not support sampling controls backed by "
+                f"vLLM logits processors ({controls})."
+            )
 
     @classmethod
     def get_torch_device(cls, device_id: int = 0) -> torch.device:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import psutil
 import torch
 from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum
-from vllm.sampling_params import SamplingParams
 
 import vllm_metal.envs as envs
 from vllm_metal.config import get_config
@@ -223,6 +222,10 @@ class MetalPlatform(Platform):
     @classmethod
     def validate_request(cls, processed_inputs: object, params: object) -> None:
         """Reject request options that Metal cannot apply correctly."""
+        # Keep this import out of module scope: platform discovery imports this
+        # module before vLLM finishes selecting the active platform.
+        from vllm.sampling_params import SamplingParams
+
         if not isinstance(params, SamplingParams):
             return
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -224,6 +224,7 @@ class MetalPlatform(Platform):
         """Reject request options that Metal cannot apply correctly."""
         # Keep this import out of module scope: platform discovery imports this
         # module before vLLM finishes selecting the active platform.
+        from vllm.exceptions import VLLMValidationError
         from vllm.sampling_params import SamplingParams
 
         if not isinstance(params, SamplingParams):
@@ -240,9 +241,10 @@ class MetalPlatform(Platform):
         ]
         if unsupported_controls:
             controls = ", ".join(unsupported_controls)
-            raise NotImplementedError(
+            raise VLLMValidationError(
                 "vllm-metal does not support sampling controls backed by "
-                f"vLLM logits processors ({controls})."
+                f"vLLM logits processors ({controls}).",
+                parameter=unsupported_controls[0],
             )
 
     @classmethod

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -266,7 +266,6 @@ class DraftModelProposer:
             ctx.prefill_reqs,
             ctx.prefill_result_modes,
             ctx.request_states,
-            logitsprocs=ctx.logitsprocs,
         )
         plans: list[_DraftPlan] = []
         for req_id, state in eligible:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -26,7 +26,6 @@ from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.tasks import SupportedTask
-from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     GrammarOutput,
@@ -40,7 +39,6 @@ from vllm.v1.outputs import (
     LogprobsLists,
     ModelRunnerOutput,
 )
-from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
@@ -316,18 +314,6 @@ class MetalModelRunner:
 
         # vLLM Sampler for token sampling with temperature, top_k, top_p support
         self._sampler = Sampler()
-
-        # Build logits processors (includes custom plugins from entry-points)
-        pin_memory = is_pin_memory_available()
-        custom_lp = vllm_config.model_config.logits_processors
-        custom_logitsprocs = tuple(custom_lp) if custom_lp is not None else ()
-        self._logitsprocs = build_logitsprocs(
-            vllm_config,
-            device,
-            pin_memory,
-            self._is_pooling,
-            custom_logitsprocs,
-        )
 
         # vLLM v1 async scheduling calls sample_tokens after execute_model.
         # Keep the latest execution output so sample_tokens can return it.
@@ -847,7 +833,6 @@ class MetalModelRunner:
             output_token_id_lists,
             vocab_size=self._vocab_size,
             device=self.device,
-            logitsprocs=self._logitsprocs,
             generators=generators,
         ).make_sampling_metadata()
 
@@ -884,7 +869,6 @@ class MetalModelRunner:
             [[]],
             vocab_size=vocab_size,
             device=self.device,
-            logitsprocs=self._logitsprocs,
             generators=generators,
         )
         result = sample_from_logits(last_logits, batch, self._sampler, self.device)
@@ -946,7 +930,6 @@ class MetalModelRunner:
             output_tokens_list,
             vocab_size=vocab_size,
             device=self.device,
-            logitsprocs=self._logitsprocs,
             generators=generators,
         )
         result = sample_from_logits(
@@ -994,7 +977,6 @@ class MetalModelRunner:
                 [state.token_ids[state.prompt_len :]],
                 vocab_size=vocab_size,
                 device=self.device,
-                logitsprocs=self._logitsprocs,
                 generators=generators,
             )
             result = sample_from_logits(last_logits, batch, self._sampler, self.device)
@@ -1278,7 +1260,6 @@ class MetalModelRunner:
 
         # ---- sample tokens ----
         vocab_size = self._vocab_size
-        logitsprocs = self._logitsprocs
         decode_token_ids: list[list[int]] = [[] for _ in decode_reqs]
         decode_logprobs_rows: list[LogprobsLists | None] = [None for _ in decode_reqs]
         if has_scheduled_drafts:
@@ -1294,7 +1275,6 @@ class MetalModelRunner:
                     logits,
                     [req for _, req, _ in spec_items],
                     [segment for _, _, segment in spec_items],
-                    logitsprocs=logitsprocs,
                 )
                 for (decode_index, _, _), sampled_ids in zip(
                     spec_items,
@@ -1335,7 +1315,6 @@ class MetalModelRunner:
                     output_tokens_list,
                     vocab_size=vocab_size,
                     device=self.device,
-                    logitsprocs=logitsprocs,
                     generators=generators,
                 )
                 plain_result = sample_from_logits(
@@ -1361,7 +1340,6 @@ class MetalModelRunner:
                 self._sampler,
                 self.device,
                 vocab_size=vocab_size,
-                logitsprocs=logitsprocs,
             )
             decode_token_ids = [[token_id] for token_id in decode_result.token_ids]
             decode_logprobs = decode_result.logprobs
@@ -1373,7 +1351,6 @@ class MetalModelRunner:
             self._sampler,
             self.device,
             vocab_size=vocab_size,
-            logitsprocs=logitsprocs,
         )
 
         # ---- update decode state ----
@@ -1459,7 +1436,6 @@ class MetalModelRunner:
             cu_seqlens=cu_seqlens,
             num_decode_segments=num_decode_segments,
             num_speculative_tokens=num_speculative_tokens,
-            logitsprocs=self._logitsprocs,
             finished_req_ids=scheduler_output.finished_req_ids,
         )
         self._draft_token_ids = (
@@ -1573,7 +1549,6 @@ class MetalModelRunner:
             self._spec_decode_preflight_reqs(scheduler_output),
             paged_attention_enabled=self._paged_attention_runtime is not None,
             is_hybrid=self.is_hybrid,
-            logitsprocs=self._logitsprocs,
             use_async_scheduling=self.use_async_scheduling,
             speculative_config=self.vllm_config.speculative_config,
         )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -281,6 +281,11 @@ class MetalModelRunner:
             vllm_config: vLLM configuration
             device: PyTorch device (CPU for Metal interop)
         """
+        if vllm_config.model_config.logits_processors:
+            raise NotImplementedError(
+                "vllm-metal does not support custom logits processors."
+            )
+
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
         self.cache_config = vllm_config.cache_config
@@ -1855,6 +1860,26 @@ class MetalModelRunner:
         scheduler_output: SchedulerOutput,
     ) -> None:
         """Register new requests and execute any required per-request prefill."""
+        for new_req in new_reqs:
+            sampling_params = new_req.sampling_params
+            if sampling_params is None:
+                continue
+            unsupported_controls = [
+                name
+                for name, enabled in (
+                    ("min_p", sampling_params.min_p > 0.0),
+                    ("logit_bias", bool(sampling_params.logit_bias)),
+                    ("min_tokens", sampling_params.min_tokens > 0),
+                )
+                if enabled
+            ]
+            if unsupported_controls:
+                controls = ", ".join(unsupported_controls)
+                raise NotImplementedError(
+                    "vllm-metal does not support sampling controls backed by "
+                    f"vLLM logits processors ({controls}); request={new_req.req_id!r}."
+                )
+
         batch.new_reqs_by_id = {req.req_id: req for req in new_reqs}
 
         for new_req in new_reqs:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1839,26 +1839,6 @@ class MetalModelRunner:
         scheduler_output: SchedulerOutput,
     ) -> None:
         """Register new requests and execute any required per-request prefill."""
-        for new_req in new_reqs:
-            sampling_params = new_req.sampling_params
-            if sampling_params is None:
-                continue
-            unsupported_controls = [
-                name
-                for name, enabled in (
-                    ("min_p", sampling_params.min_p > 0.0),
-                    ("logit_bias", bool(sampling_params.logit_bias)),
-                    ("min_tokens", sampling_params.min_tokens > 0),
-                )
-                if enabled
-            ]
-            if unsupported_controls:
-                controls = ", ".join(unsupported_controls)
-                raise NotImplementedError(
-                    "vllm-metal does not support sampling controls backed by "
-                    f"vLLM logits processors ({controls}); request={new_req.req_id!r}."
-                )
-
         batch.new_reqs_by_id = {req.req_id: req for req in new_reqs}
 
         for new_req in new_reqs:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -13,6 +13,7 @@ Key contracts:
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from importlib.metadata import entry_points
 from typing import Any, Literal, NamedTuple, TypeAlias
 
 import mlx.core as mx
@@ -39,6 +40,7 @@ from vllm.v1.outputs import (
     LogprobsLists,
     ModelRunnerOutput,
 )
+from vllm.v1.sample.logits_processor import LOGITSPROCS_GROUP
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
@@ -279,7 +281,9 @@ class MetalModelRunner:
             vllm_config: vLLM configuration
             device: PyTorch device (CPU for Metal interop)
         """
-        if vllm_config.model_config.logits_processors:
+        if vllm_config.model_config.logits_processors or entry_points(
+            group=LOGITSPROCS_GROUP
+        ):
             raise NotImplementedError(
                 "vllm-metal does not support custom logits processors."
             )

--- a/vllm_metal/v1/ngram_proposer.py
+++ b/vllm_metal/v1/ngram_proposer.py
@@ -172,7 +172,6 @@ class NgramProposer:
                 ctx.prefill_reqs,
                 ctx.prefill_result_modes,
                 ctx.request_states,
-                logitsprocs=ctx.logitsprocs,
             )
         )
         if not drafting:

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -23,8 +23,6 @@ from vllm.v1.outputs import DraftTokenIds
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
-    from vllm.v1.sample.logits_processor import LogitsProcessors
-
     from vllm_metal.v1.model_runner import (
         MetalModelRunner,
         PrefillRequest,
@@ -53,7 +51,6 @@ class ProposeContext:
     cu_seqlens: Sequence[int]
     num_decode_segments: int
     num_speculative_tokens: int
-    logitsprocs: LogitsProcessors | None
     # Request ids the scheduler finished this step. vLLM can hand a finished
     # id straight back out to a new request in the same step, so a proposer
     # that keeps its own per-request state must clear against this, not
@@ -140,7 +137,6 @@ class Gemma4MTPProposer:
             request_states=ctx.request_states,
             cu_seqlens=ctx.cu_seqlens,
             num_decode_segments=ctx.num_decode_segments,
-            logitsprocs=ctx.logitsprocs,
         )
         if not seeds:
             return None

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -14,16 +14,13 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils.torch_utils import make_tensor_with_pad
 from vllm.v1.outputs import LogprobsLists
 from vllm.v1.sample.logits_processor import LogitsProcessors
-from vllm.v1.sample.logits_processor.builtin import (
-    LogitBiasLogitsProcessor,
-    MinTokensLogitsProcessor,
-)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 
 GREEDY_TEMPERATURE_EPS = 1e-5
+_EMPTY_LOGITSPROCS = LogitsProcessors()
 
 
 @dataclass(frozen=True)
@@ -41,10 +38,7 @@ class SamplingBatch:
     ``SamplingMetadata`` construction out of ``model_runner.py`` while the
     runner is being slimmed down.
 
-    Today it owns only the sampling-side state for one step. As more per-step
-    batch state moves out of ``model_runner.py``, this should evolve into a
-    fuller ``MetalInputBatch``-style owner that can absorb request indexing,
-    token views, generators, logits processor ownership, and metadata refresh.
+    Today it owns only the sampling-side state for one step.
     """
 
     def __init__(
@@ -55,7 +49,6 @@ class SamplingBatch:
         *,
         vocab_size: int,
         device: torch.device,
-        logitsprocs: LogitsProcessors | None = None,
         generators: dict[int, torch.Generator] | None = None,
     ) -> None:
         batch_size = len(sampling_params_list)
@@ -77,7 +70,6 @@ class SamplingBatch:
         self.output_token_id_lists = list(output_token_id_lists)
         self.vocab_size = vocab_size
         self.device = device
-        self.logitsprocs = logitsprocs or LogitsProcessors()
         self.generators = {} if generators is None else generators
         self.all_greedy = all(
             sampling_params.temperature < GREEDY_TEMPERATURE_EPS
@@ -170,16 +162,6 @@ class SamplingBatch:
 
     def can_use_native_greedy(self) -> bool:
         """Return whether MLX argmax matches the requested sampling behavior."""
-        # MinTokens and LogitBias are the only non-argmax-invariant builtins, and
-        # both are no-ops unless their request params are set. Gate on those params
-        # below so standard greedy decode uses native MLX argmax instead of bridging
-        # the full-vocab logits to the torch sampler every step. Any other
-        # non-argmax-invariant processor forces the safe torch path.
-        if any(
-            type(proc) not in (MinTokensLogitsProcessor, LogitBiasLogitsProcessor)
-            for proc in self.logitsprocs.non_argmax_invariant
-        ):
-            return False
         return all(
             sampling_params.temperature < GREEDY_TEMPERATURE_EPS
             and sampling_params.top_k <= 0
@@ -190,8 +172,6 @@ class SamplingBatch:
             and sampling_params.logprobs is None
             and not sampling_params.allowed_token_ids
             and not sampling_params.bad_words_token_ids
-            and not sampling_params.logit_bias
-            and (sampling_params.min_tokens or 0) == 0
             for sampling_params in self.sampling_params_list
         )
 
@@ -332,7 +312,7 @@ class SamplingBatch:
             no_penalties=self.no_penalties,
             allowed_token_ids_mask=self._make_allowed_token_ids_mask(),
             bad_words_token_ids=self._make_bad_words_token_ids(),
-            logitsprocs=self.logitsprocs,
+            logitsprocs=_EMPTY_LOGITSPROCS,
             logprob_token_ids=None,
         )
 
@@ -387,7 +367,6 @@ def sample_decode_tokens(
     device: torch.device,
     *,
     vocab_size: int,
-    logitsprocs: LogitsProcessors | None = None,
 ) -> _SamplingResult:
     """Sample one token per decode request from evaluated logits.
 
@@ -398,8 +377,6 @@ def sample_decode_tokens(
         sampler: vLLM Sampler instance.
         device: PyTorch device for the torch bridge path.
         vocab_size: Model vocabulary size.
-        logitsprocs: Optional logits processors.
-
     Returns:
         Sampled token IDs and optional logprobs, one row per decode request.
     """
@@ -427,7 +404,6 @@ def sample_decode_tokens(
         output_tokens_list,
         vocab_size=vocab_size,
         device=device,
-        logitsprocs=logitsprocs,
         generators=generators,
     )
     return sample_from_logits(decode_logits, batch, sampler, device)
@@ -442,7 +418,6 @@ def sample_prefill_tokens(
     device: torch.device,
     *,
     vocab_size: int,
-    logitsprocs: LogitsProcessors | None = None,
 ) -> _SamplingResult:
     """Sample one token per prefill request from the last logit position.
 
@@ -454,8 +429,6 @@ def sample_prefill_tokens(
         sampler: vLLM Sampler instance.
         device: PyTorch device for the torch bridge path.
         vocab_size: Model vocabulary size.
-        logitsprocs: Optional logits processors.
-
     Returns:
         Sampled token IDs and optional logprobs, one row per prefill request.
     """
@@ -485,7 +458,6 @@ def sample_prefill_tokens(
             [prompt_for_meta[prompt_len:]],
             vocab_size=vocab_size,
             device=device,
-            logitsprocs=logitsprocs,
             generators=generators,
         )
         result = sample_from_logits(last_logits, batch, sampler, device)

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -9,8 +9,6 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 import mlx.core as mx
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.sample.logits_processor import LogitsProcessors
-from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
 
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPDraftSeed
 from vllm_metal.v1.sampling_batch import GREEDY_TEMPERATURE_EPS
@@ -28,7 +26,6 @@ class _PagedDecodeStateLike(Protocol):
 
 class _SpecDecodeRequestStateLike(Protocol):
     sampling_params: Any
-    generated_tokens: int
 
 
 class _SpecDecodePrefillLike(Protocol):
@@ -121,7 +118,6 @@ class SpeculativeDecodeController:
         *,
         paged_attention_enabled: bool,
         is_hybrid: bool,
-        logitsprocs: LogitsProcessors | None,
         use_async_scheduling: bool = False,
         speculative_config: SpeculativeConfig | None = None,
     ) -> None:
@@ -196,7 +192,7 @@ class SpeculativeDecodeController:
                 )
             draft_reqs.append((req_id, request_by_id[req_id]))
 
-        self._validate_greedy_sampling(draft_reqs, logitsprocs=logitsprocs)
+        self._validate_greedy_sampling(draft_reqs)
 
     def build_decode_segments(
         self,
@@ -249,8 +245,6 @@ class SpeculativeDecodeController:
         logits: mx.array,
         decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
         decode_segments: Sequence[PagedDecodeSegment],
-        *,
-        logitsprocs: LogitsProcessors | None,
     ) -> list[list[int]]:
         """Verify scheduled draft tokens with greedy target logits."""
         if len(decode_reqs) != len(decode_segments):
@@ -266,7 +260,7 @@ class SpeculativeDecodeController:
                     f"metadata: {req_id!r} != {segment.req_id!r}"
                 )
 
-        self._validate_greedy_sampling(decode_reqs, logitsprocs=logitsprocs)
+        self._validate_greedy_sampling(decode_reqs)
 
         num_decode_rows = max(
             segment.start_row + segment.num_query_tokens for segment in decode_segments
@@ -311,7 +305,6 @@ class SpeculativeDecodeController:
         request_states: Mapping[str, _SpecDecodeRequestStateLike],
         cu_seqlens: Sequence[int],
         num_decode_segments: int,
-        logitsprocs: LogitsProcessors | None,
     ) -> tuple[Gemma4MTPDraftSeed, ...]:
         """Build target-row seeds for one-token Gemma4 MTP drafts."""
         seeds: list[Gemma4MTPDraftSeed] = []
@@ -321,11 +314,7 @@ class SpeculativeDecodeController:
             decode_token_ids,
             strict=True,
         ):
-            if not sampled_ids or not self.can_draft_greedy(
-                req_id,
-                state,
-                logitsprocs=logitsprocs,
-            ):
+            if not sampled_ids or not self.can_draft_greedy(req_id, state):
                 continue
             accepted_offset = len(sampled_ids) - 1
             seeds.append(
@@ -344,11 +333,7 @@ class SpeculativeDecodeController:
             if result_mode == "intermediate":
                 continue
             state = request_states.get(prefill.req_id)
-            if state is None or not self.can_draft_greedy(
-                prefill.req_id,
-                state,
-                logitsprocs=logitsprocs,
-            ):
+            if state is None or not self.can_draft_greedy(prefill.req_id, state):
                 continue
             prefill_end = cu_seqlens[num_decode_segments + i + 1]
             seeds.append(
@@ -367,15 +352,10 @@ class SpeculativeDecodeController:
         self,
         req_id: str,
         request_state: _SpecDecodeRequestStateLike,
-        *,
-        logitsprocs: LogitsProcessors | None,
     ) -> bool:
         """Whether a request may be drafted under greedy-only spec decode."""
         try:
-            self._validate_greedy_sampling(
-                [(req_id, request_state)],
-                logitsprocs=logitsprocs,
-            )
+            self._validate_greedy_sampling([(req_id, request_state)])
         except NotImplementedError:
             return False
         return True
@@ -387,8 +367,6 @@ class SpeculativeDecodeController:
         prefill_reqs: Sequence[_SpecDecodePrefillLike],
         prefill_result_modes: Sequence[str],
         request_states: Mapping[str, _SpecDecodeRequestStateLike],
-        *,
-        logitsprocs: LogitsProcessors | None,
     ) -> Sequence[tuple[str, RequestState]]:
         """Filter ``ctx`` to requests eligible for drafting this step.
 
@@ -411,7 +389,7 @@ class SpeculativeDecodeController:
         ):
             if not sampled_ids:
                 continue
-            if not self.can_draft_greedy(req_id, state, logitsprocs=logitsprocs):
+            if not self.can_draft_greedy(req_id, state):
                 continue
             eligible.append((req_id, state))  # type: ignore[arg-type]
             seen.add(req_id)
@@ -422,9 +400,7 @@ class SpeculativeDecodeController:
             if result_mode == "intermediate" or prefill.req_id in seen:
                 continue
             state = request_states.get(prefill.req_id)
-            if state is None or not self.can_draft_greedy(
-                prefill.req_id, state, logitsprocs=logitsprocs
-            ):
+            if state is None or not self.can_draft_greedy(prefill.req_id, state):
                 continue
             eligible.append((prefill.req_id, state))  # type: ignore[arg-type]
 
@@ -433,8 +409,6 @@ class SpeculativeDecodeController:
     def _validate_greedy_sampling(
         self,
         decode_reqs: Sequence[tuple[str, _SpecDecodeRequestStateLike]],
-        *,
-        logitsprocs: LogitsProcessors | None,
     ) -> None:
         for _, request_state in decode_reqs:
             sampling_params = request_state.sampling_params
@@ -455,31 +429,6 @@ class SpeculativeDecodeController:
                     "supports greedy sampling only (temperature=0, no "
                     "penalties, constraints, or logprobs)."
                 )
-
-            if (
-                sampling_params.min_tokens
-                and request_state.generated_tokens < sampling_params.min_tokens
-                and sampling_params.all_stop_token_ids
-            ):
-                raise NotImplementedError(
-                    "Speculative decode verification on Metal does not support "
-                    "active min_tokens constraints yet."
-                )
-
-        if logitsprocs is None:
-            return
-
-        unsupported_processors = [
-            processor
-            for processor in logitsprocs.non_argmax_invariant
-            if not isinstance(processor, MinTokensLogitsProcessor)
-        ]
-        if unsupported_processors:
-            raise NotImplementedError(
-                "Speculative decode verification on Metal currently supports "
-                "greedy sampling only; non-argmax logits processors are not "
-                "supported."
-            )
 
 
 __all__ = [


### PR DESCRIPTION
This PR is:

- To reject logits processor options that Metal does not support.
- To remove logits processor state that was passed around but not actually used correctly.
- To reject custom logits processor plugins at startup instead of ignoring them.
- To keep the empty logits processor object that vLLM still requires for sampling metadata.

Metal does not currently support `min_p`, `logit_bias`, `min_tokens`, or custom logits processors. Before this PR, some of that plumbing existed, but the behavior was incomplete. This could make unsupported options look like they worked.

After this PR, supported sampling still works, and unsupported logits processor options fail clearly.
