### PR TITLE
Trust resolved draft config for Gemma4 MTP assistant loading

### DIFF
--- a/tests/test_gemma4_mtp_assistant.py
+++ b/tests/test_gemma4_mtp_assistant.py
@@ -93,6 +93,7 @@ def _validate_assistant_config(
 def _speculative_config(*, hf_config: object | None = None) -> SimpleNamespace:
     draft_config = SimpleNamespace(
         model="/assistant",
+        revision=None,
         hf_config=hf_config or SimpleNamespace(model_type="gemma4_mtp"),
     )
     return SimpleNamespace(
@@ -755,9 +756,9 @@ def test_loader_passes_revision_and_keeps_cache_keys_separate() -> None:
         model_path_resolver=lambda model_name: model_name,
     )
     spec_a = _speculative_config()
-    spec_a.revision = "rev-a"
+    spec_a.draft_model_config.revision = "rev-a"
     spec_b = _speculative_config()
-    spec_b.revision = "rev-b"
+    spec_b.draft_model_config.revision = "rev-b"
 
     first = loader.load_if_needed(
         speculative_config=spec_a,
@@ -776,28 +777,6 @@ def test_loader_passes_revision_and_keeps_cache_keys_separate() -> None:
     assert first is not third
     assert load_model_calls == 2
     assert download_calls == [("/assistant", "rev-a"), ("/assistant", "rev-b")]
-
-
-def test_loader_prefers_resolved_draft_model_revision() -> None:
-    download_calls: list[tuple[str, str | None]] = []
-
-    loader = Gemma4MTPAssistantLoader(
-        load_model_fn=lambda *args, **kwargs: (object(), _assistant_config()),
-        download_fn=lambda model_name, revision: (
-            download_calls.append((model_name, revision)) or Path(model_name)
-        ),
-        model_path_resolver=lambda model_name: model_name,
-    )
-    spec = _speculative_config()
-    spec.revision = "outer-rev"
-    spec.draft_model_config.revision = "draft-rev"
-
-    loader.load_if_needed(
-        speculative_config=spec,
-        target_model_args=_target_args(),
-    )
-
-    assert download_calls == [("/assistant", "draft-rev")]
 
 
 def test_model_args_preserve_text_config_vocab_size() -> None:

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -585,6 +585,7 @@ class TestModelLifecycle:
             method="mtp",
             draft_model_config=SimpleNamespace(
                 model="assistant",
+                revision=None,
                 hf_config=SimpleNamespace(model_type="gemma4_mtp"),
             ),
         )
@@ -621,6 +622,7 @@ class TestModelLifecycle:
             method="mtp",
             draft_model_config=SimpleNamespace(
                 model="assistant",
+                revision=None,
                 hf_config=SimpleNamespace(model_type="gemma4_mtp"),
             ),
         )
@@ -663,6 +665,7 @@ class TestModelLifecycle:
             revision=None,
             draft_model_config=SimpleNamespace(
                 model="/assistant",
+                revision=None,
                 hf_config=SimpleNamespace(model_type="gemma4_mtp"),
             ),
         )

--- a/vllm_metal/v1/gemma4_mtp.py
+++ b/vllm_metal/v1/gemma4_mtp.py
@@ -21,6 +21,8 @@ from vllm_metal.v1.mlx_lm_paths import mlx_lm_compatible_model_path
 logger = init_logger(__name__)
 
 if TYPE_CHECKING:
+    from vllm.config import ModelConfig, SpeculativeConfig
+
     from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 
 GEMMA4_MTP_DEFAULT_NUM_CENTROIDS = 2048
@@ -256,7 +258,7 @@ class Gemma4MTPAssistantLoader:
     def load_if_needed(
         self,
         *,
-        speculative_config: Any | None,
+        speculative_config: SpeculativeConfig | None,
         target_model_args: Mapping[str, Any],
     ) -> Gemma4MTPAssistantRuntime | None:
         """Load the Gemma4 MTP assistant configured for this target model."""
@@ -428,39 +430,29 @@ class Gemma4MTPAssistantSource:
     revision: str | None
 
     @classmethod
-    def is_gemma4_mtp(cls, speculative_config: Any | None) -> bool:
-        if (
-            speculative_config is None
-            or getattr(speculative_config, "method", None) != "mtp"
-        ):
+    def is_gemma4_mtp(cls, speculative_config: SpeculativeConfig | None) -> bool:
+        if speculative_config is None or speculative_config.method != "mtp":
             return False
 
-        draft_model_config = getattr(speculative_config, "draft_model_config", None)
+        draft_model_config: ModelConfig | None = speculative_config.draft_model_config
         if draft_model_config is None:
             return False
 
-        hf_config = getattr(draft_model_config, "hf_config", None)
-        return Gemma4MTPAssistantMetadata.is_assistant_config(hf_config)
+        return Gemma4MTPAssistantMetadata.is_assistant_config(
+            draft_model_config.hf_config
+        )
 
     @classmethod
     def from_speculative_config(
         cls,
-        speculative_config: Any,
+        speculative_config: SpeculativeConfig,
     ) -> Gemma4MTPAssistantSource:
-        draft_model_config = getattr(speculative_config, "draft_model_config", None)
-        model_name = getattr(draft_model_config, "model", None) or getattr(
-            speculative_config,
-            "model",
-            None,
-        )
+        draft_model_config: ModelConfig = speculative_config.draft_model_config
+        model_name = draft_model_config.model
         if not model_name:
             raise ValueError("Gemma4 MTP speculative config is missing the draft model")
 
-        revision = getattr(draft_model_config, "revision", None) or getattr(
-            speculative_config,
-            "revision",
-            None,
-        )
+        revision = draft_model_config.revision
         return cls(
             model_name=str(model_name),
             revision=str(revision) if revision else None,


### PR DESCRIPTION
This PR is:

- To use vLLM’s resolved `draft_model_config` as the source of truth for Gemma4 MTP assistant loading.
- To remove fallback reads from the outer speculative config.
- To keep the assistant cache key tied to the draft model revision vLLM actually resolved.

vLLM 0.27 builds the draft `ModelConfig` before Metal sees the speculative config, so the Gemma4 assistant loader should trust that typed contract directly.

Local smoke prompts confirmed the Gemma4 target and MTP assistant load together and produce coherent chat outputs on Metal.

| Prompt | Output |
|---|---|
| `Write one short sentence about the Moon.` | `The Moon orbits the Earth, casting a silvery glow across the night sky.` |
| `Answer with one word: What color is grass?` | `Green` |
| `Complete this sentence naturally: Apple pie tastes` | `Here are several ways to complete the sentence, depending on the desired tone and focus: ...` |
