### PR TITLE
Add encoder pooling backend foundation

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -39,6 +39,7 @@ def make_stub_runner(
     defaults: dict[str, Any] = {
         "vllm_config": SimpleNamespace(
             speculative_config=None,
+            lora_config=None,
             # The value MetalPlatform resolves for the in-process executor.
             parallel_config=SimpleNamespace(distributed_executor_backend="uni"),
         ),

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -207,7 +207,7 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is False
 
-    def test_generation_load_request_resolves_effective_vlm_once(self) -> None:
+    def test_model_load_request_resolves_effective_vlm_once(self) -> None:
         hf_config = SimpleNamespace(model_type="custom")
         calls: list[object] = []
 
@@ -233,7 +233,7 @@ class TestModelLifecycle:
         assert request.tokenizer_config == {"trust_remote_code": True}
         assert calls == [hf_config]
 
-    def test_generation_load_request_marks_pipeline_stage_lazy(self) -> None:
+    def test_model_load_request_marks_pipeline_stage_lazy(self) -> None:
         # A pipeline-parallel stage (pp.size > 1) loads weights lazily so it can
         # prune its non-owned layers before the first eval; a single-stage load
         # stays eager. lazy_weights is the typed contract the mlx_lm loader reads.

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -23,6 +23,7 @@ from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.model_lifecycle import (  # noqa: E402
+    LoadedEncoderPoolingModel,
     LoadedGenerationModel,
     ModelLifecycle,
 )
@@ -557,7 +558,7 @@ class TestMetalPoolingCapabilities:
             assert runner._pooling_backend is None
 
         with (
-            patch.object(lifecycle, "_load_model", return_value=loaded),
+            patch.object(lifecycle, "_load_generation", return_value=loaded),
             patch.object(lifecycle, "_install_generation_model"),
             patch.object(lifecycle, "resolve_model_dims"),
             patch.object(lifecycle, "_install_runtime_extensions"),
@@ -584,7 +585,7 @@ class TestMetalPoolingCapabilities:
         )
         lifecycle = ModelLifecycle(runner, runner._model_adapter)
         runner._model_lifecycle = lifecycle
-        loaded = LoadedGenerationModel(
+        loaded = LoadedEncoderPoolingModel(
             model=SimpleNamespace(config=SimpleNamespace(vocab_size=16)),
             tokenizer=object(),
             model_args={"vocab_size": 16},
@@ -592,7 +593,7 @@ class TestMetalPoolingCapabilities:
         )
 
         with (
-            patch.object(lifecycle, "_load_model", return_value=loaded),
+            patch.object(lifecycle, "_load_encoder_pooling", return_value=loaded),
             patch.object(lifecycle, "resolve_model_dims") as resolve_dims,
             patch.object(lifecycle, "_install_runtime_extensions") as extensions,
         ):

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -531,7 +531,7 @@ class TestMetalPoolingCapabilities:
         ) == ("pooling_no_kv")
         assert runner.get_kv_cache_spec() == {}
         runner.initialize_kv_cache(
-            KVCacheConfig(num_blocks=0, kv_cache_tensors=[], kv_cache_groups=[])
+            KVCacheConfig(num_blocks=1, kv_cache_tensors=[], kv_cache_groups=[])
         )
 
     def test_load_model_installs_pooling_backend_after_lora_setup(self) -> None:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -204,6 +204,8 @@ def _pooling_model_config(**overrides):
         "quantization": None,
         "trust_remote_code": False,
         "revision": None,
+        "tokenizer": "stub-pooling-model",
+        "tokenizer_revision": None,
         "get_head_size": lambda: 128,
     }
     values.update(overrides)
@@ -653,6 +655,8 @@ class TestMetalPoolingCapabilities:
 
         model_config = _encoder_model_config(
             model=str(tmp_path),
+            tokenizer="custom-tokenizer",
+            tokenizer_revision="tokenizer-revision",
             hf_config=torch_config,
             dtype=torch.float32,
         )
@@ -661,7 +665,7 @@ class TestMetalPoolingCapabilities:
             "vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta."
             "AutoTokenizer.from_pretrained",
             return_value=object(),
-        ):
+        ) as load_tokenizer:
             mlx_model, _, model_args, pooling_backend = load_xlm_roberta_backend(
                 model_config
             )
@@ -710,6 +714,11 @@ class TestMetalPoolingCapabilities:
             expected_cls,
             atol=1e-5,
             rtol=1e-5,
+        )
+        load_tokenizer.assert_called_once_with(
+            "custom-tokenizer",
+            revision="tokenizer-revision",
+            trust_remote_code=False,
         )
 
     def test_xlm_roberta_loader_rejects_quantization_before_download(self) -> None:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -10,11 +10,13 @@ import mlx.core as mx
 import numpy as np
 import pytest
 import torch
+from mlx.utils import tree_flatten
 
 pytest.importorskip("vllm", reason="vllm not installed")
 
 from vllm.pooling_params import LateInteractionParams, PoolingParams  # noqa: E402
 from vllm.v1.core.sched.output import NewRequestData  # noqa: E402
+from vllm.v1.kv_cache_interface import KVCacheConfig  # noqa: E402
 
 from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
