### PR TITLE
Project logits only for sampled rows on the paged prefill path

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -69,6 +69,7 @@ def make_stub_runner(
         "_intermediate_forward_supported": True,
         "_draft_token_ids": None,
         "_execute_model_state": None,
+        "_selective_logits_supported": False,
         "pp": None,
         "_pp_model": None,
         "_model_adapter": DefaultModelAdapter(),

--- a/tests/test_grammar_bitmask.py
+++ b/tests/test_grammar_bitmask.py
@@ -256,6 +256,41 @@ class TestApplyGrammarBitmaskPaged:
         for row in [1, 2]:
             assert np.all(np.isfinite(result[0, row]))
 
+    def test_compact_mixed_layout_keeps_decode_rows_and_moves_prefill_rows(
+        self,
+    ) -> None:
+        """Compact layout: decode rows stay in place, prefill rows move down.
+
+        Packed rows are [d0][p0 x3] = 4 rows; the projected tensor is
+        [d0][p0 last] = 2 rows. The decode row keeps index 0 (that is why the
+        decode prefix is never gathered), and p0's row moves from 3 to 1.
+        """
+        allowed_decode = 7
+        allowed_prefill = 15
+        logits = _uniform_logits_3d(2)
+        decode_reqs = [_make_decode_req("d0")]
+        prefill_reqs = [_make_prefill_req("p0", 3)]
+        compact_cu = [0, 1, 2]
+        sched = _make_scheduler_output(["d0", "p0"])
+        bitmask = np.vstack(
+            [
+                _make_single_token_bitmask(allowed_decode),
+                _make_single_token_bitmask(allowed_prefill),
+            ]
+        )
+        grammar = _make_grammar_output(["d0", "p0"], bitmask)
+
+        result = _to_numpy(
+            _applier.apply_paged(
+                sched, grammar, decode_reqs, prefill_reqs, compact_cu, 1, logits
+            )
+        )
+
+        assert np.isfinite(result[0, 0, allowed_decode])
+        assert result[0, 0, (allowed_decode + 1) % VOCAB_SIZE] == float("-inf")
+        assert np.isfinite(result[0, 1, allowed_prefill])
+        assert result[0, 1, (allowed_prefill + 1) % VOCAB_SIZE] == float("-inf")
+
     def test_row_span_metadata_masks_verification_rows_and_prefill_tail(self) -> None:
         """Row-span metadata must mask structured rows while leaving plain spec rows alone."""
         allowed_decode_rows = (7, 8, 9)
@@ -783,6 +818,7 @@ class TestSampleTokensGrammarPagedPath:
             logits=logits,
             target_hidden_states=None,
             cu_seqlens=[0, 1],
+            logits_cu_seqlens=[0, 1],
             decode_segments=(
                 mr.PagedDecodeSegment(
                     req_id="r0",

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -326,6 +326,144 @@ class TestTargetForward:
         assert output.hidden_states.tolist() == [[2.0, 3.0]]
         assert output.logits.tolist() == [[[6.0, 7.0]]]
 
+    def test_selective_logits_match_the_full_projection_rows(self) -> None:
+        # The head must see only the requested rows, and the result must equal
+        # those rows of the full projection.
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]])
+
+        class Head:
+            def __init__(self) -> None:
+                self.seen_rows: int | None = None
+
+            def __call__(self, hidden_states):
+                self.seen_rows = hidden_states.shape[-2]
+                return hidden_states * 3.0
+
+        head = Head()
+        model = SimpleNamespace(
+            model=Backbone(), lm_head=head, final_logit_softcapping=None
+        )
+        adapter = DefaultModelAdapter()
+
+        full = adapter.target_forward(
+            model, mx.array([[1, 2, 3, 4]]), cache=[], collect_hidden_states=True
+        )
+        selected = adapter.target_forward(
+            model,
+            mx.array([[1, 2, 3, 4]]),
+            cache=[],
+            logits_indices=mx.array([1, 3], dtype=mx.int32),
+        )
+
+        assert head.seen_rows == 2
+        assert selected.logits.tolist() == [
+            [full.logits[0, 1].tolist(), full.logits[0, 3].tolist()]
+        ]
+
+    def test_selective_logits_keep_full_hidden_states_for_mtp(self) -> None:
+        # Gemma4 MTP seeds index target_hidden_row in the packed layout, so the
+        # hidden states must stay row-major over every input row.
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]])
+
+        model = SimpleNamespace(
+            model=Backbone(),
+            lm_head=lambda hidden_states: hidden_states,
+            final_logit_softcapping=None,
+        )
+
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[1, 2, 3]]),
+            cache=[],
+            collect_hidden_states=True,
+            logits_indices=mx.array([2], dtype=mx.int32),
+        )
+
+        assert output.hidden_states.shape == (3, 2)
+        assert output.logits.shape == (1, 1, 2)
+
+    def test_selective_logits_apply_softcapping_to_selected_rows(self) -> None:
+        # Post-projection scaling must not be skipped by the selective path.
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[-2.0, 0.0], [2.0, 4.0]]])
+
+        model = SimpleNamespace(
+            model=Backbone(),
+            lm_head=lambda hidden_states: hidden_states,
+            final_logit_softcapping=2.0,
+        )
+
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[1, 2]]),
+            cache=[],
+            logits_indices=mx.array([1], dtype=mx.int32),
+        )
+
+        expected = mx.tanh(mx.array([[[2.0, 4.0]]]) / 2.0) * 2.0
+        mx.eval(output.logits, expected)
+        assert mx.allclose(output.logits, expected).item()
+
+
+class TestSupportsSelectiveLogits:
+    """The load-time probe that decides whether the split backbone/head path
+    reproduces a model's own output head.
+
+    A wrapper may scale inside its own ``__call__``, which the split path would
+    not reproduce, so the probe compares a one-row forward both ways and only
+    accepts an exact match."""
+
+    def test_accepts_a_head_reproduced_by_the_split_path(self) -> None:
+        class Model:
+            def __init__(self) -> None:
+                self.model = lambda input_ids, cache=None: mx.array([[[1.0, 2.0]]])
+                self.final_logit_softcapping = None
+
+            def __call__(self, input_ids, cache=None):
+                return self.compute_logits(self.model(input_ids, cache=cache))
+
+            def compute_logits(self, hidden_states):
+                return hidden_states * 3.0
+
+        assert DefaultModelAdapter().supports_selective_logits(Model()) is True
+
+    def test_rejects_a_head_with_scaling_hidden_in_the_forward(self) -> None:
+        # The wrapper multiplies after the head, the way Cohere's logit_scale or
+        # Granite's logits_scaling do.  The split path cannot see that, so the
+        # probe must decline rather than return wrong logits.
+        class Model:
+            def __init__(self) -> None:
+                self.model = lambda input_ids, cache=None: mx.array([[[1.0, 2.0]]])
+                self.final_logit_softcapping = None
+
+            def __call__(self, input_ids, cache=None):
+                return self.compute_logits(self.model(input_ids, cache=cache)) * 0.5
+
+            def compute_logits(self, hidden_states):
+                return hidden_states * 3.0
+
+        assert DefaultModelAdapter().supports_selective_logits(Model()) is False
+
+    def test_rejects_a_model_the_split_path_cannot_drive(self) -> None:
+        # No `.model` backbone: the split path raises, so the probe declines
+        # instead of propagating out of load_model.
+        class Model:
+            def __call__(self, input_ids, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0]]])
+
+        assert DefaultModelAdapter().supports_selective_logits(Model()) is False
+
+
+class TestTargetForwardEmbeddings:
     def test_target_input_embeddings_use_target_embed_scale(self) -> None:
         class Embedding:
             def __call__(self, input_ids):

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2420,7 +2420,9 @@ class TestSelectiveLogitsLoRAGate:
             scheduler_config=SimpleNamespace(max_num_seqs=1, max_num_batched_tokens=1),
             kv_cache_dtype=None,
         )
