### PR TITLE
LFM2/LFM2.5 paged serving with prefix caching

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -89,6 +89,7 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Qwen3 | ✅ | GQA (paged) | ✅ | `Qwen/Qwen3-0.6B` |
 | Qwen3.5 / 3.6 / 3.8 | ✅ | Hybrid SDPA + GDN linear (3.6 adds MoE) | 🔵 | `mlx-community/Qwen3.8-27B-8bit` |
 | Qwen3-Next | ✅ | Hybrid SDPA + GDN linear | 🔵 | `mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit` |
+| LFM2 / LFM2.5 | ✅ | Hybrid SDPA + ShortConv | ✅ | `LiquidAI/LFM2.5-1.2B-Instruct` |
 | Gemma 4 | ✅ | GQA + per-layer sliding window + YOCO | ✅ | `mlx-community/gemma-4-E2B-it` |
 | Gemma 3 | ✅ | GQA (paged) | ✅ | `mlx-community/gemma-3-1b-it-qat-4bit` |
 | Llama 3 | ✅ | GQA (paged) | ✅ | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` |

--- a/tests/attention/test_align_state_manager.py
+++ b/tests/attention/test_align_state_manager.py
@@ -8,7 +8,7 @@ from tests.stub_runner import make_gdn_hybrid_plan
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
-from vllm_metal.attention.state import AlignGDNStateManager
+from vllm_metal.attention.state import AlignStateManager
 
 BLOCK = 4
 
@@ -50,7 +50,7 @@ def _slab(cache: GDNPagedStateCache, layer: int, slab: int) -> tuple:
     )
 
 
-class TestAlignGDNStateManager:
+class TestAlignStateManager:
     def _populate(self, manager, req_ids, tables, positions):
         ctx = PagedAttentionContext(slot_mapping=[])
         manager.populate_step_context(
@@ -63,28 +63,28 @@ class TestAlignGDNStateManager:
 
     def test_fresh_request_zeroes_its_state_block(self) -> None:
         cache = _make_cache()
-        manager = AlignGDNStateManager(cache, BLOCK)
+        manager = AlignStateManager(cache, BLOCK)
         _fill_slab(cache, 0, 3, 7.0)  # stale bytes from a previous block life
 
         ctx = self._populate(
             manager, ["req-A"], [[[3]]], [(0, 2)]
         )  # fresh, 2 tokens into block 3
 
-        assert ctx.gdn_group_slot_mappings == ([3],)
-        assert ctx.gdn_slot_mapping is None  # align sets only group mappings
+        assert ctx.state_group_slot_mappings == ([3],)
+        assert ctx.state_slot_mapping is None  # align sets only group mappings
         conv, rec = _slab(cache, 0, 3)
         assert np.all(conv == 0) and np.all(rec == 0)
 
     def test_boundary_crossing_copies_forward_and_keeps_checkpoint(self) -> None:
         cache = _make_cache()
-        manager = AlignGDNStateManager(cache, BLOCK)
+        manager = AlignStateManager(cache, BLOCK)
         _fill_slab(cache, 0, 2, 5.0)  # request's state after 4 tokens in block 2
         _fill_slab(cache, 1, 2, 5.0)
 
         # num_computed=4 (block boundary), decoding 1 token → lands in block idx 1
         ctx = self._populate(manager, ["req-A"], [[[2, 6]]], [(4, 1)])
 
-        assert ctx.gdn_group_slot_mappings == ([6],)
+        assert ctx.state_group_slot_mappings == ([6],)
         for layer in (0, 1):
             conv_src, rec_src = _slab(cache, layer, 2)
             conv_dst, rec_dst = _slab(cache, layer, 6)
@@ -106,14 +106,14 @@ class TestAlignGDNStateManager:
         cache = _make_cache(num_layers=2)
         cache.set_layer_layout([0, 1], [0, 0])
         assert cache.num_state_pools == 1
-        manager = AlignGDNStateManager(cache, BLOCK)
+        manager = AlignStateManager(cache, BLOCK)
         _fill_slab(cache, 0, 2, 5.0)
         _fill_slab(cache, 1, 3, 8.0)
 
         # One request; group 0 crosses 2→6, group 1 crosses 3→7.
         ctx = self._populate(manager, ["req-A"], [[[2, 6], [3, 7]]], [(4, 1)])
 
-        assert ctx.gdn_group_slot_mappings == ([6], [7])
+        assert ctx.state_group_slot_mappings == ([6], [7])
         conv, _ = _slab(cache, 0, 6)
         np.testing.assert_array_equal(conv, 5.0)  # group 0 moved its rows
         conv, _ = _slab(cache, 1, 7)
@@ -123,13 +123,13 @@ class TestAlignGDNStateManager:
 
     def test_pool_materializes_lazily_by_high_water_block_id(self) -> None:
         cache = _make_cache(num_blocks=8, initial_blocks=2)
-        manager = AlignGDNStateManager(cache, BLOCK)
+        manager = AlignStateManager(cache, BLOCK)
 
         # Fresh request lands in block 5, beyond the initially materialized
         # slabs; the pool grows to cover it (geometric, capped at max_seqs).
         ctx = self._populate(manager, ["req-A"], [[[5]]], [(0, 2)])
 
-        assert ctx.gdn_group_slot_mappings == ([5],)
+        assert ctx.state_group_slot_mappings == ([5],)
         assert cache.allocated_seqs == 6
         conv, rec = _slab(cache, 0, 5)
         assert np.all(conv == 0) and np.all(rec == 0)

--- a/tests/attention/test_request_state_manager.py
+++ b/tests/attention/test_request_state_manager.py
@@ -9,7 +9,7 @@ from tests.stub_runner import make_gdn_hybrid_plan
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
-from vllm_metal.attention.state import HybridGDNStateManager
+from vllm_metal.attention.state import RequestStateManager
 
 
 def _make_cache(*, num_layers: int = 2, max_seqs: int = 2) -> GDNPagedStateCache:
@@ -30,10 +30,10 @@ def _make_context() -> PagedAttentionContext:
     return PagedAttentionContext(slot_mapping=[])
 
 
-class TestHybridGDNStateManager:
+class TestRequestStateManager:
     def test_assign_step_slots_grows_state_cache_once(self) -> None:
         cache = _make_cache(max_seqs=3)
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
 
         slots = manager.assign_step_slots(["req-A", "req-B"])
 
@@ -44,7 +44,7 @@ class TestHybridGDNStateManager:
 
     def test_assign_step_slots_is_atomic_on_grow_failure(self) -> None:
         cache = _make_cache(max_seqs=1)
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
 
         with pytest.raises(RuntimeError, match="more slots than max_num_seqs"):
             manager.assign_step_slots(["req-A", "req-B"])
@@ -53,14 +53,14 @@ class TestHybridGDNStateManager:
         assert manager.request_slots == {}
         assert manager.free_slots == ()
 
-    def test_populate_step_context_sets_gdn_slot_mapping(self) -> None:
+    def test_populate_step_context_sets_state_slot_mapping(self) -> None:
         cache = _make_cache()
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         ctx = _make_context()
 
         manager.populate_step_context(req_ids=["req-A", "req-B"], ctx=ctx)
 
-        assert ctx.gdn_slot_mapping == [0, 1]
+        assert ctx.state_slot_mapping == [0, 1]
         assert manager.request_slots == {"req-A": 0, "req-B": 1}
 
     def test_extend_forward_eval_outputs_uses_pending_compact_state(self) -> None:
@@ -75,7 +75,7 @@ class TestHybridGDNStateManager:
             initial_seqs=0,
             dtype=mx.float32,
         )
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         manager.assign_step_slots(["req-A", "req-B"])
         cache.set_pending_conv_state(0, [1], mx.full((1, 1, 4), 7, dtype=mx.float32))
         cache.set_pending_recurrent_state(
@@ -106,7 +106,7 @@ class TestHybridGDNStateManager:
             initial_seqs=0,
             dtype=mx.float32,
         )
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         manager.assign_step_slots(["done"])
         slot = manager.request_slots["done"]
 
@@ -129,7 +129,7 @@ class TestHybridGDNStateManager:
 
     def test_materialize_pending_state_clears_flag_once(self) -> None:
         cache = _make_cache(max_seqs=2)
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         manager.assign_step_slots(["req-A", "req-B"])
 
         manager.release_requests({"req-A", "req-B"})
@@ -154,7 +154,7 @@ class TestHybridGDNStateManager:
             initial_seqs=0,
             dtype=mx.float32,
         )
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         released_slot = manager.assign_step_slots(["done"])[0]
 
         manager.release_requests({"done"})
@@ -180,7 +180,7 @@ class TestHybridGDNStateManager:
 
     def test_reused_slot_is_zeroed_before_new_request_uses_it(self) -> None:
         cache = _make_cache(num_layers=1, max_seqs=2)
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         slot = manager.assign_step_slots(["req-A"])[0]
 
         conv = cache.conv_states[0]
@@ -201,7 +201,7 @@ class TestHybridGDNStateManager:
 
     def test_reused_slot_does_not_touch_other_live_slot(self) -> None:
         cache = _make_cache(num_layers=1, max_seqs=2)
-        manager = HybridGDNStateManager(cache)
+        manager = RequestStateManager(cache)
         slot_a, slot_b = manager.assign_step_slots(["req-A", "req-B"])
 
         conv_states = cache.conv_states[0]
@@ -227,7 +227,7 @@ class TestHybridGDNStateManager:
 
 
 class TestHybridPagedAttentionRuntime:
-    def test_initialize_wires_gdn_state_manager_delegation(self) -> None:
+    def test_initialize_wires_state_manager_delegation(self) -> None:
         runtime = HybridPagedAttentionRuntime(
             hybrid_plan=make_gdn_hybrid_plan(
                 2,
@@ -249,10 +249,10 @@ class TestHybridPagedAttentionRuntime:
         ctx = _make_context()
         runtime.populate_step_context(req_ids=["req-A"], ctx=ctx)
 
-        assert ctx.gdn_slot_mapping == [0]
+        assert ctx.state_slot_mapping == [0]
 
         cache = runtime.state_cache
-        slot = ctx.gdn_slot_mapping[0]
+        slot = ctx.state_slot_mapping[0]
         cache.set_pending_conv_state(0, [slot], mx.full((1, 1, 4), 7, dtype=mx.float32))
         cache.set_pending_recurrent_state(
             0,
@@ -265,4 +265,4 @@ class TestHybridPagedAttentionRuntime:
 
         assert not cache.has_pending_conv_state(0)
         assert not cache.has_pending_recurrent_state(0)
-        assert runtime.gdn_state_manager.needs_materialize is False
+        assert runtime.state_manager.needs_materialize is False

--- a/tests/attention/test_shortconv_cache.py
+++ b/tests/attention/test_shortconv_cache.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from vllm_metal.attention.caches.shortconv_cache import ShortConvStateCache
 from vllm_metal.attention.context import PagedAttentionContext
-from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
+from vllm_metal.attention.state import AlignStateManager, RequestStateManager
 
 
 def _cache(
@@ -71,7 +71,7 @@ def test_scheduler_copies_each_physical_pool_once_and_grows_for_destination() ->
 def test_partial_prefix_cow_preserves_producer_and_consumer_checkpoint() -> None:
     cache = _cache(num_layers=1)
     _write(cache, 0, 2, 5)  # state after six tokens, inside scheduler block 1
-    manager = AlignGDNStateManager(cache, block_size=4)
+    manager = AlignStateManager(cache, block_size=4)
 
     # A producer keeps its append-only running table; scheduler moves the
     # partial cache entry to block 5 before another token overwrites block 2.
@@ -83,7 +83,7 @@ def test_partial_prefix_cow_preserves_producer_and_consumer_checkpoint() -> None
     # because both computed and scheduled positions are in that same block.
     cache.copy_blocks([(5, 6)])
     ctx = _populate(manager, ["consumer"], [[[0, 6]]], [(6, 2)])
-    assert ctx.gdn_group_slot_mappings == ([6],)
+    assert ctx.state_group_slot_mappings == ([6],)
     values = _values(cache)
     np.testing.assert_array_equal(values[2], 7)
     np.testing.assert_array_equal(values[5], 5)
@@ -97,7 +97,7 @@ def test_partial_prefix_cow_preserves_producer_and_consumer_checkpoint() -> None
 
 def test_none_mode_recycled_request_slot_is_reset_in_every_layer() -> None:
     cache = _cache(initial_seqs=0)
-    manager = HybridGDNStateManager(cache)
+    manager = RequestStateManager(cache)
     assert manager.assign_step_slots(["a", "b"]) == [0, 1]
     for layer in range(cache.num_layers):
         _write(cache, layer, 0, 5 + layer)

--- a/tests/attention/test_shortconv_cache.py
+++ b/tests/attention/test_shortconv_cache.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ShortConv pool and scheduler checkpoint lifecycle regressions."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+from vllm_metal.attention.caches.shortconv_cache import ShortConvStateCache
+from vllm_metal.attention.context import PagedAttentionContext
+from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
+
+
+def _cache(
+    *,
+    num_layers: int = 2,
+    initial_seqs: int = 8,
+) -> ShortConvStateCache:
+    return ShortConvStateCache(
+        num_layers=num_layers,
+        max_seqs=8,
+        conv_kernel_dim=3,
+        conv_dim=4,
+        initial_seqs=initial_seqs,
+        dtype=mx.bfloat16,
+    )
+
+
+def _write(cache: ShortConvStateCache, layer: int, slot: int, value: int) -> None:
+    cache.write_conv_rows(
+        layer, mx.full((1, 2, 4), value), mx.array([slot], dtype=mx.int32)
+    )
+
+
+def _values(cache: ShortConvStateCache, layer: int = 0) -> np.ndarray:
+    mx.eval(*cache.updated_state_arrays())
+    return np.array(cache.conv_states[layer].astype(mx.float32))
+
+
+def _populate(manager, req_ids, tables, positions) -> PagedAttentionContext:
+    ctx = PagedAttentionContext(slot_mapping=[])
+    manager.populate_step_context(
+        req_ids=req_ids,
+        ctx=ctx,
+        state_block_ids=tables,
+        step_positions=positions,
+    )
+    return ctx
+
+
+def test_scheduler_copies_each_physical_pool_once_and_grows_for_destination() -> None:
+    cache = _cache(num_layers=3, initial_seqs=3)
+    cache.set_layer_layout([0, 1, 0], [0, 0, 1])
+    for layer in (0, 2):
+        _write(cache, layer, 1, 5 + layer)
+        _write(cache, layer, 2, 9 + layer)
+
+    # An accidental second copy through the shared sibling would overwrite
+    # destination 6 with the updated value at source 2.
+    cache.copy_blocks([(1, 2), (2, 6)])
+
+    assert cache.allocated_seqs == 7
+    assert cache.conv_states[0] is cache.conv_states[1]
+    for layer in (0, 2):
+        values = _values(cache, layer)
+        np.testing.assert_array_equal(values[1], 5 + layer)
+        np.testing.assert_array_equal(values[2], 5 + layer)
+        np.testing.assert_array_equal(values[6], 9 + layer)
+
+
+def test_partial_prefix_cow_preserves_producer_and_consumer_checkpoint() -> None:
+    cache = _cache(num_layers=1)
+    _write(cache, 0, 2, 5)  # state after six tokens, inside scheduler block 1
+    manager = AlignGDNStateManager(cache, block_size=4)
+
+    # A producer keeps its append-only running table; scheduler moves the
+    # partial cache entry to block 5 before another token overwrites block 2.
+    cache.copy_blocks([(2, 5)])
+    _populate(manager, ["producer"], [[[0, 2]]], [(6, 1)])
+    _write(cache, 0, 2, 7)
+
+    # A new hit is redirected to private block 6. Copy precedes state planning
+    # because both computed and scheduled positions are in that same block.
+    cache.copy_blocks([(5, 6)])
+    ctx = _populate(manager, ["consumer"], [[[0, 6]]], [(6, 2)])
+    assert ctx.gdn_group_slot_mappings == ([6],)
+    values = _values(cache)
+    np.testing.assert_array_equal(values[2], 7)
+    np.testing.assert_array_equal(values[5], 5)
+    np.testing.assert_array_equal(values[6], 5)
+
+    _write(cache, 0, 6, 11)
+    values = _values(cache)
+    np.testing.assert_array_equal(values[5], 5)
+    np.testing.assert_array_equal(values[6], 11)
+
+
+def test_none_mode_recycled_request_slot_is_reset_in_every_layer() -> None:
+    cache = _cache(initial_seqs=0)
+    manager = HybridGDNStateManager(cache)
+    assert manager.assign_step_slots(["a", "b"]) == [0, 1]
+    for layer in range(cache.num_layers):
+        _write(cache, layer, 0, 5 + layer)
+        _write(cache, layer, 1, 9 + layer)
+
+    manager.release_requests({"a"})
+    assert manager.assign_step_slots(["b", "c"]) == [1, 0]
+    for layer in range(cache.num_layers):
+        values = _values(cache, layer)
+        np.testing.assert_array_equal(values[0], 0)
+        np.testing.assert_array_equal(values[1], 9 + layer)

--- a/tests/attention/test_shortconv_wrapper.py
+++ b/tests/attention/test_shortconv_wrapper.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ShortConvPagedWrapper math vs the unmodified mlx_lm LFM2 module.
+
+The wrapper must reproduce ``mlx_lm.models.lfm2.ShortConv`` exactly: packed
+multi-request forwards through the paged state pool have to match running
+each request sequentially against mlx_lm's own ``ArraysCache``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from mlx_lm.models.cache import ArraysCache
+from mlx_lm.models.lfm2 import ModelArgs, ShortConv
+
+from vllm_metal.attention.caches.shortconv_cache import ShortConvStateCache
+from vllm_metal.attention.context import (
+    PagedAttentionContext,
+    clear_context,
+    set_context,
+)
+from vllm_metal.attention.impls.shortconv import ShortConvPagedWrapper
+
+HIDDEN = 32
+L_CACHE = 3
+MAX_SEQS = 8
+
+ATOL = 1e-5
+RTOL = 1e-5
+
+
+@pytest.fixture(autouse=True)
+def _cpu_device_and_clean_context():
+    # Pin the math-equivalence comparison to the CPU stream: the GPU fp32
+    # matmul kernels choose different precision paths by row count (M=1 gemv
+    # is exact, M>=2 tiles accumulate at reduced precision on M5), so packed
+    # vs sequential shapes would differ by kernel choice, not by wrapper math.
+    default_device = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    yield
+    mx.set_default_device(default_device)
+    clear_context()
+
+
+def _make_module() -> ShortConv:
+    args = ModelArgs(
+        model_type="lfm2",
+        vocab_size=64,
+        hidden_size=HIDDEN,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        norm_eps=1e-5,
+        conv_bias=True,
+        conv_L_cache=L_CACHE,
+        block_dim=HIDDEN,
+        block_ff_dim=64,
+        block_multiple_of=8,
+        block_ffn_dim_multiplier=1.0,
+        block_auto_adjust_ff_dim=False,
+        layer_types=["conv", "full_attention"],
+    )
+    return ShortConv(args, layer_idx=0)
+
+
+def _make_wrapper(
+    module: ShortConv,
+) -> tuple[ShortConvPagedWrapper, ShortConvStateCache]:
+    state_cache = ShortConvStateCache(
+        num_layers=1,
+        max_seqs=MAX_SEQS,
+        conv_kernel_dim=L_CACHE,
+        conv_dim=HIDDEN,
+        initial_seqs=MAX_SEQS,
+        dtype=mx.float32,
+    )
+    wrapper = ShortConvPagedWrapper(
+        module, layer_idx=0, cache_idx=0, state_cache=state_cache
+    )
+    return wrapper, state_cache
+
+
+def _set_packed_context(
+    seg_lens: list[int], slot_ids: list[int], grouped: bool
+) -> None:
+    cu_seqlens = [0]
+    for seg_len in seg_lens:
+        cu_seqlens.append(cu_seqlens[-1] + seg_len)
+    # Mirror prepare_grouped: decode requests (single-token segments) are
+    # packed first, so a leading run of 1-token segments is the decode set.
+    # This drives the wrapper's batched pure-decode fast path on all-decode
+    # steps, exactly like the real runner.
+    num_decode = 0
+    for seg_len in seg_lens:
+        if seg_len != 1:
+            break
+        num_decode += 1
+    set_context(
+        PagedAttentionContext(
+            slot_mapping=[],
+            cu_seqlens=cu_seqlens,
+            gdn_slot_mapping=None if grouped else list(slot_ids),
+            gdn_group_slot_mappings=(list(slot_ids),) if grouped else None,
+            num_decode_requests=num_decode,
+        )
+    )
+
+
+def _run_wrapper_step(
+    wrapper: ShortConvPagedWrapper,
+    chunks: list[mx.array],
+    slot_ids: list[int],
+    grouped: bool,
+) -> list[mx.array]:
+    """Run one packed forward and split the output back per request."""
+    seg_lens = [chunk.shape[1] for chunk in chunks]
+    _set_packed_context(seg_lens, slot_ids, grouped)
+    packed = mx.concatenate(chunks, axis=1)
+    out = wrapper(packed)
+    clear_context()
+    outputs = []
+    start = 0
+    for seg_len in seg_lens:
+        outputs.append(out[:, start : start + seg_len, :])
+        start += seg_len
+    return outputs
+
+
+def _assert_close(actual: mx.array, expected: mx.array) -> None:
+    np.testing.assert_allclose(
+        np.array(actual, copy=False),
+        np.array(expected, copy=False),
+        atol=ATOL,
+        rtol=RTOL,
+    )
+
+
+class TestShortConvPagedWrapper:
+    @pytest.mark.parametrize(
+        "grouped", [False, True], ids=["request-slots", "block-slots"]
+    )
+    def test_packed_multi_request_matches_sequential_reference(self, grouped) -> None:
+        """Three requests packed per step vs mlx_lm cache-by-cache reference.
+
+        Runs a prefill step and two decode steps; both the per-step outputs
+        and the final conv states must match the reference to fp tolerance.
+        """
+        mx.random.seed(0)
+        module = _make_module()
+        wrapper, state_cache = _make_wrapper(module)
+
+        slot_ids = [2, 0, 5]
+        # Per request: prefill chunk then two single-token decode chunks.
+        request_chunks = [
+            [mx.random.normal((1, t, HIDDEN)) for t in (5, 1, 1)],
+            [mx.random.normal((1, t, HIDDEN)) for t in (3, 1, 1)],
+            [mx.random.normal((1, t, HIDDEN)) for t in (7, 1, 1)],
+        ]
+
+        # Reference: each request sequentially with mlx_lm's own cache.
+        ref_outputs: list[list[mx.array]] = []
+        ref_caches: list[ArraysCache] = []
+        for chunks in request_chunks:
+            cache = ArraysCache(size=1)
+            ref_outputs.append(
+                [module(chunk, mask=None, cache=cache) for chunk in chunks]
+            )
+            ref_caches.append(cache)
+
+        # Wrapper: the three requests packed together, one step at a time.
+        for step in range(3):
+            chunks = [request_chunks[req][step] for req in range(3)]
+            outputs = _run_wrapper_step(wrapper, chunks, slot_ids, grouped)
+            for req in range(3):
+                _assert_close(outputs[req], ref_outputs[req][step])
+
+        # Final per-request conv state must match the mlx_lm cache tail.
+        for req, slot in enumerate(slot_ids):
+            _assert_close(
+                state_cache.conv_states[0][slot : slot + 1],
+                ref_caches[req][0],
+            )

--- a/tests/attention/test_shortconv_wrapper.py
+++ b/tests/attention/test_shortconv_wrapper.py
@@ -101,8 +101,8 @@ def _set_packed_context(
         PagedAttentionContext(
             slot_mapping=[],
             cu_seqlens=cu_seqlens,
-            gdn_slot_mapping=None if grouped else list(slot_ids),
-            gdn_group_slot_mappings=(list(slot_ids),) if grouped else None,
+            state_slot_mapping=None if grouped else list(slot_ids),
+            state_group_slot_mappings=(list(slot_ids),) if grouped else None,
             num_decode_requests=num_decode,
         )
     )

--- a/tests/test_gdn_lazy_wrapper.py
+++ b/tests/test_gdn_lazy_wrapper.py
@@ -978,7 +978,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
             PagedAttentionContext(
                 slot_mapping=[0, 1],
                 cu_seqlens=[0, 1, 2],
-                gdn_slot_mapping=[1, 1],
+                state_slot_mapping=[1, 1],
             )
         )
 
@@ -989,7 +989,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         finally:
             clear_context()
 
-    def test_requires_gdn_slot_mapping_in_paged_context(self) -> None:
+    def test_requires_state_slot_mapping_in_paged_context(self) -> None:
         # Arrange
         inner = _TinyGDNInner()
         cache = _make_state_cache(
@@ -1011,7 +1011,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
 
         # Act / Assert
         try:
-            with pytest.raises(RuntimeError, match="gdn_slot_mapping"):
+            with pytest.raises(RuntimeError, match="state_slot_mapping"):
                 wrapper(mx.ones((1, 2, inner.conv_dim), dtype=mx.float32))
         finally:
             clear_context()
@@ -1033,7 +1033,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
             PagedAttentionContext(
                 slot_mapping=[0, 1],
                 cu_seqlens=[0, 1, 2],
-                gdn_slot_mapping=[0, cache.max_seqs],
+                state_slot_mapping=[0, cache.max_seqs],
             )
         )
 
@@ -1063,7 +1063,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
             PagedAttentionContext(
                 slot_mapping=[0, 1],
                 cu_seqlens=[0, 1, 2],
-                gdn_slot_mapping=[0, 1],
+                state_slot_mapping=[0, 1],
             )
         )
 
@@ -1119,7 +1119,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
             PagedAttentionContext(
                 slot_mapping=[0, 1],
                 cu_seqlens=[0, 1, 2],
-                gdn_slot_mapping=[0, 1],
+                state_slot_mapping=[0, 1],
             )
         )
 

--- a/tests/test_shortconv_hybrid_spec.py
+++ b/tests/test_shortconv_hybrid_spec.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LFM2 family routing, scheduler layout, and physical cache integration."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from importlib import import_module
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+import torch
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.core.kv_cache_utils import (
+    get_kv_cache_config_from_groups,
+    get_kv_cache_groups,
+)
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
+from vllm_metal.config import MetalConfig
+from vllm_metal.v1.model_lifecycle import ModelLifecycle
+
+BLOCK_SIZE = 16
+NUM_BLOCKS = 12
+ATTENTION_INDICES = (1, 4)
+STATE_INDICES = (0, 2, 3, 5)
+
+
+@pytest.fixture(params=["lfm2", "lfm2_moe"])
+def lfm_model(request):
+    module = import_module(f"mlx_lm.models.{request.param}")
+    args = {
+        "model_type": request.param,
+        "vocab_size": 32,
+        "hidden_size": 64,
+        "num_hidden_layers": 6,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "max_position_embeddings": 128,
+        "norm_eps": 1e-5,
+        "conv_bias": False,
+        "conv_L_cache": 3,
+        # The nonalternating layout catches implicit interval assumptions.
+        "layer_types": [
+            "conv",
+            "full_attention",
+            "conv",
+            "conv",
+            "full_attention",
+            "conv",
+        ],
+    }
+    if request.param == "lfm2":
+        args.update(
+            block_dim=64,
+            block_ff_dim=128,
+            block_multiple_of=16,
+            block_ffn_dim_multiplier=1.0,
+            block_auto_adjust_ff_dim=False,
+        )
+    else:
+        args.update(
+            intermediate_size=128,
+            moe_intermediate_size=64,
+            num_experts=2,
+            num_experts_per_tok=1,
+            norm_topk_prob=True,
+            use_expert_bias=False,
+            num_dense_layers=1,
+        )
+    return module.Model(module.ModelArgs(**args))
+
+
+@pytest.fixture(autouse=True)
+def _ordinary_paged_cache(monkeypatch):
+    monkeypatch.setattr(
+        "vllm_metal.v1.cache_policy.get_config",
+        lambda: MetalConfig(
+            memory_fraction=-1.0,
+            mlx_device="gpu",
+            use_paged_attention=True,
+            turboquant=False,
+        ),
+    )
+
+
+def _runner(model, *, mode="align"):
+    runner = make_stub_runner(
+        model=model,
+        model_args=asdict(model.args),
+        is_hybrid=True,
+        kv_cache_dtype=mx.bfloat16,
+        cache_config=SimpleNamespace(
+            block_size=BLOCK_SIZE,
+            mamba_block_size=BLOCK_SIZE if mode == "align" else 128,
+            mamba_page_size_padded=None,
+            mamba_cache_mode=mode,
+            num_gpu_blocks_override=None,
+        ),
+        scheduler_config=SimpleNamespace(
+            max_num_seqs=3,
+            disable_hybrid_kv_cache_manager=False,
+        ),
+    )
+    ModelLifecycle(runner, runner._model_adapter).resolve_model_dims()
+    return runner
+
+
+def _runtime(runner):
+    runtime = runner.build_paged_attention_runtime(block_size=BLOCK_SIZE)
+    assert isinstance(runtime, HybridPagedAttentionRuntime)
+    runtime.initialize(NUM_BLOCKS)
+    runner.install_paged_attention_runtime(runtime, block_size=BLOCK_SIZE)
+    return runtime
+
+
+@pytest.mark.parametrize("mode", ["none", "align"])
+def test_scheduler_spec_bills_only_the_convolution_tail(lfm_model, mode):
+    runner = _runner(lfm_model, mode=mode)
+    specs = runner.get_kv_cache_spec()
+    expected_names = {
+        *(f"layers.{i}.conv" for i in STATE_INDICES),
+        *(f"layers.{i}.self_attn" for i in ATTENTION_INDICES),
+    }
+    assert set(specs) == expected_names
+    for index in STATE_INDICES:
+        spec = specs[f"layers.{index}.conv"]
+        assert isinstance(spec, MambaSpec)
+        assert spec.shapes == ((2, 64),)
+        assert spec.dtypes == (torch.bfloat16,)
+        assert spec.mamba_type == MambaAttentionBackendEnum.SHORT_CONV
+        assert spec.mamba_cache_mode == mode
+        assert spec.block_size == (BLOCK_SIZE if mode == "align" else 128)
+        assert spec.page_size_bytes == 256
+    for index in ATTENTION_INDICES:
+        spec = specs[f"layers.{index}.self_attn"]
+        assert isinstance(spec, FullAttentionSpec)
+        assert spec.page_size_bytes == 2048
+    assert runner.linear_cache_bytes_per_slot() == 4 * 256
+    assert runner.get_cache_block_size_bytes() == 2 * 2048
+
+
+def test_upstream_scheduler_groups_adopt_conv_names_and_shared_state_pools(lfm_model):
+    """Round-trip real vLLM grouping, including its shared_by physical layout."""
+    runner = _runner(lfm_model)
+    runtime = _runtime(runner)
+    engine_config = SimpleNamespace(
+        cache_config=runner.cache_config,
+        scheduler_config=runner.scheduler_config,
+        kv_transfer_config=None,
+    )
+    groups = get_kv_cache_groups(engine_config, runner.get_kv_cache_spec())
+    scheduler_cache = get_kv_cache_config_from_groups(
+        engine_config,
+        groups,
+        available_memory=NUM_BLOCKS * runner.get_cache_block_size_bytes(),
+    )
+    assert scheduler_cache.num_blocks == NUM_BLOCKS
+    runner.initialize_kv_cache(scheduler_cache)
+
+    expected_state_groups = tuple(
+        i
+        for i, group in enumerate(groups)
+        if isinstance(group.kv_cache_spec, MambaSpec)
+    )
+    expected_attention_groups = tuple(
+        i
+        for i, group in enumerate(groups)
+        if isinstance(group.kv_cache_spec, FullAttentionSpec)
+    )
+    assert len(expected_state_groups) == 2
+    assert len(expected_attention_groups) == 1
+    assert runtime.state_scheduler_group_indices() == expected_state_groups
+    assert runtime.kv_scheduler_group_indices() == expected_attention_groups
+    assert runner._paged_state_group_indices == expected_state_groups
+
+    cache = runtime.state_cache
+    assert cache.allocated_seqs == 0
+    cache.ensure_capacity(NUM_BLOCKS)
+    assert cache.num_state_pools == 2
+    for tensor in scheduler_cache.kv_cache_tensors:
+        indices = [
+            STATE_INDICES.index(int(name.split(".")[1]))
+            for name in tensor.shared_by
+            if name.endswith(".conv")
+        ]
+        assert len(indices) == 2
+        assert cache.conv_states[indices[0]] is cache.conv_states[indices[1]]
+        assert cache.layer_group_ordinal(indices[0]) != cache.layer_group_ordinal(
+            indices[1]
+        )
+    assert (
+        sum(array.nbytes for array in cache.updated_state_arrays())
+        == NUM_BLOCKS * 2 * 256
+    )
+    assert runner._cache_policy.hybrid_align_state_bytes_per_block() == 2 * 256
+    assert runner._cache_policy.hybrid_align_growth_bytes_per_block() == 256

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -24,7 +24,7 @@ import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
-from vllm_metal.attention.state import HybridGDNStateManager
+from vllm_metal.attention.state import RequestStateManager
 from vllm_metal.distributed.pipeline import PipelineGroup
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPDraftSeed
@@ -34,29 +34,29 @@ from vllm_metal.v1.spec_decode import PagedDecodeSegment
 
 class HybridRuntimeStub:
     def __init__(self, state_cache: GDNPagedStateCache) -> None:
-        self._gdn_state_manager = HybridGDNStateManager(state_cache)
+        self._state_manager = RequestStateManager(state_cache)
 
     def needs_step_context(self) -> bool:
         return True
 
     @property
-    def gdn_state_manager(self) -> HybridGDNStateManager:
-        return self._gdn_state_manager
+    def state_manager(self) -> RequestStateManager:
+        return self._state_manager
 
     def populate_step_context(
         self, *, req_ids: list[str], ctx, state_block_ids=None, step_positions=None
     ) -> None:
         del state_block_ids, step_positions
-        self._gdn_state_manager.populate_step_context(req_ids=req_ids, ctx=ctx)
+        self._state_manager.populate_step_context(req_ids=req_ids, ctx=ctx)
 
     def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:
-        self._gdn_state_manager.extend_forward_eval_outputs(outputs)
+        self._state_manager.extend_forward_eval_outputs(outputs)
 
     def release_requests(self, req_ids: set[str]) -> None:
-        self._gdn_state_manager.release_requests(req_ids)
+        self._state_manager.release_requests(req_ids)
 
     def materialize_pending_state(self) -> None:
-        self._gdn_state_manager.materialize_pending_state()
+        self._state_manager.materialize_pending_state()
 
 
 class ForwardOutputRuntimeStub:
@@ -696,7 +696,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
             )
 
         assert mr.get_context() is None
-        assert backend.gdn_state_manager.request_slots == {}
+        assert backend.state_manager.request_slots == {}
 
     def test_start_paged_forward_collects_hidden_states_for_gemma4_mtp(
         self, monkeypatch
@@ -1548,7 +1548,7 @@ class TestV1MetalModelRunnerExecuteModel:
             generator=None,
             generated_tokens=0,
         )
-        slot = runtime.gdn_state_manager.assign_step_slots(["done"])[0]
+        slot = runtime.state_manager.assign_step_slots(["done"])[0]
         cache.set_pending_conv_state(0, [slot], mx.full((1, 1, 4), 7, dtype=mx.float32))
         cache.set_pending_recurrent_state(
             0,
@@ -1569,7 +1569,7 @@ class TestV1MetalModelRunnerExecuteModel:
         mx.eval(cache.conv_states[0], cache.recurrent_states[0])
         np.testing.assert_array_equal(np.array(cache.conv_states[0][slot]), 7)
         np.testing.assert_array_equal(np.array(cache.recurrent_states[0][slot]), 9)
-        assert runtime.gdn_state_manager.needs_materialize is False
+        assert runtime.state_manager.needs_materialize is False
 
     def test_non_paged_spec_decode_fails_after_cleanup_before_new_state(self) -> None:
         runner = self._make_runner()
@@ -1830,9 +1830,9 @@ class TestV1MetalModelRunnerGDNSubmit:
         )
         runner._paged_request_seq_lens["done"] = 1
 
-        released_slot = runtime.gdn_state_manager.assign_step_slots(["done"])[0]
+        released_slot = runtime.state_manager.assign_step_slots(["done"])[0]
         runner._reconcile_request_lifecycle({"done"}, materialize_runtime_state=False)
-        reused_slot = runtime.gdn_state_manager.assign_step_slots(["next"])[0]
+        reused_slot = runtime.state_manager.assign_step_slots(["next"])[0]
         assert reused_slot == released_slot
 
         cache.set_pending_conv_state(
@@ -1856,7 +1856,7 @@ class TestV1MetalModelRunnerGDNSubmit:
             np.array(cache.recurrent_states[0][reused_slot]),
             9,
         )
-        assert runtime.gdn_state_manager.needs_materialize is False
+        assert runtime.state_manager.needs_materialize is False
 
 
 class TestV1MetalModelRunnerGDNLifecycle:
@@ -1932,7 +1932,7 @@ class TestV1MetalModelRunnerGDNLifecycle:
         )
         runner._request_states[req_id] = state
         runner._paged_request_seq_lens[req_id] = 2
-        slot = runtime.gdn_state_manager.assign_step_slots([req_id])[0]
+        slot = runtime.state_manager.assign_step_slots([req_id])[0]
 
         cache.set_pending_conv_state(
             0,
@@ -1954,9 +1954,9 @@ class TestV1MetalModelRunnerGDNLifecycle:
 
         assert runner._request_states[req_id] is state
         assert runner._paged_request_seq_lens[req_id] == 2
-        assert runtime.gdn_state_manager.request_slots == {}
-        assert runtime.gdn_state_manager.free_slots == (slot,)
-        assert runtime.gdn_state_manager.needs_materialize is False
+        assert runtime.state_manager.request_slots == {}
+        assert runtime.state_manager.free_slots == (slot,)
+        assert runtime.state_manager.needs_materialize is False
         mx.eval(cache.conv_states[0], cache.recurrent_states[0])
         np.testing.assert_array_equal(np.array(cache.conv_states[0][slot]), 7)
         np.testing.assert_array_equal(np.array(cache.recurrent_states[0][slot]), 9)
@@ -1992,7 +1992,7 @@ class TestV1MetalModelRunnerGDNLifecycle:
             ctx = mr.get_context()
             assert ctx is not None
             captured["input_ids"] = input_ids.tolist()
-            captured["gdn_slot_mapping"] = list(ctx.gdn_slot_mapping or [])
+            captured["state_slot_mapping"] = list(ctx.state_slot_mapping or [])
             return mr.TargetModelForwardOutput(logits=mx.zeros((1, 2, 16)))
 
         monkeypatch.setattr(runner, "_target_forward", fake_target_forward)
@@ -2026,8 +2026,8 @@ class TestV1MetalModelRunnerGDNLifecycle:
         )
 
         assert captured["input_ids"] == [[6, 9]]
-        assert captured["gdn_slot_mapping"] == [0, 1]
-        assert runtime.gdn_state_manager.request_slots == {
+        assert captured["state_slot_mapping"] == [0, 1]
+        assert runtime.state_manager.request_slots == {
             "decode-0": 0,
             "prefill-0": 1,
         }
@@ -2057,9 +2057,9 @@ class TestV1MetalModelRunnerGDNLifecycle:
         )
         runner._paged_request_seq_lens["done"] = 1
 
-        released_slot = runtime.gdn_state_manager.assign_step_slots(["done"])[0]
+        released_slot = runtime.state_manager.assign_step_slots(["done"])[0]
         runner._reconcile_request_lifecycle({"done"}, materialize_runtime_state=False)
-        reused_slot = runtime.gdn_state_manager.assign_step_slots(["next"])[0]
+        reused_slot = runtime.state_manager.assign_step_slots(["next"])[0]
         assert reused_slot == released_slot
 
         cache.set_pending_conv_state(
@@ -2091,7 +2091,7 @@ class TestV1MetalModelRunnerGDNLifecycle:
             np.array(cache.recurrent_states[0][reused_slot]),
             9,
         )
-        assert runtime.gdn_state_manager.needs_materialize is False
+        assert runtime.state_manager.needs_materialize is False
 
 
 class TestRunnerMlaProperties:

--- a/tests/test_yoco_fast_prefill.py
+++ b/tests/test_yoco_fast_prefill.py
@@ -359,7 +359,7 @@ def test_try_enable_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> N
                     "tokens": h.shape[1],
                     "cu_seqlens": tuple(ctx.cu_seqlens),
                     "offsets": tuple(ctx.offsets),
-                    "gdn_slot_mapping": ctx.gdn_slot_mapping,
+                    "state_slot_mapping": ctx.state_slot_mapping,
                     "kv_groups": (
                         tuple(
                             (
@@ -429,7 +429,7 @@ def test_try_enable_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> N
         context_lens=[5],
         offsets=[0],
         cu_seqlens=[0, 5],
-        gdn_slot_mapping=[17],
+        state_slot_mapping=[17],
         kv_groups=(
             PagedKVGroupContext(
                 slot_mapping=[0, 1, 2, 3, 4],
@@ -458,9 +458,9 @@ def test_try_enable_gemma4_yoco_fast_prefill_reduces_shared_layer_queries() -> N
         ((4,), ((0, 1),), 4),
         ((14,), ((8, 9),), 16),
     )
-    assert text_model.layers[0].calls[0]["gdn_slot_mapping"] == [17]
-    assert text_model.layers[2].calls[0]["gdn_slot_mapping"] is None
-    assert text_model.layers[3].calls[0]["gdn_slot_mapping"] is None
+    assert text_model.layers[0].calls[0]["state_slot_mapping"] == [17]
+    assert text_model.layers[2].calls[0]["state_slot_mapping"] is None
+    assert text_model.layers[3].calls[0]["state_slot_mapping"] is None
     assert out[0, 0, 0].item() == 3
     assert out[0, 4, 0].item() == 10
 

--- a/vllm_metal/attention/caches/protocol.py
+++ b/vllm_metal/attention/caches/protocol.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+"""State-pool operations shared by hybrid runtimes and state managers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+import mlx.core as mx
+
+
+class PagedStateCache(Protocol):
+    """Own state slabs without exposing a family's tensor layout or kernels."""
+
+    max_seqs: int
+    allocated_seqs: int
+
+    @property
+    def num_state_pools(self) -> int: ...
+
+    def ensure_capacity(self, num_seqs: int) -> None: ...
+
+    def reset_slot(self, slot: int) -> None: ...
+
+    def set_layer_layout(
+        self, group_ordinals: list[int], pool_ordinals: list[int]
+    ) -> None: ...
+
+    def layers_for_group_ordinal(self, ordinal: int) -> list[int]: ...
+
+    def copy_slots(
+        self, src_ids: list[int], dst_ids: list[int], layer_indices: list[int]
+    ) -> None: ...
+
+    def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None: ...
+
+    def zero_slots(self, slot_ids: list[int], layer_indices: list[int]) -> None: ...
+
+    def apply_pending_states(self) -> None: ...
+
+    def updated_state_arrays(self) -> list[mx.array]: ...

--- a/vllm_metal/attention/caches/shortconv_cache.py
+++ b/vllm_metal/attention/caches/shortconv_cache.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Convolution-only state for LFM2-style ShortConv layers.
+
+Each slab holds the last ``conv_kernel_dim - 1`` gated input rows, shaped
+``[history, conv_dim]`` in the activation dtype. None mode assigns slabs to
+requests; align mode addresses them by scheduler block id and shares physical
+pools according to the scheduler's layer layout.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable, Sequence
+
+import mlx.core as mx
+
+
+@functools.cache
+def _native_row_scatter() -> Callable[..., mx.array]:
+    """Reuse the native row primitive without copying the whole state pool."""
+    from vllm_metal.metal import get_ops
+
+    return get_ops().gdn_state_scatter
+
+
+class ShortConvStateCache:
+    """MLX convolution tails with the shared hybrid state lifecycle API."""
+
+    def __init__(
+        self,
+        *,
+        num_layers: int,
+        max_seqs: int,
+        conv_kernel_dim: int,
+        conv_dim: int,
+        initial_seqs: int | None = None,
+        dtype: mx.Dtype = mx.float16,
+    ) -> None:
+        if dtype not in (mx.float16, mx.bfloat16, mx.float32):
+            raise ValueError(f"Unsupported dtype for ShortConv state cache: {dtype}")
+        if max_seqs < 0:
+            raise ValueError("max_seqs must be non-negative")
+        if conv_kernel_dim < 2:
+            raise ValueError("conv_kernel_dim must be at least 2 to carry state")
+        if initial_seqs is None:
+            initial_seqs = max_seqs
+        if initial_seqs < 0 or initial_seqs > max_seqs:
+            raise ValueError(
+                "initial_seqs must be between 0 and max_seqs "
+                f"(got {initial_seqs}, max_seqs={max_seqs})"
+            )
+
+        self.num_layers = num_layers
+        self.max_seqs = max_seqs
+        self.allocated_seqs = initial_seqs
+        self.conv_kernel_dim = conv_kernel_dim
+        self.conv_dim = conv_dim
+        self.dtype = dtype
+        self.conv_states = [
+            mx.zeros(self._conv_shape(initial_seqs), dtype=dtype)
+            for _ in range(num_layers)
+        ]
+        self._layer_group_ordinals = [0] * num_layers
+        self._pool_siblings = [[i] for i in range(num_layers)]
+        self._canonical_layers = list(range(num_layers))
+        mx.eval(*self.updated_state_arrays())
+
+    def _conv_shape(self, num_seqs: int) -> tuple[int, int, int]:
+        return (num_seqs, self.conv_kernel_dim - 1, self.conv_dim)
+
+    @property
+    def num_state_pools(self) -> int:
+        """Number of distinct physical pools under the adopted layout."""
+        return len(self._canonical_layers)
+
+    def store_conv_state(self, layer_idx: int, array: mx.array) -> None:
+        """Rebind every layer sharing this physical pool to its new handle."""
+        for sibling in self._pool_siblings[layer_idx]:
+            self.conv_states[sibling] = array
+
+    def ensure_capacity(self, num_seqs: int) -> None:
+        """Grow physical pools to cover the requested slab ids."""
+        if num_seqs < 0:
+            raise ValueError("num_seqs must be non-negative")
+        if num_seqs > self.max_seqs:
+            raise RuntimeError(
+                "ShortConv state cache requested more slots than max_num_seqs "
+                f"({num_seqs} > {self.max_seqs})"
+            )
+        if num_seqs <= self.allocated_seqs:
+            return
+
+        for layer_idx in self._canonical_layers:
+            grown = mx.zeros(self._conv_shape(num_seqs), dtype=self.dtype)
+            if self.allocated_seqs:
+                grown[: self.allocated_seqs] = self.conv_states[layer_idx]
+            # Finish one pool at a time so growth holds only one old pool
+            # beyond the final allocation, as budgeted by the hybrid plan.
+            mx.eval(grown)
+            self.store_conv_state(layer_idx, grown)
+        self.allocated_seqs = num_seqs
+
+    def require_allocated_slots(self, slot_ids: list[int]) -> None:
+        """Validate slabs against both the hard cap and allocated storage."""
+        if any(slot < 0 or slot >= self.max_seqs for slot in slot_ids):
+            raise RuntimeError("ShortConv wrapper received out-of-range slot mapping")
+        if any(slot >= self.allocated_seqs for slot in slot_ids):
+            raise RuntimeError(
+                "ShortConv wrapper received slot mapping beyond allocated state cache"
+            )
+
+    def reset_slot(self, slot: int) -> None:
+        """Clear a private request slot before reusing it in none mode."""
+        self.zero_slots([slot], self._canonical_layers)
+
+    def set_layer_layout(
+        self, group_ordinals: list[int], pool_ordinals: list[int]
+    ) -> None:
+        """Adopt scheduler groups and physical pools before any state is written.
+
+        Layers may share a pool only across different groups, whose scheduler
+        block ids are disjoint. None mode retains the initial one-pool-per-layer
+        layout because its slots are private request indices.
+        """
+        if not (len(group_ordinals) == len(pool_ordinals) == self.num_layers):
+            raise ValueError(
+                "expected one group and one pool ordinal per ShortConv layer "
+                f"({self.num_layers}), got {len(group_ordinals)}/{len(pool_ordinals)}"
+            )
+        pool_members: dict[int, list[int]] = {}
+        for layer_idx, pool in enumerate(pool_ordinals):
+            pool_members.setdefault(pool, []).append(layer_idx)
+        for pool, members in pool_members.items():
+            groups = [group_ordinals[i] for i in members]
+            if len(set(groups)) != len(groups):
+                raise ValueError(
+                    f"state pool {pool} is shared by two layers of the same "
+                    f"mamba cache group (layers {members}); their slab rows "
+                    "would collide"
+                )
+
+        self._layer_group_ordinals = list(group_ordinals)
+        self._pool_siblings = [pool_members[pool] for pool in pool_ordinals]
+        self._canonical_layers = sorted(members[0] for members in pool_members.values())
+        for layer_idx in self._canonical_layers:
+            self.store_conv_state(layer_idx, self.conv_states[layer_idx])
+
+    def layer_group_ordinal(self, cache_idx: int) -> int:
+        """Return the block-table group addressing one layer's state."""
+        return self._layer_group_ordinals[cache_idx]
+
+    def layers_for_group_ordinal(self, ordinal: int) -> list[int]:
+        """Return the layer cache indices owned by one scheduler group."""
+        return [
+            idx
+            for idx, group in enumerate(self._layer_group_ordinals)
+            if group == ordinal
+        ]
+
+    def write_conv_rows(self, layer_idx: int, rows: mx.array, ids: mx.array) -> None:
+        """Write distinct slabs in place and chain updates across pool siblings."""
+        pool = self.conv_states[layer_idx]
+        # Indexed MLX assignment casts implicitly; the native primitive needs
+        # the exact pool dtype. Only the compact rows are converted here.
+        updated = _native_row_scatter()(pool, rows.astype(pool.dtype), ids)
+        self.store_conv_state(layer_idx, updated)
+
+    def copy_slots(
+        self, src_ids: list[int], dst_ids: list[int], layer_indices: list[int]
+    ) -> None:
+        """Copy slabs without advancing or overwriting the source checkpoint."""
+        if not src_ids or not layer_indices:
+            return
+        self.require_allocated_slots(src_ids)
+        self.require_allocated_slots(dst_ids)
+        src = mx.array(src_ids, dtype=mx.int32)
+        dst = mx.array(dst_ids, dtype=mx.int32)
+        for layer_idx in layer_indices:
+            # Gather all sources before the in-place write: a destination may
+            # also be another pair's source. The temporary is only O(rows).
+            self.write_conv_rows(layer_idx, self.conv_states[layer_idx][src], dst)
+
+    def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None:
+        """Apply scheduler copy-on-write operations to each physical pool once."""
+        if not block_copies:
+            return
+        src_ids, dst_ids = zip(*block_copies, strict=True)
+        self.ensure_capacity(max(*src_ids, *dst_ids) + 1)
+        self.copy_slots(list(src_ids), list(dst_ids), self._canonical_layers)
+
+    def zero_slots(self, slot_ids: list[int], layer_indices: list[int]) -> None:
+        """Zero only the given slabs when their scheduler blocks are recycled."""
+        if not slot_ids or not layer_indices:
+            return
+        self.require_allocated_slots(slot_ids)
+        ids = mx.array(slot_ids, dtype=mx.int32)
+        zeros = mx.zeros(self._conv_shape(len(slot_ids)), dtype=self.dtype)
+        for layer_idx in layer_indices:
+            self.write_conv_rows(layer_idx, zeros, ids)
+
+    def apply_pending_states(self) -> None:
+        """No-op: ShortConv writes its new tail directly to the stable pool."""
+
+    def updated_state_arrays(self) -> list[mx.array]:
+        """Submit one authoritative array per physical pool after a forward."""
+        return [self.conv_states[i] for i in self._canonical_layers]

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -62,15 +62,15 @@ class PagedAttentionContext:
     # Cumulative sequence length array: [0, len0, len0+len1, ...]
     # (length = num_requests + 1).
     cu_seqlens: list[int] | None = None
-    # GDN state slot mappings — exactly one of the two is set for hybrid
+    # State slot mappings — exactly one of the two is set for hybrid
     # models (both None for non-hybrid).  In mamba_cache_mode "none" the
-    # state manager sets ``gdn_slot_mapping`` (request batch position →
-    # private stable slot, shared by every linear layer); under align-mode
-    # prefix caching it sets ``gdn_group_slot_mappings`` instead (one list
+    # state manager sets ``state_slot_mapping`` (request batch position →
+    # private stable slot, shared by every state layer); under align-mode
+    # prefix caching it sets ``state_group_slot_mappings`` instead (one list
     # per mamba cache group, request batch position → that group's scheduler
     # block id / state slab).
-    gdn_slot_mapping: list[int] | None = None
-    gdn_group_slot_mappings: tuple[list[int], ...] | None = None
+    state_slot_mapping: list[int] | None = None
+    state_group_slot_mappings: tuple[list[int], ...] | None = None
     # Number of decode requests packed at the front of the batch.
     # This lets attention wrappers distinguish pure prefill from mixed prefill+decode
     # without reverse-engineering one-token segments from ``cu_seqlens``.

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -159,13 +159,13 @@ class GDNPagedAttentionWrapper(nn.Module):
             raise RuntimeError("GDN wrapper requires cu_seqlens in context")
 
         num_requests = len(cu_seqlens) - 1
-        if ctx.gdn_group_slot_mappings is not None:
+        if ctx.state_group_slot_mappings is not None:
             ordinal = self._gdn_state_cache.layer_group_ordinal(self._gdn_cache_idx)
-            slot_ids = ctx.gdn_group_slot_mappings[ordinal]
-        elif ctx.gdn_slot_mapping is not None:
-            slot_ids = ctx.gdn_slot_mapping
+            slot_ids = ctx.state_group_slot_mappings[ordinal]
+        elif ctx.state_slot_mapping is not None:
+            slot_ids = ctx.state_slot_mapping
         else:
-            raise RuntimeError("GDN wrapper requires gdn_slot_mapping in context")
+            raise RuntimeError("GDN wrapper requires state_slot_mapping in context")
         if len(slot_ids) != num_requests:
             raise RuntimeError("GDN wrapper requires one slot per request")
         if len(set(slot_ids)) != len(slot_ids):

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -6,8 +6,8 @@ between ``n_heads`` (queries) and ``n_kv_heads`` (keys/values) is handled
 transparently by the Metal paged attention kernel.
 
 Handles models whose attention module exposes:
-- ``q_proj``, ``k_proj``, ``o_proj`` linear projections (``v_proj`` optional —
-  see K-eq-V variant below)
+- ``q_proj``, ``k_proj``, ``o_proj`` / ``out_proj`` linear projections
+  (``v_proj`` optional — see K-eq-V variant below)
 - ``rope`` / ``rotary_emb`` for rotary position embeddings, or precomputed
   ``position_embeddings`` supplied by the caller
 - ``n_heads``, ``n_kv_heads`` head counts
@@ -91,7 +91,7 @@ def is_sdpa(module: nn.Module) -> bool:
     Accepts two contracts:
 
     - Split-projection SDPA: ``q_proj`` / ``k_proj`` / output projection
-      (``o_proj``, or ``dense`` as in ``mlx_lm.models.phi``), plus
+      (``o_proj``, ``dense`` in Phi, or ``out_proj`` in LFM2), plus
       EITHER ``v_proj`` OR the explicit ``use_k_eq_v = True`` opt-in.
       The latter admits Gemma4 26B / 31B full-attention layers which
       share the K projection for values and never define ``v_proj``
@@ -241,11 +241,12 @@ def _output_projection(module: nn.Module) -> nn.Module | None:
     """Return the attention-output projection on *module*.
 
     Nearly every mlx_lm SDPA architecture calls it ``o_proj``; Phi-1/1.5
-    (``mlx_lm.models.phi``) spell theirs ``dense``.  Probing by name keeps
-    ``is_sdpa`` and the forward path aligned on the same alias set instead
+    (``mlx_lm.models.phi``) spell theirs ``dense`` and LFM2 uses ``out_proj``.
+    Probing by name keeps ``is_sdpa`` and the forward path aligned on the
+    same alias set instead
     of the forward breaking on architectures that already pass dispatch.
     """
-    for name in ("o_proj", "dense"):
+    for name in ("o_proj", "dense", "out_proj"):
         proj = getattr(module, name, None)
         if proj is not None:
             return proj

--- a/vllm_metal/attention/impls/shortconv.py
+++ b/vllm_metal/attention/impls/shortconv.py
@@ -60,11 +60,11 @@ class ShortConvPagedWrapper(nn.Module):
 
         cache_idx = self._cache_idx
         state_cache = self._state_cache
-        if ctx.gdn_group_slot_mappings is not None:
+        if ctx.state_group_slot_mappings is not None:
             ordinal = state_cache.layer_group_ordinal(cache_idx)
-            slots = ctx.gdn_group_slot_mappings[ordinal]
+            slots = ctx.state_group_slot_mappings[ordinal]
         else:
-            slots = ctx.gdn_slot_mapping
+            slots = ctx.state_slot_mapping
         boundaries = ctx.cu_seqlens
         if slots is None or len(slots) != len(boundaries) - 1:
             raise RuntimeError("ShortConv requires one state slot per packed request")

--- a/vllm_metal/attention/impls/shortconv.py
+++ b/vllm_metal/attention/impls/shortconv.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LFM2 ShortConv with per-request or scheduler-block-indexed state.
+
+The checkpoint is the last ``L_cache - 1`` rows of the gated input B*x,
+before convolution. Align-mode state motion happens before this wrapper;
+the wrapper writes only the destination selected for each request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from vllm_metal.attention.caches.shortconv_cache import ShortConvStateCache
+from vllm_metal.attention.context import get_context
+
+
+def is_shortconv(module: nn.Module) -> bool:
+    return (
+        hasattr(module, "conv")
+        and hasattr(module, "in_proj")
+        and hasattr(module, "out_proj")
+        and hasattr(module, "L_cache")
+        and not hasattr(module, "q_proj")
+    )
+
+
+class ShortConvPagedWrapper(nn.Module):
+    """Apply the native LFM2 operation independently to packed requests."""
+
+    def __init__(
+        self,
+        inner: nn.Module,
+        layer_idx: int,
+        cache_idx: int,
+        state_cache: ShortConvStateCache,
+    ) -> None:
+        super().__init__()
+        object.__setattr__(self, "_inner", inner)
+        self.rebind_state_cache(state_cache, cache_idx=cache_idx)
+
+    def rebind_state_cache(
+        self, state_cache: ShortConvStateCache, *, cache_idx: int
+    ) -> None:
+        object.__setattr__(self, "_state_cache", state_cache)
+        object.__setattr__(self, "_cache_idx", cache_idx)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array | None = None,
+        cache: nn.Module | None = None,
+        **kwargs: Any,
+    ) -> mx.array:
+        ctx = get_context()
+        if ctx is None:
+            return self._inner(x, mask=mask, cache=cache)
+
+        cache_idx = self._cache_idx
+        state_cache = self._state_cache
+        if ctx.gdn_group_slot_mappings is not None:
+            ordinal = state_cache.layer_group_ordinal(cache_idx)
+            slots = ctx.gdn_group_slot_mappings[ordinal]
+        else:
+            slots = ctx.gdn_slot_mapping
+        boundaries = ctx.cu_seqlens
+        if slots is None or len(slots) != len(boundaries) - 1:
+            raise RuntimeError("ShortConv requires one state slot per packed request")
+        if len(set(slots)) != len(slots):
+            raise RuntimeError("ShortConv requires distinct destination state slots")
+        state_cache.require_allocated_slots(slots)
+
+        inner = self._inner
+        b_gate, c_gate, x_gate = mx.split(inner.in_proj(x), 3, axis=-1)
+        bx = b_gate * x_gate
+        pool = state_cache.conv_states[cache_idx]
+        ids = mx.array(slots, dtype=mx.int32)
+        n_keep = inner.L_cache - 1
+        if boundaries == list(range(len(slots) + 1)):
+            # One token per request: a single batched convolution.
+            conv_input = mx.concatenate(
+                [pool[ids], bx.reshape(len(slots), 1, -1)], axis=1
+            )
+            updates = conv_input[:, -n_keep:, :]
+            conv_out = inner.conv(conv_input).reshape(1, len(slots), -1)
+        else:
+            outputs = []
+            tails = []
+            for request, slot in enumerate(slots):
+                start, end = boundaries[request : request + 2]
+                conv_input = mx.concatenate(
+                    [pool[slot : slot + 1], bx[:, start:end, :]], axis=1
+                )
+                outputs.append(inner.conv(conv_input))
+                tails.append(conv_input[:, -n_keep:, :])
+            conv_out = mx.concatenate(outputs, axis=1)
+            updates = mx.concatenate(tails, axis=0)
+
+        # All tokens in this forward are committed. Speculative verification
+        # remains rejected because it would require rolling this state back.
+        state_cache.write_conv_rows(cache_idx, updates, ids)
+        return inner.out_proj(c_gate * conv_out)

--- a/vllm_metal/attention/impls/shortconv.py
+++ b/vllm_metal/attention/impls/shortconv.py
@@ -8,8 +8,6 @@ the wrapper writes only the destination selected for each request.
 
 from __future__ import annotations
 
-from typing import Any
-
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -52,7 +50,6 @@ class ShortConvPagedWrapper(nn.Module):
         x: mx.array,
         mask: mx.array | None = None,
         cache: nn.Module | None = None,
-        **kwargs: Any,
     ) -> mx.array:
         ctx = get_context()
         if ctx is None:

--- a/vllm_metal/attention/patching.py
+++ b/vllm_metal/attention/patching.py
@@ -37,8 +37,9 @@ def find_layers(model: Any) -> list[Any]:
         )
 
 
-# Attribute names to probe on each layer, in priority order.
-_ATTN_ATTR_NAMES = ("self_attn", "linear_attn", "attention")
+# Attribute names to probe on each layer, in priority order. LFM2 uses
+# ``conv`` for its ShortConv layers, which have no attention submodule.
+_ATTN_ATTR_NAMES = ("self_attn", "linear_attn", "attention", "conv")
 
 
 def find_attn_attr(layer: Any) -> str | None:

--- a/vllm_metal/attention/runtime/base.py
+++ b/vllm_metal/attention/runtime/base.py
@@ -25,7 +25,7 @@ class PagedAttentionRuntimeBase:
 
     Subclasses allocate their primary paged cache onto ``self._cache`` in
     ``initialize()``.  The primary cache must expose ``num_blocks``.  Secondary
-    caches (e.g. the hybrid GDN state cache) remain the subclass's concern.
+    caches (e.g. the hybrid state cache) remain the subclass's concern.
     """
 
     # Primary paged cache; ``None`` until ``initialize()`` runs.  Subclasses set

--- a/vllm_metal/attention/runtime/factory.py
+++ b/vllm_metal/attention/runtime/factory.py
@@ -11,6 +11,10 @@ from vllm_metal.attention.runtime.families.gdn import (
     build_gdn_hybrid_plan,
     supports_gdn_hybrid,
 )
+from vllm_metal.attention.runtime.families.shortconv import (
+    build_shortconv_hybrid_plan,
+    supports_shortconv_hybrid,
+)
 from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
 
 
@@ -26,6 +30,10 @@ _STATE_FAMILY_PLAN_BUILDERS = (
     StateFamilyPlanBuilder(
         supports=supports_gdn_hybrid,
         build=build_gdn_hybrid_plan,
+    ),
+    StateFamilyPlanBuilder(
+        supports=supports_shortconv_hybrid,
+        build=build_shortconv_hybrid_plan,
     ),
 )
 

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -7,9 +7,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+import mlx.core as mx
 import torch
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 
+from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.impls.linear import (
     GDNPagedAttentionWrapper,
     is_linear_attention,
@@ -22,6 +24,7 @@ from vllm_metal.attention.runtime.hybrid_plan import (
     LayerRole,
     RecurrentStateGeometry,
     StateFamilySpec,
+    StateGeometry,
 )
 
 
@@ -96,15 +99,40 @@ class GDNHybridConfig:
         )
 
 
+def _create_gdn_state_cache(
+    *,
+    geometry: StateGeometry,
+    num_layers: int,
+    max_seqs: int,
+    initial_seqs: int,
+    dtype: mx.Dtype,
+) -> GDNPagedStateCache:
+    if not isinstance(geometry, RecurrentStateGeometry):
+        raise TypeError("GDN state cache requires recurrent state geometry")
+    return GDNPagedStateCache(
+        num_layers=num_layers,
+        max_seqs=max_seqs,
+        conv_kernel_dim=geometry.conv_kernel_dim,
+        conv_dim=geometry.conv_dim,
+        num_v_heads=geometry.num_v_heads,
+        value_head_dim=geometry.value_head_dim,
+        key_head_dim=geometry.key_head_dim,
+        initial_seqs=initial_seqs,
+        dtype=dtype,
+    )
+
+
 _GDN_FAMILY = StateFamilySpec(
     label="gdn",
     wrapper_cls=GDNPagedAttentionWrapper,
     is_state_module=is_linear_attention,
     mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
     # Match the fp32 recurrent pool used for kernel accumulation.
-    recurrent_dtype=torch.float32,
+    state_dtypes=(None, torch.float32),
     # Scheduler-side mamba caching strategies the GDN state path implements.
     supported_cache_modes=("none", "align"),
+    layer_name="linear_attn",
+    create_state_cache=_create_gdn_state_cache,
 )
 
 

--- a/vllm_metal/attention/runtime/families/shortconv.py
+++ b/vllm_metal/attention/runtime/families/shortconv.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LFM2 / LFM2.5 ShortConv state family, including the MoE variants."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import mlx.core as mx
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+
+from vllm_metal.attention.caches.shortconv_cache import ShortConvStateCache
+from vllm_metal.attention.impls.shortconv import ShortConvPagedWrapper, is_shortconv
+from vllm_metal.attention.runtime.hybrid_plan import (
+    ATTENTION_LAYER,
+    STATE_LAYER,
+    ConvStateGeometry,
+    HybridLayerPlan,
+    HybridRuntimePlan,
+    StateFamilySpec,
+    StateGeometry,
+)
+
+
+def _create_shortconv_state_cache(
+    *,
+    geometry: StateGeometry,
+    num_layers: int,
+    max_seqs: int,
+    initial_seqs: int,
+    dtype: mx.Dtype,
+) -> ShortConvStateCache:
+    if not isinstance(geometry, ConvStateGeometry):
+        raise TypeError("ShortConv state cache requires convolution-only geometry")
+    return ShortConvStateCache(
+        num_layers=num_layers,
+        max_seqs=max_seqs,
+        conv_kernel_dim=geometry.conv_kernel_dim,
+        conv_dim=geometry.conv_dim,
+        initial_seqs=initial_seqs,
+        dtype=dtype,
+    )
+
+
+_SHORTCONV_FAMILY = StateFamilySpec(
+    label="shortconv",
+    wrapper_cls=ShortConvPagedWrapper,
+    is_state_module=is_shortconv,
+    mamba_type=MambaAttentionBackendEnum.SHORT_CONV,
+    state_dtypes=(None,),
+    supported_cache_modes=("none", "align"),
+    layer_name="conv",
+    create_state_cache=_create_shortconv_state_cache,
+)
+
+
+def supports_shortconv_hybrid(model_args: Mapping[str, Any]) -> bool:
+    return model_args.get("model_type") in ("lfm2", "lfm2_moe")
+
+
+def build_shortconv_hybrid_plan(
+    model_args: Mapping[str, Any], num_layers: int
+) -> HybridRuntimePlan:
+    """Resolve explicit attention/conv layer roles and the pre-conv tail shape."""
+    layer_types = model_args.get("layer_types")
+    if layer_types is None:
+        # Older LFM2 configs enumerate attention indices instead. mlx-lm's
+        # decoder uses these same indices when it constructs the layers.
+        attention_indices = model_args.get("full_attn_idxs")
+        if attention_indices is None:
+            raise ValueError(
+                "ShortConv model args require layer_types or full_attn_idxs"
+            )
+        layer_types = [
+            "full_attention" if i in attention_indices else "conv"
+            for i in range(num_layers)
+        ]
+    if len(layer_types) != num_layers:
+        raise ValueError("ShortConv layer_types must contain one entry per model layer")
+    unsupported = set(layer_types) - {"conv", "full_attention"}
+    if unsupported:
+        raise ValueError(f"Unsupported ShortConv layer_types: {sorted(unsupported)}")
+    if set(layer_types) != {"conv", "full_attention"}:
+        raise ValueError(
+            "ShortConv hybrid requires both attention and convolution layers"
+        )
+    attention_indices = model_args.get("full_attn_idxs")
+    if attention_indices is not None and set(attention_indices) != {
+        i for i, role in enumerate(layer_types) if role == "full_attention"
+    }:
+        # mlx-lm constructs layers from full_attn_idxs when both are present.
+        # Do not report a different state/KV topology to the scheduler.
+        raise ValueError("ShortConv layer_types and full_attn_idxs disagree")
+    kernel = model_args.get("conv_L_cache")
+    width = model_args.get("hidden_size")
+    if type(kernel) is not int or kernel < 2:
+        raise ValueError("ShortConv conv_L_cache must be an integer >= 2")
+    if type(width) is not int or width <= 0:
+        raise ValueError("ShortConv hidden_size must be a positive integer")
+    return HybridRuntimePlan(
+        layers=HybridLayerPlan(
+            layer_roles=tuple(
+                ATTENTION_LAYER if role == "full_attention" else STATE_LAYER
+                for role in layer_types
+            )
+        ),
+        family=_SHORTCONV_FAMILY,
+        geometry=ConvStateGeometry(conv_kernel_dim=kernel, conv_dim=width),
+    )

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -1,12 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Paged attention runtime for hybrid models (SDPA + linear attention).
+"""Paged SDPA and state-family execution for hybrid models.
 
-Handles models like Qwen3.5 where some layers use standard dot-product
-attention (paged KV cache) and others use GDN linear attention (fixed-size
-recurrent state).
-
-SDPA layers use the native Metal SDPA kernel (same as ``MHAPagedAttentionRuntime``).
-GDN layers use MLX-native state management via ``GDNPagedAttentionWrapper``.
+The family plan supplies layer roles, state geometry, allocation and wrappers.
+The runtime pairs its state cache with paged KV and the none/align lifecycle.
 """
 
 from __future__ import annotations
@@ -18,8 +14,8 @@ import mlx.core as mx
 import mlx.nn as nn
 from vllm.logger import init_logger
 
-from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.attention.caches.protocol import PagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext
 from vllm_metal.attention.impls.sdpa import is_sdpa
 from vllm_metal.attention.impls.sdpa_wrapper import (
@@ -34,11 +30,7 @@ logger = init_logger(__name__)
 
 
 class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
-    """Paged attention runtime for hybrid SDPA + linear attention models.
-
-    SDPA layers: paged Metal kernel (via SDPAPagedAttentionWrapper)
-    GDN layers: MLX-native state management (via GDNPagedAttentionWrapper)
-    """
+    """Execute attention and state layers through their registered wrappers."""
 
     def __init__(
         self,
@@ -81,7 +73,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         self._v_quant = v_quant
 
         self._cache = None
-        self._state_cache: GDNPagedStateCache | None = None
+        self._state_cache: PagedStateCache | None = None
         self._gdn_state_manager: HybridGDNStateManager | AlignGDNStateManager | None = (
             None
         )
@@ -113,15 +105,10 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         # None mode keeps one slab per resident request and grows on demand.
         align = self._mamba_cache_mode == "align"
         state_slots = num_blocks if align else self._max_num_seqs
-        state_geometry = self._hybrid_plan.geometry
-        self._state_cache = GDNPagedStateCache(
+        self._state_cache = self._hybrid_plan.family.create_state_cache(
+            geometry=self._hybrid_plan.geometry,
             num_layers=self._hybrid_plan.layers.num_state,
             max_seqs=state_slots,
-            conv_kernel_dim=state_geometry.conv_kernel_dim,
-            conv_dim=state_geometry.conv_dim,
-            num_v_heads=state_geometry.num_v_heads,
-            value_head_dim=state_geometry.value_head_dim,
-            key_head_dim=state_geometry.key_head_dim,
             initial_seqs=0,
             dtype=self._dtype,
         )
@@ -133,10 +120,11 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
 
         logger.info(
             "Hybrid cache initialized: %d SDPA layers (%d blocks), "
-            "%d linear layers (%d/%d GDN slots allocated, mamba_cache_mode=%s)",
+            "%d %s layers (%d/%d state slots allocated, mamba_cache_mode=%s)",
             self._hybrid_plan.layers.num_attention,
             num_blocks,
             self._hybrid_plan.layers.num_state,
+            self._hybrid_plan.family.label,
             self._state_cache.allocated_seqs,
             self._state_cache.max_seqs,
             self._mamba_cache_mode,
@@ -230,7 +218,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         return self._require_initialized("kv_cache")
 
     @property
-    def state_cache(self) -> GDNPagedStateCache:
+    def state_cache(self) -> PagedStateCache:
         if self._state_cache is None:
             raise RuntimeError("state_cache accessed before initialize()")
         return self._state_cache

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -24,7 +24,7 @@ from vllm_metal.attention.impls.sdpa_wrapper import (
 from vllm_metal.attention.patching import walk_and_wrap
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
 from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
-from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
+from vllm_metal.attention.state import AlignStateManager, RequestStateManager
 
 logger = init_logger(__name__)
 
@@ -74,9 +74,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
 
         self._cache = None
         self._state_cache: PagedStateCache | None = None
-        self._gdn_state_manager: HybridGDNStateManager | AlignGDNStateManager | None = (
-            None
-        )
+        self._state_manager: RequestStateManager | AlignStateManager | None = None
         self._scheduler_group_indices = (0,)
         self._group_block_sizes = (block_size,)
 
@@ -112,10 +110,10 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
             initial_seqs=0,
             dtype=self._dtype,
         )
-        self._gdn_state_manager = (
-            AlignGDNStateManager(self._state_cache, self._block_size)
+        self._state_manager = (
+            AlignStateManager(self._state_cache, self._block_size)
             if align
-            else HybridGDNStateManager(self._state_cache)
+            else RequestStateManager(self._state_cache)
         )
 
         logger.info(
@@ -143,9 +141,9 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
 
         ``group_index`` is the group owning SDPA KV blocks (kernel block
         tables); ``state_group_indices`` are the mamba cache groups whose
-        block ids key the GDN recurrent state slabs;
+        block ids key the operator state slabs;
         ``layer_group_ordinals[cache_idx]`` records which of those groups
-        each linear layer belongs to (the engine stripes same-spec layers
+        each state layer belongs to (the engine stripes same-spec layers
         across several groups) and ``layer_pool_ordinals[cache_idx]`` which
         physical state pool it shares (one pool per within-group position,
         following ``kv_cache_tensors.shared_by``).
@@ -224,16 +222,16 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         return self._state_cache
 
     @property
-    def gdn_state_manager(self) -> HybridGDNStateManager | AlignGDNStateManager:
-        if self._gdn_state_manager is None:
-            raise RuntimeError("gdn_state_manager accessed before initialize()")
-        return self._gdn_state_manager
+    def state_manager(self) -> RequestStateManager | AlignStateManager:
+        if self._state_manager is None:
+            raise RuntimeError("state_manager accessed before initialize()")
+        return self._state_manager
 
     def needs_step_context(self) -> bool:
         return True
 
     def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None:
-        """Apply scheduler CoW copies to SDPA KV and align-mode GDN state."""
+        """Apply scheduler CoW copies to SDPA KV and align-mode state."""
         self.kv_cache.copy_blocks(block_copies)
         if self._mamba_cache_mode == "align":
             self.state_cache.copy_blocks(block_copies)
@@ -246,7 +244,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         state_block_ids: list[list[list[int]]] | None = None,
         step_positions: list[tuple[int, int]] | None = None,
     ) -> None:
-        self.gdn_state_manager.populate_step_context(
+        self.state_manager.populate_step_context(
             req_ids=req_ids,
             ctx=ctx,
             state_block_ids=state_block_ids,
@@ -254,10 +252,10 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         )
 
     def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:
-        self.gdn_state_manager.extend_forward_eval_outputs(outputs)
+        self.state_manager.extend_forward_eval_outputs(outputs)
 
     def release_requests(self, req_ids: set[str]) -> None:
-        self.gdn_state_manager.release_requests(req_ids)
+        self.state_manager.release_requests(req_ids)
 
     def materialize_pending_state(self) -> None:
-        self.gdn_state_manager.materialize_pending_state()
+        self.state_manager.materialize_pending_state()

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -10,14 +10,16 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from math import prod
 from typing import Any, Literal, Protocol, TypeAlias
 
+import mlx.core as mx
 import mlx.nn as nn
 import torch
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.kv_cache_interface import MambaSpec
 
-from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
+from vllm_metal.attention.caches.protocol import PagedStateCache
 
 LayerRole: TypeAlias = Literal["attention", "state"]
 
@@ -33,11 +35,11 @@ class PagedStateWrapper(Protocol):
         inner: nn.Module,
         layer_idx: int,
         cache_idx: int,
-        state_cache: GDNPagedStateCache,
+        state_cache: PagedStateCache,
     ) -> None: ...
 
     def rebind_state_cache(
-        self, state_cache: GDNPagedStateCache, *, cache_idx: int
+        self, state_cache: PagedStateCache, *, cache_idx: int
     ) -> None: ...
 
 
@@ -102,6 +104,42 @@ class RecurrentStateGeometry:
     value_head_dim: int
     key_head_dim: int
 
+    @property
+    def state_shapes(self) -> tuple[tuple[int, ...], ...]:
+        return (
+            (self.conv_kernel_dim - 1, self.conv_dim),
+            (self.num_v_heads, self.value_head_dim, self.key_head_dim),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConvStateGeometry:
+    """Convolution tail dimensions for a family with no recurrent SSM pool."""
+
+    conv_kernel_dim: int
+    conv_dim: int
+
+    @property
+    def state_shapes(self) -> tuple[tuple[int, ...], ...]:
+        return ((self.conv_kernel_dim - 1, self.conv_dim),)
+
+
+StateGeometry: TypeAlias = RecurrentStateGeometry | ConvStateGeometry
+
+
+class StateCacheFactory(Protocol):
+    """Allocate a family's state pools using its resolved geometry."""
+
+    def __call__(
+        self,
+        *,
+        geometry: StateGeometry,
+        num_layers: int,
+        max_seqs: int,
+        initial_seqs: int,
+        dtype: mx.Dtype,
+    ) -> PagedStateCache: ...
+
 
 @dataclass(frozen=True, slots=True)
 class StateFamilySpec:
@@ -111,8 +149,12 @@ class StateFamilySpec:
     wrapper_cls: type[PagedStateWrapper]
     is_state_module: Callable[[Any], bool]
     mamba_type: MambaAttentionBackendEnum
-    recurrent_dtype: torch.dtype
+    # None follows the runtime's convolution dtype; fixed dtypes describe
+    # accumulation state such as GDN's fp32 recurrent matrix.
+    state_dtypes: tuple[torch.dtype | None, ...]
     supported_cache_modes: tuple[str, ...]
+    layer_name: str
+    create_state_cache: StateCacheFactory
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,21 +163,16 @@ class HybridRuntimePlan:
 
     layers: HybridLayerPlan
     family: StateFamilySpec
-    geometry: RecurrentStateGeometry
+    geometry: StateGeometry
 
     def state_bytes_per_layer(self, conv_dtype_size: int) -> int:
         """Bytes one request holds in one recurrent state layer."""
-        geometry = self.geometry
-        conv_bytes = (
-            (geometry.conv_kernel_dim - 1) * geometry.conv_dim * conv_dtype_size
+        return sum(
+            prod(shape) * (conv_dtype_size if dtype is None else dtype.itemsize)
+            for shape, dtype in zip(
+                self.geometry.state_shapes, self.family.state_dtypes, strict=True
+            )
         )
-        recurrent_bytes = (
-            geometry.num_v_heads
-            * geometry.value_head_dim
-            * geometry.key_head_dim
-            * self.family.recurrent_dtype.itemsize
-        )
-        return conv_bytes + recurrent_bytes
 
     def state_cache_spec(
         self,
@@ -146,17 +183,12 @@ class HybridRuntimePlan:
         mamba_cache_mode: str,
     ) -> MambaSpec:
         """Build the scheduler-visible state spec for one state layer."""
-        geometry = self.geometry
         return MambaSpec(
-            shapes=(
-                (geometry.conv_kernel_dim - 1, geometry.conv_dim),
-                (
-                    geometry.num_v_heads,
-                    geometry.value_head_dim,
-                    geometry.key_head_dim,
-                ),
+            shapes=self.geometry.state_shapes,
+            dtypes=tuple(
+                conv_dtype if dtype is None else dtype
+                for dtype in self.family.state_dtypes
             ),
-            dtypes=(conv_dtype, self.family.recurrent_dtype),
             block_size=mamba_block_size,
             page_size_padded=page_size_padded,
             mamba_type=self.family.mamba_type,

--- a/vllm_metal/attention/state/__init__.py
+++ b/vllm_metal/attention/state/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-from vllm_metal.attention.state.align import AlignGDNStateManager
-from vllm_metal.attention.state.gdn import HybridGDNStateManager
+from vllm_metal.attention.state.align import AlignStateManager
+from vllm_metal.attention.state.request import RequestStateManager
 
-__all__ = ["AlignGDNStateManager", "HybridGDNStateManager"]
+__all__ = ["AlignStateManager", "RequestStateManager"]

--- a/vllm_metal/attention/state/align.py
+++ b/vllm_metal/attention/state/align.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING
 
 import mlx.core as mx
 
-from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
+from vllm_metal.attention.caches.protocol import PagedStateCache
 
 if TYPE_CHECKING:
     from vllm_metal.attention.context import PagedAttentionContext
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 class AlignGDNStateManager:
     """Drive block-indexed GDN state for align-mode prefix caching."""
 
-    def __init__(self, state_cache: GDNPagedStateCache, block_size: int) -> None:
+    def __init__(self, state_cache: PagedStateCache, block_size: int) -> None:
         self._state_cache = state_cache
         self._block_size = block_size
         self._needs_materialize = False

--- a/vllm_metal/attention/state/align.py
+++ b/vllm_metal/attention/state/align.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Align-mode GDN state lifecycle (hybrid prefix caching).
+"""Align-mode state lifecycle (hybrid prefix caching).
 
 With ``mamba_cache_mode="align"`` the scheduler's mamba cache groups carry a
 position-indexed block table per request, exactly like upstream: the state
@@ -39,8 +39,8 @@ if TYPE_CHECKING:
     from vllm_metal.attention.context import PagedAttentionContext
 
 
-class AlignGDNStateManager:
-    """Drive block-indexed GDN state for align-mode prefix caching."""
+class AlignStateManager:
+    """Drive block-indexed state for align-mode prefix caching."""
 
     def __init__(self, state_cache: PagedStateCache, block_size: int) -> None:
         self._state_cache = state_cache
@@ -69,12 +69,12 @@ class AlignGDNStateManager:
         """
         if state_block_ids is None or step_positions is None:
             raise RuntimeError(
-                "align-mode GDN state requires per-request mamba block ids "
+                "align-mode state requires per-request mamba block ids "
                 "and (num_computed, num_scheduled) step positions"
             )
         if not (len(state_block_ids) == len(step_positions) == len(req_ids)):
             raise RuntimeError(
-                "align GDN state manager requires block ids and step positions "
+                "align state manager requires block ids and step positions "
                 f"for every request (got {len(state_block_ids)} tables / "
                 f"{len(step_positions)} positions for {len(req_ids)} requests)"
             )
@@ -110,13 +110,13 @@ class AlignGDNStateManager:
                 row = state_block_ids[req_idx][group]
                 if num_scheduled <= 0:
                     raise RuntimeError(
-                        f"align GDN state manager: request "
+                        f"align state manager: request "
                         f"{req_ids[req_idx]!r} scheduled {num_scheduled} tokens"
                     )
                 dst_idx = (num_computed + num_scheduled - 1) // self._block_size
                 if dst_idx >= len(row):
                     raise RuntimeError(
-                        f"align GDN state manager: request "
+                        f"align state manager: request "
                         f"{req_ids[req_idx]!r} needs state block index "
                         f"{dst_idx} but its mamba block table has {len(row)} "
                         "entries"
@@ -137,11 +137,11 @@ class AlignGDNStateManager:
             self._state_cache.copy_slots(copy_src, copy_dst, layer_indices)
             group_mappings.append(dst_ids)
 
-        ctx.gdn_group_slot_mappings = tuple(group_mappings)
+        ctx.state_group_slot_mappings = tuple(group_mappings)
         self._needs_materialize = True
 
     def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:
-        """Append authoritative GDN state arrays that the forward mutates."""
+        """Append authoritative state arrays that the forward mutates."""
         outputs.extend(self._state_cache.updated_state_arrays())
 
     def release_requests(self, req_ids: set[str]) -> None:
@@ -154,7 +154,7 @@ class AlignGDNStateManager:
         del req_ids
 
     def materialize_pending_state(self) -> None:
-        """Force stable GDN arrays out of the lazy graph between steps."""
+        """Force stable state arrays out of the lazy graph between steps."""
         if not self._needs_materialize:
             return
         self._state_cache.apply_pending_states()

--- a/vllm_metal/attention/state/gdn.py
+++ b/vllm_metal/attention/state/gdn.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 
 import mlx.core as mx
 
-from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
+from vllm_metal.attention.caches.protocol import PagedStateCache
 
 if TYPE_CHECKING:
     from vllm_metal.attention.context import PagedAttentionContext
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class HybridGDNStateManager:
     """Own request-to-slot lifecycle for one hybrid runtime."""
 
-    def __init__(self, state_cache: GDNPagedStateCache) -> None:
+    def __init__(self, state_cache: PagedStateCache) -> None:
         self._state_cache = state_cache
         self._req_to_slot: dict[str, int] = {}
         self._free_slots: list[int] = []

--- a/vllm_metal/attention/state/request.py
+++ b/vllm_metal/attention/state/request.py
@@ -1,15 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Hybrid GDN request-state lifecycle.
+"""Hybrid request-state lifecycle.
 
 The hybrid paged runtime owns two different state systems:
 
 - SDPA KV cache, indexed by scheduler block tables
-- GDN recurrent state, indexed by one stable slot per resident request
+- Operator state, indexed by one stable slot per resident request
 
-`HybridGDNStateManager` owns the second one. It keeps request-to-slot
-assignment stable across request reordering, grows the recurrent cache when new
+`RequestStateManager` owns the second one. It keeps request-to-slot
+assignment stable across request reordering, grows the state cache when new
 requests arrive, resets reused slots before they are handed to a new request,
-and tracks when stable GDN arrays must be materialized out of the lazy graph.
+and tracks when stable state arrays must be materialized out of the lazy graph.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from vllm_metal.attention.context import PagedAttentionContext
 
 
-class HybridGDNStateManager:
+class RequestStateManager:
     """Own request-to-slot lifecycle for one hybrid runtime."""
 
     def __init__(self, state_cache: PagedStateCache) -> None:
@@ -56,15 +56,15 @@ class HybridGDNStateManager:
         state_block_ids: list[list[list[int]]] | None = None,
         step_positions: list[tuple[int, int]] | None = None,
     ) -> None:
-        """Attach stable GDN slot ids to one forward-pass context.
+        """Attach stable state slot ids to one forward-pass context.
 
         Scheduler block ids and step positions drive align-mode state motion
-        (see ``AlignGDNStateManager``); this manager keeps one private slot
+        (see ``AlignStateManager``); this manager keeps one private slot
         per request for its whole lifetime, so it ignores them.  Accepting
         them keeps both managers on one signature.
         """
         del state_block_ids, step_positions
-        ctx.gdn_slot_mapping = self.assign_step_slots(req_ids)
+        ctx.state_slot_mapping = self.assign_step_slots(req_ids)
 
     def assign_step_slots(self, req_ids: list[str]) -> list[int]:
         """Plan one scheduler step's stable request-to-slot mapping atomically."""
@@ -116,11 +116,11 @@ class HybridGDNStateManager:
         return step_slot_ids
 
     def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:
-        """Append authoritative GDN state arrays that the forward mutates."""
+        """Append authoritative state arrays that the forward mutates."""
         outputs.extend(self._state_cache.updated_state_arrays())
 
     def release_requests(self, req_ids: set[str]) -> None:
-        """Release slots for requests whose recurrent state is no longer valid."""
+        """Release slots for requests whose state is no longer valid."""
         freed_slots: list[int] = []
         for req_id in req_ids:
             slot = self._req_to_slot.pop(req_id, None)
@@ -135,7 +135,7 @@ class HybridGDNStateManager:
         self._free_slots.extend(freed_slots)
 
     def materialize_pending_state(self) -> None:
-        """Force stable GDN arrays after a slot release updated them lazily."""
+        """Force stable state arrays after a slot release updated them lazily."""
         if not self._needs_materialize:
             return
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -513,14 +513,31 @@ class MetalPlatform(Platform):
 
         if model_config is not None and model_config.is_hybrid:
             cache_config = vllm_config.cache_config
-            if cache_config.mamba_ssm_cache_dtype == "auto":
-                cache_config.mamba_ssm_cache_dtype = "float32"
-            elif cache_config.mamba_ssm_cache_dtype != "float32":
+            is_shortconv = getattr(model_config.hf_config, "model_type", None) in (
+                "lfm2",
+                "lfm2_moe",
+            )
+            if (
+                is_shortconv
+                and cache_config.mamba_cache_dtype != "auto"
+                and cache_config.mamba_cache_dtype
+                != str(model_config.dtype).removeprefix("torch.")
+            ):
                 raise NotImplementedError(
-                    "Hybrid models on Metal require "
-                    "--mamba-ssm-cache-dtype float32 because recurrent state is "
-                    "stored in fp32."
+                    "ShortConv state on Metal uses the model dtype; "
+                    "--mamba-cache-dtype must be auto or match --dtype."
                 )
+            # ShortConv has only a model-dtype convolution tail. The fp32
+            # requirement belongs to families with recurrent SSM state.
+            if not is_shortconv:
+                if cache_config.mamba_ssm_cache_dtype == "auto":
+                    cache_config.mamba_ssm_cache_dtype = "float32"
+                elif cache_config.mamba_ssm_cache_dtype != "float32":
+                    raise NotImplementedError(
+                        "Hybrid models on Metal require "
+                        "--mamba-ssm-cache-dtype float32 because recurrent state is "
+                        "stored in fp32."
+                    )
             if cache_config.mamba_cache_mode == "all":
                 # Before the downgrades below, which overwrite the mode: an
                 # explicit --mamba-cache-mode all must fail fast on every path.

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -391,7 +391,9 @@ class ModelCachePolicy:
             state_spec = self._state_layer_spec(hybrid_plan, torch_dtype)
             for layer_idx in range(num_spec_layers):
                 if hybrid_plan.layers.is_state_layer(layer_idx):
-                    specs[f"layers.{layer_idx}.linear_attn"] = state_spec
+                    specs[f"layers.{layer_idx}.{hybrid_plan.family.layer_name}"] = (
+                        state_spec
+                    )
                 else:
                     specs[f"layers.{layer_idx}.self_attn"] = attention_spec(layer_idx)
         else:
@@ -666,7 +668,7 @@ class ModelCachePolicy:
         layer_pool_ordinals: list[int] | None = None
         if self._runner.cache_config.mamba_cache_mode == "align":
             cache_idx_by_name = {
-                f"layers.{layer_idx}.linear_attn": cache_idx
+                f"layers.{layer_idx}.{hybrid_plan.family.layer_name}": cache_idx
                 for cache_idx, layer_idx in enumerate(layer_plan.state_indices)
             }
             mamba_group_ids = [

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -657,10 +657,10 @@ class ModelCachePolicy:
         block_size = kv_cache_config.kv_cache_groups[
             group_index
         ].kv_cache_spec.block_size
-        # Align mode keys GDN state slabs by scheduler block id.  The engine
-        # stripes same-spec linear layers across several mamba cache groups
+        # Align mode keys hybrid state slabs by scheduler block id.  The engine
+        # stripes same-spec state layers across several mamba cache groups
         # (each group hands every request one block-table row), so the runtime
-        # needs all those groups plus each linear layer's group ordinal.  None
+        # needs all those groups plus each state layer's group ordinal.  None
         # mode keeps a private per-request slot pool and ignores the
         # scheduler's mamba groups.
         state_group_indices: tuple[int, ...] = ()
@@ -686,17 +686,16 @@ class ModelCachePolicy:
                         raise RuntimeError(
                             f"mamba cache group {mamba_group_id} holds "
                             f"{layer_name!r}, which is not one of the "
-                            "runner's linear-attention layers"
+                            "runner's hybrid state layers"
                         )
                     layer_group_ordinals[cache_idx] = ordinal
             if -1 in layer_group_ordinals:
                 raise RuntimeError(
-                    "scheduler mamba cache groups do not cover every "
-                    "linear-attention layer"
+                    "scheduler mamba cache groups do not cover every hybrid state layer"
                 )
             # Physical pools follow the engine's tensor sharing: each
             # kv_cache_tensor is shared by one layer from each cache group, so
-            # linear layers sharing a tensor share one state pool (their
+            # state layers sharing a tensor share one state pool (their
             # groups own disjoint block ids and never collide).
             layer_pool_ordinals = [-1] * len(cache_idx_by_name)
             pools_used = 0
@@ -711,14 +710,14 @@ class ModelCachePolicy:
                 for cache_idx in members:
                     if layer_pool_ordinals[cache_idx] != -1:
                         raise RuntimeError(
-                            "a linear-attention layer appears in two "
+                            "a hybrid state layer appears in two "
                             "kv_cache_tensors; cannot derive state pools"
                         )
                     layer_pool_ordinals[cache_idx] = pools_used
                 pools_used += 1
             if -1 in layer_pool_ordinals:
                 raise RuntimeError(
-                    "kv_cache_tensors do not cover every linear-attention "
+                    "kv_cache_tensors do not cover every hybrid state "
                     "layer; cannot derive state pools"
                 )
             budgeted = _align_state_pool_count(
@@ -726,7 +725,7 @@ class ModelCachePolicy:
             )
             if pools_used > budgeted:
                 raise RuntimeError(
-                    f"engine layout needs {pools_used} GDN state pools but "
+                    f"engine layout needs {pools_used} hybrid state pools but "
                     f"the memory plan budgeted {budgeted}; refusing to "
                     "exceed the paged memory budget"
                 )

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -721,7 +721,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
                 types surface loudly here instead of silently falling back
                 to full-attention shapes.
         """
-        layer_types = args.get("layer_types", [])
+        layer_types = args.get("layer_types") or []
         global_head_dim = args.get("global_head_dim")
         if len(layer_types) != num_layers or not global_head_dim:
             return None


### PR DESCRIPTION
## Summary

(I've been working on this for a very long time, because I wanna settle the shared state management & align mode prefix caching from Qwen3.5+ first. Now they are all in a usable shape, so I pick it up. LFM is a good model for mac inference! )

Adds paged text generation for LFM2 and LFM2.5 dense and MoE models, with prefix caching. 

* **supported**: Prefix caching defaults to `align`(same with upstream vllm). 
* **unsupported**: `all` mode and speculative decoding remain unsupported.

* commit 1 is the full LFM support (conv layer, prefix caching .etc)
* commit 2 is pure renaming, because now we have two kinds of state now. I checked the upstream vllm naming, and use state for shared worker machinery, and retain GDN / ShortConv for the concrete implementations.

## Performance

Serving output throughput is generated output tokens divided by total benchmark wall time, including prefill and scheduling. These runs do not isolate decode-kernel speed.

Sonnet, nominal **1024 input + 128 output tokens**, **100 requests/run**, rate **10/s**, concurrency **32**. The figure shows medians of two fresh-server runs on an M5 Pro (64 GiB); all 1,600 requests succeeded. Memory fraction: 0.3 for the small pair, 0.5 for the 8B pair.

<img width="2676" height="1536" alt="benchmark_comparison" src="https://github.com/user-attachments/assets/22bedd13-827f-4c77-9204-9cd8e74d7864" />

<details>
<summary>Reproduce the performance comparison</summary>

Run from revision `761e583`, with the vllm-metal environment active. Tested with macOS 26.6.2, vLLM 0.28.0+cpu, MLX 0.32.0, MLX-LM `254d153`, mlx-vlm 0.6.4, and Transformers 5.12.1. Native checkpoint dtypes are preserved.

Select one row below, then run with `APC=off` and `APC=on`, twice each. Restart the server for every run; reverse model order in the second repetition. No client warmup or discarded measured runs.

| `MODEL` | `REVISION` | `FRACTION` |
|---|---|---:|
| `Qwen/Qwen3.5-0.8B` | `2fc06364715b967f1860aea9cf38778875588b17` | 0.3 |
| `LiquidAI/LFM2.5-1.2B-Instruct` | `df58c174f05ff733f83f8cae10ea9298224c8006` | 0.3 |
| `Qwen/Qwen3-8B` | `b968826d9c46dd6066d109eabc6255188de91218` | 0.5 |
| `LiquidAI/LFM2.5-8B-A1B` | `b9aebfcbe28b6cb374042f495d733037550ab146` | 0.5 |

```bash
# Bash; use a free port. Change these values for each model/mode/repetition.
set -eo pipefail
MODEL=LiquidAI/LFM2.5-1.2B-Instruct
REVISION=df58c174f05ff733f83f8cae10ea9298224c8006
FRACTION=0.3
APC=on
REP=1
PORT=8000

