### PR TITLE
Reject eager checkpoint loaders under pipeline parallelism

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -114,7 +114,7 @@ curl -s http://10.0.0.1:8000/v1/completions -H 'Content-Type: application/json' 
   -d '{"model":"Qwen/Qwen3-0.6B","prompt":"The capital of France is","max_tokens":16,"temperature":0}'
 ```
 
-Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networksetup -setdhcp "Thunderbolt Bridge"`. Once the small model works end to end, try larger models across the two Macs (each stage still loads the full model first — see [Limitations](#limitations)).
+Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networksetup -setdhcp "Thunderbolt Bridge"`. Once the small model works end to end, try larger native MLX safetensors models across the two Macs (see [Limitations](#limitations)).
 
 `VLLM_HOST_IP` is the load-bearing piece: it makes vLLM's `get_ip()` return the Thunderbolt address, so the cross-stage hand-off forms over the cable.
 
@@ -158,7 +158,7 @@ mlx.launch -n 2 --backend ring tools/pp_parity_check.py Qwen/Qwen3-0.6B
 
 ## Limitations
 
-- **Peak memory = full model per node.** Each stage loads the whole model before dropping its non-owned layers, so Phase 0 splits compute, not load-time memory — it can't serve a model too large for one Mac.
+- **Checkpoint loading.** Native MLX safetensors load lazily, then each stage drops its non-owned transformer layers before materialization. AWQ and GGUF are rejected under PP because their loaders still materialize the complete model on every stage before slicing.
 - **Co-located stages oversubscribe the KV budget.** Each stage applies `VLLM_METAL_MEMORY_FRACTION` to the whole device independently — neither knows the other exists — so two stages on one Mac claim roughly twice the fraction. Lower it when stacking. Separate Macs are unaffected.
 - **Synchronous scheduling required.** Run with `--no-async-scheduling` (the engine fails loud otherwise).
 - **TP=1 only.** PP+TP is rejected; tensor parallelism (`--tensor-parallel-size > 1`) is not implemented.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -114,7 +114,7 @@ curl -s http://10.0.0.1:8000/v1/completions -H 'Content-Type: application/json' 
   -d '{"model":"Qwen/Qwen3-0.6B","prompt":"The capital of France is","max_tokens":16,"temperature":0}'
 ```
 
-Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networksetup -setdhcp "Thunderbolt Bridge"`. Once the small model works end to end, try larger supported MLX-LM safetensors models across the two Macs (see [Limitations](#limitations)).
+Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networksetup -setdhcp "Thunderbolt Bridge"`. Once the small model works end to end, try larger models across the two Macs.
 
 `VLLM_HOST_IP` is the load-bearing piece: it makes vLLM's `get_ip()` return the Thunderbolt address, so the cross-stage hand-off forms over the cable.
 
@@ -158,7 +158,7 @@ mlx.launch -n 2 --backend ring tools/pp_parity_check.py Qwen/Qwen3-0.6B
 
 ## Limitations
 
-- **Checkpoint loading.** Supported text-only MLX-LM safetensors load lazily, then each stage drops its non-owned transformer layers before materialization. AWQ and GGUF are rejected under PP because their loaders still materialize the complete model on every stage before slicing.
+- **Checkpoint loading.** PP lazily slices MLX-LM safetensors; AWQ and GGUF are rejected because their loaders materialize the full model before slicing.
 - **Co-located stages oversubscribe the KV budget.** Each stage applies `VLLM_METAL_MEMORY_FRACTION` to the whole device independently — neither knows the other exists — so two stages on one Mac claim roughly twice the fraction. Lower it when stacking. Separate Macs are unaffected.
 - **Synchronous scheduling required.** Run with `--no-async-scheduling` (the engine fails loud otherwise).
 - **TP=1 only.** PP+TP is rejected; tensor parallelism (`--tensor-parallel-size > 1`) is not implemented.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -114,7 +114,7 @@ curl -s http://10.0.0.1:8000/v1/completions -H 'Content-Type: application/json' 
   -d '{"model":"Qwen/Qwen3-0.6B","prompt":"The capital of France is","max_tokens":16,"temperature":0}'
 ```
 
-Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networksetup -setdhcp "Thunderbolt Bridge"`. Once the small model works end to end, try larger native MLX safetensors models across the two Macs (see [Limitations](#limitations)).
+Tear down with `ray stop` on **both** Macs, then revert the bridge: `sudo networksetup -setdhcp "Thunderbolt Bridge"`. Once the small model works end to end, try larger supported MLX-LM safetensors models across the two Macs (see [Limitations](#limitations)).
 
 `VLLM_HOST_IP` is the load-bearing piece: it makes vLLM's `get_ip()` return the Thunderbolt address, so the cross-stage hand-off forms over the cable.
 
@@ -158,7 +158,7 @@ mlx.launch -n 2 --backend ring tools/pp_parity_check.py Qwen/Qwen3-0.6B
 
 ## Limitations
 
-- **Checkpoint loading.** Native MLX safetensors load lazily, then each stage drops its non-owned transformer layers before materialization. AWQ and GGUF are rejected under PP because their loaders still materialize the complete model on every stage before slicing.
+- **Checkpoint loading.** Supported text-only MLX-LM safetensors load lazily, then each stage drops its non-owned transformer layers before materialization. AWQ and GGUF are rejected under PP because their loaders still materialize the complete model on every stage before slicing.
 - **Co-located stages oversubscribe the KV budget.** Each stage applies `VLLM_METAL_MEMORY_FRACTION` to the whole device independently — neither knows the other exists — so two stages on one Mac claim roughly twice the fraction. Lower it when stacking. Separate Macs are unaffected.
 - **Synchronous scheduling required.** Run with `--no-async-scheduling` (the engine fails loud otherwise).
 - **TP=1 only.** PP+TP is rejected; tensor parallelism (`--tensor-parallel-size > 1`) is not implemented.

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -446,6 +446,11 @@ class TestModelLifecycle:
         text_tokenizer = object()
         vlm_model = _qwen35_vlm_model()
         vlm_tokenizer = object()
+        vlm_lazy: list[bool] = []
+
+        def _load_vlm(_model_name: str, *, lazy: bool) -> tuple[object, object]:
+            vlm_lazy.append(lazy)
+            return vlm_model, vlm_tokenizer
 
         class _StubAWQLoader:
             @classmethod
@@ -458,11 +463,7 @@ class TestModelLifecycle:
             "mlx_lm_load",
             lambda *_args, **_kwargs: (text_model, text_tokenizer),
         )
-        monkeypatch.setattr(
-            model_lifecycle,
-            "mlx_vlm_load",
-            lambda _model_name: (vlm_model, vlm_tokenizer),
-        )
+        monkeypatch.setattr(model_lifecycle, "mlx_vlm_load", _load_vlm)
 
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
@@ -488,11 +489,13 @@ class TestModelLifecycle:
                 is_multimodal_model=True,
             )
         )
+        runner.pp = PipelineGroup(SimpleNamespace(rank=lambda: 0, size=lambda: 2))
         lifecycle.load()
 
         assert runner.model is vlm_model
         assert runner.tokenizer is vlm_tokenizer
         assert runner._is_vlm is True
+        assert vlm_lazy == [True]
 
     @pytest.mark.slow
     def test_load_auto_mode_real_qwen_fp8_checkpoint(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -438,32 +438,28 @@ class TestModelLifecycle:
         assert runner._multimodal_adapter is None
         assert runner.encoder_cache is None
 
-    def test_load_separates_text_and_vlm_loader_paths(
+    def test_load_forced_text_backbone_uses_mlx_lm_loader(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         text_model = SimpleNamespace(config=_text_config())
         text_tokenizer = object()
-        vlm_model = _qwen35_vlm_model()
-        vlm_tokenizer = object()
-        vlm_lazy: list[bool] = []
-
-        def _load_vlm(_model_name: str, *, lazy: bool) -> tuple[object, object]:
-            vlm_lazy.append(lazy)
-            return vlm_model, vlm_tokenizer
 
         class _StubAWQLoader:
             @classmethod
             def for_model(cls, _model_name: str) -> None:
                 return None
 
+        def _load_text(
+            _model_name: str,
+            *,
+            tokenizer_config: object,
+            lazy: bool,
+        ) -> tuple[object, object]:
+            return text_model, text_tokenizer
+
         monkeypatch.setattr(model_lifecycle, "AWQQuantLoader", _StubAWQLoader)
-        monkeypatch.setattr(
-            model_lifecycle,
-            "mlx_lm_load",
-            lambda *_args, **_kwargs: (text_model, text_tokenizer),
-        )
-        monkeypatch.setattr(model_lifecycle, "mlx_vlm_load", _load_vlm)
+        monkeypatch.setattr(model_lifecycle, "mlx_lm_load", _load_text)
 
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
@@ -477,8 +473,22 @@ class TestModelLifecycle:
         assert runner.tokenizer is text_tokenizer
         assert runner._is_vlm is False
 
+    def test_load_vlm_pipeline_parallel_uses_mlx_vlm_lazy_loading(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        vlm_model = _qwen35_vlm_model()
+        vlm_tokenizer = object()
+        vlm_lazy: list[bool] = []
+
+        def _load_vlm(_model_name: str, *, lazy: bool) -> tuple[object, object]:
+            vlm_lazy.append(lazy)
+            return vlm_model, vlm_tokenizer
+
+        monkeypatch.setattr(model_lifecycle, "mlx_vlm_load", _load_vlm)
         monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "multimodal-native")
         reset_config()
+
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
                 hf_config=SimpleNamespace(

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -137,7 +137,10 @@ class TestMetalPlatform:
                 tensor_parallel_size=2,
                 disable_custom_all_reduce=False,
             ),
-            model_config=None,
+            model_config=SimpleNamespace(
+                is_hybrid=False,
+                quantization="auto_awq",
+            ),
         )
         with pytest.raises(
             NotImplementedError, match="alone or combined with pipeline"
@@ -578,7 +581,10 @@ class TestMetalPlatform:
             NotImplementedError, match="combining data parallelism with"
         ):
             MetalPlatform.check_and_update_config(
-                self._dp_vllm_config(parallel={"pipeline_parallel_size": 2})
+                self._dp_vllm_config(
+                    parallel={"pipeline_parallel_size": 2},
+                    model={"quantization": "gguf"},
+                )
             )
 
     def test_check_and_update_config_rejects_dp_speculative_decoding(self) -> None:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -110,7 +110,7 @@ class TestMetalPlatform:
             MetalPlatform.check_and_update_config(vllm_config)
 
     @pytest.mark.parametrize(
-        ("quantization", "multimodal_config", "should_reject"),
+        ("quantization", "multimodal_config", "rejects_pp"),
         [
             (None, None, False),
             ("auto_awq", None, True),
@@ -119,12 +119,12 @@ class TestMetalPlatform:
         ],
         ids=["safetensors", "text-awq", "text-gguf", "multimodal-awq"],
     )
-    def test_check_and_update_config_allows_pipeline_parallel(
+    def test_check_and_update_config_handles_pipeline_loader_routes(
         self,
         monkeypatch: pytest.MonkeyPatch,
         quantization: str | None,
         multimodal_config: SimpleNamespace | None,
-        should_reject: bool,
+        rejects_pp: bool,
     ) -> None:
         """PP admits lazy loaders and rejects proven eager text loaders."""
         self._patch_stt_resolution(monkeypatch, is_stt=False)
@@ -160,8 +160,6 @@ class TestMetalPlatform:
                     is_hybrid=False,
                     quantization=quantization,
                 ),
-                # PP requires synchronous scheduling: the first stage has no
-                # sampler and rebuilds tokens from the scheduler.
                 scheduler_config=SimpleNamespace(
                     async_scheduling=False,
                     enable_chunked_prefill=True,
@@ -172,17 +170,15 @@ class TestMetalPlatform:
                 lora_config=None,
             )
 
-            if should_reject:
+            if rejects_pp:
                 with pytest.raises(
                     NotImplementedError, match=r"AWQ or GGUF.*pipeline_parallel_size=1"
                 ):
                     MetalPlatform.check_and_update_config(vllm_config)
                 return
 
-            # Does not raise: PP>1 with TP=1 and sync scheduling falls through.
             MetalPlatform.check_and_update_config(vllm_config)
 
-            # "uni" cannot host two stages, so PP>1 defaults to the mp executor.
             assert vllm_config.parallel_config.distributed_executor_backend == "mp"
             assert (
                 vllm_config.parallel_config.worker_cls

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -109,13 +109,24 @@ class TestMetalPlatform:
         ):
             MetalPlatform.check_and_update_config(vllm_config)
 
-    @pytest.mark.parametrize("quantization", [None, "auto_awq", "gguf"])
+    @pytest.mark.parametrize(
+        ("quantization", "multimodal_config", "should_reject"),
+        [
+            (None, None, False),
+            ("auto_awq", None, True),
+            ("gguf", None, True),
+            ("auto_awq", SimpleNamespace(), False),
+        ],
+        ids=["safetensors", "text-awq", "text-gguf", "multimodal-awq"],
+    )
     def test_check_and_update_config_allows_pipeline_parallel(
         self,
         monkeypatch: pytest.MonkeyPatch,
         quantization: str | None,
+        multimodal_config: SimpleNamespace | None,
+        should_reject: bool,
     ) -> None:
-        """PP admits lazy MLX-LM loading and rejects proven eager loaders."""
+        """PP admits lazy loaders and rejects proven eager text loaders."""
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
         reset_config()
@@ -137,8 +148,15 @@ class TestMetalPlatform:
                     disable_cascade_attn=False,
                     tokenizer=None,
                     max_model_len=32768,
-                    multimodal_config=None,
-                    hf_config=SimpleNamespace(model_type="qwen3"),
+                    multimodal_config=multimodal_config,
+                    hf_config=(
+                        SimpleNamespace(
+                            model_type="qwen3_vl",
+                            architectures=["Qwen3VLForConditionalGeneration"],
+                        )
+                        if multimodal_config is not None
+                        else SimpleNamespace(model_type="qwen3")
+                    ),
                     is_hybrid=False,
                     quantization=quantization,
                 ),
@@ -154,7 +172,7 @@ class TestMetalPlatform:
                 lora_config=None,
             )
 
-            if quantization is not None:
+            if should_reject:
                 with pytest.raises(
                     NotImplementedError, match=r"AWQ or GGUF.*pipeline_parallel_size=1"
                 ):

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -34,6 +34,41 @@ class TestMetalPlatform:
     """Tests for MetalPlatform class."""
 
     @staticmethod
+    def _pp_vllm_config(*, quantization: str | None = None) -> SimpleNamespace:
+        """Return a complete, supported PP config with one loader override."""
+        return SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                worker_cls="auto",
+                distributed_executor_backend="auto",
+                pipeline_parallel_size=2,
+                tensor_parallel_size=1,
+                disable_custom_all_reduce=False,
+            ),
+            cache_config=SimpleNamespace(
+                kv_cache_dtype_skip_layers=[],
+                block_size=None,
+            ),
+            model_config=SimpleNamespace(
+                model="test-model",
+                disable_cascade_attn=False,
+                tokenizer=None,
+                max_model_len=32768,
+                multimodal_config=None,
+                hf_config=SimpleNamespace(model_type="qwen3"),
+                is_hybrid=False,
+                quantization=quantization,
+            ),
+            scheduler_config=SimpleNamespace(
+                async_scheduling=False,
+                enable_chunked_prefill=True,
+                max_num_batched_tokens=2048,
+                max_num_scheduled_tokens=None,
+            ),
+            speculative_config=None,
+            lora_config=None,
+        )
+
+    @staticmethod
     def _patch_stt_resolution(
         monkeypatch: pytest.MonkeyPatch,
         *,
@@ -109,47 +144,22 @@ class TestMetalPlatform:
         ):
             MetalPlatform.check_and_update_config(vllm_config)
 
-    def test_check_and_update_config_allows_pipeline_parallel(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize(
+        "quantization",
+        [None, "fp8"],
+        ids=["mlx-lm", "mlx-lm-fp8"],
+    )
+    def test_check_and_update_config_allows_lazy_pipeline_loader(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        quantization: str | None,
     ) -> None:
-        """PP>1 with TP=1 is allowed and selects the multiproc executor."""
+        """PP>1 admits MLX loaders that remain lazy until stage slicing."""
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
         reset_config()
         try:
-            vllm_config = SimpleNamespace(
-                parallel_config=SimpleNamespace(
-                    worker_cls="auto",
-                    distributed_executor_backend="auto",
-                    pipeline_parallel_size=2,
-                    tensor_parallel_size=1,
-                    disable_custom_all_reduce=False,
-                ),
-                cache_config=SimpleNamespace(
-                    kv_cache_dtype_skip_layers=[],
-                    block_size=None,
-                ),
-                model_config=SimpleNamespace(
-                    model="test-model",
-                    disable_cascade_attn=False,
-                    tokenizer=None,
-                    max_model_len=32768,
-                    multimodal_config=None,
-                    hf_config=SimpleNamespace(model_type="qwen3"),
-                    is_hybrid=False,
-                ),
-                # PP requires synchronous scheduling: the first stage has no
-                # sampler and rebuilds tokens from the scheduler, so a valid PP
-                # config sets async_scheduling False (see the reject test below).
-                scheduler_config=SimpleNamespace(
-                    async_scheduling=False,
-                    enable_chunked_prefill=True,
-                    max_num_batched_tokens=2048,
-                    max_num_scheduled_tokens=None,
-                ),
-                speculative_config=None,
-                lora_config=None,
-            )
+            vllm_config = self._pp_vllm_config(quantization=quantization)
 
             # Does not raise: PP>1 with TP=1 and sync scheduling falls through.
             MetalPlatform.check_and_update_config(vllm_config)
@@ -160,6 +170,31 @@ class TestMetalPlatform:
                 vllm_config.parallel_config.worker_cls
                 == "vllm_metal.v1.worker.MetalWorker"
             )
+        finally:
+            reset_config()
+
+    @pytest.mark.parametrize(
+        ("quantization", "loader_name"),
+        [("auto_awq", "AWQ"), ("gguf", "GGUF")],
+    )
+    def test_check_and_update_config_rejects_eager_pipeline_loader(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        quantization: str,
+        loader_name: str,
+    ) -> None:
+        """PP rejects loaders that materialize every stage's complete model."""
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        reset_config()
+        try:
+            vllm_config = self._pp_vllm_config(quantization=quantization)
+
+            with pytest.raises(
+                NotImplementedError,
+                match=rf"{loader_name}.*pipeline_parallel_size=1",
+            ):
+                MetalPlatform.check_and_update_config(vllm_config)
         finally:
             reset_config()
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -35,7 +35,7 @@ class TestMetalPlatform:
 
     @staticmethod
     def _pp_vllm_config(*, quantization: str | None = None) -> SimpleNamespace:
-        """Return a complete, supported PP config with one loader override."""
+        """Return an otherwise valid PP config with one loader override."""
         return SimpleNamespace(
             parallel_config=SimpleNamespace(
                 worker_cls="auto",
@@ -315,6 +315,7 @@ class TestMetalPlatform:
                 multimodal_config=None,
                 hf_config=SimpleNamespace(model_type="whisper"),
                 is_hybrid=False,
+                quantization=None,
             ),
             scheduler_config=SimpleNamespace(
                 async_scheduling=False,
@@ -417,6 +418,7 @@ class TestMetalPlatform:
             "max_model_len": 32768,
             "hf_config": SimpleNamespace(model_type="qwen3"),
             "is_hybrid": False,
+            "quantization": None,
         }
         model_fields.update(model or {})
         return SimpleNamespace(

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -34,41 +34,6 @@ class TestMetalPlatform:
     """Tests for MetalPlatform class."""
 
     @staticmethod
-    def _pp_vllm_config(*, quantization: str | None = None) -> SimpleNamespace:
-        """Return an otherwise valid PP config with one loader override."""
-        return SimpleNamespace(
-            parallel_config=SimpleNamespace(
-                worker_cls="auto",
-                distributed_executor_backend="auto",
-                pipeline_parallel_size=2,
-                tensor_parallel_size=1,
-                disable_custom_all_reduce=False,
-            ),
-            cache_config=SimpleNamespace(
-                kv_cache_dtype_skip_layers=[],
-                block_size=None,
-            ),
-            model_config=SimpleNamespace(
-                model="test-model",
-                disable_cascade_attn=False,
-                tokenizer=None,
-                max_model_len=32768,
-                multimodal_config=None,
-                hf_config=SimpleNamespace(model_type="qwen3"),
-                is_hybrid=False,
-                quantization=quantization,
-            ),
-            scheduler_config=SimpleNamespace(
-                async_scheduling=False,
-                enable_chunked_prefill=True,
-                max_num_batched_tokens=2048,
-                max_num_scheduled_tokens=None,
-            ),
-            speculative_config=None,
-            lora_config=None,
-        )
-
-    @staticmethod
     def _patch_stt_resolution(
         monkeypatch: pytest.MonkeyPatch,
         *,
@@ -137,32 +102,64 @@ class TestMetalPlatform:
                 tensor_parallel_size=2,
                 disable_custom_all_reduce=False,
             ),
-            model_config=SimpleNamespace(
-                is_hybrid=False,
-                quantization="auto_awq",
-            ),
+            model_config=None,
         )
         with pytest.raises(
             NotImplementedError, match="alone or combined with pipeline"
         ):
             MetalPlatform.check_and_update_config(vllm_config)
 
-    @pytest.mark.parametrize(
-        "quantization",
-        [None, "fp8"],
-        ids=["mlx-lm", "mlx-lm-fp8"],
-    )
-    def test_check_and_update_config_allows_lazy_pipeline_loader(
+    @pytest.mark.parametrize("quantization", [None, "auto_awq", "gguf"])
+    def test_check_and_update_config_allows_pipeline_parallel(
         self,
         monkeypatch: pytest.MonkeyPatch,
         quantization: str | None,
     ) -> None:
-        """PP>1 admits MLX loaders that remain lazy until stage slicing."""
+        """PP admits lazy MLX-LM loading and rejects proven eager loaders."""
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
         reset_config()
         try:
-            vllm_config = self._pp_vllm_config(quantization=quantization)
+            vllm_config = SimpleNamespace(
+                parallel_config=SimpleNamespace(
+                    worker_cls="auto",
+                    distributed_executor_backend="auto",
+                    pipeline_parallel_size=2,
+                    tensor_parallel_size=1,
+                    disable_custom_all_reduce=False,
+                ),
+                cache_config=SimpleNamespace(
+                    kv_cache_dtype_skip_layers=[],
+                    block_size=None,
+                ),
+                model_config=SimpleNamespace(
+                    model="test-model",
+                    disable_cascade_attn=False,
+                    tokenizer=None,
+                    max_model_len=32768,
+                    multimodal_config=None,
+                    hf_config=SimpleNamespace(model_type="qwen3"),
+                    is_hybrid=False,
+                    quantization=quantization,
+                ),
+                # PP requires synchronous scheduling: the first stage has no
+                # sampler and rebuilds tokens from the scheduler.
+                scheduler_config=SimpleNamespace(
+                    async_scheduling=False,
+                    enable_chunked_prefill=True,
+                    max_num_batched_tokens=2048,
+                    max_num_scheduled_tokens=None,
+                ),
+                speculative_config=None,
+                lora_config=None,
+            )
+
+            if quantization is not None:
+                with pytest.raises(
+                    NotImplementedError, match=r"AWQ or GGUF.*pipeline_parallel_size=1"
+                ):
+                    MetalPlatform.check_and_update_config(vllm_config)
+                return
 
             # Does not raise: PP>1 with TP=1 and sync scheduling falls through.
             MetalPlatform.check_and_update_config(vllm_config)
@@ -173,31 +170,6 @@ class TestMetalPlatform:
                 vllm_config.parallel_config.worker_cls
                 == "vllm_metal.v1.worker.MetalWorker"
             )
-        finally:
-            reset_config()
-
-    @pytest.mark.parametrize(
-        ("quantization", "loader_name"),
-        [("auto_awq", "AWQ"), ("gguf", "GGUF")],
-    )
-    def test_check_and_update_config_rejects_eager_pipeline_loader(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        quantization: str,
-        loader_name: str,
-    ) -> None:
-        """PP rejects loaders that materialize every stage's complete model."""
-        self._patch_stt_resolution(monkeypatch, is_stt=False)
-        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
-        reset_config()
-        try:
-            vllm_config = self._pp_vllm_config(quantization=quantization)
-
-            with pytest.raises(
-                NotImplementedError,
-                match=rf"{loader_name}.*pipeline_parallel_size=1",
-            ):
-                MetalPlatform.check_and_update_config(vllm_config)
         finally:
             reset_config()
 
@@ -421,7 +393,6 @@ class TestMetalPlatform:
             "max_model_len": 32768,
             "hf_config": SimpleNamespace(model_type="qwen3"),
             "is_hybrid": False,
-            "quantization": None,
         }
         model_fields.update(model or {})
         return SimpleNamespace(
@@ -581,10 +552,7 @@ class TestMetalPlatform:
             NotImplementedError, match="combining data parallelism with"
         ):
             MetalPlatform.check_and_update_config(
-                self._dp_vllm_config(
-                    parallel={"pipeline_parallel_size": 2},
-                    model={"quantization": "gguf"},
-                )
+                self._dp_vllm_config(parallel={"pipeline_parallel_size": 2})
             )
 
     def test_check_and_update_config_rejects_dp_speculative_decoding(self) -> None:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -290,7 +290,6 @@ class TestMetalPlatform:
                 multimodal_config=None,
                 hf_config=SimpleNamespace(model_type="whisper"),
                 is_hybrid=False,
-                quantization=None,
             ),
             scheduler_config=SimpleNamespace(
                 async_scheduling=False,

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -608,23 +608,16 @@ class MetalPlatform(Platform):
             # rejections (multimodal, STT) further below, so an unsupported DP
             # config fails fast before any ray.init side effect.
 
-        # A stage can prune non-owned weights before materialization only when
-        # its loader preserves MLX's lazy arrays. The generic mlx_lm path does;
-        # AWQ's checkpoint-wide repack and the custom GGUF load do not. Keep
-        # this after the topology guards above so TP and DP+PP configurations
-        # retain their more fundamental, actionable errors. vLLM 0.26
-        # normalizes AWQ to auto_awq; the Metal GGUF integration registers gguf.
-        eager_loader = None
-        if parallel_config.pipeline_parallel_size > 1 and model_config is not None:
-            if model_config.quantization == "gguf":
-                eager_loader = "GGUF"
-            elif model_config.quantization == "auto_awq":
-                eager_loader = "AWQ"
-        if eager_loader is not None:
+        # AWQ and GGUF materialize the full checkpoint before stage slicing.
+        if (
+            parallel_config.pipeline_parallel_size > 1
+            and model_config is not None
+            and model_config.quantization in ("auto_awq", "gguf")
+        ):
             raise NotImplementedError(
-                f"Pipeline parallelism does not support {eager_loader} "
-                "checkpoints because the loader materializes the complete model "
-                "on every stage before stage slicing. Use "
+                "Pipeline parallelism does not support AWQ or GGUF checkpoints "
+                "because their loaders materialize the complete model on every "
+                "stage before stage slicing. Use "
                 "pipeline_parallel_size=1 or an MLX-LM safetensors checkpoint."
             )
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -511,27 +511,6 @@ class MetalPlatform(Platform):
                     f"{max_port}"
                 )
 
