### PR TITLE
Fix hybrid MambaSpec cache accounting

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -34,9 +34,13 @@ def make_stub_runner(
 
     defaults: dict[str, Any] = {
         "vllm_config": SimpleNamespace(speculative_config=None),
-        "cache_config": SimpleNamespace(mamba_page_size_padded=None),
+        "cache_config": SimpleNamespace(
+            mamba_page_size_padded=None,
+            mamba_block_size=2048,
+            mamba_cache_mode="none",
+        ),
         "model_config": SimpleNamespace(
-            runner_type="generate", get_head_size=lambda: 128
+            runner_type="generate", get_head_size=lambda: 128, max_model_len=2048
         ),
         "model": object(),
         "_is_vlm": False,

--- a/tests/test_kv_cache_spec_capacity.py
+++ b/tests/test_kv_cache_spec_capacity.py
@@ -7,8 +7,9 @@ from types import SimpleNamespace
 
 import mlx.core as mx
 import torch
+from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_utils import get_uniform_page_size
-from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, MLAAttentionSpec
 
 from tests.stub_runner import make_stub_runner
 
@@ -90,3 +91,41 @@ def test_plain_attention_spec_is_unchanged() -> None:
 
     metal_per_block = 2 * BLOCK_SIZE * DTYPE.itemsize * layers * 4 * 256
     assert _engine_blocks(specs, metal_per_block) == POOL_BLOCKS
+
+
+def test_hybrid_mamba_spec_reserves_one_state_block_per_request() -> None:
+    attention_block_size = 544
+    max_model_len = 2048
+    runner = make_stub_runner(
+        model_args={"full_attention_interval": 2},
+        model_config=SimpleNamespace(
+            runner_type="generate",
+            get_head_size=lambda: 128,
+            max_model_len=max_model_len,
+        ),
+        num_layers=2,
+        num_sdpa_layers=1,
+        num_linear_layers=1,
+        sdpa_layer_indices={1},
+        num_kv_heads=1,
+        head_dim=128,
+        kv_cache_dtype=mx.float16,
+        cache_config=SimpleNamespace(
+            block_size=attention_block_size,
+            mamba_page_size_padded=None,
+            mamba_block_size=max_model_len,
+            mamba_cache_mode="none",
+        ),
+        linear_conv_kernel_dim=4,
+        linear_conv_dim=64,
+        linear_num_v_heads=1,
+        linear_value_head_dim=64,
+        linear_key_head_dim=64,
+    )
+
+    spec = runner._cache_policy.get_kv_cache_spec()["layers.0.linear_attn"]
+    prompt_tokens = 1301
+    assert isinstance(spec, MambaSpec)
+    assert cdiv(prompt_tokens, attention_block_size) == 3
+    assert spec.block_size == max_model_len
+    assert cdiv(prompt_tokens, spec.block_size) == 1

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -8,7 +8,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
-from vllm.config import ParallelConfig, VllmConfig
+from vllm.config import CacheConfig, ParallelConfig, VllmConfig
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig
 from vllm.v1.core.kv_cache_utils import (
@@ -999,6 +999,7 @@ class TestMetalPlatform:
                     kv_cache_dtype_skip_layers=[],
                     enable_prefix_caching=True,
                     mamba_cache_mode="none",
+                    mamba_ssm_cache_dtype="float32",
                 ),
                 "Prefix caching",
             ),
@@ -1008,6 +1009,7 @@ class TestMetalPlatform:
                     kv_cache_dtype_skip_layers=[],
                     enable_prefix_caching=False,
                     mamba_cache_mode="all",
+                    mamba_ssm_cache_dtype="float32",
                 ),
                 "Mamba cache modes",
             ),
@@ -1024,37 +1026,62 @@ class TestMetalPlatform:
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
         reset_config()
         try:
-            vllm_config = SimpleNamespace(
-                speculative_config=None,
-                parallel_config=SimpleNamespace(
-                    worker_cls="auto",
-                    distributed_executor_backend="auto",
-                    pipeline_parallel_size=1,
-                    tensor_parallel_size=1,
-                    disable_custom_all_reduce=False,
-                ),
-                cache_config=cache_config,
-                model_config=SimpleNamespace(
-                    model="test-model",
-                    disable_cascade_attn=False,
-                    tokenizer=None,
-                    max_model_len=32768,
-                    multimodal_config=None,
-                    hf_config=SimpleNamespace(model_type="qwen3"),
-                    is_hybrid=True,
-                ),
-                scheduler_config=SimpleNamespace(
-                    async_scheduling=True,
-                    enable_chunked_prefill=True,
-                    max_num_batched_tokens=2048,
-                    max_num_scheduled_tokens=None,
-                ),
-            )
+            vllm_config = self._hybrid_vllm_config(cache_config)
 
             with pytest.raises(NotImplementedError, match=err_match):
                 MetalPlatform.check_and_update_config(vllm_config)
         finally:
             reset_config()