# Untimed setup: cache the pinned checkpoint and dataset.
HF_HUB_OFFLINE=0 hf download "$MODEL" --revision "$REVISION" \
  --include '*.safetensors' --include '*.json' --include '*.txt' \
  --include '*.model' --include '*.jinja'
MODEL_PATH=$(python - "$MODEL" "$REVISION" <<'PYCODE'
import sys
from pathlib import Path
from huggingface_hub import hf_hub_download
print(Path(hf_hub_download(sys.argv[1], 'config.json',
    revision=sys.argv[2], local_files_only=True)).parent)
PYCODE
)
curl -fsSL https://raw.githubusercontent.com/vllm-project/vllm/v0.28.0/benchmarks/sonnet.txt -o sonnet.txt
printf '%s  sonnet.txt\n' d58663195ba6780da5f029b920c7ac00cad1e435ee1df7e03bf9ec2470f8dea4 | shasum -a 256 -c -

export PYTHONPATH="$PWD" HF_HUB_OFFLINE=1
export VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION="$FRACTION"
export VLLM_ENABLE_V1_MULTIPROCESSING=1 GLOO_SOCKET_IFNAME=lo0 TOKENIZERS_PARALLELISM=false
python -m vllm_metal.metal.build
CACHE_ARGS=()
if [ "$APC" = off ]; then CACHE_ARGS+=(--no-enable-prefix-caching); fi
RUN="${MODEL##*/}-${APC}-r${REP}"