-            # A stage can prune non-owned weights before materialization only
-            # when its loader preserves MLX's lazy arrays. The generic mlx_lm
-            # path does; AWQ's checkpoint-wide repack and the custom GGUF load
-            # do not. Reject those exact owners before spawning one eager full-
-            # model load per stage. vLLM 0.26 normalizes AWQ to auto_awq while
-            # the Metal GGUF integration registers gguf directly.
-            eager_loader = None
-            if model_config is not None:
-                if model_config.quantization == "gguf":
-                    eager_loader = "GGUF"
-                elif model_config.quantization == "auto_awq":
-                    eager_loader = "AWQ"
-            if eager_loader is not None:
-                raise NotImplementedError(
-                    f"Pipeline parallelism does not support {eager_loader} "
-                    "checkpoints because the loader materializes the complete "
-                    "model on every stage before stage slicing. Use "
-                    "pipeline_parallel_size=1 or a native MLX safetensors "
-                    "checkpoint."
-                )
-
         # Tensor parallelism is not supported on Metal/MLX yet: a single Apple
         # GPU per node cannot shard a TP>1 model, and there is no cross-device
         # collective wired in (mx.distributed). Only TP=1 is validated. Reject
@@ -628,6 +607,26 @@ class MetalPlatform(Platform):
             # NB: the Ray job-level hook is registered only AFTER the remaining DP
             # rejections (multimodal, STT) further below, so an unsupported DP
             # config fails fast before any ray.init side effect.
