### PR TITLE
Trim weak platform block-size tests

### DIFF
--- a/tests/test_platform_update_block_size.py
+++ b/tests/test_platform_update_block_size.py
@@ -22,7 +22,6 @@ class TestFindNonSsmBackend:
         """Test: _find_non_ssm_backend returns a MetalBackend class."""
         backend_cls = MetalPlatform._find_non_ssm_backend(None)  # type: ignore
 
-        assert backend_cls is not None
         assert backend_cls.get_name() == "METAL_ATTN"
 
     def test_metal_backend_kernel_block_sizes(self):
@@ -41,26 +40,6 @@ class TestFindNonSsmBackend:
         assert len(sizes) == 1
         assert isinstance(sizes[0], MultipleOf)
         assert sizes[0].base == 16
-
-    def test_metal_backend_required_methods(self):
-        """Test: MetalBackend has all required AttentionBackend methods."""
-        backend_cls = MetalPlatform._find_non_ssm_backend(None)  # type: ignore
-
-        # Check all required static methods exist
-        assert hasattr(backend_cls, "get_name")
-        assert hasattr(backend_cls, "get_supported_kernel_block_sizes")
-        assert hasattr(backend_cls, "get_impl_cls")
-        assert hasattr(backend_cls, "get_builder_cls")
-        assert hasattr(backend_cls, "get_kv_cache_shape")
-
-        # Verify they raise NotImplementedError (not implemented for block_size calc)
-        with pytest.raises(NotImplementedError):
-            backend_cls.get_impl_cls()  # type: ignore
-        with pytest.raises(NotImplementedError):
-            backend_cls.get_builder_cls()  # type: ignore
-        with pytest.raises(NotImplementedError):
-            backend_cls.get_kv_cache_shape()  # type: ignore
-
 
 class TestUpdateBlockSizeForBackend:
     """Test suite for update_block_size_for_backend() method."""
@@ -203,19 +182,3 @@ class TestUpdateBlockSizeForBackend:
 
             assert "Hybrid model" in caplog.text
             assert "paged attention" in caplog.text
-
-    def test_wrapper_preserves_super_block_size(
-        self, vllm_config, stub_super_update, caplog
-    ):
-        """Test: wrapper does not mutate block_size set by base implementation."""
-        vllm_config.cache_config.block_size = 64
-
-        with patch("vllm_metal.config.get_config") as mock_get_config:
-            mock_metal_config = MagicMock()
-            mock_metal_config.use_paged_attention = True
-            mock_get_config.return_value = mock_metal_config
-
-            MetalPlatform.update_block_size_for_backend(vllm_config)
-
-            assert vllm_config.cache_config.block_size == 64
-            assert "Metal paged attention requires block_size" not in caplog.text

--- a/tests/test_platform_update_block_size.py
+++ b/tests/test_platform_update_block_size.py
@@ -41,6 +41,7 @@ class TestFindNonSsmBackend:
         assert isinstance(sizes[0], MultipleOf)
         assert sizes[0].base == 16
 
+
 class TestUpdateBlockSizeForBackend:
     """Test suite for update_block_size_for_backend() method."""
 
@@ -125,21 +126,30 @@ class TestUpdateBlockSizeForBackend:
 
         assert vllm_config.cache_config.block_size == 64
 
-    def test_non_hybrid_model_skipped(self, vllm_config):
-        """Test: Non-hybrid model skips Metal-specific adjustments.
+    def test_non_hybrid_model_uses_base_update_only(
+        self, vllm_config, stub_super_update, caplog, monkeypatch
+    ):
+        """Test: non-hybrid models delegate to vLLM without hybrid warning."""
+        import logging
 
-        Non-hybrid models use base implementation without Metal adjustments.
-        """
-        # Set model as non-hybrid
+        def _base_update(config):
+            config.cache_config.block_size = 64
+
+        stub_super_update.side_effect = _base_update
         vllm_config.model_config.is_hybrid = False
-        original_block_size = vllm_config.cache_config.block_size
+        monkeypatch.setattr(logging.getLogger("vllm_metal"), "propagate", True)
 
-        # Execute (should use base implementation only)
-        MetalPlatform.update_block_size_for_backend(vllm_config)
+        with patch("vllm_metal.config.get_config") as mock_get_config:
+            mock_metal_config = MagicMock()
+            mock_metal_config.use_paged_attention = True
+            mock_get_config.return_value = mock_metal_config
 
-        # For non-hybrid, base implementation may adjust block_size
-        # but Metal-specific paged attention adjustment should not apply
-        assert vllm_config.cache_config.block_size >= original_block_size
+            with caplog.at_level(logging.WARNING, logger="vllm_metal.platform"):
+                MetalPlatform.update_block_size_for_backend(vllm_config)
+
+        stub_super_update.assert_called_once_with(vllm_config)
+        assert vllm_config.cache_config.block_size == 64
+        assert "Hybrid model" not in caplog.text
 
     def test_model_config_none(self):
         """Test: None model_config returns early without error."""


### PR DESCRIPTION
This PR is:

- To remove platform block-size tests that only assert declarations or no-op state.
- To tighten non-hybrid coverage so it proves delegation to vLLM's base block-size update.
- To keep Metal block-size runtime behavior unchanged.
