### PR TITLE
[Pooling] Add BGE-M3 sparse token classification

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -36,6 +36,7 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | --- | --- | --- | --- |
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
+| BGE-M3 / XLM-RoBERTa | 🔵 | `pooling` / dense `embed` only (`vllm-metal[embeddings]`) | `mlx-community/bge-m3-mlx-8bit` |
 
 ## Multimodal Language Models
 

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -36,7 +36,7 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | --- | --- | --- | --- |
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
-| BGE-M3 / XLM-RoBERTa | 🔵 | `pooling` / dense `embed` only (`vllm-metal[embeddings]`) | `mlx-community/bge-m3-mlx-8bit` |
+| BGE-M3 / XLM-RoBERTa | 🔵 | `pooling` / dense `embed`; BGE-M3 sparse `token_classify` (`vllm-metal[embeddings]`) | `mlx-community/bge-m3-mlx-8bit` |
 
 ## Multimodal Language Models
 

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -11,6 +11,10 @@ reranker checkpoints that vLLM converts with
 `is_original_qwen3_reranker=True`. This path returns one scalar score tensor
 per request through the same `pooler_output` contract.
 
+BGE-M3 additionally supports `token_classify`, returning one sparse lexical
+weight per prompt token after matching boundary BOS and EOS tokens are removed.
+Token IDs remain available through vLLM's `/tokenize` endpoint.
+
 ## Scope
 
 Current scope is intentionally narrow:
@@ -25,6 +29,8 @@ Current scope is intentionally narrow:
 - encoder embedding checkpoints loaded through optional `mlx-embeddings`
   (`XLMRobertaModel` / `RobertaEmbeddingModel` / `BgeM3EmbeddingModel`), with
   CLS pooling and L2 normalization for dense vectors
+- BGE-M3 sparse lexical weights for `mlx-community/bge-m3-mlx-8bit` with an
+  explicit `pooler_config.task="token_classify"`
 - Qwen3 reranker cross-encoder scores from the final prompt-token hidden state,
   using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
   embeddings are tied
@@ -35,6 +41,36 @@ Install the encoder path with:
 pip install "vllm-metal[embeddings]"
 ```
 
+## Runtime flow
+
+BGE-M3 sparse pooling reuses the encoder forward from the dense path, then
+applies the official `sparse_linear` head to every token instead of reducing a
+request to one sequence vector. The output stays inside vLLM's existing
+`pooler_output` contract: one CPU tensor per request, with one lexical weight
+per prompt token after matching boundary BOS and EOS tokens are removed.
+
+1. Model-level `PoolerConfig(task="token_classify")` requests the BGE-M3 sparse
+   capability at load time; request-level `PoolingParams(task="token_classify")`
+   selects it for a call. Other encoder checkpoints continue to expose dense
+   `embed` only.
+2. For `mlx-community/bge-m3-mlx-8bit`, `EncoderEmbeddingAdapter` loads the MLX
+   encoder checkpoint and the official `BAAI/bge-m3` `sparse_linear.pt` head
+   from a pinned revision. The head is converted once and retained by the
+   adapter; dense-only loads do not fetch it.
+3. The paged runner forwards packed encoder requests independently so
+   bidirectional attention cannot cross request boundaries. Pooling slices the
+   resulting hidden-state pack with the same cumulative sequence boundaries.
+4. The packed hidden states run through `sparse_linear` and bias once. Each
+   request slice then applies logit calibration and its activation setting;
+   matching boundary BOS and EOS rows are removed before the tensor crosses
+   from MLX to CPU PyTorch.
+
+Token-wise pooling requires one complete, uncached encoder prefill. A chunked
+or resumed request is rejected before the encoder forward rather than returning
+weights for only the last chunk. The worker advertises `token_classify` only
+after the adapter has loaded a valid BGE-M3 sparse head. Batched complete
+requests remain supported and preserve request order.
+
 ## Unsupported
 
 The Metal runner rejects these cases with diagnostic errors:
@@ -42,9 +78,8 @@ The Metal runner rejects these cases with diagnostic errors:
 - generic classification heads, generic reranking models, and late interaction
 - sequence pooling strategies other than LAST for decoder embed models, and
   other than CLS/LAST for encoder embed models (`MEAN`, `ALL`, `STEP`)
-- token-level pooling, including BGE-M3 sparse `token_classify` lexical weights
-  (tracked as a follow-up to
-  [#589](https://github.com/vllm-project/vllm-metal/issues/589))
+- token-level embedding, combined dense+sparse output, and token classification
+  for models other than the supported BGE-M3 checkpoint
 - chunked long-input embedding aggregation (`enable_chunked_processing`)
 - non-paged pooling execution
 - multimodal embeddings and scheduled encoder inputs
@@ -71,6 +106,25 @@ llm = LLM(
 )
 outputs = llm.embed(["hello metal", "semantic search"])
 print(len(outputs), len(outputs[0].outputs.embedding))
+```
+
+BGE-M3 sparse lexical weights:
+
+```python
+from vllm import LLM
+from vllm.config import PoolerConfig
+
+llm = LLM(
+    model="mlx-community/bge-m3-mlx-8bit",
+    runner="pooling",
+    pooler_config=PoolerConfig(task="token_classify"),
+    max_model_len=512,
+)
+outputs = llm.encode(
+    ["hello metal", "semantic search"],
+    pooling_task="token_classify",
+)
+print(outputs[0].outputs.data)
 ```
 
 Dense BGE-M3 / XLM-RoBERTa (requires `vllm-metal[embeddings]`):
