### PR TITLE
Document Qwen3.8 support and update status markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 ---
 *Latest News* 🔥
 
+- [2026/08] Qwen3.8 now runs on Metal! `mlx-community/Qwen3.8-27B-8bit` serves a 27B hybrid SDPA + GDN linear model on a single Apple Silicon Mac.
 - [2026/04] We released the new version v0.2.0! Unified paged varlen Metal kernel is now the default attention backend. 83x TTFT, 3.6x throughput compared to v0.1.0.
 
 ---

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -52,8 +52,10 @@ Native multimodal support currently targets image-only vision-language requests 
 `--enable-prefix-caching`. Since
 [#283](https://github.com/vllm-project/vllm-metal/pull/283), unified paged-KV
 models reuse shared prefixes by default. Upstream vLLM keeps it off for
-hybrid/Mamba models, so those rows stay `❌`. These values describe default
-engine behavior, not exhaustive per-model benchmarking on Metal.
+hybrid/Mamba models; hybrid GDN models opt in with `--enable-prefix-caching`
+since [#584](https://github.com/vllm-project/vllm-metal/pull/584), so those rows
+are `🔵`. These values describe default engine behavior, not exhaustive
+per-model benchmarking on Metal.
 
 HF AWQ checkpoints load through mlx-lm's `_transform_awq_weights` repack, with an
 entry-point preflight that normalizes AutoAWQ aliases (`w_bit`, `q_group_size`,
@@ -83,9 +85,9 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Model | Support | Attention Kernel | Automatic Prefix Cache | Example checkpoint |
 | --- | --- | --- | --- | --- |
 | Qwen3 | ✅ | GQA (paged) | ✅ | `Qwen/Qwen3-0.6B` |
-| Qwen3.5 / 3.6 | ✅ | Hybrid SDPA + GDN linear (3.6 adds MoE) | ❌ | `Qwen/Qwen3.5-0.8B` |
-| Qwen3-Next | ✅ | Hybrid SDPA + GDN linear | ❌ | `mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit` |
-| Gemma 4 | 🔵 | GQA + per-layer sliding window + YOCO | ✅ | `mlx-community/gemma-4-E2B-it` |
+| Qwen3.5 / 3.6 / 3.8 | ✅ | Hybrid SDPA + GDN linear (3.6 adds MoE) | 🔵 | `mlx-community/Qwen3.8-27B-8bit` |
+| Qwen3-Next | ✅ | Hybrid SDPA + GDN linear | 🔵 | `mlx-community/Qwen3-Next-80B-A3B-Instruct-8bit` |
+| Gemma 4 | ✅ | GQA + per-layer sliding window + YOCO | ✅ | `mlx-community/gemma-4-E2B-it` |
 | Gemma 3 | ✅ | GQA (paged) | ✅ | `mlx-community/gemma-3-1b-it-qat-4bit` |
 | Llama 3 | ✅ | GQA (paged) | ✅ | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` |
 | Mistral-7B | ✅ | GQA (paged) | ✅ | `mlx-community/Mistral-7B-Instruct-v0.3-4bit` |


### PR DESCRIPTION
## Summary

- Add Qwen3.8 to the existing Qwen3.5/3.6 family row and update the example checkpoint to `mlx-community/Qwen3.8-27B-8bit`.
- Mark automatic prefix caching as experimental for the hybrid GDN rows (`Qwen3.5 / 3.6 / 3.8` and `Qwen3-Next`) following #584. Prefix caching remains opt-in through `--enable-prefix-caching`.
- Mark Gemma 4 as supported.
- Add Qwen3.8 to the README news section.

## Verification

Tested `mlx-community/Qwen3.8-27B-8bit` end to end on an M5 Pro with 68.7 GB unified memory, vLLM 0.27.0, and default plugin settings:

| Metric | Result |
| --- | --- |
| Engine initialization | 52.5 s |
| GPU KV cache | 187,830 tokens (22.9x concurrency at 8k context) |
| Single-stream decode | 9.01 tok/s |
| Batch size 3 | 18.3 tok/s aggregate |

Reasoning, coding, and word-problem prompts completed successfully. No code changes were required because vLLM 0.27.0 already registers `Qwen3_5ForConditionalGeneration`.

The 55.6 GB upstream BF16 checkpoint does not fit within the 55.66 GB Metal working set. The 28.6 GB MLX 8-bit conversion fits, but contains neither vision nor MTP tensors and therefore serves text only.

The prefix-cache markers reflect support added in #584; this PR does not add model-specific prefix-cache benchmarks.