### PR TITLE
Add BGE-M3 encoder pooling

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -36,6 +36,7 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | --- | --- | --- | --- |
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
+| BGE-M3 | 🔵 | `pooling` / `embed`, `token_classify` (encoder) | `BAAI/bge-m3` |
 
 ## Multimodal Language Models
 

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -1,15 +1,18 @@
 # Text Pooling
 
-Metal V1 has experimental text-only `embed` pooling support for compatible
-pooling models. Supported requests run as prefill-only work, return one CPU
-L2-normalized embedding tensor per finished request through vLLM's
-`pooler_output` contract, and do not sample generation tokens.
+Metal V1 has experimental text-only `embed`, `classify`, and
+`token_classify` pooling support for compatible pooling models. Supported
+requests return CPU tensors through vLLM's `pooler_output` contract and do not
+sample generation tokens.
 
 It also has experimental text-only `classify` support for original Qwen3
 reranker checkpoints that vLLM converts with
 `Qwen3ForSequenceClassification`, `classifier_from_token=["no", "yes"]`, and
 `is_original_qwen3_reranker=True`. This path returns one scalar score tensor
 per request through the same `pooler_output` contract.
+
+Canonical unquantized `BAAI/bge-m3` is supported on the encoder pooling path
+for dense `embed` output and sparse `token_classify` lexical weights.
 
 ## Scope
 
@@ -22,24 +25,30 @@ Current scope is intentionally narrow:
   and `is_original_qwen3_reranker=True`
 - decoder-style text models that expose token hidden states through the MLX
   transformer body
-- sequence embeddings from the final prompt-token hidden state with LAST
-  pooling and L2 normalization on the paged Metal V1 path
+- decoder sequence embeddings from the final prompt-token hidden state with
+  LAST pooling and L2 normalization on the paged Metal V1 path
 - Qwen3 reranker cross-encoder scores from the final prompt-token hidden state,
   using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
   embeddings are tied
+- BGE-M3 dense embeddings from the CLS hidden state, L2-normalized
+- BGE-M3 sparse lexical weights through `/pooling` with
+  `pooler_config.task="token_classify"`
 
 ## Unsupported
 
 The Metal runner rejects these cases with diagnostic errors:
 
 - generic classification heads, generic reranking models, and late interaction
-- sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`, `STEP`)
-- token-level pooling
+- decoder sequence pooling strategies other than LAST (`MEAN`, `CLS`, `ALL`,
+  `STEP`)
+- generic token-level pooling outside the BGE-M3 `token_classify` path
 - chunked long-input embedding aggregation (`enable_chunked_processing`)
-- non-paged pooling execution
+- non-paged decoder pooling execution
 - multimodal embeddings and scheduled encoder inputs
 - prompt embeddings
 - unsafe dimension requests
+- MLX Community BGE-M3 checkpoints that do not ship the sparse sidecar required
+  by `token_classify`
 
 Direct model-provided embedding tensors are intentionally out of scope for this
 MVP. Add that path only after a real model requires it and the output contract
@@ -47,7 +56,8 @@ is validated end to end.
 
 ## Usage
 
-Set `VLLM_METAL_USE_PAGED_ATTENTION=1` for the current text pooling MVP.
+Set `VLLM_METAL_USE_PAGED_ATTENTION=1` for decoder pooling models. Encoder
+pooling models such as BGE-M3 do not use decoder KV cache or paged attention.
 
 ### Offline Embeddings
 
@@ -130,8 +140,42 @@ curl http://localhost:8000/score \
   -d '{"text_1":["What is the capital of China?"],"text_2":["The capital of China is Beijing."]}'
 ```
 
