### PR TITLE
Route Qwen MLX quant text wrappers through mlx_lm

### DIFF
--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -87,11 +87,6 @@ class TestShouldForceTextBackbone:
                 "Qwen3VLForConditionalGeneration",
                 SimpleNamespace(spatial_merge_size=2),
             ),
-            (
-                "qwen3_5",
-                "Qwen3_5ForConditionalGeneration",
-                SimpleNamespace(spatial_merge_size=2),
-            ),
             # An arbitrary non-allowlisted multimodal model.
             ("llava", "LlavaForConditionalGeneration", None),
         ],
@@ -108,6 +103,20 @@ class TestShouldForceTextBackbone:
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
+
+    def test_mlx_quant_qwen35_wrapper_uses_auto_override_with_vision_config(
+        self,
+    ) -> None:
+        hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            architectures=["Qwen3_5ForConditionalGeneration"],
+            quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+            vision_config=SimpleNamespace(spatial_merge_size=2),
+            text_config=SimpleNamespace(model_type="qwen3_5_text"),
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is True
 
     def test_multimodal_native_mode_disables_mlx_quant_override(
         self, monkeypatch
@@ -408,6 +417,7 @@ class TestNormalizeModelConfig:
         [
             ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
             ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+            ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
         ],
     )
     def test_clears_multimodal_config_for_mlx_quant_wrapper_in_auto_mode(

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -58,8 +58,8 @@ class TestShouldForceTextBackbone:
     @pytest.mark.parametrize(
         ("model_type", "architecture"),
         [
-            # The real pair of the motivating checkpoints
-            # (Qwen3.6-35B-A3B MLX 4-bit, issue #571).
+            # Dense and MoE MLX 4-bit wrappers from issues #580 and #571.
+            ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
             ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
             ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
         ],
@@ -77,25 +77,33 @@ class TestShouldForceTextBackbone:
         assert result is True
 
     @pytest.mark.parametrize(
-        ("model_type", "architecture"),
+        ("model_type", "architecture", "vision_config"),
         [
             # The flagship native-multimodal checkpoint family
             # (mlx-community Qwen3-VL MLX conversions carry the same
             # top-level quantization dict) must keep the native path.
-            ("qwen3_vl", "Qwen3VLForConditionalGeneration"),
-            # A natively-adapted Qwen3.5 VL wrapper keeps image serving.
-            ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+            (
+                "qwen3_vl",
+                "Qwen3VLForConditionalGeneration",
+                SimpleNamespace(spatial_merge_size=2),
+            ),
+            (
+                "qwen3_5",
+                "Qwen3_5ForConditionalGeneration",
+                SimpleNamespace(spatial_merge_size=2),
+            ),
             # An arbitrary non-allowlisted multimodal model.
-            ("llava", "LlavaForConditionalGeneration"),
+            ("llava", "LlavaForConditionalGeneration", None),
         ],
     )
     def test_mlx_quant_natively_adapted_arch_skips_auto_override(
-        self, model_type: str, architecture: str
+        self, model_type: str, architecture: str, vision_config: object | None
     ) -> None:
         hf_config = SimpleNamespace(
             model_type=model_type,
             architectures=[architecture],
             quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+            vision_config=vision_config,
         )
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
@@ -157,7 +165,7 @@ class TestShouldForceTextBackbone:
         assert result is False
 
     def test_non_overridden_model_type_is_not_forced_in_auto_mode(self) -> None:
-        hf_config = SimpleNamespace(model_type="qwen3_5")
+        hf_config = SimpleNamespace(model_type="qwen3_5", architectures=[])
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
@@ -171,12 +179,6 @@ class TestShouldForceTextBackbone:
             architectures=["Qwen3_5ForConditionalGeneration"],
             quantization_config={"quant_method": "fp8"},
         )
-        adapter = DefaultModelAdapter()
-        result = adapter.should_force_text_backbone(hf_config)
-        assert result is False
-
-    def test_missing_model_type_is_not_forced(self) -> None:
-        hf_config = SimpleNamespace()
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
@@ -401,12 +403,21 @@ class TestNormalizeModelConfig:
 
         assert model_config.multimodal_config is None
 
-    def test_clears_multimodal_config_for_mlx_quant_moe_in_auto_mode(self) -> None:
+    @pytest.mark.parametrize(
+        ("model_type", "architecture"),
+        [
+            ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
+            ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+        ],
+    )
+    def test_clears_multimodal_config_for_mlx_quant_wrapper_in_auto_mode(
+        self, model_type: str, architecture: str
+    ) -> None:
         model_config = SimpleNamespace(
             multimodal_config=SimpleNamespace(language_model_only=False),
             hf_config=SimpleNamespace(
-                model_type="qwen3_5_moe",
-                architectures=["Qwen3_5MoeForConditionalGeneration"],
+                model_type=model_type,
+                architectures=[architecture],
                 quantization={"group_size": 64, "bits": 4, "mode": "affine"},
             ),
         )
@@ -419,7 +430,7 @@ class TestNormalizeModelConfig:
         sentinel = SimpleNamespace(language_model_only=False)
         model_config = SimpleNamespace(
             multimodal_config=sentinel,
-            hf_config=SimpleNamespace(model_type="qwen3_vl"),
+            hf_config=SimpleNamespace(model_type="qwen3_vl", architectures=[]),
         )
 
         DefaultModelAdapter().normalize_model_config(model_config)

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -340,6 +340,8 @@ class TestModelLifecycle:
                     model_type="qwen3_5",
                     architectures=["Qwen3_5ForConditionalGeneration"],
                     quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+                    vision_config=SimpleNamespace(spatial_merge_size=2),
+                    text_config=SimpleNamespace(model_type="qwen3_5_text"),
                 ),
                 is_multimodal_model=True,
             )

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -329,6 +329,27 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is False
 