@@ -30,6 +32,13 @@ from vllm_metal.v1.pooling.backends.decoder.models.qwen3 import (  # noqa: E402
 from vllm_metal.v1.pooling.backends.decoder.runtime import (  # noqa: E402
     DecoderModelView,
     MetalDecoderPoolingBackend,
+)
+from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (  # noqa: E402
+    XLMRobertaArgs,
+    XLMRobertaModel,
+)
+from vllm_metal.v1.pooling.backends.encoder.runtime import (  # noqa: E402
+    MetalEncoderPoolingBackend,
 )
 from vllm_metal.v1.pooling.contract import (  # noqa: E402
     DecoderPoolingSpan,
@@ -106,6 +115,15 @@ class _NonArraySequenceModel:
         return object()
 
 
+class _EncoderModel:
+    def __call__(self, input_ids, attention_mask):
+        del attention_mask
+        rows = []
+        for row in np.array(input_ids).tolist():
+            rows.append([[float(tok), float(tok + 1), 1.0] for tok in row])
+        return mx.array(rows, dtype=mx.float32)
+
+
 class _PoolingModel:
     def __init__(self, sequence_model: object | None = None) -> None:
         self.model = sequence_model or _SequenceModel()
@@ -177,6 +195,7 @@ def _pooling_model_config(**overrides):
         "pooler_config": _pooler_config(),
         "quantization": None,
         "trust_remote_code": False,
+        "revision": None,
         "get_head_size": lambda: 128,
     }
     values.update(overrides)
@@ -187,6 +206,18 @@ def _classification_model_config(**overrides):
     values = {
         "hf_config": _qwen3_reranker_hf_config(),
         "pooler_config": _pooler_config(),
+    }
+    values.update(overrides)
+    return _pooling_model_config(**values)
+
+
+def _encoder_model_config(**overrides):
+    values = {
+        "hf_config": _hf_config(
+            architectures=["XLMRobertaModel"],
+            model_type="xlm-roberta",
+        ),
+        "pooler_config": _pooler_config(seq_pooling_type="CLS"),
     }
     values.update(overrides)
     return _pooling_model_config(**values)
@@ -351,6 +382,21 @@ class TestMetalPoolingCapabilities:
 
         assert runner.supported_worker_tasks() == ("classify",)
 
+    def test_supported_worker_tasks_for_encoder_embedding_model_without_paged_attention(
+        self,
+    ) -> None:
+        runner = _make_runner(
+            paged=False,
+            model_config=_encoder_model_config(),
+        )
+        runner._pooling_backend = MetalEncoderPoolingBackend(
+            PoolingConfigView(runner.model_config),
+            _EncoderModel(),
+            pad_token_id=1,
+        )
+
+        assert runner.supported_worker_tasks() == ("embed",)
+
     def test_supported_worker_tasks_for_untied_qwen3_reranker_model(self) -> None:
         runner = _make_runner(
             model=_UntiedClassifierModel(),
@@ -440,13 +486,21 @@ class TestMetalPoolingCapabilities:
 
     def test_supported_worker_tasks_uses_backend_paged_capability(self) -> None:
         class _NoPagedBackend:
-            capabilities = PoolingCapabilities(requires_paged_attention=False)
+            capabilities = PoolingCapabilities(
+                execution_kind="encoder",
+                requires_paged_attention=False,
+                uses_kv_cache=False,
+                supports_chunked_requests=False,
+            )
 
             def supported_tasks(self):
                 return ("embed",)
 
             def validate_params(self, pooling_params):
                 del pooling_params
+
+            def profile_forward(self, input_ids):
+                return input_ids
 
         runner = _make_runner(paged=False)
         runner._pooling_backend = _NoPagedBackend()
@@ -459,6 +513,25 @@ class TestMetalPoolingCapabilities:
         )
 
         assert gen_runner.supported_worker_tasks() == ("generate",)
+
+    def test_encoder_pooling_reports_empty_kv_spec(self) -> None:
+        runner = _make_runner(
+            paged=False,
+            model_config=_encoder_model_config(),
+        )
+        runner._pooling_backend = MetalEncoderPoolingBackend(
+            PoolingConfigView(runner.model_config),
+            _EncoderModel(),
+            pad_token_id=1,
+        )
+
+        assert runner.scheduler_memory_reporting_mode(
+            paged_attention_enabled=False
+        ) == ("pooling_no_kv")
+        assert runner.get_kv_cache_spec() == {}
+        runner.initialize_kv_cache(
+            KVCacheConfig(num_blocks=0, kv_cache_tensors=[], kv_cache_groups=[])
+        )
 
     def test_load_model_installs_pooling_backend_after_lora_setup(self) -> None:
         events: list[str] = []
@@ -484,7 +557,7 @@ class TestMetalPoolingCapabilities:
             assert runner._pooling_backend is None
 
         with (
-            patch.object(lifecycle, "_load_generation", return_value=loaded),
+            patch.object(lifecycle, "_load_model", return_value=loaded),
             patch.object(lifecycle, "_install_generation_model"),
             patch.object(lifecycle, "resolve_model_dims"),
             patch.object(lifecycle, "_install_runtime_extensions"),
@@ -495,6 +568,39 @@ class TestMetalPoolingCapabilities:
         assert events == ["lora"]
         assert runner._pooling_backend is not None
         assert runner._pooling_backend.supported_tasks() == ("embed",)
+
+    def test_load_model_installs_encoder_backend_without_generation_extensions(
+        self,
+    ) -> None:
+        runner = _make_runner(
+            paged=False,
+            model_config=_encoder_model_config(),
+        )
+        runner._pooling_backend = None
+        pooling_backend = MetalEncoderPoolingBackend(
+            PoolingConfigView(runner.model_config),
+            _EncoderModel(),
+            pad_token_id=1,
+        )
+        lifecycle = ModelLifecycle(runner, runner._model_adapter)
+        runner._model_lifecycle = lifecycle
+        loaded = LoadedGenerationModel(
+            model=SimpleNamespace(config=SimpleNamespace(vocab_size=16)),
+            tokenizer=object(),
+            model_args={"vocab_size": 16},
+            pooling_backend=pooling_backend,
+        )
+
+        with (
+            patch.object(lifecycle, "_load_model", return_value=loaded),
+            patch.object(lifecycle, "resolve_model_dims") as resolve_dims,
+            patch.object(lifecycle, "_install_runtime_extensions") as extensions,
+        ):
+            runner.load_model()
+
+        assert runner._pooling_backend is pooling_backend
+        resolve_dims.assert_not_called()
+        extensions.assert_not_called()
 
     def test_duplicate_supported_pooler_tasks_fail_at_backend_construction(
         self,
@@ -519,6 +625,24 @@ class TestMetalPoolingCapabilities:
                 (_SupportedEmbedPooler(), _SupportedEmbedPooler()),
             )
 
+    def test_xlm_roberta_model_uses_hf_weight_names(self) -> None:
+        model = XLMRobertaModel(
+            XLMRobertaArgs(
+                hidden_size=4,
+                num_hidden_layers=1,
+                intermediate_size=8,
+                num_attention_heads=2,
+                max_position_embeddings=8,
+                vocab_size=16,
+            )
+        )
+        names = {name for name, _ in tree_flatten(model.parameters())}
+
+        assert "embeddings.word_embeddings.weight" in names
+        assert "encoder.layer.0.attention.self.query.weight" in names
+        assert "encoder.layer.0.intermediate.dense.weight" in names
+        assert "encoder.layer.0.output.dense.weight" in names
+
 
 class TestMetalPoolingRunnerOutput:
     def test_paged_embed_preserves_request_order(self) -> None:
@@ -538,6 +662,31 @@ class TestMetalPoolingRunnerOutput:
         assert out.pooler_output is not None
         _assert_embedding(out.pooler_output[0], 5)
         _assert_embedding(out.pooler_output[1], 9)
+
+    def test_encoder_embed_preserves_request_order_without_paged_attention(
+        self,
+    ) -> None:
+        runner = _make_runner(
+            paged=False,
+            model_config=_encoder_model_config(),
+        )
+        runner._pooling_backend = MetalEncoderPoolingBackend(
+            PoolingConfigView(runner.model_config),
+            _EncoderModel(),
+            pad_token_id=1,
+        )
+        req_b = _new_req("req-b", [4, 5])
+        req_a = _new_req("req-a", [7, 8, 9])
+
+        with patch("vllm_metal.v1.model_runner.prepare_grouped") as prepare:
+            out = _execute_pooling(runner, _scheduler_output(new_reqs=[req_b, req_a]))
+
+        prepare.assert_not_called()
+        assert out.req_ids == ["req-b", "req-a"]
+        assert out.sampled_token_ids == [[], []]
+        assert out.pooler_output is not None
+        _assert_embedding(out.pooler_output[0], 4)
+        _assert_embedding(out.pooler_output[1], 7)
 
     def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(self) -> None:
         runner = _make_runner()
@@ -684,6 +833,26 @@ class TestMetalPoolingFailFast:
 
         with pytest.raises(NotImplementedError, match="paged attention"):
             runner.execute_model(_scheduler_output(new_reqs=[req]))
+
+    def test_encoder_pooling_rejects_chunked_requests(self) -> None:
+        runner = _make_runner(
+            paged=False,
+            model_config=_encoder_model_config(),
+        )
+        runner._pooling_backend = MetalEncoderPoolingBackend(
+            PoolingConfigView(runner.model_config),
+            _EncoderModel(),
+            pad_token_id=1,
+        )
+        req = _new_req("req-0", [1, 2, 3], num_computed_tokens=1)
+
+        with pytest.raises(NotImplementedError, match="full-prompt"):
+            runner.execute_model(
+                _scheduler_output(
+                    new_reqs=[req],
+                    num_scheduled_tokens={"req-0": 2},
+                )
+            )
 
     @pytest.mark.parametrize(
         "task",

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -10,7 +10,9 @@ import mlx.core as mx
 import numpy as np
 import pytest
 import torch
-from mlx.utils import tree_flatten
+from torch.nn.functional import normalize
+from transformers import XLMRobertaConfig as TorchXLMRobertaConfig
+from transformers import XLMRobertaModel as TorchXLMRobertaModel
 
 pytest.importorskip("vllm", reason="vllm not installed")
 
@@ -21,6 +23,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig  # noqa: E402
 from tests.stub_runner import make_stub_runner  # noqa: E402
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
+from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.model_lifecycle import (  # noqa: E402
     LoadedEncoderPoolingModel,
@@ -35,8 +38,7 @@ from vllm_metal.v1.pooling.backends.decoder.runtime import (  # noqa: E402
     MetalDecoderPoolingBackend,
 )
 from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (  # noqa: E402
-    XLMRobertaArgs,
-    XLMRobertaModel,
+    load_xlm_roberta_backend,
 )
 from vllm_metal.v1.pooling.backends.encoder.runtime import (  # noqa: E402
     MetalEncoderPoolingBackend,
@@ -147,13 +149,18 @@ class _ClassifierTokenizer:
         return [] if token_id is None else [token_id]
 
 
+class _HFConfig(SimpleNamespace):
+    def to_dict(self):
+        return vars(self).copy()
+
+
 def _hf_config(**overrides):
     values = {
         "architectures": ["Qwen3ForCausalLM"],
         "model_type": "qwen3",
     }
     values.update(overrides)
-    return SimpleNamespace(**values)
+    return _HFConfig(**values)
 
 
 def _qwen3_reranker_hf_config(**overrides):
@@ -623,23 +630,97 @@ class TestMetalPoolingCapabilities:
                 (_SupportedEmbedPooler(), _SupportedEmbedPooler()),
             )
 
-    def test_xlm_roberta_model_uses_hf_weight_names(self) -> None:
-        model = XLMRobertaModel(
-            XLMRobertaArgs(
-                hidden_size=4,
-                num_hidden_layers=1,
-                intermediate_size=8,
-                num_attention_heads=2,
-                max_position_embeddings=8,
-                vocab_size=16,
-            )
+    def test_xlm_roberta_checkpoint_matches_transformers(
+        self,
+        tmp_path,
+    ) -> None:
+        torch.manual_seed(0)
+        torch_config = TorchXLMRobertaConfig(
+            vocab_size=17,
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=16,
+            max_position_embeddings=16,
+            type_vocab_size=1,
+            layer_norm_eps=1e-5,
+            pad_token_id=1,
+            hidden_act="gelu",
+            position_embedding_type="absolute",
         )
-        names = {name for name, _ in tree_flatten(model.parameters())}
+        transformers_model = TorchXLMRobertaModel(torch_config).eval()
+        transformers_model.save_pretrained(tmp_path, safe_serialization=True)
 
-        assert "embeddings.word_embeddings.weight" in names
-        assert "encoder.layer.0.attention.self.query.weight" in names
-        assert "encoder.layer.0.intermediate.dense.weight" in names
-        assert "encoder.layer.0.output.dense.weight" in names
+        model_config = _encoder_model_config(
+            model=str(tmp_path),
+            hf_config=torch_config,
+            dtype=torch.float32,
+        )
+
+        with patch(
+            "vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta."
+            "AutoTokenizer.from_pretrained",
+            return_value=object(),
+        ):
+            mlx_model, _, model_args, pooling_backend = load_xlm_roberta_backend(
+                model_config
+            )
+
+        input_ids = torch.tensor(
+            [
+                [0, 5, 6, 2, 1],
+                [0, 7, 2, 1, 1],
+            ],
+            dtype=torch.long,
+        )
+        attention_mask = (input_ids != torch_config.pad_token_id).to(torch.long)
+        with torch.no_grad():
+            expected_hidden = transformers_model(
+                input_ids,
+                attention_mask=attention_mask,
+            ).last_hidden_state
+
+        actual_hidden = mlx_model(
+            mx.array(input_ids.numpy(), dtype=mx.int32),
+            mx.array(attention_mask.numpy(), dtype=mx.int32),
+        )
+        actual_hidden_torch = mlx_to_torch(
+            actual_hidden.astype(mx.float32),
+            device="cpu",
+        )
+
+        assert model_args["hidden_size"] == torch_config.hidden_size
+        assert torch.allclose(
+            actual_hidden_torch,
+            expected_hidden,
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+        request = _new_req("req-0", [0, 5, 6, 2], task="embed")
+        outputs = pooling_backend.pool_scheduler_output(
+            _scheduler_output(new_reqs=[request]),
+            model_config,
+        )
+        expected_cls = normalize(expected_hidden[0, 0].float(), dim=0)
+
+        assert len(outputs) == 1
+        assert torch.allclose(
+            outputs[0].pooler_output,
+            expected_cls,
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    def test_xlm_roberta_loader_rejects_quantization_before_download(self) -> None:
+        model_config = _encoder_model_config(
+            model="missing-xlm-roberta-model",
+            hf_config=TorchXLMRobertaConfig(),
+            quantization="awq",
+        )
+
+        with pytest.raises(NotImplementedError, match="quantization"):
+            load_xlm_roberta_backend(model_config)
 
 
 class TestMetalPoolingRunnerOutput:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -393,7 +393,6 @@ class TestMetalPoolingCapabilities:
         runner._pooling_backend = MetalEncoderPoolingBackend(
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
-            pad_token_id=1,
         )
 
         assert runner.supported_worker_tasks() == ("embed",)
@@ -523,7 +522,6 @@ class TestMetalPoolingCapabilities:
         runner._pooling_backend = MetalEncoderPoolingBackend(
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
-            pad_token_id=1,
         )
 
         assert runner.scheduler_memory_reporting_mode(
@@ -581,7 +579,6 @@ class TestMetalPoolingCapabilities:
         pooling_backend = MetalEncoderPoolingBackend(
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
-            pad_token_id=1,
         )
         lifecycle = ModelLifecycle(runner, runner._model_adapter)
         runner._model_lifecycle = lifecycle
@@ -674,7 +671,6 @@ class TestMetalPoolingRunnerOutput:
         runner._pooling_backend = MetalEncoderPoolingBackend(
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
-            pad_token_id=1,
         )
         req_b = _new_req("req-b", [4, 5])
         req_a = _new_req("req-a", [7, 8, 9])
@@ -843,7 +839,6 @@ class TestMetalPoolingFailFast:
         runner._pooling_backend = MetalEncoderPoolingBackend(
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
-            pad_token_id=1,
         )
         req = _new_req("req-0", [1, 2, 3], num_computed_tokens=1)
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -283,9 +283,16 @@ class ModelCachePolicy:
     ) -> Literal[
         "paged_attention_capacity",
         "paged_attention_mha_layout_budget",
+        "pooling_no_kv",
         "single_sequence_estimate",
     ]:
         """Return which scheduler memory-reporting mode worker should use."""
+        pooling_backend = self._runner._pooling_backend
+        if (
+            pooling_backend is not None
+            and not pooling_backend.capabilities.uses_kv_cache
+        ):
+            return "pooling_no_kv"
         if paged_attention_enabled:
             if self._uses_deferred_mha_layout():
                 return "paged_attention_mha_layout_budget"
@@ -316,6 +323,13 @@ class ModelCachePolicy:
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Build the scheduler-visible KV cache specification."""
+        pooling_backend = self._runner._pooling_backend
+        if (
+            pooling_backend is not None
+            and not pooling_backend.capabilities.uses_kv_cache
+        ):
+            return {}
+
         self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
@@ -434,6 +448,23 @@ class ModelCachePolicy:
         adopt its grouping before serving.
         """
         runtime = self._runner.paged_attention_runtime
+        pooling_backend = self._runner._pooling_backend
+        if (
+            pooling_backend is not None
+            and not pooling_backend.capabilities.uses_kv_cache
+        ):
+            if (
+                kv_cache_config.num_blocks
+                or kv_cache_config.kv_cache_groups
+                or kv_cache_config.kv_cache_tensors
+            ):
+                raise ValueError(
+                    "Metal encoder pooling does not use KV cache, but vLLM "
+                    "returned a non-empty KV cache config."
+                )
+            logger.info("Encoder pooling: no KV cache initialized.")
+            return
+
         if self._uses_deferred_mha_layout():
             if runtime is not None:
                 raise RuntimeError(
@@ -1024,6 +1055,11 @@ class WorkerCachePlanner:
                 plan.kv_budget / 1e9,
             )
             return plan.kv_budget
+
+        if mode == "pooling_no_kv":
+            self._worker.model_runner.profile_run()
+            logger.info("Encoder pooling: reporting zero KV-cache bytes")
+            return 0
 
         available = self._worker._one_sequence_kv_bytes()
         logger.info(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -453,11 +453,7 @@ class ModelCachePolicy:
             pooling_backend is not None
             and not pooling_backend.capabilities.uses_kv_cache
         ):
-            if (
-                kv_cache_config.num_blocks
-                or kv_cache_config.kv_cache_groups
-                or kv_cache_config.kv_cache_tensors
-            ):
+            if kv_cache_config.kv_cache_groups or kv_cache_config.kv_cache_tensors:
                 raise ValueError(
                     "Metal encoder pooling does not use KV cache, but vLLM "
                     "returned a non-empty KV cache config."

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -193,13 +193,13 @@ class ModelLifecycle:
                 "Metal encoder pooling does not support LoRA yet."
             )
 
-        model, tokenizer, pooling_backend = load_encoder_pooling_backend(
+        model, tokenizer, model_args, pooling_backend = load_encoder_pooling_backend(
             runner.model_config
         )
         return LoadedEncoderPoolingModel(
             model=model,
             tokenizer=tokenizer,
-            model_args=self._config_to_mapping(model.config),
+            model_args=model_args,
             pooling_backend=pooling_backend,
         )
 

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -28,6 +28,11 @@ from vllm_metal.v1.model_adapter import ModelAdapter
 from vllm_metal.v1.pooling.backends.decoder.factory import (
     build_decoder_pooling_backend,
 )
+from vllm_metal.v1.pooling.backends.encoder.factory import (
+    load_encoder_pooling_backend,
+    supports_encoder_pooling_backend,
+)
+from vllm_metal.v1.pooling.contract import ExecutablePoolingBackend
 
 # Engine-core subprocesses don't always re-invoke `vllm_metal._register()`,
 # so the compat patches applied there may be missing here. Reapply on import
@@ -108,11 +113,12 @@ class GenerationLoadRequest:
 
 @dataclass(frozen=True, slots=True)
 class LoadedGenerationModel:
-    """Loaded generation model plus metadata needed to wire the runner."""
+    """Loaded model plus metadata needed to wire the runner."""
 
     model: Any
     tokenizer: Any
     model_args: dict[str, Any]
+    pooling_backend: ExecutablePoolingBackend | None = None
 
 
 class ModelLifecycle:
@@ -125,12 +131,24 @@ class ModelLifecycle:
         self._model_adapter = model_adapter
 
     def load(self) -> None:
-        """Load the generation model and install runner runtime state."""
+        """Load the configured model and install runner runtime state."""
 
         request = GenerationLoadRequest.from_runner(self._runner, self._model_adapter)
-        loaded_model = self._load_generation(request)
+        loaded_model = self._load_model(request)
 
         self._install_generation_model(loaded_model, request)
+        if loaded_model.pooling_backend is not None:
+            runner = self._runner
+            if runner.pp is not None and runner.pp.size > 1:
+                raise NotImplementedError(
+                    "Metal encoder pooling does not support pipeline parallelism yet."
+                )
+            if runner.vllm_config.lora_config is not None:
+                raise NotImplementedError(
+                    "Metal encoder pooling does not support LoRA yet."
+                )
+            self._runner._pooling_backend = loaded_model.pooling_backend
+            return
 
         # Runtime extensions may depend on dimensions derived from model_args.
         self.resolve_model_dims()
@@ -157,10 +175,23 @@ class ModelLifecycle:
         self._reject_pipeline_parallel_with_per_layer_metadata()
         self._install_hybrid_attention_dims(args)
 
-    def _load_generation(
+    def _load_model(
         self,
         request: GenerationLoadRequest,
     ) -> LoadedGenerationModel:
+        if self._runner._is_pooling and supports_encoder_pooling_backend(
+            request.model_config
+        ):
+            model, tokenizer, pooling_backend = load_encoder_pooling_backend(
+                request.model_config
+            )
+            return LoadedGenerationModel(
+                model=model,
+                tokenizer=tokenizer,
+                model_args=self._config_to_mapping(model.config),
+                pooling_backend=pooling_backend,
+            )
+
         model, tokenizer = self._load_generation_model(
             request.model_name,
             request.is_vlm,

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -32,7 +32,7 @@ from vllm_metal.v1.pooling.backends.encoder.factory import (
     load_encoder_pooling_backend,
     supports_encoder_pooling_backend,
 )
-from vllm_metal.v1.pooling.contract import ExecutablePoolingBackend
+from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
 
 # Engine-core subprocesses don't always re-invoke `vllm_metal._register()`,
 # so the compat patches applied there may be missing here. Reapply on import
@@ -113,12 +113,21 @@ class GenerationLoadRequest:
 
 @dataclass(frozen=True, slots=True)
 class LoadedGenerationModel:
-    """Loaded model plus metadata needed to wire the runner."""
+    """Loaded generation model plus metadata needed to wire the runner."""
 
     model: Any
     tokenizer: Any
     model_args: dict[str, Any]
-    pooling_backend: ExecutablePoolingBackend | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedEncoderPoolingModel:
+    """Loaded encoder model plus its pooling backend."""
+
+    model: Any
+    tokenizer: Any
+    model_args: dict[str, Any]
+    pooling_backend: EncoderPoolingBackend
 
 
 class ModelLifecycle:
@@ -133,22 +142,15 @@ class ModelLifecycle:
     def load(self) -> None:
         """Load the configured model and install runner runtime state."""
 
+        loaded_encoder_model = self._load_encoder_pooling()
+        if loaded_encoder_model is not None:
+            self._install_encoder_pooling_model(loaded_encoder_model)
+            return
+
         request = GenerationLoadRequest.from_runner(self._runner, self._model_adapter)
-        loaded_model = self._load_model(request)
+        loaded_model = self._load_generation(request)
 
         self._install_generation_model(loaded_model, request)
-        if loaded_model.pooling_backend is not None:
-            runner = self._runner
-            if runner.pp is not None and runner.pp.size > 1:
-                raise NotImplementedError(
-                    "Metal encoder pooling does not support pipeline parallelism yet."
-                )
-            if runner.vllm_config.lora_config is not None:
-                raise NotImplementedError(
-                    "Metal encoder pooling does not support LoRA yet."
-                )
-            self._runner._pooling_backend = loaded_model.pooling_backend
-            return
 
         # Runtime extensions may depend on dimensions derived from model_args.
         self.resolve_model_dims()
@@ -175,23 +177,36 @@ class ModelLifecycle:
         self._reject_pipeline_parallel_with_per_layer_metadata()
         self._install_hybrid_attention_dims(args)
 
-    def _load_model(
+    def _load_encoder_pooling(self) -> LoadedEncoderPoolingModel | None:
+        runner = self._runner
+        if not runner._is_pooling or not supports_encoder_pooling_backend(
+            runner.model_config
+        ):
+            return None
+
+        if runner.pp is not None and runner.pp.size > 1:
+            raise NotImplementedError(
+                "Metal encoder pooling does not support pipeline parallelism yet."
+            )
+        if runner.vllm_config.lora_config is not None:
+            raise NotImplementedError(
+                "Metal encoder pooling does not support LoRA yet."
+            )
+
+        model, tokenizer, pooling_backend = load_encoder_pooling_backend(
+            runner.model_config
+        )
+        return LoadedEncoderPoolingModel(
+            model=model,
+            tokenizer=tokenizer,
+            model_args=self._config_to_mapping(model.config),
+            pooling_backend=pooling_backend,
+        )
+
+    def _load_generation(
         self,
         request: GenerationLoadRequest,
     ) -> LoadedGenerationModel:
-        if self._runner._is_pooling and supports_encoder_pooling_backend(
-            request.model_config
-        ):
-            model, tokenizer, pooling_backend = load_encoder_pooling_backend(
-                request.model_config
-            )
-            return LoadedGenerationModel(
-                model=model,
-                tokenizer=tokenizer,
-                model_args=self._config_to_mapping(model.config),
-                pooling_backend=pooling_backend,
-            )
-
         model, tokenizer = self._load_generation_model(
             request.model_name,
             request.is_vlm,
@@ -206,6 +221,21 @@ class ModelLifecycle:
             tokenizer=tokenizer,
             model_args=self._extract_model_args(model, request.is_vlm),
         )
+
+    def _install_encoder_pooling_model(
+        self,
+        loaded_model: LoadedEncoderPoolingModel,
+    ) -> None:
+        runner = self._runner
+        runner.model = loaded_model.model
+        runner.tokenizer = loaded_model.tokenizer
+        runner._is_vlm = False
+        runner._multimodal_adapter = None
+        runner.encoder_cache = None
+        runner.model_args = loaded_model.model_args
+        runner._vocab_size = int(loaded_model.model_args["vocab_size"])
+        runner._pooling_backend = loaded_model.pooling_backend
+        logger.debug("Model args: %s", loaded_model.model_args)
 
     def _load_generation_model(
         self,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -761,6 +761,8 @@ class MetalModelRunner:
         growth during serving (issue #234).
         """
         warmup_len = self.scheduler_config.max_num_batched_tokens
+        if self._uses_encoder_pooling_backend():
+            warmup_len = min(warmup_len, self.model_config.max_model_len)
         mx.clear_cache()
         cache_before = mx.get_cache_memory()
         dummy_tokens = mx.zeros((1, warmup_len), dtype=mx.int32)
@@ -2577,6 +2579,8 @@ class MetalModelRunner:
         """
         if self.model is None:
             raise RuntimeError("Model not loaded")
+        if self._uses_encoder_pooling_backend():
+            return self._run_encoder_pooling_batch(scheduler_output)
 
         # Gate the decode pipeline for this step BEFORE any state mutation:
         # an ineligible step must resolve the pending deferred sample first so
@@ -2641,9 +2645,6 @@ class MetalModelRunner:
                 "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
                 "to use structured output."
             )
-
-        if self._uses_encoder_pooling_backend():
-            return self._run_encoder_pooling_batch(scheduler_output)
 
         batch = _ExecutionBatch()
         self._handle_new_requests(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -14,7 +14,7 @@ Key contracts:
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
-from typing import Any, Literal, NamedTuple, TypeAlias
+from typing import Any, Literal, NamedTuple, TypeAlias, cast
 
 import mlx.core as mx
 import numpy as np
@@ -100,6 +100,8 @@ from vllm_metal.v1.pooling.contract import (
     DecoderPoolingBackend,
     DecoderPoolingBatch,
     DecoderPoolingSpan,
+    EncoderPoolingBackend,
+    ExecutablePoolingBackend,
 )
 from vllm_metal.v1.pooling.validation import validate_pooling_request
 from vllm_metal.v1.proposer import (
@@ -129,6 +131,7 @@ SchedulerMemoryReportingMode: TypeAlias = Literal[
     "stt_nominal",
     "paged_attention_capacity",
     "paged_attention_mha_layout_budget",
+    "pooling_no_kv",
     "single_sequence_estimate",
 ]
 
@@ -349,7 +352,7 @@ class MetalModelRunner:
         self._is_pooling: bool = (
             getattr(self.model_config, "runner_type", None) == "pooling"
         )
-        self._pooling_backend: DecoderPoolingBackend | None = None
+        self._pooling_backend: ExecutablePoolingBackend | None = None
         self._multimodal_adapter: MultimodalRuntimeAdapter | None = None
         self._gemma4_mtp_assistant: Gemma4MTPAssistantRuntime | None = None
         self._drafter: MetalProposer | None = None
@@ -523,16 +526,22 @@ class MetalModelRunner:
     def supported_worker_tasks(self) -> tuple[SupportedTask, ...]:
         """Return worker task capabilities for the loaded model."""
         if self._is_pooling:
-            backend = self._pooling_backend
-            if backend is None:
+            pooling_backend = self._pooling_backend
+            if pooling_backend is None:
                 return ()
             if (
-                backend.capabilities.requires_paged_attention
+                pooling_backend.capabilities.requires_paged_attention
                 and self._paged_attention_runtime is None
             ):
                 return ()
-            return backend.supported_tasks()
+            return pooling_backend.supported_tasks()
         return ("generate",)
+
+    def _uses_encoder_pooling_backend(self) -> bool:
+        return (
+            self._pooling_backend is not None
+            and self._pooling_backend.capabilities.execution_kind == "encoder"
+        )
 
     def _has_paged_pooling_work(
         self,
@@ -553,6 +562,8 @@ class MetalModelRunner:
     def load_model(self) -> None:
         """Load the configured model and derive runtime metadata."""
         self._model_lifecycle.load()
+        if self._uses_encoder_pooling_backend():
+            return
         # Prune non-owned layers adjacent to the (lazy) load, before LoRA setup or
         # cache profiling materialize weights. No-op on the single-stage path.
         if self.pp is not None:
@@ -761,7 +772,7 @@ class MetalModelRunner:
     def _dummy_forward_outputs(self, input_ids: mx.array) -> list[mx.array]:
         if self._is_pooling:
             assert self._pooling_backend is not None
-            return [self._pooling_backend.forward_packed(input_ids, None)]
+            return [self._pooling_backend.profile_forward(input_ids)]
 
         if self.pp is not None and self.pp.size > 1:
             # Profile the PP stage shape: non-first stages never embed and
@@ -1266,7 +1277,11 @@ class MetalModelRunner:
             )
             if has_pooling_work:
                 assert self._pooling_backend is not None
-                pooling_hidden_states = self._pooling_backend.forward_packed(
+                decoder_pooling_backend = cast(
+                    DecoderPoolingBackend,
+                    self._pooling_backend,
+                )
+                pooling_hidden_states = decoder_pooling_backend.forward_packed(
                     input_ids,
                     offset_caches,
                 )
@@ -1475,12 +1490,16 @@ class MetalModelRunner:
 
         if pooling_hidden_states is not None:
             assert self._pooling_backend is not None
+            decoder_pooling_backend = cast(
+                DecoderPoolingBackend,
+                self._pooling_backend,
+            )
             mx.eval(pooling_hidden_states)
             pooling_batch = batch.decoder_pooling_batch(
                 cu_seqlens,
                 num_decode_segments,
             )
-            pooler_outputs = self._pooling_backend.pool_packed(
+            pooler_outputs = decoder_pooling_backend.pool_packed(
                 pooling_hidden_states,
                 pooling_batch,
             )
@@ -2119,7 +2138,7 @@ class MetalModelRunner:
             validate_pooling_request(
                 new_req,
                 self.model_config,
-                backend=self._pooling_backend,
+                pooling_backend=self._pooling_backend,
                 paged_attention_enabled=self._paged_attention_runtime is not None,
             )
 
@@ -2418,6 +2437,21 @@ class MetalModelRunner:
             pooler_output=batch.pooler_outputs,
         )
 
+    def _run_encoder_pooling_batch(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> ModelRunnerOutput:
+        assert self._pooling_backend is not None
+        pooling_backend = cast(EncoderPoolingBackend, self._pooling_backend)
+        batch = _ExecutionBatch()
+        for output in pooling_backend.pool_scheduler_output(
+            scheduler_output,
+            self.model_config,
+        ):
+            batch.add_output(output.req_id, [], None, output.pooler_output)
+        self._validate_scheduled_outputs(batch, scheduler_output)
+        return self._build_output(batch)
+
     def _run_non_paged_decode_batch(self, batch: _ExecutionBatch) -> None:
         """Run non-paged decode work."""
         if batch.valid_decode_reqs:
@@ -2607,6 +2641,9 @@ class MetalModelRunner:
                 "Enable paged attention (VLLM_METAL_USE_PAGED_ATTENTION=1) "
                 "to use structured output."
             )
+
+        if self._uses_encoder_pooling_backend():
+            return self._run_encoder_pooling_batch(scheduler_output)
 
         batch = _ExecutionBatch()
         self._handle_new_requests(

--- a/vllm_metal/v1/pooling/backends/decoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/decoder/runtime.py
@@ -116,7 +116,12 @@ class LastTokenEmbeddingPooler:
 class MetalDecoderPoolingBackend:
     """Decoder pooling backend for current Metal text pooling behavior."""
 
-    capabilities = PoolingCapabilities(requires_paged_attention=True)
+    capabilities = PoolingCapabilities(
+        execution_kind="decoder",
+        requires_paged_attention=True,
+        uses_kv_cache=True,
+        supports_chunked_requests=True,
+    )
 
     def __init__(
         self,
@@ -132,16 +137,19 @@ class MetalDecoderPoolingBackend:
         return tuple(self.poolers_by_task)
 
     def validate_params(self, pooling_params: PoolingParams) -> None:
+        self.config.reject_unsupported_pooler_config()
         task = pooling_params.task or EMBED_TASK
         if task not in self.poolers_by_task:
             self._raise_unsupported_task(pooling_params.task)
+
+    def profile_forward(self, input_ids: mx.array) -> mx.array:
+        return self.forward_packed(input_ids, None)
 
     def forward_packed(
         self,
         input_ids: mx.array,
         offset_caches: list[OffsetCache] | None,
     ) -> mx.array:
-        self.config.reject_unsupported_pooler_config()
         if not self.model_view.has_sequence_model:
             raise NotImplementedError(
                 "Metal pooling requires an MLX model with a callable "

--- a/vllm_metal/v1/pooling/backends/encoder/__init__.py
+++ b/vllm_metal/v1/pooling/backends/encoder/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Encoder pooling backend package."""

--- a/vllm_metal/v1/pooling/backends/encoder/factory.py
+++ b/vllm_metal/v1/pooling/backends/encoder/factory.py
@@ -14,7 +14,7 @@ from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
 from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
 from vllm_metal.v1.pooling.validation import PoolingConfigView
 
-EncoderBackendLoadResult = tuple[Any, Any, EncoderPoolingBackend]
+EncoderBackendLoadResult = tuple[Any, Any, dict[str, Any], EncoderPoolingBackend]
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_metal/v1/pooling/backends/encoder/factory.py
+++ b/vllm_metal/v1/pooling/backends/encoder/factory.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Factory for encoder pooling backends."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
+    load_xlm_roberta_backend,
+    supports_xlm_roberta_encoder,
+)
+from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
+from vllm_metal.v1.pooling.validation import PoolingConfigView
+
+
+def supports_encoder_pooling_backend(model_config: Any) -> bool:
+    config = PoolingConfigView(model_config)
+    return (
+        config.runner_type == "pooling"
+        and config.is_text_only
+        and supports_xlm_roberta_encoder(model_config)
+    )
+
+
+def load_encoder_pooling_backend(
+    model_config: Any,
+) -> tuple[Any, Any, EncoderPoolingBackend]:
+    return load_xlm_roberta_backend(model_config)

--- a/vllm_metal/v1/pooling/backends/encoder/factory.py
+++ b/vllm_metal/v1/pooling/backends/encoder/factory.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
@@ -12,17 +14,40 @@ from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
 from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
 from vllm_metal.v1.pooling.validation import PoolingConfigView
 
+EncoderBackendLoadResult = tuple[Any, Any, EncoderPoolingBackend]
+
+
+@dataclass(frozen=True, slots=True)
+class EncoderBackendLoader:
+    supports: Callable[[Any], bool]
+    load: Callable[[Any], EncoderBackendLoadResult]
+
+
+_ENCODER_BACKEND_LOADERS = (
+    EncoderBackendLoader(
+        supports=supports_xlm_roberta_encoder,
+        load=load_xlm_roberta_backend,
+    ),
+)
+
 
 def supports_encoder_pooling_backend(model_config: Any) -> bool:
     config = PoolingConfigView(model_config)
     return (
         config.runner_type == "pooling"
         and config.is_text_only
-        and supports_xlm_roberta_encoder(model_config)
+        and any(loader.supports(model_config) for loader in _ENCODER_BACKEND_LOADERS)
     )
 
 
 def load_encoder_pooling_backend(
     model_config: Any,
-) -> tuple[Any, Any, EncoderPoolingBackend]:
-    return load_xlm_roberta_backend(model_config)
+) -> EncoderBackendLoadResult:
+    for loader in _ENCODER_BACKEND_LOADERS:
+        if loader.supports(model_config):
+            return loader.load(model_config)
+
+    config = PoolingConfigView(model_config)
+    raise NotImplementedError(
+        f"Metal encoder pooling has no backend for model={config.label}."
+    )

--- a/vllm_metal/v1/pooling/backends/encoder/factory.py
+++ b/vllm_metal/v1/pooling/backends/encoder/factory.py
@@ -24,6 +24,9 @@ class EncoderBackendLoader:
 
 
 _ENCODER_BACKEND_LOADERS = (
+    # Decoder pooling wraps the already-loaded generation model. Encoder pooling
+    # has model-family-owned loaders because it does not use the generation
+    # loader, paged attention, or KV cache.
     EncoderBackendLoader(
         supports=supports_xlm_roberta_encoder,
         load=load_xlm_roberta_backend,

--- a/vllm_metal/v1/pooling/backends/encoder/models/__init__.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Encoder model families."""

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import json
 import math
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
@@ -14,6 +13,7 @@ import mlx.nn as nn
 from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
+from vllm_metal.pytorch_backend.tensor_bridge import TORCH_TO_MLX_DTYPE
 from vllm_metal.v1.pooling.backends.encoder.runtime import MetalEncoderPoolingBackend
 from vllm_metal.v1.pooling.validation import PoolingConfigView
 
@@ -244,6 +244,20 @@ def supports_xlm_roberta_encoder(model_config: Any) -> bool:
 def load_xlm_roberta_backend(
     model_config: Any,
 ) -> tuple[Any, Any, dict[str, Any], MetalEncoderPoolingBackend]:
+    hf_config = model_config.hf_config
+    if model_config.quantization is not None:
+        raise NotImplementedError(
+            "Metal XLM-R encoder pooling does not support quantization yet."
+        )
+    if hf_config.position_embedding_type != "absolute":
+        raise NotImplementedError(
+            "Metal XLM-R encoder pooling supports only absolute position embeddings."
+        )
+    if hf_config.hidden_act != "gelu":
+        raise NotImplementedError(
+            "Metal XLM-R encoder pooling supports only GELU activation."
+        )
+
     model_path = Path(model_config.model)
     if not model_path.exists():
         model_path = Path(
@@ -253,19 +267,26 @@ def load_xlm_roberta_backend(
             )
         )
 
-    config = json.loads((model_path / "config.json").read_text())
     weight_files = sorted(model_path.glob("model*.safetensors"))
     if not weight_files:
         weight_files = sorted(model_path.glob("*.safetensors"))
     if not weight_files:
         raise FileNotFoundError(f"No safetensors found in {model_path}.")
 
+    config = hf_config.to_dict()
+    target_dtype = TORCH_TO_MLX_DTYPE[model_config.dtype]
     args = XLMRobertaArgs.from_config(config)
     model = XLMRobertaModel(args)
     weights: dict[str, mx.array] = {}
     for weight_file in weight_files:
         weights.update(mx.load(str(weight_file)))
     weights = model.sanitize(weights)
+    weights = {
+        name: value.astype(target_dtype)
+        if mx.issubdtype(value.dtype, mx.floating)
+        else value
+        for name, value in weights.items()
+    }
     model.load_weights(list(weights.items()), strict=True)
     mx.eval(model.parameters())
 

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -276,6 +276,5 @@ def load_xlm_roberta_backend(
     pooling_backend = MetalEncoderPoolingBackend(
         PoolingConfigView(model_config),
         model,
-        pad_token_id=int(config.get("pad_token_id", 1)),
     )
     return model, tokenizer, asdict(args), pooling_backend

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import json
 import math
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass, fields
 from pathlib import Path
 from typing import Any
 
@@ -243,7 +243,7 @@ def supports_xlm_roberta_encoder(model_config: Any) -> bool:
 
 def load_xlm_roberta_backend(
     model_config: Any,
-) -> tuple[Any, Any, MetalEncoderPoolingBackend]:
+) -> tuple[Any, Any, dict[str, Any], MetalEncoderPoolingBackend]:
     model_path = Path(model_config.model)
     if not model_path.exists():
         model_path = Path(
@@ -260,7 +260,8 @@ def load_xlm_roberta_backend(
     if not weight_files:
         raise FileNotFoundError(f"No safetensors found in {model_path}.")
 
-    model = XLMRobertaModel(XLMRobertaArgs.from_config(config))
+    args = XLMRobertaArgs.from_config(config)
+    model = XLMRobertaModel(args)
     weights: dict[str, mx.array] = {}
     for weight_file in weight_files:
         weights.update(mx.load(str(weight_file)))
@@ -277,4 +278,4 @@ def load_xlm_roberta_backend(
         model,
         pad_token_id=int(config.get("pad_token_id", 1)),
     )
-    return model, tokenizer, pooling_backend
+    return model, tokenizer, asdict(args), pooling_backend

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MLX XLM-RoBERTa / RoBERTa encoder family."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from huggingface_hub import snapshot_download
+from transformers import AutoTokenizer
+
+from vllm_metal.v1.pooling.backends.encoder.runtime import MetalEncoderPoolingBackend
+from vllm_metal.v1.pooling.validation import PoolingConfigView
+
+_MODEL_TYPES = frozenset({"xlm-roberta", "roberta"})
+_ARCHITECTURES = frozenset({"XLMRobertaModel", "RobertaModel"})
+
+
+@dataclass(frozen=True, slots=True)
+class XLMRobertaArgs:
+    model_type: str = "xlm-roberta"
+    hidden_size: int = 768
+    num_hidden_layers: int = 12
+    intermediate_size: int = 3072
+    num_attention_heads: int = 12
+    max_position_embeddings: int = 512
+    vocab_size: int = 250002
+    type_vocab_size: int = 1
+    layer_norm_eps: float = 1e-5
+    pad_token_id: int = 1
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> XLMRobertaArgs:
+        names = {field.name for field in fields(cls)}
+        return cls(**{name: config[name] for name in names if name in config})
+
+
+class XLMRobertaEmbeddings(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.word_embeddings = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.position_embeddings = nn.Embedding(
+            args.max_position_embeddings,
+            args.hidden_size,
+        )
+        self.token_type_embeddings = nn.Embedding(
+            args.type_vocab_size,
+            args.hidden_size,
+        )
+        self.LayerNorm = nn.LayerNorm(args.hidden_size, eps=args.layer_norm_eps)
+        self.padding_idx = args.pad_token_id
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        token_type_ids: mx.array | None = None,
+        position_ids: mx.array | None = None,
+    ) -> mx.array:
+        if token_type_ids is None:
+            token_type_ids = mx.zeros(input_ids.shape, dtype=mx.int32)
+        if position_ids is None:
+            position_ids = self._position_ids(input_ids)
+        return self.LayerNorm(
+            self.word_embeddings(input_ids)
+            + self.token_type_embeddings(token_type_ids)
+            + self.position_embeddings(position_ids)
+        )
+
+    def _position_ids(self, input_ids: mx.array) -> mx.array:
+        mask = (input_ids != self.padding_idx).astype(mx.int32)
+        return mx.cumsum(mask, axis=1) * mask + self.padding_idx
+
+
+class XLMRobertaSelfAttention(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        if args.hidden_size % args.num_attention_heads != 0:
+            raise ValueError(
+                f"hidden_size={args.hidden_size} must divide by "
+                f"num_attention_heads={args.num_attention_heads}."
+            )
+        self.num_heads = args.num_attention_heads
+        self.head_dim = args.hidden_size // args.num_attention_heads
+        self.hidden_size = args.hidden_size
+        self.query = nn.Linear(args.hidden_size, args.hidden_size)
+        self.key = nn.Linear(args.hidden_size, args.hidden_size)
+        self.value = nn.Linear(args.hidden_size, args.hidden_size)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array:
+        query = self._split_heads(self.query(hidden_states))
+        key = self._split_heads(self.key(hidden_states))
+        value = self._split_heads(self.value(hidden_states))
+        scores = (query @ key.transpose(0, 1, 3, 2)) / math.sqrt(self.head_dim)
+        probs = mx.softmax(scores + attention_mask, axis=-1)
+        context = probs @ value
+        batch, _, seq_len, _ = context.shape
+        return context.transpose(0, 2, 1, 3).reshape(
+            batch,
+            seq_len,
+            self.hidden_size,
+        )
+
+    def _split_heads(self, tensor: mx.array) -> mx.array:
+        batch, seq_len, _ = tensor.shape
+        return tensor.reshape(batch, seq_len, self.num_heads, self.head_dim).transpose(
+            0,
+            2,
+            1,
+            3,
+        )
+
+
+class XLMRobertaSelfOutput(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.hidden_size, args.hidden_size)
+        self.LayerNorm = nn.LayerNorm(args.hidden_size, eps=args.layer_norm_eps)
+
+    def __call__(self, hidden_states: mx.array, residual: mx.array) -> mx.array:
+        return self.LayerNorm(self.dense(hidden_states) + residual)
+
+
+class XLMRobertaAttention(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.self = XLMRobertaSelfAttention(args)
+        self.output = XLMRobertaSelfOutput(args)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array:
+        return self.output(
+            self.self(hidden_states, attention_mask),
+            hidden_states,
+        )
+
+
+class XLMRobertaIntermediate(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.hidden_size, args.intermediate_size)
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        return nn.gelu(self.dense(hidden_states))
+
+
+class XLMRobertaOutput(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.dense = nn.Linear(args.intermediate_size, args.hidden_size)
+        self.LayerNorm = nn.LayerNorm(args.hidden_size, eps=args.layer_norm_eps)
+
+    def __call__(self, hidden_states: mx.array, residual: mx.array) -> mx.array:
+        return self.LayerNorm(self.dense(hidden_states) + residual)
+
+
+class XLMRobertaLayer(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.attention = XLMRobertaAttention(args)
+        self.intermediate = XLMRobertaIntermediate(args)
+        self.output = XLMRobertaOutput(args)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array:
+        attention_output = self.attention(hidden_states, attention_mask)
+        intermediate_output = self.intermediate(attention_output)
+        return self.output(intermediate_output, attention_output)
+
+
+class XLMRobertaEncoder(nn.Module):
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.layer = [XLMRobertaLayer(args) for _ in range(args.num_hidden_layers)]
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array:
+        for layer in self.layer:
+            hidden_states = layer(hidden_states, attention_mask)
+        return hidden_states
+
+
+class XLMRobertaModel(nn.Module):
+    """Encoder-only XLM-RoBERTa/RoBERTa backbone returning hidden states."""
+
+    def __init__(self, args: XLMRobertaArgs) -> None:
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.embeddings = XLMRobertaEmbeddings(args)
+        self.encoder = XLMRobertaEncoder(args)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> mx.array:
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        hidden_states = self.embeddings(input_ids)
+        return self.encoder(
+            hidden_states, self._extended_attention_mask(attention_mask)
+        )
+
+    def sanitize(self, weights: dict[str, mx.array]) -> dict[str, mx.array]:
+        return {
+            key: value
+            for key, value in weights.items()
+            if not key.endswith(".position_ids") and not key.startswith("pooler.")
+        }
+
+    def _extended_attention_mask(self, attention_mask: mx.array) -> mx.array:
+        mask = attention_mask.astype(mx.float32)
+        mask = mx.expand_dims(mx.expand_dims(mask, 1), 1)
+        return (1.0 - mask) * -1e4
+
+
+def supports_xlm_roberta_encoder(model_config: Any) -> bool:
+    hf_config = model_config.hf_config
+    architectures = tuple(str(value) for value in hf_config.architectures or ())
+    model_type = str(hf_config.model_type).replace("_", "-")
+    if architectures:
+        return any(architecture in _ARCHITECTURES for architecture in architectures)
+    return model_type in _MODEL_TYPES
+
+
+def load_xlm_roberta_backend(
+    model_config: Any,
+) -> tuple[Any, Any, MetalEncoderPoolingBackend]:
+    model_path = Path(model_config.model)
+    if not model_path.exists():
+        model_path = Path(
+            snapshot_download(
+                repo_id=model_config.model,
+                revision=model_config.revision,
+            )
+        )
+
+    config = json.loads((model_path / "config.json").read_text())
+    weight_files = sorted(model_path.glob("model*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("*.safetensors"))
+    if not weight_files:
+        raise FileNotFoundError(f"No safetensors found in {model_path}.")
+
+    model = XLMRobertaModel(XLMRobertaArgs.from_config(config))
+    weights: dict[str, mx.array] = {}
+    for weight_file in weight_files:
+        weights.update(mx.load(str(weight_file)))
+    weights = model.sanitize(weights)
+    model.load_weights(list(weights.items()), strict=True)
+    mx.eval(model.parameters())
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        trust_remote_code=model_config.trust_remote_code,
+    )
+    pooling_backend = MetalEncoderPoolingBackend(
+        PoolingConfigView(model_config),
+        model,
+        pad_token_id=int(config.get("pad_token_id", 1)),
+    )
+    return model, tokenizer, pooling_backend

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -291,7 +291,8 @@ def load_xlm_roberta_backend(
     mx.eval(model.parameters())
 
     tokenizer = AutoTokenizer.from_pretrained(
-        model_path,
+        model_config.tokenizer,
+        revision=model_config.tokenizer_revision,
         trust_remote_code=model_config.trust_remote_code,
     )
     pooling_backend = MetalEncoderPoolingBackend(

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generic encoder pooling backend.
+
+Encoder pooling runs full prompts with bidirectional attention. It does not use
+decoder KV cache, paged attention, or chunked request state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import mlx.core as mx
+import torch
+from vllm.pooling_params import PoolingParams
+from vllm.tasks import PoolingTask
+from vllm.v1.core.sched.output import SchedulerOutput
+
+from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+from vllm_metal.v1.pooling.contract import (
+    EMBED_TASK,
+    EncoderPoolingOutput,
+    PoolingCapabilities,
+)
+from vllm_metal.v1.pooling.validation import (
+    PoolingConfigView,
+    validate_pooling_request,
+)
+
+_MIN_NORM = 1e-12
+_ENCODER_POOLING_TYPES = (None, "CLS", "LAST")
+
+
+@dataclass(frozen=True, slots=True)
+class EncoderPoolingRequest:
+    req_id: str
+    token_ids: tuple[int, ...]
+    pooling_params: PoolingParams
+
+
+@dataclass(frozen=True, slots=True)
+class EncoderPoolingBatch:
+    requests: tuple[EncoderPoolingRequest, ...]
+
+
+class MetalEncoderPoolingBackend:
+    """Dense encoder embedding backend for full-prompt pooling."""
+
+    capabilities = PoolingCapabilities(
+        execution_kind="encoder",
+        requires_paged_attention=False,
+        uses_kv_cache=False,
+        supports_chunked_requests=False,
+    )
+
+    def __init__(
+        self,
+        config: PoolingConfigView,
+        forward: Callable[[mx.array, mx.array], mx.array],
+        pad_token_id: int,
+    ) -> None:
+        self.config = config
+        self._forward = forward
+        self._pad_token_id = pad_token_id
+
+    def supported_tasks(self) -> tuple[PoolingTask, ...]:
+        if self._supports_embed():
+            return (EMBED_TASK,)
+        return ()
+
+    def validate_params(self, pooling_params: PoolingParams) -> None:
+        if not self._supports_embed() or pooling_params.task not in (None, EMBED_TASK):
+            raise NotImplementedError(
+                "Metal encoder pooling supports only task='embed' "
+                f"for model={self.config.label}."
+            )
+
+    def profile_forward(self, input_ids: mx.array) -> mx.array:
+        attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        return self.forward_padded(input_ids, attention_mask)
+
+    def forward_padded(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array:
+        hidden_states = self._forward(input_ids, attention_mask)
+        if hidden_states.ndim != 3:
+            raise ValueError(
+                "Metal encoder pooling expected hidden states with shape "
+                f"[batch, tokens, hidden], got {hidden_states.shape} "
+                f"for model={self.config.label}."
+            )
+        return hidden_states
+
+    def pool_scheduler_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_config: object,
+    ) -> tuple[EncoderPoolingOutput, ...]:
+        batch = self._batch_from_scheduler_output(scheduler_output, model_config)
+        pooler_outputs = self._pool_batch(batch)
+        return tuple(
+            EncoderPoolingOutput(request.req_id, pooler_output)
+            for request, pooler_output in zip(
+                batch.requests,
+                pooler_outputs,
+                strict=True,
+            )
+        )
+
+    def _pool_batch(self, batch: EncoderPoolingBatch) -> tuple[torch.Tensor, ...]:
+        if not batch.requests:
+            return ()
+
+        input_ids, attention_mask = self._padded_inputs(batch)
+        hidden_states = self.forward_padded(input_ids, attention_mask)
+        outputs: list[torch.Tensor] = []
+        for row, request in enumerate(batch.requests):
+            outputs.append(self._pool_one(hidden_states, row, len(request.token_ids)))
+        return tuple(outputs)
+
+    def _batch_from_scheduler_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_config: object,
+    ) -> EncoderPoolingBatch:
+        self._reject_scheduler_state(scheduler_output)
+        requests: list[EncoderPoolingRequest] = []
+        for new_req in scheduler_output.scheduled_new_reqs:
+            validate_pooling_request(
+                new_req,
+                model_config,
+                pooling_backend=self,
+                paged_attention_enabled=False,
+            )
+            if new_req.pooling_params is None:
+                raise RuntimeError(
+                    "Encoder pooling received a scheduled non-pooling request."
+                )
+            requests.append(
+                EncoderPoolingRequest(
+                    req_id=new_req.req_id,
+                    token_ids=tuple(new_req.prompt_token_ids or ()),
+                    pooling_params=new_req.pooling_params,
+                )
+            )
+        return EncoderPoolingBatch(tuple(requests))
+
+    def _reject_scheduler_state(self, scheduler_output: SchedulerOutput) -> None:
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        if cached_reqs.req_ids:
+            raise NotImplementedError(
+                "Metal encoder pooling does not support cached, resumed, "
+                "or chunked requests yet."
+            )
+        if scheduler_output.preempted_req_ids:
+            raise NotImplementedError(
+                "Metal encoder pooling does not support preempted requests yet."
+            )
+        for new_req in scheduler_output.scheduled_new_reqs:
+            token_ids = new_req.prompt_token_ids or []
+            scheduled_tokens = scheduler_output.num_scheduled_tokens[new_req.req_id]
+            if new_req.num_computed_tokens != 0 or scheduled_tokens != len(token_ids):
+                raise NotImplementedError(
+                    "Metal encoder pooling requires full-prompt scheduling; "
+                    "partial or chunked pooling requests are not supported yet."
+                )
+
+    def _supports_embed(self) -> bool:
+        return (
+            self.config.is_text_only
+            and self.config.task in (None, EMBED_TASK)
+            and self.config.sequence_pooling_type in _ENCODER_POOLING_TYPES
+            and self.config.embed_activation_allowed
+            and not self.config.chunked_processing_enabled
+        )
+
+    def _padded_inputs(
+        self,
+        batch: EncoderPoolingBatch,
+    ) -> tuple[mx.array, mx.array]:
+        max_len = max(len(request.token_ids) for request in batch.requests)
+        rows: list[list[int]] = []
+        masks: list[list[int]] = []
+        for request in batch.requests:
+            token_ids = list(request.token_ids)
+            padding = [self._pad_token_id] * (max_len - len(token_ids))
+            rows.append(token_ids + padding)
+            masks.append([1] * len(token_ids) + [0] * len(padding))
+        return (
+            mx.array(rows, dtype=mx.int32),
+            mx.array(masks, dtype=mx.int32),
+        )
+
+    def _pool_one(
+        self,
+        hidden_states: mx.array,
+        row: int,
+        token_count: int,
+    ) -> torch.Tensor:
+        if token_count <= 0:
+            raise ValueError("Metal encoder pooling requires at least one token.")
+        token_index = (
+            0 if self.config.sequence_pooling_type != "LAST" else token_count - 1
+        )
+        vector = hidden_states[row, token_index, :].astype(mx.float32)
+        norm = mx.sqrt(mx.sum(vector * vector))
+        norm = mx.maximum(norm, mx.array(_MIN_NORM, dtype=mx.float32))
+        tensor = mlx_to_torch(mx.contiguous(vector / norm), device="cpu")
+        return tensor.detach().clone()

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -57,11 +57,9 @@ class MetalEncoderPoolingBackend:
         self,
         config: PoolingConfigView,
         forward: Callable[[mx.array, mx.array], mx.array],
-        pad_token_id: int,
     ) -> None:
         self.config = config
         self._forward = forward
-        self._pad_token_id = pad_token_id
 
     def supported_tasks(self) -> tuple[PoolingTask, ...]:
         if self._supports_embed():
@@ -110,14 +108,12 @@ class MetalEncoderPoolingBackend:
         )
 
     def _pool_batch(self, batch: EncoderPoolingBatch) -> tuple[torch.Tensor, ...]:
-        if not batch.requests:
-            return ()
-
-        input_ids, attention_mask = self._padded_inputs(batch)
-        hidden_states = self.forward_padded(input_ids, attention_mask)
         outputs: list[torch.Tensor] = []
-        for row, request in enumerate(batch.requests):
-            outputs.append(self._pool_one(hidden_states, row, len(request.token_ids)))
+        for request in batch.requests:
+            input_ids = mx.array([request.token_ids], dtype=mx.int32)
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+            hidden_states = self.forward_padded(input_ids, attention_mask)
+            outputs.append(self._pool_one(hidden_states, 0, len(request.token_ids)))
         return tuple(outputs)
 
     def _batch_from_scheduler_output(
@@ -174,23 +170,6 @@ class MetalEncoderPoolingBackend:
             and self.config.sequence_pooling_type in _ENCODER_POOLING_TYPES
             and self.config.embed_activation_allowed
             and not self.config.chunked_processing_enabled
-        )
-
-    def _padded_inputs(
-        self,
-        batch: EncoderPoolingBatch,
-    ) -> tuple[mx.array, mx.array]:
-        max_len = max(len(request.token_ids) for request in batch.requests)
-        rows: list[list[int]] = []
-        masks: list[list[int]] = []
-        for request in batch.requests:
-            token_ids = list(request.token_ids)
-            padding = [self._pad_token_id] * (max_len - len(token_ids))
-            rows.append(token_ids + padding)
-            masks.append([1] * len(token_ids) + [0] * len(padding))
-        return (
-            mx.array(rows, dtype=mx.int32),
-            mx.array(masks, dtype=mx.int32),
         )
 
     def _pool_one(

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -35,12 +35,6 @@ _ENCODER_POOLING_TYPES = (None, "CLS", "LAST")
 class EncoderPoolingRequest:
     req_id: str
     token_ids: tuple[int, ...]
-    pooling_params: PoolingParams
-
-
-@dataclass(frozen=True, slots=True)
-class EncoderPoolingBatch:
-    requests: tuple[EncoderPoolingRequest, ...]
 
 
 class MetalEncoderPoolingBackend:
@@ -96,31 +90,26 @@ class MetalEncoderPoolingBackend:
         scheduler_output: SchedulerOutput,
         model_config: object,
     ) -> tuple[EncoderPoolingOutput, ...]:
-        batch = self._batch_from_scheduler_output(scheduler_output, model_config)
-        pooler_outputs = self._pool_batch(batch)
+        requests = self._requests_from_scheduler_output(
+            scheduler_output,
+            model_config,
+        )
         return tuple(
-            EncoderPoolingOutput(request.req_id, pooler_output)
-            for request, pooler_output in zip(
-                batch.requests,
-                pooler_outputs,
-                strict=True,
-            )
+            EncoderPoolingOutput(request.req_id, self._pool_request(request))
+            for request in requests
         )
 
-    def _pool_batch(self, batch: EncoderPoolingBatch) -> tuple[torch.Tensor, ...]:
-        outputs: list[torch.Tensor] = []
-        for request in batch.requests:
-            input_ids = mx.array([request.token_ids], dtype=mx.int32)
-            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
-            hidden_states = self.forward_padded(input_ids, attention_mask)
-            outputs.append(self._pool_one(hidden_states, 0, len(request.token_ids)))
-        return tuple(outputs)
+    def _pool_request(self, request: EncoderPoolingRequest) -> torch.Tensor:
+        input_ids = mx.array([request.token_ids], dtype=mx.int32)
+        attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        hidden_states = self.forward_padded(input_ids, attention_mask)
+        return self._pool_one(hidden_states, 0, len(request.token_ids))
 
-    def _batch_from_scheduler_output(
+    def _requests_from_scheduler_output(
         self,
         scheduler_output: SchedulerOutput,
         model_config: object,
-    ) -> EncoderPoolingBatch:
+    ) -> tuple[EncoderPoolingRequest, ...]:
         self._reject_scheduler_state(scheduler_output)
         requests: list[EncoderPoolingRequest] = []
         for new_req in scheduler_output.scheduled_new_reqs:
@@ -138,10 +127,9 @@ class MetalEncoderPoolingBackend:
                 EncoderPoolingRequest(
                     req_id=new_req.req_id,
                     token_ids=tuple(new_req.prompt_token_ids or ()),
-                    pooling_params=new_req.pooling_params,
                 )
             )
-        return EncoderPoolingBatch(tuple(requests))
+        return tuple(requests)
 
     def _reject_scheduler_state(self, scheduler_output: SchedulerOutput) -> None:
         cached_reqs = scheduler_output.scheduled_cached_reqs

--- a/vllm_metal/v1/pooling/contract.py
+++ b/vllm_metal/v1/pooling/contract.py
@@ -4,22 +4,27 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Literal, Protocol, TypeAlias
 
 import mlx.core as mx
 import torch
 from vllm.pooling_params import PoolingParams
 from vllm.tasks import PoolingTask
+from vllm.v1.core.sched.output import SchedulerOutput
 
 from vllm_metal.attention.context import OffsetCache
 
 EMBED_TASK: PoolingTask = "embed"
 CLASSIFY_TASK: PoolingTask = "classify"
+PoolingExecutionKind: TypeAlias = Literal["decoder", "encoder"]
 
 
 @dataclass(frozen=True, slots=True)
 class PoolingCapabilities:
+    execution_kind: PoolingExecutionKind
     requires_paged_attention: bool
+    uses_kv_cache: bool
+    supports_chunked_requests: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,8 +40,16 @@ class DecoderPoolingBatch:
     spans: tuple[DecoderPoolingSpan, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class EncoderPoolingOutput:
+    req_id: str
+    pooler_output: torch.Tensor
+
+
 class PoolingBackend(Protocol):
     capabilities: PoolingCapabilities
+
+    def profile_forward(self, input_ids: mx.array) -> mx.array: ...
 
     def supported_tasks(self) -> tuple[PoolingTask, ...]: ...
 
@@ -69,3 +82,20 @@ class DecoderPoolingBackend(PoolingBackend, Protocol):
         hidden_states: mx.array,
         batch: DecoderPoolingBatch,
     ) -> tuple[torch.Tensor | None, ...]: ...
+
+
+class EncoderPoolingBackend(PoolingBackend, Protocol):
+    def forward_padded(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array,
+    ) -> mx.array: ...
+
+    def pool_scheduler_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_config: object,
+    ) -> tuple[EncoderPoolingOutput, ...]: ...
+
+
+ExecutablePoolingBackend: TypeAlias = DecoderPoolingBackend | EncoderPoolingBackend

--- a/vllm_metal/v1/pooling/validation.py
+++ b/vllm_metal/v1/pooling/validation.py
@@ -91,6 +91,13 @@ class PoolingConfigView:
         )
 
     @property
+    def sequence_pooling_type(self) -> str | None:
+        for pooling_type in self.sequence_pooling_types:
+            if pooling_type is not None:
+                return pooling_type
+        return None
+
+    @property
     def embed_activation_allowed(self) -> bool:
         return self.pooler_config.use_activation is not False
 
@@ -159,14 +166,14 @@ class PoolingConfigView:
 def validate_pooling_request(
     new_req: NewRequestData,
     model_config: Any,
-    backend: PoolingBackend | None,
+    pooling_backend: PoolingBackend | None,
     paged_attention_enabled: bool,
 ) -> None:
     pooling_params = new_req.pooling_params
     if pooling_params is None:
         return
 
-    if backend is None:
+    if pooling_backend is None:
         raise RuntimeError("Metal pooling backend is not installed.")
 
     config = PoolingConfigView(model_config)
@@ -175,14 +182,13 @@ def validate_pooling_request(
             "Metal pooling requires runner_type='pooling'; got "
             f"{config.runner_type!r} for model={config.label}."
         )
-    config.reject_unsupported_pooler_config()
     unsupported_option = config.unsupported_pooling_option(pooling_params)
     if unsupported_option is not None:
         raise NotImplementedError(
             f"Metal pooling does not support {unsupported_option} "
             f"for model={config.label}."
         )
-    backend.validate_params(pooling_params)
+    pooling_backend.validate_params(pooling_params)
     if new_req.mm_features:
         raise NotImplementedError(
             "Multimodal pooling inputs are not supported on Metal yet."
@@ -191,7 +197,10 @@ def validate_pooling_request(
         raise NotImplementedError(
             "Prompt-embedding pooling inputs are not supported on Metal yet."
         )
-    if backend.capabilities.requires_paged_attention and not paged_attention_enabled:
+    if (
+        pooling_backend.capabilities.requires_paged_attention
+        and not paged_attention_enabled
+    ):
         raise NotImplementedError(
             "Metal pooling currently requires paged attention; "
             "set VLLM_METAL_USE_PAGED_ATTENTION=1."


### PR DESCRIPTION
This PR is:

- To add the encoder pooling runtime path without using decoder KV cache or paged attention.
- To add a minimal native XLM-R/RoBERTa backbone as the foundation for BGE-M3 pooling.
- To keep decoder pooling on the existing generation loader while encoder pooling owns its model-family loader.
- To preserve vLLM’s configured tokenizer and resolved model config contracts.

Note:

This is the PR2 foundation for BGE-M3 support. It does not claim broad XLM-R/RoBERTa model support as a product feature. The local backbone exists because `mlx-lm` / `mlx-vlm` do not currently provide a license-compatible encoder implementation for this path.

Follow-up plan:

- PR3: Add BGE-M3 dense embedding behavior on top of this encoder backend.
- PR4: Add BGE-M3 sparse `token_classify` / lexical-weight output.