python -m vllm.entrypoints.openai.api_server \
  --model "$MODEL_PATH" --served-model-name "$MODEL" \
  --max-model-len 2048 --host 127.0.0.1 --port "$PORT" \
  --generation-config vllm "${CACHE_ARGS[@]}" > "$RUN.server.log" 2>&1 &
SERVER_PID=$!
trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
until curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; do
  kill -0 "$SERVER_PID" 2>/dev/null || exit 1
  sleep 1
done

python -m vllm.entrypoints.cli.main bench serve \
  --backend vllm --base-url "http://127.0.0.1:$PORT" \
  --model "$MODEL" --tokenizer "$MODEL_PATH" --endpoint /v1/completions \
  --dataset-name sonnet --dataset-path sonnet.txt \
  --sonnet-input-len 1024 --sonnet-output-len 128 --sonnet-prefix-len 200 \
  --num-prompts 100 --request-rate 10 --max-concurrency 32 \
  --temperature 0 --ignore-eos --seed 0 --num-warmups 0 \
  --save-result --save-detailed --result-dir benchmark-results \
  --result-filename "$RUN.json" --label "$RUN" --disable-tqdm \
  | tee "$RUN.client.log"

kill "$SERVER_PID"
wait "$SERVER_PID" || true
trap - EXIT
```

Sonnet samples whole lines: mean inputs were 941 vs 1,014 tokens for the small pair, and 1,012 for both 8B models. The 8B comparison matches total weight size, not FLOPs. The 200-token prefix is shorter than Qwen3.5's 544-token state block, giving it zero cache hits versus 17–19% for the other models; APC-off is the cleaner model comparison.





</details>

vllm-metal vs vllm-cpu

(FP32 is faster than BF16 in vllm-cpu)

<img width="2560" height="1061" alt="serving_cpu_vs_metal" src="https://github.com/user-attachments/assets/c3a00a31-4281-44ca-b5bc-ca2d5d99f4ec" />

### Prefix caching

Upstream vLLM `prefix_repetition`: **1,152 shared + 128 unique input tokens**, 128 output tokens. Same hardware, models, memory fractions, 100 requests/run, rate 10/s, and concurrency 32 as above. Medians of two fresh-server runs, each seeded with one untimed request; all 1,600 measured requests succeeded.



<img width="2316" height="1429" alt="apc_comparison" src="https://github.com/user-attachments/assets/d565546c-dc6c-42fb-8a91-908ec8e54c1b" />

| Model | Serving output tok/s, off → on | Serving speedup | Mean TTFT (ms), off → on | Cached input tokens |
|---|---:|---:|---:|---:|
| Qwen3.5-0.8B | 474.5 → 684.1 | 1.44× | 824.4 → 143.7 | 85.0% |
| LFM2.5-1.2B | 644.9 → 1035.4 | 1.61× | 768.1 → 113.3 | 89.8% |
| Qwen3-8B | 84.4 → 166.1 | 1.97× | 6930.6 → 1177.8 | 89.9% |
| LFM2.5-8B-A1B | 211.9 → 279.2 | 1.32× | 1868.5 → 609.6 | 89.9% |

<details>
<summary>Reproduce the APC comparison</summary>

Use the same environment and pinned checkpoint table above. Run each model with `APC=off` and `APC=on`, twice each, restarting the server each time and reversing order in the second repetition. Set `FRACTION=0.5` for either 8B model. Native artifacts must be built as in the earlier reproduction. The measured runtime is `a64066f`; subsequent commits trim tests and rename shared state interfaces without changing the serving algorithms.

```bash
#!/usr/bin/env bash
# Run from the PR checkout with its environment active and checkpoint cached.
set -eo pipefail
MODEL=${MODEL:-LiquidAI/LFM2.5-1.2B-Instruct}
REVISION=${REVISION:-df58c174f05ff733f83f8cae10ea9298224c8006}
FRACTION=${FRACTION:-0.3}
APC=${APC:-on}
REP=${REP:-1}
PORT=${PORT:-8000}
MODEL_PATH=$(python - "$MODEL" "$REVISION" <<'PY'
import sys
from pathlib import Path
from huggingface_hub import hf_hub_download
print(Path(hf_hub_download(sys.argv[1], 'config.json',
    revision=sys.argv[2], local_files_only=True)).parent)
PY
)
export PYTHONPATH="$PWD" HF_HUB_OFFLINE=1
export VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION="$FRACTION"
export VLLM_ENABLE_V1_MULTIPROCESSING=1 GLOO_SOCKET_IFNAME=lo0 TOKENIZERS_PARALLELISM=false
CACHE_ARGS=()
if [ "$APC" = off ]; then CACHE_ARGS+=(--no-enable-prefix-caching); fi
RUN="${MODEL##*/}-prefix-repetition-${APC}-r${REP}"
python -m vllm.entrypoints.openai.api_server \
  --model "$MODEL_PATH" --served-model-name "$MODEL" \
  --max-model-len 2048 --host 127.0.0.1 --port "$PORT" \
  --generation-config vllm "${CACHE_ARGS[@]}" > "$RUN.server.log" 2>&1 &