-        runner._model_lifecycle = SimpleNamespace(load=lambda: None)
+        runner._model_lifecycle = SimpleNamespace(
+            load=lambda: None, install_decode_dispatch=lambda: None
+        )
         runner._lora = SimpleNamespace(
             enabled=lora_enabled, setup=lambda **kwargs: None
         )
@@ -3321,18 +3323,13 @@ class TestIntermediateBodyOnlyForward:
             kv_cache_dtype=None,
         )
         runner._intermediate_forward_supported = False
-<<<<<<< HEAD
-        runner._model_lifecycle = SimpleNamespace(load=lambda: events.append("load"))
-        runner._lora = SimpleNamespace(
-            enabled=False, setup=lambda **kwargs: events.append("lora")
-        )
-=======
         runner._model_lifecycle = SimpleNamespace(
             load=lambda: events.append("load"),
             install_decode_dispatch=lambda: events.append("install"),
         )
-        runner._lora = SimpleNamespace(setup=lambda **kwargs: events.append("lora"))
->>>>>>> origin/main
+        runner._lora = SimpleNamespace(
+            enabled=False, setup=lambda **kwargs: events.append("lora")
+        )
 
         # Act
         runner.load_model()

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -421,6 +421,12 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
                 0,
                 *[s.start_row + s.num_query_tokens for s in decode_segments],
             ],
+            # Decode-only batches need every row, so the logits layout matches
+            # the packed one whether or not selection is available.
+            logits_cu_seqlens=[
+                0,
+                *[s.start_row + s.num_query_tokens for s in decode_segments],
+            ],
             decode_segments=decode_segments,
             num_decode_tokens=sum(s.num_query_tokens for s in decode_segments),
             mm_prefill_deltas={},
@@ -447,8 +453,13 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["block_size"] = block_sizes[0]
             captured["merge_verify_windows"] = merge_verify_windows
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
             del cache