+    def test_load_uses_adapter_override_for_qwen35_mlx_quant_dense_wrapper(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _stub_generation_model(monkeypatch, config=_text_config())
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                hf_config=SimpleNamespace(
+                    model_type="qwen3_5",
+                    architectures=["Qwen3_5ForConditionalGeneration"],
+                    quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+                ),
+                is_multimodal_model=True,
+            )
+        )
+
+        lifecycle.load()
+
+        assert runner._is_vlm is False
+        assert runner._multimodal_adapter is None
+
     def test_load_multimodal_native_mode_keeps_qwen35_fp8_as_vlm(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -404,7 +425,7 @@ class TestModelLifecycle:
         )
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
-                hf_config=SimpleNamespace(model_type="phi3_v"),
+                hf_config=SimpleNamespace(model_type="phi3_v", architectures=[]),
                 is_multimodal_model=True,
             )
         )

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1407,7 +1407,7 @@ class TestMetalPlatform:
                 tokenizer=None,
                 max_model_len=128,
                 multimodal_config=sentinel,
-                hf_config=SimpleNamespace(model_type="qwen3_vl"),
+                hf_config=SimpleNamespace(model_type="qwen3_vl", architectures=[]),
                 is_hybrid=False,
             )
             vllm_config = SimpleNamespace(

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -240,32 +240,37 @@ class DefaultModelAdapter(ModelAdapter):
             return True
 
         architectures_from_hf = tuple(hf_config.architectures or ())
-        if not any(
+        has_text_backbone_architecture = any(
             arch in _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES
             for arch in architectures_from_hf
-        ):
+        )
+        if not has_text_backbone_architecture:
             return False
 
-        quantization_config_from_hf = getattr(hf_config, "quantization_config", None)
-        if isinstance(quantization_config_from_hf, dict):
-            quant_method = quantization_config_from_hf.get("quant_method")
-        else:
-            quant_method = getattr(quantization_config_from_hf, "quant_method", None)
-        if quant_method == "fp8":
+        if self._has_fp8_quantization_config(hf_config):
             return True
 
         # MLX affine checkpoints carry a top-level `quantization` dict.  The
         # same conditional-generation architecture string can describe a dense
         # text wrapper or a real VL model, so keep native only when the config
         # exposes the native VL contract.
-        mlx_quantization_from_hf = getattr(hf_config, "quantization", None)
-        if (
-            not isinstance(mlx_quantization_from_hf, dict)
-            or "bits" not in mlx_quantization_from_hf
-        ):
+        if not self._has_mlx_quantized_weights(hf_config):
             return False
         return not self._has_native_qwen_vl_config(
             hf_config, model_type_from_hf, architectures_from_hf
+        )
+
+    def _has_fp8_quantization_config(self, hf_config: Any) -> bool:
+        quantization_config_from_hf = getattr(hf_config, "quantization_config", None)
+        if isinstance(quantization_config_from_hf, dict):
+            return quantization_config_from_hf.get("quant_method") == "fp8"
+        return getattr(quantization_config_from_hf, "quant_method", None) == "fp8"
+
+    def _has_mlx_quantized_weights(self, hf_config: Any) -> bool:
+        mlx_quantization_from_hf = getattr(hf_config, "quantization", None)
+        return (
+            isinstance(mlx_quantization_from_hf, dict)
+            and "bits" in mlx_quantization_from_hf
         )
 
     def _has_native_qwen_vl_config(

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -196,18 +196,6 @@ _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES: frozenset[str] = frozenset(
         "Qwen3_6MoeForConditionalGeneration",
     }
 )
-# MLX-quantized wrappers are only force-texted when no native multimodal
-# adapter covers the architecture (see _QWEN3_VL_ARCHITECTURES):
-# Qwen3_5ForConditionalGeneration has one, so its MLX checkpoints keep the
-# native path and image serving; the rest would run the bare language model
-# with unset mrope state and generate garbled output.
-_MLX_QUANT_TEXT_BACKBONE_ARCHITECTURES: frozenset[str] = frozenset(
-    {
-        "Qwen3_5MoeForConditionalGeneration",
-        "Qwen3_6ForConditionalGeneration",
-        "Qwen3_6MoeForConditionalGeneration",
-    }
-)
 _QWEN3_VL_MODEL_TYPES: frozenset[str] = frozenset({"qwen3_5", "qwen3_vl"})
 _QWEN3_VL_ARCHITECTURES: frozenset[str] = frozenset(
     {
@@ -239,19 +227,19 @@ class DefaultModelAdapter(ModelAdapter):
         marked multimodal even when served text-only, and both quantized
         families diverge under mlx_vlm.load() — FP8 fails on
         `*_weight_scale_inv` tensors, while MLX affine checkpoints load but,
-        for architectures with no native multimodal adapter, run the bare
-        language model with unset mrope state and generate garbled output.
-        Both route through the mlx_lm text loader instead; MLX-quant
-        wrappers covered by a native adapter keep the multimodal path.
+        unless the config exposes a real VL shape, run the bare language model
+        with unset mrope state and generate garbled output.  Both route through
+        the mlx_lm text loader instead; MLX-quant wrappers with a native VL
+        config keep the multimodal path.
         """
         if hf_config is None:
             return False
 
-        model_type = getattr(hf_config, "model_type", "")
+        model_type = hf_config.model_type
         if model_type in _TEXT_BACKBONE_OVERRIDE_TYPES:
             return True
 
-        architectures = getattr(hf_config, "architectures", ()) or ()
+        architectures = tuple(hf_config.architectures or ())
         if not any(
             arch in _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES for arch in architectures
         ):
@@ -264,15 +252,24 @@ class DefaultModelAdapter(ModelAdapter):
             quant_method = getattr(quantization_config, "quant_method", None)
         if quant_method == "fp8":
             return True
-        # MLX affine checkpoints carry a top-level `quantization` dict; only
-        # architectures without a native multimodal adapter are force-texted
-        # (see _MLX_QUANT_TEXT_BACKBONE_ARCHITECTURES).
-        if not any(
-            arch in _MLX_QUANT_TEXT_BACKBONE_ARCHITECTURES for arch in architectures
+        # MLX affine checkpoints carry a top-level `quantization` dict.  The
+        # same conditional-generation architecture string can describe a dense
+        # text wrapper or a real VL model, so keep native only when the config
+        # exposes the native VL contract.
+        mlx_quantization = getattr(hf_config, "quantization", None)
+        if not isinstance(mlx_quantization, dict) or "bits" not in mlx_quantization:
+            return False
+        return not self._has_native_qwen_vl_config(hf_config, model_type, architectures)
+
+    def _has_native_qwen_vl_config(
+        self, hf_config: Any, model_type: str, architectures: Sequence[str]
+    ) -> bool:
+        if not (
+            model_type in _QWEN3_VL_MODEL_TYPES
+            or any(arch in _QWEN3_VL_ARCHITECTURES for arch in architectures)
         ):
             return False
-        mlx_quantization = getattr(hf_config, "quantization", None)
-        return isinstance(mlx_quantization, dict) and "bits" in mlx_quantization
+        return getattr(hf_config, "vision_config", None) is not None
 
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether the current serve mode should use the text-only path.

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -250,15 +250,12 @@ class DefaultModelAdapter(ModelAdapter):
         if self._has_fp8_quantization_config(hf_config):
             return True
 
-        # MLX affine checkpoints carry a top-level `quantization` dict.  The
-        # same conditional-generation architecture string can describe a dense
-        # text wrapper or a real VL model, so keep native only when the config
-        # exposes the native VL contract.
-        if not self._has_mlx_quantized_weights(hf_config):
-            return False
-        return not self._has_native_qwen_vl_config(
-            hf_config, model_type_from_hf, architectures_from_hf
-        )
+        # MLX affine Qwen3.5/Qwen3.6 text wrappers may still carry a
+        # vision_config, but mlx_vlm drives those text-only checkpoints with
+        # unset mRoPE state and produces garbled output.  Real Qwen3-VL uses
+        # Qwen3VLForConditionalGeneration, which is not in the text-wrapper
+        # architecture set above and therefore keeps the native path.
+        return self._has_mlx_quantized_weights(hf_config)
 
     def _has_fp8_quantization_config(self, hf_config: Any) -> bool:
         quantization_config_from_hf = getattr(hf_config, "quantization_config", None)
@@ -272,19 +269,6 @@ class DefaultModelAdapter(ModelAdapter):
             isinstance(mlx_quantization_from_hf, dict)
             and "bits" in mlx_quantization_from_hf
         )
-
-    def _has_native_qwen_vl_config(
-        self,
-        hf_config: Any,
-        model_type_from_hf: str,
-        architectures_from_hf: Sequence[str],
-    ) -> bool:
-        if not (
-            model_type_from_hf in _QWEN3_VL_MODEL_TYPES
-            or any(arch in _QWEN3_VL_ARCHITECTURES for arch in architectures_from_hf)
-        ):
-            return False
-        return getattr(hf_config, "vision_config", None) is not None
 
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether the current serve mode should use the text-only path.

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -235,38 +235,48 @@ class DefaultModelAdapter(ModelAdapter):
         if hf_config is None:
             return False
 
-        model_type = hf_config.model_type
-        if model_type in _TEXT_BACKBONE_OVERRIDE_TYPES:
+        model_type_from_hf = hf_config.model_type
+        if model_type_from_hf in _TEXT_BACKBONE_OVERRIDE_TYPES:
             return True
 
-        architectures = tuple(hf_config.architectures or ())
+        architectures_from_hf = tuple(hf_config.architectures or ())
         if not any(
-            arch in _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES for arch in architectures
+            arch in _TEXT_BACKBONE_OVERRIDE_ARCHITECTURES
+            for arch in architectures_from_hf
         ):
             return False
 
-        quantization_config = getattr(hf_config, "quantization_config", None)
-        if isinstance(quantization_config, dict):
-            quant_method = quantization_config.get("quant_method")
+        quantization_config_from_hf = getattr(hf_config, "quantization_config", None)
+        if isinstance(quantization_config_from_hf, dict):
+            quant_method = quantization_config_from_hf.get("quant_method")
         else:
-            quant_method = getattr(quantization_config, "quant_method", None)
+            quant_method = getattr(quantization_config_from_hf, "quant_method", None)
         if quant_method == "fp8":
             return True
+
         # MLX affine checkpoints carry a top-level `quantization` dict.  The
         # same conditional-generation architecture string can describe a dense
         # text wrapper or a real VL model, so keep native only when the config
         # exposes the native VL contract.
-        mlx_quantization = getattr(hf_config, "quantization", None)
-        if not isinstance(mlx_quantization, dict) or "bits" not in mlx_quantization:
+        mlx_quantization_from_hf = getattr(hf_config, "quantization", None)
+        if (
+            not isinstance(mlx_quantization_from_hf, dict)
+            or "bits" not in mlx_quantization_from_hf
+        ):
             return False
-        return not self._has_native_qwen_vl_config(hf_config, model_type, architectures)
+        return not self._has_native_qwen_vl_config(
+            hf_config, model_type_from_hf, architectures_from_hf
+        )
 
     def _has_native_qwen_vl_config(
-        self, hf_config: Any, model_type: str, architectures: Sequence[str]
+        self,
+        hf_config: Any,
+        model_type_from_hf: str,
+        architectures_from_hf: Sequence[str],
     ) -> bool:
         if not (
-            model_type in _QWEN3_VL_MODEL_TYPES
-            or any(arch in _QWEN3_VL_ARCHITECTURES for arch in architectures)
+            model_type_from_hf in _QWEN3_VL_MODEL_TYPES
+            or any(arch in _QWEN3_VL_ARCHITECTURES for arch in architectures_from_hf)
         ):
             return False
         return getattr(hf_config, "vision_config", None) is not None


### PR DESCRIPTION
This PR is:

- To route dense Qwen3.5 MLX affine quant text wrappers through `mlx_lm`.
- To keep real Qwen VL MLX quant checkpoints on the native multimodal path when `vision_config` is present.
- To replace the architecture-only check with a clearer config-shape check.

Fixes #580.

Qwen3.5 dense text wrappers and real Qwen VL checkpoints can share `Qwen3_5ForConditionalGeneration`, so the architecture string alone is not enough. The routing now uses the checkpoint shape: MLX quant without `vision_config` uses the text path, while MLX quant with `vision_config` stays multimodal.