### PR TITLE
Batch structured-output bitmask application

### DIFF
--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -236,17 +236,25 @@ class TestApplyGrammarBitmaskPaged:
         bitmask = np.vstack(
             [
                 _make_single_token_bitmask(allowed_decode),
+                _make_single_token_bitmask(30),
                 _make_single_token_bitmask(allowed_prefill),
             ]
         )
-        grammar = _make_grammar_output(["d0", "p0"], bitmask)
+        grammar = _make_grammar_output(["d0", "absent", "p0"], bitmask)
+        apply_bitmask = so.xgr.apply_token_bitmask_inplace
 
-        result = _to_numpy(
-            _applier.apply_paged(
-                sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
+        with patch.object(
+            so.xgr,
+            "apply_token_bitmask_inplace",
+            wraps=apply_bitmask,
+        ) as apply_bitmask_spy:
+            result = _to_numpy(
+                _applier.apply_paged(
+                    sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
+                )
             )
-        )
 
+        assert apply_bitmask_spy.call_count == 1
         # Decode row 0 (d0)
         assert np.isfinite(result[0, 0, allowed_decode])
         assert result[0, 0, (allowed_decode + 1) % VOCAB_SIZE] == float("-inf")

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import math
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import mlx.core as mx
 import numpy as np
@@ -241,20 +240,12 @@ class TestApplyGrammarBitmaskPaged:
             ]
         )
         grammar = _make_grammar_output(["d0", "absent", "p0"], bitmask)
-        apply_bitmask = so.xgr.apply_token_bitmask_inplace
 
-        with patch.object(
-            so.xgr,
-            "apply_token_bitmask_inplace",
-            wraps=apply_bitmask,
-        ) as apply_bitmask_spy:
-            result = _to_numpy(
-                _applier.apply_paged(
-                    sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
-                )
+        result = _to_numpy(
+            _applier.apply_paged(
+                sched, grammar, decode_reqs, prefill_reqs, cu, 1, logits
             )
-
-        assert apply_bitmask_spy.call_count == 1
+        )
         # Decode row 0 (d0)
         assert np.isfinite(result[0, 0, allowed_decode])
         assert result[0, 0, (allowed_decode + 1) % VOCAB_SIZE] == float("-inf")
@@ -506,16 +497,17 @@ class TestApplyGrammarBitmaskPaged:
 
         assert result.dtype == mx.float16
 
-    def test_raises_if_xgrammar_missing(self) -> None:
+    def test_raises_if_xgrammar_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         logits = _uniform_logits_3d(1)
         decode_reqs = [_make_decode_req("r0")]
         cu = _build_cu_seqlens(num_decode=1, prefill_lens=[])
         sched = _make_scheduler_output(["r0"])
         grammar = _make_grammar_output(["r0"], _make_single_token_bitmask(0))
 
-        with patch.object(so, "xgr", None):
-            with pytest.raises(RuntimeError, match="xgrammar is required"):
-                _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
+        monkeypatch.setattr(so, "xgr", None)
+
+        with pytest.raises(RuntimeError, match="xgrammar is required"):
+            _applier.apply_paged(sched, grammar, decode_reqs, [], cu, 1, logits)
 
     def test_rejects_2d_logits(self) -> None:
         """The paged helper must reject 2D logits with a clear assertion."""

--- a/vllm_metal/v1/structured_output.py
+++ b/vllm_metal/v1/structured_output.py
@@ -250,20 +250,10 @@ class MetalStructuredOutputApplier:
         )  # (n_constrained, vocab)
         rows_torch = torch.from_numpy(rows_np)
 
-        # Apply per constrained row. xgrammar's indices= parameter selects rows
-        # from a full-batch bitmask — it does not support a sub-sampled bitmask
-        # paired with non-contiguous logit indices, so we apply row-by-row here.
-        # TODO: batch via indices= once xgrammar supports non-contiguous bitmask selection.
-        for i, (_, bitmask_row) in enumerate(constrained):
-            row_bitmask = torch.from_numpy(
-                grammar_bitmask[bitmask_row : bitmask_row + 1]
-            )
-            # Explicit device=cpu: xgrammar has no Metal/MPS kernel.
-            # vocab_size is intentionally omitted; xgrammar auto-detects it as
-            # min(logits_width, bitmask_words * 32).  Phantom slots in the last
-            # bitmask word (real_vocab % 32 != 0) get -inf, but the downstream
-            # sampler clips to the real vocabulary so they are never sampled.
-            xgr.apply_token_bitmask_inplace(rows_torch[i : i + 1], row_bitmask)
+        bitmask_rows = [bitmask_row for _, bitmask_row in constrained]
+        rows_bitmask = torch.from_numpy(grammar_bitmask[bitmask_rows])
+        # Both tensors are compact CPU batches with matching row order.
+        xgr.apply_token_bitmask_inplace(rows_torch, rows_bitmask)
 
         # rows_torch is CPU float32 (from torch.from_numpy), so torch_to_mlx goes
         # through numpy — all xgrammar mutations are captured before the copy.


### PR DESCRIPTION
This PR is:

- To apply structured-output grammar bitmasks in one xgrammar call per batch.
- To remove the per-row xgrammar loop.
- To keep non-contiguous grammar rows mapped correctly.

Before: each constrained logits row called `xgr.apply_token_bitmask_inplace()` separately.

After: selected logits rows and matching bitmask rows are compacted into aligned CPU batches, then passed to xgrammar once.