SERVER_PID=$!
trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
until curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; do
  kill -0 "$SERVER_PID" 2>/dev/null || exit 1
  sleep 1
done

# Untimed seed, identical in both APC arms. Match completion-side BOS handling.
python - "$MODEL_PATH" "$MODEL" "$PORT" <<'PY'
import sys, requests
from vllm.benchmarks.datasets.datasets import PrefixRepetitionRandomDataset
from vllm.tokenizers import get_tokenizer
tokenizer = get_tokenizer(sys.argv[1])
samples = PrefixRepetitionRandomDataset(random_seed=0).sample(
    tokenizer=tokenizer, num_requests=100, prefix_len=1152,
    suffix_len=128, num_prefixes=1, output_len=128)
# 1088 is divisible by both default state block sizes (16 and 544).
# One extra prompt token preserves that boundary when decoding starts.
prefix = tokenizer.encode(samples[0].prompt, add_special_tokens=True)[:1089]
response = requests.post(f'http://127.0.0.1:{sys.argv[3]}/v1/completions',
    json=dict(model=sys.argv[2], prompt=prefix, max_tokens=1,
              temperature=0, ignore_eos=True), timeout=180)
response.raise_for_status()
assert response.json()['usage']['prompt_tokens'] == 1089
assert response.json()['usage']['completion_tokens'] == 1
PY
curl -fsS "http://127.0.0.1:$PORT/metrics" > "$RUN.metrics-before.txt"
python -m vllm.entrypoints.cli.main bench serve \
  --backend vllm --base-url "http://127.0.0.1:$PORT" \
  --model "$MODEL" --tokenizer "$MODEL_PATH" --endpoint /v1/completions \
  --dataset-name prefix_repetition \
  --prefix-repetition-prefix-len 1152 --prefix-repetition-suffix-len 128 \
  --prefix-repetition-num-prefixes 1 --prefix-repetition-output-len 128 \
  --num-prompts 100 --request-rate 10 --max-concurrency 32 \
  --temperature 0 --ignore-eos --seed 0 --num-warmups 0 \
  --ready-check-timeout-sec 0 \
  --save-result --save-detailed --result-dir benchmark-results \
  --result-filename "$RUN.json" --label "$RUN" --disable-tqdm \
  | tee "$RUN.client.log"
