### PR TITLE
Bump vLLM to 0.27.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Pinned by full URL because no index serves it: PyPI's vllm has no macOS
 # wheel yet. To bump, raise VLLM_VERSION to a release that attaches one —
 # not every release does; v0.26.0 was the first.
-VLLM_VERSION="0.26.0"
+VLLM_VERSION="0.27.0"
 VLLM_WHEEL_URL="https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}%2Bcpu-cp312-cp312-macosx_11_0_arm64.whl"
 
 _cleanup_dirs=()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
-    # Keep aligned with vLLM 0.26.0's Transformers lower bound.
+    # Keep aligned with vLLM 0.27.0's Transformers lower bound.
     # Temporary cap: transformers 5.13.0 (released 2026-07-03) breaks MLX Metal
     # availability inside the vLLM process on GitHub's macOS runner VMs, so
     # platform resolution falls back to CPU. Verified A/B on the same runner:
@@ -60,7 +60,7 @@ dependencies = [
     # Core utilities
     "numpy>=1.24.0",
     "psutil>=5.9.0",
-    # Keep aligned with vLLM 0.26.0's FastAPI/Starlette bounds. vLLM caps fastapi
+    # Keep aligned with vLLM 0.27.0's FastAPI/Starlette bounds. vLLM caps fastapi
     # itself (requirements/common.txt): 0.133.0 is the first release supporting
     # Starlette 1.0, and <0.137.0 avoids the FastAPI 0.137 route-tree change that
     # breaks its handler overrides. The earlier prometheus crash (vllm#45597) is

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -1156,7 +1156,7 @@ class WorkerCachePlanner:
         1. Numeric VLLM_METAL_MEMORY_FRACTION, for example 0.6, wins.
         2. Otherwise, VLLM_METAL_MEMORY_FRACTION=auto uses the user-provided
            --gpu-memory-utilization value.
-        3. If the user did not provide --gpu-memory-utilization, vLLM 0.26.0
+        3. If the user did not provide --gpu-memory-utilization, vLLM 0.27.0
            supplies its default value, 0.92.
         """
         metal_config = self._worker.metal_config


### PR DESCRIPTION
This pr bump vLLM to 0.27.0.
| Metric | vLLM 0.26.0 | vLLM 0.27.0 | Delta |
|---|---:|---:|---:|
| Output tok/s | 974.26 | 990.70 | +1.7% |
| Total tok/s | 4498.23 | 4574.15 | +1.7% |
| Mean TTFT (ms) | 3834.31 | 3714.32 | -3.1% |
| P99 TTFT (ms) | 6984.28 | 6783.76 | -2.9% |
| Mean TPOT (ms) | 75.85 | 75.06 | -1.0% |
| P99 TPOT (ms) | 93.41 | 92.65 | -0.8% |
| Duration (s) | 15.40 | 15.14 | -1.7% |