+
+        # A stage can prune non-owned weights before materialization only when
+        # its loader preserves MLX's lazy arrays. The generic mlx_lm path does;
+        # AWQ's checkpoint-wide repack and the custom GGUF load do not. Keep
+        # this after the topology guards above so TP and DP+PP configurations
+        # retain their more fundamental, actionable errors. vLLM 0.26
+        # normalizes AWQ to auto_awq; the Metal GGUF integration registers gguf.
+        eager_loader = None
+        if parallel_config.pipeline_parallel_size > 1 and model_config is not None:
+            if model_config.quantization == "gguf":
+                eager_loader = "GGUF"
+            elif model_config.quantization == "auto_awq":
+                eager_loader = "AWQ"
+        if eager_loader is not None:
+            raise NotImplementedError(
+                f"Pipeline parallelism does not support {eager_loader} "
+                "checkpoints because the loader materializes the complete model "
+                "on every stage before stage slicing. Use "
+                "pipeline_parallel_size=1 or an MLX-LM safetensors checkpoint."
+            )
 
         scheduler_config = vllm_config.scheduler_config
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -511,6 +511,27 @@ class MetalPlatform(Platform):
                     f"{max_port}"
                 )
 
+            # A stage can prune non-owned weights before materialization only
+            # when its loader preserves MLX's lazy arrays. The generic mlx_lm
+            # path does; AWQ's checkpoint-wide repack and the custom GGUF load
+            # do not. Reject those exact owners before spawning one eager full-
+            # model load per stage. vLLM 0.26 normalizes AWQ to auto_awq while
+            # the Metal GGUF integration registers gguf directly.
+            eager_loader = None
+            if model_config is not None:
+                if model_config.quantization == "gguf":
+                    eager_loader = "GGUF"
+                elif model_config.quantization == "auto_awq":
+                    eager_loader = "AWQ"
+            if eager_loader is not None:
+                raise NotImplementedError(
+                    f"Pipeline parallelism does not support {eager_loader} "
+                    "checkpoints because the loader materializes the complete "
+                    "model on every stage before stage slicing. Use "
+                    "pipeline_parallel_size=1 or a native MLX safetensors "
+                    "checkpoint."
+                )
+
         # Tensor parallelism is not supported on Metal/MLX yet: a single Apple
         # GPU per node cannot shard a TP>1 model, and there is no cross-device
         # collective wired in (mx.distributed). Only TP=1 is validated. Reject

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -608,19 +608,6 @@ class MetalPlatform(Platform):
             # rejections (multimodal, STT) further below, so an unsupported DP
             # config fails fast before any ray.init side effect.
 
