### PR TITLE
Add dense BGE-M3 / XLM-RoBERTa embed via native Apache encoder

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -36,6 +36,7 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | --- | --- | --- | --- |
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
+| BGE-M3 / XLM-RoBERTa | 🔵 | `pooling` / dense `embed` only (`vllm-metal[embeddings]`) | `mlx-community/bge-m3-mlx-8bit` |
 
 ## Multimodal Language Models
 

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -36,7 +36,7 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | --- | --- | --- | --- |
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
-| BGE-M3 / XLM-RoBERTa | 🔵 | `pooling` / dense `embed` only (`vllm-metal[embeddings]`) | `mlx-community/bge-m3-mlx-8bit` |
+| BGE-M3 / XLM-RoBERTa | 🔵 | `pooling` / dense `embed` only (native Metal encoder) | `mlx-community/bge-m3-mlx-8bit` |
 
 ## Multimodal Language Models
 

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -21,20 +21,30 @@ Current scope is intentionally narrow:
   `Qwen3ForSequenceClassification`, `classifier_from_token=["no", "yes"]`,
   and `is_original_qwen3_reranker=True`
 - decoder-style text models that expose token hidden states through the MLX
-  transformer body
-- sequence embeddings from the final prompt-token hidden state with LAST
-  pooling and L2 normalization on the paged Metal V1 path
+  transformer body (LAST pooling)
+- encoder embedding checkpoints loaded through optional `mlx-embeddings`
+  (`XLMRobertaModel` / `RobertaEmbeddingModel` / `BgeM3EmbeddingModel`), with
+  CLS pooling and L2 normalization for dense vectors
 - Qwen3 reranker cross-encoder scores from the final prompt-token hidden state,
   using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
   embeddings are tied
+
+Install the encoder path with:
+
+```bash
+pip install "vllm-metal[embeddings]"
+```
 
 ## Unsupported
 
 The Metal runner rejects these cases with diagnostic errors:
 
 - generic classification heads, generic reranking models, and late interaction
-- sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`, `STEP`)
-- token-level pooling
+- sequence pooling strategies other than LAST for decoder embed models, and
+  other than CLS/LAST for encoder embed models (`MEAN`, `ALL`, `STEP`)
+- token-level pooling, including BGE-M3 sparse `token_classify` lexical weights
+  (tracked as a follow-up to
+  [#589](https://github.com/vllm-project/vllm-metal/issues/589))
 - chunked long-input embedding aggregation (`enable_chunked_processing`)
 - non-paged pooling execution
 - multimodal embeddings and scheduled encoder inputs
@@ -56,6 +66,20 @@ from vllm import LLM
 
 llm = LLM(
     model="mlx-community/Qwen3-Embedding-0.6B-8bit",
+    runner="pooling",
+    max_model_len=512,
+)
+outputs = llm.embed(["hello metal", "semantic search"])
+print(len(outputs), len(outputs[0].outputs.embedding))
+```
+
+Dense BGE-M3 / XLM-RoBERTa (requires `vllm-metal[embeddings]`):
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="mlx-community/bge-m3-mlx-8bit",
     runner="pooling",
     max_model_len=512,
 )

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -22,18 +22,12 @@ Current scope is intentionally narrow:
   and `is_original_qwen3_reranker=True`
 - decoder-style text models that expose token hidden states through the MLX
   transformer body (LAST pooling)
-- encoder embedding checkpoints loaded through optional `mlx-embeddings`
-  (`XLMRobertaModel` / `RobertaEmbeddingModel` / `BgeM3EmbeddingModel`), with
-  CLS pooling and L2 normalization for dense vectors
+- encoder embedding checkpoints loaded through Metal's native Apache-2.0
+  XLM-RoBERTa / RoBERTa MLX backend (`XLMRobertaModel` / `RobertaEmbeddingModel` /
+  `BgeM3EmbeddingModel`), with CLS pooling and L2 normalization for dense vectors
 - Qwen3 reranker cross-encoder scores from the final prompt-token hidden state,
   using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
   embeddings are tied
-
-Install the encoder path with:
-
-```bash
-pip install "vllm-metal[embeddings]"
-```
 
 ## Unsupported
 
@@ -73,7 +67,7 @@ outputs = llm.embed(["hello metal", "semantic search"])
 print(len(outputs), len(outputs[0].outputs.embedding))
 ```
 
-Dense BGE-M3 / XLM-RoBERTa (requires `vllm-metal[embeddings]`):
+Dense BGE-M3 / XLM-RoBERTa (native Metal encoder backend):
 
 ```python
 from vllm import LLM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,15 +81,21 @@ stt = [
     "librosa>=0.10.2",
     "numba>=0.59.0",  # Required by librosa on Python 3.12+
 ]
+embeddings = [
+    # Encoder embedding models (XLM-RoBERTa / BGE-M3 dense embed). Required for
+    # mlx-community BGE-M3 checkpoints; sparse token_classify is a follow-up.
+    "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+]
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=0.21.0",
     "ruff==0.16.0",
     "mypy>=1.19.1",
     "gguf>=0.17.0",
+    "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 all = [
-    "vllm-metal[gguf,stt,dev]",
+    "vllm-metal[gguf,stt,embeddings,dev]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,21 +81,15 @@ stt = [
     "librosa>=0.10.2",
     "numba>=0.59.0",  # Required by librosa on Python 3.12+
 ]