+
+    @pytest.mark.parametrize(
+        ("dtype", "reject"),
+        [("auto", False), ("float16", True), ("bfloat16", True)],
+    )
+    def test_check_and_update_config_hybrid_gdn_state_dtype(
+        self, dtype: str, reject: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cache_config = CacheConfig(
+            enable_prefix_caching=False, mamba_ssm_cache_dtype=dtype
+        )
+        vllm_config = self._hybrid_vllm_config(cache_config)
+
+        if reject:
+            with pytest.raises(NotImplementedError, match="require.*float32"):
+                MetalPlatform.check_and_update_config(vllm_config)
+        else:
+            self._patch_stt_resolution(monkeypatch, is_stt=False)
+            MetalPlatform.check_and_update_config(vllm_config)
+            assert cache_config.mamba_ssm_cache_dtype == "float32"
+
+    @staticmethod
+    def _hybrid_vllm_config(cache_config: object) -> SimpleNamespace:
+        return SimpleNamespace(
+            speculative_config=None,
+            lora_config=None,
+            parallel_config=SimpleNamespace(
+                worker_cls="auto",
+                distributed_executor_backend="auto",
+                pipeline_parallel_size=1,
+                tensor_parallel_size=1,
+                disable_custom_all_reduce=False,
+            ),
+            cache_config=cache_config,
+            model_config=SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=32768,
+                multimodal_config=None,
+                hf_config=SimpleNamespace(model_type="qwen3"),
+                is_hybrid=True,
+            ),
+            scheduler_config=SimpleNamespace(
+                async_scheduling=True,
+                enable_chunked_prefill=True,
+                max_num_batched_tokens=2048,
+                max_num_scheduled_tokens=None,
+            ),
+        )
 
     def test_check_and_update_config_increases_max_num_scheduled_tokens_below_max_model_len(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Hybrid + TurboQuant sizing must match the runtime's packed KV layout."""
 
+import math
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -28,6 +29,7 @@ NUM_LAYERS = 8
 SDPA_LAYERS = [3, 7]
 KV_HEADS = 4
 HEAD_DIM = 128
+MAMBA_BLOCK_SIZE = 2048
 K_QUANT = "q4_0"
 V_QUANT = "q4_0"
 
@@ -52,7 +54,10 @@ def _hybrid_runner():
         head_dim=HEAD_DIM,
         kv_cache_dtype=mx.float16,
         cache_config=SimpleNamespace(
-            block_size=BLOCK_SIZE, mamba_page_size_padded=None
+            block_size=BLOCK_SIZE,
+            mamba_page_size_padded=None,
+            mamba_block_size=MAMBA_BLOCK_SIZE,
+            mamba_cache_mode="none",
         ),
         scheduler_config=SimpleNamespace(max_num_seqs=4),
         linear_conv_kernel_dim=4,
@@ -109,7 +114,10 @@ class TestHybridTurboQuantCachePolicy:
                 head_dim=HEAD_DIM,
                 kv_cache_dtype=mx.float16,
                 cache_config=SimpleNamespace(
-                    block_size=BLOCK_SIZE, mamba_page_size_padded=None
+                    block_size=BLOCK_SIZE,
+                    mamba_page_size_padded=None,
+                    mamba_block_size=MAMBA_BLOCK_SIZE,
+                    mamba_cache_mode="none",
                 ),
                 scheduler_config=SimpleNamespace(max_num_seqs=4),
                 linear_conv_kernel_dim=4,
@@ -156,10 +164,12 @@ class TestTurboQuantHybridAlignment:
         )
 
     def _vllm_config_with_cache(self, cache_config: CacheConfig) -> SimpleNamespace:
