### PR TITLE
Default MLX command-buffer limits on macOS

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,16 @@
 | `VLLM_METAL_VISIBLE_DEVICES` | — | Set automatically by the Ray executor per worker (the device-control var); not user-configurable. See [Distributed](distributed.md). |
 | `VLLM_METAL_RING_BASE_PORT` | `32323` | Base TCP port for the MLX ring data plane under pipeline parallelism; stage *r* binds `base + r` (so the default is `32323`/`32324` for two stages). Set the **same** value on every node to move the ring off a busy port — e.g. when an `mlx.launch` job, a restart still in `TIME_WAIT`, or another PP job holds the default. See [Distributed](distributed.md#pipeline-parallelism). |
 
+## MLX Command-Buffer Defaults
+
+On macOS the plugin defaults `MLX_MAX_OPS_PER_BUFFER` and
+`MLX_MAX_MB_PER_BUFFER` to `2000` via `setdefault`, so a value you export
+yourself always wins; the two limits default independently, so setting
+one keeps the plugin default for the other. MLX's own defaults are sized for small generate
+loops; a vLLM decode step on a large MoE model builds thousands of lazy
+ops per step, and the resulting per-buffer commit overhead slows the step
+submit. `2000` sits on the measured plateau. Outputs are unaffected.
+
 ## Multimodal Serve Modes
 
 - `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.

--- a/tests/test_macos_defaults.py
+++ b/tests/test_macos_defaults.py
@@ -6,6 +6,8 @@ import logging
 import os
 import sys
 
+import pytest
+
 import vllm_metal as vm
 
 
@@ -31,6 +33,61 @@ def test_apply_macos_defaults_noop_on_non_macos(monkeypatch) -> None:
 
     vm._apply_macos_defaults()
     assert "VLLM_WORKER_MULTIPROC_METHOD" not in os.environ
+
+
+def test_apply_mlx_buffer_defaults_sets_both_limits(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.delenv("MLX_MAX_OPS_PER_BUFFER", raising=False)
+    monkeypatch.delenv("MLX_MAX_MB_PER_BUFFER", raising=False)
+
+    vm._apply_mlx_buffer_defaults()
+
+    assert os.environ["MLX_MAX_OPS_PER_BUFFER"] == "2000"
+    assert os.environ["MLX_MAX_MB_PER_BUFFER"] == "2000"
+
+
+def test_apply_mlx_buffer_defaults_respects_user_values(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv("MLX_MAX_OPS_PER_BUFFER", "50")
+    monkeypatch.setenv("MLX_MAX_MB_PER_BUFFER", "128")
+
+    vm._apply_mlx_buffer_defaults()
+
+    assert os.environ["MLX_MAX_OPS_PER_BUFFER"] == "50"
+    assert os.environ["MLX_MAX_MB_PER_BUFFER"] == "128"
+
+
+@pytest.mark.parametrize(
+    ("kept", "defaulted"),
+    [
+        ("MLX_MAX_OPS_PER_BUFFER", "MLX_MAX_MB_PER_BUFFER"),
+        ("MLX_MAX_MB_PER_BUFFER", "MLX_MAX_OPS_PER_BUFFER"),
+    ],
+)
+def test_apply_mlx_buffer_defaults_defaults_each_var_independently(
+    monkeypatch, kept: str, defaulted: str
+) -> None:
+    # The two limits are independent split thresholds: a user tuning one
+    # keeps it, and the other still gets the plugin default.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setenv(kept, "50")
+    monkeypatch.delenv(defaulted, raising=False)
+
+    vm._apply_mlx_buffer_defaults()
+
+    assert os.environ[kept] == "50"
+    assert os.environ[defaulted] == "2000"
+
+
+def test_apply_mlx_buffer_defaults_noop_on_non_macos(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.delenv("MLX_MAX_OPS_PER_BUFFER", raising=False)
+    monkeypatch.delenv("MLX_MAX_MB_PER_BUFFER", raising=False)
+
+    vm._apply_mlx_buffer_defaults()
+
+    assert "MLX_MAX_OPS_PER_BUFFER" not in os.environ
+    assert "MLX_MAX_MB_PER_BUFFER" not in os.environ
 
 
 def test_apply_macos_defaults_logs_when_setting(monkeypatch, caplog) -> None:

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -60,6 +60,28 @@ def _apply_macos_defaults() -> None:
     )
 
 
+# MLX splits each lazy evaluation into command buffers after this many ops /
+# this much memory; its defaults suit small generate loops, while a vLLM
+# decode step builds thousands of lazy ops per submit. 2000 sits on the
+# measured plateau, and ``setdefault`` keeps user values authoritative.
+_MLX_BUFFER_ENV_DEFAULTS = {
+    "MLX_MAX_OPS_PER_BUFFER": "2000",
+    "MLX_MAX_MB_PER_BUFFER": "2000",
+}
+
+
+def _apply_mlx_buffer_defaults() -> None:
+    """Default MLX command-buffer limits to decode-step-sized values."""
+    if sys.platform != "darwin":
+        return
+    for name, value in _MLX_BUFFER_ENV_DEFAULTS.items():
+        if name not in os.environ:
+            logger.debug(
+                "Defaulting %s=%s (set it explicitly to override).", name, value
+            )
+        os.environ.setdefault(name, value)
+
+
 # Lazy imports to avoid loading vLLM dependencies when just importing the Rust extension
 def __getattr__(name):
     """Lazy import module components."""
@@ -103,6 +125,7 @@ def _register() -> str | None:
     """
     _configure_logging()
     _apply_macos_defaults()
+    _apply_mlx_buffer_defaults()
 
     # Register our env vars with vLLM's registry so validate_environ()
     # does not warn about unknown VLLM_METAL_* / VLLM_MLX_* variables.


### PR DESCRIPTION
A vLLM decode step on a large MoE model builds thousands of lazy ops per submit, and MLX's command-buffer split defaults are sized for small generate loops, so the step submit spends much of its time on per-buffer commits. This defaults `MLX_MAX_OPS_PER_BUFFER` and `MLX_MAX_MB_PER_BUFFER` to `2000` during plugin registration on macOS, via `setdefault` so a value the user exports always wins; the two limits default independently.

Standalone on main this is worth 42.4 to 44.8 tok/s single-stream (`Qwen3.6-35B-A3B-4bit`, M1 Ultra, greedy 256 tokens, temperature 0), and greedy output is byte-identical. 2000 sits on a measured plateau (1000 and 2000 equal within noise), so the smaller value ships. The effect compounds with the decode pipelining change I'll send next, which is where most of the win in my branch came from.

The defaults reach every process: `_register` re-runs during platform resolution in the EngineCore, and spawned workers inherit the parent environment either way. Tests pin the exact default strings, per-variable user override, independent defaulting, and the non-macOS no-op.