-embeddings = [
-    # Encoder embedding models (XLM-RoBERTa / BGE-M3 dense embed). Required for
-    # mlx-community BGE-M3 checkpoints; sparse token_classify is a follow-up.
-    "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-]
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=0.21.0",
     "ruff==0.16.0",
     "mypy>=1.19.1",
     "gguf>=0.17.0",
-    "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 all = [
-    "vllm-metal[gguf,stt,embeddings,dev]",
+    "vllm-metal[gguf,stt,dev]",
 ]
 
 [project.urls]

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -50,6 +50,7 @@ def make_stub_runner(
         "model": object(),
         "_is_vlm": False,
         "_multimodal_adapter": None,
+        "_encoder_embedding_adapter": None,
         "_gemma4_mtp_assistant": None,
         "_drafter": None,
         "encoder_cache": None,

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the encoder embedding adapter (#589 PR1)."""
+"""Tests for the native encoder embedding adapter (#589 PR1)."""
 
 from __future__ import annotations
 
@@ -7,13 +7,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
-import pytest
 
+from vllm_metal.v1.encoder.xlm_roberta import XLMRobertaArgs, XLMRobertaModel
 from vllm_metal.v1.encoder_embeddings import (
     EncoderEmbeddingAdapter,
-    MlxEmbeddingsEncoderModel,
+    NativeEncoderModel,
     is_encoder_embedding_config,
-    load_mlx_embeddings_model,
     requires_mlx_embeddings_load,
 )
 from vllm_metal.v1.pooling import (
@@ -45,39 +44,32 @@ def _encoder_model_config(**overrides):
     return SimpleNamespace(**values)
 
 
-class _FakeEmbeddingsOutput:
-    def __init__(self, hidden_states: mx.array) -> None:
-        self.last_hidden_state = hidden_states
+class _FakeEncoderModule(XLMRobertaModel):
+    """Minimal stand-in that records calls like the real encoder body."""
 
-
-class _FakeEmbeddingsModule:
     def __init__(self) -> None:
-        self.config = SimpleNamespace(
-            model_type="xlm-roberta",
-            hidden_size=4,
-            vocab_size=16,
-            num_hidden_layers=2,
-            num_attention_heads=2,
-            num_key_value_heads=2,
-            head_dim=2,
-            max_position_embeddings=32,
-        )
-        self.calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+        # Skip nn.Module init graph; only need call behavior for unit tests.
+        self.args = XLMRobertaArgs(hidden_size=4, num_hidden_layers=1)
+        self.config = self.args
+        self.calls: list[tuple[tuple[int, ...], tuple[int, ...] | None]] = []
 
-    def __call__(self, input_ids, attention_mask=None):
+    def __call__(self, input_ids, attention_mask=None, token_type_ids=None):
         shape = tuple(int(x) for x in input_ids.shape)
-        mask_shape = tuple(int(x) for x in attention_mask.shape)
+        mask_shape = (
+            None
+            if attention_mask is None
+            else tuple(int(x) for x in attention_mask.shape)
+        )
         self.calls.append((shape, mask_shape))
         tokens = int(input_ids.shape[-1])
         rows = [[float(i), float(i + 1), 0.0, 1.0] for i in range(tokens)]
-        return _FakeEmbeddingsOutput(mx.array([rows], dtype=mx.float32))
+        return mx.array([rows], dtype=mx.float32)
 
 
 class TestEncoderEmbeddingDetection:
     def test_detects_xlm_roberta_and_bge_architectures(self) -> None:
         assert EncoderEmbeddingAdapter.matches_config(_encoder_model_config())
         assert EncoderEmbeddingAdapter.requires_load(_encoder_model_config())
-        # Compatibility aliases keep older imports working.
         assert is_encoder_embedding_config(_encoder_model_config())
         assert requires_mlx_embeddings_load(_encoder_model_config())
         assert EncoderEmbeddingAdapter.matches_config(
@@ -97,7 +89,6 @@ class TestEncoderEmbeddingDetection:
             )
         )
         assert not EncoderEmbeddingAdapter.matches_config(config)
-        assert not EncoderEmbeddingAdapter.requires_load(config)
 
     def test_owns_cls_pooling_defaults(self) -> None:
         assert EncoderEmbeddingAdapter.default_sequence_pooling_type == "CLS"
@@ -109,29 +100,14 @@ class TestEncoderEmbeddingDetection:
         assert EncoderEmbeddingAdapter.skip_paged_attention_patch is True
 
 
-class TestMlxEmbeddingsLoad:
-    def test_missing_extra_raises_install_hint(self) -> None:
-        with (
-            patch(
-                "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
-                side_effect=ImportError(
-                    "Loading encoder embedding models such as XLM-RoBERTa / BGE-M3 "
-                    "requires the optional 'mlx-embeddings' package. Install it with: "
-                    'pip install "vllm-metal[embeddings]"'
-                ),
-            ),
-            pytest.raises(ImportError, match=r"vllm-metal\[embeddings\]"),
-        ):
-            EncoderEmbeddingAdapter.load("mlx-community/bge-m3-mlx-8bit")
-
+class TestNativeEncoderLoad:
     def test_wraps_loaded_model_with_adapter(self) -> None:
-        fake = _FakeEmbeddingsModule()
+        fake = _FakeEncoderModule()
         tokenizer = object()
-        load_mock = MagicMock(return_value=(fake, tokenizer))
         with patch(
-            "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
-            return_value=load_mock,
-        ):
+            "vllm_metal.v1.encoder_embeddings.load_encoder_model",
+            return_value=(fake, tokenizer),
+        ) as load_mock:
             model, loaded_tokenizer, adapter = EncoderEmbeddingAdapter.load(
                 "mlx-community/bge-m3-mlx-8bit",
                 tokenizer_config={"trust_remote_code": True},
@@ -144,7 +120,7 @@ class TestMlxEmbeddingsLoad:
             lazy=True,
         )
         assert loaded_tokenizer is tokenizer
-        assert isinstance(model, MlxEmbeddingsEncoderModel)
+        assert isinstance(model, NativeEncoderModel)
         assert isinstance(adapter, EncoderEmbeddingAdapter)
         assert adapter.model is model
         assert EncoderEmbeddingAdapter.from_loaded_model(model) is not None
@@ -153,27 +129,13 @@ class TestMlxEmbeddingsLoad:
         assert hidden.shape == (1, 3, 4)
         assert fake.calls == [((1, 3), (1, 3))]
 
-    def test_compatibility_load_helper_still_works(self) -> None:
-        fake = _FakeEmbeddingsModule()
-        tokenizer = object()
-        load_mock = MagicMock(return_value=(fake, tokenizer))
-        with patch(
-            "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
-            return_value=load_mock,
-        ):
-            model, loaded_tokenizer = load_mlx_embeddings_model(
-                "mlx-community/bge-m3-mlx-8bit"
-            )
-        assert isinstance(model, MlxEmbeddingsEncoderModel)
-        assert loaded_tokenizer is tokenizer
-
 
 class TestEncoderPagedSetup:
     def test_setup_paged_attention_skips_patching_via_adapter(self) -> None:
         from vllm_metal.v1.cache_policy import WorkerCachePlanner
 
-        fake = _FakeEmbeddingsModule()
-        model = MlxEmbeddingsEncoderModel(fake)
+        fake = _FakeEncoderModule()
+        model = NativeEncoderModel(fake)
         adapter = EncoderEmbeddingAdapter(model)
         runner = SimpleNamespace(
             model=model,
@@ -227,13 +189,12 @@ class TestEncoderPagedSetup:
 
 class TestEncoderPoolingForward:
     def test_supports_embed_for_encoder_adapter(self) -> None:
-        fake = _FakeEmbeddingsModule()
-        model = MlxEmbeddingsEncoderModel(fake)
+        model = NativeEncoderModel(_FakeEncoderModule())
         assert supports_embed_pooling(model, _encoder_model_config())
 
     def test_forwards_packed_segments_independently(self) -> None:
-        fake = _FakeEmbeddingsModule()
-        model = MlxEmbeddingsEncoderModel(fake)
+        fake = _FakeEncoderModule()
+        model = NativeEncoderModel(fake)
         adapter = EncoderEmbeddingAdapter(model)
         hidden = forward_sequence_hidden_states(
             model,
@@ -245,6 +206,5 @@ class TestEncoderPoolingForward:
         )
         assert hidden.shape == (1, 5, 4)
         assert fake.calls == [((1, 2), (1, 2)), ((1, 3), (1, 3))]
-        # First token of each independent segment starts its own row index 0.
         assert float(hidden[0, 0, 0]) == 0.0
         assert float(hidden[0, 2, 0]) == 0.0

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -138,6 +138,61 @@ class TestMlxEmbeddingsLoad:
         assert fake.calls == [((1, 3), (1, 3))]
 
 
+class TestEncoderPagedSetup:
+    def test_setup_paged_attention_skips_patching_encoder_models(self) -> None:
+        from vllm_metal.v1.cache_policy import WorkerCachePlanner
+
+        fake = _FakeEmbeddingsModule()
+        model = MlxEmbeddingsEncoderModel(fake)
+        runner = SimpleNamespace(
+            model=model,
+            is_mla=False,
+            validate_paged_attention_support=MagicMock(),
+            build_paged_attention_runtime=MagicMock(),
+            install_gemma4_mtp_kv_sharing=MagicMock(),
+            install_drafter=MagicMock(),
+            install_paged_attention_runtime=MagicMock(),
+            model_args={
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "head_dim": 2,
+                "hidden_size": 4,
+            },
+            kv_cache_dtype=mx.float16,
+            metal_config=SimpleNamespace(use_paged_attention=True),
+        )
+        backend = MagicMock()
+        backend.patch_model = MagicMock(return_value=2)
+        backend.initialize = MagicMock()
+        runner.build_paged_attention_runtime.return_value = backend
+
+        worker = SimpleNamespace(model_runner=runner)
+        planner = WorkerCachePlanner(worker)
+
+        plan = SimpleNamespace(
+            block_size=16,
+            num_blocks=4,
+            per_block_bytes=1024,
+            format_breakdown=lambda: "stub",
+        )
+        with (
+            patch.object(planner, "_paged_attention_plan", return_value=plan),
+            patch(
+                "vllm_metal.v1.cache_policy.get_config",
+                return_value=SimpleNamespace(turboquant=False, k_quant=None),
+            ),
+            patch(
+                "vllm_metal.v1.cache_policy.try_enable_gemma4_yoco_fast_prefill",
+                return_value=None,
+            ),
+        ):
+            planner.setup_paged_attention(overhead=0)
+
+        backend.patch_model.assert_not_called()
+        runner.install_paged_attention_runtime.assert_called_once()
+
+
 class TestEncoderPoolingForward:
     def test_supports_embed_for_encoder_adapter(self) -> None:
         fake = _FakeEmbeddingsModule()

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the mlx-embeddings encoder load path (#589 PR1)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.v1.encoder_embeddings import (
+    MlxEmbeddingsEncoderModel,
+    is_encoder_embedding_config,
+    load_mlx_embeddings_model,
+    requires_mlx_embeddings_load,
+)
+from vllm_metal.v1.pooling import (
+    forward_sequence_hidden_states,
+    supports_embed_pooling,
+)
+
+
+def _encoder_model_config(**overrides):
+    values = {
+        "runner_type": "pooling",
+        "served_model_name": "mlx-community/bge-m3-mlx-8bit",
+        "model": "mlx-community/bge-m3-mlx-8bit",
+        "hf_config": SimpleNamespace(
+            architectures=["XLMRobertaModel"],
+            model_type="xlm-roberta",
+        ),
+        "pooler_config": SimpleNamespace(
+            task="embed",
+            pooling_type=None,
+            seq_pooling_type="CLS",
+            enable_chunked_processing=False,
+            use_activation=None,
+            dimensions=None,
+        ),
+        "multimodal_config": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _FakeEmbeddingsOutput:
+    def __init__(self, hidden_states: mx.array) -> None:
+        self.last_hidden_state = hidden_states
+
+
+class _FakeEmbeddingsModule:
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(
+            model_type="xlm-roberta",
+            hidden_size=4,
+            vocab_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=2,
+            max_position_embeddings=32,
+        )
+        self.calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+
+    def __call__(self, input_ids, attention_mask=None):
+        shape = tuple(int(x) for x in input_ids.shape)
+        mask_shape = tuple(int(x) for x in attention_mask.shape)
+        self.calls.append((shape, mask_shape))
+        tokens = int(input_ids.shape[-1])
+        rows = [[float(i), float(i + 1), 0.0, 1.0] for i in range(tokens)]
+        return _FakeEmbeddingsOutput(mx.array([rows], dtype=mx.float32))
+
+
+class TestEncoderEmbeddingDetection:
+    def test_detects_xlm_roberta_and_bge_architectures(self) -> None:
+        assert is_encoder_embedding_config(_encoder_model_config())
+        assert requires_mlx_embeddings_load(_encoder_model_config())
+        assert is_encoder_embedding_config(
+            _encoder_model_config(
+                hf_config=SimpleNamespace(
+                    architectures=["BgeM3EmbeddingModel"],
+                    model_type="xlm-roberta",
+                )
+            )
+        )
+
+    def test_rejects_decoder_embedding_configs(self) -> None:
+        config = _encoder_model_config(
+            hf_config=SimpleNamespace(
+                architectures=["Qwen3ForCausalLM"],
+                model_type="qwen3",
+            )
+        )
+        assert not is_encoder_embedding_config(config)
+        assert not requires_mlx_embeddings_load(config)
+
+
+class TestMlxEmbeddingsLoad:
+    def test_missing_extra_raises_install_hint(self) -> None:
+        with (
+            patch(
+                "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+                side_effect=ImportError(
+                    "Loading encoder embedding models such as XLM-RoBERTa / BGE-M3 "
+                    "requires the optional 'mlx-embeddings' package. Install it with: "
+                    'pip install "vllm-metal[embeddings]"'
+                ),
+            ),
+            pytest.raises(ImportError, match=r"vllm-metal\[embeddings\]"),
+        ):
+            load_mlx_embeddings_model("mlx-community/bge-m3-mlx-8bit")
+
+    def test_wraps_loaded_model_with_sequence_body(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        tokenizer = object()
+        load_mock = MagicMock(return_value=(fake, tokenizer))
+        with patch(
+            "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+            return_value=load_mock,
+        ):
+            model, loaded_tokenizer = load_mlx_embeddings_model(
+                "mlx-community/bge-m3-mlx-8bit",
+                tokenizer_config={"trust_remote_code": True},
+                lazy=True,
+            )
+
+        load_mock.assert_called_once_with(
+            "mlx-community/bge-m3-mlx-8bit",
+            tokenizer_config={"trust_remote_code": True},
+            lazy=True,
+        )
+        assert loaded_tokenizer is tokenizer
+        assert isinstance(model, MlxEmbeddingsEncoderModel)
+        assert model.is_mlx_embeddings_encoder is True
+        hidden = model.model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=MagicMock())
+        assert hidden.shape == (1, 3, 4)
+        assert fake.calls == [((1, 3), (1, 3))]
+
+
+class TestEncoderPoolingForward:
+    def test_supports_embed_for_encoder_adapter(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        model = MlxEmbeddingsEncoderModel(fake)
+        assert supports_embed_pooling(model, _encoder_model_config())
+
+    def test_forwards_packed_segments_independently(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        model = MlxEmbeddingsEncoderModel(fake)
+        hidden = forward_sequence_hidden_states(
+            model,
+            mx.array([[10, 11, 20, 21, 22]], dtype=mx.int32),
+            cache=[MagicMock()],
+            model_config=_encoder_model_config(),
+            segment_lengths=[2, 3],
+        )
+        assert hidden.shape == (1, 5, 4)
+        assert fake.calls == [((1, 2), (1, 2)), ((1, 3), (1, 3))]
+        # First token of each independent segment starts its own row index 0.
+        assert float(hidden[0, 0, 0]) == 0.0
+        assert float(hidden[0, 2, 0]) == 0.0

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the mlx-embeddings encoder load path (#589 PR1)."""
+"""Tests for the encoder embedding adapter (#589 PR1)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import mlx.core as mx
 import pytest
 
 from vllm_metal.v1.encoder_embeddings import (
+    EncoderEmbeddingAdapter,
     MlxEmbeddingsEncoderModel,
     is_encoder_embedding_config,
     load_mlx_embeddings_model,
@@ -74,9 +75,12 @@ class _FakeEmbeddingsModule:
 
 class TestEncoderEmbeddingDetection:
     def test_detects_xlm_roberta_and_bge_architectures(self) -> None:
+        assert EncoderEmbeddingAdapter.matches_config(_encoder_model_config())
+        assert EncoderEmbeddingAdapter.requires_load(_encoder_model_config())
+        # Compatibility aliases keep older imports working.
         assert is_encoder_embedding_config(_encoder_model_config())
         assert requires_mlx_embeddings_load(_encoder_model_config())
-        assert is_encoder_embedding_config(
+        assert EncoderEmbeddingAdapter.matches_config(
             _encoder_model_config(
                 hf_config=SimpleNamespace(
                     architectures=["BgeM3EmbeddingModel"],
@@ -92,8 +96,17 @@ class TestEncoderEmbeddingDetection:
                 model_type="qwen3",
             )
         )
-        assert not is_encoder_embedding_config(config)
-        assert not requires_mlx_embeddings_load(config)
+        assert not EncoderEmbeddingAdapter.matches_config(config)
+        assert not EncoderEmbeddingAdapter.requires_load(config)
+
+    def test_owns_cls_pooling_defaults(self) -> None:
+        assert EncoderEmbeddingAdapter.default_sequence_pooling_type == "CLS"
+        assert EncoderEmbeddingAdapter.allowed_sequence_pooling_types == (
+            None,
+            "CLS",
+            "LAST",
+        )
+        assert EncoderEmbeddingAdapter.skip_paged_attention_patch is True
 
 
 class TestMlxEmbeddingsLoad:
@@ -109,9 +122,9 @@ class TestMlxEmbeddingsLoad:
             ),
             pytest.raises(ImportError, match=r"vllm-metal\[embeddings\]"),
         ):
-            load_mlx_embeddings_model("mlx-community/bge-m3-mlx-8bit")
+            EncoderEmbeddingAdapter.load("mlx-community/bge-m3-mlx-8bit")
 
-    def test_wraps_loaded_model_with_sequence_body(self) -> None:
+    def test_wraps_loaded_model_with_adapter(self) -> None:
         fake = _FakeEmbeddingsModule()
         tokenizer = object()
         load_mock = MagicMock(return_value=(fake, tokenizer))
@@ -119,7 +132,7 @@ class TestMlxEmbeddingsLoad:
             "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
             return_value=load_mock,
         ):
-            model, loaded_tokenizer = load_mlx_embeddings_model(
+            model, loaded_tokenizer, adapter = EncoderEmbeddingAdapter.load(
                 "mlx-community/bge-m3-mlx-8bit",
                 tokenizer_config={"trust_remote_code": True},
                 lazy=True,
@@ -132,21 +145,40 @@ class TestMlxEmbeddingsLoad:
         )
         assert loaded_tokenizer is tokenizer
         assert isinstance(model, MlxEmbeddingsEncoderModel)
-        assert model.is_mlx_embeddings_encoder is True
+        assert isinstance(adapter, EncoderEmbeddingAdapter)
+        assert adapter.model is model
+        assert EncoderEmbeddingAdapter.from_loaded_model(model) is not None
+        assert EncoderEmbeddingAdapter.from_loaded_model(object()) is None
         hidden = model.model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=MagicMock())
         assert hidden.shape == (1, 3, 4)
         assert fake.calls == [((1, 3), (1, 3))]
 
+    def test_compatibility_load_helper_still_works(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        tokenizer = object()
+        load_mock = MagicMock(return_value=(fake, tokenizer))
+        with patch(
+            "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+            return_value=load_mock,
+        ):
+            model, loaded_tokenizer = load_mlx_embeddings_model(
+                "mlx-community/bge-m3-mlx-8bit"
+            )
+        assert isinstance(model, MlxEmbeddingsEncoderModel)
+        assert loaded_tokenizer is tokenizer
+
 
 class TestEncoderPagedSetup:
-    def test_setup_paged_attention_skips_patching_encoder_models(self) -> None:
+    def test_setup_paged_attention_skips_patching_via_adapter(self) -> None:
         from vllm_metal.v1.cache_policy import WorkerCachePlanner
 
         fake = _FakeEmbeddingsModule()
         model = MlxEmbeddingsEncoderModel(fake)
+        adapter = EncoderEmbeddingAdapter(model)
         runner = SimpleNamespace(
             model=model,
             is_mla=False,
+            _encoder_embedding_adapter=adapter,
             validate_paged_attention_support=MagicMock(),
             build_paged_attention_runtime=MagicMock(),
             install_gemma4_mtp_kv_sharing=MagicMock(),
@@ -202,12 +234,14 @@ class TestEncoderPoolingForward:
     def test_forwards_packed_segments_independently(self) -> None:
         fake = _FakeEmbeddingsModule()
         model = MlxEmbeddingsEncoderModel(fake)
+        adapter = EncoderEmbeddingAdapter(model)
         hidden = forward_sequence_hidden_states(
             model,
             mx.array([[10, 11, 20, 21, 22]], dtype=mx.int32),
             cache=[MagicMock()],
             model_config=_encoder_model_config(),
             segment_lengths=[2, 3],
+            encoder_adapter=adapter,
         )
         assert hidden.shape == (1, 5, 4)
         assert fake.calls == [((1, 2), (1, 2)), ((1, 3), (1, 3))]

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -22,7 +22,7 @@ from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noq
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.encoder_embeddings import (  # noqa: E402
     EncoderEmbeddingAdapter,
-    MlxEmbeddingsEncoderModel,
+    NativeEncoderModel,
 )
 from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
@@ -331,11 +331,11 @@ class _FakeEncoderOutput:
 
 
 class _FakeEncoderModule:
-    def __call__(self, input_ids, attention_mask=None):
-        del attention_mask
+    def __call__(self, input_ids, attention_mask=None, token_type_ids=None):
+        del attention_mask, token_type_ids
         token_ids = np.array(input_ids).reshape(-1).tolist()
         rows = [[float(tok), float(tok + 1), 1.0] for tok in token_ids]
-        return _FakeEncoderOutput(mx.array([rows], dtype=mx.float32))
+        return mx.array([rows], dtype=mx.float32)
 
 
 class TestMetalPoolingCapabilities:
@@ -346,7 +346,7 @@ class TestMetalPoolingCapabilities:
 
     def test_supported_worker_tasks_for_encoder_cls_embedding_model(self) -> None:
         runner = _make_runner(
-            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model=NativeEncoderModel(_FakeEncoderModule()),
             model_config=_encoder_pooling_model_config(),
         )
 
@@ -485,7 +485,7 @@ class TestMetalPoolingRunnerOutput:
 
     def test_paged_encoder_cls_embed_uses_first_token(self) -> None:
         runner = _make_runner(
-            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model=NativeEncoderModel(_FakeEncoderModule()),
             model_config=_encoder_pooling_model_config(),
         )
         req_b = _new_req("req-b", [4, 5])
@@ -666,7 +666,7 @@ class TestMetalPoolingFailFast:
 
     def test_token_classify_fail_fast_mentions_sparse_followup(self) -> None:
         runner = _make_runner(
-            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model=NativeEncoderModel(_FakeEncoderModule()),
             model_config=_encoder_pooling_model_config(),
         )
         req = _new_req("req-0", [1, 2], task="token_classify")

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -20,7 +20,10 @@ from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
-from vllm_metal.v1.encoder_embeddings import MlxEmbeddingsEncoderModel  # noqa: E402
+from vllm_metal.v1.encoder_embeddings import (  # noqa: E402
+    EncoderEmbeddingAdapter,
+    MlxEmbeddingsEncoderModel,
+)
 from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
 
@@ -170,8 +173,9 @@ def _make_runner(
     model_config: object | None = None,
     tokenizer: object | None = None,
 ):
-    return make_stub_runner(
-        model=model or _PoolingModel(),
+    resolved_model = model or _PoolingModel()
+    runner = make_stub_runner(
+        model=resolved_model,
         model_config=model_config or _pooling_model_config(),
         tokenizer=tokenizer,
         _paged_attention_runtime=(
@@ -187,7 +191,11 @@ def _make_runner(
         ),
         _paged_block_size=4,
         num_layers=1,
+        _encoder_embedding_adapter=EncoderEmbeddingAdapter.from_loaded_model(
+            resolved_model
+        ),
     )
+    return runner
 
 
 def _pooling_params(task: str | None = None, **overrides) -> PoolingParams:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -20,6 +20,7 @@ from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
+from vllm_metal.v1.encoder_embeddings import MlxEmbeddingsEncoderModel  # noqa: E402
 from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
 
@@ -298,9 +299,48 @@ def _execute_pooling(runner, sched):
     return out
 
 
+def _encoder_hf_config(**overrides):
+    values = {
+        "architectures": ["XLMRobertaModel"],
+        "model_type": "xlm-roberta",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _encoder_pooling_model_config(**overrides):
+    values = {
+        "hf_config": _encoder_hf_config(),
+        "pooler_config": _pooler_config(task="embed", seq_pooling_type="CLS"),
+    }
+    values.update(overrides)
+    return _pooling_model_config(**values)
+
+
+class _FakeEncoderOutput:
+    def __init__(self, hidden_states: mx.array) -> None:
+        self.last_hidden_state = hidden_states
+
+
+class _FakeEncoderModule:
+    def __call__(self, input_ids, attention_mask=None):
+        del attention_mask
+        token_ids = np.array(input_ids).reshape(-1).tolist()
+        rows = [[float(tok), float(tok + 1), 1.0] for tok in token_ids]
+        return _FakeEncoderOutput(mx.array([rows], dtype=mx.float32))
+
+
 class TestMetalPoolingCapabilities:
     def test_supported_worker_tasks_for_last_text_embedding_model(self) -> None:
         runner = _make_runner()
+
+        assert runner.supported_worker_tasks() == ("embed",)
+
+    def test_supported_worker_tasks_for_encoder_cls_embedding_model(self) -> None:
+        runner = _make_runner(
+            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model_config=_encoder_pooling_model_config(),
+        )
 
         assert runner.supported_worker_tasks() == ("embed",)
 
@@ -434,6 +474,27 @@ class TestMetalPoolingRunnerOutput:
         assert out.pooler_output is not None
         _assert_embedding(out.pooler_output[0], 5)
         _assert_embedding(out.pooler_output[1], 9)
+
+    def test_paged_encoder_cls_embed_uses_first_token(self) -> None:
+        runner = _make_runner(
+            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model_config=_encoder_pooling_model_config(),
+        )
+        req_b = _new_req("req-b", [4, 5])
+        req_a = _new_req("req-a", [7, 8, 9])
+        sched = _scheduler_output(new_reqs=[req_b, req_a])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_grouped"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.req_ids == ["req-b", "req-a"]
+        assert out.pooler_output is not None
+        # CLS uses the first token of each packed segment, not the last.
+        _assert_embedding(out.pooler_output[0], 4)
+        _assert_embedding(out.pooler_output[1], 7)
 
     def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(self) -> None:
         runner = _make_runner()
@@ -571,7 +632,10 @@ class TestMetalPoolingFailFast:
         )
         req = _new_req("req-0", [1, 2], task="embed")
 
-        with pytest.raises(NotImplementedError, match="decoder-style checkpoint"):
+        with pytest.raises(
+            NotImplementedError,
+            match="decoder-style embedding checkpoint or an encoder embedding",
+        ):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
     def test_pooling_requires_paged_attention(self) -> None:
@@ -583,13 +647,23 @@ class TestMetalPoolingFailFast:
 
     @pytest.mark.parametrize(
         "task",
-        ["token_embed", "token_classify", "plugin"],
+        ["token_embed", "plugin"],
     )
     def test_unsupported_pooling_tasks_fail_fast(self, task: str) -> None:
         runner = _make_runner()
         req = _new_req("req-0", [1, 2], task=task)
 
         with pytest.raises(NotImplementedError, match="task"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_token_classify_fail_fast_mentions_sparse_followup(self) -> None:
+        runner = _make_runner(
+            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model_config=_encoder_pooling_model_config(),
+        )
+        req = _new_req("req-0", [1, 2], task="token_classify")
+
+        with pytest.raises(NotImplementedError, match="sparse lexical weights"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
     def test_classify_hidden_state_shape_fails_fast(self) -> None:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -950,15 +950,16 @@ class WorkerCachePlanner:
             backend,
             block_size=plan.block_size,
         )
-        # Encoder embedding models (mlx-embeddings XLM-RoBERTa / BGE-M3) own
-        # bidirectional attention internally. They still use the paged scheduler
-        # for pooling batch bookkeeping, but there are no mlx-lm-style
-        # ``model.layers`` to wrap — skip patching rather than fail loud.
-        model = self._worker.model_runner.model
-        if getattr(model, "is_mlx_embeddings_encoder", False):
+        # Encoder embedding adapters own bidirectional attention. They still use
+        # the paged scheduler for pooling batch bookkeeping, but there are no
+        # mlx-lm-style ``model.layers`` to wrap — skip patching rather than fail.
+        encoder_adapter = getattr(
+            self._worker.model_runner, "_encoder_embedding_adapter", None
+        )
+        if encoder_adapter is not None and encoder_adapter.skip_paged_attention_patch:
             n_patched = 0
         else:
-            n_patched = backend.patch_model(model)
+            n_patched = backend.patch_model(self._worker.model_runner.model)
         self._worker.model_runner.install_drafter(
             num_blocks=plan.num_blocks,
             block_size=plan.block_size,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -950,7 +950,15 @@ class WorkerCachePlanner:
             backend,
             block_size=plan.block_size,
         )
-        n_patched = backend.patch_model(self._worker.model_runner.model)
+        # Encoder embedding models (mlx-embeddings XLM-RoBERTa / BGE-M3) own
+        # bidirectional attention internally. They still use the paged scheduler
+        # for pooling batch bookkeeping, but there are no mlx-lm-style
+        # ``model.layers`` to wrap — skip patching rather than fail loud.
+        model = self._worker.model_runner.model
+        if getattr(model, "is_mlx_embeddings_encoder", False):
+            n_patched = 0
+        else:
+            n_patched = backend.patch_model(model)
         self._worker.model_runner.install_drafter(
             num_blocks=plan.num_blocks,
             block_size=plan.block_size,

--- a/vllm_metal/v1/encoder/__init__.py
+++ b/vllm_metal/v1/encoder/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native encoder embedding models for Metal pooling."""
+
+from vllm_metal.v1.encoder.xlm_roberta import XLMRobertaArgs, XLMRobertaModel
+
+__all__ = ["XLMRobertaArgs", "XLMRobertaModel"]

--- a/vllm_metal/v1/encoder/loader.py
+++ b/vllm_metal/v1/encoder/loader.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Load native MLX encoder embedding checkpoints (Apache-2.0)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from vllm_metal.v1.encoder.xlm_roberta import XLMRobertaArgs, XLMRobertaModel
+
+_ENCODER_MODEL_TYPES = frozenset({"xlm-roberta", "roberta", "xlm_roberta"})
+
+
+def load_encoder_model(
+    model_name: str | Path,
+    *,
+    tokenizer_config: dict[str, Any] | None = None,
+    lazy: bool = False,
+) -> tuple[XLMRobertaModel, Any]:
+    """Load an XLM-RoBERTa / RoBERTa encoder + HuggingFace tokenizer."""
+    model_path = _resolve_model_path(model_name)
+    config = _read_config(model_path)
+    model_type = str(config.get("model_type", "")).replace("_", "-")
+    if model_type not in {t.replace("_", "-") for t in _ENCODER_MODEL_TYPES}:
+        raise ValueError(
+            "Native Metal encoder loader currently supports model_type "
+            f"'xlm-roberta' / 'roberta'; got {config.get('model_type')!r}."
+        )
+
+    args = XLMRobertaArgs.from_dict(config)
+    model = XLMRobertaModel(args)
+    _load_weights_into_model(model, model_path, config)
+    if not lazy:
+        mx.eval(model.parameters())
+
+    tokenizer = _load_tokenizer(model_path, tokenizer_config or {})
+    return model, tokenizer
+
+
+def _resolve_model_path(model_path: str | Path) -> Path:
+    path = Path(model_path)
+    if path.exists():
+        return path
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:  # pragma: no cover
+        raise ValueError(
+            f"Could not download model {model_path}: huggingface_hub is not installed"
+        ) from exc
+    try:
+        return Path(snapshot_download(repo_id=str(model_path)))
+    except OSError as exc:
+        raise ValueError(f"Could not download model: {model_path}") from exc
+
+
+def _read_config(model_path: Path) -> dict[str, Any]:
+    config_path = model_path / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"config.json not found in {model_path}")
+    with config_path.open() as handle:
+        return json.load(handle)
+
+
+def _load_weights(model_path: Path) -> dict[str, mx.array]:
+    weight_files = sorted(model_path.glob("model*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("*.safetensors"))
+    if not weight_files:
+        raise FileNotFoundError(f"No safetensors found in {model_path}")
+    weights: dict[str, mx.array] = {}
+    for weight_file in weight_files:
+        weights.update(mx.load(str(weight_file)))
+    return weights
+
+
+def _load_weights_into_model(
+    model: XLMRobertaModel,
+    model_path: Path,
+    config: dict[str, Any],
+) -> None:
+    weights = _load_weights(model_path)
+    weights = model.sanitize(weights)
+
+    quantization = config.get("quantization")
+    if quantization is not None:
+
+        def class_predicate(path: str, module: nn.Module) -> bool:
+            return hasattr(module, "to_quantized") and f"{path}.scales" in weights
+
+        nn.quantize(
+            model,
+            group_size=quantization["group_size"],
+            bits=quantization["bits"],
+            mode=quantization.get("mode", "affine"),
+            class_predicate=class_predicate,
+        )
+
+    model.load_weights(list(weights.items()), strict=True)
+
+
+def _load_tokenizer(model_path: Path, tokenizer_config: dict[str, Any]) -> Any:
+    try:
+        from transformers import AutoTokenizer
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "Loading encoder embedding tokenizers requires transformers."
+        ) from exc
+    return AutoTokenizer.from_pretrained(model_path, **tokenizer_config)

--- a/vllm_metal/v1/encoder/xlm_roberta.py
+++ b/vllm_metal/v1/encoder/xlm_roberta.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MLX XLM-RoBERTa / RoBERTa encoder (Apache-2.0, no mlx-embeddings).
+
+Architecture follows the public HuggingFace Bert/XLM-RoBERTa layout so MLX
+quantized checkpoints (e.g. mlx-community BGE-M3) load by matching parameter
+paths. Implemented in-tree to keep vllm-metal Apache-2.0 compatible.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@dataclass
+class XLMRobertaArgs:
+    model_type: str = "xlm-roberta"
+    hidden_size: int = 768
+    num_hidden_layers: int = 12
+    intermediate_size: int = 3072
+    num_attention_heads: int = 12
+    max_position_embeddings: int = 512
+    vocab_size: int = 250002
+    type_vocab_size: int = 1
+    layer_norm_eps: float = 1e-5
+    hidden_dropout_prob: float = 0.0
+    attention_probs_dropout_prob: float = 0.0
+    pad_token_id: int = 1
+    bos_token_id: int = 0
+    eos_token_id: int = 2
+    add_pooling_layer: bool = True
+    position_embedding_type: str = "absolute"
+
+    @classmethod
+    def from_dict(cls, params: dict[str, Any]) -> XLMRobertaArgs:
+        fields = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
+        return cls(**{k: v for k, v in params.items() if k in fields})
+
+
+class XLMRobertaEmbeddings(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.word_embeddings = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.position_embeddings = nn.Embedding(
+            args.max_position_embeddings, args.hidden_size
+        )
+        self.token_type_embeddings = nn.Embedding(
+            args.type_vocab_size, args.hidden_size
+        )
+        self.LayerNorm = nn.LayerNorm(args.hidden_size, eps=args.layer_norm_eps)
+        self.padding_idx = args.pad_token_id
+
+    def _position_ids(self, input_ids: mx.array) -> mx.array:
+        # HuggingFace XLM-RoBERTa: cumulative positions skipping pads, then + pad_idx.
+        mask = (input_ids != self.padding_idx).astype(mx.int32)
+        incremental = mx.cumsum(mask, axis=1) * mask
+        return incremental + self.padding_idx
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        token_type_ids: mx.array | None = None,
+        position_ids: mx.array | None = None,
+    ) -> mx.array:
+        if token_type_ids is None:
+            token_type_ids = mx.zeros(input_ids.shape, dtype=mx.int32)
+        if position_ids is None:
+            position_ids = self._position_ids(input_ids)
+
+        embeddings = (
+            self.word_embeddings(input_ids)
+            + self.token_type_embeddings(token_type_ids)
+            + self.position_embeddings(position_ids)
+        )
+        return self.LayerNorm(embeddings)
+
+
+class XLMRobertaSelfAttention(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        if args.hidden_size % args.num_attention_heads != 0:
+            raise ValueError(
+                f"hidden_size {args.hidden_size} not divisible by "
+                f"num_attention_heads {args.num_attention_heads}"
+            )
+        self.num_attention_heads = args.num_attention_heads
+        self.attention_head_size = args.hidden_size // args.num_attention_heads
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+        self.query = nn.Linear(args.hidden_size, self.all_head_size)
+        self.key = nn.Linear(args.hidden_size, self.all_head_size)
+        self.value = nn.Linear(args.hidden_size, self.all_head_size)
+
+    def _transpose_for_scores(self, x: mx.array) -> mx.array:
+        batch, seq, _ = x.shape
+        x = x.reshape(batch, seq, self.num_attention_heads, self.attention_head_size)
+        return x.transpose(0, 2, 1, 3)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> mx.array:
+        query = self._transpose_for_scores(self.query(hidden_states))
+        key = self._transpose_for_scores(self.key(hidden_states))
+        value = self._transpose_for_scores(self.value(hidden_states))
+
+        scale = 1.0 / math.sqrt(self.attention_head_size)
+        scores = (query @ key.transpose(0, 1, 3, 2)) * scale
+        if attention_mask is not None:
+            scores = scores + attention_mask
+        probs = mx.softmax(scores, axis=-1)
+        context = probs @ value
+        context = context.transpose(0, 2, 1, 3)
+        batch, seq, _, _ = context.shape
+        return context.reshape(batch, seq, self.all_head_size)
+
+
+class XLMRobertaSelfOutput(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.hidden_size, args.hidden_size)
+        self.LayerNorm = nn.LayerNorm(args.hidden_size, eps=args.layer_norm_eps)
+
+    def __call__(self, hidden_states: mx.array, input_tensor: mx.array) -> mx.array:
+        return self.LayerNorm(self.dense(hidden_states) + input_tensor)
+
+
+class XLMRobertaAttention(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.self = XLMRobertaSelfAttention(args)
+        self.output = XLMRobertaSelfOutput(args)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> mx.array:
+        self_out = self.self(hidden_states, attention_mask=attention_mask)
+        return self.output(self_out, hidden_states)
+
+
+class XLMRobertaIntermediate(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.hidden_size, args.intermediate_size)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        return nn.gelu(self.dense(hidden_states))
+
+
+class XLMRobertaOutput(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.intermediate_size, args.hidden_size)
+        self.LayerNorm = nn.LayerNorm(args.hidden_size, eps=args.layer_norm_eps)
+
+    def __call__(self, hidden_states: mx.array, input_tensor: mx.array) -> mx.array:
+        return self.LayerNorm(self.dense(hidden_states) + input_tensor)
+
+
+class XLMRobertaLayer(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.attention = XLMRobertaAttention(args)
+        self.intermediate = XLMRobertaIntermediate(args)
+        self.output = XLMRobertaOutput(args)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> mx.array:
+        attention_out = self.attention(hidden_states, attention_mask=attention_mask)
+        intermediate = self.intermediate(attention_out)
+        return self.output(intermediate, attention_out)
+
+
+class XLMRobertaEncoder(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.layer = [XLMRobertaLayer(args) for _ in range(args.num_hidden_layers)]
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> mx.array:
+        for layer in self.layer:
+            hidden_states = layer(hidden_states, attention_mask=attention_mask)
+        return hidden_states
+
+
+class XLMRobertaPooler(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.hidden_size, args.hidden_size)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        return mx.tanh(self.dense(hidden_states[:, 0]))
+
+
+class XLMRobertaModel(nn.Module):
+    """Encoder-only XLM-RoBERTa / RoBERTa backbone returning last hidden states."""
+
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.embeddings = XLMRobertaEmbeddings(args)
+        self.encoder = XLMRobertaEncoder(args)
+        self.pooler = XLMRobertaPooler(args) if args.add_pooling_layer else None
+
+    def _extended_attention_mask(self, attention_mask: mx.array) -> mx.array:
+        # HF convention: 1 = keep, 0 = mask. Broadcast to [B, 1, 1, S].
+        mask = attention_mask.astype(mx.float32)
+        mask = mx.expand_dims(mx.expand_dims(mask, 1), 1)
+        return (1.0 - mask) * -1e4
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array | None = None,
+        token_type_ids: mx.array | None = None,
+    ) -> mx.array:
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        extended = self._extended_attention_mask(attention_mask)
+        hidden = self.embeddings(input_ids, token_type_ids=token_type_ids)
+        return self.encoder(hidden, attention_mask=extended)
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        """Drop unused keys that some converters may include."""
+        return {
+            k: v
+            for k, v in weights.items()
+            if not k.endswith(".position_ids") and "rotary" not in k
+        }

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Encoder embedding load path via optional mlx-embeddings (#589 PR1)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+
+_ENCODER_EMBEDDING_ARCHITECTURES = frozenset(
+    {
+        "XLMRobertaModel",
+        "RobertaModel",
+        "RobertaEmbeddingModel",
+        "BgeM3EmbeddingModel",
+    }
+)
+_ENCODER_EMBEDDING_MODEL_TYPES = frozenset(
+    {
+        "xlm-roberta",
+        "roberta",
+        "xlm_roberta",
+    }
+)
+
+
+def is_encoder_embedding_architecture(architecture: str) -> bool:
+    return architecture in _ENCODER_EMBEDDING_ARCHITECTURES
+
+
+def is_encoder_embedding_model_type(model_type: str | None) -> bool:
+    if model_type is None:
+        return False
+    return model_type.replace("_", "-") in {
+        value.replace("_", "-") for value in _ENCODER_EMBEDDING_MODEL_TYPES
+    }
+
+
+def is_encoder_embedding_config(model_config: Any) -> bool:
+    """Return whether vLLM resolved this as an encoder embedding checkpoint."""
+    hf_config = getattr(model_config, "hf_config", None)
+    architectures: list[str] = []
+    for source in (model_config, hf_config):
+        values = getattr(source, "architectures", None)
+        if isinstance(values, (list, tuple)):
+            architectures.extend(str(arch) for arch in values)
+    if any(is_encoder_embedding_architecture(arch) for arch in architectures):
+        return True
+    model_type = getattr(hf_config, "model_type", None)
+    return is_encoder_embedding_model_type(
+        str(model_type) if model_type is not None else None
+    )
+
+
+def requires_mlx_embeddings_load(model_config: Any) -> bool:
+    """True when Metal should load weights through mlx-embeddings."""
+    return is_encoder_embedding_config(model_config)
+
+
+class _EncoderSequenceBody:
+    """Callable transformer body returning ``[1, tokens, hidden]`` states."""
+
+    def __init__(self, model: Any) -> None:
+        self._model = model
+
+    def __call__(self, input_ids: mx.array, cache: Any = None) -> mx.array:
+        del cache  # Encoder embeddings are bidirectional and cache-free.
+        if input_ids.ndim == 1:
+            input_ids = input_ids.reshape(1, -1)
+        attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        output = self._model(input_ids, attention_mask=attention_mask)
+        hidden_states = getattr(output, "last_hidden_state", None)
+        if hidden_states is None:
+            raise ValueError(
+                "mlx-embeddings encoder forward did not return last_hidden_state; "
+                f"got {type(output)!r}."
+            )
+        return hidden_states
+
+
+class MlxEmbeddingsEncoderModel:
+    """Thin adapter so Metal pooling can use mlx-embeddings models."""
+
+    is_mlx_embeddings_encoder = True
+
+    def __init__(self, model: Any) -> None:
+        self._model = model
+        self.config = getattr(model, "config", None)
+        self.args = self.config
+        self.model = _EncoderSequenceBody(model)
+
+
+def _import_mlx_embeddings_load() -> Any:
+    try:
+        from mlx_embeddings import load as mlx_embeddings_load
+    except ImportError as exc:
+        raise ImportError(
+            "Loading encoder embedding models such as XLM-RoBERTa / BGE-M3 "
+            "requires the optional 'mlx-embeddings' package. Install it with: "
+            'pip install "vllm-metal[embeddings]"'
+        ) from exc
+    return mlx_embeddings_load
+
+
+def load_mlx_embeddings_model(
+    model_name: str,
+    *,
+    tokenizer_config: dict[str, Any] | None = None,
+    lazy: bool = False,
+) -> tuple[MlxEmbeddingsEncoderModel, Any]:
+    """Load an encoder embedding checkpoint through mlx-embeddings."""
+    mlx_embeddings_load = _import_mlx_embeddings_load()
+    model, tokenizer = mlx_embeddings_load(
+        model_name,
+        tokenizer_config=dict(tokenizer_config or {}),
+        lazy=lazy,
+    )
+    return MlxEmbeddingsEncoderModel(model), tokenizer

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Encoder embedding load path via optional mlx-embeddings (#589 PR1)."""
+"""Encoder embedding adapter via optional mlx-embeddings (#589 PR1).
+
+Owns load, bidirectional segment forward, CLS pooling defaults, and paged
+attention patch-skipping so encoder special-cases stay in one place.
+"""
 
 from __future__ import annotations
 
@@ -22,39 +26,7 @@ _ENCODER_EMBEDDING_MODEL_TYPES = frozenset(
         "xlm_roberta",
     }
 )
-
-
-def is_encoder_embedding_architecture(architecture: str) -> bool:
-    return architecture in _ENCODER_EMBEDDING_ARCHITECTURES
-
-
-def is_encoder_embedding_model_type(model_type: str | None) -> bool:
-    if model_type is None:
-        return False
-    return model_type.replace("_", "-") in {
-        value.replace("_", "-") for value in _ENCODER_EMBEDDING_MODEL_TYPES
-    }
-
-
-def is_encoder_embedding_config(model_config: Any) -> bool:
-    """Return whether vLLM resolved this as an encoder embedding checkpoint."""
-    hf_config = getattr(model_config, "hf_config", None)
-    architectures: list[str] = []
-    for source in (model_config, hf_config):
-        values = getattr(source, "architectures", None)
-        if isinstance(values, (list, tuple)):
-            architectures.extend(str(arch) for arch in values)
-    if any(is_encoder_embedding_architecture(arch) for arch in architectures):
-        return True
-    model_type = getattr(hf_config, "model_type", None)
-    return is_encoder_embedding_model_type(
-        str(model_type) if model_type is not None else None
-    )
-
-
-def requires_mlx_embeddings_load(model_config: Any) -> bool:
-    """True when Metal should load weights through mlx-embeddings."""
-    return is_encoder_embedding_config(model_config)
+_ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 
 
 class _EncoderSequenceBody:
@@ -79,9 +51,7 @@ class _EncoderSequenceBody:
 
 
 class MlxEmbeddingsEncoderModel:
-    """Thin adapter so Metal pooling can use mlx-embeddings models."""
-
-    is_mlx_embeddings_encoder = True
+    """Weight wrapper exposing a Metal-compatible ``.model`` body."""
 
     def __init__(self, model: Any) -> None:
         self._model = model
@@ -109,17 +79,131 @@ def _import_mlx_embeddings_load() -> Any:
     return mlx_embeddings_load
 
 
+class EncoderEmbeddingAdapter:
+    """Single owner for mlx-embeddings encoder embedding behavior on Metal."""
+
+    skip_paged_attention_patch = True
+    default_sequence_pooling_type = "CLS"
+    allowed_sequence_pooling_types = _ENCODER_SEQUENCE_POOLING
+
+    def __init__(self, model: MlxEmbeddingsEncoderModel) -> None:
+        self.model = model
+
+    @staticmethod
+    def matches_architecture(architecture: str) -> bool:
+        return architecture in _ENCODER_EMBEDDING_ARCHITECTURES
+
+    @staticmethod
+    def matches_model_type(model_type: str | None) -> bool:
+        if model_type is None:
+            return False
+        return model_type.replace("_", "-") in {
+            value.replace("_", "-") for value in _ENCODER_EMBEDDING_MODEL_TYPES
+        }
+
+    @classmethod
+    def matches_config(cls, model_config: Any) -> bool:
+        """Return whether vLLM resolved this as an encoder embedding checkpoint."""
+        hf_config = getattr(model_config, "hf_config", None)
+        architectures: list[str] = []
+        for source in (model_config, hf_config):
+            values = getattr(source, "architectures", None)
+            if isinstance(values, (list, tuple)):
+                architectures.extend(str(arch) for arch in values)
+        if any(cls.matches_architecture(arch) for arch in architectures):
+            return True
+        model_type = getattr(hf_config, "model_type", None)
+        return cls.matches_model_type(
+            str(model_type) if model_type is not None else None
+        )
+
+    @classmethod
+    def requires_load(cls, model_config: Any) -> bool:
+        """True when Metal should load weights through mlx-embeddings."""
+        return cls.matches_config(model_config)
+
+    @classmethod
+    def load(
+        cls,
+        model_name: str,
+        *,
+        tokenizer_config: dict[str, Any] | None = None,
+        lazy: bool = False,
+    ) -> tuple[MlxEmbeddingsEncoderModel, Any, EncoderEmbeddingAdapter]:
+        """Load an encoder embedding checkpoint and return model + adapter."""
+        mlx_embeddings_load = _import_mlx_embeddings_load()
+        raw_model, tokenizer = mlx_embeddings_load(
+            model_name,
+            tokenizer_config=dict(tokenizer_config or {}),
+            lazy=lazy,
+        )
+        model = MlxEmbeddingsEncoderModel(raw_model)
+        return model, tokenizer, cls(model)
+
+    @classmethod
+    def from_loaded_model(cls, model: Any) -> EncoderEmbeddingAdapter | None:
+        """Return an adapter when ``model`` is the encoder weight wrapper."""
+        if isinstance(model, MlxEmbeddingsEncoderModel):
+            return cls(model)
+        return None
+
+    def forward_sequence_hidden_states(
+        self,
+        input_ids: mx.array,
+        *,
+        segment_lengths: list[int] | None = None,
+        model_label: str = "encoder-embedding",
+    ) -> mx.array:
+        """Forward each packed segment independently (bidirectional)."""
+        body = self.model.model
+        flat = input_ids.reshape(-1)
+        total_tokens = int(flat.shape[0])
+        if not segment_lengths:
+            segment_lengths = [total_tokens]
+        if sum(segment_lengths) != total_tokens:
+            raise ValueError(
+                "Encoder pooling segment_lengths "
+                f"{segment_lengths!r} do not cover input tokens "
+                f"{total_tokens} for model={model_label}."
+            )
+
+        parts: list[mx.array] = []
+        offset = 0
+        for length in segment_lengths:
+            segment = flat[offset : offset + length].reshape(1, length)
+            parts.append(body(segment))
+            offset += length
+        if len(parts) == 1:
+            return parts[0]
+        return mx.concatenate(parts, axis=1)
+
+
+# Compatibility aliases used by older call sites / tests.
+def is_encoder_embedding_architecture(architecture: str) -> bool:
+    return EncoderEmbeddingAdapter.matches_architecture(architecture)
+
+
+def is_encoder_embedding_model_type(model_type: str | None) -> bool:
+    return EncoderEmbeddingAdapter.matches_model_type(model_type)
+
+
+def is_encoder_embedding_config(model_config: Any) -> bool:
+    return EncoderEmbeddingAdapter.matches_config(model_config)
+
+
+def requires_mlx_embeddings_load(model_config: Any) -> bool:
+    return EncoderEmbeddingAdapter.requires_load(model_config)
+
+
 def load_mlx_embeddings_model(
     model_name: str,
     *,
     tokenizer_config: dict[str, Any] | None = None,
     lazy: bool = False,
 ) -> tuple[MlxEmbeddingsEncoderModel, Any]:
-    """Load an encoder embedding checkpoint through mlx-embeddings."""
-    mlx_embeddings_load = _import_mlx_embeddings_load()
-    model, tokenizer = mlx_embeddings_load(
+    model, tokenizer, _adapter = EncoderEmbeddingAdapter.load(
         model_name,
-        tokenizer_config=dict(tokenizer_config or {}),
+        tokenizer_config=tokenizer_config,
         lazy=lazy,
     )
-    return MlxEmbeddingsEncoderModel(model), tokenizer
+    return model, tokenizer

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -89,6 +89,13 @@ class MlxEmbeddingsEncoderModel:
         self.args = self.config
         self.model = _EncoderSequenceBody(model)
 
+    def modules(self) -> list[Any]:
+        """Expose child modules for vLLM engine cleanup hooks."""
+        inner_modules = getattr(self._model, "modules", None)
+        if callable(inner_modules):
+            return list(inner_modules())
+        return [self._model]
+
 
 def _import_mlx_embeddings_load() -> Any:
     try:

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Encoder embedding adapter via optional mlx-embeddings (#589 PR1).
+"""Encoder embedding adapter via native Apache-2.0 MLX XLM-RoBERTa.
 
 Owns load, bidirectional segment forward, CLS pooling defaults, and paged
 attention patch-skipping so encoder special-cases stay in one place.
+
+Does **not** depend on GPLv3 ``mlx-embeddings``.
 """
 
 from __future__ import annotations
@@ -10,6 +12,9 @@ from __future__ import annotations
 from typing import Any
 
 import mlx.core as mx
+
+from vllm_metal.v1.encoder.loader import load_encoder_model
+from vllm_metal.v1.encoder.xlm_roberta import XLMRobertaModel
 
 _ENCODER_EMBEDDING_ARCHITECTURES = frozenset(
     {
@@ -32,7 +37,7 @@ _ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 class _EncoderSequenceBody:
     """Callable transformer body returning ``[1, tokens, hidden]`` states."""
 
-    def __init__(self, model: Any) -> None:
+    def __init__(self, model: XLMRobertaModel) -> None:
         self._model = model
 
     def __call__(self, input_ids: mx.array, cache: Any = None) -> mx.array:
@@ -40,20 +45,13 @@ class _EncoderSequenceBody:
         if input_ids.ndim == 1:
             input_ids = input_ids.reshape(1, -1)
         attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
-        output = self._model(input_ids, attention_mask=attention_mask)
-        hidden_states = getattr(output, "last_hidden_state", None)
-        if hidden_states is None:
-            raise ValueError(
-                "mlx-embeddings encoder forward did not return last_hidden_state; "
-                f"got {type(output)!r}."
-            )
-        return hidden_states
+        return self._model(input_ids, attention_mask=attention_mask)
 
 
-class MlxEmbeddingsEncoderModel:
+class NativeEncoderModel:
     """Weight wrapper exposing a Metal-compatible ``.model`` body."""
 
-    def __init__(self, model: Any) -> None:
+    def __init__(self, model: XLMRobertaModel) -> None:
         self._model = model
         self.config = getattr(model, "config", None)
         self.args = self.config
@@ -67,26 +65,18 @@ class MlxEmbeddingsEncoderModel:
         return [self._model]
 
 
-def _import_mlx_embeddings_load() -> Any:
-    try:
-        from mlx_embeddings import load as mlx_embeddings_load
-    except ImportError as exc:
-        raise ImportError(
-            "Loading encoder embedding models such as XLM-RoBERTa / BGE-M3 "
-            "requires the optional 'mlx-embeddings' package. Install it with: "
-            'pip install "vllm-metal[embeddings]"'
-        ) from exc
-    return mlx_embeddings_load
+# Back-compat alias used by older tests/docs wording.
+MlxEmbeddingsEncoderModel = NativeEncoderModel
 
 
 class EncoderEmbeddingAdapter:
-    """Single owner for mlx-embeddings encoder embedding behavior on Metal."""
+    """Single owner for native encoder embedding behavior on Metal."""
 
     skip_paged_attention_patch = True
     default_sequence_pooling_type = "CLS"
     allowed_sequence_pooling_types = _ENCODER_SEQUENCE_POOLING
 
-    def __init__(self, model: MlxEmbeddingsEncoderModel) -> None:
+    def __init__(self, model: NativeEncoderModel) -> None:
         self.model = model
 
     @staticmethod
@@ -119,7 +109,7 @@ class EncoderEmbeddingAdapter:
 
     @classmethod
     def requires_load(cls, model_config: Any) -> bool:
-        """True when Metal should load weights through mlx-embeddings."""
+        """True when Metal should load weights through the native encoder path."""
         return cls.matches_config(model_config)
 
     @classmethod
@@ -129,21 +119,20 @@ class EncoderEmbeddingAdapter:
         *,
         tokenizer_config: dict[str, Any] | None = None,
         lazy: bool = False,
-    ) -> tuple[MlxEmbeddingsEncoderModel, Any, EncoderEmbeddingAdapter]:
-        """Load an encoder embedding checkpoint and return model + adapter."""
-        mlx_embeddings_load = _import_mlx_embeddings_load()
-        raw_model, tokenizer = mlx_embeddings_load(
+    ) -> tuple[NativeEncoderModel, Any, EncoderEmbeddingAdapter]:
+        """Load a native encoder embedding checkpoint and return model + adapter."""
+        raw_model, tokenizer = load_encoder_model(
             model_name,
-            tokenizer_config=dict(tokenizer_config or {}),
+            tokenizer_config=tokenizer_config,
             lazy=lazy,
         )
-        model = MlxEmbeddingsEncoderModel(raw_model)
+        model = NativeEncoderModel(raw_model)
         return model, tokenizer, cls(model)
 
     @classmethod
     def from_loaded_model(cls, model: Any) -> EncoderEmbeddingAdapter | None:
         """Return an adapter when ``model`` is the encoder weight wrapper."""
-        if isinstance(model, MlxEmbeddingsEncoderModel):
+        if isinstance(model, NativeEncoderModel):
             return cls(model)
         return None
 
@@ -178,7 +167,6 @@ class EncoderEmbeddingAdapter:
         return mx.concatenate(parts, axis=1)
 
 
-# Compatibility aliases used by older call sites / tests.
 def is_encoder_embedding_architecture(architecture: str) -> bool:
     return EncoderEmbeddingAdapter.matches_architecture(architecture)
 
@@ -192,6 +180,7 @@ def is_encoder_embedding_config(model_config: Any) -> bool:
 
 
 def requires_mlx_embeddings_load(model_config: Any) -> bool:
+    """Deprecated alias: native encoder load gate."""
     return EncoderEmbeddingAdapter.requires_load(model_config)
 
 
@@ -200,7 +189,8 @@ def load_mlx_embeddings_model(
     *,
     tokenizer_config: dict[str, Any] | None = None,
     lazy: bool = False,
-) -> tuple[MlxEmbeddingsEncoderModel, Any]:
+) -> tuple[NativeEncoderModel, Any]:
+    """Deprecated alias for native encoder load (no mlx-embeddings)."""
     model, tokenizer, _adapter = EncoderEmbeddingAdapter.load(
         model_name,
         tokenizer_config=tokenizer_config,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -19,10 +19,7 @@ from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
 from vllm_metal.utils import get_model_download_path
-from vllm_metal.v1.encoder_embeddings import (
-    load_mlx_embeddings_model,
-    requires_mlx_embeddings_load,
-)
+from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
 from vllm_metal.v1.mlx_lm_paths import (
     mlx_lm_compatible_model_path as _mlx_lm_compatible_model_path,
@@ -219,7 +216,7 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
-        elif requires_mlx_embeddings_load(model_config):
+        elif EncoderEmbeddingAdapter.requires_load(model_config):
             load_label = "MLX-Embeddings model"
             model, tokenizer = self._load_mlx_embeddings_model(
                 model_name,
@@ -300,11 +297,15 @@ class ModelLifecycle:
         *,
         lazy: bool = False,
     ) -> tuple[Any, Any]:
-        return load_mlx_embeddings_model(
+        model, tokenizer, adapter = EncoderEmbeddingAdapter.load(
             model_name,
             tokenizer_config=dict(tokenizer_config),
             lazy=lazy,
         )
+        # Stash for _install_generation_model; avoids a second from_loaded_model
+        # dance when the load path already constructed the adapter.
+        self._pending_encoder_embedding_adapter = adapter
+        return model, tokenizer
 
     def _install_generation_model(
         self,
@@ -329,6 +330,12 @@ class ModelLifecycle:
         runner._multimodal_adapter = multimodal_adapter
         runner.encoder_cache = (
             EncoderCache() if multimodal_adapter is not None else None
+        )
+
+        pending = getattr(self, "_pending_encoder_embedding_adapter", None)
+        self._pending_encoder_embedding_adapter = None
+        runner._encoder_embedding_adapter = pending or (
+            EncoderEmbeddingAdapter.from_loaded_model(loaded_model.model)
         )
 
         # Dimension resolution reads model_args immediately after this phase.

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -19,6 +19,10 @@ from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
 from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.encoder_embeddings import (
+    load_mlx_embeddings_model,
+    requires_mlx_embeddings_load,
+)
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
 from vllm_metal.v1.mlx_lm_paths import (
     mlx_lm_compatible_model_path as _mlx_lm_compatible_model_path,
@@ -215,6 +219,14 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
+        elif requires_mlx_embeddings_load(model_config):
+            load_label = "MLX-Embeddings model"
+            model, tokenizer = self._load_mlx_embeddings_model(
+                model_name,
+                tokenizer_config,
+                lazy=lazy_weights,
+            )
+
         else:
             load_label = "MLX-LM model"
             model, tokenizer = self._load_mlx_lm_text_model(
@@ -280,6 +292,19 @@ class ModelLifecycle:
                 lazy=lazy,
             )
         return model, tokenizer
+
+    def _load_mlx_embeddings_model(
+        self,
+        model_name: str,
+        tokenizer_config: Mapping[str, Any],
+        *,
+        lazy: bool = False,
+    ) -> tuple[Any, Any]:
+        return load_mlx_embeddings_model(
+            model_name,
+            tokenizer_config=dict(tokenizer_config),
+            lazy=lazy,
+        )
 
     def _install_generation_model(
         self,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -217,7 +217,7 @@ class ModelLifecycle:
             )
 
         elif EncoderEmbeddingAdapter.requires_load(model_config):
-            load_label = "MLX-Embeddings model"
+            load_label = "Native encoder model"
             model, tokenizer = self._load_mlx_embeddings_model(
                 model_name,
                 tokenizer_config,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1211,6 +1211,7 @@ class MetalModelRunner:
                     input_ids,
                     cache=offset_caches,
                     model_config=self.model_config,
+                    segment_lengths=[len(pr.token_ids) for pr in prefill_reqs],
                 )
             elif use_mm_forward:
                 model_output, mm_prefill_deltas = self._run_mm_paged_forward(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -83,6 +83,7 @@ from vllm_metal.v1.decode_pipeline import (
     SamplingShape,
     SchedulerStepShape,
 )
+from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 from vllm_metal.v1.gemma4_mtp import (
     Gemma4MTPAssistantRuntime,
     Gemma4MTPAssistantSource,
@@ -322,6 +323,7 @@ class MetalModelRunner:
             getattr(self.model_config, "runner_type", None) == "pooling"
         )
         self._multimodal_adapter: MultimodalRuntimeAdapter | None = None
+        self._encoder_embedding_adapter: EncoderEmbeddingAdapter | None = None
         self._gemma4_mtp_assistant: Gemma4MTPAssistantRuntime | None = None
         self._drafter: MetalProposer | None = None
         self.encoder_cache: EncoderCache | None = None
@@ -704,6 +706,7 @@ class MetalModelRunner:
                 self._forward_model,
                 input_ids,
                 model_config=self.model_config,
+                encoder_adapter=self._encoder_embedding_adapter,
             )
 
         if self.pp is not None and self.pp.size > 1:
@@ -1212,6 +1215,7 @@ class MetalModelRunner:
                     cache=offset_caches,
                     model_config=self.model_config,
                     segment_lengths=[len(pr.token_ids) for pr in prefill_reqs],
+                    encoder_adapter=self._encoder_embedding_adapter,
                 )
             elif use_mm_forward:
                 model_output, mm_prefill_deltas = self._run_mm_paged_forward(

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -12,11 +12,13 @@ from vllm.tasks import SupportedTask
 from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+from vllm_metal.v1.encoder_embeddings import is_encoder_embedding_config
 
 _EMBED_POOLER_TASKS = (None, "embed")
 _CLASSIFY_POOLER_TASKS = (None, "classify")
 _SUPPORTED_POOLER_TASKS = (None, "embed", "classify")
 _LAST_POOLING = (None, "LAST")
+_ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 _QWEN3_RERANKER_TOKENS = ("no", "yes")
 
 
@@ -62,9 +64,24 @@ def _sequence_pooling_types(model_config: Any) -> tuple[str | None, str | None]:
     )
 
 
-def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
+def _allowed_sequence_pooling_types(model_config: Any) -> tuple[str | None, ...]:
+    if is_encoder_embedding_config(model_config):
+        return _ENCODER_SEQUENCE_POOLING
+    return _LAST_POOLING
+
+
+def _effective_sequence_pooling_type(model_config: Any) -> str:
+    """Resolve the sequence pooling strategy Metal will apply."""
     for pooling_type in _sequence_pooling_types(model_config):
-        if pooling_type not in _LAST_POOLING:
+        if pooling_type is not None:
+            return pooling_type
+    return "CLS" if is_encoder_embedding_config(model_config) else "LAST"
+
+
+def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
+    allowed = _allowed_sequence_pooling_types(model_config)
+    for pooling_type in _sequence_pooling_types(model_config):
+        if pooling_type not in allowed:
             return pooling_type
     return None
 
@@ -100,8 +117,12 @@ def _reject_unsupported_pooler_config(model_config: Any) -> None:
 
     seq_pooling_type = _unsupported_sequence_pooling_type(model_config)
     if seq_pooling_type is not None:
+        allowed = ", ".join(
+            repr(value) for value in _allowed_sequence_pooling_types(model_config)
+        )
         raise NotImplementedError(
-            "Metal pooling currently supports only LAST sequence pooling; "
+            "Metal pooling currently supports only "
+            f"{allowed} sequence pooling for this model; "
             f"got {seq_pooling_type!r} for model={_model_label(model_config)}."
         )
     if _chunked_processing_enabled(model_config):
@@ -119,6 +140,12 @@ def _is_decoder_embedding_config(model_config: Any) -> bool:
         or arch.endswith("ForTextEncoding")
         or arch.endswith("EmbeddingModel")
         for arch in architectures
+    )
+
+
+def _is_embed_capable_config(model_config: Any) -> bool:
+    return _is_decoder_embedding_config(model_config) or is_encoder_embedding_config(
+        model_config
     )
 
 
@@ -170,7 +197,7 @@ def _classifier_logits_fn(model: Any, model_config: Any) -> Any | None:
 
 
 def supports_embed_pooling(model: Any, model_config: Any) -> bool:
-    """Return whether this loaded model can use Metal's LAST embed path."""
+    """Return whether this loaded model can use Metal's dense embed path."""
     if getattr(model_config, "multimodal_config", None) is not None:
         return False
     if _pooler_task(model_config) not in _EMBED_POOLER_TASKS:
@@ -181,9 +208,7 @@ def supports_embed_pooling(model: Any, model_config: Any) -> bool:
         return False
     if _chunked_processing_enabled(model_config):
         return False
-    return sequence_model(model) is not None and _is_decoder_embedding_config(
-        model_config
-    )
+    return sequence_model(model) is not None and _is_embed_capable_config(model_config)
 
 
 def _resolve_token_id(tokenizer: Any, token: str) -> int | None:
@@ -283,7 +308,7 @@ def validate_pooling_params(
     pooling_params: PoolingParams,
     model_config: Any,
 ) -> None:
-    """Validate the narrow text-only LAST pooling contract."""
+    """Validate the narrow text-only Metal pooling contract."""
     model = _model_label(model_config)
     if getattr(model_config, "runner_type", None) != "pooling":
         raise NotImplementedError(
@@ -294,9 +319,11 @@ def validate_pooling_params(
 
     task = pooling_params.task
     if task in (None, "embed"):
-        if not _is_decoder_embedding_config(model_config):
+        if not _is_embed_capable_config(model_config):
             raise NotImplementedError(
-                "Metal embed pooling requires a decoder-style checkpoint; got "
+                "Metal embed pooling requires a decoder-style embedding "
+                "checkpoint or an encoder embedding checkpoint "
+                "(XLM-RoBERTa / RoBERTa / BGE-M3); got "
                 f"architectures={_architecture_names(model_config)!r} for model="
                 f"{model}."
             )
@@ -310,6 +337,13 @@ def validate_pooling_params(
                 f"architectures={_architecture_names(model_config)!r} for model="
                 f"{model}."
             )
+    elif task == "token_classify":
+        raise NotImplementedError(
+            "Metal pooling does not yet support task='token_classify' "
+            "(BGE-M3 sparse lexical weights). Dense embed for encoder models "
+            "is supported; sparse token_classify is tracked as a follow-up "
+            f"to #589 for model={model}."
+        )
     else:
         raise NotImplementedError(
             "Metal pooling supports only text-only task='embed' and the "
@@ -361,6 +395,7 @@ def forward_sequence_hidden_states(
     *,
     cache: Any,
     model_config: Any,
+    segment_lengths: list[int] | None = None,
 ) -> mx.array:
     """Run the transformer body and return per-token hidden states."""
     _reject_unsupported_pooler_config(model_config)
@@ -372,7 +407,17 @@ def forward_sequence_hidden_states(
             "runner='pooling'."
         )
 
-    hidden_states = body(input_ids) if cache is None else body(input_ids, cache=cache)
+    if is_encoder_embedding_config(model_config):
+        hidden_states = _forward_encoder_sequence_hidden_states(
+            body,
+            input_ids,
+            segment_lengths=segment_lengths,
+            model_config=model_config,
+        )
+    else:
+        hidden_states = (
+            body(input_ids) if cache is None else body(input_ids, cache=cache)
+        )
 
     if not hasattr(hidden_states, "shape") or not hasattr(hidden_states, "dtype"):
         raise ValueError(
@@ -381,6 +426,36 @@ def forward_sequence_hidden_states(
             f"{_model_label(model_config)}."
         )
     return hidden_states
+
+
+def _forward_encoder_sequence_hidden_states(
+    body: Any,
+    input_ids: mx.array,
+    *,
+    segment_lengths: list[int] | None,
+    model_config: Any,
+) -> mx.array:
+    """Forward each packed encoder segment independently (bidirectional)."""
+    flat = input_ids.reshape(-1)
+    total_tokens = int(flat.shape[0])
+    if not segment_lengths:
+        segment_lengths = [total_tokens]
+    if sum(segment_lengths) != total_tokens:
+        raise ValueError(
+            "Encoder pooling segment_lengths "
+            f"{segment_lengths!r} do not cover input tokens "
+            f"{total_tokens} for model={_model_label(model_config)}."
+        )
+
+    parts: list[mx.array] = []
+    offset = 0
+    for length in segment_lengths:
+        segment = flat[offset : offset + length].reshape(1, length)
+        parts.append(body(segment))
+        offset += length
+    if len(parts) == 1:
+        return parts[0]
+    return mx.concatenate(parts, axis=1)
 
 
 def pooling_dummy_forward_outputs(
@@ -427,7 +502,7 @@ def pool_sequence_embedding(
     token_index: int,
     model_config: Any,
 ) -> torch.Tensor:
-    """Return a normalized CPU LAST embedding for one finished request."""
+    """Return a normalized CPU sequence embedding for one finished request."""
     if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
         raise ValueError(
             "Metal embed pooling expected hidden states with shape "
@@ -582,6 +657,8 @@ def pool_paged_prefill_batch(
 
         if entry.result_mode == "intermediate":
             token_indices.append(None)
+        elif _effective_sequence_pooling_type(model_config) == "CLS":
+            token_indices.append(cu_seqlens[num_decode_segments + i])
         else:
             token_indices.append(cu_seqlens[num_decode_segments + i + 1] - 1)
 

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -12,13 +12,12 @@ from vllm.tasks import SupportedTask
 from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
-from vllm_metal.v1.encoder_embeddings import is_encoder_embedding_config
+from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 
 _EMBED_POOLER_TASKS = (None, "embed")
 _CLASSIFY_POOLER_TASKS = (None, "classify")
 _SUPPORTED_POOLER_TASKS = (None, "embed", "classify")
 _LAST_POOLING = (None, "LAST")
-_ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 _QWEN3_RERANKER_TOKENS = ("no", "yes")
 
 
@@ -65,8 +64,8 @@ def _sequence_pooling_types(model_config: Any) -> tuple[str | None, str | None]:
 
 
 def _allowed_sequence_pooling_types(model_config: Any) -> tuple[str | None, ...]:
-    if is_encoder_embedding_config(model_config):
-        return _ENCODER_SEQUENCE_POOLING
+    if EncoderEmbeddingAdapter.matches_config(model_config):
+        return EncoderEmbeddingAdapter.allowed_sequence_pooling_types
     return _LAST_POOLING
 
 
@@ -75,7 +74,9 @@ def _effective_sequence_pooling_type(model_config: Any) -> str:
     for pooling_type in _sequence_pooling_types(model_config):
         if pooling_type is not None:
             return pooling_type
-    return "CLS" if is_encoder_embedding_config(model_config) else "LAST"
+    if EncoderEmbeddingAdapter.matches_config(model_config):
+        return EncoderEmbeddingAdapter.default_sequence_pooling_type
+    return "LAST"
 
 
 def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
@@ -144,9 +145,9 @@ def _is_decoder_embedding_config(model_config: Any) -> bool:
 
 
 def _is_embed_capable_config(model_config: Any) -> bool:
-    return _is_decoder_embedding_config(model_config) or is_encoder_embedding_config(
+    return _is_decoder_embedding_config(
         model_config
-    )
+    ) or EncoderEmbeddingAdapter.matches_config(model_config)
 
 
 def _is_qwen3_token_logit_classifier(model_config: Any) -> bool:
@@ -396,6 +397,7 @@ def forward_sequence_hidden_states(
     cache: Any,
     model_config: Any,
     segment_lengths: list[int] | None = None,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> mx.array:
     """Run the transformer body and return per-token hidden states."""
     _reject_unsupported_pooler_config(model_config)
@@ -407,12 +409,11 @@ def forward_sequence_hidden_states(
             "runner='pooling'."
         )
 
-    if is_encoder_embedding_config(model_config):
-        hidden_states = _forward_encoder_sequence_hidden_states(
-            body,
+    if encoder_adapter is not None:
+        hidden_states = encoder_adapter.forward_sequence_hidden_states(
             input_ids,
             segment_lengths=segment_lengths,
-            model_config=model_config,
+            model_label=_model_label(model_config),
         )
     else:
         hidden_states = (
@@ -428,41 +429,12 @@ def forward_sequence_hidden_states(
     return hidden_states
 
 
-def _forward_encoder_sequence_hidden_states(
-    body: Any,
-    input_ids: mx.array,
-    *,
-    segment_lengths: list[int] | None,
-    model_config: Any,
-) -> mx.array:
-    """Forward each packed encoder segment independently (bidirectional)."""
-    flat = input_ids.reshape(-1)
-    total_tokens = int(flat.shape[0])
-    if not segment_lengths:
-        segment_lengths = [total_tokens]
-    if sum(segment_lengths) != total_tokens:
-        raise ValueError(
-            "Encoder pooling segment_lengths "
-            f"{segment_lengths!r} do not cover input tokens "
-            f"{total_tokens} for model={_model_label(model_config)}."
-        )
-
-    parts: list[mx.array] = []
-    offset = 0
-    for length in segment_lengths:
-        segment = flat[offset : offset + length].reshape(1, length)
-        parts.append(body(segment))
-        offset += length
-    if len(parts) == 1:
-        return parts[0]
-    return mx.concatenate(parts, axis=1)
-
-
 def pooling_dummy_forward_outputs(
     model: Any,
     input_ids: mx.array,
     *,
     model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> list[mx.array]:
     """Return warm-up outputs for a pooling model."""
     return [
@@ -471,6 +443,7 @@ def pooling_dummy_forward_outputs(
             input_ids,
             cache=None,
             model_config=model_config,
+            encoder_adapter=encoder_adapter,
         )
     ]
 


### PR DESCRIPTION
## Summary
- Load encoder embedding checkpoints (`XLMRobertaModel` / RoBERTa / BGE-M3) through a **native Apache-2.0 MLX XLM-RoBERTa backend** in `vllm_metal/v1/encoder/`.
- `EncoderEmbeddingAdapter` owns loading, segment-wise bidirectional forward, CLS pooling defaults, and paged-attention patch skipping (single ownership boundary).
- Serve dense `embed` with CLS + L2. Sparse `token_classify` is out of scope here.

Partial progress on #589 (dense path only). Sparse lexical weights are being pursued separately in #599.

## Review feedback addressed
1. **Structure:** encoder special-cases live behind one adapter (load / forward / pooling defaults / patch skip).
2. **License:** dropped GPLv3 `mlx-embeddings`; native in-tree Apache-2.0 XLM-R/RoBERTa backend instead (not added to package extras).

## Test plan
- [x] `pytest tests/test_encoder_embeddings.py tests/test_v1_pooling.py`
- [x] Native load smoke for `mlx-community/bge-m3-mlx-8bit`
- [x] Offline e2e `LLM(..., runner="pooling").embed(["hello metal"])` with tight memory limits → `dim=1024`, `backend: XLMRobertaModel`