+            captured["logits_indices"] = (
+                None if logits_indices is None else logits_indices.tolist()
+            )
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
             return mr.TargetModelForwardOutput(
@@ -507,8 +518,10 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             del prefill_info, block_sizes, merge_verify_windows
             captured["decode_info"] = decode_info
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
-            del cache, collect_hidden_states
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, collect_hidden_states, logits_indices
             captured["input_ids"] = input_ids.tolist()
             return mr.TargetModelForwardOutput(
                 logits=mx.zeros((1, 1, 16)),
@@ -555,8 +568,13 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_sizes[0]
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
             del cache
+            captured["logits_indices"] = (
+                None if logits_indices is None else logits_indices.tolist()
+            )
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
             return mr.TargetModelForwardOutput(logits=mx.zeros((1, 1, 16)))
@@ -699,8 +717,13 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_sizes[0]
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
             del cache
+            captured["logits_indices"] = (
+                None if logits_indices is None else logits_indices.tolist()
+            )
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
             return mr.TargetModelForwardOutput(
@@ -750,8 +773,13 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_sizes[0]
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
             del cache
+            captured["logits_indices"] = (
+                None if logits_indices is None else logits_indices.tolist()
+            )
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
             return mr.TargetModelForwardOutput(
@@ -810,8 +838,13 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             captured["prefill_info"] = prefill_info
             captured["block_size"] = block_sizes[0]
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
             del cache
+            captured["logits_indices"] = (
+                None if logits_indices is None else logits_indices.tolist()
+            )
             captured["input_ids"] = input_ids.tolist()
             captured["collect_hidden_states"] = collect_hidden_states
             return mr.TargetModelForwardOutput(logits=mx.zeros((1, 2, 16)))
@@ -1060,6 +1093,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             logits=self._make_logits([0, 7]),
             target_hidden_states=mx.array([[1.0, 0.0, 0.0, 0.0], [2.0, 0.0, 0.0, 0.0]]),
             cu_seqlens=[0, 2],
+            logits_cu_seqlens=[0, 2],
             decode_segments=(),
             num_decode_tokens=0,
             mm_prefill_deltas={},
@@ -1937,8 +1971,10 @@ class TestV1MetalModelRunnerGDNLifecycle:
 
         captured: dict[str, object] = {}
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
-            del cache, collect_hidden_states
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, collect_hidden_states, logits_indices
             ctx = mr.get_context()
             assert ctx is not None
             captured["input_ids"] = input_ids.tolist()
@@ -2070,6 +2106,195 @@ class TestRunnerMlaProperties:
             {"num_hidden_layers": 32, "num_attention_heads": 32, "hidden_size": 4096}
         )
         assert runner.is_mla is False
+
+
+class TestPagedLogitsIndices:
+    """Row selection for the paged target forward.
+
+    The packed row order is ``[decode/spec rows][prefill 0 rows]...``. Every
+    decode row is consumed, but prefill sampling only reads each segment's last
+    row, so those are the only rows the projection has to produce."""
+
+    def _make_runner(self, **attrs) -> mr.MetalModelRunner:
+        return make_stub_runner(_selective_logits_supported=True, **attrs)
+
+    def test_returns_none_when_selection_unsupported(self) -> None:
+        runner = make_stub_runner(_selective_logits_supported=False)
+        assert (
+            runner._paged_logits_indices(
+                [0, 4], num_decode_tokens=0, num_decode_segments=0
+            )
+            is None
+        )
+
+    def test_returns_none_for_pure_decode(self) -> None:
+        # Every row is sampled, so selecting would gather all of them and buy
+        # nothing; the model's own __call__ is kept instead.
+        runner = self._make_runner()
+        assert (
+            runner._paged_logits_indices(
+                [0, 1, 2], num_decode_tokens=2, num_decode_segments=2
+            )
+            is None
+        )
+
+    def test_selects_last_row_of_each_prefill(self) -> None:
+        runner = self._make_runner()
+        indices = runner._paged_logits_indices(
+            [0, 4, 6, 9], num_decode_tokens=0, num_decode_segments=0
+        )
+        assert indices is not None
+        assert indices.tolist() == [3, 5, 8]
+        assert indices.dtype == mx.int32
+
+    def test_keeps_decode_prefix_then_appends_prefill_rows(self) -> None:
+        # 2 decode rows, then prefills of 3 and 2 rows. Decode rows stay in place
+        # so start_row stays valid; the prefill ends are 1+3-1=4 and 4+2-1=6.
+        runner = self._make_runner()
+        indices = runner._paged_logits_indices(
+            [0, 1, 2, 5, 7], num_decode_tokens=2, num_decode_segments=2
+        )
+        assert indices is not None
+        assert indices.tolist() == [0, 1, 4, 6]
+
+    def test_keeps_full_spec_verify_span_in_mixed_batch(self) -> None:
+        # All three verify rows survive (argmax over the whole span decides
+        # acceptance); only the prefill's final row 6 is added.
+        runner = self._make_runner()
+        indices = runner._paged_logits_indices(
+            [0, 3, 7], num_decode_tokens=3, num_decode_segments=1
+        )
+        assert indices is not None
+        assert indices.tolist() == [0, 1, 2, 6]
+
+
+class TestCompactLogitsCuSeqlens:
+    """Boundary rewrite for selectively projected logits.
+
+    ``cu_seqlens`` keeps describing the packed hidden states (the pooler and the
+    Gemma4 MTP proposer index those); the rewritten copy describes the logits
+    tensor, whose prefill spans are one row each."""
+
+    def test_prefill_spans_collapse_to_one_row(self) -> None:
+        compact = mr._compact_logits_cu_seqlens([0, 4, 6, 9], num_decode_segments=0)
+        assert compact == [0, 1, 2, 3]
+
+    def test_decode_prefix_lengths_are_preserved(self) -> None:
+        compact = mr._compact_logits_cu_seqlens([0, 1, 2, 5, 7], num_decode_segments=2)
+        assert compact == [0, 1, 2, 3, 4]
+
+    def test_spec_verify_span_length_is_preserved(self) -> None:
+        compact = mr._compact_logits_cu_seqlens([0, 3, 7], num_decode_segments=1)
+        assert compact == [0, 3, 4]
+
+
+class TestStartPagedForwardSelectiveLogits:
+    """``_start_paged_forward`` wiring: what it asks the adapter for, and the
+    logits layout it records for the sampling half of the step."""
+
+    def _make_runner(self, **attrs) -> mr.MetalModelRunner:
+        return make_stub_runner(
+            model_args={"vocab_size": 16},
+            _paged_block_size=4,
+            num_layers=0,
+            **{"_selective_logits_supported": True, **attrs},
+        )
+
+    def _make_prefill(self, req_id: str, token_ids: list[int]) -> mr.PrefillRequest:
+        return mr.PrefillRequest(
+            req_id=req_id,
+            token_ids=token_ids,
+            sampling_params=SamplingParams(),
+            block_ids=[[0]],
+            generator=None,
+            prompt_len=len(token_ids),
+            start_pos=0,
+            full_prompt_token_ids=None,
+        )
+
+    def _run(
+        self,
+        runner: mr.MetalModelRunner,
+        monkeypatch,
+        prefill_reqs: list[mr.PrefillRequest],
+        *,
+        num_logits_rows: int,
+    ) -> dict[str, object]:
+        captured: dict[str, object] = {}
+
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, collect_hidden_states
+            captured["logits_indices"] = (
+                None if logits_indices is None else logits_indices.tolist()
+            )
+            return mr.TargetModelForwardOutput(
+                logits=mx.zeros((1, num_logits_rows, 16)),
+            )
+
+        monkeypatch.setattr(mr, "prepare_grouped", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
+
+        scheduler_output = self._make_scheduler_output(
+            {pr.req_id: len(pr.token_ids) for pr in prefill_reqs}
+        )
+        runner._start_paged_forward(
+            mr._ExecutionBatch(),
+            prefill_reqs=prefill_reqs,
+            decode_reqs=[],
+            scheduler_output=scheduler_output,
+        )
+        return captured
+
+    def _make_scheduler_output(
+        self, num_scheduled_tokens: dict[str, int]
+    ) -> SchedulerOutput:
+        return SchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=CachedRequestData.make_empty(),
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=[],
+            finished_req_ids=set(),
+            free_encoder_mm_hashes=[],
+            num_invalid_spec_tokens=None,
+            num_spec_tokens_to_schedule=1,
+        )
+
+    def test_requests_only_the_sampled_prefill_rows(self, monkeypatch) -> None:
+        # Two prefills of 3 and 2 tokens pack 5 rows; only rows 2 and 4 sample.
+        runner = self._make_runner()
+        captured = self._run(
+            runner,
+            monkeypatch,
+            [self._make_prefill("r0", [1, 2, 3]), self._make_prefill("r1", [4, 5])],
+            num_logits_rows=2,
+        )
+
+        assert captured["logits_indices"] == [2, 4]
+        state = runner._execute_model_state
+        assert state is not None
+        # The packed layout is kept for the hidden-state consumers...
+        assert state.cu_seqlens == [0, 3, 5]
+        # ...while the logits layout has one row per prefill.
+        assert state.logits_cu_seqlens == [0, 1, 2]
+
+    def test_does_not_request_selection_when_unsupported(self, monkeypatch) -> None:
+        runner = self._make_runner(_selective_logits_supported=False)
+        captured = self._run(
+            runner,
+            monkeypatch,
+            [self._make_prefill("r0", [1, 2, 3])],
+            num_logits_rows=3,
+        )
+
+        assert captured["logits_indices"] is None
+        state = runner._execute_model_state
+        assert state is not None
+        assert state.logits_cu_seqlens == state.cu_seqlens == [0, 3]
 
 
 class TestMergeVerifyWindows:
@@ -2441,6 +2666,8 @@ class TestDeferredDecodeSampleThreading:
             target_hidden_states=None,
             pooling_hidden_states=None,
             cu_seqlens=list(range(len(decode_reqs) + 1)),
+            # Decode-only batch: one row per request, so selection is a no-op.
+            logits_cu_seqlens=list(range(len(decode_reqs) + 1)),
             decode_segments=[],
             num_decode_tokens=len(decode_reqs),
             mm_prefill_deltas={},
@@ -2506,8 +2733,10 @@ class TestDeferredDecodeSampleThreading:
         )
         captured: dict[str, object] = {}
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
-            del cache, collect_hidden_states
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, collect_hidden_states, logits_indices
             captured["input_ids"] = input_ids.tolist()
             return mr.TargetModelForwardOutput(
                 logits=mx.zeros((1, 1, 4)), hidden_states=None
@@ -2927,8 +3156,10 @@ class TestIntermediateBodyOnlyForward:
                 )
             )
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
-            del cache, collect_hidden_states
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, collect_hidden_states, logits_indices
             captured["full_forward_tokens"] = input_ids.tolist()
             num_tokens = input_ids.shape[1]
             return mr.TargetModelForwardOutput(
@@ -2965,8 +3196,10 @@ class TestIntermediateBodyOnlyForward:
         runner._paged_block_size = 4
         runner._intermediate_forward_supported = False
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
-            del cache, collect_hidden_states
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, collect_hidden_states, logits_indices
             captured["full_forward_tokens"] = input_ids.tolist()
             return mr.TargetModelForwardOutput(
                 logits=mx.zeros((1, 2, 16)), hidden_states=None
@@ -3031,8 +3264,10 @@ class TestIntermediateBodyOnlyForward:
             needs_target_hidden_states=lambda decode_segments, has_final_prefill: True
         )
 
-        def fake_target_forward(input_ids, *, cache, collect_hidden_states):
-            del cache
+        def fake_target_forward(
+            input_ids, *, cache, collect_hidden_states, logits_indices=None
+        ):
+            del cache, logits_indices
             captured["collect_hidden_states"] = collect_hidden_states
             return mr.TargetModelForwardOutput(
                 logits=mx.zeros((1, 2, 16)),
@@ -3072,6 +3307,7 @@ class TestIntermediateBodyOnlyForward:
             target_hidden_states=None,
             pooling_hidden_states=None,
             cu_seqlens=[0, 2],
+            logits_cu_seqlens=[0, 2],
             decode_segments=(),
             num_decode_tokens=len(decode_reqs),
             mm_prefill_deltas={},

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2168,26 +2168,6 @@ class TestPagedLogitsIndices:
         assert indices.tolist() == [0, 1, 2, 6]
 
 
-class TestCompactLogitsCuSeqlens:
-    """Boundary rewrite for selectively projected logits.
-
-    ``cu_seqlens`` keeps describing the packed hidden states (the pooler and the
-    Gemma4 MTP proposer index those); the rewritten copy describes the logits
-    tensor, whose prefill spans are one row each."""
-
-    def test_prefill_spans_collapse_to_one_row(self) -> None:
-        compact = mr._compact_logits_cu_seqlens([0, 4, 6, 9], num_decode_segments=0)
-        assert compact == [0, 1, 2, 3]
-
-    def test_decode_prefix_lengths_are_preserved(self) -> None:
-        compact = mr._compact_logits_cu_seqlens([0, 1, 2, 5, 7], num_decode_segments=2)
-        assert compact == [0, 1, 2, 3, 4]
-
-    def test_spec_verify_span_length_is_preserved(self) -> None:
-        compact = mr._compact_logits_cu_seqlens([0, 3, 7], num_decode_segments=1)
-        assert compact == [0, 3, 4]
-
-
 class TestStartPagedForwardSelectiveLogits:
     """``_start_paged_forward`` wiring: what it asks the adapter for, and the
     logits layout it records for the sampling half of the step."""
@@ -2219,6 +2199,8 @@ class TestStartPagedForwardSelectiveLogits:
         prefill_reqs: list[mr.PrefillRequest],
         *,
         num_logits_rows: int,
+        decode_reqs: list[tuple[str, mr.RequestState]] | None = None,
+        spec_tokens: dict[str, list[int]] | None = None,
     ) -> dict[str, object]:
         captured: dict[str, object] = {}
 
@@ -2236,26 +2218,32 @@ class TestStartPagedForwardSelectiveLogits:
         monkeypatch.setattr(mr, "prepare_grouped", lambda *a, **k: None)
         monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
 
-        scheduler_output = self._make_scheduler_output(
-            {pr.req_id: len(pr.token_ids) for pr in prefill_reqs}
-        )
+        decode_reqs = decode_reqs or []
+        spec_tokens = spec_tokens or {}
+        num_scheduled = {
+            req_id: 1 + len(spec_tokens.get(req_id, ())) for req_id, _ in decode_reqs
+        }
+        num_scheduled.update({pr.req_id: len(pr.token_ids) for pr in prefill_reqs})
+        scheduler_output = self._make_scheduler_output(num_scheduled, spec_tokens)
         runner._start_paged_forward(
             mr._ExecutionBatch(),
             prefill_reqs=prefill_reqs,
-            decode_reqs=[],
+            decode_reqs=decode_reqs,
             scheduler_output=scheduler_output,
         )
         return captured
 
     def _make_scheduler_output(
-        self, num_scheduled_tokens: dict[str, int]
+        self,
+        num_scheduled_tokens: dict[str, int],
+        spec_tokens: dict[str, list[int]] | None = None,
     ) -> SchedulerOutput:
         return SchedulerOutput(
             scheduled_new_reqs=[],
             scheduled_cached_reqs=CachedRequestData.make_empty(),
             num_scheduled_tokens=num_scheduled_tokens,
             total_num_scheduled_tokens=sum(num_scheduled_tokens.values()),
-            scheduled_spec_decode_tokens={},
+            scheduled_spec_decode_tokens=spec_tokens or {},
             scheduled_encoder_inputs={},
             num_common_prefix_blocks=[],
             finished_req_ids=set(),
@@ -2295,6 +2283,62 @@ class TestStartPagedForwardSelectiveLogits:
         state = runner._execute_model_state
         assert state is not None
         assert state.logits_cu_seqlens == state.cu_seqlens == [0, 3]
+
+    def test_keeps_decode_prefix_rows_ahead_of_prefill_rows(self, monkeypatch) -> None:
+        # 2 decode rows, then a 3-token prefill. The decode rows stay in place so
+        # each segment's start_row is still valid; only the prefill's last row is
+        # added, and the logits layout keeps the decode prefix verbatim.
+        runner = self._make_runner()
+        runner._paged_request_seq_lens["d0"] = 1
+        runner._paged_request_seq_lens["d1"] = 1
+        captured = self._run(
+            runner,
+            monkeypatch,
+            [self._make_prefill("r0", [1, 2, 3])],
+            num_logits_rows=3,
+            decode_reqs=[
+                ("d0", self._make_decode_state()),
+                ("d1", self._make_decode_state()),
+            ],
+        )
+
+        assert captured["logits_indices"] == [0, 1, 4]
+        state = runner._execute_model_state
+        assert state is not None
+        assert state.cu_seqlens == [0, 1, 2, 5]
+        assert state.logits_cu_seqlens == [0, 1, 2, 3]
+
+    def test_keeps_whole_spec_verify_span(self, monkeypatch) -> None:
+        # Spec verification reads the argmax over its whole span, so all 3 verify
+        # rows survive and the span length carries into the logits layout.
+        runner = self._make_runner()
+        runner._paged_request_seq_lens["d0"] = 1
+        captured = self._run(
+            runner,
+            monkeypatch,
+            [self._make_prefill("r0", [1, 2, 3, 4])],
+            num_logits_rows=4,
+            decode_reqs=[("d0", self._make_decode_state([1, 6]))],
+            spec_tokens={"d0": [7, 8]},
+        )
+
+        assert captured["logits_indices"] == [0, 1, 2, 6]
+        state = runner._execute_model_state
+        assert state is not None
+        assert state.cu_seqlens == [0, 3, 7]
+        assert state.logits_cu_seqlens == [0, 3, 4]
+
+    def _make_decode_state(self, token_ids: list[int] | None = None) -> mr.RequestState:
+        token_ids = [1] if token_ids is None else token_ids
+        return mr.RequestState(
+            token_ids=token_ids,
+            prompt_len=1,
+            cache=[],
+            sampling_params=SamplingParams(temperature=0.0),
+            generator=None,
+            generated_tokens=len(token_ids) - 1,
+            block_ids=[[0, 1]],
+        )
 
 
 class TestMergeVerifyWindows:

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2361,6 +2361,34 @@ class TestLoadModelPipelineSplitOrdering:
         assert events == ["load", "split", "lora"]
 
 
+class TestSelectiveLogitsLoRAGate:
+    def _load(self, *, lora_enabled: bool) -> mr.MetalModelRunner:
+        runner = make_stub_runner(
+            model_config=SimpleNamespace(runner_type="generate", hf_config=None),
+            metal_config=SimpleNamespace(use_paged_attention=True),
+            scheduler_config=SimpleNamespace(max_num_seqs=1, max_num_batched_tokens=1),
+            kv_cache_dtype=None,
+        )
+        runner._model_lifecycle = SimpleNamespace(load=lambda: None)
+        runner._lora = SimpleNamespace(
+            enabled=lora_enabled, setup=lambda **kwargs: None
+        )
+        runner._model_adapter = SimpleNamespace(
+            supports_intermediate_forward=lambda model: False,
+            supports_selective_logits=lambda model: True,
+        )
+        runner.load_model()
+        return runner
+
+    def test_selection_disabled_when_lora_is_active(self) -> None:
+        # Punica routes one index per packed token, while selection hands the
+        # head one row per sequence, so the two cannot share a step.
+        assert self._load(lora_enabled=True)._selective_logits_supported is False
+
+    def test_selection_still_enabled_without_lora(self) -> None:
+        assert self._load(lora_enabled=False)._selective_logits_supported is True
+
+
 class _StageDummyRecorder:
     """Stands in for PipelinedModel: records the ids the dummy forward gets."""
 
@@ -3237,7 +3265,9 @@ class TestIntermediateBodyOnlyForward:
         )
         runner._intermediate_forward_supported = False
         runner._model_lifecycle = SimpleNamespace(load=lambda: events.append("load"))
-        runner._lora = SimpleNamespace(setup=lambda **kwargs: events.append("lora"))
+        runner._lora = SimpleNamespace(
+            enabled=False, setup=lambda **kwargs: events.append("lora")
+        )
 
         # Act
         runner.load_model()

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2108,8 +2108,8 @@ class TestRunnerMlaProperties:
         assert runner.is_mla is False
 
 
-class TestPagedLogitsIndices:
-    """Row selection for the paged target forward.
+class TestPagedLogitsLayout:
+    """Row selection for the paged target forward, and the boundaries it makes.
 
     The packed row order is ``[decode/spec rows][prefill 0 rows]...``. Every
     decode row is consumed, but prefill sampling only reads each segment's last
@@ -2118,54 +2118,54 @@ class TestPagedLogitsIndices:
     def _make_runner(self, **attrs) -> mr.MetalModelRunner:
         return make_stub_runner(_selective_logits_supported=True, **attrs)
 
-    def test_returns_none_when_selection_unsupported(self) -> None:
+    def test_projects_every_row_when_selection_unsupported(self) -> None:
         runner = make_stub_runner(_selective_logits_supported=False)
-        assert (
-            runner._paged_logits_indices(
-                [0, 4], num_decode_tokens=0, num_decode_segments=0
-            )
-            is None
-        )
+        layout = runner._paged_logits_layout([0, 4], num_decode_segments=0)
+        assert layout.indices is None
+        assert layout.cu_seqlens == [0, 4]
 
-    def test_returns_none_for_pure_decode(self) -> None:
+    def test_projects_every_row_for_pure_decode(self) -> None:
         # Every row is sampled, so selecting would gather all of them and buy
         # nothing; the model's own __call__ is kept instead.
         runner = self._make_runner()
-        assert (
-            runner._paged_logits_indices(
-                [0, 1, 2], num_decode_tokens=2, num_decode_segments=2
-            )
-            is None
-        )
+        layout = runner._paged_logits_layout([0, 1, 2], num_decode_segments=2)
+        assert layout.indices is None
+        assert layout.cu_seqlens == [0, 1, 2]
+
+    def test_projects_every_row_when_prefills_are_single_token(self) -> None:
+        # Two 1-token prefill chunks: the selection would be the identity, so
+        # gathering would cost a copy and the split head for no rows saved.
+        runner = self._make_runner()
+        layout = runner._paged_logits_layout([0, 1, 2], num_decode_segments=0)
+        assert layout.indices is None
+        assert layout.cu_seqlens == [0, 1, 2]
 
     def test_selects_last_row_of_each_prefill(self) -> None:
         runner = self._make_runner()
-        indices = runner._paged_logits_indices(
-            [0, 4, 6, 9], num_decode_tokens=0, num_decode_segments=0
-        )
-        assert indices is not None
-        assert indices.tolist() == [3, 5, 8]
-        assert indices.dtype == mx.int32
+        layout = runner._paged_logits_layout([0, 4, 6, 9], num_decode_segments=0)
+        assert layout.indices is not None
+        assert layout.indices.tolist() == [3, 5, 8]
+        assert layout.indices.dtype == mx.int32
+        assert layout.cu_seqlens == [0, 1, 2, 3]
 
     def test_keeps_decode_prefix_then_appends_prefill_rows(self) -> None:
         # 2 decode rows, then prefills of 3 and 2 rows. Decode rows stay in place
         # so start_row stays valid; the prefill ends are 1+3-1=4 and 4+2-1=6.
         runner = self._make_runner()
-        indices = runner._paged_logits_indices(
-            [0, 1, 2, 5, 7], num_decode_tokens=2, num_decode_segments=2
-        )
-        assert indices is not None
-        assert indices.tolist() == [0, 1, 4, 6]
+        layout = runner._paged_logits_layout([0, 1, 2, 5, 7], num_decode_segments=2)
+        assert layout.indices is not None
+        assert layout.indices.tolist() == [0, 1, 4, 6]
+        assert layout.cu_seqlens == [0, 1, 2, 3, 4]
 
     def test_keeps_full_spec_verify_span_in_mixed_batch(self) -> None:
         # All three verify rows survive (argmax over the whole span decides
         # acceptance); only the prefill's final row 6 is added.
         runner = self._make_runner()
-        indices = runner._paged_logits_indices(
-            [0, 3, 7], num_decode_tokens=3, num_decode_segments=1
-        )
-        assert indices is not None
-        assert indices.tolist() == [0, 1, 2, 6]
+        layout = runner._paged_logits_layout([0, 3, 7], num_decode_segments=1)
+        assert layout.indices is not None
+        assert layout.indices.tolist() == [0, 1, 2, 6]
+        # The spec span keeps its width; the prefill collapses to one row.
+        assert layout.cu_seqlens == [0, 3, 4]
 
 
 class TestStartPagedForwardSelectiveLogits:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -489,7 +489,7 @@ class TestMetalPoolingCapabilities:
             patch.object(lifecycle, "resolve_model_dims"),
             patch.object(lifecycle, "_install_runtime_extensions"),
         ):
-            runner._lora = SimpleNamespace(setup=setup_lora)
+            runner._lora = SimpleNamespace(enabled=False, setup=setup_lora)
             runner.load_model()
 
         assert events == ["lora"]

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -156,8 +156,16 @@ class ModelAdapter(Protocol):
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        logits_indices: mx.array | None = None,
     ) -> TargetModelForwardOutput:
