### PR TITLE
Pin mlx-lm to a git SHA to unblock Laguna support (#562)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ dependencies = [
     # a wheel built against one MLX is only ABI-safe against that exact MLX.
     # Rebuild and re-release the wheel on every MLX bump.
     "mlx==0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    "mlx-lm>=0.31.3; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # Git SHA, not a version: architectures merged after the 0.31.3 release
+    # (2026-04-22) never reach PyPI, and Laguna is one of them. main still
+    # self-reports "0.31.3", so this looks like a no-op upgrade -- it is not.
+    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@254d153fdeb6f150edd4fc5a54f9828638481fa8 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
     # Temporary cap: xgrammar's prebuilt wheels are compiled against a specific
     # apache-tvm-ffi C++ ABI but declare only `apache-tvm-ffi>=0.1.9`, so a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ dependencies = [
     # a wheel built against one MLX is only ABI-safe against that exact MLX.
     # Rebuild and re-release the wheel on every MLX bump.
     "mlx==0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    # Git SHA, not a version: architectures merged after the 0.31.3 release
-    # (2026-04-22) never reach PyPI, and Laguna is one of them. main still
-    # self-reports "0.31.3", so this looks like a no-op upgrade -- it is not.
+    # Git SHA (2026-08-05), not a version: architectures merged after the
+    # 0.31.3 release (2026-04-22) never reach PyPI. main still self-reports
+    # "0.31.3", so this looks like a no-op upgrade -- it is not.
     "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@254d153fdeb6f150edd4fc5a54f9828638481fa8 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
     # Temporary cap: xgrammar's prebuilt wheels are compiled against a specific

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -282,15 +282,10 @@ class TestGemma4MTPConfigCompatPatch:
             "_patch_mlx_lm_qwen35_fp8_sanitize",
             lambda: calls.append("qwen35_fp8"),
         )
-        monkeypatch.setattr(
-            compat,
-            "_patch_mlx_lm_gemma4_kv_shared_sanitize",
-            lambda: calls.append("gemma4_kv"),
-        )
 
         compat.apply_compat_patches()
 
-        assert calls == ["bytelevel", "qwen35_fp8", "gemma4_kv"]
+        assert calls == ["bytelevel", "qwen35_fp8"]
 
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):
@@ -609,149 +604,6 @@ class TestQwen35Fp8CompatPatch:
         assert sanitized[
             "model.language_model.layers.0.self_attn.q_proj.weight"
         ].shape == (128, 128)