@@ -103,6 +157,10 @@ curl http://localhost:8000/v1/embeddings \
   -H "Content-Type: application/json" \
   -d '{"model":"mlx-community/Qwen3-Embedding-0.6B-8bit","input":["hello metal","semantic search"]}'
 ```
+
+For sparse BGE-M3, pass `--pooler-config '{"task":"token_classify"}'` to
+`vllm serve` and call `/pooling` with `"task":"token_classify"`. Use
+`/tokenize` when token IDs are needed alongside the returned weights.
 
 ### Offline Qwen3 Reranking
 
@@ -157,5 +215,6 @@ curl http://localhost:8000/score \
 ## Validation
 
 Do not add a model row to [Supported Models](supported_models.md) until a real
-`LLM.embed`, `/v1/embeddings`, `LLM.score`, or `/score` smoke passes on Apple
-Silicon with the model name, revision, command, and output shape recorded.
+`LLM.embed`, `/v1/embeddings`, `LLM.encode`, `/pooling`, `LLM.score`, or `/score`
+smoke passes on Apple Silicon with the model name, revision, command, output
+shape, and any token-ID-to-lexical-weight reference recorded.

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -21,20 +21,30 @@ Current scope is intentionally narrow:
   `Qwen3ForSequenceClassification`, `classifier_from_token=["no", "yes"]`,
   and `is_original_qwen3_reranker=True`
 - decoder-style text models that expose token hidden states through the MLX
-  transformer body
-- sequence embeddings from the final prompt-token hidden state with LAST
-  pooling and L2 normalization on the paged Metal V1 path
+  transformer body (LAST pooling)
+- encoder embedding checkpoints loaded through optional `mlx-embeddings`
+  (`XLMRobertaModel` / `RobertaEmbeddingModel` / `BgeM3EmbeddingModel`), with
+  CLS pooling and L2 normalization for dense vectors
 - Qwen3 reranker cross-encoder scores from the final prompt-token hidden state,
   using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
   embeddings are tied
+
+Install the encoder path with:
+
+```bash
+pip install "vllm-metal[embeddings]"
+```
 
 ## Unsupported
 
 The Metal runner rejects these cases with diagnostic errors:
 
 - generic classification heads, generic reranking models, and late interaction
-- sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`, `STEP`)
-- token-level pooling
+- sequence pooling strategies other than LAST for decoder embed models, and
+  other than CLS/LAST for encoder embed models (`MEAN`, `ALL`, `STEP`)
+- token-level pooling, including BGE-M3 sparse `token_classify` lexical weights
+  (tracked as a follow-up to
+  [#589](https://github.com/vllm-project/vllm-metal/issues/589))
 - chunked long-input embedding aggregation (`enable_chunked_processing`)
 - non-paged pooling execution
 - multimodal embeddings and scheduled encoder inputs
@@ -56,6 +66,20 @@ from vllm import LLM
 
 llm = LLM(
     model="mlx-community/Qwen3-Embedding-0.6B-8bit",
+    runner="pooling",
+    max_model_len=512,
+)
+outputs = llm.embed(["hello metal", "semantic search"])
+print(len(outputs), len(outputs[0].outputs.embedding))
+```
+
+Dense BGE-M3 / XLM-RoBERTa (requires `vllm-metal[embeddings]`):
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="mlx-community/bge-m3-mlx-8bit",
     runner="pooling",
     max_model_len=512,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,8 @@ stt = [
     "numba>=0.59.0",  # Required by librosa on Python 3.12+
 ]
 embeddings = [
-    # Encoder embedding models (XLM-RoBERTa / BGE-M3 dense embed). Required for
-    # mlx-community BGE-M3 checkpoints; sparse token_classify is a follow-up.
+    # Encoder embedding models (XLM-RoBERTa / BGE-M3 dense and sparse pooling).
+    # Required for mlx-community BGE-M3 checkpoints.
     "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,15 +84,21 @@ stt = [
     "librosa>=0.10.2",
     "numba>=0.59.0",  # Required by librosa on Python 3.12+
 ]
+embeddings = [
+    # Encoder embedding models (XLM-RoBERTa / BGE-M3 dense embed). Required for
+    # mlx-community BGE-M3 checkpoints; sparse token_classify is a follow-up.
+    "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+]
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=0.21.0",
     "ruff==0.16.0",
     "mypy>=1.19.1",
     "gguf>=0.17.0",
+    "mlx-embeddings>=0.1.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
 ]
 all = [
-    "vllm-metal[gguf,stt,dev]",
+    "vllm-metal[gguf,stt,embeddings,dev]",
 ]
 
 [project.urls]

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -50,6 +50,7 @@ def make_stub_runner(
         "model": object(),
         "_is_vlm": False,
         "_multimodal_adapter": None,
+        "_encoder_embedding_adapter": None,
         "_gemma4_mtp_assistant": None,
         "_drafter": None,
         "encoder_cache": None,

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -3,15 +3,19 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import mlx.core as mx
 import pytest
+import torch
 
 from vllm_metal.v1.encoder_embeddings import (
+    BgeM3SparseHead,
     EncoderEmbeddingAdapter,
     MlxEmbeddingsEncoderModel,
+    _load_bge_m3_sparse_head,
     is_encoder_embedding_config,
     load_mlx_embeddings_model,
     requires_mlx_embeddings_load,
@@ -19,6 +23,23 @@ from vllm_metal.v1.encoder_embeddings import (
 from vllm_metal.v1.pooling import (
     forward_sequence_hidden_states,
     supports_embed_pooling,
+)
+
+_BGE_M3_MODEL_ID = "mlx-community/bge-m3-mlx-8bit"
+_BGE_M3_MODEL_REVISION = "7eca4a1c6ea1a0c5efc37598b369012f3985910f"
+_BGE_M3_HI_TOKEN_ID = 2673
+_BGE_M3_HI_REFERENCE_WEIGHT = 0.26710861921310425
+_BGE_M3_8BIT_REFERENCE_REL_TOLERANCE = 0.02
+_BGE_M3_REQUIRED_FILES = (
+    "config.json",
+    "config_sentence_transformers.json",
+    "model.safetensors",
+    "model.safetensors.index.json",
+    "modules.json",
+    "sentence_bert_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
 )
 
 
@@ -30,6 +51,9 @@ def _encoder_model_config(**overrides):
         "hf_config": SimpleNamespace(
             architectures=["XLMRobertaModel"],
             model_type="xlm-roberta",
+            hidden_size=4,
+            bos_token_id=0,
+            eos_token_id=2,
         ),
         "pooler_config": SimpleNamespace(
             task="embed",
@@ -61,6 +85,8 @@ class _FakeEmbeddingsModule:
             num_key_value_heads=2,
             head_dim=2,
             max_position_embeddings=32,
+            bos_token_id=0,
+            eos_token_id=2,
         )
         self.calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
 
@@ -166,6 +192,247 @@ class TestMlxEmbeddingsLoad:
             )
         assert isinstance(model, MlxEmbeddingsEncoderModel)
         assert loaded_tokenizer is tokenizer
+
+    def test_loads_sparse_head_only_for_explicit_bge_m3_token_classify(
+        self,
+    ) -> None:
+        fake = _FakeEmbeddingsModule()
+        tokenizer = object()
+        sparse_head = BgeM3SparseHead(
+            weight=mx.ones((1, 4), dtype=mx.float32),
+            bias=mx.zeros((1,), dtype=mx.float32),
+            bos_token_id=0,
+            eos_token_id=2,
+        )
+        load_mock = MagicMock(return_value=(fake, tokenizer))
+        sparse_load_mock = MagicMock(return_value=sparse_head)
+        config = _encoder_model_config(
+            pooler_config=SimpleNamespace(task="token_classify")
+        )
+
+        with (
+            patch(
+                "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+                return_value=load_mock,
+            ),
+            patch(
+                "vllm_metal.v1.encoder_embeddings._load_bge_m3_sparse_head",
+                sparse_load_mock,
+            ),
+        ):
+            _model, _tokenizer, adapter = EncoderEmbeddingAdapter.load(
+                "cached/model/path",
+                model_config=config,
+            )
+
+        sparse_load_mock.assert_called_once_with(config.hf_config)
+        assert adapter.supports_token_classify
+
+    def test_dense_bge_m3_load_does_not_fetch_sparse_head(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        load_mock = MagicMock(return_value=(fake, object()))
+        with (
+            patch(
+                "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+                return_value=load_mock,
+            ),
+            patch(
+                "vllm_metal.v1.encoder_embeddings._load_bge_m3_sparse_head"
+            ) as sparse_load_mock,
+        ):
+            _model, _tokenizer, adapter = EncoderEmbeddingAdapter.load(
+                "cached/model/path",
+                model_config=_encoder_model_config(),
+            )
+
+        sparse_load_mock.assert_not_called()
+        assert not adapter.supports_token_classify
+
+    def test_token_classify_rejects_unrelated_encoder_model(self) -> None:
+        config = _encoder_model_config(
+            model="other/xlm-roberta",
+            served_model_name="other/xlm-roberta",
+            pooler_config=SimpleNamespace(task="token_classify"),
+        )
+        with pytest.raises(NotImplementedError, match="mlx-community/bge-m3"):
+            EncoderEmbeddingAdapter.load(
+                "cached/model/path",
+                model_config=config,
+            )
+
+
+class TestBgeM3SparseHead:
+    def test_applies_bias_relu_and_filters_bos_eos(self) -> None:
+        head = BgeM3SparseHead(
+            weight=mx.array([[1.0, 0.0, 0.0]], dtype=mx.float32),
+            bias=mx.array([-1.5], dtype=mx.float32),
+            bos_token_id=0,
+            eos_token_id=2,
+        )
+        hidden_states = mx.array(
+            [
+                [100.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [4.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [100.0, 0.0, 0.0],
+            ],
+            dtype=mx.float32,
+        )
+
+        token_logits = head.project_token_logits(hidden_states)
+        activated = head.filter_token_weights(
+            token_logits,
+            token_ids=[0, 41, 0, 2, 42, 2],
+            use_activation=True,
+        )
+        raw = head.filter_token_weights(
+            token_logits,
+            token_ids=[0, 41, 0, 2, 42, 2],
+            use_activation=False,
+        )
+
+        assert mx.allclose(
+            activated,
+            mx.array([1.5, 0.0, 2.5, 0.0], dtype=mx.float32),
+        )
+        assert mx.allclose(
+            raw,
+            mx.array([1.5, -0.5, 2.5, -0.5], dtype=mx.float32),
+        )
+
+    def test_rejects_invalid_weight_shape(self) -> None:
+        with pytest.raises(ValueError, match=r"\[1, hidden\]"):
+            BgeM3SparseHead(
+                weight=mx.ones((2, 4), dtype=mx.float32),
+                bias=mx.zeros((1,), dtype=mx.float32),
+                bos_token_id=0,
+                eos_token_id=2,
+            )
+
+    def test_official_head_loader_is_revision_pinned(self) -> None:
+        state = {
+            "weight": torch.ones((1, 4), dtype=torch.float16),
+            "bias": torch.zeros((1,), dtype=torch.float16),
+        }
+        config = SimpleNamespace(hidden_size=4, bos_token_id=0, eos_token_id=2)
+
+        with (
+            patch(
+                "vllm_metal.v1.encoder_embeddings.hf_hub_download",
+                return_value="/tmp/sparse_linear.pt",
+            ) as download_mock,
+            patch(
+                "vllm_metal.v1.encoder_embeddings.torch.load",
+                return_value=state,
+            ) as torch_load_mock,
+        ):
+            head = _load_bge_m3_sparse_head(config)
+
+        download_mock.assert_called_once_with(
+            repo_id="BAAI/bge-m3",
+            filename="sparse_linear.pt",
+            revision="5617a9f61b028005a4858fdac845db406aefb181",
+        )
+        torch_load_mock.assert_called_once_with(
+            "/tmp/sparse_linear.pt",
+            map_location="cpu",
+            weights_only=True,
+        )
+        assert head.supports_hidden_size(4)
+
+    def test_official_head_loader_rejects_nonfinite_weights(self) -> None:
+        state = {
+            "weight": torch.tensor([[float("nan"), 0.0]], dtype=torch.float16),
+            "bias": torch.zeros((1,), dtype=torch.float16),
+        }
+        config = SimpleNamespace(hidden_size=2, bos_token_id=0, eos_token_id=2)
+
+        with (
+            patch(
+                "vllm_metal.v1.encoder_embeddings.hf_hub_download",
+                return_value="/tmp/sparse_linear.pt",
+            ),
+            patch(
+                "vllm_metal.v1.encoder_embeddings.torch.load",
+                return_value=state,
+            ),
+            pytest.raises(ValueError, match="must be finite"),
+        ):
+            _load_bge_m3_sparse_head(config)
+
+    @pytest.mark.slow
+    def test_cached_real_bge_m3_hi_matches_upstream_sparse_reference(self) -> None:
+        from huggingface_hub import try_to_load_from_cache
+
+        cached_model_files = {
+            filename: try_to_load_from_cache(
+                _BGE_M3_MODEL_ID,
+                filename,
+                revision=_BGE_M3_MODEL_REVISION,
+            )
+            for filename in _BGE_M3_REQUIRED_FILES
+        }
+        head_path = try_to_load_from_cache(
+            "BAAI/bge-m3",
+            "sparse_linear.pt",
+            revision="5617a9f61b028005a4858fdac845db406aefb181",
+        )
+        missing_files = [
+            filename
+            for filename, path in cached_model_files.items()
+            if not isinstance(path, str)
+        ]
+        if not isinstance(head_path, str):
+            missing_files.append("BAAI/bge-m3/sparse_linear.pt")
+        if missing_files:
+            pytest.skip(
+                "Pinned BGE-M3 files not in the Hugging Face cache: "
+                f"{missing_files}; "
+                f"pre-pull with `hf download {_BGE_M3_MODEL_ID} "
+                f"--revision {_BGE_M3_MODEL_REVISION}`"
+            )
+
+        config_path = cached_model_files["config.json"]
+        assert isinstance(config_path, str)
+        assert isinstance(head_path, str)
+        model_config = _encoder_model_config(
+            pooler_config=SimpleNamespace(task="token_classify"),
+            hf_config=SimpleNamespace(
+                architectures=["XLMRobertaModel"],
+                model_type="xlm-roberta",
+                hidden_size=1024,
+                bos_token_id=0,
+                eos_token_id=2,
+            ),
+        )
+        with patch(
+            "vllm_metal.v1.encoder_embeddings.hf_hub_download",
+            return_value=head_path,
+        ):
+            _model, tokenizer, adapter = EncoderEmbeddingAdapter.load(
+                str(Path(config_path).parent),
+                model_config=model_config,
+            )
+        token_ids = tokenizer.encode("Hi", add_special_tokens=True)
+        hidden_states = adapter.forward_sequence_hidden_states(
+            mx.array(token_ids, dtype=mx.int32),
+            segment_lengths=[len(token_ids)],
+        )
+        weights = adapter.filter_sparse_token_weights(
+            adapter.sparse_token_logits(hidden_states[0]),
+            token_ids=token_ids,
+            use_activation=True,
+        )
+        mx.eval(weights)
+
+        assert token_ids == [0, _BGE_M3_HI_TOKEN_ID, 2]
+        assert tuple(weights.shape) == (1,)
+        assert float(weights.item()) == pytest.approx(
+            _BGE_M3_HI_REFERENCE_WEIGHT,
+            rel=_BGE_M3_8BIT_REFERENCE_REL_TOLERANCE,
+        )
 
 
 class TestEncoderPagedSetup:

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -138,6 +138,61 @@ class TestMlxEmbeddingsLoad:
         assert fake.calls == [((1, 3), (1, 3))]
 
 
+class TestEncoderPagedSetup:
+    def test_setup_paged_attention_skips_patching_encoder_models(self) -> None:
+        from vllm_metal.v1.cache_policy import WorkerCachePlanner
+
+        fake = _FakeEmbeddingsModule()
+        model = MlxEmbeddingsEncoderModel(fake)
+        runner = SimpleNamespace(
+            model=model,
+            is_mla=False,
+            validate_paged_attention_support=MagicMock(),
+            build_paged_attention_runtime=MagicMock(),
+            install_gemma4_mtp_kv_sharing=MagicMock(),
+            install_drafter=MagicMock(),
+            install_paged_attention_runtime=MagicMock(),
+            model_args={
+                "num_hidden_layers": 2,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "head_dim": 2,
+                "hidden_size": 4,
+            },
+            kv_cache_dtype=mx.float16,
+            metal_config=SimpleNamespace(use_paged_attention=True),
+        )
+        backend = MagicMock()
+        backend.patch_model = MagicMock(return_value=2)
+        backend.initialize = MagicMock()
+        runner.build_paged_attention_runtime.return_value = backend
+
+        worker = SimpleNamespace(model_runner=runner)
+        planner = WorkerCachePlanner(worker)
+
+        plan = SimpleNamespace(
+            block_size=16,
+            num_blocks=4,
+            per_block_bytes=1024,
+            format_breakdown=lambda: "stub",
+        )
+        with (
+            patch.object(planner, "_paged_attention_plan", return_value=plan),
+            patch(
+                "vllm_metal.v1.cache_policy.get_config",
+                return_value=SimpleNamespace(turboquant=False, k_quant=None),
+            ),
+            patch(
+                "vllm_metal.v1.cache_policy.try_enable_gemma4_yoco_fast_prefill",
+                return_value=None,
+            ),
+        ):
+            planner.setup_paged_attention(overhead=0)
+
+        backend.patch_model.assert_not_called()
+        runner.install_paged_attention_runtime.assert_called_once()
+
+
 class TestEncoderPoolingForward:
     def test_supports_embed_for_encoder_adapter(self) -> None:
         fake = _FakeEmbeddingsModule()

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the mlx-embeddings encoder load path (#589 PR1)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.v1.encoder_embeddings import (
+    MlxEmbeddingsEncoderModel,
+    is_encoder_embedding_config,
+    load_mlx_embeddings_model,
+    requires_mlx_embeddings_load,
+)
+from vllm_metal.v1.pooling import (
+    forward_sequence_hidden_states,
+    supports_embed_pooling,
+)
+
+
+def _encoder_model_config(**overrides):
+    values = {
+        "runner_type": "pooling",
+        "served_model_name": "mlx-community/bge-m3-mlx-8bit",
+        "model": "mlx-community/bge-m3-mlx-8bit",
+        "hf_config": SimpleNamespace(
+            architectures=["XLMRobertaModel"],
+            model_type="xlm-roberta",
+        ),
+        "pooler_config": SimpleNamespace(
+            task="embed",
+            pooling_type=None,
+            seq_pooling_type="CLS",
+            enable_chunked_processing=False,
+            use_activation=None,
+            dimensions=None,
+        ),
+        "multimodal_config": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _FakeEmbeddingsOutput:
+    def __init__(self, hidden_states: mx.array) -> None:
+        self.last_hidden_state = hidden_states
+
+
+class _FakeEmbeddingsModule:
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(
+            model_type="xlm-roberta",
+            hidden_size=4,
+            vocab_size=16,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=2,
+            max_position_embeddings=32,
+        )
+        self.calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+
+    def __call__(self, input_ids, attention_mask=None):
+        shape = tuple(int(x) for x in input_ids.shape)
+        mask_shape = tuple(int(x) for x in attention_mask.shape)
+        self.calls.append((shape, mask_shape))
+        tokens = int(input_ids.shape[-1])
+        rows = [[float(i), float(i + 1), 0.0, 1.0] for i in range(tokens)]
+        return _FakeEmbeddingsOutput(mx.array([rows], dtype=mx.float32))
+
+
+class TestEncoderEmbeddingDetection:
+    def test_detects_xlm_roberta_and_bge_architectures(self) -> None:
+        assert is_encoder_embedding_config(_encoder_model_config())
+        assert requires_mlx_embeddings_load(_encoder_model_config())
+        assert is_encoder_embedding_config(
+            _encoder_model_config(
+                hf_config=SimpleNamespace(
+                    architectures=["BgeM3EmbeddingModel"],
+                    model_type="xlm-roberta",
+                )
+            )
+        )
+
+    def test_rejects_decoder_embedding_configs(self) -> None:
+        config = _encoder_model_config(
+            hf_config=SimpleNamespace(
+                architectures=["Qwen3ForCausalLM"],
+                model_type="qwen3",
+            )
+        )
+        assert not is_encoder_embedding_config(config)
+        assert not requires_mlx_embeddings_load(config)
+
+
+class TestMlxEmbeddingsLoad:
+    def test_missing_extra_raises_install_hint(self) -> None:
+        with (
+            patch(
+                "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+                side_effect=ImportError(
+                    "Loading encoder embedding models such as XLM-RoBERTa / BGE-M3 "
+                    "requires the optional 'mlx-embeddings' package. Install it with: "
+                    'pip install "vllm-metal[embeddings]"'
+                ),
+            ),
+            pytest.raises(ImportError, match=r"vllm-metal\[embeddings\]"),
+        ):
+            load_mlx_embeddings_model("mlx-community/bge-m3-mlx-8bit")
+
+    def test_wraps_loaded_model_with_sequence_body(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        tokenizer = object()
+        load_mock = MagicMock(return_value=(fake, tokenizer))
+        with patch(
+            "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+            return_value=load_mock,
+        ):
+            model, loaded_tokenizer = load_mlx_embeddings_model(
+                "mlx-community/bge-m3-mlx-8bit",
+                tokenizer_config={"trust_remote_code": True},
+                lazy=True,
+            )
+
+        load_mock.assert_called_once_with(
+            "mlx-community/bge-m3-mlx-8bit",
+            tokenizer_config={"trust_remote_code": True},
+            lazy=True,
+        )
+        assert loaded_tokenizer is tokenizer
+        assert isinstance(model, MlxEmbeddingsEncoderModel)
+        assert model.is_mlx_embeddings_encoder is True
+        hidden = model.model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=MagicMock())
+        assert hidden.shape == (1, 3, 4)
+        assert fake.calls == [((1, 3), (1, 3))]
+
+
+class TestEncoderPoolingForward:
+    def test_supports_embed_for_encoder_adapter(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        model = MlxEmbeddingsEncoderModel(fake)
+        assert supports_embed_pooling(model, _encoder_model_config())
+
+    def test_forwards_packed_segments_independently(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        model = MlxEmbeddingsEncoderModel(fake)
+        hidden = forward_sequence_hidden_states(
+            model,
+            mx.array([[10, 11, 20, 21, 22]], dtype=mx.int32),
+            cache=[MagicMock()],
+            model_config=_encoder_model_config(),
+            segment_lengths=[2, 3],
+        )
+        assert hidden.shape == (1, 5, 4)
+        assert fake.calls == [((1, 2), (1, 2)), ((1, 3), (1, 3))]
+        # First token of each independent segment starts its own row index 0.
+        assert float(hidden[0, 0, 0]) == 0.0
+        assert float(hidden[0, 2, 0]) == 0.0

--- a/tests/test_encoder_embeddings.py
+++ b/tests/test_encoder_embeddings.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the mlx-embeddings encoder load path (#589 PR1)."""
+"""Tests for the encoder embedding adapter (#589 PR1)."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import mlx.core as mx
 import pytest
 
 from vllm_metal.v1.encoder_embeddings import (
+    EncoderEmbeddingAdapter,
     MlxEmbeddingsEncoderModel,
     is_encoder_embedding_config,
     load_mlx_embeddings_model,
@@ -74,9 +75,12 @@ class _FakeEmbeddingsModule:
 
 class TestEncoderEmbeddingDetection:
     def test_detects_xlm_roberta_and_bge_architectures(self) -> None:
+        assert EncoderEmbeddingAdapter.matches_config(_encoder_model_config())
+        assert EncoderEmbeddingAdapter.requires_load(_encoder_model_config())
+        # Compatibility aliases keep older imports working.
         assert is_encoder_embedding_config(_encoder_model_config())
         assert requires_mlx_embeddings_load(_encoder_model_config())
-        assert is_encoder_embedding_config(
+        assert EncoderEmbeddingAdapter.matches_config(
             _encoder_model_config(
                 hf_config=SimpleNamespace(
                     architectures=["BgeM3EmbeddingModel"],
@@ -92,8 +96,17 @@ class TestEncoderEmbeddingDetection:
                 model_type="qwen3",
             )
         )
-        assert not is_encoder_embedding_config(config)
-        assert not requires_mlx_embeddings_load(config)
+        assert not EncoderEmbeddingAdapter.matches_config(config)
+        assert not EncoderEmbeddingAdapter.requires_load(config)
+
+    def test_owns_cls_pooling_defaults(self) -> None:
+        assert EncoderEmbeddingAdapter.default_sequence_pooling_type == "CLS"
+        assert EncoderEmbeddingAdapter.allowed_sequence_pooling_types == (
+            None,
+            "CLS",
+            "LAST",
+        )
+        assert EncoderEmbeddingAdapter.skip_paged_attention_patch is True
 
 
 class TestMlxEmbeddingsLoad:
@@ -109,9 +122,9 @@ class TestMlxEmbeddingsLoad:
             ),
             pytest.raises(ImportError, match=r"vllm-metal\[embeddings\]"),
         ):
-            load_mlx_embeddings_model("mlx-community/bge-m3-mlx-8bit")
+            EncoderEmbeddingAdapter.load("mlx-community/bge-m3-mlx-8bit")
 
-    def test_wraps_loaded_model_with_sequence_body(self) -> None:
+    def test_wraps_loaded_model_with_adapter(self) -> None:
         fake = _FakeEmbeddingsModule()
         tokenizer = object()
         load_mock = MagicMock(return_value=(fake, tokenizer))
@@ -119,7 +132,7 @@ class TestMlxEmbeddingsLoad:
             "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
             return_value=load_mock,
         ):
-            model, loaded_tokenizer = load_mlx_embeddings_model(
+            model, loaded_tokenizer, adapter = EncoderEmbeddingAdapter.load(
                 "mlx-community/bge-m3-mlx-8bit",
                 tokenizer_config={"trust_remote_code": True},
                 lazy=True,
@@ -132,21 +145,40 @@ class TestMlxEmbeddingsLoad:
         )
         assert loaded_tokenizer is tokenizer
         assert isinstance(model, MlxEmbeddingsEncoderModel)
-        assert model.is_mlx_embeddings_encoder is True
+        assert isinstance(adapter, EncoderEmbeddingAdapter)
+        assert adapter.model is model
+        assert EncoderEmbeddingAdapter.from_loaded_model(model) is not None
+        assert EncoderEmbeddingAdapter.from_loaded_model(object()) is None
         hidden = model.model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=MagicMock())
         assert hidden.shape == (1, 3, 4)
         assert fake.calls == [((1, 3), (1, 3))]
 
+    def test_compatibility_load_helper_still_works(self) -> None:
+        fake = _FakeEmbeddingsModule()
+        tokenizer = object()
+        load_mock = MagicMock(return_value=(fake, tokenizer))
+        with patch(
+            "vllm_metal.v1.encoder_embeddings._import_mlx_embeddings_load",
+            return_value=load_mock,
+        ):
+            model, loaded_tokenizer = load_mlx_embeddings_model(
+                "mlx-community/bge-m3-mlx-8bit"
+            )
+        assert isinstance(model, MlxEmbeddingsEncoderModel)
+        assert loaded_tokenizer is tokenizer
+
 
 class TestEncoderPagedSetup:
-    def test_setup_paged_attention_skips_patching_encoder_models(self) -> None:
+    def test_setup_paged_attention_skips_patching_via_adapter(self) -> None:
         from vllm_metal.v1.cache_policy import WorkerCachePlanner
 
         fake = _FakeEmbeddingsModule()
         model = MlxEmbeddingsEncoderModel(fake)
+        adapter = EncoderEmbeddingAdapter(model)
         runner = SimpleNamespace(
             model=model,
             is_mla=False,
+            _encoder_embedding_adapter=adapter,
             validate_paged_attention_support=MagicMock(),
             build_paged_attention_runtime=MagicMock(),
             install_gemma4_mtp_kv_sharing=MagicMock(),
@@ -202,12 +234,14 @@ class TestEncoderPoolingForward:
     def test_forwards_packed_segments_independently(self) -> None:
         fake = _FakeEmbeddingsModule()
         model = MlxEmbeddingsEncoderModel(fake)
+        adapter = EncoderEmbeddingAdapter(model)
         hidden = forward_sequence_hidden_states(
             model,
             mx.array([[10, 11, 20, 21, 22]], dtype=mx.int32),
             cache=[MagicMock()],
             model_config=_encoder_model_config(),
             segment_lengths=[2, 3],
+            encoder_adapter=adapter,
         )
         assert hidden.shape == (1, 5, 4)
         assert fake.calls == [((1, 2), (1, 2)), ((1, 3), (1, 3))]

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -288,6 +288,57 @@ class TestModelLifecycle:
         lifecycle._load_mlx_lm_text_model("stub", {}, lazy=False)
         assert captured["lazy"] is False
 
+    def test_load_mlx_embeddings_forwards_model_config_for_sparse_capability(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+        model = object()
+        tokenizer = object()
+        adapter = object()
+        model_config = _runner_model_config(
+            model="mlx-community/bge-m3-mlx-8bit",
+            pooler_config=SimpleNamespace(task="token_classify"),
+        )
+
+        def _fake_load(
+            model_name: str,
+            *,
+            model_config: object,
+            tokenizer_config: dict[str, object],
+            lazy: bool,
+        ) -> tuple[object, object, object]:
+            captured.update(
+                model_name=model_name,
+                model_config=model_config,
+                tokenizer_config=tokenizer_config,
+                lazy=lazy,
+            )
+            return model, tokenizer, adapter
+
+        monkeypatch.setattr(
+            model_lifecycle.EncoderEmbeddingAdapter,
+            "load",
+            _fake_load,
+        )
+        lifecycle, _runner = _make_lifecycle(model_config=model_config)
+
+        loaded_model, loaded_tokenizer = lifecycle._load_mlx_embeddings_model(
+            "cached/model/path",
+            {"trust_remote_code": True},
+            model_config=model_config,
+            lazy=True,
+        )
+
+        assert loaded_model is model
+        assert loaded_tokenizer is tokenizer
+        assert captured == {
+            "model_name": "cached/model/path",
+            "model_config": model_config,
+            "tokenizer_config": {"trust_remote_code": True},
+            "lazy": True,
+        }
+
     def test_load_uses_adapter_override_for_qwen35_fp8_conditional_generation(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -21,6 +21,7 @@ from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.encoder_embeddings import (  # noqa: E402
+    BgeM3SparseHead,
     EncoderEmbeddingAdapter,
     MlxEmbeddingsEncoderModel,
 )
@@ -172,6 +173,7 @@ def _make_runner(
     model: object | None = None,
     model_config: object | None = None,
     tokenizer: object | None = None,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ):
     resolved_model = model or _PoolingModel()
     runner = make_stub_runner(
@@ -191,8 +193,10 @@ def _make_runner(
         ),
         _paged_block_size=4,
         num_layers=1,
-        _encoder_embedding_adapter=EncoderEmbeddingAdapter.from_loaded_model(
-            resolved_model
+        _encoder_embedding_adapter=(
+            encoder_adapter
+            if encoder_adapter is not None
+            else EncoderEmbeddingAdapter.from_loaded_model(resolved_model)
         ),
     )
     return runner
@@ -210,6 +214,7 @@ def _new_req(
     num_computed_tokens: int = 0,
     block_ids: list[int] | None = None,
     pooling_params: PoolingParams | None = None,
+    lora_request: object | None = None,
 ) -> NewRequestData:
     return NewRequestData(
         req_id=req_id,
@@ -219,7 +224,7 @@ def _new_req(
         pooling_params=pooling_params or _pooling_params(task),
         block_ids=(block_ids or [0, 1],),
         num_computed_tokens=num_computed_tokens,
-        lora_request=None,
+        lora_request=lora_request,
         prompt_embeds=None,
     )
 
@@ -325,17 +330,57 @@ def _encoder_pooling_model_config(**overrides):
     return _pooling_model_config(**values)
 
 
+def _bge_m3_sparse_model_config(**overrides):
+    values = {
+        "model": "mlx-community/bge-m3-mlx-8bit",
+        "served_model_name": "mlx-community/bge-m3-mlx-8bit",
+        "hf_config": _encoder_hf_config(
+            hidden_size=3,
+            bos_token_id=0,
+            eos_token_id=2,
+        ),
+        "pooler_config": _pooler_config(
+            task="token_classify",
+            seq_pooling_type="CLS",
+            enable_chunked_processing=False,
+        ),
+    }
+    values.update(overrides)
+    return _pooling_model_config(**values)
+
+
 class _FakeEncoderOutput:
     def __init__(self, hidden_states: mx.array) -> None:
         self.last_hidden_state = hidden_states
 
 
 class _FakeEncoderModule:
+    def __init__(self) -> None:
+        self.calls: list[list[int]] = []
+
     def __call__(self, input_ids, attention_mask=None):
         del attention_mask
         token_ids = np.array(input_ids).reshape(-1).tolist()
+        self.calls.append(token_ids)
         rows = [[float(tok), float(tok + 1), 1.0] for tok in token_ids]
         return _FakeEncoderOutput(mx.array([rows], dtype=mx.float32))
+
+
+def _sparse_encoder_components() -> tuple[
+    MlxEmbeddingsEncoderModel,
+    EncoderEmbeddingAdapter,
+    _FakeEncoderModule,
+]:
+    encoder = _FakeEncoderModule()
+    model = MlxEmbeddingsEncoderModel(encoder)
+    sparse_head = BgeM3SparseHead(
+        weight=mx.array([[1.0, 0.0, 0.0]], dtype=mx.float32),
+        bias=mx.array([-5.5], dtype=mx.float32),
+        bos_token_id=0,
+        eos_token_id=2,
+    )
+    adapter = EncoderEmbeddingAdapter(model, sparse_head=sparse_head)
+    return model, adapter, encoder
 
 
 class TestMetalPoolingCapabilities:
@@ -351,6 +396,16 @@ class TestMetalPoolingCapabilities:
         )
 
         assert runner.supported_worker_tasks() == ("embed",)
+
+    def test_supported_worker_tasks_for_bge_m3_sparse_model(self) -> None:
+        model, adapter, _encoder = _sparse_encoder_components()
+        runner = _make_runner(
+            model=model,
+            model_config=_bge_m3_sparse_model_config(),
+            encoder_adapter=adapter,
+        )
+
+        assert runner.supported_worker_tasks() == ("token_classify",)
 
     def test_supported_worker_tasks_rejects_incompatible_pooling_model(self) -> None:
         runner = make_stub_runner(
@@ -503,6 +558,121 @@ class TestMetalPoolingRunnerOutput:
         # CLS uses the first token of each packed segment, not the last.
         _assert_embedding(out.pooler_output[0], 4)
         _assert_embedding(out.pooler_output[1], 7)
+
+    def test_paged_bge_m3_sparse_preserves_token_spans_and_request_order(
+        self,
+    ) -> None:
+        model, adapter, encoder = _sparse_encoder_components()
+        runner = _make_runner(
+            model=model,
+            model_config=_bge_m3_sparse_model_config(),
+            encoder_adapter=adapter,
+        )
+        req_b = _new_req(
+            "req-b",
+            [0, 4, 6, 2],
+            pooling_params=_pooling_params(
+                task="token_classify",
+                requires_token_ids=True,
+            ),
+        )
+        req_a = _new_req(
+            "req-a",
+            [0, 9, 2],
+            pooling_params=_pooling_params(
+                task="token_classify",
+                requires_token_ids=True,
+            ),
+        )
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_grouped"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+            patch.object(
+                adapter,
+                "sparse_token_logits",
+                wraps=adapter.sparse_token_logits,
+            ) as sparse_projection,
+        ):
+            out = _execute_pooling(runner, _scheduler_output(new_reqs=[req_b, req_a]))
+
+        assert out.req_ids == ["req-b", "req-a"]
+        assert out.sampled_token_ids == [[], []]
+        assert out.pooler_output is not None
+        assert torch.equal(out.pooler_output[0], torch.tensor([0.0, 0.5]))
+        assert torch.equal(out.pooler_output[1], torch.tensor([3.5]))
+        assert encoder.calls == [[0, 4, 6, 2], [0, 9, 2]]
+        sparse_projection.assert_called_once()
+
+    def test_paged_bge_m3_sparse_calibrates_before_relu(self) -> None:
+        model, adapter, _encoder = _sparse_encoder_components()
+        runner = _make_runner(
+            model=model,
+            model_config=_bge_m3_sparse_model_config(
+                pooler_config=_pooler_config(
+                    task="token_classify",
+                    seq_pooling_type="CLS",
+                    enable_chunked_processing=False,
+                    logit_mean=1.5,
+                    logit_sigma=2.0,
+                )
+            ),
+            encoder_adapter=adapter,
+        )
+        req = _new_req(
+            "req-0",
+            [0, 6, 2],
+            pooling_params=_pooling_params(task="token_classify"),
+        )
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_grouped"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, _scheduler_output(new_reqs=[req]))
+
+        assert out.pooler_output is not None
+        assert torch.equal(out.pooler_output[0], torch.tensor([0.0]))
+
+    def test_paged_bge_m3_sparse_returns_empty_tensor_for_boundary_only_input(
+        self,
+    ) -> None:
+        model, adapter, _encoder = _sparse_encoder_components()
+        runner = _make_runner(
+            model=model,
+            model_config=_bge_m3_sparse_model_config(),
+            encoder_adapter=adapter,
+        )
+        empty_req = _new_req(
+            "empty",
+            [0, 2],
+            pooling_params=_pooling_params(task="token_classify"),
+        )
+        body_req = _new_req(
+            "body",
+            [0, 6, 2],
+            pooling_params=_pooling_params(task="token_classify"),
+        )
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_grouped"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+            patch.object(
+                adapter,
+                "sparse_token_logits",
+                wraps=adapter.sparse_token_logits,
+            ) as sparse_projection,
+        ):
+            out = _execute_pooling(
+                runner,
+                _scheduler_output(new_reqs=[empty_req, body_req]),
+            )
+
+        assert out.req_ids == ["empty", "body"]
+        assert out.pooler_output is not None
+        assert torch.equal(out.pooler_output[0], torch.empty(0))
+        assert torch.equal(out.pooler_output[1], torch.tensor([0.5]))
+        sparse_projection.assert_called_once()
 
     def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(self) -> None:
         runner = _make_runner()
@@ -664,15 +834,87 @@ class TestMetalPoolingFailFast:
         with pytest.raises(NotImplementedError, match="task"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
-    def test_token_classify_fail_fast_mentions_sparse_followup(self) -> None:
+    def test_token_classify_rejects_encoder_without_sparse_head(self) -> None:
         runner = _make_runner(
             model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
-            model_config=_encoder_pooling_model_config(),
+            model_config=_bge_m3_sparse_model_config(),
         )
         req = _new_req("req-0", [1, 2], task="token_classify")
 
-        with pytest.raises(NotImplementedError, match="sparse lexical weights"):
+        with pytest.raises(NotImplementedError, match="sparse head"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    @pytest.mark.parametrize(
+        ("num_computed_tokens", "num_scheduled_tokens"),
+        [
+            (0, 2),
+            (1, 3),
+        ],
+    )
+    def test_token_classify_rejects_partial_or_prefix_cached_new_request(
+        self,
+        num_computed_tokens: int,
+        num_scheduled_tokens: int,
+    ) -> None:
+        model, adapter, encoder = _sparse_encoder_components()
+        runner = _make_runner(
+            model=model,
+            model_config=_bge_m3_sparse_model_config(),
+            encoder_adapter=adapter,
+        )
+        req = _new_req(
+            "req-0",
+            [0, 4, 5, 2],
+            num_computed_tokens=num_computed_tokens,
+            pooling_params=_pooling_params(task="token_classify"),
+            lora_request=SimpleNamespace(lora_int_id=7),
+        )
+        runner._lora = MagicMock()
+        sched = _scheduler_output(
+            new_reqs=[req],
+            num_scheduled_tokens={"req-0": num_scheduled_tokens},
+        )
+
+        with pytest.raises(NotImplementedError, match="complete, uncached prefill"):
+            runner.execute_model(sched)
+
+        assert encoder.calls == []
+        assert "req-0" not in runner._request_states
+        runner._lora.add_adapter.assert_not_called()
+
+    def test_token_classify_rejects_resumed_cache_before_state_mutation(self) -> None:
+        model, adapter, encoder = _sparse_encoder_components()
+        runner = _make_runner(
+            model=model,
+            model_config=_bge_m3_sparse_model_config(),
+            encoder_adapter=adapter,
+        )
+        runner._request_states["req-0"] = mr.RequestState(
+            token_ids=[0, 4, 5, 2, 9],
+            prompt_len=4,
+            cache=[],
+            sampling_params=mr.SamplingParams(),
+            pooling_params=_pooling_params(task="token_classify"),
+            generated_tokens=1,
+            block_ids=[[0, 1]],
+        )
+        runner._paged_request_seq_lens["req-0"] = 5
+        sched = _scheduler_output(
+            cached_req_ids=["req-0"],
+            cached_num_computed_tokens=[2],
+            num_scheduled_tokens={"req-0": 2},
+        )
+        sched.scheduled_cached_reqs.resumed_req_ids = {"req-0"}
+        sched.scheduled_cached_reqs.new_block_ids = [([7, 8],)]
+
+        with pytest.raises(NotImplementedError, match="complete, uncached prefill"):
+            runner.execute_model(sched)
+
+        assert encoder.calls == []
+        state = runner._request_states["req-0"]
+        assert state.block_ids == [[0, 1]]
+        assert state.generated_tokens == 1
+        assert runner._paged_request_seq_lens["req-0"] == 5
 
     def test_classify_hidden_state_shape_fails_fast(self) -> None:
         with pytest.raises(ValueError, match="hidden states with shape"):

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -20,7 +20,10 @@ from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
-from vllm_metal.v1.encoder_embeddings import MlxEmbeddingsEncoderModel  # noqa: E402
+from vllm_metal.v1.encoder_embeddings import (  # noqa: E402
+    EncoderEmbeddingAdapter,
+    MlxEmbeddingsEncoderModel,
+)
 from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
 
@@ -170,8 +173,9 @@ def _make_runner(
     model_config: object | None = None,
     tokenizer: object | None = None,
 ):
-    return make_stub_runner(
-        model=model or _PoolingModel(),
+    resolved_model = model or _PoolingModel()
+    runner = make_stub_runner(
+        model=resolved_model,
         model_config=model_config or _pooling_model_config(),
         tokenizer=tokenizer,
         _paged_attention_runtime=(
@@ -187,7 +191,11 @@ def _make_runner(
         ),
         _paged_block_size=4,
         num_layers=1,
+        _encoder_embedding_adapter=EncoderEmbeddingAdapter.from_loaded_model(
+            resolved_model
+        ),
     )
+    return runner
 
 
 def _pooling_params(task: str | None = None, **overrides) -> PoolingParams:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -20,6 +20,7 @@ from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
+from vllm_metal.v1.encoder_embeddings import MlxEmbeddingsEncoderModel  # noqa: E402
 from vllm_metal.v1.pooling import pool_sequence_classification  # noqa: E402
 
 
@@ -298,9 +299,48 @@ def _execute_pooling(runner, sched):
     return out
 
 
+def _encoder_hf_config(**overrides):
+    values = {
+        "architectures": ["XLMRobertaModel"],
+        "model_type": "xlm-roberta",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _encoder_pooling_model_config(**overrides):
+    values = {
+        "hf_config": _encoder_hf_config(),
+        "pooler_config": _pooler_config(task="embed", seq_pooling_type="CLS"),
+    }
+    values.update(overrides)
+    return _pooling_model_config(**values)
+
+
+class _FakeEncoderOutput:
+    def __init__(self, hidden_states: mx.array) -> None:
+        self.last_hidden_state = hidden_states
+
+
+class _FakeEncoderModule:
+    def __call__(self, input_ids, attention_mask=None):
+        del attention_mask
+        token_ids = np.array(input_ids).reshape(-1).tolist()
+        rows = [[float(tok), float(tok + 1), 1.0] for tok in token_ids]
+        return _FakeEncoderOutput(mx.array([rows], dtype=mx.float32))
+
+
 class TestMetalPoolingCapabilities:
     def test_supported_worker_tasks_for_last_text_embedding_model(self) -> None:
         runner = _make_runner()
+
+        assert runner.supported_worker_tasks() == ("embed",)
+
+    def test_supported_worker_tasks_for_encoder_cls_embedding_model(self) -> None:
+        runner = _make_runner(
+            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model_config=_encoder_pooling_model_config(),
+        )
 
         assert runner.supported_worker_tasks() == ("embed",)
 
@@ -434,6 +474,27 @@ class TestMetalPoolingRunnerOutput:
         assert out.pooler_output is not None
         _assert_embedding(out.pooler_output[0], 5)
         _assert_embedding(out.pooler_output[1], 9)
+
+    def test_paged_encoder_cls_embed_uses_first_token(self) -> None:
+        runner = _make_runner(
+            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model_config=_encoder_pooling_model_config(),
+        )
+        req_b = _new_req("req-b", [4, 5])
+        req_a = _new_req("req-a", [7, 8, 9])
+        sched = _scheduler_output(new_reqs=[req_b, req_a])
+
+        with (
+            patch("vllm_metal.v1.model_runner.prepare_grouped"),
+            patch("vllm_metal.v1.model_runner.clear_context"),
+        ):
+            out = _execute_pooling(runner, sched)
+
+        assert out.req_ids == ["req-b", "req-a"]
+        assert out.pooler_output is not None
+        # CLS uses the first token of each packed segment, not the last.
+        _assert_embedding(out.pooler_output[0], 4)
+        _assert_embedding(out.pooler_output[1], 7)
 
     def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(self) -> None:
         runner = _make_runner()
@@ -571,7 +632,10 @@ class TestMetalPoolingFailFast:
         )
         req = _new_req("req-0", [1, 2], task="embed")
 
-        with pytest.raises(NotImplementedError, match="decoder-style checkpoint"):
+        with pytest.raises(
+            NotImplementedError,
+            match="decoder-style embedding checkpoint or an encoder embedding",
+        ):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
     def test_pooling_requires_paged_attention(self) -> None:
@@ -583,13 +647,23 @@ class TestMetalPoolingFailFast:
 
     @pytest.mark.parametrize(
         "task",
-        ["token_embed", "token_classify", "plugin"],
+        ["token_embed", "plugin"],
     )
     def test_unsupported_pooling_tasks_fail_fast(self, task: str) -> None:
         runner = _make_runner()
         req = _new_req("req-0", [1, 2], task=task)
 
         with pytest.raises(NotImplementedError, match="task"):
+            runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_token_classify_fail_fast_mentions_sparse_followup(self) -> None:
+        runner = _make_runner(
+            model=MlxEmbeddingsEncoderModel(_FakeEncoderModule()),
+            model_config=_encoder_pooling_model_config(),
+        )
+        req = _new_req("req-0", [1, 2], task="token_classify")
+
+        with pytest.raises(NotImplementedError, match="sparse lexical weights"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
 
     def test_classify_hidden_state_shape_fails_fast(self) -> None:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -950,15 +950,16 @@ class WorkerCachePlanner:
             backend,
             block_size=plan.block_size,
         )
-        # Encoder embedding models (mlx-embeddings XLM-RoBERTa / BGE-M3) own
-        # bidirectional attention internally. They still use the paged scheduler
-        # for pooling batch bookkeeping, but there are no mlx-lm-style
-        # ``model.layers`` to wrap — skip patching rather than fail loud.
-        model = self._worker.model_runner.model
-        if getattr(model, "is_mlx_embeddings_encoder", False):
+        # Encoder embedding adapters own bidirectional attention. They still use
+        # the paged scheduler for pooling batch bookkeeping, but there are no
+        # mlx-lm-style ``model.layers`` to wrap — skip patching rather than fail.
+        encoder_adapter = getattr(
+            self._worker.model_runner, "_encoder_embedding_adapter", None
+        )
+        if encoder_adapter is not None and encoder_adapter.skip_paged_attention_patch:
             n_patched = 0
         else:
-            n_patched = backend.patch_model(model)
+            n_patched = backend.patch_model(self._worker.model_runner.model)
         self._worker.model_runner.install_drafter(
             num_blocks=plan.num_blocks,
             block_size=plan.block_size,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -950,7 +950,15 @@ class WorkerCachePlanner:
             backend,
             block_size=plan.block_size,
         )
-        n_patched = backend.patch_model(self._worker.model_runner.model)
+        # Encoder embedding models (mlx-embeddings XLM-RoBERTa / BGE-M3) own
+        # bidirectional attention internally. They still use the paged scheduler
+        # for pooling batch bookkeeping, but there are no mlx-lm-style
+        # ``model.layers`` to wrap — skip patching rather than fail loud.
+        model = self._worker.model_runner.model
+        if getattr(model, "is_mlx_embeddings_encoder", False):
+            n_patched = 0
+        else:
+            n_patched = backend.patch_model(model)
         self._worker.model_runner.install_drafter(
             num_blocks=plan.num_blocks,
             block_size=plan.block_size,

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Encoder embedding load path via optional mlx-embeddings (#589 PR1)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+
+_ENCODER_EMBEDDING_ARCHITECTURES = frozenset(
+    {
+        "XLMRobertaModel",
+        "RobertaModel",
+        "RobertaEmbeddingModel",
+        "BgeM3EmbeddingModel",
+    }
+)
+_ENCODER_EMBEDDING_MODEL_TYPES = frozenset(
+    {
+        "xlm-roberta",
+        "roberta",
+        "xlm_roberta",
+    }
+)
+
+
+def is_encoder_embedding_architecture(architecture: str) -> bool:
+    return architecture in _ENCODER_EMBEDDING_ARCHITECTURES
+
+
+def is_encoder_embedding_model_type(model_type: str | None) -> bool:
+    if model_type is None:
+        return False
+    return model_type.replace("_", "-") in {
+        value.replace("_", "-") for value in _ENCODER_EMBEDDING_MODEL_TYPES
+    }
+
+
+def is_encoder_embedding_config(model_config: Any) -> bool:
+    """Return whether vLLM resolved this as an encoder embedding checkpoint."""
+    hf_config = getattr(model_config, "hf_config", None)
+    architectures: list[str] = []
+    for source in (model_config, hf_config):
+        values = getattr(source, "architectures", None)
+        if isinstance(values, (list, tuple)):
+            architectures.extend(str(arch) for arch in values)
+    if any(is_encoder_embedding_architecture(arch) for arch in architectures):
+        return True
+    model_type = getattr(hf_config, "model_type", None)
+    return is_encoder_embedding_model_type(
+        str(model_type) if model_type is not None else None
+    )
+
+
+def requires_mlx_embeddings_load(model_config: Any) -> bool:
+    """True when Metal should load weights through mlx-embeddings."""
+    return is_encoder_embedding_config(model_config)
+
+
+class _EncoderSequenceBody:
+    """Callable transformer body returning ``[1, tokens, hidden]`` states."""
+
+    def __init__(self, model: Any) -> None:
+        self._model = model
+
+    def __call__(self, input_ids: mx.array, cache: Any = None) -> mx.array:
+        del cache  # Encoder embeddings are bidirectional and cache-free.
+        if input_ids.ndim == 1:
+            input_ids = input_ids.reshape(1, -1)
+        attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        output = self._model(input_ids, attention_mask=attention_mask)
+        hidden_states = getattr(output, "last_hidden_state", None)
+        if hidden_states is None:
+            raise ValueError(
+                "mlx-embeddings encoder forward did not return last_hidden_state; "
+                f"got {type(output)!r}."
+            )
+        return hidden_states
+
+
+class MlxEmbeddingsEncoderModel:
+    """Thin adapter so Metal pooling can use mlx-embeddings models."""
+
+    is_mlx_embeddings_encoder = True
+
+    def __init__(self, model: Any) -> None:
+        self._model = model
+        self.config = getattr(model, "config", None)
+        self.args = self.config
+        self.model = _EncoderSequenceBody(model)
+
+
+def _import_mlx_embeddings_load() -> Any:
+    try:
+        from mlx_embeddings import load as mlx_embeddings_load
+    except ImportError as exc:
+        raise ImportError(
+            "Loading encoder embedding models such as XLM-RoBERTa / BGE-M3 "
+            "requires the optional 'mlx-embeddings' package. Install it with: "
+            'pip install "vllm-metal[embeddings]"'
+        ) from exc
+    return mlx_embeddings_load
+
+
+def load_mlx_embeddings_model(
+    model_name: str,
+    *,
+    tokenizer_config: dict[str, Any] | None = None,
+    lazy: bool = False,
+) -> tuple[MlxEmbeddingsEncoderModel, Any]:
+    """Load an encoder embedding checkpoint through mlx-embeddings."""
+    mlx_embeddings_load = _import_mlx_embeddings_load()
+    model, tokenizer = mlx_embeddings_load(
+        model_name,
+        tokenizer_config=dict(tokenizer_config or {}),
+        lazy=lazy,
+    )
+    return MlxEmbeddingsEncoderModel(model), tokenizer

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Encoder embedding load path via optional mlx-embeddings (#589 PR1)."""
+"""Encoder embedding adapter via optional mlx-embeddings (#589 PR1).
+
+Owns load, bidirectional segment forward, CLS pooling defaults, and paged
+attention patch-skipping so encoder special-cases stay in one place.
+"""
 
 from __future__ import annotations
 
@@ -22,39 +26,7 @@ _ENCODER_EMBEDDING_MODEL_TYPES = frozenset(
         "xlm_roberta",
     }
 )
-
-
-def is_encoder_embedding_architecture(architecture: str) -> bool:
-    return architecture in _ENCODER_EMBEDDING_ARCHITECTURES
-
-
-def is_encoder_embedding_model_type(model_type: str | None) -> bool:
-    if model_type is None:
-        return False
-    return model_type.replace("_", "-") in {
-        value.replace("_", "-") for value in _ENCODER_EMBEDDING_MODEL_TYPES
-    }
-
-
-def is_encoder_embedding_config(model_config: Any) -> bool:
-    """Return whether vLLM resolved this as an encoder embedding checkpoint."""
-    hf_config = getattr(model_config, "hf_config", None)
-    architectures: list[str] = []
-    for source in (model_config, hf_config):
-        values = getattr(source, "architectures", None)
-        if isinstance(values, (list, tuple)):
-            architectures.extend(str(arch) for arch in values)
-    if any(is_encoder_embedding_architecture(arch) for arch in architectures):
-        return True
-    model_type = getattr(hf_config, "model_type", None)
-    return is_encoder_embedding_model_type(
-        str(model_type) if model_type is not None else None
-    )
-
-
-def requires_mlx_embeddings_load(model_config: Any) -> bool:
-    """True when Metal should load weights through mlx-embeddings."""
-    return is_encoder_embedding_config(model_config)
+_ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 
 
 class _EncoderSequenceBody:
@@ -79,9 +51,7 @@ class _EncoderSequenceBody:
 
 
 class MlxEmbeddingsEncoderModel:
-    """Thin adapter so Metal pooling can use mlx-embeddings models."""
-
-    is_mlx_embeddings_encoder = True
+    """Weight wrapper exposing a Metal-compatible ``.model`` body."""
 
     def __init__(self, model: Any) -> None:
         self._model = model
@@ -109,17 +79,131 @@ def _import_mlx_embeddings_load() -> Any:
     return mlx_embeddings_load
 
 
+class EncoderEmbeddingAdapter:
+    """Single owner for mlx-embeddings encoder embedding behavior on Metal."""
+
+    skip_paged_attention_patch = True
+    default_sequence_pooling_type = "CLS"
+    allowed_sequence_pooling_types = _ENCODER_SEQUENCE_POOLING
+
+    def __init__(self, model: MlxEmbeddingsEncoderModel) -> None:
+        self.model = model
+
+    @staticmethod
+    def matches_architecture(architecture: str) -> bool:
+        return architecture in _ENCODER_EMBEDDING_ARCHITECTURES
+
+    @staticmethod
+    def matches_model_type(model_type: str | None) -> bool:
+        if model_type is None:
+            return False
+        return model_type.replace("_", "-") in {
+            value.replace("_", "-") for value in _ENCODER_EMBEDDING_MODEL_TYPES
+        }
+
+    @classmethod
+    def matches_config(cls, model_config: Any) -> bool:
+        """Return whether vLLM resolved this as an encoder embedding checkpoint."""
+        hf_config = getattr(model_config, "hf_config", None)
+        architectures: list[str] = []
+        for source in (model_config, hf_config):
+            values = getattr(source, "architectures", None)
+            if isinstance(values, (list, tuple)):
+                architectures.extend(str(arch) for arch in values)
+        if any(cls.matches_architecture(arch) for arch in architectures):
+            return True
+        model_type = getattr(hf_config, "model_type", None)
+        return cls.matches_model_type(
+            str(model_type) if model_type is not None else None
+        )
+
+    @classmethod
+    def requires_load(cls, model_config: Any) -> bool:
+        """True when Metal should load weights through mlx-embeddings."""
+        return cls.matches_config(model_config)
+
+    @classmethod
+    def load(
+        cls,
+        model_name: str,
+        *,
+        tokenizer_config: dict[str, Any] | None = None,
+        lazy: bool = False,
+    ) -> tuple[MlxEmbeddingsEncoderModel, Any, EncoderEmbeddingAdapter]:
+        """Load an encoder embedding checkpoint and return model + adapter."""
+        mlx_embeddings_load = _import_mlx_embeddings_load()
+        raw_model, tokenizer = mlx_embeddings_load(
+            model_name,
+            tokenizer_config=dict(tokenizer_config or {}),
+            lazy=lazy,
+        )
+        model = MlxEmbeddingsEncoderModel(raw_model)
+        return model, tokenizer, cls(model)
+
+    @classmethod
+    def from_loaded_model(cls, model: Any) -> EncoderEmbeddingAdapter | None:
+        """Return an adapter when ``model`` is the encoder weight wrapper."""
+        if isinstance(model, MlxEmbeddingsEncoderModel):
+            return cls(model)
+        return None
+
+    def forward_sequence_hidden_states(
+        self,
+        input_ids: mx.array,
+        *,
+        segment_lengths: list[int] | None = None,
+        model_label: str = "encoder-embedding",
+    ) -> mx.array:
+        """Forward each packed segment independently (bidirectional)."""
+        body = self.model.model
+        flat = input_ids.reshape(-1)
+        total_tokens = int(flat.shape[0])
+        if not segment_lengths:
+            segment_lengths = [total_tokens]
+        if sum(segment_lengths) != total_tokens:
+            raise ValueError(
+                "Encoder pooling segment_lengths "
+                f"{segment_lengths!r} do not cover input tokens "
+                f"{total_tokens} for model={model_label}."
+            )
+
+        parts: list[mx.array] = []
+        offset = 0
+        for length in segment_lengths:
+            segment = flat[offset : offset + length].reshape(1, length)
+            parts.append(body(segment))
+            offset += length
+        if len(parts) == 1:
+            return parts[0]
+        return mx.concatenate(parts, axis=1)
+
+
+# Compatibility aliases used by older call sites / tests.
+def is_encoder_embedding_architecture(architecture: str) -> bool:
+    return EncoderEmbeddingAdapter.matches_architecture(architecture)
+
+
+def is_encoder_embedding_model_type(model_type: str | None) -> bool:
+    return EncoderEmbeddingAdapter.matches_model_type(model_type)
+
+
+def is_encoder_embedding_config(model_config: Any) -> bool:
+    return EncoderEmbeddingAdapter.matches_config(model_config)
+
+
+def requires_mlx_embeddings_load(model_config: Any) -> bool:
+    return EncoderEmbeddingAdapter.requires_load(model_config)
+
+
 def load_mlx_embeddings_model(
     model_name: str,
     *,
     tokenizer_config: dict[str, Any] | None = None,
     lazy: bool = False,
 ) -> tuple[MlxEmbeddingsEncoderModel, Any]:
-    """Load an encoder embedding checkpoint through mlx-embeddings."""
-    mlx_embeddings_load = _import_mlx_embeddings_load()
-    model, tokenizer = mlx_embeddings_load(
+    model, tokenizer, _adapter = EncoderEmbeddingAdapter.load(
         model_name,
-        tokenizer_config=dict(tokenizer_config or {}),
+        tokenizer_config=tokenizer_config,
         lazy=lazy,
     )
-    return MlxEmbeddingsEncoderModel(model), tokenizer
+    return model, tokenizer

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -7,9 +7,14 @@ attention patch-skipping so encoder special-cases stay in one place.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import mlx.core as mx
+import torch
+from huggingface_hub import hf_hub_download
+
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 
 _ENCODER_EMBEDDING_ARCHITECTURES = frozenset(
     {
@@ -27,6 +32,139 @@ _ENCODER_EMBEDDING_MODEL_TYPES = frozenset(
     }
 )
 _ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
+_BGE_M3_SPARSE_MODEL_ID = "mlx-community/bge-m3-mlx-8bit"
+_BGE_M3_SPARSE_HEAD_REPO_ID = "BAAI/bge-m3"
+_BGE_M3_SPARSE_HEAD_REVISION = "5617a9f61b028005a4858fdac845db406aefb181"
+_BGE_M3_SPARSE_HEAD_FILENAME = "sparse_linear.pt"
+
+
+class BgeM3SparseHead:
+    """Immutable MLX sparse lexical head owned by the encoder adapter."""
+
+    def __init__(
+        self,
+        *,
+        weight: mx.array,
+        bias: mx.array,
+        bos_token_id: int,
+        eos_token_id: int,
+    ) -> None:
+        if weight.ndim != 2 or tuple(weight.shape[:1]) != (1,):
+            raise ValueError(
+                "BGE-M3 sparse head weight must have shape [1, hidden], "
+                f"got {weight.shape}."
+            )
+        if bias.ndim != 1 or tuple(bias.shape) != (1,):
+            raise ValueError(
+                f"BGE-M3 sparse head bias must have shape [1], got {bias.shape}."
+            )
+        self._weight = weight.astype(mx.float32)
+        self._bias = bias.astype(mx.float32)
+        self._bos_token_id = bos_token_id
+        self._eos_token_id = eos_token_id
+
+    def supports_hidden_size(self, hidden_size: int) -> bool:
+        return int(self._weight.shape[1]) == hidden_size
+
+    def project_token_logits(self, hidden_states: mx.array) -> mx.array:
+        """Apply the sparse linear projection to packed token states once."""
+        if hidden_states.ndim != 2:
+            raise ValueError(
+                "BGE-M3 sparse pooling expected hidden states with shape "
+                f"[tokens, hidden], got {hidden_states.shape}."
+            )
+        if not self.supports_hidden_size(int(hidden_states.shape[1])):
+            raise ValueError(
+                "BGE-M3 sparse head hidden size does not match encoder output; "
+                f"head={self._weight.shape[1]}, hidden={hidden_states.shape[1]}."
+            )
+        return mx.squeeze(
+            hidden_states.astype(mx.float32) @ self._weight.T + self._bias,
+            axis=-1,
+        )
+
+    def filter_token_weights(
+        self,
+        token_logits: mx.array,
+        *,
+        token_ids: list[int],
+        use_activation: bool,
+    ) -> mx.array:
+        """Apply activation and remove matching boundary BOS/EOS rows."""
+        if token_logits.ndim != 1:
+            raise ValueError(
+                "BGE-M3 sparse pooling expected token logits with shape "
+                f"[tokens], got {token_logits.shape}."
+            )
+        if int(token_logits.shape[0]) != len(token_ids):
+            raise ValueError(
+                "BGE-M3 sparse pooling token IDs must align with hidden states; "
+                f"got {len(token_ids)} IDs for {token_logits.shape[0]} rows."
+            )
+
+        if use_activation:
+            token_logits = mx.maximum(
+                token_logits,
+                mx.array(0.0, dtype=mx.float32),
+            )
+
+        retained_start = 1 if token_ids[0] == self._bos_token_id else 0
+        retained_end = (
+            len(token_ids) - 1
+            if token_ids[-1] == self._eos_token_id
+            else len(token_ids)
+        )
+        retained_indices = list(range(retained_start, retained_end))
+        if not retained_indices:
+            return mx.zeros((0,), dtype=mx.float32)
+        return token_logits[mx.array(retained_indices, dtype=mx.int32)]
+
+
+def _load_bge_m3_sparse_head(model_config: Any) -> BgeM3SparseHead:
+    """Load the official BGE-M3 sparse head from a fixed upstream revision."""
+    hidden_size = getattr(model_config, "hidden_size", None)
+    bos_token_id = getattr(model_config, "bos_token_id", None)
+    eos_token_id = getattr(model_config, "eos_token_id", None)
+    if not all(
+        isinstance(value, int) for value in (hidden_size, bos_token_id, eos_token_id)
+    ):
+        raise ValueError(
+            "BGE-M3 sparse pooling requires integer hidden_size, bos_token_id, "
+            "and eos_token_id in the encoder config."
+        )
+
+    head_path = hf_hub_download(
+        repo_id=_BGE_M3_SPARSE_HEAD_REPO_ID,
+        filename=_BGE_M3_SPARSE_HEAD_FILENAME,
+        revision=_BGE_M3_SPARSE_HEAD_REVISION,
+    )
+    state = torch.load(head_path, map_location="cpu", weights_only=True)
+    if not isinstance(state, Mapping):
+        raise ValueError("BGE-M3 sparse_linear.pt must contain a state mapping.")
+    weight = state.get("weight")
+    bias = state.get("bias")
+    if not isinstance(weight, torch.Tensor) or not isinstance(bias, torch.Tensor):
+        raise ValueError(
+            "BGE-M3 sparse_linear.pt must contain tensor 'weight' and 'bias'."
+        )
+    if not weight.is_floating_point() or not bias.is_floating_point():
+        raise ValueError(
+            "BGE-M3 sparse_linear.pt weight and bias must be floating point."
+        )
+    if not torch.isfinite(weight).all() or not torch.isfinite(bias).all():
+        raise ValueError("BGE-M3 sparse_linear.pt weight and bias must be finite.")
+    if tuple(weight.shape) != (1, hidden_size) or tuple(bias.shape) != (1,):
+        raise ValueError(
+            "BGE-M3 sparse_linear.pt shape does not match the encoder; "
+            f"weight={tuple(weight.shape)}, bias={tuple(bias.shape)}, "
+            f"hidden_size={hidden_size}."
+        )
+    return BgeM3SparseHead(
+        weight=torch_to_mlx(weight.float()),
+        bias=torch_to_mlx(bias.float()),
+        bos_token_id=bos_token_id,
+        eos_token_id=eos_token_id,
+    )
 
 
 class _EncoderSequenceBody:
@@ -53,11 +191,17 @@ class _EncoderSequenceBody:
 class MlxEmbeddingsEncoderModel:
     """Weight wrapper exposing a Metal-compatible ``.model`` body."""
 
-    def __init__(self, model: Any) -> None:
+    def __init__(
+        self,
+        model: Any,
+        *,
+        sparse_head: BgeM3SparseHead | None = None,
+    ) -> None:
         self._model = model
         self.config = getattr(model, "config", None)
         self.args = self.config
         self.model = _EncoderSequenceBody(model)
+        self.sparse_head = sparse_head
 
     def modules(self) -> list[Any]:
         """Expose child modules for vLLM engine cleanup hooks."""
@@ -86,8 +230,14 @@ class EncoderEmbeddingAdapter:
     default_sequence_pooling_type = "CLS"
     allowed_sequence_pooling_types = _ENCODER_SEQUENCE_POOLING
 
-    def __init__(self, model: MlxEmbeddingsEncoderModel) -> None:
+    def __init__(
+        self,
+        model: MlxEmbeddingsEncoderModel,
+        *,
+        sparse_head: BgeM3SparseHead | None = None,
+    ) -> None:
         self.model = model
+        self.sparse_head = sparse_head or model.sparse_head
 
     @staticmethod
     def matches_architecture(architecture: str) -> bool:
@@ -122,22 +272,48 @@ class EncoderEmbeddingAdapter:
         """True when Metal should load weights through mlx-embeddings."""
         return cls.matches_config(model_config)
 
+    @staticmethod
+    def requests_token_classify(model_config: Any | None) -> bool:
+        pooler_config = getattr(model_config, "pooler_config", None)
+        return getattr(pooler_config, "task", None) == "token_classify"
+
+    @staticmethod
+    def supports_sparse_model_config(model_config: Any | None) -> bool:
+        return getattr(model_config, "model", None) == _BGE_M3_SPARSE_MODEL_ID
+
+    @property
+    def supports_token_classify(self) -> bool:
+        return self.sparse_head is not None
+
     @classmethod
     def load(
         cls,
         model_name: str,
         *,
+        model_config: Any | None = None,
         tokenizer_config: dict[str, Any] | None = None,
         lazy: bool = False,
     ) -> tuple[MlxEmbeddingsEncoderModel, Any, EncoderEmbeddingAdapter]:
         """Load an encoder embedding checkpoint and return model + adapter."""
+        load_sparse_head = cls.requests_token_classify(model_config)
+        if load_sparse_head and not cls.supports_sparse_model_config(model_config):
+            raise NotImplementedError(
+                "BGE-M3 sparse token classification currently supports only "
+                f"{_BGE_M3_SPARSE_MODEL_ID!r}."
+            )
+
         mlx_embeddings_load = _import_mlx_embeddings_load()
         raw_model, tokenizer = mlx_embeddings_load(
             model_name,
             tokenizer_config=dict(tokenizer_config or {}),
             lazy=lazy,
         )
-        model = MlxEmbeddingsEncoderModel(raw_model)
+        sparse_head = (
+            _load_bge_m3_sparse_head(getattr(model_config, "hf_config", None))
+            if load_sparse_head
+            else None
+        )
+        model = MlxEmbeddingsEncoderModel(raw_model, sparse_head=sparse_head)
         return model, tokenizer, cls(model)
 
     @classmethod
@@ -176,6 +352,29 @@ class EncoderEmbeddingAdapter:
         if len(parts) == 1:
             return parts[0]
         return mx.concatenate(parts, axis=1)
+
+    def sparse_token_logits(self, hidden_states: mx.array) -> mx.array:
+        return self._require_sparse_head().project_token_logits(hidden_states)
+
+    def filter_sparse_token_weights(
+        self,
+        token_logits: mx.array,
+        *,
+        token_ids: list[int],
+        use_activation: bool,
+    ) -> mx.array:
+        return self._require_sparse_head().filter_token_weights(
+            token_logits,
+            token_ids=token_ids,
+            use_activation=use_activation,
+        )
+
+    def _require_sparse_head(self) -> BgeM3SparseHead:
+        if self.sparse_head is None:
+            raise NotImplementedError(
+                "BGE-M3 token_classify requires a loaded sparse head."
+            )
+        return self.sparse_head
 
 
 # Compatibility aliases used by older call sites / tests.

--- a/vllm_metal/v1/encoder_embeddings.py
+++ b/vllm_metal/v1/encoder_embeddings.py
@@ -89,6 +89,13 @@ class MlxEmbeddingsEncoderModel:
         self.args = self.config
         self.model = _EncoderSequenceBody(model)
 
+    def modules(self) -> list[Any]:
+        """Expose child modules for vLLM engine cleanup hooks."""
+        inner_modules = getattr(self._model, "modules", None)
+        if callable(inner_modules):
+            return list(inner_modules())
+        return [self._model]
+
 
 def _import_mlx_embeddings_load() -> Any:
     try:

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -19,10 +19,7 @@ from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
 from vllm_metal.utils import get_model_download_path
-from vllm_metal.v1.encoder_embeddings import (
-    load_mlx_embeddings_model,
-    requires_mlx_embeddings_load,
-)
+from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
 from vllm_metal.v1.mlx_lm_paths import (
     mlx_lm_compatible_model_path as _mlx_lm_compatible_model_path,
@@ -219,7 +216,7 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
-        elif requires_mlx_embeddings_load(model_config):
+        elif EncoderEmbeddingAdapter.requires_load(model_config):
             load_label = "MLX-Embeddings model"
             model, tokenizer = self._load_mlx_embeddings_model(
                 model_name,
@@ -300,11 +297,15 @@ class ModelLifecycle:
         *,
         lazy: bool = False,
     ) -> tuple[Any, Any]:
-        return load_mlx_embeddings_model(
+        model, tokenizer, adapter = EncoderEmbeddingAdapter.load(
             model_name,
             tokenizer_config=dict(tokenizer_config),
             lazy=lazy,
         )
+        # Stash for _install_generation_model; avoids a second from_loaded_model
+        # dance when the load path already constructed the adapter.
+        self._pending_encoder_embedding_adapter = adapter
+        return model, tokenizer
 
     def _install_generation_model(
         self,
@@ -329,6 +330,12 @@ class ModelLifecycle:
         runner._multimodal_adapter = multimodal_adapter
         runner.encoder_cache = (
             EncoderCache() if multimodal_adapter is not None else None
+        )
+
+        pending = getattr(self, "_pending_encoder_embedding_adapter", None)
+        self._pending_encoder_embedding_adapter = None
+        runner._encoder_embedding_adapter = pending or (
+            EncoderEmbeddingAdapter.from_loaded_model(loaded_model.model)
         )
 
         # Dimension resolution reads model_args immediately after this phase.

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -19,6 +19,10 @@ from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
 from vllm_metal.quant.awq_loader import AWQQuantLoader
 from vllm_metal.utils import get_model_download_path
+from vllm_metal.v1.encoder_embeddings import (
+    load_mlx_embeddings_model,
+    requires_mlx_embeddings_load,
+)
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPAssistantLoader
 from vllm_metal.v1.mlx_lm_paths import (
     mlx_lm_compatible_model_path as _mlx_lm_compatible_model_path,
@@ -215,6 +219,14 @@ class ModelLifecycle:
                 tokenizer_config,
             )
 
+        elif requires_mlx_embeddings_load(model_config):
+            load_label = "MLX-Embeddings model"
+            model, tokenizer = self._load_mlx_embeddings_model(
+                model_name,
+                tokenizer_config,
+                lazy=lazy_weights,
+            )
+
         else:
             load_label = "MLX-LM model"
             model, tokenizer = self._load_mlx_lm_text_model(
@@ -280,6 +292,19 @@ class ModelLifecycle:
                 lazy=lazy,
             )
         return model, tokenizer
+
+    def _load_mlx_embeddings_model(
+        self,
+        model_name: str,
+        tokenizer_config: Mapping[str, Any],
+        *,
+        lazy: bool = False,
+    ) -> tuple[Any, Any]:
+        return load_mlx_embeddings_model(
+            model_name,
+            tokenizer_config=dict(tokenizer_config),
+            lazy=lazy,
+        )
 
     def _install_generation_model(
         self,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -221,6 +221,7 @@ class ModelLifecycle:
             model, tokenizer = self._load_mlx_embeddings_model(
                 model_name,
                 tokenizer_config,
+                model_config=model_config,
                 lazy=lazy_weights,
             )
 
@@ -295,10 +296,12 @@ class ModelLifecycle:
         model_name: str,
         tokenizer_config: Mapping[str, Any],
         *,
+        model_config: Any | None = None,
         lazy: bool = False,
     ) -> tuple[Any, Any]:
         model, tokenizer, adapter = EncoderEmbeddingAdapter.load(
             model_name,
+            model_config=model_config,
             tokenizer_config=dict(tokenizer_config),
             lazy=lazy,
         )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -104,6 +104,7 @@ from vllm_metal.v1.pooling import (
     pooling_dummy_forward_outputs,
     supported_pooling_tasks,
     validate_pooling_request,
+    validate_token_classify_prefill,
 )
 from vllm_metal.v1.proposer import (
     Gemma4MTPProposer,
@@ -495,7 +496,10 @@ class MetalModelRunner:
             if self._paged_attention_runtime is None:
                 return ()
             return supported_pooling_tasks(
-                self._forward_model, self.model_config, self.tokenizer
+                self._forward_model,
+                self.model_config,
+                self.tokenizer,
+                self._encoder_embedding_adapter,
             )
         return ("generate",)
 
@@ -1403,6 +1407,7 @@ class MetalModelRunner:
                 model=self._forward_model,
                 tokenizer=self.tokenizer,
                 model_config=self.model_config,
+                encoder_adapter=self._encoder_embedding_adapter,
             )
             return batch, scheduler_output
 
@@ -2017,6 +2022,7 @@ class MetalModelRunner:
                 new_req,
                 self.model_config,
                 paged_attention_enabled=self._paged_attention_runtime is not None,
+                encoder_adapter=self._encoder_embedding_adapter,
             )
 
             # mm_features were pre-registered before encoder dispatch in
@@ -2042,6 +2048,14 @@ class MetalModelRunner:
                 scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
                 computed_tokens = new_req.num_computed_tokens
                 prompt_len = len(token_ids)
+                validate_token_classify_prefill(
+                    pooling_params,
+                    req_id=req_id,
+                    num_computed_tokens=computed_tokens,
+                    num_scheduled_tokens=scheduled_tokens,
+                    prompt_len=prompt_len,
+                    cached_request=False,
+                )
                 cur_len = computed_tokens + scheduled_tokens
                 is_intermediate = cur_len < prompt_len
 
@@ -2098,6 +2112,42 @@ class MetalModelRunner:
                 generated_tokens=1,
                 block_ids=[],
                 lora_id=lora_id,
+            )
+
+    def _validate_token_classify_scheduler_output(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> None:
+        """Reject partial or cached token pooling before request mutation."""
+        for new_req in scheduler_output.scheduled_new_reqs:
+            pooling_params = new_req.pooling_params
+            if pooling_params is None or pooling_params.task != "token_classify":
+                continue
+            token_ids = new_req.prompt_token_ids or []
+            validate_token_classify_prefill(
+                pooling_params,
+                req_id=new_req.req_id,
+                num_computed_tokens=new_req.num_computed_tokens,
+                num_scheduled_tokens=scheduler_output.num_scheduled_tokens[
+                    new_req.req_id
+                ],
+                prompt_len=len(token_ids),
+                cached_request=False,
+            )
+
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        for idx, req_id in enumerate(cached_reqs.req_ids):
+            state = self._request_states[req_id]
+            pooling_params = state.pooling_params
+            if pooling_params is None or pooling_params.task != "token_classify":
+                continue
+            validate_token_classify_prefill(
+                pooling_params,
+                req_id=req_id,
+                num_computed_tokens=cached_reqs.num_computed_tokens[idx],
+                num_scheduled_tokens=scheduler_output.num_scheduled_tokens[req_id],
+                prompt_len=state.prompt_len,
+                cached_request=True,
             )
 
     def _update_pp_stage_states(self, scheduler_output: SchedulerOutput) -> None:
@@ -2202,6 +2252,14 @@ class MetalModelRunner:
                 computed_tokens = cached_reqs.num_computed_tokens[idx]
                 scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
                 target_len = computed_tokens + scheduled_tokens
+                validate_token_classify_prefill(
+                    state.pooling_params,
+                    req_id=req_id,
+                    num_computed_tokens=computed_tokens,
+                    num_scheduled_tokens=scheduled_tokens,
+                    prompt_len=state.prompt_len,
+                    cached_request=True,
+                )
                 is_intermediate = target_len < len(state.token_ids)
 
                 output_idx = batch.add_output(req_id, [])
@@ -2459,6 +2517,12 @@ class MetalModelRunner:
             self._validate_spec_decode_supported(scheduler_output)
         except (NotImplementedError, ValueError) as exc:
             spec_decode_error = exc
+        token_classify_schedule_error: Exception | None = None
+        if not missing_cached_state_req_ids:
+            try:
+                self._validate_token_classify_scheduler_output(scheduler_output)
+            except (NotImplementedError, ValueError) as exc:
+                token_classify_schedule_error = exc
         has_unsupported_non_paged_structured_output = (
             self._paged_attention_runtime is None
             and scheduler_output.has_structured_output_requests
@@ -2466,6 +2530,7 @@ class MetalModelRunner:
         will_fail_fast_before_model_work = (
             has_scheduled_encoder_inputs
             or spec_decode_error is not None
+            or token_classify_schedule_error is not None
             or has_unsupported_non_paged_structured_output
             or bool(missing_cached_state_req_ids)
         )
@@ -2485,6 +2550,8 @@ class MetalModelRunner:
                 f"{missing_cached_state_req_ids[:16]}. "
                 "This is a scheduler/runner state desync."
             )
+        if token_classify_schedule_error is not None:
+            raise token_classify_schedule_error
         # Pre-register mm_features so a new request whose first encoder input
         # lands in the same SchedulerOutput is already known to the encoder
         # cache when dispatch runs.

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1211,6 +1211,7 @@ class MetalModelRunner:
                     input_ids,
                     cache=offset_caches,
                     model_config=self.model_config,
+                    segment_lengths=[len(pr.token_ids) for pr in prefill_reqs],
                 )
             elif use_mm_forward:
                 model_output, mm_prefill_deltas = self._run_mm_paged_forward(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -83,6 +83,7 @@ from vllm_metal.v1.decode_pipeline import (
     SamplingShape,
     SchedulerStepShape,
 )
+from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 from vllm_metal.v1.gemma4_mtp import (
     Gemma4MTPAssistantRuntime,
     Gemma4MTPAssistantSource,
@@ -322,6 +323,7 @@ class MetalModelRunner:
             getattr(self.model_config, "runner_type", None) == "pooling"
         )
         self._multimodal_adapter: MultimodalRuntimeAdapter | None = None
+        self._encoder_embedding_adapter: EncoderEmbeddingAdapter | None = None
         self._gemma4_mtp_assistant: Gemma4MTPAssistantRuntime | None = None
         self._drafter: MetalProposer | None = None
         self.encoder_cache: EncoderCache | None = None
@@ -704,6 +706,7 @@ class MetalModelRunner:
                 self._forward_model,
                 input_ids,
                 model_config=self.model_config,
+                encoder_adapter=self._encoder_embedding_adapter,
             )
 
         if self.pp is not None and self.pp.size > 1:
@@ -1212,6 +1215,7 @@ class MetalModelRunner:
                     cache=offset_caches,
                     model_config=self.model_config,
                     segment_lengths=[len(pr.token_ids) for pr in prefill_reqs],
+                    encoder_adapter=self._encoder_embedding_adapter,
                 )
             elif use_mm_forward:
                 model_output, mm_prefill_deltas = self._run_mm_paged_forward(

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -16,7 +16,8 @@ from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 
 _EMBED_POOLER_TASKS = (None, "embed")
 _CLASSIFY_POOLER_TASKS = (None, "classify")
-_SUPPORTED_POOLER_TASKS = (None, "embed", "classify")
+_TOKEN_CLASSIFY_POOLER_TASKS = (None, "token_classify")
+_SUPPORTED_POOLER_TASKS = (None, "embed", "classify", "token_classify")
 _LAST_POOLING = (None, "LAST")
 _QWEN3_RERANKER_TOKENS = ("no", "yes")
 
@@ -113,7 +114,8 @@ def _reject_unsupported_pooler_config(model_config: Any) -> None:
     if task not in _SUPPORTED_POOLER_TASKS:
         raise NotImplementedError(
             "Metal pooling supports only pooler_config.task unset, 'embed', "
-            f"or 'classify'; got {task!r} for model={_model_label(model_config)}."
+            f"'classify', or 'token_classify'; got {task!r} for "
+            f"model={_model_label(model_config)}."
         )
 
     seq_pooling_type = _unsupported_sequence_pooling_type(model_config)
@@ -267,10 +269,29 @@ def supports_classify_pooling(
     )
 
 
+def supports_token_classify_pooling(
+    model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None,
+) -> bool:
+    """Return whether the loaded adapter owns a BGE-M3 sparse head."""
+    if getattr(model_config, "multimodal_config", None) is not None:
+        return False
+    if _pooler_task(model_config) not in _TOKEN_CLASSIFY_POOLER_TASKS:
+        return False
+    if _chunked_processing_enabled(model_config):
+        return False
+    return bool(
+        EncoderEmbeddingAdapter.supports_sparse_model_config(model_config)
+        and encoder_adapter is not None
+        and encoder_adapter.supports_token_classify
+    )
+
+
 def supported_pooling_tasks(
     model: Any,
     model_config: Any,
     tokenizer: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> tuple[SupportedTask, ...]:
     """Return Metal pooling tasks supported by this loaded model."""
     tasks: list[SupportedTask] = []
@@ -278,6 +299,8 @@ def supported_pooling_tasks(
         tasks.append("embed")
     if supports_classify_pooling(model, model_config, tokenizer):
         tasks.append("classify")
+    if supports_token_classify_pooling(model_config, encoder_adapter):
+        tasks.append("token_classify")
     return tuple(tasks)
 
 
@@ -287,7 +310,7 @@ def _unsupported_pooling_option(
 ) -> str | None:
     if pooling_params.late_interaction_params is not None:
         return "late-interaction parameters"
-    if pooling_params.requires_token_ids:
+    if pooling_params.requires_token_ids and pooling_params.task != "token_classify":
         return "token-level ALL pooling outputs"
     if pooling_params.step_tag_id is not None:
         return "STEP pooling parameters"
@@ -295,7 +318,10 @@ def _unsupported_pooling_option(
         return "returned_token_ids"
     if pooling_params.extra_kwargs:
         return "extra pooling kwargs"
-    if pooling_params.task != "classify" and pooling_params.use_activation is False:
+    if (
+        pooling_params.task not in ("classify", "token_classify")
+        and pooling_params.use_activation is False
+    ):
         return "use_activation=False"
     if (
         pooling_params.dimensions is not None
@@ -308,6 +334,7 @@ def _unsupported_pooling_option(
 def validate_pooling_params(
     pooling_params: PoolingParams,
     model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> None:
     """Validate the narrow text-only Metal pooling contract."""
     model = _model_label(model_config)
@@ -339,16 +366,16 @@ def validate_pooling_params(
                 f"{model}."
             )
     elif task == "token_classify":
-        raise NotImplementedError(
-            "Metal pooling does not yet support task='token_classify' "
-            "(BGE-M3 sparse lexical weights). Dense embed for encoder models "
-            "is supported; sparse token_classify is tracked as a follow-up "
-            f"to #589 for model={model}."
-        )
+        if not supports_token_classify_pooling(model_config, encoder_adapter):
+            raise NotImplementedError(
+                "Metal token_classify requires the supported BGE-M3 encoder "
+                f"and a loaded sparse head; model={model}."
+            )
     else:
         raise NotImplementedError(
-            "Metal pooling supports only text-only task='embed' and the "
-            "Qwen3 reranker task='classify' for now; "
+            "Metal pooling supports only text-only task='embed', the "
+            "Qwen3 reranker task='classify', and supported BGE-M3 "
+            "task='token_classify'; "
             f"got task={task!r} for model={model}."
         )
 
@@ -364,13 +391,18 @@ def validate_pooling_request(
     model_config: Any,
     *,
     paged_attention_enabled: bool,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> None:
     """Validate the request-level contract for Metal text pooling."""
     pooling_params = new_req.pooling_params
     if pooling_params is None:
         return
 
-    validate_pooling_params(pooling_params, model_config)
+    validate_pooling_params(
+        pooling_params,
+        model_config,
+        encoder_adapter=encoder_adapter,
+    )
     if new_req.mm_features:
         raise NotImplementedError(
             "Multimodal pooling inputs are not supported on Metal yet."
@@ -387,6 +419,26 @@ def validate_pooling_request(
     if not (new_req.prompt_token_ids or []):
         raise ValueError(
             f"Metal pooling requires prompt_token_ids for request {new_req.req_id!r}."
+        )
+
+
+def validate_token_classify_prefill(
+    pooling_params: PoolingParams | None,
+    *,
+    req_id: str,
+    num_computed_tokens: int,
+    num_scheduled_tokens: int,
+    prompt_len: int,
+    cached_request: bool,
+) -> None:
+    """Reject partial token pooling before encoder work is constructed."""
+    if pooling_params is None or pooling_params.task != "token_classify":
+        return
+    if cached_request or num_computed_tokens != 0 or num_scheduled_tokens != prompt_len:
+        raise NotImplementedError(
+            "Metal token_classify requires one complete, uncached prefill; "
+            f"request={req_id!r}, computed={num_computed_tokens}, "
+            f"scheduled={num_scheduled_tokens}, prompt_len={prompt_len}."
         )
 
 
@@ -503,6 +555,20 @@ def _classifier_use_activation(
     return getattr(_pooler_config(model_config), "use_activation", None) is not False
 
 
+def _calibrate_classifier_logits(
+    logits: mx.array,
+    model_config: Any,
+) -> mx.array:
+    pooler_config = _pooler_config(model_config)
+    logit_mean = getattr(pooler_config, "logit_mean", None)
+    logit_sigma = getattr(pooler_config, "logit_sigma", None)
+    if logit_mean is not None:
+        logits = logits - float(logit_mean)
+    if logit_sigma is not None:
+        logits = logits / float(logit_sigma)
+    return logits
+
+
 def pool_sequence_classification(
     hidden_states: mx.array,
     *,
@@ -546,14 +612,9 @@ def pool_sequence_classification(
         )
 
     token_logits = vocab_logits[mx.array([no_id, yes_id], dtype=mx.int32)]
-    score = token_logits[1] - token_logits[0]
-    pooler_config = _pooler_config(model_config)
-    logit_mean = getattr(pooler_config, "logit_mean", None)
-    logit_sigma = getattr(pooler_config, "logit_sigma", None)
-    if logit_mean is not None:
-        score = score - float(logit_mean)
-    if logit_sigma is not None:
-        score = score / float(logit_sigma)
+    score = _calibrate_classifier_logits(
+        token_logits[1] - token_logits[0], model_config
+    )
     if _classifier_use_activation(pooling_params, model_config):
         score = mx.sigmoid(score)
 
@@ -561,19 +622,65 @@ def pool_sequence_classification(
     return tensor.detach().clone()
 
 
+def pool_bge_m3_token_classification(
+    sparse_logits: mx.array,
+    *,
+    token_span: tuple[int, int],
+    token_ids: list[int],
+    pooling_params: PoolingParams,
+    model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None,
+) -> torch.Tensor:
+    """Return per-token BGE-M3 lexical weights for one complete request."""
+    if encoder_adapter is None or not encoder_adapter.supports_token_classify:
+        raise NotImplementedError(
+            "Metal token_classify requires a loaded BGE-M3 sparse head."
+        )
+
+    start, end = token_span
+    if start < 0 or end < start or end > sparse_logits.shape[0]:
+        raise ValueError(
+            f"Metal token_classify span {token_span!r} is outside sparse logit "
+            f"shape {sparse_logits.shape} for model={_model_label(model_config)}."
+        )
+    calibrated_logits = _calibrate_classifier_logits(
+        sparse_logits[start:end],
+        model_config,
+    )
+    weights = encoder_adapter.filter_sparse_token_weights(
+        calibrated_logits,
+        token_ids=token_ids,
+        use_activation=_classifier_use_activation(pooling_params, model_config),
+    )
+    if weights.size == 0:
+        return torch.empty((0,), dtype=torch.float32, device="cpu")
+    tensor = mlx_to_torch(mx.contiguous(weights), device="cpu", already_contiguous=True)
+    return tensor.detach().clone()
+
+
 def pool_sequence_batch(
     hidden_states: mx.array,
     *,
     token_indices: list[int | None],
+    token_spans: list[tuple[int, int] | None],
+    prompt_token_ids: list[list[int]],
     pooling_params: list[PoolingParams],
     model: Any,
     tokenizer: Any,
     model_config: Any,
+    sparse_logits: mx.array | None = None,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> list[torch.Tensor | None]:
     """Pool a paged prefill batch; unfinished chunks return ``None``."""
     outputs: list[torch.Tensor | None] = []
-    for token_index, params in zip(token_indices, pooling_params, strict=True):
-        if token_index is None:
+    for token_index, token_span, token_ids, params in zip(
+        token_indices,
+        token_spans,
+        prompt_token_ids,
+        pooling_params,
+        strict=True,
+    ):
+        if token_index is None and token_span is None:
             outputs.append(None)
             continue
         task = params.task
@@ -586,6 +693,7 @@ def pool_sequence_batch(
                 )
             )
         elif task == "classify":
+            assert token_index is not None
             outputs.append(
                 pool_sequence_classification(
                     hidden_states,
@@ -596,10 +704,27 @@ def pool_sequence_batch(
                     model_config=model_config,
                 )
             )
+        elif task == "token_classify":
+            assert token_span is not None
+            if sparse_logits is None:
+                raise RuntimeError(
+                    "Metal token_classify batch is missing packed sparse logits."
+                )
+            outputs.append(
+                pool_bge_m3_token_classification(
+                    sparse_logits,
+                    token_span=token_span,
+                    token_ids=token_ids,
+                    pooling_params=params,
+                    model_config=model_config,
+                    encoder_adapter=encoder_adapter,
+                )
+            )
         else:
             raise NotImplementedError(
-                "Metal pooling supports only text-only task='embed' and the "
-                "Qwen3 reranker task='classify' for now; "
+                "Metal pooling supports only text-only task='embed', the "
+                "Qwen3 reranker task='classify', and supported BGE-M3 "
+                "task='token_classify'; "
                 f"got task={task!r} for model={_model_label(model_config)}."
             )
     return outputs
@@ -614,11 +739,12 @@ def pool_paged_prefill_batch(
     model: Any,
     tokenizer: Any,
     model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> list[torch.Tensor | None]:
     """Pool a paged prefill batch; unfinished chunks return ``None``."""
-    mx.eval(hidden_states)
-
     token_indices: list[int | None] = []
+    token_spans: list[tuple[int, int] | None] = []
+    prompt_token_ids: list[list[int]] = []
     pooling_params: list[PoolingParams] = []
     for i, entry in enumerate(prefill_entries):
         pooling_params_for_req = entry.prefill.pooling_params
@@ -627,6 +753,26 @@ def pool_paged_prefill_batch(
                 "Paged pooling batch contained a non-pooling prefill request."
             )
         pooling_params.append(pooling_params_for_req)
+        prompt_token_ids.append(entry.prefill.token_ids)
+
+        span_start = cu_seqlens[num_decode_segments + i]
+        span_end = cu_seqlens[num_decode_segments + i + 1]
+        if pooling_params_for_req.task == "token_classify":
+            prefill = entry.prefill
+            if (
+                entry.result_mode != "new_final"
+                or prefill.start_pos != 0
+                or prefill.prompt_len != len(prefill.token_ids)
+            ):
+                raise NotImplementedError(
+                    "Metal token_classify requires one complete, uncached prefill; "
+                    f"request={prefill.req_id!r}, mode={entry.result_mode!r}, "
+                    f"start_pos={prefill.start_pos}, prompt_len={prefill.prompt_len}, "
+                    f"forwarded={len(prefill.token_ids)}."
+                )
+            token_indices.append(None)
+            token_spans.append((span_start, span_end))
+            continue
 
         if entry.result_mode == "intermediate":
             token_indices.append(None)
@@ -634,14 +780,36 @@ def pool_paged_prefill_batch(
             token_indices.append(cu_seqlens[num_decode_segments + i])
         else:
             token_indices.append(cu_seqlens[num_decode_segments + i + 1] - 1)
+        token_spans.append(None)
+
+    sparse_logits = None
+    if any(params.task == "token_classify" for params in pooling_params):
+        if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
+            raise ValueError(
+                "Metal token_classify expected hidden states with shape "
+                f"[1, tokens, hidden], got {hidden_states.shape} "
+                f"for model={_model_label(model_config)}."
+            )
+        if encoder_adapter is None or not encoder_adapter.supports_token_classify:
+            raise NotImplementedError(
+                "Metal token_classify requires a loaded BGE-M3 sparse head."
+            )
+        sparse_logits = encoder_adapter.sparse_token_logits(hidden_states[0])
+        mx.eval(sparse_logits)
+    else:
+        mx.eval(hidden_states)
 
     return pool_sequence_batch(
         hidden_states,
         token_indices=token_indices,
+        token_spans=token_spans,
+        prompt_token_ids=prompt_token_ids,
         pooling_params=pooling_params,
         model=model,
         tokenizer=tokenizer,
         model_config=model_config,
+        sparse_logits=sparse_logits,
+        encoder_adapter=encoder_adapter,
     )
 
 
@@ -654,6 +822,7 @@ def finish_paged_pooling_batch(
     model: Any,
     tokenizer: Any,
     model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> None:
     """Convert final paged prefill hidden states into batch pooler outputs."""
     pooler_outputs = pool_paged_prefill_batch(
@@ -664,6 +833,7 @@ def finish_paged_pooling_batch(
         model=model,
         tokenizer=tokenizer,
         model_config=model_config,
+        encoder_adapter=encoder_adapter,
     )
     for entry, pooler_output in zip(
         batch.paged_prefill_entries, pooler_outputs, strict=True

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -12,11 +12,13 @@ from vllm.tasks import SupportedTask
 from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+from vllm_metal.v1.encoder_embeddings import is_encoder_embedding_config
 
 _EMBED_POOLER_TASKS = (None, "embed")
 _CLASSIFY_POOLER_TASKS = (None, "classify")
 _SUPPORTED_POOLER_TASKS = (None, "embed", "classify")
 _LAST_POOLING = (None, "LAST")
+_ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 _QWEN3_RERANKER_TOKENS = ("no", "yes")
 
 
@@ -62,9 +64,24 @@ def _sequence_pooling_types(model_config: Any) -> tuple[str | None, str | None]:
     )
 
 
-def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
+def _allowed_sequence_pooling_types(model_config: Any) -> tuple[str | None, ...]:
+    if is_encoder_embedding_config(model_config):
+        return _ENCODER_SEQUENCE_POOLING
+    return _LAST_POOLING
+
+
+def _effective_sequence_pooling_type(model_config: Any) -> str:
+    """Resolve the sequence pooling strategy Metal will apply."""
     for pooling_type in _sequence_pooling_types(model_config):
-        if pooling_type not in _LAST_POOLING:
+        if pooling_type is not None:
+            return pooling_type
+    return "CLS" if is_encoder_embedding_config(model_config) else "LAST"
+
+
+def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
+    allowed = _allowed_sequence_pooling_types(model_config)
+    for pooling_type in _sequence_pooling_types(model_config):
+        if pooling_type not in allowed:
             return pooling_type
     return None
 
@@ -100,8 +117,12 @@ def _reject_unsupported_pooler_config(model_config: Any) -> None:
 
     seq_pooling_type = _unsupported_sequence_pooling_type(model_config)
     if seq_pooling_type is not None:
+        allowed = ", ".join(
+            repr(value) for value in _allowed_sequence_pooling_types(model_config)
+        )
         raise NotImplementedError(
-            "Metal pooling currently supports only LAST sequence pooling; "
+            "Metal pooling currently supports only "
+            f"{allowed} sequence pooling for this model; "
             f"got {seq_pooling_type!r} for model={_model_label(model_config)}."
         )
     if _chunked_processing_enabled(model_config):
@@ -119,6 +140,12 @@ def _is_decoder_embedding_config(model_config: Any) -> bool:
         or arch.endswith("ForTextEncoding")
         or arch.endswith("EmbeddingModel")
         for arch in architectures
+    )
+
+
+def _is_embed_capable_config(model_config: Any) -> bool:
+    return _is_decoder_embedding_config(model_config) or is_encoder_embedding_config(
+        model_config
     )
 
 
@@ -170,7 +197,7 @@ def _classifier_logits_fn(model: Any, model_config: Any) -> Any | None:
 
 
 def supports_embed_pooling(model: Any, model_config: Any) -> bool:
-    """Return whether this loaded model can use Metal's LAST embed path."""
+    """Return whether this loaded model can use Metal's dense embed path."""
     if getattr(model_config, "multimodal_config", None) is not None:
         return False
     if _pooler_task(model_config) not in _EMBED_POOLER_TASKS:
@@ -181,9 +208,7 @@ def supports_embed_pooling(model: Any, model_config: Any) -> bool:
         return False
     if _chunked_processing_enabled(model_config):
         return False
-    return sequence_model(model) is not None and _is_decoder_embedding_config(
-        model_config
-    )
+    return sequence_model(model) is not None and _is_embed_capable_config(model_config)
 
 
 def _resolve_token_id(tokenizer: Any, token: str) -> int | None:
@@ -283,7 +308,7 @@ def validate_pooling_params(
     pooling_params: PoolingParams,
     model_config: Any,
 ) -> None:
-    """Validate the narrow text-only LAST pooling contract."""
+    """Validate the narrow text-only Metal pooling contract."""
     model = _model_label(model_config)
     if getattr(model_config, "runner_type", None) != "pooling":
         raise NotImplementedError(
@@ -294,9 +319,11 @@ def validate_pooling_params(
 
     task = pooling_params.task
     if task in (None, "embed"):
-        if not _is_decoder_embedding_config(model_config):
+        if not _is_embed_capable_config(model_config):
             raise NotImplementedError(
-                "Metal embed pooling requires a decoder-style checkpoint; got "
+                "Metal embed pooling requires a decoder-style embedding "
+                "checkpoint or an encoder embedding checkpoint "
+                "(XLM-RoBERTa / RoBERTa / BGE-M3); got "
                 f"architectures={_architecture_names(model_config)!r} for model="
                 f"{model}."
             )
@@ -310,6 +337,13 @@ def validate_pooling_params(
                 f"architectures={_architecture_names(model_config)!r} for model="
                 f"{model}."
             )
+    elif task == "token_classify":
+        raise NotImplementedError(
+            "Metal pooling does not yet support task='token_classify' "
+            "(BGE-M3 sparse lexical weights). Dense embed for encoder models "
+            "is supported; sparse token_classify is tracked as a follow-up "
+            f"to #589 for model={model}."
+        )
     else:
         raise NotImplementedError(
             "Metal pooling supports only text-only task='embed' and the "
@@ -361,6 +395,7 @@ def forward_sequence_hidden_states(
     *,
     cache: Any,
     model_config: Any,
+    segment_lengths: list[int] | None = None,
 ) -> mx.array:
     """Run the transformer body and return per-token hidden states."""
     _reject_unsupported_pooler_config(model_config)
@@ -372,7 +407,17 @@ def forward_sequence_hidden_states(
             "runner='pooling'."
         )
 
-    hidden_states = body(input_ids) if cache is None else body(input_ids, cache=cache)
+    if is_encoder_embedding_config(model_config):
+        hidden_states = _forward_encoder_sequence_hidden_states(
+            body,
+            input_ids,
+            segment_lengths=segment_lengths,
+            model_config=model_config,
+        )
+    else:
+        hidden_states = (
+            body(input_ids) if cache is None else body(input_ids, cache=cache)
+        )
 
     if not hasattr(hidden_states, "shape") or not hasattr(hidden_states, "dtype"):
         raise ValueError(
@@ -381,6 +426,36 @@ def forward_sequence_hidden_states(
             f"{_model_label(model_config)}."
         )
     return hidden_states
+
+
+def _forward_encoder_sequence_hidden_states(
+    body: Any,
+    input_ids: mx.array,
+    *,
+    segment_lengths: list[int] | None,
+    model_config: Any,
+) -> mx.array:
+    """Forward each packed encoder segment independently (bidirectional)."""
+    flat = input_ids.reshape(-1)
+    total_tokens = int(flat.shape[0])
+    if not segment_lengths:
+        segment_lengths = [total_tokens]
+    if sum(segment_lengths) != total_tokens:
+        raise ValueError(
+            "Encoder pooling segment_lengths "
+            f"{segment_lengths!r} do not cover input tokens "
+            f"{total_tokens} for model={_model_label(model_config)}."
+        )
+
+    parts: list[mx.array] = []
+    offset = 0
+    for length in segment_lengths:
+        segment = flat[offset : offset + length].reshape(1, length)
+        parts.append(body(segment))
+        offset += length
+    if len(parts) == 1:
+        return parts[0]
+    return mx.concatenate(parts, axis=1)
 
 
 def pooling_dummy_forward_outputs(
@@ -427,7 +502,7 @@ def pool_sequence_embedding(
     token_index: int,
     model_config: Any,
 ) -> torch.Tensor:
-    """Return a normalized CPU LAST embedding for one finished request."""
+    """Return a normalized CPU sequence embedding for one finished request."""
     if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
         raise ValueError(
             "Metal embed pooling expected hidden states with shape "
@@ -582,6 +657,8 @@ def pool_paged_prefill_batch(
 
         if entry.result_mode == "intermediate":
             token_indices.append(None)
+        elif _effective_sequence_pooling_type(model_config) == "CLS":
+            token_indices.append(cu_seqlens[num_decode_segments + i])
         else:
             token_indices.append(cu_seqlens[num_decode_segments + i + 1] - 1)
 

--- a/vllm_metal/v1/pooling.py
+++ b/vllm_metal/v1/pooling.py
@@ -12,13 +12,12 @@ from vllm.tasks import SupportedTask
 from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
-from vllm_metal.v1.encoder_embeddings import is_encoder_embedding_config
+from vllm_metal.v1.encoder_embeddings import EncoderEmbeddingAdapter
 
 _EMBED_POOLER_TASKS = (None, "embed")
 _CLASSIFY_POOLER_TASKS = (None, "classify")
 _SUPPORTED_POOLER_TASKS = (None, "embed", "classify")
 _LAST_POOLING = (None, "LAST")
-_ENCODER_SEQUENCE_POOLING = (None, "CLS", "LAST")
 _QWEN3_RERANKER_TOKENS = ("no", "yes")
 
 
@@ -65,8 +64,8 @@ def _sequence_pooling_types(model_config: Any) -> tuple[str | None, str | None]:
 
 
 def _allowed_sequence_pooling_types(model_config: Any) -> tuple[str | None, ...]:
-    if is_encoder_embedding_config(model_config):
-        return _ENCODER_SEQUENCE_POOLING
+    if EncoderEmbeddingAdapter.matches_config(model_config):
+        return EncoderEmbeddingAdapter.allowed_sequence_pooling_types
     return _LAST_POOLING
 
 
@@ -75,7 +74,9 @@ def _effective_sequence_pooling_type(model_config: Any) -> str:
     for pooling_type in _sequence_pooling_types(model_config):
         if pooling_type is not None:
             return pooling_type
-    return "CLS" if is_encoder_embedding_config(model_config) else "LAST"
+    if EncoderEmbeddingAdapter.matches_config(model_config):
+        return EncoderEmbeddingAdapter.default_sequence_pooling_type
+    return "LAST"
 
 
 def _unsupported_sequence_pooling_type(model_config: Any) -> str | None:
@@ -144,9 +145,9 @@ def _is_decoder_embedding_config(model_config: Any) -> bool:
 
 
 def _is_embed_capable_config(model_config: Any) -> bool:
-    return _is_decoder_embedding_config(model_config) or is_encoder_embedding_config(
+    return _is_decoder_embedding_config(
         model_config
-    )
+    ) or EncoderEmbeddingAdapter.matches_config(model_config)
 
 
 def _is_qwen3_token_logit_classifier(model_config: Any) -> bool:
@@ -396,6 +397,7 @@ def forward_sequence_hidden_states(
     cache: Any,
     model_config: Any,
     segment_lengths: list[int] | None = None,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> mx.array:
     """Run the transformer body and return per-token hidden states."""
     _reject_unsupported_pooler_config(model_config)
@@ -407,12 +409,11 @@ def forward_sequence_hidden_states(
             "runner='pooling'."
         )
 
-    if is_encoder_embedding_config(model_config):
-        hidden_states = _forward_encoder_sequence_hidden_states(
-            body,
+    if encoder_adapter is not None:
+        hidden_states = encoder_adapter.forward_sequence_hidden_states(
             input_ids,
             segment_lengths=segment_lengths,
-            model_config=model_config,
+            model_label=_model_label(model_config),
         )
     else:
         hidden_states = (
@@ -428,41 +429,12 @@ def forward_sequence_hidden_states(
     return hidden_states
 
 
-def _forward_encoder_sequence_hidden_states(
-    body: Any,
-    input_ids: mx.array,
-    *,
-    segment_lengths: list[int] | None,
-    model_config: Any,
-) -> mx.array:
-    """Forward each packed encoder segment independently (bidirectional)."""
-    flat = input_ids.reshape(-1)
-    total_tokens = int(flat.shape[0])
-    if not segment_lengths:
-        segment_lengths = [total_tokens]
-    if sum(segment_lengths) != total_tokens:
-        raise ValueError(
-            "Encoder pooling segment_lengths "
-            f"{segment_lengths!r} do not cover input tokens "
-            f"{total_tokens} for model={_model_label(model_config)}."
-        )
-
-    parts: list[mx.array] = []
-    offset = 0
-    for length in segment_lengths:
-        segment = flat[offset : offset + length].reshape(1, length)
-        parts.append(body(segment))
-        offset += length
-    if len(parts) == 1:
-        return parts[0]
-    return mx.concatenate(parts, axis=1)
-
-
 def pooling_dummy_forward_outputs(
     model: Any,
     input_ids: mx.array,
     *,
     model_config: Any,
+    encoder_adapter: EncoderEmbeddingAdapter | None = None,
 ) -> list[mx.array]:
     """Return warm-up outputs for a pooling model."""
     return [
@@ -471,6 +443,7 @@ def pooling_dummy_forward_outputs(
             input_ids,
             cache=None,
             model_config=model_config,
+            encoder_adapter=encoder_adapter,
         )
     ]
 


### PR DESCRIPTION
TL;DR: This adds BGE-M3 sparse lexical weights through vLLM's existing `token_classify` pooling contract. It is stacked on #594 (native Apache-2.0 XLM-RoBERTa encoder), so the reviewed diff below is the sparse increment; once #594 merges this becomes sparse-only. **Update (2026-08-13): the sparse head now builds on the native Apache encoder under `vllm_metal/v1/encoder/` — no GPLv3 `mlx-embeddings` dependency.**

## What changed

The encoder adapter now owns one validated sparse head and the pooling path keeps token/request boundaries explicit.

- Load the official `BAAI/bge-m3` `sparse_linear.pt` from a pinned revision only for the exact `mlx-community/bge-m3-mlx-8bit` checkpoint with model-level `token_classify` enabled. The sparse head is attached to `NativeEncoderModel` via `EncoderEmbeddingAdapter.load(model_config=...)`.
- Project packed hidden states once, then slice per request, apply logit calibration and optional ReLU, remove matching boundary BOS/EOS rows, and return CPU tensors in request order.
- Advertise `token_classify` only after the head loads successfully; dense-only BGE/XLM-R loads do not fetch it.
- Reject partial, prefix-cached, or resumed token-classify prefills before LoRA/cache/request ownership changes.
- Document offline and `/pooling` usage, plus the distinction between model-level capability and request-level dispatch.

The dense-encoder base is unchanged from #594; this PR's increment is the `BgeM3SparseHead` + `pool_bge_m3_token_classification` + token-classify scheduling/validation wiring.

## Verification

The sparse logic (`BgeM3SparseHead` projection / BOS-EOS filtering / ReLU, `_load_bge_m3_sparse_head` revision-pinning, and the `NativeEncoderModel` adapter wiring through `EncoderEmbeddingAdapter.load(model_config=)`) was re-verified after porting onto the native encoder.

- `BgeM3SparseHead` math (`project_token_logits` / `filter_token_weights`) matches the earlier reference outputs; invalid-shape and non-finite-weight rejection pass.
- Adapter load with `task="token_classify"` fetches the sparse head (`supports_token_classify is True`); dense-only load does not fetch it; unrelated encoder models are rejected.
- `ruff`-level compile check passes on all touched files.

⚠️ The figures below were captured on the earlier `mlx-embeddings`-based head. After porting to the native encoder, the sparse pooling math is byte-identical (it operates purely on MLX hidden states, loader-agnostic), but the full numeric suite has not been re-run on this environment (vllm 0.27.0 unavailable on this macOS toolchain). I will re-confirm parity on the M4 Pro and update:

- `pytest tests/test_encoder_embeddings.py tests/test_model_lifecycle.py tests/test_v1_pooling.py -q`: previously 102 passed, 1 skipped.
- Pinned, cache-only real-model parity test: `Hi` tokenizes to `[0, 2673, 2]`; 8-bit lexical weight `0.2698793411` vs upstream full-precision reference `0.2671086192` (1.04% relative error).
- Real `LLM.encode` batch: empty input returns `[]`; `Hi` returns `[0.2698793411]`.
- Temporary server: `/health`, `/tokenize`, `/pooling` returned HTTP 200; `/pooling` preserved the empty/`Hi` batch order and shapes.

The source checkout has no prebuilt `_paged_ops` and this Mac has Command Line Tools rather than full Xcode, so the runtime smokes bypassed only the unused native-kernel warm-up; the engine reported zero encoder layers patched.