-        """Run the target text model and optionally retain target hidden states."""
+        """Run the target text model and optionally retain target hidden states.
+
+        ``logits_indices`` requests logits for those input rows only, and is
+        valid only when :meth:`supports_selective_logits` returned ``True``.
+        """
+
+    def supports_selective_logits(self, model: Any) -> bool:
+        """Whether ``target_forward`` may honour ``logits_indices`` for ``model``."""
 
     def target_input_embeddings(self, model: Any, input_ids: mx.array) -> mx.array:
         """Return target/backbone-dim token embeddings for ``input_ids``."""
@@ -410,9 +418,15 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        logits_indices: mx.array | None = None,
     ) -> TargetModelForwardOutput:
-        """Run the target model and return logits plus optional hidden states."""
-        if not collect_hidden_states:
+        """Run the target model and return logits plus optional hidden states.
+
+        ``logits_indices`` projects the head outside the model's own
+        ``__call__``, so callers must gate it on
+        :meth:`supports_selective_logits`; this method trusts them.
+        """
+        if logits_indices is None and not collect_hidden_states:
             output = model(input_ids, cache=cache)
             return TargetModelForwardOutput(
                 logits=self.extract_logits(output),
@@ -424,11 +438,58 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             input_ids,
             cache=cache,
         )