curl -fsS "http://127.0.0.1:$PORT/metrics" > "$RUN.metrics-after.txt"
kill "$SERVER_PID"
wait "$SERVER_PID" || true
trap - EXIT
```

The seed uses 1,089 prompt tokens and one output token to preserve the common 1,088-token checkpoint. Metrics are sampled after the seed, so its work is excluded. Dense LFM adds BOS, giving 1,281 input tokens per measured request; the other models use 1,280. Default state blocks remain 544 tokens for Qwen3.5 and 16 for the others.

Four initial dense-LFM runs were retained as diagnostics and repeated after correcting BOS handling in the untimed seed. The table uses the two corrected repetitions. This synthetic workload measures high prefix reuse; it does not represent general application traffic.

</details>

## Correctness

Manual native-checkpoint validation for LFM2.5-1.2B-Instruct and LFM2-1.2B: **19/19 exact token comparisons per checkpoint against independently run MLX**, using matched prefill chunks. Each match is an identical 12-token continuation. The local diagnostic covers singleton/concurrent generation, APC off, align, and fine-prefix modes.

| Checkpoint | Exact matches |
|---|---:|
| LFM2.5-1.2B-Instruct | 19/19 |
| LFM2-1.2B | 19/19 |
| LFM2.5-8B-A1B | 16/19 |

The separate HTTP test matches 5/5 outputs; three concurrent branches each reuse 160 tokens. MoE's remaining differences arise at numerical boundaries; ShortConv-only full-model traces are bit-exact to MLX.

<details>
<summary>Reproduce native-checkpoint correctness checks</summary>

Checkpoint-specific E2E checks are local diagnostics, excluded from the repository test suite. From the same checkout/environment, fetch the pinned harness into a temporary directory and run it against both dense checkpoints:

```bash
set -eo pipefail
export PYTHONPATH="$PWD" VLLM_METAL_LFM2_E2E=1
E2E_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lfm2-diagnostic.XXXXXX")
E2E_SCRIPT="$E2E_DIR/checkpoint_e2e.py"
curl -fsSL \
  https://raw.githubusercontent.com/WindChimeRan/vllm-metal/3a32dfd52f6488410d333a20c87d1ff9b3a9eede/tests/test_lfm2_prefix_caching_e2e.py \
  -o "$E2E_SCRIPT"