-        # AWQ and GGUF materialize the full checkpoint before stage slicing.
-        if (
-            parallel_config.pipeline_parallel_size > 1
-            and model_config is not None
-            and model_config.quantization in ("auto_awq", "gguf")
-        ):
-            raise NotImplementedError(
-                "Pipeline parallelism does not support AWQ or GGUF checkpoints "
-                "because their loaders materialize the complete model on every "
-                "stage before stage slicing. Use "
-                "pipeline_parallel_size=1 or an MLX-LM safetensors checkpoint."
-            )
-
         scheduler_config = vllm_config.scheduler_config
 
         # Pipeline parallelism relays each sampled token to the first stage via the
@@ -762,6 +749,21 @@ class MetalPlatform(Platform):
             if was_async_scheduling and not scheduler_config.async_scheduling:
                 logger.info("STT: disabled async_scheduling")
             logger.info("STT model detected")
+
+        # The text AWQ and GGUF loaders materialize the full checkpoint before
+        # stage slicing. Multimodal and STT models take different loader paths.
+        if (
+            parallel_config.pipeline_parallel_size > 1
+            and model_config is not None
+            and model_config.multimodal_config is None
+            and model_config.quantization in ("auto_awq", "gguf")
+        ):
+            raise NotImplementedError(
+                "Pipeline parallelism does not support AWQ or GGUF checkpoints "
+                "because their loaders materialize the complete model on every "
+                "stage before stage slicing. Use "
+                "pipeline_parallel_size=1 or an MLX-LM safetensors checkpoint."
+            )
 
         # Data parallelism passed every admission guard above (including the
         # multimodal and STT rejections). Only now — after all fail-fasts, before

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -82,8 +82,8 @@ class GenerationLoadRequest:
         gguf_source = None if is_vlm else GGUFLoadSource.from_model_config(model_config)
 
         # A pipeline-parallel stage prunes its non-owned layers right after load, so