-        logits = self._compute_target_logits(model, hidden_states)
+        flat_hidden_states = self._flatten_target_hidden_states(hidden_states)
+        if logits_indices is None:
+            logits = self._compute_target_logits(model, hidden_states)
+            return TargetModelForwardOutput(
+                logits=logits,
+                hidden_states=flat_hidden_states if collect_hidden_states else None,
+            )
+
+        # `[None]` restores the leading batch axis the callers' `logits[0, row]`
+        # indexing expects. The hidden states stay row-major over ALL input rows,
+        # so the drafter's `target_hidden_row` keeps indexing the packed layout.
+        selected_hidden_states = mx.take(flat_hidden_states, logits_indices, axis=0)
         return TargetModelForwardOutput(
-            logits=logits,
-            hidden_states=self._flatten_target_hidden_states(hidden_states),
+            logits=self._compute_target_logits(model, selected_hidden_states[None]),
+            hidden_states=flat_hidden_states if collect_hidden_states else None,
         )
+
+    def supports_selective_logits(self, model: Any) -> bool:
+        """Whether the split backbone/head path reproduces this model's head.
+
+        No ``mlx_lm`` model exposes a ``compute_logits`` contract, and some scale
+        the head output inside their own ``__call__`` (Cohere's ``logit_scale``,
+        Granite's ``logits_scaling``), which `_compute_target_logits` would not
+        reproduce — a silent wrong-logits bug rather than a crash. Rather than
+        keep a model allowlist in sync with ``mlx_lm``, probe the loaded object
+        for bit-exact agreement on one row.
+
+        Resolved once after load: the probe runs a cacheless forward, which is
+        only safe while no ``PagedAttentionContext`` is installed.
+        """
+        probe_ids = mx.zeros((1, 1), dtype=mx.int32)
+        try:
+            reference = self.extract_logits(model(probe_ids, cache=None))
+            hidden_states = self._forward_target_hidden_states(
+                model, probe_ids, cache=None
+            )
+            split = self._compute_target_logits(model, hidden_states)
+            mx.eval(reference, split)
+            # array_equal is False on a shape mismatch, so this covers both.
+            matches = bool(mx.array_equal(reference, split).item())
+        except Exception:
+            # A wrapper the split path cannot drive (extra forward argument,
+            # missing backbone, unexpected output container).
+            matches = False
+
+        if not matches:
+            logger.info(
+                "Metal: %s output head is not reproducible outside its forward; "
+                "using full logits.",
+                type(model).__name__,
+            )
+        return matches
 
     def target_input_embeddings(self, model: Any, input_ids: mx.array) -> mx.array:
         """Return target/backbone-dim token embeddings for Gemma4 MTP feedback."""

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -158,6 +158,22 @@ def _create_request_generator(
     return generator
 
 
+def _compact_logits_cu_seqlens(
+    cu_seqlens: list[int],
+    *,
+    num_decode_segments: int,
+) -> list[int]:
+    """Return ``cu_seqlens`` rewritten for selectively projected logits.
+
+    The decode/spec prefix is projected unchanged, so its boundaries carry over
+    verbatim; each prefill segment collapses to its single last-token row.
+    """
+    compact = cu_seqlens[: num_decode_segments + 1]
+    for _ in cu_seqlens[num_decode_segments + 1 :]:
+        compact.append(compact[-1] + 1)
+    return compact
+
+
 @dataclass
 class RequestState:
     """State for an ongoing request with KV cache."""
@@ -293,6 +309,9 @@ class _PagedForwardState(NamedTuple):
     cu_seqlens: list[int]
     decode_segments: tuple[PagedDecodeSegment, ...]
     num_decode_tokens: int
+    # Boundaries in ``logits``; equals ``cu_seqlens`` unless the forward
+    # projected only the sampled rows.
+    logits_cu_seqlens: list[int]
     # ``{req_id: mrope_position_delta}`` from paged mm prefill;
     # ``_sample_paged_batch`` stashes each onto ``RequestState``.
     mm_prefill_deltas: dict[str, int]
@@ -396,6 +415,10 @@ class MetalModelRunner:
         # Async forward state: stashed by execute_model, consumed by
         # sample_tokens (mirrors upstream's execute_model_state pattern).
         self._execute_model_state: _PagedForwardState | None = None
+
+        # Resolved in load_model by probing the output head; False until then so
+        # a partially initialized runner keeps full logits.
+        self._selective_logits_supported: bool = False
 
         # Pipeline-parallel group (set by the worker when pipeline_parallel_size
         # > 1). None means single-stage: the forward and sampling paths run
@@ -578,6 +601,14 @@ class MetalModelRunner:
             dtype=self.kv_cache_dtype or mx.float16,
             max_position_embeddings=max_position_embeddings,
         )
