### PR TITLE
Trim obsolete Metal platform capability glue

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -828,12 +828,6 @@ class TestMetalPlatform:
         finally:
             reset_config()
 
-    def test_device_capability(self) -> None:
-        """Test device capability."""
-        major, minor = MetalPlatform.get_device_capability()
-        assert isinstance(major, int)
-        assert isinstance(minor, int)
-
     def test_get_attn_backend_cls_returns_cpu_backend(self) -> None:
         """Metal platform should return a concrete backend path."""
         cfg = AttentionSelectorConfig(

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import psutil
 import torch
-from vllm.platforms.interface import DeviceCapability, Platform, PlatformEnum
+from vllm.platforms.interface import Platform, PlatformEnum
 
 import vllm_metal.envs as envs
 from vllm_metal.config import get_config
@@ -130,21 +130,6 @@ class MetalPlatform(Platform):
             return bool(mx.metal.is_available())
         except (ImportError, AttributeError, RuntimeError):
             return False
-
-    @classmethod
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
-        """Get device compute capability.
-
-        Returns a fake capability for compatibility with CUDA-centric code.
-
-        Args:
-            device_id: Device index (ignored)
-
-        Returns:
-            DeviceCapability with (major, minor) version
-        """
-        # Return a reasonable value for compatibility
-        return DeviceCapability(major=8, minor=0)
 
     @classmethod
     def get_device_count(cls) -> int:
@@ -1005,21 +990,6 @@ class MetalPlatform(Platform):
         if attn_selector_config.use_sparse:
             raise NotImplementedError("Sparse Attention is not supported on Metal/MLX.")
         return AttentionBackendEnum.CPU_ATTN.get_path()
-
-    @classmethod
-    def verify_quantization(cls, quant: str) -> None:
-        """Verify that quantization method is supported.
-
-        Args:
-            quant: Quantization method name
-
-        Raises:
-            ValueError: If quantization is not supported
-        """
-        # Allow all quantization methods to pass through - actual support
-        # depends on the model implementation. This avoids blocking models
-        # that use quantization formats we may be able to handle.
-        pass
 
     @classmethod
     def is_pin_memory_available(cls) -> bool:


### PR DESCRIPTION
This PR is:

- To trust vLLM 0.27 platform defaults for device capability and quantization validation.
- To remove Metal’s fake SM80 device capability.
- To delete a test that only asserted the fake capability shape.

vLLM now returns `None` for non-CUDA device capability, and an empty `supported_quantization` list already means there is no platform-side quantization filter. The Metal overrides were redundant and the fake CUDA capability was misleading.
