### PR TITLE
Stop defaulting MLX buffer memory limit

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,13 +19,13 @@
 
 ## MLX Command-Buffer Defaults
 
-On macOS the plugin defaults `MLX_MAX_OPS_PER_BUFFER` and
-`MLX_MAX_MB_PER_BUFFER` to `2000` via `setdefault`, so a value you export
-yourself always wins; the two limits default independently, so setting
-one keeps the plugin default for the other. MLX's own defaults are sized for small generate
-loops; a vLLM decode step on a large MoE model builds thousands of lazy
-ops per step, and the resulting per-buffer commit overhead slows the step
-submit. `2000` sits on the measured plateau. Outputs are unaffected.
+On macOS the plugin defaults `MLX_MAX_OPS_PER_BUFFER` to `2000` via
+`setdefault`, so a value you export yourself always wins. MLX's own default is
+sized for small generate loops; a vLLM decode step on a large MoE model builds
+thousands of lazy ops per step, and the resulting per-buffer commit overhead
+slows the step submit. `2000` sits on the measured plateau. The plugin does not
+default `MLX_MAX_MB_PER_BUFFER`; large global MB limits can inflate startup
+profile memory and reduce the KV budget. Outputs are unaffected.
 
 ## Multimodal Serve Modes
 

--- a/tests/test_macos_defaults.py
+++ b/tests/test_macos_defaults.py
@@ -6,8 +6,6 @@ import logging
 import os
 import sys
 
-import pytest
-
 import vllm_metal as vm
 
 
@@ -35,7 +33,7 @@ def test_apply_macos_defaults_noop_on_non_macos(monkeypatch) -> None:
     assert "VLLM_WORKER_MULTIPROC_METHOD" not in os.environ
 
 
-def test_apply_mlx_buffer_defaults_sets_both_limits(monkeypatch) -> None:
+def test_apply_mlx_buffer_defaults_sets_ops_limit_only(monkeypatch) -> None:
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.delenv("MLX_MAX_OPS_PER_BUFFER", raising=False)
     monkeypatch.delenv("MLX_MAX_MB_PER_BUFFER", raising=False)
@@ -43,7 +41,7 @@ def test_apply_mlx_buffer_defaults_sets_both_limits(monkeypatch) -> None:
     vm._apply_mlx_buffer_defaults()
 
     assert os.environ["MLX_MAX_OPS_PER_BUFFER"] == "2000"
-    assert os.environ["MLX_MAX_MB_PER_BUFFER"] == "2000"
+    assert "MLX_MAX_MB_PER_BUFFER" not in os.environ
 
 
 def test_apply_mlx_buffer_defaults_respects_user_values(monkeypatch) -> None:
@@ -57,26 +55,17 @@ def test_apply_mlx_buffer_defaults_respects_user_values(monkeypatch) -> None:
     assert os.environ["MLX_MAX_MB_PER_BUFFER"] == "128"
 
 
-@pytest.mark.parametrize(
-    ("kept", "defaulted"),
-    [
-        ("MLX_MAX_OPS_PER_BUFFER", "MLX_MAX_MB_PER_BUFFER"),
-        ("MLX_MAX_MB_PER_BUFFER", "MLX_MAX_OPS_PER_BUFFER"),
-    ],
-)
-def test_apply_mlx_buffer_defaults_defaults_each_var_independently(
-    monkeypatch, kept: str, defaulted: str
+def test_apply_mlx_buffer_defaults_preserves_user_mb_limit(
+    monkeypatch,
 ) -> None:
-    # The two limits are independent split thresholds: a user tuning one
-    # keeps it, and the other still gets the plugin default.
     monkeypatch.setattr(sys, "platform", "darwin")
-    monkeypatch.setenv(kept, "50")
-    monkeypatch.delenv(defaulted, raising=False)
+    monkeypatch.delenv("MLX_MAX_OPS_PER_BUFFER", raising=False)
+    monkeypatch.setenv("MLX_MAX_MB_PER_BUFFER", "128")
 
     vm._apply_mlx_buffer_defaults()
 
-    assert os.environ[kept] == "50"
-    assert os.environ[defaulted] == "2000"
+    assert os.environ["MLX_MAX_OPS_PER_BUFFER"] == "2000"
+    assert os.environ["MLX_MAX_MB_PER_BUFFER"] == "128"
 
 
 def test_apply_mlx_buffer_defaults_noop_on_non_macos(monkeypatch) -> None:

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -60,13 +60,12 @@ def _apply_macos_defaults() -> None:
     )
 
 
-# MLX splits each lazy evaluation into command buffers after this many ops /
-# this much memory; its defaults suit small generate loops, while a vLLM
-# decode step builds thousands of lazy ops per submit. 2000 sits on the
-# measured plateau, and ``setdefault`` keeps user values authoritative.
+# MLX splits each lazy evaluation into command buffers after this many ops;
+# its defaults suit small generate loops, while a vLLM decode step builds
+# thousands of lazy ops per submit. 2000 sits on the measured plateau, and
+# ``setdefault`` keeps user values authoritative.
 _MLX_BUFFER_ENV_DEFAULTS = {
     "MLX_MAX_OPS_PER_BUFFER": "2000",
-    "MLX_MAX_MB_PER_BUFFER": "2000",
 }
 
 


### PR DESCRIPTION
This PR is:

- To keep the `MLX_MAX_OPS_PER_BUFFER=2000` default from #578.
- To stop defaulting `MLX_MAX_MB_PER_BUFFER`.
- To avoid inflating startup profile memory and shrinking the KV budget.

Fixes #585.

Note:

`MLX_MAX_MB_PER_BUFFER=2000` can make `profile_run()` measure a much larger MLX buffer-cache delta at high `max_num_batched_tokens`. That inflated overhead is then subtracted from the paged KV budget, so valid offline or high-batched-token runs can fail startup. Users can still set `MLX_MAX_MB_PER_BUFFER` manually if they want to tune it.