+        # Probed here because it runs a cacheless one-token forward, which is
+        # only safe before a paged context is installed. PP and multimodal take
+        # other forward branches that never request selection.
+        self._selective_logits_supported = (
+            self.pp is None
+            and not self._is_vlm
+            and self._model_adapter.supports_selective_logits(self._forward_model)
+        )
         if self._is_pooling:
             self._model_lifecycle.install_pooling_backend()
 
@@ -684,13 +715,46 @@ class MetalModelRunner:
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        logits_indices: mx.array | None = None,
     ) -> TargetModelForwardOutput:
         return self._model_adapter.target_forward(
             self._forward_model,
             input_ids,
             cache=cache,
             collect_hidden_states=collect_hidden_states,
+            logits_indices=logits_indices,
         )
+
+    def _paged_logits_indices(
+        self,
+        cu_seqlens: list[int],
+        *,
+        num_decode_tokens: int,
+        num_decode_segments: int,
+    ) -> mx.array | None:
+        """Return the sampled rows of the packed sequence, or None for all rows.
+
+        The packed order is ``[decode/spec rows][prefill 0 rows]...``. Every
+        decode row is consumed (spec verification reads its whole span), but
+        prefill sampling only ever reads each segment's last row, so the head
+        need not project the rest.
+
+        ``None`` means every row is already needed — any pure-decode step — so
+        those keep the model's own ``__call__`` and pay no gather.
+        """
+        if not self._selective_logits_supported:
+            return None
+        num_rows = cu_seqlens[-1]
+        selected = [
+            *range(num_decode_tokens),
+            *(
+                cu_seqlens[num_decode_segments + i + 1] - 1
+                for i in range(len(cu_seqlens) - num_decode_segments - 1)
+            ),
+        ]
+        if len(selected) == num_rows:
+            return None
+        return mx.array(selected, dtype=mx.int32)
 
     def _target_input_embeddings(self, input_ids: mx.array) -> mx.array:
         return self._model_adapter.target_input_embeddings(
@@ -1189,7 +1253,16 @@ class MetalModelRunner:
         for pr in prefill_reqs:
             prefill_info.append((pr.block_ids, len(pr.token_ids), pr.start_pos))
 
+        # ---- build cu_seqlens for logit extraction ----
+        # Before the forward: the sampled-row selection derives from these.
+        cu_seqlens: list[int] = [0]
+        for segment in decode_segments:
+            cu_seqlens.append(cu_seqlens[-1] + segment.num_query_tokens)
+        for pr in prefill_reqs:
+            cu_seqlens.append(cu_seqlens[-1] + len(pr.token_ids))
+
         logits: mx.array | None = None
+        logits_indices: mx.array | None = None
         target_hidden_states: mx.array | None = None
         pooling_hidden_states: mx.array | None = None
         intermediate_hidden: mx.array | None = None
@@ -1317,10 +1390,16 @@ class MetalModelRunner:
                     logits = None
                     target_hidden_states = None
                 else:
+                    logits_indices = self._paged_logits_indices(
+                        cu_seqlens,
+                        num_decode_tokens=num_decode_tokens,
+                        num_decode_segments=len(decode_segments),
+                    )
                     target_output = self._target_forward(
                         input_ids,
                         cache=offset_caches,
                         collect_hidden_states=collect_target_hidden_states,
+                        logits_indices=logits_indices,
                     )
                     logits = target_output.logits
                     target_hidden_states = target_output.hidden_states
@@ -1349,13 +1428,6 @@ class MetalModelRunner:
                 forward_outputs.append(target_hidden_states)
             self._submit_paged_forward_outputs(*forward_outputs)
 
-        # ---- build cu_seqlens for logit extraction ----
-        cu_seqlens: list[int] = [0]
-        for segment in decode_segments:
-            cu_seqlens.append(cu_seqlens[-1] + segment.num_query_tokens)
-        for pr in prefill_reqs:
-            cu_seqlens.append(cu_seqlens[-1] + len(pr.token_ids))
-
         self._execute_model_state = _PagedForwardState(
             batch=batch,
             prefill_reqs=prefill_reqs,
@@ -1365,6 +1437,13 @@ class MetalModelRunner:
             target_hidden_states=target_hidden_states,
             pooling_hidden_states=pooling_hidden_states,
             cu_seqlens=cu_seqlens,
+            logits_cu_seqlens=(
+                cu_seqlens
+                if logits_indices is None
+                else _compact_logits_cu_seqlens(
+                    cu_seqlens, num_decode_segments=len(decode_segments)
+                )
+            ),
             decode_segments=decode_segments,
             num_decode_tokens=num_decode_tokens,
             mm_prefill_deltas=mm_prefill_deltas,
@@ -1464,6 +1543,9 @@ class MetalModelRunner:
         target_hidden_states = paged_state.target_hidden_states
         pooling_hidden_states = paged_state.pooling_hidden_states
         cu_seqlens = paged_state.cu_seqlens
+        # Everything indexing `logits` uses these; `cu_seqlens` stays the packed
+        # hidden-state layout the pooler and MTP proposer index.
+        logits_cu_seqlens = paged_state.logits_cu_seqlens
         decode_segments = paged_state.decode_segments
         num_decode_segments = len(decode_segments)
         num_decode_tokens = paged_state.num_decode_tokens
@@ -1528,7 +1610,7 @@ class MetalModelRunner:
                 grammar_output,
                 decode_reqs,
                 prefill_reqs,
-                cu_seqlens,
+                logits_cu_seqlens,
                 num_decode_segments,
                 logits,
                 decode_segments=decode_segments,
@@ -1622,7 +1704,7 @@ class MetalModelRunner:
         prefill_result = sample_prefill_tokens(
             logits,
             prefill_reqs,
-            cu_seqlens,
+            logits_cu_seqlens,
             num_decode_segments,
             self._sampler,
             self.device,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -281,6 +281,18 @@ class _ExecutionBatch:
         return DecoderPoolingBatch(tuple(spans))
 
 
+class _PagedLogitsLayout(NamedTuple):
+    """How the head projects this step's packed rows.
+
+    ``indices`` is None when every packed row gets projected: unsupported
+    models and steps with nothing to drop both keep the model's own
+    ``__call__``. ``cu_seqlens`` always describes the resulting logits.
+    """
+
+    indices: mx.array | None
+    cu_seqlens: list[int]
+
+
 class _PagedForwardState(NamedTuple):
     """State stashed by ``_start_paged_forward`` for ``_sample_paged_batch``."""
 
@@ -710,34 +722,40 @@ class MetalModelRunner:
             logits_indices=logits_indices,
         )
 
-    def _paged_logits_indices(
+    def _paged_logits_layout(
         self,
         cu_seqlens: list[int],
         *,
-        num_decode_tokens: int,
         num_decode_segments: int,
-    ) -> mx.array | None:
-        """Return the sampled rows of the packed sequence, or None for all rows.
+    ) -> _PagedLogitsLayout:
+        """Pick the rows the sampler reads, and the boundaries they land on.
 
         The packed order is ``[decode/spec rows][prefill 0 rows]...``. Every
         decode row is consumed (spec verification reads its whole span), but
         prefill sampling only ever reads each segment's last row, so the head
         need not project the rest.
 
-        ``None`` means every row is already needed — a pure-decode step, or one
-        whose prefill segments are all single-token — so those keep the model's
-        own ``__call__`` and pay no gather.
+        No ``indices`` means every row is already needed — a pure-decode step,
+        or one whose prefill segments are all single-token — so those keep the
+        model's own ``__call__``, pay no gather, and keep the packed
+        boundaries.
         """
-        if not self._selective_logits_supported:
-            return None
+        decode_bounds = cu_seqlens[: num_decode_segments + 1]
         # Boundaries past the decode prefix are the prefill segment ends; the
         # row before each is the one prefill sampling reads.
         prefill_ends = cu_seqlens[num_decode_segments + 1 :]
-        if num_decode_tokens + len(prefill_ends) == cu_seqlens[-1]:
-            return None
-        return mx.array(
-            [*range(num_decode_tokens), *(end - 1 for end in prefill_ends)],
-            dtype=mx.int32,
+        num_decode_rows = decode_bounds[-1]
+        num_selected = num_decode_rows + len(prefill_ends)
+        if not self._selective_logits_supported or num_selected == cu_seqlens[-1]:
+            return _PagedLogitsLayout(None, cu_seqlens)
+        return _PagedLogitsLayout(
+            mx.array(
+                [*range(num_decode_rows), *(end - 1 for end in prefill_ends)],
+                dtype=mx.int32,
+            ),
+            # The decode/spec prefix keeps its boundaries; every prefill
+            # segment collapses to the single row that was projected.
+            [*decode_bounds, *range(num_decode_rows + 1, num_selected + 1)],
         )
 
     def _target_input_embeddings(self, input_ids: mx.array) -> mx.array:
@@ -1246,7 +1264,9 @@ class MetalModelRunner:
             cu_seqlens.append(cu_seqlens[-1] + len(pr.token_ids))
 
         logits: mx.array | None = None
-        logits_indices: mx.array | None = None
+        # Overwritten by the branch that runs the target forward; the other
+        # branches project nothing, so the packed boundaries stand.
+        logits_layout = _PagedLogitsLayout(None, cu_seqlens)
         target_hidden_states: mx.array | None = None
         pooling_hidden_states: mx.array | None = None
         intermediate_hidden: mx.array | None = None
@@ -1374,16 +1394,15 @@ class MetalModelRunner:
                     logits = None
                     target_hidden_states = None
                 else:
-                    logits_indices = self._paged_logits_indices(
+                    logits_layout = self._paged_logits_layout(
                         cu_seqlens,
-                        num_decode_tokens=num_decode_tokens,
                         num_decode_segments=len(decode_segments),
                     )
                     target_output = self._target_forward(
                         input_ids,
                         cache=offset_caches,
                         collect_hidden_states=collect_target_hidden_states,
-                        logits_indices=logits_indices,
+                        logits_indices=logits_layout.indices,
                     )
                     logits = target_output.logits
                     target_hidden_states = target_output.hidden_states
@@ -1412,17 +1431,9 @@ class MetalModelRunner:
                 forward_outputs.append(target_hidden_states)
             self._submit_paged_forward_outputs(*forward_outputs)
 
-        # `cu_seqlens` keeps describing the packed hidden states, which the pooler
-        # and the Gemma4 MTP proposer index. When the head only projected the
-        # sampled rows, the logits tensor has a different layout: the decode/spec
-        # prefix is unchanged and every prefill segment is now one row.
-        if logits_indices is None:
-            logits_cu_seqlens = cu_seqlens
-        else:
-            logits_cu_seqlens = cu_seqlens[: len(decode_segments) + 1]
-            for _ in cu_seqlens[len(decode_segments) + 1 :]:
-                logits_cu_seqlens.append(logits_cu_seqlens[-1] + 1)
-
+        # `cu_seqlens` keeps describing the packed hidden states, which the
+        # pooler and the Gemma4 MTP proposer index; `logits_layout.cu_seqlens`
+        # describes the tensor the head actually produced.
         self._execute_model_state = _PagedForwardState(
             batch=batch,
             prefill_reqs=prefill_reqs,
@@ -1432,7 +1443,7 @@ class MetalModelRunner:
             target_hidden_states=target_hidden_states,
             pooling_hidden_states=pooling_hidden_states,
             cu_seqlens=cu_seqlens,
-            logits_cu_seqlens=logits_cu_seqlens,
+            logits_cu_seqlens=logits_layout.cu_seqlens,
             decode_segments=decode_segments,
             num_decode_tokens=num_decode_tokens,
             mm_prefill_deltas=mm_prefill_deltas,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -724,22 +724,21 @@ class MetalModelRunner:
         prefill sampling only ever reads each segment's last row, so the head
         need not project the rest.
 
-        ``None`` means every row is already needed — any pure-decode step — so
-        those keep the model's own ``__call__`` and pay no gather.
+        ``None`` means every row is already needed — a pure-decode step, or one
+        whose prefill segments are all single-token — so those keep the model's
+        own ``__call__`` and pay no gather.
         """
         if not self._selective_logits_supported:
             return None
-        num_rows = cu_seqlens[-1]
-        selected = [
-            *range(num_decode_tokens),
-            *(
-                cu_seqlens[num_decode_segments + i + 1] - 1
-                for i in range(len(cu_seqlens) - num_decode_segments - 1)
-            ),
-        ]
-        if len(selected) == num_rows:
+        # Boundaries past the decode prefix are the prefill segment ends; the
+        # row before each is the one prefill sampling reads.
+        prefill_ends = cu_seqlens[num_decode_segments + 1 :]
+        if num_decode_tokens + len(prefill_ends) == cu_seqlens[-1]:
             return None
-        return mx.array(selected, dtype=mx.int32)
+        return mx.array(
+            [*range(num_decode_tokens), *(end - 1 for end in prefill_ends)],
+            dtype=mx.int32,
+        )
 
     def _target_input_embeddings(self, input_ids: mx.array) -> mx.array:
         return self._model_adapter.target_input_embeddings(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -158,22 +158,6 @@ def _create_request_generator(
     return generator
 
 
-def _compact_logits_cu_seqlens(
-    cu_seqlens: list[int],
-    *,
-    num_decode_segments: int,
-) -> list[int]:
-    """Return ``cu_seqlens`` rewritten for selectively projected logits.
-
-    The decode/spec prefix is projected unchanged, so its boundaries carry over
-    verbatim; each prefill segment collapses to its single last-token row.
-    """
-    compact = cu_seqlens[: num_decode_segments + 1]
-    for _ in cu_seqlens[num_decode_segments + 1 :]:
-        compact.append(compact[-1] + 1)
-    return compact
-
-
 @dataclass
 class RequestState:
     """State for an ongoing request with KV cache."""
@@ -1429,6 +1413,17 @@ class MetalModelRunner:
                 forward_outputs.append(target_hidden_states)
             self._submit_paged_forward_outputs(*forward_outputs)
 
+        # `cu_seqlens` keeps describing the packed hidden states, which the pooler
+        # and the Gemma4 MTP proposer index. When the head only projected the
+        # sampled rows, the logits tensor has a different layout: the decode/spec
+        # prefix is unchanged and every prefill segment is now one row.
+        if logits_indices is None:
+            logits_cu_seqlens = cu_seqlens
+        else:
+            logits_cu_seqlens = cu_seqlens[: len(decode_segments) + 1]
+            for _ in cu_seqlens[len(decode_segments) + 1 :]:
+                logits_cu_seqlens.append(logits_cu_seqlens[-1] + 1)
+
         self._execute_model_state = _PagedForwardState(
             batch=batch,
             prefill_reqs=prefill_reqs,
@@ -1438,13 +1433,7 @@ class MetalModelRunner:
             target_hidden_states=target_hidden_states,
             pooling_hidden_states=pooling_hidden_states,
             cu_seqlens=cu_seqlens,
-            logits_cu_seqlens=(
-                cu_seqlens
-                if logits_indices is None
-                else _compact_logits_cu_seqlens(
-                    cu_seqlens, num_decode_segments=len(decode_segments)
-                )
-            ),
+            logits_cu_seqlens=logits_cu_seqlens,
             decode_segments=decode_segments,
             num_decode_tokens=num_decode_tokens,
             mm_prefill_deltas=mm_prefill_deltas,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -607,6 +607,7 @@ class MetalModelRunner:
         self._selective_logits_supported = (
             self.pp is None
             and not self._is_vlm
+            and not self._lora.enabled
             and self._model_adapter.supports_selective_logits(self._forward_model)
         )
         if self._is_pooling:


### PR DESCRIPTION
## Summary

The paged text path projects the output head over **every** packed row, but sampling reads only one row per
prefill segment (`_build_paged_row_targets` takes `cu_seqlens[num_decode + j + 1] - 1`). For a 2048-token prompt
that is 2047 wasted rows of `[hidden_dim × vocab_size]` matmul and a `[2048 × 151936]` tensor materialized to
sample one row.

`ModelAdapter.target_forward` gains an optional `logits_indices`: prefill steps gather the sampled rows and run
the head on those alone; pure-decode steps pass `None` and are byte-for-byte unchanged. `_PagedForwardState`
carries a new `logits_cu_seqlens`, since logits are no longer row-aligned with the input — hidden-state consumers
keep `cu_seqlens` for the spec drafter. Implements #525.

**A model's head is not always reproducible outside its `__call__`, and getting that wrong yields silently wrong
logits, not a crash** (Cohere's `logit_scale`, Granite's `logits_scaling`). Rather than an `mlx_lm` allowlist,
`supports_selective_logits` probes once at load and demands bit-exact equality with the model's own output;
mismatches keep full logits and log why.

## Benchmarks

`vllm bench serve --model Qwen/Qwen3-0.6B --dataset-name random --random-input-len 2048 --random-output-len 16
--num-prompts 40`, M3 Pro, vllm 0.26.0. 5 iterations per arm, **interleaved** with a restart per arm, medians;
40/40 requests OK across all 10 runs.

| metric | before | after | delta |
|---|---|---|---|
| Output throughput | 20.26 tok/s | 23.46 tok/s | **+15.8%** |
| Mean TTFT | 17644.89 ms | 15375.80 ms | **−12.9%** |
| Mean TPOT | 571.96 ms | 485.36 ms | **−15.1%** |
| Duration | 31.58 s | 27.28 s | **−13.6%** |

CV ≤ 3.2% and the arms' ranges are **disjoint** on all four. The machine was not idle — hence the interleaving,
so load drift could not land in one arm — so absolute numbers are low for this hardware and the ratio is the
result. Isolated head projection at 2048 rows: 107.00 → 2.51 ms, 593.5 MiB avoided.

## Testing
```
pytest tests/test_model_adapter.py tests/test_v1_model_runner_generate.py tests/test_grammar_bitmask.py tests/test_decode_pipeline.py
224 passed
```

Covers index selection, `logits_cu_seqlens` compaction, selective and full projections agreeing on sampled rows,
the probe rejecting a model that scales its head output, and bitmask application under the compacted layout.
Prompt logprobs are unimplemented here (`prompt_logprobs_dict={}` is hardcoded), so dropping non-last prefill
rows regresses nothing. Also updates #588's new `_paged_state` helper and `fake_target_forward` stub (6 lines) to
match the file's eight others.

---

AI assistance was used in developing this change. The problem analysis, design, benchmarks and tests were
reviewed and verified by me, and I am responsible for all submitted changes.
