### PR TITLE
docs: verify Apertus-8B-Instruct-2509-4bit on M5 16GB

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -103,4 +103,4 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | SmolLM3-3B | ✅ | GQA (paged) | ✅ | `mlx-community/SmolLM3-3B-4bit` |
 | Granite 3.3 | 🔵 | GQA (paged) | ✅ | `mlx-community/granite-3.3-8b-instruct-4bit` |
 | EXAONE 4.0 | 🔵 | GQA (paged) | ✅ | `mlx-community/exaone-4.0-1.2b-4bit` |
-| Apertus	✅ | GQA (paged)|	✅ | mlx-community/Apertus-8B-Instruct-2509-4bit |
+| Apertus |	✅ | GQA (paged)|	✅ | `mlx-community/Apertus-8B-Instruct-2509-4bit` |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -103,3 +103,4 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | SmolLM3-3B | ✅ | GQA (paged) | ✅ | `mlx-community/SmolLM3-3B-4bit` |
 | Granite 3.3 | 🔵 | GQA (paged) | ✅ | `mlx-community/granite-3.3-8b-instruct-4bit` |
 | EXAONE 4.0 | 🔵 | GQA (paged) | ✅ | `mlx-community/exaone-4.0-1.2b-4bit` |
+| Apertus	✅ | GQA (paged)|	✅ | mlx-community/Apertus-8B-Instruct-2509-4bit |


### PR DESCRIPTION
## Add Apertus-8B-Instruct to supported models

Tested `mlx-community/Apertus-8B-Instruct-2509-4bit` per #289.

**Hardware**: Apple M5, 16GB unified memory
**macOS**: 26.3
**vllm-metal**: 0.3.0.dev20260810145134
**Command**: `vllm serve mlx-community/Apertus-8B-Instruct-2509-4bit --max-model-len 8192`

**Result**: ✅ Working
- Loads and serves without errors via the OpenAI-compatible chat endpoint
- Sustained generation throughput ~20-25 tokens/s
- GPU actively engaged via Metal backend (confirmed via powermetrics: ~100% GPU active residency)
- Automatic prefix caching functioning correctly (hit rate up to 89.5%)

**Note**: on repeated testing with the same prompt, generation occasionally degraded into repetitive/alliterative output on one out of several runs. Not consistently reproducible across runs, so noting for visibility rather than as a confirmed bug — may be inherent sampling variance.

Related to #289.