+        cache_config.mamba_block_size = MAMBA_BLOCK_SIZE
         return SimpleNamespace(
             model_config=SimpleNamespace(
                 is_hybrid=True,
                 architecture="StubHybridForCausalLM",
+                max_model_len=MAMBA_BLOCK_SIZE,
                 dtype=torch.float16,
                 use_mla=False,
                 get_num_kv_heads=lambda parallel_config: KV_HEADS,
@@ -277,12 +287,12 @@ class TestTurboQuantHybridAlignment:
         assert {group.kv_cache_spec.page_size_bytes for group in groups} == {
             cache_config.block_size * self._TQ_PAGE_1_TOKEN
         }
-        if cache_config.prefix_match_unit is None:
-            assert hash_block_size == scheduler_block_size
-        else:
+        expected_scheduler = math.lcm(expected_block, runner.model_config.max_model_len)
+        assert scheduler_block_size == expected_scheduler
+        if cache_config.prefix_match_unit is not None:
             assert cache_config.block_size % cache_config.prefix_match_unit == 0
-            assert scheduler_block_size % cache_config.prefix_match_unit == 0
-            assert hash_block_size == cache_config.prefix_match_unit
+        # Divergent Mamba block sizes disable fine-grained hashing upstream.
+        assert hash_block_size == scheduler_block_size
 
     def test_initialize_kv_cache_selects_sdpa_scheduler_group(
         self, monkeypatch

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -17,6 +17,7 @@ import mlx.core as mx
 import mlx.nn as nn
 import torch
 from vllm.logger import init_logger
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.kv_cache_interface import MambaSpec
 
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
@@ -46,25 +47,24 @@ def _build_linear_layer_spec(
     key_head_dim: int,
     torch_dtype: torch.dtype,
     page_size_padded: int | None = None,
-    block_size: int,
+    mamba_block_size: int,
+    mamba_cache_mode: str = "none",
 ) -> MambaSpec:
-    """Build a MambaSpec for one GDN linear attention layer.
+    """Build the scheduler-visible GDN state spec.
 
-    Args:
-        page_size_padded: Optional padded page size from cache_config to
-            align Mamba page size with attention page size in hybrid models.
-        block_size: Tokens per block.  Must match the SDPA block_size so
-            the scheduler's unified block pool can serve both layer types
-            without running out of blocks prematurely.
+    A max-length Mamba block gives each request one block in ``none`` mode.
     """
     return MambaSpec(
         shapes=(
             (conv_kernel_dim - 1, conv_dim),
             (num_v_heads, value_head_dim, key_head_dim),
         ),
-        dtypes=(torch_dtype, torch_dtype),
-        block_size=block_size,
+        # Match the fp32 recurrent pool used for kernel accumulation.
+        dtypes=(torch_dtype, torch.float32),
+        block_size=mamba_block_size,
         page_size_padded=page_size_padded,
+        mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+        mamba_cache_mode=mamba_cache_mode,
     )
 
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -448,6 +448,14 @@ class MetalPlatform(Platform):
 
         if model_config is not None and model_config.is_hybrid:
             cache_config = vllm_config.cache_config
+            if cache_config.mamba_ssm_cache_dtype == "auto":
+                cache_config.mamba_ssm_cache_dtype = "float32"
+            elif cache_config.mamba_ssm_cache_dtype != "float32":
+                raise NotImplementedError(
+                    "Hybrid GDN models on Metal require "
+                    "--mamba-ssm-cache-dtype float32 because recurrent state is "
+                    "stored in fp32."
+                )
             if (
                 cache_config.enable_prefix_caching
                 or cache_config.mamba_cache_mode != "none"

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -325,6 +325,10 @@ class ModelCachePolicy:
                 and layer_idx not in self._runner.sdpa_layer_indices
             ):
                 layer_name = f"layers.{layer_idx}.linear_attn"
+                cache_config = self._runner.cache_config
+                mamba_block_size = cache_config.mamba_block_size
+                # Upstream resolves this during config setup and asserts it here.
+                assert mamba_block_size is not None
                 specs[layer_name] = _build_linear_layer_spec(
                     conv_kernel_dim=self._runner.linear_conv_kernel_dim,
                     conv_dim=self._runner.linear_conv_dim,
@@ -332,8 +336,9 @@ class ModelCachePolicy:
                     value_head_dim=self._runner.linear_value_head_dim,
                     key_head_dim=self._runner.linear_key_head_dim,
                     torch_dtype=torch_dtype,
-                    page_size_padded=self._runner.cache_config.mamba_page_size_padded,
-                    block_size=block_size,
+                    page_size_padded=cache_config.mamba_page_size_padded,
+                    mamba_block_size=mamba_block_size,
+                    mamba_cache_mode=cache_config.mamba_cache_mode,
                 )
             elif use_turboquant:
                 layer_name = f"layers.{layer_idx}.self_attn"


### PR DESCRIPTION
## Summary

- **Problem:** Hybrid GDN linear attention keeps one fixed-size convolution + recurrent state per request, but its scheduler-visible `MambaSpec` described that state like a token-growing attention cache. This silently wasted pool capacity and under-declared the recurrent state's fp32 storage.
- **Before:** The spec used the smaller attention `block_size` and declared both state tensors at the model dtype. Because the scheduler allocates `ceil(sequence_length / spec.block_size)` blocks, a 1,301-token request with a 544-token attention block reserved three Mamba blocks per cache group even though only one state block was needed. The runtime also stored the recurrent matrix in fp32 while the spec commonly billed it as fp16/bf16.
- **After:** The spec uses `cache_config.mamba_block_size` (`max_model_len` while prefix caching is disabled), declares the recurrent matrix as fp32, identifies the backend as `GDN_ATTN`, and propagates `mamba_cache_mode`. Any valid request therefore reserves one Mamba state block per group in `none` mode, and scheduler memory accounting matches the runtime layout.
- **Core fix:** `MambaSpec(block_size=mamba_block_size, dtypes=(torch_dtype, torch.float32), mamba_type=GDN_ATTN, mamba_cache_mode=cache_config.mamba_cache_mode)`.
- **Scheduler compatibility:** When attention and Mamba block sizes differ, grouping follows upstream's LCM alignment and fine-hash fallback behavior.
- **Regression coverage:** A general, non-TurboQuant cache-spec test captures the three-block-to-one-block fix; the existing TurboQuant integration test pins the affected grouping behavior.

- Future PR: this will unlock the support to Qwen3.5-3.8, LFM2.5 models, and prefix caching support. 

## Testing

- `pytest -q tests/test_kv_cache_spec_capacity.py tests/test_turboquant_hybrid_sizing.py` (14 passed)
- `ruff check` on all changed Python files