+### BGE-M3 Dense Embeddings
+
+```bash
+vllm serve BAAI/bge-m3 \
+  --runner pooling \
+  --max-model-len 8192
+```
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"model":"BAAI/bge-m3","input":["what is sparse retrieval?","lexical matching example"]}'
+```
+
+### BGE-M3 Sparse Lexical Weights
+
+Start the server with the `token_classify` pooling task and the BGE-M3
+architecture override expected by vLLM's pooling contract.
+
+```bash
+vllm serve BAAI/bge-m3 \
+  --runner pooling \
+  --max-model-len 8192 \
+  --pooler-config '{"task":"token_classify"}' \
+  --hf-overrides '{"architectures":["BgeM3EmbeddingModel"]}'
+```
+
+```bash
+curl http://localhost:8000/pooling \
+  -H "Content-Type: application/json" \
+  -d '{"model":"BAAI/bge-m3","input":["what is sparse retrieval?"]}'
+```
+
 ## Validation
 
 Do not add a model row to [Supported Models](supported_models.md) until a real
-`LLM.embed`, `/v1/embeddings`, `LLM.score`, or `/score` smoke passes on Apple
-Silicon with the model name, revision, command, and output shape recorded.
+`LLM.embed`, `/v1/embeddings`, `LLM.score`, `/score`, or `/pooling` smoke
+passes on Apple Silicon with the model name, revision, command, and output
+shape recorded.

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -39,6 +39,9 @@ from vllm_metal.v1.pooling.backends.decoder.runtime import (  # noqa: E402
 from vllm_metal.v1.pooling.backends.encoder.factory import (  # noqa: E402
     load_encoder_pooling_backend,
 )
+from vllm_metal.v1.pooling.backends.encoder.models.loading import (  # noqa: E402
+    load_encoder_weight_file,
+)
 from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (  # noqa: E402
     load_xlm_roberta_backend,
 )
@@ -760,6 +763,18 @@ class TestMetalPoolingCapabilities:
 
         with pytest.raises(NotImplementedError, match="quantization"):
             load_xlm_roberta_backend(model_config)
+
+    def test_encoder_torch_weight_loader_accepts_bfloat16(self, tmp_path) -> None:
+        weight_path = tmp_path / "pytorch_model.bin"
+        torch.save(
+            {"encoder.layer.weight": torch.ones((2, 2), dtype=torch.bfloat16)},
+            weight_path,
+        )
+
+        weights = load_encoder_weight_file(weight_path)
+
+        assert weights["encoder.layer.weight"].dtype == mx.bfloat16
+        assert weights["encoder.layer.weight"].shape == (2, 2)
 
     def test_bge_m3_dense_pooling_uses_encoder_backbone(self, tmp_path) -> None:
         torch.manual_seed(0)

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -12,7 +11,6 @@ import numpy as np
 import pytest
 import torch
 from torch.nn.functional import normalize
-from transformers import AutoConfig
 from transformers import XLMRobertaConfig as TorchXLMRobertaConfig
 from transformers import XLMRobertaModel as TorchXLMRobertaModel
 
@@ -279,72 +277,6 @@ def _save_bge_m3_sparse_head(tmp_path, hidden_size: int) -> torch.nn.Linear:
     sparse_linear = torch.nn.Linear(hidden_size, 1)
     torch.save(sparse_linear.state_dict(), tmp_path / "sparse_linear.pt")
     return sparse_linear
-
-
-def _pool_real_bge(pooling_backend, model_config, tokenizer, sentence: str):
-    token_ids = tokenizer(sentence).input_ids
-    request = _new_req("req-0", token_ids, task="embed")
-    outputs = pooling_backend.pool_scheduler_output(
-        _scheduler_output(new_reqs=[request]),
-        model_config,
-    )
-    return outputs[0].pooler_output
-
-
-def _real_bge_sparse_weights(
-    pooling_backend,
-    model_config,
-    tokenizer,
-    sentence: str,
-) -> dict[int, float]:
-    token_ids = tokenizer(sentence).input_ids
-    request = _new_req(
-        "req-0",
-        token_ids,
-        pooling_params=_pooling_params(
-            task="token_classify",
-            requires_token_ids=True,
-        ),
-    )
-    outputs = pooling_backend.pool_scheduler_output(
-        _scheduler_output(new_reqs=[request]),
-        model_config,
-    )
-    sparse_scores = outputs[0].pooler_output.tolist()
-    if token_ids[0] == tokenizer.bos_token_id:
-        token_ids = token_ids[1:]
-    if token_ids[-1] == tokenizer.eos_token_id:
-        token_ids = token_ids[:-1]
-    weights: dict[int, float] = {}
-    for token_id, score in zip(token_ids, sparse_scores, strict=True):
-        weights[token_id] = max(float(score), weights.get(token_id, 0.0))
-    return weights
-
-
-def _real_bge_lexical_score(
-    pooling_backend,
-    model_config,
-    tokenizer,
-    query: str,
-    document: str,
-) -> float:
-    query_weights = _real_bge_sparse_weights(
-        pooling_backend,
-        model_config,
-        tokenizer,
-        query,
-    )
-    document_weights = _real_bge_sparse_weights(
-        pooling_backend,
-        model_config,
-        tokenizer,
-        document,
-    )
-    return sum(
-        weight * document_weights[token_id]
-        for token_id, weight in query_weights.items()
-        if token_id in document_weights
-    )
 
 
 def _make_runner(
@@ -922,67 +854,6 @@ class TestMetalPoolingCapabilities:
             atol=1e-5,
             rtol=1e-5,
         )
-
-    @pytest.mark.skipif(
-        "VLLM_METAL_BGE_M3_CHECKPOINT" not in os.environ,
-        reason="set VLLM_METAL_BGE_M3_CHECKPOINT to run real BGE-M3 parity",
-    )
-    def test_real_bge_m3_checkpoint_matches_reference_scores(self) -> None:
-        checkpoint = os.environ["VLLM_METAL_BGE_M3_CHECKPOINT"]
-        hf_config = AutoConfig.from_pretrained(checkpoint)
-        hf_config.architectures = ["BgeM3EmbeddingModel"]
-        model_config = _bge_m3_model_config(
-            model=checkpoint,
-            tokenizer=checkpoint,
-            hf_config=hf_config,
-            dtype=torch.float16,
-        )
-        loaded_backend = load_encoder_pooling_backend(model_config)
-        sentences_1 = ["What is BGE M3?", "Definition of BM25"]
-        sentences_2 = [
-            "BGE M3 is an embedding model supporting dense retrieval, "
-            "lexical matching and multi-vector interaction.",
-            "BM25 is a bag-of-words retrieval function that ranks a set "
-            "of documents based on the query terms appearing in each document",
-        ]
-
-        embeddings_1 = torch.stack(
-            [
-                _pool_real_bge(
-                    loaded_backend.pooling_backend,
-                    model_config,
-                    loaded_backend.tokenizer,
-                    sentence,
-                )
-                for sentence in sentences_1
-            ]
-        )
-        embeddings_2 = torch.stack(
-            [
-                _pool_real_bge(
-                    loaded_backend.pooling_backend,
-                    model_config,
-                    loaded_backend.tokenizer,
-                    sentence,
-                )
-                for sentence in sentences_2
-            ]
-        )
-
-        assert embeddings_1.shape[1] == 1024
-        assert torch.allclose(
-            embeddings_1 @ embeddings_2.T,
-            torch.tensor([[0.6259, 0.3474], [0.3309, 0.6734]]),
-            rtol=0.01,
-            atol=0.01,
-        )
-        assert _real_bge_lexical_score(
-            loaded_backend.pooling_backend,
-            model_config,
-            loaded_backend.tokenizer,
-            sentences_1[0],
-            sentences_2[0],
-        ) == pytest.approx(0.19554901123046875, rel=0.01)
 
 
 class TestMetalPoolingRunnerOutput:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -28,7 +28,6 @@ from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noq
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
 from vllm_metal.v1.model_lifecycle import (  # noqa: E402
-    LoadedEncoderPoolingModel,
     LoadedGenerationModel,
     ModelLifecycle,
 )
@@ -50,6 +49,7 @@ from vllm_metal.v1.pooling.backends.encoder.runtime import (  # noqa: E402
 )
 from vllm_metal.v1.pooling.contract import (  # noqa: E402
     DecoderPoolingSpan,
+    LoadedEncoderBackend,
     PoolingCapabilities,
 )
 from vllm_metal.v1.pooling.validation import PoolingConfigView  # noqa: E402
@@ -705,7 +705,7 @@ class TestMetalPoolingCapabilities:
         )
         lifecycle = ModelLifecycle(runner, runner._model_adapter)
         runner._model_lifecycle = lifecycle
-        loaded = LoadedEncoderPoolingModel(
+        loaded = LoadedEncoderBackend(
             model=SimpleNamespace(config=SimpleNamespace(vocab_size=16)),
             tokenizer=object(),
             model_args={"vocab_size": 16},
@@ -766,9 +766,7 @@ class TestMetalPoolingCapabilities:
             "AutoTokenizer.from_pretrained",
             return_value=object(),
         ) as load_tokenizer:
-            mlx_model, _, model_args, pooling_backend = load_xlm_roberta_backend(
-                model_config
-            )
+            loaded_backend = load_xlm_roberta_backend(model_config)
 
         input_ids = torch.tensor(
             [
@@ -784,7 +782,7 @@ class TestMetalPoolingCapabilities:
                 attention_mask=attention_mask,
             ).last_hidden_state
 
-        actual_hidden = mlx_model(
+        actual_hidden = loaded_backend.model(
             mx.array(input_ids.numpy(), dtype=mx.int32),
             mx.array(attention_mask.numpy(), dtype=mx.int32),
         )
@@ -793,7 +791,7 @@ class TestMetalPoolingCapabilities:
             device="cpu",
         )
 
-        assert model_args["hidden_size"] == torch_config.hidden_size
+        assert loaded_backend.model_args["hidden_size"] == torch_config.hidden_size
         assert torch.allclose(
             actual_hidden_torch,
             expected_hidden,
@@ -802,7 +800,7 @@ class TestMetalPoolingCapabilities:
         )
 
         request = _new_req("req-0", [0, 5, 6, 2], task="embed")
-        outputs = pooling_backend.pool_scheduler_output(
+        outputs = loaded_backend.pooling_backend.pool_scheduler_output(
             _scheduler_output(new_reqs=[request]),
             model_config,
         )
@@ -850,7 +848,7 @@ class TestMetalPoolingCapabilities:
             "AutoTokenizer.from_pretrained",
             return_value=object(),
         ):
-            _, _, _, pooling_backend = load_encoder_pooling_backend(model_config)
+            loaded_backend = load_encoder_pooling_backend(model_config)
 
         input_ids = torch.tensor([[0, 5, 6, 2]], dtype=torch.long)
         attention_mask = (input_ids != torch_config.pad_token_id).to(torch.long)
@@ -861,7 +859,7 @@ class TestMetalPoolingCapabilities:
             ).last_hidden_state
         request = _new_req("req-0", input_ids[0].tolist(), task="embed")
 
-        outputs = pooling_backend.pool_scheduler_output(
+        outputs = loaded_backend.pooling_backend.pool_scheduler_output(
             _scheduler_output(new_reqs=[request]),
             model_config,
         )
@@ -893,7 +891,7 @@ class TestMetalPoolingCapabilities:
             "AutoTokenizer.from_pretrained",
             return_value=object(),
         ):
-            _, _, _, pooling_backend = load_encoder_pooling_backend(model_config)
+            loaded_backend = load_encoder_pooling_backend(model_config)
 
         input_ids = torch.tensor([[0, 5, 6, 2]], dtype=torch.long)
         attention_mask = (input_ids != torch_config.pad_token_id).to(torch.long)
@@ -912,7 +910,7 @@ class TestMetalPoolingCapabilities:
                 requires_token_ids=True,
             ),
         )
-        outputs = pooling_backend.pool_scheduler_output(
+        outputs = loaded_backend.pooling_backend.pool_scheduler_output(
             _scheduler_output(new_reqs=[request]),
             model_config,
         )
@@ -939,7 +937,7 @@ class TestMetalPoolingCapabilities:
             hf_config=hf_config,
             dtype=torch.float16,
         )
-        _, tokenizer, _, pooling_backend = load_encoder_pooling_backend(model_config)
+        loaded_backend = load_encoder_pooling_backend(model_config)
         sentences_1 = ["What is BGE M3?", "Definition of BM25"]
         sentences_2 = [
             "BGE M3 is an embedding model supporting dense retrieval, "
@@ -950,13 +948,23 @@ class TestMetalPoolingCapabilities:
 
         embeddings_1 = torch.stack(
             [
-                _pool_real_bge(pooling_backend, model_config, tokenizer, sentence)
+                _pool_real_bge(
+                    loaded_backend.pooling_backend,
+                    model_config,
+                    loaded_backend.tokenizer,
+                    sentence,
+                )
                 for sentence in sentences_1
             ]
         )
         embeddings_2 = torch.stack(
             [
-                _pool_real_bge(pooling_backend, model_config, tokenizer, sentence)
+                _pool_real_bge(
+                    loaded_backend.pooling_backend,
+                    model_config,
+                    loaded_backend.tokenizer,
+                    sentence,
+                )
                 for sentence in sentences_2
             ]
         )
@@ -969,9 +977,9 @@ class TestMetalPoolingCapabilities:
             atol=0.01,
         )
         assert _real_bge_lexical_score(
-            pooling_backend,
+            loaded_backend.pooling_backend,
             model_config,
-            tokenizer,
+            loaded_backend.tokenizer,
             sentences_1[0],
             sentences_2[0],
         ) == pytest.approx(0.19554901123046875, rel=0.01)

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -30,15 +30,15 @@ from vllm_metal.v1.model_lifecycle import (  # noqa: E402
     LoadedGenerationModel,
     ModelLifecycle,
 )
-from vllm_metal.v1.pooling.backends.encoder.factory import (  # noqa: E402
-    load_encoder_pooling_backend,
-)
 from vllm_metal.v1.pooling.backends.decoder.models.qwen3 import (  # noqa: E402
     Qwen3RerankerPooler,
 )
 from vllm_metal.v1.pooling.backends.decoder.runtime import (  # noqa: E402
     DecoderModelView,
     MetalDecoderPoolingBackend,
+)
+from vllm_metal.v1.pooling.backends.encoder.factory import (  # noqa: E402
+    load_encoder_pooling_backend,
 )
 from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (  # noqa: E402
     load_xlm_roberta_backend,

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -11,6 +12,7 @@ import numpy as np
 import pytest
 import torch
 from torch.nn.functional import normalize
+from transformers import AutoConfig
 from transformers import XLMRobertaConfig as TorchXLMRobertaConfig
 from transformers import XLMRobertaModel as TorchXLMRobertaModel
 
@@ -261,6 +263,87 @@ def _tiny_xlm_roberta_config() -> TorchXLMRobertaConfig:
         pad_token_id=1,
         hidden_act="gelu",
         position_embedding_type="absolute",
+    )
+
+
+def _save_tiny_xlm_roberta_checkpoint(tmp_path, architecture: str | None = None):
+    torch_config = _tiny_xlm_roberta_config()
+    transformers_model = TorchXLMRobertaModel(torch_config).eval()
+    transformers_model.save_pretrained(tmp_path, safe_serialization=True)
+    if architecture is not None:
+        torch_config.architectures = [architecture]
+    return torch_config, transformers_model
+
+
+def _save_bge_m3_sparse_head(tmp_path, hidden_size: int) -> torch.nn.Linear:
+    sparse_linear = torch.nn.Linear(hidden_size, 1)
+    torch.save(sparse_linear.state_dict(), tmp_path / "sparse_linear.pt")
+    return sparse_linear
+
+
+def _pool_real_bge(pooling_backend, model_config, tokenizer, sentence: str):
+    token_ids = tokenizer(sentence).input_ids
+    request = _new_req("req-0", token_ids, task="embed")
+    outputs = pooling_backend.pool_scheduler_output(
+        _scheduler_output(new_reqs=[request]),
+        model_config,
+    )
+    return outputs[0].pooler_output
+
+
+def _real_bge_sparse_weights(
+    pooling_backend,
+    model_config,
+    tokenizer,
+    sentence: str,
+) -> dict[int, float]:
+    token_ids = tokenizer(sentence).input_ids
+    request = _new_req(
+        "req-0",
+        token_ids,
+        pooling_params=_pooling_params(
+            task="token_classify",
+            requires_token_ids=True,
+        ),
+    )
+    outputs = pooling_backend.pool_scheduler_output(
+        _scheduler_output(new_reqs=[request]),
+        model_config,
+    )
+    sparse_scores = outputs[0].pooler_output.tolist()
+    if token_ids[0] == tokenizer.bos_token_id:
+        token_ids = token_ids[1:]
+    if token_ids[-1] == tokenizer.eos_token_id:
+        token_ids = token_ids[:-1]
+    weights: dict[int, float] = {}
+    for token_id, score in zip(token_ids, sparse_scores, strict=True):
+        weights[token_id] = max(float(score), weights.get(token_id, 0.0))
+    return weights
+
+
+def _real_bge_lexical_score(
+    pooling_backend,
+    model_config,
+    tokenizer,
+    query: str,
+    document: str,
+) -> float:
+    query_weights = _real_bge_sparse_weights(
+        pooling_backend,
+        model_config,
+        tokenizer,
+        query,
+    )
+    document_weights = _real_bge_sparse_weights(
+        pooling_backend,
+        model_config,
+        tokenizer,
+        document,
+    )
+    return sum(
+        weight * document_weights[token_id]
+        for token_id, weight in query_weights.items()
+        if token_id in document_weights
     )
 
 
@@ -668,9 +751,7 @@ class TestMetalPoolingCapabilities:
         tmp_path,
     ) -> None:
         torch.manual_seed(0)
-        torch_config = _tiny_xlm_roberta_config()
-        transformers_model = TorchXLMRobertaModel(torch_config).eval()
-        transformers_model.save_pretrained(tmp_path, safe_serialization=True)
+        torch_config, transformers_model = _save_tiny_xlm_roberta_checkpoint(tmp_path)
 
         model_config = _encoder_model_config(
             model=str(tmp_path),
@@ -752,10 +833,11 @@ class TestMetalPoolingCapabilities:
 
     def test_bge_m3_dense_pooling_uses_encoder_backbone(self, tmp_path) -> None:
         torch.manual_seed(0)
-        torch_config = _tiny_xlm_roberta_config()
-        transformers_model = TorchXLMRobertaModel(torch_config).eval()
-        transformers_model.save_pretrained(tmp_path, safe_serialization=True)
-        torch_config.architectures = ["BgeM3EmbeddingModel"]
+        torch_config, transformers_model = _save_tiny_xlm_roberta_checkpoint(
+            tmp_path,
+            "BgeM3EmbeddingModel",
+        )
+        _save_bge_m3_sparse_head(tmp_path, torch_config.hidden_size)
         model_config = _bge_m3_model_config(
             model=str(tmp_path),
             tokenizer=str(tmp_path),
@@ -791,6 +873,108 @@ class TestMetalPoolingCapabilities:
             atol=1e-5,
             rtol=1e-5,
         )
+
+    def test_bge_m3_token_classify_uses_sparse_head(self, tmp_path) -> None:
+        torch.manual_seed(0)
+        torch_config, transformers_model = _save_tiny_xlm_roberta_checkpoint(
+            tmp_path,
+            "BgeM3EmbeddingModel",
+        )
+        sparse_linear = _save_bge_m3_sparse_head(tmp_path, torch_config.hidden_size)
+        model_config = _bge_m3_model_config(
+            model=str(tmp_path),
+            tokenizer=str(tmp_path),
+            hf_config=torch_config,
+            dtype=torch.float32,
+        )
+
+        with patch(
+            "vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta."
+            "AutoTokenizer.from_pretrained",
+            return_value=object(),
+        ):
+            _, _, _, pooling_backend = load_encoder_pooling_backend(model_config)
+
+        input_ids = torch.tensor([[0, 5, 6, 2]], dtype=torch.long)
+        attention_mask = (input_ids != torch_config.pad_token_id).to(torch.long)
+        with torch.no_grad():
+            hidden_states = transformers_model(
+                input_ids,
+                attention_mask=attention_mask,
+            ).last_hidden_state
+            expected_scores = torch.relu(sparse_linear(hidden_states[0]))
+
+        request = _new_req(
+            "req-0",
+            input_ids[0].tolist(),
+            pooling_params=_pooling_params(
+                task="token_classify",
+                requires_token_ids=True,
+            ),
+        )
+        outputs = pooling_backend.pool_scheduler_output(
+            _scheduler_output(new_reqs=[request]),
+            model_config,
+        )
+
+        assert len(outputs) == 1
+        assert torch.allclose(
+            outputs[0].pooler_output,
+            expected_scores.squeeze(-1)[1:-1],
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
+    @pytest.mark.skipif(
+        "VLLM_METAL_BGE_M3_CHECKPOINT" not in os.environ,
+        reason="set VLLM_METAL_BGE_M3_CHECKPOINT to run real BGE-M3 parity",
+    )
+    def test_real_bge_m3_checkpoint_matches_reference_scores(self) -> None:
+        checkpoint = os.environ["VLLM_METAL_BGE_M3_CHECKPOINT"]
+        hf_config = AutoConfig.from_pretrained(checkpoint)
+        hf_config.architectures = ["BgeM3EmbeddingModel"]
+        model_config = _bge_m3_model_config(
+            model=checkpoint,
+            tokenizer=checkpoint,
+            hf_config=hf_config,
+            dtype=torch.float16,
+        )
+        _, tokenizer, _, pooling_backend = load_encoder_pooling_backend(model_config)
+        sentences_1 = ["What is BGE M3?", "Definition of BM25"]
+        sentences_2 = [
+            "BGE M3 is an embedding model supporting dense retrieval, "
+            "lexical matching and multi-vector interaction.",
+            "BM25 is a bag-of-words retrieval function that ranks a set "
+            "of documents based on the query terms appearing in each document",
+        ]
+
+        embeddings_1 = torch.stack(
+            [
+                _pool_real_bge(pooling_backend, model_config, tokenizer, sentence)
+                for sentence in sentences_1
+            ]
+        )
+        embeddings_2 = torch.stack(
+            [
+                _pool_real_bge(pooling_backend, model_config, tokenizer, sentence)
+                for sentence in sentences_2
+            ]
+        )
+
+        assert embeddings_1.shape[1] == 1024
+        assert torch.allclose(
+            embeddings_1 @ embeddings_2.T,
+            torch.tensor([[0.6259, 0.3474], [0.3309, 0.6734]]),
+            rtol=0.01,
+            atol=0.01,
+        )
+        assert _real_bge_lexical_score(
+            pooling_backend,
+            model_config,
+            tokenizer,
+            sentences_1[0],
+            sentences_2[0],
+        ) == pytest.approx(0.19554901123046875, rel=0.01)
 
 
 class TestMetalPoolingRunnerOutput:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -30,6 +30,9 @@ from vllm_metal.v1.model_lifecycle import (  # noqa: E402
     LoadedGenerationModel,
     ModelLifecycle,
 )
+from vllm_metal.v1.pooling.backends.encoder.factory import (  # noqa: E402
+    load_encoder_pooling_backend,
+)
 from vllm_metal.v1.pooling.backends.decoder.models.qwen3 import (  # noqa: E402
     Qwen3RerankerPooler,
 )
@@ -225,6 +228,18 @@ def _encoder_model_config(**overrides):
     values = {
         "hf_config": _hf_config(
             architectures=["XLMRobertaModel"],
+            model_type="xlm-roberta",
+        ),
+        "pooler_config": _pooler_config(seq_pooling_type="CLS"),
+    }
+    values.update(overrides)
+    return _pooling_model_config(**values)
+
+
+def _bge_m3_model_config(**overrides):
+    values = {
+        "hf_config": _hf_config(
+            architectures=["BgeM3EmbeddingModel"],
             model_type="xlm-roberta",
         ),
         "pooler_config": _pooler_config(seq_pooling_type="CLS"),
@@ -730,6 +745,60 @@ class TestMetalPoolingCapabilities:
 
         with pytest.raises(NotImplementedError, match="quantization"):
             load_xlm_roberta_backend(model_config)
+
+    def test_bge_m3_dense_pooling_uses_encoder_backbone(self, tmp_path) -> None:
+        torch.manual_seed(0)
+        torch_config = TorchXLMRobertaConfig(
+            vocab_size=17,
+            hidden_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            intermediate_size=16,
+            max_position_embeddings=16,
+            type_vocab_size=1,
+            layer_norm_eps=1e-5,
+            pad_token_id=1,
+            hidden_act="gelu",
+            position_embedding_type="absolute",
+        )
+        transformers_model = TorchXLMRobertaModel(torch_config).eval()
+        transformers_model.save_pretrained(tmp_path, safe_serialization=True)
+        torch_config.architectures = ["BgeM3EmbeddingModel"]
+        model_config = _bge_m3_model_config(
+            model=str(tmp_path),
+            tokenizer=str(tmp_path),
+            hf_config=torch_config,
+            dtype=torch.float32,
+        )
+
+        with patch(
+            "vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta."
+            "AutoTokenizer.from_pretrained",
+            return_value=object(),
+        ):
+            _, _, _, pooling_backend = load_encoder_pooling_backend(model_config)
+
+        input_ids = torch.tensor([[0, 5, 6, 2]], dtype=torch.long)
+        attention_mask = (input_ids != torch_config.pad_token_id).to(torch.long)
+        with torch.no_grad():
+            expected_hidden = transformers_model(
+                input_ids,
+                attention_mask=attention_mask,
+            ).last_hidden_state
+        request = _new_req("req-0", input_ids[0].tolist(), task="embed")
+
+        outputs = pooling_backend.pool_scheduler_output(
+            _scheduler_output(new_reqs=[request]),
+            model_config,
+        )
+
+        assert len(outputs) == 1
+        assert torch.allclose(
+            outputs[0].pooler_output,
+            normalize(expected_hidden[0, 0].float(), dim=0),
+            atol=1e-5,
+            rtol=1e-5,
+        )
 
 
 class TestMetalPoolingRunnerOutput:

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -248,6 +248,22 @@ def _bge_m3_model_config(**overrides):
     return _pooling_model_config(**values)
 
 
+def _tiny_xlm_roberta_config() -> TorchXLMRobertaConfig:
+    return TorchXLMRobertaConfig(
+        vocab_size=17,
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=16,
+        max_position_embeddings=16,
+        type_vocab_size=1,
+        layer_norm_eps=1e-5,
+        pad_token_id=1,
+        hidden_act="gelu",
+        position_embedding_type="absolute",
+    )
+
+
 def _make_runner(
     *,
     paged: bool = True,
@@ -652,19 +668,7 @@ class TestMetalPoolingCapabilities:
         tmp_path,
     ) -> None:
         torch.manual_seed(0)
-        torch_config = TorchXLMRobertaConfig(
-            vocab_size=17,
-            hidden_size=8,
-            num_hidden_layers=1,
-            num_attention_heads=2,
-            intermediate_size=16,
-            max_position_embeddings=16,
-            type_vocab_size=1,
-            layer_norm_eps=1e-5,
-            pad_token_id=1,
-            hidden_act="gelu",
-            position_embedding_type="absolute",
-        )
+        torch_config = _tiny_xlm_roberta_config()
         transformers_model = TorchXLMRobertaModel(torch_config).eval()
         transformers_model.save_pretrained(tmp_path, safe_serialization=True)
 
@@ -748,19 +752,7 @@ class TestMetalPoolingCapabilities:
 
     def test_bge_m3_dense_pooling_uses_encoder_backbone(self, tmp_path) -> None:
         torch.manual_seed(0)
-        torch_config = TorchXLMRobertaConfig(
-            vocab_size=17,
-            hidden_size=8,
-            num_hidden_layers=1,
-            num_attention_heads=2,
-            intermediate_size=16,
-            max_position_embeddings=16,
-            type_vocab_size=1,
-            layer_norm_eps=1e-5,
-            pad_token_id=1,
-            hidden_act="gelu",
-            position_embedding_type="absolute",
-        )
+        torch_config = _tiny_xlm_roberta_config()
         transformers_model = TorchXLMRobertaModel(torch_config).eval()
         transformers_model.save_pretrained(tmp_path, safe_serialization=True)
         torch_config.architectures = ["BgeM3EmbeddingModel"]

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -32,7 +32,7 @@ from vllm_metal.v1.pooling.backends.encoder.factory import (
     load_encoder_pooling_backend,
     supports_encoder_pooling_backend,
 )
-from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
+from vllm_metal.v1.pooling.contract import LoadedEncoderBackend
 
 # Engine-core subprocesses don't always re-invoke `vllm_metal._register()`,
 # so the compat patches applied there may be missing here. Reapply on import
@@ -120,16 +120,6 @@ class LoadedGenerationModel:
     model_args: dict[str, Any]
 
 
-@dataclass(frozen=True, slots=True)
-class LoadedEncoderPoolingModel:
-    """Loaded encoder model plus its pooling backend."""
-
-    model: Any
-    tokenizer: Any
-    model_args: dict[str, Any]
-    pooling_backend: EncoderPoolingBackend
-
-
 class ModelLifecycle:
     def __init__(
         self,
@@ -177,7 +167,7 @@ class ModelLifecycle:
         self._reject_pipeline_parallel_with_per_layer_metadata()
         self._install_hybrid_attention_dims(args)
 
-    def _load_encoder_pooling(self) -> LoadedEncoderPoolingModel | None:
+    def _load_encoder_pooling(self) -> LoadedEncoderBackend | None:
         runner = self._runner
         if not runner._is_pooling or not supports_encoder_pooling_backend(
             runner.model_config
@@ -193,15 +183,7 @@ class ModelLifecycle:
                 "Metal encoder pooling does not support LoRA yet."
             )
 
-        model, tokenizer, model_args, pooling_backend = load_encoder_pooling_backend(
-            runner.model_config
-        )
-        return LoadedEncoderPoolingModel(
-            model=model,
-            tokenizer=tokenizer,
-            model_args=model_args,
-            pooling_backend=pooling_backend,
-        )
+        return load_encoder_pooling_backend(runner.model_config)
 
     def _load_generation(
         self,
@@ -224,7 +206,7 @@ class ModelLifecycle:
 
     def _install_encoder_pooling_model(
         self,
-        loaded_model: LoadedEncoderPoolingModel,
+        loaded_model: LoadedEncoderBackend,
     ) -> None:
         runner = self._runner
         runner.model = loaded_model.model

--- a/vllm_metal/v1/pooling/backends/decoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/decoder/runtime.py
@@ -114,7 +114,7 @@ class LastTokenEmbeddingPooler:
 
 
 class MetalDecoderPoolingBackend:
-    """Decoder pooling backend for current Metal text pooling behavior."""
+    """Concrete DecoderPoolingBackend for Metal decoder pooling."""
 
     capabilities = PoolingCapabilities(
         execution_kind="decoder",

--- a/vllm_metal/v1/pooling/backends/encoder/factory.py
+++ b/vllm_metal/v1/pooling/backends/encoder/factory.py
@@ -7,6 +7,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from vllm_metal.v1.pooling.backends.encoder.models.bge_m3 import (
+    load_bge_m3_backend,
+    supports_bge_m3_encoder,
+)
 from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
     load_xlm_roberta_backend,
     supports_xlm_roberta_encoder,
@@ -27,6 +31,10 @@ _ENCODER_BACKEND_LOADERS = (
     # Decoder pooling wraps the already-loaded generation model. Encoder pooling
     # has model-family-owned loaders because it does not use the generation
     # loader, paged attention, or KV cache.
+    EncoderBackendLoader(
+        supports=supports_bge_m3_encoder,
+        load=load_bge_m3_backend,
+    ),
     EncoderBackendLoader(
         supports=supports_xlm_roberta_encoder,
         load=load_xlm_roberta_backend,

--- a/vllm_metal/v1/pooling/backends/encoder/factory.py
+++ b/vllm_metal/v1/pooling/backends/encoder/factory.py
@@ -15,16 +15,14 @@ from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
     load_xlm_roberta_backend,
     supports_xlm_roberta_encoder,
 )
-from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
+from vllm_metal.v1.pooling.contract import LoadedEncoderBackend
 from vllm_metal.v1.pooling.validation import PoolingConfigView
-
-EncoderBackendLoadResult = tuple[Any, Any, dict[str, Any], EncoderPoolingBackend]
 
 
 @dataclass(frozen=True, slots=True)
 class EncoderBackendLoader:
     supports: Callable[[Any], bool]
-    load: Callable[[Any], EncoderBackendLoadResult]
+    load: Callable[[Any], LoadedEncoderBackend]
 
 
 _ENCODER_BACKEND_LOADERS = (
@@ -53,7 +51,7 @@ def supports_encoder_pooling_backend(model_config: Any) -> bool:
 
 def load_encoder_pooling_backend(
     model_config: Any,
-) -> EncoderBackendLoadResult:
+) -> LoadedEncoderBackend:
     for loader in _ENCODER_BACKEND_LOADERS:
         if loader.supports(model_config):
             return loader.load(model_config)

--- a/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
@@ -29,7 +29,7 @@ from vllm_metal.v1.pooling.backends.encoder.runtime import (
 from vllm_metal.v1.pooling.contract import (
     EMBED_TASK,
     TOKEN_CLASSIFY_TASK,
-    EncoderPoolingBackend,
+    LoadedEncoderBackend,
 )
 from vllm_metal.v1.pooling.validation import PoolingConfigView
 
@@ -64,7 +64,10 @@ class BgeM3Pooler:
         if pooling_params.task in (None, EMBED_TASK):
             self.embedding_pooler.validate_params(pooling_params)
             return
-        if pooling_params.task == TOKEN_CLASSIFY_TASK and self._supports_token_classify():
+        if (
+            pooling_params.task == TOKEN_CLASSIFY_TASK
+            and self._supports_token_classify()
+        ):
             return
         raise NotImplementedError(
             "Metal BGE-M3 pooling supports only task='embed' or "
@@ -104,7 +107,9 @@ class BgeM3Pooler:
         tensor = mlx_to_torch(mx.contiguous(scores), device="cpu")
         tensor = tensor.detach().clone().squeeze(-1)
         start = 1 if request.token_ids[0] == self.bos_token_id else 0
-        end = -1 if request.token_ids[-1] == self.eos_token_id else len(request.token_ids)
+        end = (
+            -1 if request.token_ids[-1] == self.eos_token_id else len(request.token_ids)
+        )
         return tensor[start:end]
 
 
@@ -117,21 +122,26 @@ def supports_bge_m3_encoder(model_config: Any) -> bool:
 
 def load_bge_m3_backend(
     model_config: Any,
-) -> tuple[Any, Any, dict[str, Any], EncoderPoolingBackend]:
-    model, tokenizer, model_args, _ = load_xlm_roberta_backend(model_config)
+) -> LoadedEncoderBackend:
+    loaded_backbone = load_xlm_roberta_backend(model_config)
     model_path = encoder_model_path(model_config)
     config = PoolingConfigView(model_config)
     sparse_linear = load_sparse_linear(
         model_path,
-        int(model_args["hidden_size"]),
+        int(loaded_backbone.model_args["hidden_size"]),
         TORCH_TO_MLX_DTYPE[model_config.dtype],
     )
     pooling_backend = MetalEncoderPoolingBackend(
         config,
-        model,
+        loaded_backbone.model,
         BgeM3Pooler(config, sparse_linear),
     )
-    return model, tokenizer, model_args, pooling_backend
+    return LoadedEncoderBackend(
+        model=loaded_backbone.model,
+        tokenizer=loaded_backbone.tokenizer,
+        model_args=loaded_backbone.model_args,
+        pooling_backend=pooling_backend,
+    )
 
 
 def load_sparse_linear(

--- a/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
@@ -16,19 +16,21 @@ from vllm_metal.pytorch_backend.tensor_bridge import (
     TORCH_TO_MLX_DTYPE,
     mlx_to_torch,
 )
-from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
+from vllm_metal.v1.pooling.backends.encoder.models.loading import (
     encoder_model_path,
     load_encoder_weight_file,
+)
+from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
     load_xlm_roberta_backend,
 )
 from vllm_metal.v1.pooling.backends.encoder.runtime import (
     EncoderEmbeddingPooler,
-    EncoderPoolingRequest,
     MetalEncoderPoolingBackend,
 )
 from vllm_metal.v1.pooling.contract import (
     EMBED_TASK,
     TOKEN_CLASSIFY_TASK,
+    EncoderPoolingRequest,
     LoadedEncoderBackend,
 )
 from vllm_metal.v1.pooling.validation import PoolingConfigView
@@ -79,6 +81,7 @@ class BgeM3Pooler:
         hidden_states: mx.array,
         request: EncoderPoolingRequest,
     ) -> torch.Tensor:
+        """Dispatch one BGE-M3 request to dense embedding or sparse pooling."""
         if request.pooling_params.task == TOKEN_CLASSIFY_TASK:
             return self._pool_sparse(hidden_states, request)
         return self.embedding_pooler.pool_one(hidden_states, request)
@@ -96,6 +99,7 @@ class BgeM3Pooler:
         hidden_states: mx.array,
         request: EncoderPoolingRequest,
     ) -> torch.Tensor:
+        """Return sparse lexical scores after BOS/EOS filtering."""
         if not request.token_ids:
             raise ValueError("Metal BGE-M3 sparse pooling requires at least one token.")
 

--- a/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""BGE-M3 dense encoder pooling."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
+    load_xlm_roberta_backend,
+)
+from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
+
+_ARCHITECTURES = frozenset({"BgeM3EmbeddingModel"})
+
+
+def supports_bge_m3_encoder(model_config: Any) -> bool:
+    architectures = tuple(
+        str(value) for value in model_config.hf_config.architectures or ()
+    )
+    return any(architecture in _ARCHITECTURES for architecture in architectures)
+
+
+def load_bge_m3_backend(
+    model_config: Any,
+) -> tuple[Any, Any, dict[str, Any], EncoderPoolingBackend]:
+    # Dense BGE-M3 uses the RoBERTa/XLM-R backbone and normal CLS embed pooler.
+    # Sparse lexical heads are added separately with token_classify support.
+    return load_xlm_roberta_backend(model_config)

--- a/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/bge_m3.py
@@ -1,16 +1,111 @@
 # SPDX-License-Identifier: Apache-2.0
-"""BGE-M3 dense encoder pooling."""
+"""BGE-M3 dense and sparse encoder pooling."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
+import mlx.core as mx
+import mlx.nn as nn
+import torch
+from vllm.pooling_params import PoolingParams
+from vllm.tasks import PoolingTask
+
+from vllm_metal.pytorch_backend.tensor_bridge import (
+    TORCH_TO_MLX_DTYPE,
+    mlx_to_torch,
+)
 from vllm_metal.v1.pooling.backends.encoder.models.xlm_roberta import (
+    encoder_model_path,
+    load_encoder_weight_file,
     load_xlm_roberta_backend,
 )
-from vllm_metal.v1.pooling.contract import EncoderPoolingBackend
+from vllm_metal.v1.pooling.backends.encoder.runtime import (
+    EncoderEmbeddingPooler,
+    EncoderPoolingRequest,
+    MetalEncoderPoolingBackend,
+)
+from vllm_metal.v1.pooling.contract import (
+    EMBED_TASK,
+    TOKEN_CLASSIFY_TASK,
+    EncoderPoolingBackend,
+)
+from vllm_metal.v1.pooling.validation import PoolingConfigView
 
 _ARCHITECTURES = frozenset({"BgeM3EmbeddingModel"})
+_TOKEN_POOLING_TYPES = (None, "ALL")
+_SPARSE_LINEAR_FILE = "sparse_linear.pt"
+
+
+class BgeM3Pooler:
+    """BGE-M3 dense embedding and sparse lexical-weight pooling."""
+
+    def __init__(
+        self,
+        config: PoolingConfigView,
+        sparse_linear: nn.Linear,
+    ) -> None:
+        self.config = config
+        self.sparse_linear = sparse_linear
+        self.embedding_pooler = EncoderEmbeddingPooler(config)
+        self.bos_token_id = int(config.hf_config.bos_token_id)
+        self.eos_token_id = int(config.hf_config.eos_token_id)
+
+    def supported_tasks(self) -> tuple[PoolingTask, ...]:
+        tasks: list[PoolingTask] = []
+        if self.embedding_pooler.supported_tasks():
+            tasks.append(EMBED_TASK)
+        if self._supports_token_classify():
+            tasks.append(TOKEN_CLASSIFY_TASK)
+        return tuple(tasks)
+
+    def validate_params(self, pooling_params: PoolingParams) -> None:
+        if pooling_params.task in (None, EMBED_TASK):
+            self.embedding_pooler.validate_params(pooling_params)
+            return
+        if pooling_params.task == TOKEN_CLASSIFY_TASK and self._supports_token_classify():
+            return
+        raise NotImplementedError(
+            "Metal BGE-M3 pooling supports only task='embed' or "
+            f"task='token_classify' for model={self.config.label}."
+        )
+
+    def pool_one(
+        self,
+        hidden_states: mx.array,
+        request: EncoderPoolingRequest,
+    ) -> torch.Tensor:
+        if request.pooling_params.task == TOKEN_CLASSIFY_TASK:
+            return self._pool_sparse(hidden_states, request)
+        return self.embedding_pooler.pool_one(hidden_states, request)
+
+    def _supports_token_classify(self) -> bool:
+        return (
+            self.config.is_text_only
+            and self.config.task in (None, TOKEN_CLASSIFY_TASK)
+            and self.config.pooler_config.tok_pooling_type in _TOKEN_POOLING_TYPES
+            and not self.config.chunked_processing_enabled
+        )
+
+    def _pool_sparse(
+        self,
+        hidden_states: mx.array,
+        request: EncoderPoolingRequest,
+    ) -> torch.Tensor:
+        if not request.token_ids:
+            raise ValueError("Metal BGE-M3 sparse pooling requires at least one token.")
+
+        token_hidden_states = hidden_states[0, : len(request.token_ids), :]
+        scores = self.sparse_linear(token_hidden_states).astype(mx.float32)
+        if request.pooling_params.use_activation is not False:
+            scores = mx.maximum(scores, mx.zeros_like(scores))
+
+        tensor = mlx_to_torch(mx.contiguous(scores), device="cpu")
+        tensor = tensor.detach().clone().squeeze(-1)
+        start = 1 if request.token_ids[0] == self.bos_token_id else 0
+        end = -1 if request.token_ids[-1] == self.eos_token_id else len(request.token_ids)
+        return tensor[start:end]
 
 
 def supports_bge_m3_encoder(model_config: Any) -> bool:
@@ -23,6 +118,38 @@ def supports_bge_m3_encoder(model_config: Any) -> bool:
 def load_bge_m3_backend(
     model_config: Any,
 ) -> tuple[Any, Any, dict[str, Any], EncoderPoolingBackend]:
-    # Dense BGE-M3 uses the RoBERTa/XLM-R backbone and normal CLS embed pooler.
-    # Sparse lexical heads are added separately with token_classify support.
-    return load_xlm_roberta_backend(model_config)
+    model, tokenizer, model_args, _ = load_xlm_roberta_backend(model_config)
+    model_path = encoder_model_path(model_config)
+    config = PoolingConfigView(model_config)
+    sparse_linear = load_sparse_linear(
+        model_path,
+        int(model_args["hidden_size"]),
+        TORCH_TO_MLX_DTYPE[model_config.dtype],
+    )
+    pooling_backend = MetalEncoderPoolingBackend(
+        config,
+        model,
+        BgeM3Pooler(config, sparse_linear),
+    )
+    return model, tokenizer, model_args, pooling_backend
+
+
+def load_sparse_linear(
+    model_path: Path,
+    hidden_size: int,
+    target_dtype: mx.Dtype,
+) -> nn.Linear:
+    sparse_linear_path = model_path / _SPARSE_LINEAR_FILE
+    if not sparse_linear_path.exists():
+        raise FileNotFoundError(f"Missing BGE-M3 sparse head: {sparse_linear_path}.")
+
+    sparse_linear = nn.Linear(hidden_size, 1)
+    weights = {
+        name: value.astype(target_dtype)
+        if mx.issubdtype(value.dtype, mx.floating)
+        else value
+        for name, value in load_encoder_weight_file(sparse_linear_path).items()
+    }
+    sparse_linear.load_weights(list(weights.items()), strict=True)
+    mx.eval(sparse_linear.parameters())
+    return sparse_linear

--- a/vllm_metal/v1/pooling/backends/encoder/models/loading.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/loading.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared encoder checkpoint loading helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import torch
+from huggingface_hub import snapshot_download
+
+_ENCODER_DOWNLOAD_PATTERNS = (
+    "config.json",
+    "model*.safetensors",
+    "*.safetensors",
+    "pytorch_model*.bin",
+    "sparse_linear.pt",
+)
+
+
+def encoder_model_path(model_config: Any) -> Path:
+    model_path = Path(model_config.model)
+    if model_path.exists():
+        return model_path
+    return Path(
+        snapshot_download(
+            repo_id=str(model_config.model),
+            revision=model_config.revision,
+            allow_patterns=list(_ENCODER_DOWNLOAD_PATTERNS),
+        )
+    )
+
+
+def load_encoder_weights(model_path: Path) -> dict[str, mx.array]:
+    weight_files = sorted(model_path.glob("model*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("pytorch_model*.bin"))
+    if not weight_files:
+        raise FileNotFoundError(f"No supported encoder weights found in {model_path}.")
+
+    weights: dict[str, mx.array] = {}
+    for weight_file in weight_files:
+        weights.update(load_encoder_weight_file(weight_file))
+    return weights
+
+
+def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
+    if weight_file.suffix in (".bin", ".pt"):
+        state_dict = torch.load(weight_file, map_location="cpu", weights_only=True)
+        return {
+            name: mx.array(value.detach().cpu().numpy())
+            for name, value in state_dict.items()
+            if isinstance(value, torch.Tensor)
+        }
+    return mx.load(str(weight_file))

--- a/vllm_metal/v1/pooling/backends/encoder/models/loading.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/loading.py
@@ -10,6 +10,8 @@ import mlx.core as mx
 import torch
 from huggingface_hub import snapshot_download
 
+from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
+
 _ENCODER_DOWNLOAD_PATTERNS = (
     "config.json",
     "model*.safetensors",
@@ -51,7 +53,7 @@ def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
     if weight_file.suffix in (".bin", ".pt"):
         state_dict = torch.load(weight_file, map_location="cpu", weights_only=True)
         return {
-            name: mx.array(value.detach().cpu().numpy())
+            name: torch_to_mlx(value)
             for name, value in state_dict.items()
             if isinstance(value, torch.Tensor)
         }

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 
 import math
 from dataclasses import asdict, dataclass, fields
-from pathlib import Path
 from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
-import torch
-from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
 from vllm_metal.pytorch_backend.tensor_bridge import TORCH_TO_MLX_DTYPE
+from vllm_metal.v1.pooling.backends.encoder.models.loading import (
+    encoder_model_path,
+    load_encoder_weights,
+)
 from vllm_metal.v1.pooling.backends.encoder.runtime import MetalEncoderPoolingBackend
 from vllm_metal.v1.pooling.contract import LoadedEncoderBackend
 from vllm_metal.v1.pooling.validation import PoolingConfigView
@@ -291,41 +292,3 @@ def load_xlm_roberta_backend(
         model_args=asdict(args),
         pooling_backend=pooling_backend,
     )
-
-
-def encoder_model_path(model_config: Any) -> Path:
-    model_path = Path(model_config.model)
-    if model_path.exists():
-        return model_path
-    return Path(
-        snapshot_download(
-            repo_id=model_config.model,
-            revision=model_config.revision,
-        )
-    )
-
-
-def load_encoder_weights(model_path: Path) -> dict[str, mx.array]:
-    weight_files = sorted(model_path.glob("model*.safetensors"))
-    if not weight_files:
-        weight_files = sorted(model_path.glob("*.safetensors"))
-    if not weight_files:
-        weight_files = sorted(model_path.glob("pytorch_model*.bin"))
-    if not weight_files:
-        raise FileNotFoundError(f"No supported encoder weights found in {model_path}.")
-
-    weights: dict[str, mx.array] = {}
-    for weight_file in weight_files:
-        weights.update(load_encoder_weight_file(weight_file))
-    return weights
-
-
-def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
-    if weight_file.suffix in (".bin", ".pt"):
-        state_dict = torch.load(weight_file, map_location="cpu", weights_only=True)
-        return {
-            name: mx.array(value.detach().cpu().numpy())
-            for name, value in state_dict.items()
-            if isinstance(value, torch.Tensor)
-        }
-    return mx.load(str(weight_file))

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -16,6 +16,7 @@ from transformers import AutoTokenizer
 
 from vllm_metal.pytorch_backend.tensor_bridge import TORCH_TO_MLX_DTYPE
 from vllm_metal.v1.pooling.backends.encoder.runtime import MetalEncoderPoolingBackend
+from vllm_metal.v1.pooling.contract import LoadedEncoderBackend
 from vllm_metal.v1.pooling.validation import PoolingConfigView
 
 _MODEL_TYPES = frozenset({"xlm-roberta", "roberta"})
@@ -244,7 +245,7 @@ def supports_xlm_roberta_encoder(model_config: Any) -> bool:
 
 def load_xlm_roberta_backend(
     model_config: Any,
-) -> tuple[Any, Any, dict[str, Any], MetalEncoderPoolingBackend]:
+) -> LoadedEncoderBackend:
     hf_config = model_config.hf_config
     config = hf_config.to_dict()
     if model_config.quantization is not None or config.get("quantization") is not None:
@@ -284,7 +285,12 @@ def load_xlm_roberta_backend(
         PoolingConfigView(model_config),
         model,
     )
-    return model, tokenizer, asdict(args), pooling_backend
+    return LoadedEncoderBackend(
+        model=model,
+        tokenizer=tokenizer,
+        model_args=asdict(args),
+        pooling_backend=pooling_backend,
+    )
 
 
 def encoder_model_path(model_config: Any) -> Path:

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -315,7 +315,7 @@ def load_encoder_weights(model_path: Path) -> dict[str, mx.array]:
 
 
 def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
-    if weight_file.suffix == ".bin":
+    if weight_file.suffix in (".bin", ".pt"):
         state_dict = torch.load(weight_file, map_location="cpu", weights_only=True)
         return {
             name: mx.array(value.detach().cpu().numpy())

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
+import torch
 from huggingface_hub import snapshot_download
 from transformers import AutoTokenizer
 
@@ -245,7 +246,8 @@ def load_xlm_roberta_backend(
     model_config: Any,
 ) -> tuple[Any, Any, dict[str, Any], MetalEncoderPoolingBackend]:
     hf_config = model_config.hf_config
-    if model_config.quantization is not None:
+    config = hf_config.to_dict()
+    if model_config.quantization is not None or config.get("quantization") is not None:
         raise NotImplementedError(
             "Metal XLM-R encoder pooling does not support quantization yet."
         )
@@ -258,28 +260,11 @@ def load_xlm_roberta_backend(
             "Metal XLM-R encoder pooling supports only GELU activation."
         )
 
-    model_path = Path(model_config.model)
-    if not model_path.exists():
-        model_path = Path(
-            snapshot_download(
-                repo_id=model_config.model,
-                revision=model_config.revision,
-            )
-        )
-
-    weight_files = sorted(model_path.glob("model*.safetensors"))
-    if not weight_files:
-        weight_files = sorted(model_path.glob("*.safetensors"))
-    if not weight_files:
-        raise FileNotFoundError(f"No safetensors found in {model_path}.")
-
-    config = hf_config.to_dict()
     target_dtype = TORCH_TO_MLX_DTYPE[model_config.dtype]
     args = XLMRobertaArgs.from_config(config)
     model = XLMRobertaModel(args)
-    weights: dict[str, mx.array] = {}
-    for weight_file in weight_files:
-        weights.update(mx.load(str(weight_file)))
+    model_path = encoder_model_path(model_config)
+    weights = load_encoder_weights(model_path)
     weights = model.sanitize(weights)
     weights = {
         name: value.astype(target_dtype)
@@ -300,3 +285,41 @@ def load_xlm_roberta_backend(
         model,
     )
     return model, tokenizer, asdict(args), pooling_backend
+
+
+def encoder_model_path(model_config: Any) -> Path:
+    model_path = Path(model_config.model)
+    if model_path.exists():
+        return model_path
+    return Path(
+        snapshot_download(
+            repo_id=model_config.model,
+            revision=model_config.revision,
+        )
+    )
+
+
+def load_encoder_weights(model_path: Path) -> dict[str, mx.array]:
+    weight_files = sorted(model_path.glob("model*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("*.safetensors"))
+    if not weight_files:
+        weight_files = sorted(model_path.glob("pytorch_model*.bin"))
+    if not weight_files:
+        raise FileNotFoundError(f"No supported encoder weights found in {model_path}.")
+
+    weights: dict[str, mx.array] = {}
+    for weight_file in weight_files:
+        weights.update(load_encoder_weight_file(weight_file))
+    return weights
+
+
+def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
+    if weight_file.suffix == ".bin":
+        state_dict = torch.load(weight_file, map_location="cpu", weights_only=True)
+        return {
+            name: mx.array(value.detach().cpu().numpy())
+            for name, value in state_dict.items()
+            if isinstance(value, torch.Tensor)
+        }
+    return mx.load(str(weight_file))

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Protocol
 
 import mlx.core as mx
 import torch
@@ -35,6 +36,63 @@ _ENCODER_POOLING_TYPES = (None, "CLS", "LAST")
 class EncoderPoolingRequest:
     req_id: str
     token_ids: tuple[int, ...]
+    pooling_params: PoolingParams
+
+
+class EncoderPooler(Protocol):
+    def supported_tasks(self) -> tuple[PoolingTask, ...]: ...
+
+    def validate_params(self, pooling_params: PoolingParams) -> None: ...
+
+    def pool_one(
+        self,
+        hidden_states: mx.array,
+        request: EncoderPoolingRequest,
+    ) -> torch.Tensor: ...
+
+
+class EncoderEmbeddingPooler:
+    def __init__(self, config: PoolingConfigView) -> None:
+        self.config = config
+
+    def supported_tasks(self) -> tuple[PoolingTask, ...]:
+        if self._supports_embed():
+            return (EMBED_TASK,)
+        return ()
+
+    def validate_params(self, pooling_params: PoolingParams) -> None:
+        if not self._supports_embed() or pooling_params.task not in (None, EMBED_TASK):
+            raise NotImplementedError(
+                "Metal encoder pooling supports only task='embed' "
+                f"for model={self.config.label}."
+            )
+
+    def pool_one(
+        self,
+        hidden_states: mx.array,
+        request: EncoderPoolingRequest,
+    ) -> torch.Tensor:
+        if not request.token_ids:
+            raise ValueError("Metal encoder pooling requires at least one token.")
+        token_index = (
+            0
+            if self.config.sequence_pooling_type != "LAST"
+            else len(request.token_ids) - 1
+        )
+        vector = hidden_states[0, token_index, :].astype(mx.float32)
+        norm = mx.sqrt(mx.sum(vector * vector))
+        norm = mx.maximum(norm, mx.array(_MIN_NORM, dtype=mx.float32))
+        tensor = mlx_to_torch(mx.contiguous(vector / norm), device="cpu")
+        return tensor.detach().clone()
+
+    def _supports_embed(self) -> bool:
+        return (
+            self.config.is_text_only
+            and self.config.task in (None, EMBED_TASK)
+            and self.config.sequence_pooling_type in _ENCODER_POOLING_TYPES
+            and self.config.embed_activation_allowed
+            and not self.config.chunked_processing_enabled
+        )
 
 
 class MetalEncoderPoolingBackend:
@@ -51,21 +109,17 @@ class MetalEncoderPoolingBackend:
         self,
         config: PoolingConfigView,
         forward: Callable[[mx.array, mx.array], mx.array],
+        pooler: EncoderPooler | None = None,
     ) -> None:
         self.config = config
         self._forward = forward
+        self._pooler = pooler or EncoderEmbeddingPooler(config)
 
     def supported_tasks(self) -> tuple[PoolingTask, ...]:
-        if self._supports_embed():
-            return (EMBED_TASK,)
-        return ()
+        return self._pooler.supported_tasks()
 
     def validate_params(self, pooling_params: PoolingParams) -> None:
-        if not self._supports_embed() or pooling_params.task not in (None, EMBED_TASK):
-            raise NotImplementedError(
-                "Metal encoder pooling supports only task='embed' "
-                f"for model={self.config.label}."
-            )
+        self._pooler.validate_params(pooling_params)
 
     def profile_forward(self, input_ids: mx.array) -> mx.array:
         attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
@@ -103,7 +157,7 @@ class MetalEncoderPoolingBackend:
         input_ids = mx.array([request.token_ids], dtype=mx.int32)
         attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
         hidden_states = self.forward_padded(input_ids, attention_mask)
-        return self._pool_one(hidden_states, 0, len(request.token_ids))
+        return self._pooler.pool_one(hidden_states, request)
 
     def _requests_from_scheduler_output(
         self,
@@ -123,10 +177,12 @@ class MetalEncoderPoolingBackend:
                 raise RuntimeError(
                     "Encoder pooling received a scheduled non-pooling request."
                 )
+            pooling_params = new_req.pooling_params
             requests.append(
                 EncoderPoolingRequest(
                     req_id=new_req.req_id,
                     token_ids=tuple(new_req.prompt_token_ids or ()),
+                    pooling_params=pooling_params,
                 )
             )
         return tuple(requests)
@@ -150,29 +206,3 @@ class MetalEncoderPoolingBackend:
                     "Metal encoder pooling requires full-prompt scheduling; "
                     "partial or chunked pooling requests are not supported yet."
                 )
-
-    def _supports_embed(self) -> bool:
-        return (
-            self.config.is_text_only
-            and self.config.task in (None, EMBED_TASK)
-            and self.config.sequence_pooling_type in _ENCODER_POOLING_TYPES
-            and self.config.embed_activation_allowed
-            and not self.config.chunked_processing_enabled
-        )
-
-    def _pool_one(
-        self,
-        hidden_states: mx.array,
-        row: int,
-        token_count: int,
-    ) -> torch.Tensor:
-        if token_count <= 0:
-            raise ValueError("Metal encoder pooling requires at least one token.")
-        token_index = (
-            0 if self.config.sequence_pooling_type != "LAST" else token_count - 1
-        )
-        vector = hidden_states[row, token_index, :].astype(mx.float32)
-        norm = mx.sqrt(mx.sum(vector * vector))
-        norm = mx.maximum(norm, mx.array(_MIN_NORM, dtype=mx.float32))
-        tensor = mlx_to_torch(mx.contiguous(vector / norm), device="cpu")
-        return tensor.detach().clone()

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -78,7 +78,7 @@ class EncoderEmbeddingPooler:
 
 
 class MetalEncoderPoolingBackend:
-    """Dense encoder embedding backend for full-prompt pooling."""
+    """Concrete EncoderPoolingBackend for full-prompt encoder pooling."""
 
     capabilities = PoolingCapabilities(
         execution_kind="encoder",

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -8,8 +8,6 @@ decoder KV cache, paged attention, or chunked request state.
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
-from typing import Protocol
 
 import mlx.core as mx
 import torch
@@ -20,7 +18,9 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 from vllm_metal.v1.pooling.contract import (
     EMBED_TASK,
+    EncoderPooler,
     EncoderPoolingOutput,
+    EncoderPoolingRequest,
     PoolingCapabilities,
 )
 from vllm_metal.v1.pooling.validation import (
@@ -30,25 +30,6 @@ from vllm_metal.v1.pooling.validation import (
 
 _MIN_NORM = 1e-12
 _ENCODER_POOLING_TYPES = (None, "CLS", "LAST")
-
-
-@dataclass(frozen=True, slots=True)
-class EncoderPoolingRequest:
-    req_id: str
-    token_ids: tuple[int, ...]
-    pooling_params: PoolingParams
-
-
-class EncoderPooler(Protocol):
-    def supported_tasks(self) -> tuple[PoolingTask, ...]: ...
-
-    def validate_params(self, pooling_params: PoolingParams) -> None: ...
-
-    def pool_one(
-        self,
-        hidden_states: mx.array,
-        request: EncoderPoolingRequest,
-    ) -> torch.Tensor: ...
 
 
 class EncoderEmbeddingPooler:
@@ -72,6 +53,7 @@ class EncoderEmbeddingPooler:
         hidden_states: mx.array,
         request: EncoderPoolingRequest,
     ) -> torch.Tensor:
+        """Return one normalized CLS or LAST embedding for an encoder request."""
         if not request.token_ids:
             raise ValueError("Metal encoder pooling requires at least one token.")
         token_index = (

--- a/vllm_metal/v1/pooling/contract.py
+++ b/vllm_metal/v1/pooling/contract.py
@@ -42,9 +42,10 @@ class DecoderPoolingBatch:
 
 
 @dataclass(frozen=True, slots=True)
-class EncoderPoolingOutput:
+class EncoderPoolingRequest:
     req_id: str
-    pooler_output: torch.Tensor
+    token_ids: tuple[int, ...]
+    pooling_params: PoolingParams
 
 
 class PoolingBackend(Protocol):
@@ -85,6 +86,26 @@ class DecoderPoolingBackend(PoolingBackend, Protocol):
     ) -> tuple[torch.Tensor | None, ...]: ...
 
 
+@dataclass(frozen=True, slots=True)
+class EncoderPoolingOutput:
+    req_id: str
+    pooler_output: torch.Tensor
+
+
+class EncoderPooler(Protocol):
+    """Task-specific strategy used by an encoder pooling backend."""
+
+    def supported_tasks(self) -> tuple[PoolingTask, ...]: ...
+
+    def validate_params(self, pooling_params: PoolingParams) -> None: ...
+
+    def pool_one(
+        self,
+        hidden_states: mx.array,
+        request: EncoderPoolingRequest,
+    ) -> torch.Tensor: ...
+
+
 class EncoderPoolingBackend(PoolingBackend, Protocol):
     def forward_padded(
         self,
@@ -99,12 +120,12 @@ class EncoderPoolingBackend(PoolingBackend, Protocol):
     ) -> tuple[EncoderPoolingOutput, ...]: ...
 
 
+ExecutablePoolingBackend: TypeAlias = DecoderPoolingBackend | EncoderPoolingBackend
+
+
 @dataclass(frozen=True, slots=True)
 class LoadedEncoderBackend:
     model: Any
     tokenizer: Any
     model_args: dict[str, Any]
     pooling_backend: EncoderPoolingBackend
-
-
-ExecutablePoolingBackend: TypeAlias = DecoderPoolingBackend | EncoderPoolingBackend

--- a/vllm_metal/v1/pooling/contract.py
+++ b/vllm_metal/v1/pooling/contract.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Protocol, TypeAlias
+from typing import Any, Literal, Protocol, TypeAlias
 
 import mlx.core as mx
 import torch
@@ -97,6 +97,14 @@ class EncoderPoolingBackend(PoolingBackend, Protocol):
         scheduler_output: SchedulerOutput,
         model_config: object,
     ) -> tuple[EncoderPoolingOutput, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedEncoderBackend:
+    model: Any
+    tokenizer: Any
+    model_args: dict[str, Any]
+    pooling_backend: EncoderPoolingBackend
 
 
 ExecutablePoolingBackend: TypeAlias = DecoderPoolingBackend | EncoderPoolingBackend

--- a/vllm_metal/v1/pooling/contract.py
+++ b/vllm_metal/v1/pooling/contract.py
@@ -16,6 +16,7 @@ from vllm_metal.attention.context import OffsetCache
 
 EMBED_TASK: PoolingTask = "embed"
 CLASSIFY_TASK: PoolingTask = "classify"
+TOKEN_CLASSIFY_TASK: PoolingTask = "token_classify"
 PoolingExecutionKind: TypeAlias = Literal["decoder", "encoder"]
 
 

--- a/vllm_metal/v1/pooling/validation.py
+++ b/vllm_metal/v1/pooling/validation.py
@@ -13,6 +13,7 @@ from vllm.v1.core.sched.output import NewRequestData
 from vllm_metal.v1.pooling.contract import (
     CLASSIFY_TASK,
     EMBED_TASK,
+    TOKEN_CLASSIFY_TASK,
     PoolingBackend,
 )
 
@@ -142,7 +143,10 @@ class PoolingConfigView:
     def unsupported_pooling_option(self, pooling_params: PoolingParams) -> str | None:
         if pooling_params.late_interaction_params is not None:
             return "late-interaction parameters"
-        if pooling_params.requires_token_ids:
+        if (
+            pooling_params.requires_token_ids
+            and pooling_params.task != TOKEN_CLASSIFY_TASK
+        ):
             return "token-level ALL pooling outputs"
         if pooling_params.step_tag_id is not None:
             return "STEP pooling parameters"
@@ -151,7 +155,7 @@ class PoolingConfigView:
         if pooling_params.extra_kwargs:
             return "extra pooling kwargs"
         if (
-            pooling_params.task != CLASSIFY_TASK
+            pooling_params.task not in (CLASSIFY_TASK, TOKEN_CLASSIFY_TASK)
             and pooling_params.use_activation is False
         ):
             return "use_activation=False"


### PR DESCRIPTION
This PR is:

- To add BGE-M3 dense embedding and sparse `token_classify` support through the encoder pooling backend.
- To load canonical `BAAI/bge-m3` on the MLX runtime, including PyTorch backbone weights and `sparse_linear.pt`.
- To keep BGE-specific pooling behavior in the model-owned encoder backend instead of the runner.
- To share encoder checkpoint loading while avoiding unused repository downloads.

Note:

This supports canonical, unquantized `BAAI/bge-m3`. MLX Community BGE-M3 checkpoints are not supported in this PR because they do not include `sparse_linear.pt`, and this change intentionally ships dense + sparse BGE-M3 together.

For sparse BGE-M3, use:

```bash
vllm serve BAAI/bge-m3 \
  --runner pooling \
  --max-model-len 8192 \
  --pooler-config '{"task":"token_classify"}' \
  --hf-overrides '{"architectures":["BgeM3EmbeddingModel"]}'
```

Proof it works:

Model revision: `5617a9f61b028005a4858fdac845db406aefb181`.

Dense command:

```bash
vllm serve BAAI/bge-m3 --runner pooling --max-model-len 8192 --port 8012
```

Dense `/v1/embeddings` returned shape `(2, 1024)` with normalized embeddings and matched the upstream similarity reference:

```text
norms      [1.0, 1.0]
similarity [[0.625909, 0.347491], [0.33097, 0.673372]]
reference  [[0.6259, 0.3474], [0.3309, 0.6734]]
```

Sparse `/pooling` with `task=token_classify` returned one sparse lexical-score vector with length `8` and matched the upstream lexical-score reference:

```text
lexical_score 0.19554413560964878
reference     0.19554901123046875
abs_diff      4.8756208199662865e-06
```