printf '%s  %s\n' \
  30f1ceb20140f0718e15fd19b8798a726251eaef56cd7cbc2e738a7bc602185b \
  "$E2E_SCRIPT" | shasum -a 256 -c -
python -m vllm_metal.metal.build

for SPEC in \
  'LiquidAI/LFM2.5-1.2B-Instruct df58c174f05ff733f83f8cae10ea9298224c8006' \
  'LiquidAI/LFM2-1.2B 40f3da0d0164913923aee9462c23077868b816a3'
do
  read -r MODEL REVISION <<< "$SPEC"
  HF_HUB_OFFLINE=0 hf download "$MODEL" --revision "$REVISION" \
    --include '*.safetensors' --include '*.json' --include '*.txt' \
    --include '*.model' --include '*.jinja'
  MODEL_PATH=$(python - "$MODEL" "$REVISION" <<'PYCODE'
import sys
from pathlib import Path
from huggingface_hub import hf_hub_download
print(Path(hf_hub_download(sys.argv[1], 'config.json',
    revision=sys.argv[2], local_files_only=True)).parent)
PYCODE
)
  HF_HUB_OFFLINE=1 VLLM_METAL_MEMORY_FRACTION=0.15 \
  LFM2_MODEL_PATH="$MODEL_PATH" \
  python -m pytest "$E2E_SCRIPT" -q -s \
    --basetemp="$(mktemp -d "${TMPDIR:-/tmp}/lfm2-correctness.XXXXXX")"
done
```

For the MoE diagnostic, use `LiquidAI/LFM2.5-8B-A1B`, revision `b9aebfcbe28b6cb374042f495d733037550ab146`, with memory fraction `0.8`. Its strict comparison reports the three mismatches above and exits nonzero; no alternate expected tokens are accepted.

The reference uses full prompt chunks. Canonical `mlx_lm.generate_step` reserves the final prompt token for a separate call; five additional raw-prompt comparisons matched 4/5 sequences for each dense checkpoint and 2/5 for MoE. The controlled FP32 MoE trace first diverges in shared paged SDPA, then later expert selections amplify the difference. These results do not claim universal greedy identity across kernels or execution schedules.

</details>

## Roadmap

Built on merged #668 and #696. The native cache declaration matches the attention/`ArraysCache` split proposed in #675. The stateless layer role and Mamba-2 support remain with the Nemotron work in #644.

## Validation

- GDN prefix-cache E2E passes; all five smoke outputs match the prerequisite baseline, including one existing golden mismatch.
- Full non-slow suite: 1,986 passed, 14 skipped; nine GGUF numerical failures also reproduce on unchanged main.