-
-
-def _install_fake_gemma4_text_module(
-    monkeypatch,
-    *,
-    num_hidden_layers: int,
-    num_kv_shared_layers: int,
-):
-    mlx_lm_pkg = ModuleType("mlx_lm")
-    mlx_lm_models = ModuleType("mlx_lm.models")
-    mlx_lm_pkg.models = mlx_lm_models
-    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm_pkg)
-    monkeypatch.setitem(sys.modules, "mlx_lm.models", mlx_lm_models)
-
-    module = ModuleType("mlx_lm.models.gemma4_text")
-
-    class FakeArgs:
-        def __init__(self) -> None:
-            self.num_hidden_layers = num_hidden_layers
-            self.num_kv_shared_layers = num_kv_shared_layers
-
-    class FakeModel:
-        def __init__(self) -> None:
-            self.args = FakeArgs()
-
-        def sanitize(self, weights):
-            return dict(weights)
-
-    module.Model = FakeModel
-    monkeypatch.setitem(sys.modules, "mlx_lm.models.gemma4_text", module)
-    mlx_lm_models.gemma4_text = module
-
-    def _fake_find_spec(name: str):
-        if name == "mlx_lm.models.gemma4_text":
-            return object()
-        return None
-
-    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
-    return module
-
-
-class TestGemma4KvSharedCompatPatch:
-    def test_drop_helper_removes_54_phantom_keys_for_e4b_layout(self) -> None:
-        # E4B: 42 layers total, last 18 are KV-shared.
-        weights = {}
-        for i in range(42):
-            for suffix in (
-                "k_proj",
-                "v_proj",
-                "k_norm",
-                "q_proj",
-                "q_norm",
-                "o_proj",
-            ):
-                weights[
-                    f"language_model.model.layers.{i}.self_attn.{suffix}.weight"
-                ] = f"T{i}_{suffix}"
-
-        out = compat._drop_gemma4_kv_shared_phantom_weights(
-            weights, num_hidden_layers=42, num_kv_shared_layers=18
-        )
-
-        assert len(weights) - len(out) == 54
-        for i in range(24):
-            for suffix in (
-                "k_proj",
-                "v_proj",
-                "k_norm",
-                "q_proj",
-                "q_norm",
-                "o_proj",
-            ):
-                assert (
-                    f"language_model.model.layers.{i}.self_attn.{suffix}.weight" in out
-                )
-        for i in range(24, 42):
-            for suffix in ("k_proj", "v_proj", "k_norm"):
-                assert (
-                    f"language_model.model.layers.{i}.self_attn.{suffix}.weight"
-                    not in out
-                )
-            for suffix in ("q_proj", "q_norm", "o_proj"):
-                assert (
-                    f"language_model.model.layers.{i}.self_attn.{suffix}.weight" in out
-                )
-
-    def test_drop_helper_is_noop_without_sharing(self) -> None:
-        weights = {
-            "language_model.model.layers.0.self_attn.k_proj.weight": "T",
-            "language_model.model.layers.41.self_attn.k_proj.weight": "T",
-        }
-        out = compat._drop_gemma4_kv_shared_phantom_weights(
-            weights, num_hidden_layers=42, num_kv_shared_layers=0
-        )
-        assert out == weights
-
-    def test_drop_helper_ignores_unrelated_or_malformed_keys(self) -> None:
-        weights = {
-            "language_model.model.layers.30.self_attn.q_proj.weight": "keep",
-            "language_model.model.weird.self_attn.k_proj.weight": "keep",
-            "language_model.model.layers.5.self_attn.k_proj.weight": "keep",
-            "language_model.model.layers.30.self_attn.k_proj.weight": "drop",
-        }
-        out = compat._drop_gemma4_kv_shared_phantom_weights(
-            weights, num_hidden_layers=42, num_kv_shared_layers=18
-        )
-        assert "language_model.model.layers.30.self_attn.k_proj.weight" not in out
-        assert "language_model.model.layers.30.self_attn.q_proj.weight" in out
-        assert "language_model.model.weird.self_attn.k_proj.weight" in out
-        assert "language_model.model.layers.5.self_attn.k_proj.weight" in out
-
-    def test_patch_wraps_gemma4_text_sanitize_and_drops_phantom_keys(
-        self, monkeypatch
-    ) -> None:
-        module = _install_fake_gemma4_text_module(
-            monkeypatch, num_hidden_layers=42, num_kv_shared_layers=18
-        )
-
-        compat._patch_mlx_lm_gemma4_kv_shared_sanitize()
-
-        weights = {
-            "language_model.model.layers.0.self_attn.k_proj.weight": "T",
-            "language_model.model.layers.30.self_attn.k_proj.weight": "phantom",
-            "language_model.model.layers.30.self_attn.q_proj.weight": "real",
-        }
-        sanitized = module.Model().sanitize(weights)
-
-        assert "language_model.model.layers.30.self_attn.k_proj.weight" not in sanitized
-        assert "language_model.model.layers.0.self_attn.k_proj.weight" in sanitized
-        assert "language_model.model.layers.30.self_attn.q_proj.weight" in sanitized
-
-    def test_patch_is_idempotent(self, monkeypatch) -> None:
-        module = _install_fake_gemma4_text_module(
-            monkeypatch, num_hidden_layers=42, num_kv_shared_layers=18
-        )
-
-        compat._patch_mlx_lm_gemma4_kv_shared_sanitize()
-        once = module.Model.sanitize
-        compat._patch_mlx_lm_gemma4_kv_shared_sanitize()
-        twice = module.Model.sanitize
-
-        assert once is twice
-        assert getattr(twice, "_vllm_metal_gemma4_kv_shared_patch", False) is True
 
 
 class TestExaone4ConfigCompatPatch:

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -31,7 +31,6 @@ def apply_compat_patches() -> None:
     _apply_bytelevel_patch_during_registration()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