-        # the generic mlx_lm weights load lazily and per-stage peak stays owned-only.
-        # Only the mlx_lm path honors this; GGUF/AWQ/VLM ignore it and load eager.
+        # the generic MLX loaders stay lazy until the stage-owned weights are known.
+        # The custom GGUF and AWQ loaders cannot honor this contract.
         pp = runner.pp
         lazy_weights = pp is not None and pp.size > 1
 
@@ -204,7 +204,7 @@ class ModelLifecycle:
 
         elif is_vlm:
             load_label = "MLX-VLM model"
-            model, tokenizer = mlx_vlm_load(model_name)
+            model, tokenizer = mlx_vlm_load(model_name, lazy=lazy_weights)
 
         elif awq_loader is not None:
             load_label = "AWQ model"


### PR DESCRIPTION
This PR is:

- To reject pipeline parallelism with text AWQ and GGUF checkpoints before workers allocate model weights.
- To keep lazy MLX-LM and MLX-VLM load paths available under pipeline parallelism.
- To document the loader limitation and cover the admission behavior.

Note:

AWQ and GGUF text loaders materialize the full checkpoint before stage slicing, so PP can still OOM before it reduces per-stage memory. Users should use `pipeline_parallel_size=1` or an MLX-LM safetensors checkpoint.