-    _patch_mlx_lm_gemma4_kv_shared_sanitize()
     _patch_transformers_exaone4_config()
 
 
@@ -890,78 +889,3 @@ def _wrap_model_sanitize(
     setattr(_patched_sanitize, sentinel_attr, True)
     model_cls.sanitize = _patched_sanitize
     return True
-
-
-def _drop_gemma4_kv_shared_phantom_weights(
-    weights: Mapping[str, Any],
-    num_hidden_layers: int,
-    num_kv_shared_layers: int,
-) -> dict[str, Any]:
-    """Strip K/V/k_norm safetensors keys for KV-shared Gemma 4 layers.
-
-    Layers with index ``>= num_hidden_layers - num_kv_shared_layers`` reuse
-    K/V from earlier same-type layers (see ``Gemma4TextModel.previous_kvs``)
-    and have no destination for those tensors after mlx-lm PR #1158.
-    """
-    if not num_kv_shared_layers:
-        return dict(weights)
-
-    first_shared = num_hidden_layers - num_kv_shared_layers
-    # Generate the exact tails for every (shared_layer, suffix) pair.
-    # A key is dropped iff it ends with one of these — no parsing, no
-    # fallback, no ambiguity. Unrelated keys (e.g. "model.weird.self_attn
-    # .k_proj.weight") cannot match because the tail mandates ".layers.<N>.".
-    drop_tails = tuple(
-        f".layers.{i}.self_attn.{suffix}.weight"
-        for i in range(first_shared, num_hidden_layers)
-        for suffix in ("k_proj", "v_proj", "k_norm")
-    )
-    return {k: v for k, v in weights.items() if not k.endswith(drop_tails)}
-
-
-def _patch_mlx_lm_gemma4_kv_shared_sanitize() -> None:
-    """Drop phantom K/V/k_norm safetensors keys for KV-shared Gemma 4 layers.
-
-    mlx-lm PR #1158 gated ``k_proj``/``v_proj``/``k_norm`` allocation in
-    ``gemma4_text.Attention.__init__`` behind ``has_kv``, but the matching
-    drop step in ``Model.sanitize`` was not added. Checkpoints that still
-    serialize those tensors (e.g. ``google/gemma-4-E4B-it``) crash strict
-    weight load with ``Received N parameters not in model``.
-
-    Remove this patch once upstream lands the matching ``sanitize`` change
-    and the mlx-lm pin in ``pyproject.toml`` is bumped past it.
-    """
-    from importlib import import_module
-    from importlib.util import find_spec
-
-    if find_spec("mlx_lm.models.gemma4_text") is None:
-        return
-    try:
-        module = import_module("mlx_lm.models.gemma4_text")
-    except ImportError as exc:
-        logger.warning(
-            "Could not install mlx_lm Gemma 4 KV-shared sanitize "
-            "compatibility patch: %s",
-            exc,
-        )
-        return
-
-    model_cls = getattr(module, "Model", None)
-    if model_cls is None:
-        logger.warning(
-            "Could not install mlx_lm Gemma 4 KV-shared sanitize "
-            "compatibility patch: Model class not found in gemma4_text."
-        )
-        return
-
-    def _transform(self, weights):
-        return _drop_gemma4_kv_shared_phantom_weights(
-            weights,
-            self.args.num_hidden_layers,
-            self.args.num_kv_shared_layers,
-        )
-
-    if _wrap_model_sanitize(
-        model_cls, "_vllm_metal_gemma4_kv_shared_patch", _transform
-    ):
-        logger.debug("Patched mlx_lm gemma4_text KV-shared sanitize compatibility")


### PR DESCRIPTION
## Why

mlx-lm's last PyPI release is **0.31.3 (2026-04-22)**, but development continues on `main`, so any architecture merged after that date never reaches PyPI. We depend on `mlx-lm>=0.31.3`, which resolves to that April release.

Laguna is the immediate blocker for #562. It landed in `e5baded8` (2026-07-26) and is absent from 0.31.3, so loading `model_type: laguna` raises:

```text
ValueError: Model type laguna not supported.
```

This PR pins mlx-lm to `254d153f` (2026-08-05), which includes Laguna. The pinned revision still reports `__version__ == "0.31.3"`, so the version string does not distinguish it from the PyPI release.

## Changes

- Pin mlx-lm to `254d153f`.
- Remove the local Gemma 4 KV-shared sanitize patch and its tests. The pinned upstream revision now handles these weights natively.
- Keep the Qwen3.5 FP8 sanitize patch, which is not yet handled upstream.

## RFC: Vendor unreleased model modules

This SHA pin solves the immediate gap, but it couples vllm-metal to the full unreleased state of mlx-lm. If mlx-lm releases continue to lag behind `main`, an alternative is to vendor only the model modules we need and register them under `mlx_lm.models.*` until they ship in a release.

[oMLX](https://github.com/jundot/omlx) already uses this pattern without forking mlx-lm or maintaining a parallel model registry. At `350dc08b`, its vendored `*model.py` files under `omlx/patches/` total 9,229 lines; the largest is [`deepseek_v4_model.py`](https://github.com/jundot/omlx/blob/350dc08b757225531fecd76c8d552ae761d08082/omlx/patches/deepseek_v4/deepseek_v4_model.py) at 2,345 lines.

Its [Laguna registration helper](https://github.com/jundot/omlx/blob/350dc08b757225531fecd76c8d552ae761d08082/omlx/patches/laguna/__init__.py#L30-L51) loads a local file under the qualified name `mlx_lm.models.laguna`. The [fallback path](https://github.com/jundot/omlx/blob/350dc08b757225531fecd76c8d552ae761d08082/omlx/patches/laguna/__init__.py#L91-L105) installs it only when that exact upstream module is missing, so it becomes a no-op once mlx-lm provides the module.

This would avoid pinning the entire dependency to an unreleased commit. The tradeoff is that vllm-metal would own review, testing, and synchronization for each vendored module.

## End-to-end validation

Compared `main` with PyPI `mlx-lm==0.31.3` against this PR with `mlx-lm@254d153f`, using real `vllm serve` runs with Metal paged attention on an Apple M5 Pro. Every benchmark run completed 100/100 requests successfully.

### Correctness

Eight fixed prompts per model at `temperature=0, top_p=1, seed=0` produced identical completion text, token strings, and finish reasons:

| Model | Identical prompts | Tokens compared |
|---|---:|---:|
| `mlx-community/gemma-4-e2b-it-bf16` | 8 / 8 | 388 |
| `Qwen/Qwen3-0.6B` | 8 / 8 | 768 |

The two mlx-lm revisions also produced identical 540-key weight sets through the real Gemma 4 load path.

The available Gemma 4 checkpoint does not contain the phantom K/V keys handled by the removed patch. That case was validated separately by replaying the deleted tests' nine vectors against upstream `Model.sanitize`.

### Performance

Sonnet 1024+128, 100 prompts, rate 10, concurrency 32. Results are the mean of two warm-cache runs 

| Model | Output tok/s, main → PR | TTFT, main → PR | TPOT, main → PR |
|---|---:|---:|---:|
| Gemma 4 E2B | 346.98 → 347.35 | 250.16 → 250.84 ms | 76.81 → 76.70 ms |
| Qwen3-0.6B | 669.36 → 681.91 | 133.70 → 132.57 ms | 38.21 → 37.31 ms |

No regression. 

