### PR TITLE
Add native Qwen MTP speculative decoding with hybrid prefix caching

### DIFF
--- a/.github/workflows/qwen-mtp-serving-bench.yml
+++ b/.github/workflows/qwen-mtp-serving-bench.yml
@@ -1,0 +1,149 @@
+name: Qwen MTP Speed Matrix
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - pr/610-05-paged-qwen-mtp-prefix
+    paths:
+      - .github/workflows/qwen-mtp-serving-bench.yml
+      - benchmarks/qwen_mtp_speed_matrix.py
+      - vllm_metal/v1/proposer.py
+      - vllm_metal/v1/qwen_mtp_paged.py
+      - vllm_metal/attention/runtime/hybrid.py
+      - vllm_metal/attention/impls/linear.py
+      - vllm_metal/envs.py
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qwen-mtp-speed-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  speed-matrix:
+    runs-on: macos-15
+    timeout-minutes: 360
+    env:
+      VLLM_METAL_USE_PAGED_ATTENTION: "1"
+      VLLM_METAL_MEMORY_FRACTION: "auto"
+      GLOO_SOCKET_IFNAME: lo0
+      MODEL_DIR: /Users/runner/.cache/vllm-metal-bench/Qwen3.5-0.8B-4bit-mtp
+      MLX_LM_MTP_SHA: ac6aaffd8fdfb8c8e713e17f155d83e3d72b0a0f
+      MATRIX_DIR: /tmp/qwen-mtp-matrix
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Cache converted benchmark model
+        id: model-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.MODEL_DIR }}
+          key: qwen35-08b-4bit-mtp-${{ runner.os }}-${{ runner.arch }}-${{ env.MLX_LM_MTP_SHA }}
+
+      - name: Install vLLM Metal and exact mlx-lm MTP head
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip uv
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install \
+            'https://github.com/vllm-project/vllm/releases/download/v0.27.1/vllm-0.27.1%2Bcpu-cp312-cp312-macosx_11_0_arm64.whl'
+          VLLM_METAL_BUILD_FROM_SOURCE=1 python -m pip install -e '.[dev]'
+          python -m pip install --force-reinstall --no-deps \
+            "git+https://github.com/PhilipJohnBasile/mlx-lm@${MLX_LM_MTP_SHA}"
+          source scripts/lib.sh
+          ensure_metal_toolchain
+          build_native_artifacts
+          python - <<'PY'
+          import platform
+          import torch
+
+          print("machine:", platform.machine())
+          print("MPS available:", torch.backends.mps.is_available())
+          assert platform.machine() == "arm64"
+          assert torch.backends.mps.is_available()
+          PY
+
+      - name: Convert Qwen3.5-0.8B with MTP weights
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          source .venv/bin/activate
+          rm -rf "$MODEL_DIR"
+          mkdir -p "$(dirname "$MODEL_DIR")"
+          python -m mlx_lm.convert \
+            --hf-path Qwen/Qwen3.5-0.8B \
+            --mlx-path "$MODEL_DIR" \
+            -q \
+            --q-bits 4 \
+            --q-group-size 64
+
+      - name: Record runner metadata
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p "$MATRIX_DIR"
+          {
+            echo "git_sha=${GITHUB_SHA}"
+            echo "mlx_lm_mtp_sha=${MLX_LM_MTP_SHA}"
+            sw_vers
+            uname -a
+            sysctl -n machdep.cpu.brand_string || true
+            system_profiler SPHardwareDataType
+          } | tee "$MATRIX_DIR/runner.txt"
+
+      - name: Run baseline and native MTP speed matrix
+        id: matrix
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euxo pipefail
+          source .venv/bin/activate
+          python benchmarks/qwen_mtp_speed_matrix.py \
+            --model-dir "$MODEL_DIR" \
+            --output-dir "$MATRIX_DIR" \
+            --repeats 2 \
+            --request-timeout-s 240 \
+            --server-ready-timeout-s 720 \
+            2>&1 | tee "$MATRIX_DIR/run.log"
+
+      - name: Publish matrix summary
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "$MATRIX_DIR/matrix_summary.md" ]; then
+            cat "$MATRIX_DIR/matrix_summary.md" >>"$GITHUB_STEP_SUMMARY"
+          else
+            echo "# Qwen MTP speed matrix" >>"$GITHUB_STEP_SUMMARY"
+            echo "The matrix stopped before producing a report." \
+              >>"$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload speed matrix
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qwen-mtp-speed-matrix
+          path: ${{ env.MATRIX_DIR }}
+          if-no-files-found: error
+
+      - name: Fail when no complete MTP profile finished
+        if: steps.matrix.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "The speed matrix did not produce a complete MTP profile." >&2
+          exit 1

--- a/benchmarks/qwen_mtp_speed_matrix.py
+++ b/benchmarks/qwen_mtp_speed_matrix.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+"""Benchmark vLLM Metal native Qwen MTP across a curated speed matrix.
+
+The matrix is intentionally curated rather than a full Cartesian product. It
+keeps server launches bounded while testing the knobs most likely to affect
+Apple Silicon serving throughput: scheduler token budget, paged-attention
+block size, speculative verification-window mode, decode pipelining, GDN
+kernel mode, request concurrency, and short/long shared-prefix workloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import mlx.core as mx
+from mlx_lm.generate import mtp_generate_step
+from mlx_lm.utils import load
+from transformers import AutoTokenizer
+from vllm.benchmarks.lib.endpoint_request_func import (
+    RequestFuncInput,
+    RequestFuncOutput,
+    async_request_openai_completions,
+)
+from vllm.benchmarks.serve import fetch_spec_decode_metrics
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    mode: str
+    max_num_batched_tokens: int
+    block_size: int
+    verify_window: bool = False
+    decode_pipeline: bool = True
+    gdn_lazy: bool = True
+    enforce_eager: bool = False
+
+
+@dataclass(frozen=True)
+class Workload:
+    name: str
+    prompt_tokens: int
+    output_tokens: int
+    concurrency: int
+    requests: int
+
+
+PROFILES: tuple[Profile, ...] = (
+    # Same tuned non-MTP configuration is run first and last to measure drift.
+    Profile("baseline_ref", "baseline", 2048, 16),
+    # Conservative configuration closest to the first functional benchmark.
+    Profile("mtp_safe", "mtp", 512, 16, enforce_eager=True),
+    Profile("mtp_batch1024", "mtp", 1024, 16),
+    # Matched to baseline_ref except for native MTP itself.
+    Profile("mtp_batch2048", "mtp", 2048, 16),
+    Profile("mtp_batch4096", "mtp", 4096, 16),
+    Profile("mtp_block32", "mtp", 2048, 32),
+    Profile("mtp_verify_window", "mtp", 2048, 16, verify_window=True),
+    # Negative controls establish whether the default fast paths really win.
+    Profile("mtp_no_decode_pipeline", "mtp", 2048, 16, decode_pipeline=False),
+    Profile("mtp_gdn_fallback", "mtp", 2048, 16, gdn_lazy=False),
+    Profile("baseline_repeat", "baseline", 2048, 16),
+)
+
+WORKLOADS: tuple[Workload, ...] = (
+    Workload("interactive_c1", 1152, 128, 1, 4),
+    Workload("serving_c4", 1152, 128, 4, 8),
+    Workload("serving_c8", 1152, 128, 8, 16),
+    Workload("serving_c16", 1152, 64, 16, 32),
+    Workload("long_prefix_c1", 8192, 64, 1, 2),
+    # 8K makes the verification-window experiment meaningful while remaining
+    # within the standard hosted Apple Silicon runner's cache capacity.
+    Workload("long_prefix_c4", 8192, 64, 4, 4),
+)
+
+SPEC_CONFIG = '{"method":"mtp","num_speculative_tokens":1}'
+MODEL_MAX_LEN = 8448
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--request-timeout-s", type=float, default=240.0)
+    parser.add_argument("--server-ready-timeout-s", type=float, default=720.0)
+    parser.add_argument("--native-check-only", action="store_true")
+    args = parser.parse_args()
+    if args.repeats < 1:
+        parser.error("--repeats must be at least 1")
+    return args
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def tail(path: Path, lines: int = 250) -> str:
+    if not path.exists():
+        return "<log file was not created>"
+    return "\n".join(path.read_text(errors="replace").splitlines()[-lines:])
+
+
+def native_mtp_check(model_dir: Path, output_dir: Path) -> dict[str, Any]:
+    model, tokenizer = load(str(model_dir))
+    cache = model.make_mtp_cache()
+    if not bool(getattr(model, "supports_mtp", False)):
+        raise RuntimeError("converted model does not advertise supports_mtp")
+    if not cache:
+        raise RuntimeError("converted model returned an empty MTP cache")
+
+    target_prompt_tokens = 1152
+    seed = (
+        "Apple Silicon speculative decoding uses a shared cached prefix "
+        "and a trained multi-token prediction head. "
+    )
+    text = seed
+    while len(tokenizer.encode(text)) < target_prompt_tokens + 16:
+        text += seed
+    prompt = mx.array(
+        tokenizer.encode(text)[:target_prompt_tokens],
+        dtype=mx.uint32,
+    )
+
+    accepted = 0
+    emitted = 0
+    started = time.perf_counter()
+    for _token, _logprobs, from_draft in mtp_generate_step(
+        prompt,
+        model,
+        max_tokens=192,
+    ):
+        emitted += 1
+        accepted += int(from_draft)
+    elapsed = time.perf_counter() - started
+
+    # mlx-lm exposes whether each emitted token came from the draft, but not
+    # the total proposal-attempt count. Do not invent an acceptance denominator.
+    result = {
+        "supports_mtp": True,
+        "mtp_cache_entries": len(cache),
+        "output_tokens": emitted,
+        "accepted_draft_tokens": accepted,
+        "accepted_output_fraction": accepted / emitted if emitted else None,
+        "output_throughput_tok_s": emitted / elapsed,
+        "elapsed_s": elapsed,
+    }
+    write_json(output_dir / "native_mtp.json", result)
+    print("NATIVE_MTP_RESULT=" + json.dumps(result, sort_keys=True), flush=True)
+    return result
+
+
+def native_mtp_check_isolated(
+    model_dir: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--model-dir",
+        str(model_dir),
+        "--output-dir",
+        str(output_dir),
+        "--native-check-only",
+    ]
+    subprocess.run(command, check=True)
+    return json.loads((output_dir / "native_mtp.json").read_text())
+
+
+class Server:
+    def __init__(
+        self,
+        profile: Profile,
+        model_dir: Path,
+        port: int,
+        log_path: Path,
+        ready_timeout_s: float,
+    ) -> None:
+        self.profile = profile
+        self.model_dir = model_dir
+        self.port = port
+        self.log_path = log_path
+        self.ready_timeout_s = ready_timeout_s
+        self.process: subprocess.Popen[str] | None = None
+        self._log_handle: Any = None
+
+    def start(self) -> None:
+        executable = shutil.which("vllm")
+        if executable is None:
+            raise RuntimeError("vllm executable was not found on PATH")
+
+        command = [
+            executable,
+            "serve",
+            str(self.model_dir),
+            "--served-model-name",
+            "qwen35-mtp-bench",
+            "--enable-prefix-caching",
+            "--no-async-scheduling",
+            "--max-model-len",
+            str(MODEL_MAX_LEN),
+            "--max-num-batched-tokens",
+            str(self.profile.max_num_batched_tokens),
+            "--block-size",
+            str(self.profile.block_size),
+            "--port",
+            str(self.port),
+        ]
+        if self.profile.enforce_eager:
+            command.append("--enforce-eager")
+        if self.profile.mode == "mtp":
+            command.extend(["--speculative-config", SPEC_CONFIG])
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "VLLM_METAL_SPEC_VERIFY_WINDOW": str(int(self.profile.verify_window)),
+                "VLLM_METAL_DECODE_PIPELINE": str(int(self.profile.decode_pipeline)),
+                "VLLM_METAL_GDN_LAZY_KERNELS": str(int(self.profile.gdn_lazy)),
+            }
+        )
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._log_handle = self.log_path.open("w")
+        print(
+            "SERVER_START="
+            + json.dumps(
+                {
+                    "profile": asdict(self.profile),
+                    "command": command,
+                    "port": self.port,
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+        self.process = subprocess.Popen(
+            command,
+            stdout=self._log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            start_new_session=True,
+        )
+        self._wait_ready()
+
+    def _wait_ready(self) -> None:
+        assert self.process is not None
+        deadline = time.monotonic() + self.ready_timeout_s
+        url = f"http://127.0.0.1:{self.port}/v1/models"
+        started = time.monotonic()
+        last_error = ""
+        while time.monotonic() < deadline:
+            code = self.process.poll()
+            if code is not None:
+                raise RuntimeError(
+                    f"server {self.profile.name} exited with code {code}\n"
+                    + tail(self.log_path)
+                )
+            try:
+                with urllib.request.urlopen(url, timeout=1.0) as response:
+                    if response.status == 200:
+                        print(
+                            f"Server {self.profile.name} ready in "
+                            f"{time.monotonic() - started:.1f}s",
+                            flush=True,
+                        )
+                        return
+            except (OSError, urllib.error.URLError) as exc:
+                last_error = str(exc)
+            time.sleep(2)
+        raise RuntimeError(
+            f"server {self.profile.name} readiness timed out: {last_error}\n"
+            + tail(self.log_path)
+        )
+
+    def stop(self) -> None:
+        process = self.process
+        self.process = None
+        if process is None:
+            return
+        if process.poll() is None:
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+            try:
+                process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                process.wait(timeout=10)
+        if self._log_handle is not None:
+            self._log_handle.close()
+            self._log_handle = None
+
+
+class ServingBenchmarker:
+    def __init__(
+        self,
+        model_dir: Path,
+        port: int,
+        repeats: int,
+        request_timeout_s: float,
+    ) -> None:
+        self.model_dir = model_dir
+        self.port = port
+        self.repeats = repeats
+        self.request_timeout_s = request_timeout_s
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            str(model_dir),
+            trust_remote_code=True,
+        )
+
+    def prompt_for(self, prompt_tokens: int) -> tuple[str, int]:
+        seed = (
+            "Apple Silicon speculative decoding uses a shared cached prefix "
+            "and a trained multi-token prediction head. "
+        )
+        text = seed
+        while (
+            len(self.tokenizer.encode(text, add_special_tokens=False))
+            < prompt_tokens + 16
+        ):
+            text += seed
+        ids = self.tokenizer.encode(text, add_special_tokens=False)[:prompt_tokens]
+        prompt = self.tokenizer.decode(ids, skip_special_tokens=False)
+        actual = len(self.tokenizer.encode(prompt, add_special_tokens=False))
+        return prompt, actual
+
+    async def run(
+        self,
+        profile: Profile,
+        workload: Workload,
+    ) -> dict[str, Any]:
+        base_url = f"http://127.0.0.1:{self.port}"
+        timeout = aiohttp.ClientTimeout(total=self.request_timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(base_url + "/v1/models") as response:
+                response.raise_for_status()
+                served_model = (await response.json())["data"][0]["id"]
+
+            prompt, prompt_len = self.prompt_for(workload.prompt_tokens)
+            print(
+                f"{profile.name}/{workload.name}: prompt={prompt_len} "
+                f"output={workload.output_tokens} "
+                f"concurrency={workload.concurrency} repeats={self.repeats}",
+                flush=True,
+            )
+
+            async def one(tag: str) -> RequestFuncOutput:
+                request = RequestFuncInput(
+                    prompt=prompt,
+                    api_url=base_url + "/v1/completions",
+                    prompt_len=prompt_len,
+                    output_len=workload.output_tokens,
+                    model=served_model,
+                    ignore_eos=True,
+                    extra_body={"temperature": 0},
+                )
+                last_error = ""
+                for attempt in range(2):
+                    started = time.perf_counter()
+                    try:
+                        output = await asyncio.wait_for(
+                            async_request_openai_completions(request, session),
+                            timeout=self.request_timeout_s,
+                        )
+                    except TimeoutError as exc:
+                        last_error = f"timed out: {exc}"
+                    else:
+                        if output.success:
+                            print(
+                                f"{profile.name}/{workload.name} {tag}: "
+                                f"out={output.output_tokens} "
+                                f"ttft_ms={output.ttft * 1000:.2f} "
+                                f"e2e_s={time.perf_counter() - started:.2f}",
+                                flush=True,
+                            )
+                            return output
+                        last_error = output.error
+                    if attempt == 0:
+                        await asyncio.sleep(2)
+                raise RuntimeError(
+                    f"{profile.name}/{workload.name} {tag} failed: {last_error}"
+                )
+
+            await one("warmup")
+            metrics_before = await fetch_spec_decode_metrics(base_url, session)
+
+            repeat_metrics: list[dict[str, Any]] = []
+            all_outputs: list[RequestFuncOutput] = []
+            for repeat in range(self.repeats):
+                outputs: list[RequestFuncOutput] = []
+                started = time.perf_counter()
+                for offset in range(
+                    0,
+                    workload.requests,
+                    workload.concurrency,
+                ):
+                    wave_size = min(
+                        workload.concurrency,
+                        workload.requests - offset,
+                    )
+                    wave = await asyncio.gather(
+                        *(
+                            one(
+                                f"r{repeat + 1}:"
+                                f"{offset + index + 1}/{workload.requests}"
+                            )
+                            for index in range(wave_size)
+                        )
+                    )
+                    outputs.extend(wave)
+                elapsed = time.perf_counter() - started
+                all_outputs.extend(outputs)
+
+                total_input = sum(output.prompt_len for output in outputs)
+                total_output = sum(output.output_tokens for output in outputs)
+                repeat_metrics.append(
+                    {
+                        "repeat": repeat + 1,
+                        "elapsed_s": elapsed,
+                        "completed_output_tokens": total_output,
+                        "output_throughput_tok_s": total_output / elapsed,
+                        "total_token_throughput_tok_s": (total_input + total_output)
+                        / elapsed,
+                        "mean_ttft_ms": statistics.mean(
+                            output.ttft * 1000 for output in outputs
+                        ),
+                        "median_ttft_ms": statistics.median(
+                            output.ttft * 1000 for output in outputs
+                        ),
+                        "mean_e2e_ms": statistics.mean(
+                            output.latency * 1000 for output in outputs
+                        ),
+                    }
+                )
+
+            metrics_after = await fetch_spec_decode_metrics(base_url, session)
+            draft_tokens = 0
+            accepted_tokens = 0
+            if metrics_before is not None and metrics_after is not None:
+                draft_tokens = (
+                    metrics_after.num_draft_tokens - metrics_before.num_draft_tokens
+                )
+                accepted_tokens = (
+                    metrics_after.num_accepted_tokens
+                    - metrics_before.num_accepted_tokens
+                )
+
+            output_rates = [
+                metric["output_throughput_tok_s"] for metric in repeat_metrics
+            ]
+            total_rates = [
+                metric["total_token_throughput_tok_s"] for metric in repeat_metrics
+            ]
+            result = {
+                "profile": profile.name,
+                "mode": profile.mode,
+                "profile_config": asdict(profile),
+                "workload": workload.name,
+                "workload_config": asdict(workload),
+                "requests_per_repeat": workload.requests,
+                "repeats": self.repeats,
+                "concurrency": workload.concurrency,
+                "prompt_tokens_per_request": prompt_len,
+                "output_tokens_per_request": workload.output_tokens,
+                "output_throughput_tok_s": statistics.median(output_rates),
+                "output_throughput_min_tok_s": min(output_rates),
+                "output_throughput_max_tok_s": max(output_rates),
+                "output_throughput_cv": (
+                    statistics.pstdev(output_rates) / statistics.mean(output_rates)
+                    if len(output_rates) > 1
+                    else 0.0
+                ),
+                "total_token_throughput_tok_s": statistics.median(total_rates),
+                "mean_ttft_ms": statistics.median(
+                    metric["mean_ttft_ms"] for metric in repeat_metrics
+                ),
+                "median_ttft_ms": statistics.median(
+                    output.ttft * 1000 for output in all_outputs
+                ),
+                "mean_e2e_ms": statistics.median(
+                    metric["mean_e2e_ms"] for metric in repeat_metrics
+                ),
+                "mtp_draft_tokens": draft_tokens,
+                "mtp_accepted_tokens": accepted_tokens,
+                "mtp_acceptance_rate": (
+                    accepted_tokens / draft_tokens if draft_tokens else None
+                ),
+                "repeat_metrics": repeat_metrics,
+            }
+            print(
+                "BENCHMARK_RESULT=" + json.dumps(result, sort_keys=True),
+                flush=True,
+            )
+            return result
+
+
+def aggregate(
+    output_dir: Path,
+    rows: list[dict[str, Any]],
+    errors: list[dict[str, Any]],
+    native: dict[str, Any],
+) -> tuple[dict[str, Any], str, bool]:
+    by_workload: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        by_workload[row["workload"]].append(row)
+
+    baseline_rates: dict[str, float] = {}
+    thermal_drift: dict[str, float] = {}
+    for workload, workload_rows in by_workload.items():
+        refs = {
+            row["profile"]: row["output_throughput_tok_s"]
+            for row in workload_rows
+            if row["profile"] in {"baseline_ref", "baseline_repeat"}
+        }
+        if refs:
+            baseline_rates[workload] = statistics.median(refs.values())
+        if {"baseline_ref", "baseline_repeat"} <= refs.keys():
+            thermal_drift[workload] = (
+                refs["baseline_repeat"] / refs["baseline_ref"] - 1.0
+            )
+
+    for row in rows:
+        baseline = baseline_rates.get(row["workload"])
+        row["speedup_vs_baseline"] = (
+            row["output_throughput_tok_s"] / baseline if baseline else None
+        )
+
+    expected_workloads = set(baseline_rates)
+    profile_rows: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        if row["mode"] == "mtp" and row["speedup_vs_baseline"] is not None:
+            profile_rows[row["profile"]].append(row)
+
+    ranking: list[dict[str, Any]] = []
+    incomplete_profiles: list[dict[str, Any]] = []
+    for profile, measured_rows in profile_rows.items():
+        speedups = [row["speedup_vs_baseline"] for row in measured_rows]
+        completed = {row["workload"] for row in measured_rows}
+        item = {
+            "profile": profile,
+            "geomean_speedup": statistics.geometric_mean(speedups),
+            "minimum_speedup": min(speedups),
+            "maximum_speedup": max(speedups),
+            "workloads_completed": len(completed),
+            "complete": completed == expected_workloads,
+        }
+        (ranking if item["complete"] else incomplete_profiles).append(item)
+
+    ranking.sort(key=lambda item: item["geomean_speedup"], reverse=True)
+    incomplete_profiles.sort(
+        key=lambda item: (
+            item["workloads_completed"],
+            item["geomean_speedup"],
+        ),
+        reverse=True,
+    )
+
+    best_by_workload: dict[str, dict[str, Any]] = {}
+    for workload, workload_rows in by_workload.items():
+        mtp_rows = [row for row in workload_rows if row["mode"] == "mtp"]
+        if mtp_rows:
+            best = max(mtp_rows, key=lambda row: row["output_throughput_tok_s"])
+            best_by_workload[workload] = {
+                "profile": best["profile"],
+                "output_throughput_tok_s": best["output_throughput_tok_s"],
+                "speedup_vs_baseline": best["speedup_vs_baseline"],
+                "mtp_acceptance_rate": best["mtp_acceptance_rate"],
+            }
+
+    summary = {
+        "best_overall_profile": ranking[0] if ranking else None,
+        "ranking": ranking,
+        "incomplete_profiles": incomplete_profiles,
+        "best_by_workload": best_by_workload,
+        "baseline_output_throughput_tok_s": baseline_rates,
+        "thermal_drift": thermal_drift,
+        "native_mlx_lm_mtp": native,
+        "errors": errors,
+        "rows": rows,
+    }
+    write_json(output_dir / "matrix_summary.json", summary)
+
+    lines = [
+        "# Qwen3.5 native MTP speed matrix",
+        "",
+        "Primary score: median output tokens/s over repeated runs. Speedup uses "
+        "the median of the cold and hot tuned baseline for the same workload.",
+        "",
+        "## Overall MTP profile ranking",
+        "",
+        "| Rank | Profile | Geomean speedup | Worst | Best | Workloads |",
+        "|---:|---|---:|---:|---:|---:|",
+    ]
+    for index, item in enumerate(ranking, 1):
+        lines.append(
+            f"| {index} | {item['profile']} | "
+            f"{item['geomean_speedup']:.3f}x | "
+            f"{item['minimum_speedup']:.3f}x | "
+            f"{item['maximum_speedup']:.3f}x | "
+            f"{item['workloads_completed']} |"
+        )
+    if not ranking:
+        lines.append("| — | No complete MTP profile | — | — | — | — |")
+
+    lines.extend(
+        [
+            "",
+            "## All measurements",
+            "",
+            "| Workload | Profile | tok/s | Speedup | TTFT ms | E2E ms | "
+            "Acceptance | CV |",
+            "|---|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for workload in sorted(by_workload):
+        workload_rows = sorted(
+            by_workload[workload],
+            key=lambda row: row["output_throughput_tok_s"],
+            reverse=True,
+        )
+        for row in workload_rows:
+            acceptance = (
+                f"{100 * row['mtp_acceptance_rate']:.1f}%"
+                if row["mtp_acceptance_rate"] is not None
+                else "n/a"
+            )
+            speedup = (
+                f"{row['speedup_vs_baseline']:.3f}x"
+                if row["speedup_vs_baseline"] is not None
+                else "n/a"
+            )
+            lines.append(
+                f"| {workload} | {row['profile']} | "
+                f"{row['output_throughput_tok_s']:.2f} | {speedup} | "
+                f"{row['mean_ttft_ms']:.1f} | {row['mean_e2e_ms']:.1f} | "
+                f"{acceptance} | {100 * row['output_throughput_cv']:.1f}% |"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Baseline drift check",
+            "",
+            "| Workload | Hot-vs-cold drift |",
+            "|---|---:|",
+        ]
+    )
+    for workload, drift in sorted(thermal_drift.items()):
+        lines.append(f"| {workload} | {100 * drift:+.1f}% |")
+
+    if errors:
+        lines.extend(
+            [
+                "",
+                "## Failed cases",
+                "",
+                "| Profile | Workload | Error |",
+                "|---|---|---|",
+            ]
+        )
+        for error in errors:
+            text = str(error["error"]).replace("|", "\\|").replace("\n", " ")
+            lines.append(
+                f"| {error['profile']} | {error.get('workload', 'server')} | "
+                f"{text[:500]} |"
+            )
+
+    report = "\n".join(lines) + "\n"
+    (output_dir / "matrix_summary.md").write_text(report)
+    return summary, report, bool(ranking)
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "logs").mkdir(exist_ok=True)
+    (output_dir / "results").mkdir(exist_ok=True)
+    write_json(output_dir / "profiles.json", [asdict(item) for item in PROFILES])
+    write_json(output_dir / "workloads.json", [asdict(item) for item in WORKLOADS])
+
+    native = native_mtp_check_isolated(args.model_dir, output_dir)
+    rows: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    benchmarker = ServingBenchmarker(
+        args.model_dir,
+        args.port,
+        args.repeats,
+        args.request_timeout_s,
+    )
+    for profile in PROFILES:
+        log_path = output_dir / "logs" / f"{profile.name}.log"
+        server = Server(
+            profile,
+            args.model_dir,
+            args.port,
+            log_path,
+            args.server_ready_timeout_s,
+        )
+        try:
+            server.start()
+        except Exception as exc:
+            errors.append(
+                {
+                    "profile": profile.name,
+                    "workload": "server",
+                    "error": str(exc),
+                }
+            )
+            print(f"::warning::{profile.name} server failed: {exc}", flush=True)
+            server.stop()
+            continue
+
+        try:
+            for workload in WORKLOADS:
+                try:
+                    result = await benchmarker.run(profile, workload)
+                except Exception as exc:
+                    errors.append(
+                        {
+                            "profile": profile.name,
+                            "workload": workload.name,
+                            "error": str(exc),
+                        }
+                    )
+                    print(
+                        f"::warning::{profile.name}/{workload.name} failed: {exc}",
+                        flush=True,
+                    )
+                    continue
+                rows.append(result)
+                write_json(
+                    output_dir / "results" / f"{profile.name}__{workload.name}.json",
+                    result,
+                )
+        finally:
+            server.stop()
+            print(f"===== {profile.name} server log tail =====", flush=True)
+            print(tail(log_path), flush=True)
+
+    summary, report, has_complete_profile = aggregate(
+        output_dir,
+        rows,
+        errors,
+        native,
+    )
+    print(report, flush=True)
+    print(
+        "FINAL_MATRIX_SUMMARY="
+        + json.dumps(
+            {
+                "best_overall_profile": summary["best_overall_profile"],
+                "best_by_workload": summary["best_by_workload"],
+                "errors": len(errors),
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+    return 0 if has_complete_profile else 2
+
+
+def main() -> int:
+    args = parse_args()
+    if args.native_check_only:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        native_mtp_check(args.model_dir, args.output_dir)
+        return 0
+    try:
+        return asyncio.run(async_main(args))
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/results/qwen_mtp_copyless_promotion_20260817.md
+++ b/benchmarks/results/qwen_mtp_copyless_promotion_20260817.md
@@ -1,0 +1,106 @@
+# Qwen MTP copyless GDN-state promotion decision
+
+Date: 2026-08-17
+
+## Decision
+
+Promote the **copyless speculative GDN-state write path** into the native-Qwen-MTP feature branch. Do **not** promote the deferred request-local decode-state experiment or the copyless+deferred combination.
+
+The combination is functionally correct after repairing its method-contract collision, but it did not meet the predeclared performance gate of at least 1.05x versus copyless alone. Copyless alone is the simpler, validated winner.
+
+## Root cause of the original combined-arm failure
+
+The original breakthrough matrix reported only client-side connection failures for the combined arm. Retained server logs showed the actual initialization failure:
+
+```text
+TypeError: _try_conv_decode() got an unexpected keyword argument 'write_slot_ids'
+```
+
+The copyless candidate extends the lazy GDN decode contract with explicit source and destination state slots. The deferred-state experiment monkeypatched the same methods with the older signature, removing that destination-slot contract. A diagnostic compatibility bridge preserved copyless handling for explicit cross-slot speculative writes and deferred handling for ordinary same-slot decode.
+
+That bridge was used only to diagnose and evaluate the combination; it is not part of the promoted production diff.
+
+## Four-arm functional smoke
+
+Run: https://github.com/PhilipJohnBasile/vllm-metal/actions/runs/32026097139
+
+Model and runner:
+
+- `Qwen/Qwen3.5-0.8B`, MLX affine 4-bit, group size 64
+- exact MLX-LM MTP head `ac6aaffd8fdfb8c8e713e17f155d83e3d72b0a0f`
+- GitHub-hosted virtual Apple M1, macOS 15
+- one fresh port and retained server log per launch
+- explicit process-group termination and listener-release verification
+- deterministic greedy output and MTP metric capture
+
+| Arm | Successful launches | Output tok/s | Acceptance | Exact output parity | Listener released |
+|---|---:|---:|---:|:---:|:---:|
+| Current MTP | 1/1 | 8.356 | 33.3% | yes | yes |
+| Copyless | 1/1 | 9.597 | 33.3% | yes | yes |
+| Deferred | 1/1 | 7.799 | 33.3% | yes | yes |
+| Copyless + deferred | 1/1 | 2.508 | 33.3% | yes | yes |
+
+This established that the repaired combination could start, serve correctly, and shut down cleanly. The short run also showed enough variance risk to require the predeclared three-launch promotion gate rather than promoting from one measurement.
+
+## Three-launch promotion gate
+
+Run: https://github.com/PhilipJohnBasile/vllm-metal/actions/runs/32027165189
+
+Identical 1,152-token prompt, 64 output tokens, one warm-up request, three independent server launches per arm:
+
+| Arm | Successful launches | Median output tok/s | Throughput CV | Acceptance | Exact output parity | Listener released |
+|---|---:|---:|---:|---:|:---:|:---:|
+| Copyless | 3/3 | 12.007 | 1.7% | 31.25% | yes | 3/3 |
+| Copyless + deferred | 3/3 | 11.954 | 7.7% | 31.25% | yes | 3/3 |
+
+Promotion criteria:
+
+- 3/3 clean launches: **pass**
+- exact deterministic correctness: **pass**
+- no acceptance regression: **pass**
+- no stale listener/process leakage: **pass**
+- throughput CV at or below 10%: **pass**
+- combined throughput at least 1.05x copyless: **fail** (`0.996x`)
+
+Decision: **keep copyless only**.
+
+## Six-workload copyless result
+
+Run: https://github.com/PhilipJohnBasile/vllm-metal/actions/runs/31985707678
+
+The breakthrough matrix compared current MTP, copyless, and deferred across six serving workloads. Copyless was the fastest MTP arm on every workload, preserved output-hash parity, and improved geometric-mean throughput by **1.215x (+21.5%)** versus current MTP.
+
+| Workload | Current MTP tok/s | Copyless tok/s | Copyless / current MTP | Copyless / non-MTP baseline |
+|---|---:|---:|---:|---:|
+| Interactive, concurrency 1 | 6.832 | 8.815 | 1.290x | 0.322x |
+| Serving, concurrency 4 | 16.652 | 19.642 | 1.180x | 0.361x |
+| Long prefix, concurrency 1 | 5.696 | 7.293 | 1.280x | 0.474x |
+| Long prefix, concurrency 4 | 8.662 | 9.515 | 1.098x | 0.367x |
+| Serving, concurrency 8 | 14.230 | 17.984 | 1.264x | 0.266x |
+| Serving, concurrency 16 | 13.676 | 16.286 | 1.191x | 0.234x |
+
+Across these workloads, copyless reached a geometric mean of **0.328x** the matched non-MTP baseline, with a range of **0.234x to 0.474x**. Therefore this promotion is an internal MTP-path improvement, not evidence that native MTP is yet a net serving acceleration.
+
+Retained-prefix pressure also favored copyless: geometric mean **1.231x** versus current MTP, with output-hash parity preserved.
+
+## Promoted source validation
+
+Run: https://github.com/PhilipJohnBasile/vllm-metal/actions/runs/32029260290
+
+The final formatted source diff was applied to a clean branch based on the feature head and passed:
+
+- native Metal artifact build
+- Python compilation
+- `git diff --check`
+- 48 focused GDN/MTP tests
+- Ruff lint
+- Ruff formatting
+
+Only the direct source-to-destination speculative GDN-state changes were promoted. The diagnostic compatibility shim, deferred-state experiment, bootstrap workflow, and patch staging file were excluded from the production feature branch.
+
+## Remaining gates
+
+This result does not change the two remaining readiness blockers:
+
+1. `ml-explore/mlx-lm#1740` must merge, and this branch must pin its actual merge commit.
+2. The promoted copyless path must be qualified with dense Qwen3.8-27B on a real M5 Max before any positive Apple-Silicon performance claim.

--- a/tests/attention/test_align_gdn_state_manager.py
+++ b/tests/attention/test_align_gdn_state_manager.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 
 import mlx.core as mx
 import numpy as np
+import torch
 
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext
-from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
+from vllm_metal.attention.runtime.hybrid import (
+    HybridPagedAttentionRuntime,
+    _build_linear_layer_spec,
+)
 from vllm_metal.attention.state import AlignGDNStateManager
 
 BLOCK = 4
@@ -51,7 +55,17 @@ def _slab(cache: GDNPagedStateCache, layer: int, slab: int) -> tuple:
 
 class TestAlignGDNStateManager:
     def _populate(self, manager, req_ids, tables, positions):
-        ctx = PagedAttentionContext(slot_mapping=[])
+        # The production batch packs decode requests first. Mirror that
+        # ordering so multi-token decode can be distinguished from chunked
+        # prefill without changing the ordinary prefill path.
+        num_decode_requests = 0
+        for num_computed, _ in positions:
+            if num_computed <= 0:
+                break
+            num_decode_requests += 1
+        ctx = PagedAttentionContext(
+            slot_mapping=[], num_decode_requests=num_decode_requests
+        )
         manager.populate_step_context(
             req_ids=req_ids,
             ctx=ctx,
@@ -119,6 +133,96 @@ class TestAlignGDNStateManager:
         np.testing.assert_array_equal(conv, 8.0)  # group 1 moved its rows
         conv, _ = _slab(cache, 0, 3)  # group 1's checkpoint intact in the pool
         np.testing.assert_array_equal(conv, 8.0)
+
+    def test_speculative_window_plans_one_state_per_input_token(self) -> None:
+        cache = _make_cache(num_blocks=12)
+        manager = AlignGDNStateManager(cache, BLOCK, num_speculative_blocks=2)
+        _fill_slab(cache, 0, 3, 5.0)
+        _fill_slab(cache, 1, 3, 5.0)
+
+        # Five tokens are already computed, so block-table column 1 is the
+        # current recurrent state. The two following columns are the scheduler's
+        # speculative Mamba blocks for a [confirmed, draft1, draft2] window.
+        ctx = self._populate(
+            manager,
+            ["req-A"],
+            [[[2, 3, 6, 7]]],
+            [(5, 3)],
+        )
+
+        assert ctx.gdn_group_slot_mappings == ([7],)
+        assert ctx.gdn_group_state_chains == ([[3, 3, 6, 7]],)
+
+    def test_speculative_commit_promotes_selected_checkpoint(self) -> None:
+        cache = _make_cache(num_blocks=12)
+        manager = AlignGDNStateManager(cache, BLOCK, num_speculative_blocks=2)
+        tables = [[[2, 3, 6, 7]]]
+        positions = [(5, 3)]
+        self._populate(manager, ["req-A"], tables, positions)
+
+        # Simulate the state-producing GDN path: slot 3 after confirmed token,
+        # slot 6 after draft one, slot 7 after draft two.
+        for layer in (0, 1):
+            _fill_slab(cache, layer, 3, 10.0)
+            _fill_slab(cache, layer, 6, 20.0)
+            _fill_slab(cache, layer, 7, 30.0)
+
+        manager.commit_speculative_state(
+            req_ids=["req-A"],
+            state_block_ids=tables,
+            step_positions=positions,
+            num_sampled_tokens=[2],
+        )
+
+        # Two emitted tokens means one draft accepted. The selected snapshot is
+        # slot 6, but the committed sequence is still in block-table column 1,
+        # so it is promoted back to scheduler block 3.
+        for layer in (0, 1):
+            conv, rec = _slab(cache, layer, 3)
+            np.testing.assert_array_equal(conv, 20.0)
+            np.testing.assert_array_equal(rec, 20.0)
+
+    def test_speculative_commit_crosses_block_boundary(self) -> None:
+        cache = _make_cache(num_blocks=12)
+        manager = AlignGDNStateManager(cache, BLOCK, num_speculative_blocks=2)
+        tables = [[[2, 3, 6, 7]]]
+        positions = [(7, 3)]
+        self._populate(manager, ["req-A"], tables, positions)
+
+        for layer in (0, 1):
+            _fill_slab(cache, layer, 3, 10.0)
+            _fill_slab(cache, layer, 6, 20.0)
+            _fill_slab(cache, layer, 7, 30.0)
+
+        manager.commit_speculative_state(
+            req_ids=["req-A"],
+            state_block_ids=tables,
+            step_positions=positions,
+            num_sampled_tokens=[3],
+        )
+
+        # Three emitted tokens selects state slot 7. The accepted sequence has
+        # crossed into positional block-table column 2, so slot 7 is promoted
+        # into scheduler block 6.
+        for layer in (0, 1):
+            conv, rec = _slab(cache, layer, 6)
+            np.testing.assert_array_equal(conv, 30.0)
+            np.testing.assert_array_equal(rec, 30.0)
+
+    def test_linear_spec_reports_scheduler_speculative_blocks(self) -> None:
+        spec = _build_linear_layer_spec(
+            conv_kernel_dim=2,
+            conv_dim=4,
+            num_v_heads=1,
+            value_head_dim=4,
+            key_head_dim=32,
+            torch_dtype=torch.float16,
+            mamba_block_size=BLOCK,
+            mamba_cache_mode="align",
+            num_speculative_blocks=3,
+        )
+        assert spec.num_speculative_blocks == 3
+        assert spec.max_num_blocks_per_req is not None
 
     def test_pool_materializes_lazily_by_high_water_block_id(self) -> None:
         cache = _make_cache(num_blocks=8, initial_blocks=2)

--- a/tests/test_gdn_lazy_wrapper.py
+++ b/tests/test_gdn_lazy_wrapper.py
@@ -158,7 +158,7 @@ class TestGDNSpeculativeStateChains:
         assert np.any(recurrent[1] != recurrent[0])
         assert np.any(recurrent[2] != recurrent[1])
 
-    def test_one_draft_chain_uses_two_batch_wide_lazy_passes(self) -> None:
+    def test_multi_request_chain_batches_recurrent_but_not_conv(self) -> None:
         class FakeLazy:
             enabled = True
 
@@ -207,7 +207,7 @@ class TestGDNSpeculativeStateChains:
 
         conv = wrapper._run_conv_state_chains(state.x, state)
         assert conv.shape == (1, 4, inner.conv_dim)
-        assert fake.conv_slots == [[0, 2], [1, 3]]
+        assert fake.conv_slots == []
 
         q = mx.zeros((1, 4, 1, 32), dtype=mx.float32)
         v = mx.zeros((1, 4, 1, 4), dtype=mx.float32)
@@ -215,6 +215,52 @@ class TestGDNSpeculativeStateChains:
         recurrent = wrapper._run_recurrent_state_chains(q, q, v, gates, gates, state)
         assert recurrent.shape == (4, 1, 4)
         assert fake.recurrent_slots == [[0, 2], [1, 3]]
+
+    def test_single_request_one_draft_keeps_conv_fast_path(self) -> None:
+        class FakeLazy:
+            enabled = True
+
+            def __init__(self) -> None:
+                self.conv_slots: list[list[int]] = []
+
+            def try_conv_decode(self, mixed_qkv, _inner, _cache, _cache_idx, slot_ids):
+                self.conv_slots.append(list(slot_ids))
+                return mixed_qkv
+
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            max_seqs=2,
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        fake = FakeLazy()
+        object.__setattr__(wrapper, "_gdn_lazy", fake)
+        state = attention_linear._GDNForwardState(
+            x=mx.stack(
+                [
+                    mx.full((inner.conv_dim,), 0.01, dtype=mx.float32),
+                    mx.full((inner.conv_dim,), 0.02, dtype=mx.float32),
+                ],
+                axis=0,
+            )[None],
+            cu_seqlens=[0, 2],
+            num_requests=1,
+            total_tokens=2,
+            slot_ids=[1],
+            num_decode_requests=1,
+            state_chains=[[0, 0, 1]],
+        )
+
+        conv = wrapper._run_conv_state_chains(state.x, state)
+
+        assert conv.shape == (1, 2, inner.conv_dim)
+        assert fake.conv_slots == [[0], [1]]
 
 
 class TestGDNPagedAttentionWrapperLazyKernels:

--- a/tests/test_gdn_lazy_wrapper.py
+++ b/tests/test_gdn_lazy_wrapper.py
@@ -110,6 +110,113 @@ def _make_state_cache(
     )
 
 
+class TestGDNSpeculativeStateChains:
+    def test_full_wrapper_writes_conv_and_recurrent_snapshot_per_token(self) -> None:
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            max_seqs=4,
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        context = PagedAttentionContext(
+            slot_mapping=[],
+            cu_seqlens=[0, 3],
+            num_decode_requests=1,
+            gdn_group_slot_mappings=([2],),
+            gdn_group_state_chains=([[0, 0, 1, 2]],),
+        )
+        tokens = mx.stack(
+            [
+                mx.full((inner.conv_dim,), 0.01, dtype=mx.float32),
+                mx.full((inner.conv_dim,), 0.02, dtype=mx.float32),
+                mx.full((inner.conv_dim,), 0.03, dtype=mx.float32),
+            ],
+            axis=0,
+        )[None]
+
+        set_context(context)
+        try:
+            output = wrapper(tokens)
+        finally:
+            clear_context()
+        mx.eval(output, *cache.updated_state_arrays())
+
+        assert output.shape == (1, 3, inner.head_v_dim)
+        conv = np.array(cache.conv_states[0])
+        np.testing.assert_allclose(conv[0], 0.01, atol=1e-6)
+        np.testing.assert_allclose(conv[1], 0.02, atol=1e-6)
+        np.testing.assert_allclose(conv[2], 0.03, atol=1e-6)
+
+        recurrent = np.array(cache.recurrent_states[0])
+        assert np.any(recurrent[0] != 0)
+        assert np.any(recurrent[1] != recurrent[0])
+        assert np.any(recurrent[2] != recurrent[1])
+
+    def test_one_draft_chain_uses_two_batch_wide_lazy_passes(self) -> None:
+        class FakeLazy:
+            enabled = True
+
+            def __init__(self) -> None:
+                self.conv_slots: list[list[int]] = []
+                self.recurrent_slots: list[list[int]] = []
+
+            def try_conv_decode(self, mixed_qkv, _inner, _cache, _cache_idx, slot_ids):
+                self.conv_slots.append(list(slot_ids))
+                return mixed_qkv
+
+            def try_recurrent_decode(self, request):
+                self.recurrent_slots.append(list(request.slot_ids))
+                return mx.zeros(
+                    (
+                        request.total_tokens,
+                        request.num_value_heads,
+                        request.value_head_dim,
+                    ),
+                    dtype=request.output_dtype,
+                )
+
+        inner = _TinyGDNInner()
+        cache = _make_state_cache(
+            max_seqs=4,
+            conv_kernel_dim=inner.conv_kernel_size,
+            conv_dim=inner.conv_dim,
+            num_v_heads=inner.num_v_heads,
+            value_head_dim=inner.head_v_dim,
+            key_head_dim=inner.head_k_dim,
+        )
+        wrapper = GDNPagedAttentionWrapper(
+            inner, layer_idx=0, cache_idx=0, state_cache=cache
+        )
+        fake = FakeLazy()
+        object.__setattr__(wrapper, "_gdn_lazy", fake)
+        state = attention_linear._GDNForwardState(
+            x=mx.zeros((1, 4, inner.conv_dim), dtype=mx.float32),
+            cu_seqlens=[0, 2, 4],
+            num_requests=2,
+            total_tokens=4,
+            slot_ids=[1, 3],
+            num_decode_requests=2,
+            state_chains=[[0, 0, 1], [2, 2, 3]],
+        )
+
+        conv = wrapper._run_conv_state_chains(state.x, state)
+        assert conv.shape == (1, 4, inner.conv_dim)
+        assert fake.conv_slots == [[0, 2], [1, 3]]
+
+        q = mx.zeros((1, 4, 1, 32), dtype=mx.float32)
+        v = mx.zeros((1, 4, 1, 4), dtype=mx.float32)
+        gates = mx.zeros((1, 4, 1), dtype=mx.float32)
+        recurrent = wrapper._run_recurrent_state_chains(q, q, v, gates, gates, state)
+        assert recurrent.shape == (4, 1, 4)
+        assert fake.recurrent_slots == [[0, 2], [1, 3]]
+
+
 class TestGDNPagedAttentionWrapperLazyKernels:
     def test_mixed_batch_with_prefill_tries_recurrent_lazy_path(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_qwen_mtp_paged_cache.py
+++ b/tests/test_qwen_mtp_paged_cache.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.kv_cache_utils import get_kv_cache_groups
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import FullAttentionSpec, HiddenStateCacheSpec
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
+from vllm_metal.v1.qwen_mtp_paged import (
+    QwenMTPAttentionSpec,
+    QwenMTPBoundaryHiddenCache,
+)
+from vllm_metal.v1.spec_decode import SpeculativeDecodeController
+
+
+class TestQwenMTPAttentionSpec:
+    def test_reports_dense_key_value_page_bytes(self) -> None:
+        # Four logical latent heads represent K+V for two physical MTP KV heads.
+        spec = QwenMTPAttentionSpec(
+            block_size=4,
+            num_kv_heads=4,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        assert isinstance(spec, HiddenStateCacheSpec)
+        assert spec.page_size_bytes == 4 * 2 * (8 + 8) * 2
+        assert KVCacheSpecRegistry.get_manager_class(spec) is FullAttentionManager
+        assert KVCacheSpecRegistry.get_uniform_type_base_spec(spec) is type(spec)
+
+    def test_cache_only_group_does_not_fragment_target_groups(self) -> None:
+        mtp = QwenMTPAttentionSpec(
+            block_size=4,
+            num_kv_heads=4,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        target = FullAttentionSpec(
+            block_size=4,
+            num_kv_heads=2,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        # Production inserts the distinct cache-only MTP spec first. That makes
+        # vLLM's early uniformity probe use the custom registered base, then its
+        # cache-only extraction path removes MTP before target group sizing.
+        groups = get_kv_cache_groups(
+            SimpleNamespace(
+                scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+                speculative_config=SimpleNamespace(use_eagle=lambda: True),
+            ),
+            {
+                "mtp.layers.0.self_attn": mtp,
+                "layers.0.self_attn": target,
+                "layers.1.self_attn": target,
+                "layers.2.self_attn": target,
+                "layers.3.self_attn": target,
+            },
+        )
+
+        assert len(groups) == 2
+        target_group = next(
+            group for group in groups if "layers.0.self_attn" in group.layer_names
+        )
+        mtp_group = next(
+            group for group in groups if "mtp.layers.0.self_attn" in group.layer_names
+        )
+        assert target_group.layer_names == [
+            "layers.0.self_attn",
+            "layers.1.self_attn",
+            "layers.2.self_attn",
+            "layers.3.self_attn",
+        ]
+        assert mtp_group.layer_names == ["mtp.layers.0.self_attn"]
+        assert (
+            target_group.kv_cache_spec.page_size_bytes
+            == mtp_group.kv_cache_spec.page_size_bytes
+        )
+
+
+class TestQwenMTPBoundaryHiddenCache:
+    def test_store_read_copy_and_reuse_follow_target_blocks(self) -> None:
+        cache = QwenMTPBoundaryHiddenCache(
+            num_blocks=8,
+            block_size=4,
+            hidden_size=3,
+            dtype=mx.float32,
+        )
+        assert cache.bytes_per_block == 3 * mx.float32.size + mx.uint8.size
+        hidden = mx.array(
+            [
+                [10.0, 11.0, 12.0],
+                [20.0, 21.0, 22.0],
+                [30.0, 31.0, 32.0],
+                [40.0, 41.0, 42.0],
+            ],
+            dtype=mx.float32,
+        )
+        # Scheduler slots 8..11 complete block 2. Only its final hidden state
+        # becomes a durable warm-prefix checkpoint.
+        cache.store([8, 9, 10, 11], hidden)
+        mx.eval(cache.cache, cache.valid)
+
+        value = cache.read([0, 1, 2], token_position=11)
+        np.testing.assert_array_equal(np.array(value), [[40.0, 41.0, 42.0]])
+
+        cache.copy_blocks([(2, 5)])
+        mx.eval(cache.cache, cache.valid)
+        copied = cache.read([0, 1, 5], token_position=11)
+        np.testing.assert_array_equal(np.array(copied), [[40.0, 41.0, 42.0]])
+
+        # Beginning a new lifetime for physical block 5 invalidates the old
+        # occupant's checkpoint until that new block is complete.
+        cache.store([20], mx.array([[90.0, 91.0, 92.0]], dtype=mx.float32))
+        mx.eval(cache.valid)
+        with pytest.raises(RuntimeError, match="no valid boundary-hidden"):
+            cache.read([0, 1, 5], token_position=11)
+
+    def test_missing_unaligned_or_out_of_range_boundary_fails_closed(self) -> None:
+        cache = QwenMTPBoundaryHiddenCache(
+            num_blocks=2,
+            block_size=4,
+            hidden_size=2,
+            dtype=mx.float16,
+        )
+        with pytest.raises(RuntimeError, match="not target-block aligned"):
+            cache.read([0, 1], token_position=6)
+        with pytest.raises(RuntimeError, match="missing the boundary-hidden block"):
+            cache.read([0], token_position=7)
+        with pytest.raises(RuntimeError, match="out of range"):
+            cache.read([0, 3], token_position=7)
+        with pytest.raises(RuntimeError, match="no valid boundary-hidden"):
+            cache.read([0, 1], token_position=7)
+        with pytest.raises(RuntimeError, match="slot is out of range"):
+            cache.store([8], mx.zeros((1, 2), dtype=mx.float16))
+
+
+class _FakeQwenMTPState:
+    ready = True
+
+    def __init__(self) -> None:
+        self.copy_calls = []
+        self.hidden_calls = []
+        self.pair_calls = []
+
+    def copy_blocks(self, copies):
+        self.copy_calls.append(list(copies))
+
+    def store_target_hidden(self, ctx, hidden_states):
+        self.hidden_calls.append((ctx, hidden_states))
+
+    def read_boundary_hidden(self, block_ids, token_position):
+        self.hidden_calls.append((block_ids, token_position))
+        return mx.ones((1, 4), dtype=mx.float32)
+
+    def run_pairs(self, **kwargs):
+        self.pair_calls.append(kwargs)
+        return 17
+
+    def extend_forward_eval_outputs(self, outputs):
+        outputs.append(mx.array([1], dtype=mx.int32))
+
+
+class TestHybridRuntimeQwenMTPContract:
+    def _runtime(self) -> HybridPagedAttentionRuntime:
+        runtime = HybridPagedAttentionRuntime.__new__(HybridPagedAttentionRuntime)
+        runtime._qwen_mtp_state = _FakeQwenMTPState()
+        runtime._mamba_cache_mode = "align"
+        return runtime
+
+    def test_capability_is_exposed_only_for_ready_align_state(self) -> None:
+        runtime = self._runtime()
+        assert runtime.qwen_mtp_ready
+        assert runtime.supports_hybrid_speculative_decode()
+        runtime._mamba_cache_mode = "none"
+        assert not runtime.supports_hybrid_speculative_decode()
+
+    def test_runtime_proxies_boundary_and_pair_operations(self) -> None:
+        runtime = self._runtime()
+        hidden = runtime.qwen_mtp_boundary_hidden([[1, 2], [3, 4]], 7)
+        assert hidden.shape == (1, 4)
+        draft = runtime.qwen_mtp_run_pairs(
+            hidden_rows=mx.ones((1, 4)),
+            next_token_ids=[9],
+            block_ids_by_group=[[1, 2], [3, 4]],
+            start_pos=7,
+        )
+        assert draft == 17
+        assert runtime._qwen_mtp_state.pair_calls[0]["start_pos"] == 7
+
+
+class TestHybridSpeculativeValidationGate:
+    @staticmethod
+    def _scheduler_output():
+        return SimpleNamespace(
+            scheduled_spec_decode_tokens={"r0": [10]},
+            num_invalid_spec_tokens={},
+            num_scheduled_tokens={"r0": 2},
+        )
+
+    @staticmethod
+    def _decode_reqs():
+        return [
+            (
+                "r0",
+                SimpleNamespace(
+                    sampling_params=SamplingParams(temperature=0),
+                ),
+            )
+        ]
+
+    def test_hybrid_verification_fails_without_transactional_runtime(self) -> None:
+        with pytest.raises(NotImplementedError, match="transactional paged Qwen MTP"):
+            SpeculativeDecodeController().validate_supported(
+                self._scheduler_output(),
+                self._decode_reqs(),
+                paged_attention_enabled=True,
+                is_hybrid=True,
+                speculative_config=SimpleNamespace(),
+                hybrid_speculative_ready=False,
+            )
+
+    def test_hybrid_verification_opens_with_transactional_runtime(self) -> None:
+        SpeculativeDecodeController().validate_supported(
+            self._scheduler_output(),
+            self._decode_reqs(),
+            paged_attention_enabled=True,
+            is_hybrid=True,
+            speculative_config=SimpleNamespace(),
+            hybrid_speculative_ready=True,
+        )

--- a/tests/test_qwen_mtp_worker_budget.py
+++ b/tests/test_qwen_mtp_worker_budget.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_metal.v1.cache_policy import WorkerCachePlanner
+
+
+class TestQwenMTPWorkerBudget:
+    def test_missing_optional_reporter_defaults_to_zero(self) -> None:
+        planner = WorkerCachePlanner(SimpleNamespace(model_runner=SimpleNamespace()))
+
+        assert planner._qwen_mtp_aux_bytes_per_block() == 0
+
+    def test_public_reporter_is_used(self) -> None:
+        planner = WorkerCachePlanner(
+            SimpleNamespace(
+                model_runner=SimpleNamespace(qwen_mtp_aux_bytes_per_block=lambda: 4096)
+            )
+        )
+
+        assert planner._qwen_mtp_aux_bytes_per_block() == 4096
+
+    def test_negative_reporter_fails_closed(self) -> None:
+        planner = WorkerCachePlanner(
+            SimpleNamespace(
+                model_runner=SimpleNamespace(qwen_mtp_aux_bytes_per_block=lambda: -1)
+            )
+        )
+
+        with pytest.raises(ValueError, match="cannot be negative"):
+            planner._qwen_mtp_aux_bytes_per_block()

--- a/tests/test_qwen_mtp_wrapper_metadata.py
+++ b/tests/test_qwen_mtp_wrapper_metadata.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+
+from vllm_metal.v1.cache_policy import ModelCachePolicy
+
+
+def test_qwen_mtp_metadata_unwraps_language_model() -> None:
+    args = SimpleNamespace(
+        num_key_value_heads=2,
+        head_dim=64,
+        hidden_size=1024,
+    )
+    text_model = SimpleNamespace(
+        mtp=SimpleNamespace(layers=[object()]),
+        args=args,
+    )
+    wrapper = SimpleNamespace(
+        supports_mtp=True,
+        language_model=text_model,
+    )
+    runner = SimpleNamespace(
+        vllm_config=SimpleNamespace(speculative_config=SimpleNamespace(method="mtp")),
+        _forward_model=wrapper,
+    )
+
+    policy = ModelCachePolicy(runner, object())
+    metadata = policy._qwen_mtp_metadata()
+
+    assert metadata == (text_model, 1, 2, 64, 1024)
+
+
+def test_qwen_mtp_metadata_keeps_direct_text_model() -> None:
+    args = SimpleNamespace(
+        num_key_value_heads=4,
+        head_dim=128,
+        hidden_size=2048,
+    )
+    model = SimpleNamespace(
+        supports_mtp=True,
+        mtp=SimpleNamespace(layers=[object(), object()]),
+        args=args,
+    )
+    runner = SimpleNamespace(
+        vllm_config=SimpleNamespace(speculative_config=SimpleNamespace(method="mtp")),
+        _forward_model=model,
+    )
+
+    policy = ModelCachePolicy(runner, object())
+    metadata = policy._qwen_mtp_metadata()
+
+    assert metadata == (model, 2, 4, 128, 2048)

--- a/tests/test_qwen_native_mtp_proposer.py
+++ b/tests/test_qwen_native_mtp_proposer.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+
+from vllm_metal.v1.model_adapter import DefaultModelAdapter
+from vllm_metal.v1.proposer import ProposeContext, QwenNativeMTPProposer
+from vllm_metal.v1.spec_decode import PagedDecodeSegment
+
+VOCAB = 64
+
+
+class _FakeNativeMTPModel:
+    supports_mtp = True
+
+    def mtp_forward(self, hidden, next_token_ids, cache):
+        del hidden, cache
+        predicted = (next_token_ids.astype(mx.int32) + 1) % VOCAB
+        return mx.eye(VOCAB, dtype=mx.float32)[predicted] * 100.0
+
+    def __call__(self, input_ids, *, cache=None, return_hidden=False):
+        del cache
+        hidden = mx.repeat(input_ids[..., None].astype(mx.float32), 4, axis=-1)
+        target = (input_ids.astype(mx.int32) + 5) % VOCAB
+        logits = mx.eye(VOCAB, dtype=mx.float32)[target] * 100.0
+        if return_hidden:
+            return logits, hidden
+        return logits
+
+
+class _FakePagedRuntime:
+    qwen_mtp_ready = True
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.boundaries: dict[int, mx.array] = {}
+        self.boundary_reads: list[int] = []
+        self.batch_calls: list[dict[str, object]] = []
+        self.fail_boundary = False
+
+    def supports_hybrid_speculative_decode(self) -> bool:
+        return True
+
+    def qwen_mtp_boundary_hidden(self, block_ids_by_group, token_position):
+        assert len(block_ids_by_group) == 2
+        self.boundary_reads.append(token_position)
+        if self.fail_boundary or token_position not in self.boundaries:
+            raise RuntimeError("missing boundary")
+        return self.boundaries[token_position]
+
+    def qwen_mtp_run_pairs(
+        self,
+        *,
+        hidden_rows,
+        next_token_ids,
+        block_ids_by_group,
+        start_pos,
+    ):
+        assert len(block_ids_by_group) == 2
+        tokens = [int(token) for token in next_token_ids]
+        self.calls.append(
+            {
+                "start_pos": start_pos,
+                "tokens": tokens,
+                "hidden": [float(row[0].item()) for row in hidden_rows],
+                "mtp_blocks": list(block_ids_by_group[1]),
+            }
+        )
+        return (tokens[-1] + 1) % VOCAB
+
+    def qwen_mtp_run_pairs_batch(
+        self,
+        *,
+        hidden_rows_batch,
+        next_token_ids_batch,
+        block_ids_by_group_batch,
+        start_positions,
+        draft_request_indices=None,
+    ):
+        indices = (
+            list(range(len(hidden_rows_batch)))
+            if draft_request_indices is None
+            else list(draft_request_indices)
+        )
+        self.batch_calls.append(
+            {
+                "requests": len(hidden_rows_batch),
+                "draft_request_indices": indices,
+            }
+        )
+        all_drafts = [
+            self.qwen_mtp_run_pairs(
+                hidden_rows=hidden_rows,
+                next_token_ids=next_token_ids,
+                block_ids_by_group=block_ids_by_group,
+                start_pos=start_pos,
+            )
+            for hidden_rows, next_token_ids, block_ids_by_group, start_pos in zip(
+                hidden_rows_batch,
+                next_token_ids_batch,
+                block_ids_by_group_batch,
+                start_positions,
+                strict=True,
+            )
+        ]
+        return [all_drafts[index] for index in indices]
+
+
+class _Controller:
+    @staticmethod
+    def can_draft_greedy(req_id, state):
+        del req_id, state
+        return True
+
+
+def _runner(model=None, width=1, runtime=None):
+    return SimpleNamespace(
+        _forward_model=model or _FakeNativeMTPModel(),
+        _paged_attention_runtime=runtime or _FakePagedRuntime(),
+        vllm_config=SimpleNamespace(
+            speculative_config=SimpleNamespace(
+                method="mtp",
+                num_speculative_tokens=width,
+            )
+        ),
+        _spec_decode_controller=_Controller(),
+    )
+
+
+def _ctx(
+    *,
+    hidden,
+    decode_reqs=(),
+    decode_segments=(),
+    decode_token_ids=(),
+    prefill_reqs=(),
+    prefill_token_ids=(),
+    prefill_result_modes=(),
+    request_states=None,
+    cu_seqlens=(0,),
+    finished_req_ids=None,
+):
+    return ProposeContext(
+        target_hidden_states=hidden,
+        decode_reqs=decode_reqs,
+        decode_segments=decode_segments,
+        decode_token_ids=decode_token_ids,
+        prefill_reqs=prefill_reqs,
+        prefill_token_ids=prefill_token_ids,
+        prefill_result_modes=prefill_result_modes,
+        request_states=request_states or {},
+        cu_seqlens=cu_seqlens,
+        num_decode_segments=len(decode_segments),
+        num_speculative_tokens=1,
+        finished_req_ids=finished_req_ids or set(),
+    )
+
+
+def _hidden(*token_ids):
+    values = mx.array(token_ids, dtype=mx.float32)
+    return mx.repeat(values[:, None], 4, axis=-1)
+
+
+def _prefill(req_id, token_ids, start_pos):
+    return SimpleNamespace(
+        req_id=req_id,
+        token_ids=list(token_ids),
+        start_pos=start_pos,
+        block_ids=[[2, 3, 4, 5], [20, 21, 22, 23]],
+    )
+
+
+class TestQwenTargetHiddenContract:
+    def test_adapter_uses_model_logits_and_pre_norm_hidden(self) -> None:
+        model = _FakeNativeMTPModel()
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[2, 3]], dtype=mx.int32),
+            collect_hidden_states=True,
+        )
+        assert mx.argmax(output.logits[0, 0]).item() == 7
+        assert output.hidden_states is not None
+        assert output.hidden_states.shape == (2, 4)
+        assert output.hidden_states[0, 0].item() == 2.0
+
+
+class TestQwenNativeMTPProposerPagedTransaction:
+    def test_requires_the_trained_one_token_width(self) -> None:
+        with pytest.raises(ValueError, match="exactly one speculative token"):
+            QwenNativeMTPProposer(_runner(width=3))
+
+    def test_collects_hidden_states_for_intermediate_prefill(self) -> None:
+        proposer = QwenNativeMTPProposer(_runner())
+        assert proposer.needs_target_hidden_states([], has_final_prefill=False)
+
+    def test_chunked_prefill_decode_and_release_use_scheduler_positions(self) -> None:
+        runtime = _FakePagedRuntime()
+        proposer = QwenNativeMTPProposer(_runner(runtime=runtime))
+        sampling = SamplingParams(temperature=0)
+        state = SimpleNamespace(sampling_params=sampling)
+
+        result = proposer.propose(
+            _ctx(
+                hidden=_hidden(1, 2, 3),
+                prefill_reqs=[_prefill("r0", [1, 2, 3], 0)],
+                prefill_token_ids=[0],
+                prefill_result_modes=["intermediate"],
+                request_states={"r0": state},
+                cu_seqlens=[0, 3],
+            )
+        )
+        assert result is None
+        assert runtime.calls[-1]["start_pos"] == 0
+        assert runtime.calls[-1]["tokens"] == [2, 3]
+
+        result = proposer.propose(
+            _ctx(
+                hidden=_hidden(4, 5),
+                prefill_reqs=[_prefill("r0", [4, 5], 3)],
+                prefill_token_ids=[6],
+                prefill_result_modes=["new_final"],
+                request_states={"r0": state},
+                cu_seqlens=[0, 2],
+            )
+        )
+        assert result is not None
+        assert result.draft_token_ids == [[7]]
+        assert [(c["start_pos"], c["tokens"]) for c in runtime.calls[-2:]] == [
+            (2, [4, 5]),
+            (4, [6]),
+        ]
+
+        segment = PagedDecodeSegment(
+            req_id="r0",
+            input_token_ids=(6, 7),
+            start_row=0,
+            num_query_tokens=2,
+            draft_token_ids=(7,),
+            cache_start_pos=5,
+            block_ids=((2, 3, 4, 5), (20, 21, 22, 23)),
+        )
+        result = proposer.propose(
+            _ctx(
+                hidden=_hidden(6, 7),
+                decode_reqs=[("r0", state)],
+                decode_segments=[segment],
+                decode_token_ids=[[7, 8]],
+                request_states={"r0": state},
+                cu_seqlens=[0, 2],
+            )
+        )
+        assert result is not None
+        assert result.draft_token_ids == [[9]]
+        assert runtime.calls[-1]["start_pos"] == 5
+        assert runtime.calls[-1]["tokens"] == [7, 8]
+
+        proposer.release_requests({"r0"})
+        assert "r0" not in proposer._states
+
+    def test_scheduler_prefix_hit_resumes_after_eagle_recompute_boundary(self) -> None:
+        runtime = _FakePagedRuntime()
+        runtime.boundaries[99] = _hidden(99)
+        proposer = QwenNativeMTPProposer(_runner(runtime=runtime))
+        state = SimpleNamespace(sampling_params=SamplingParams(temperature=0))
+
+        result = proposer.propose(
+            _ctx(
+                hidden=_hidden(100, 101),
+                prefill_reqs=[_prefill("hit", [100, 101], 100)],
+                prefill_token_ids=[102],
+                prefill_result_modes=["cached_final"],
+                request_states={"hit": state},
+                cu_seqlens=[0, 2],
+            )
+        )
+        assert result is not None
+        assert result.draft_token_ids == [[39]]  # (102 + 1) % 64
+        assert runtime.boundary_reads == [99]
+        # The retained MTP shared tail is not overwritten at position 99. The
+        # EAGLE-dropped suffix recomputes target hidden 100 first, then MTP
+        # resumes at logical position 100.
+        assert [(c["start_pos"], c["tokens"]) for c in runtime.calls] == [
+            (100, [101]),
+            (101, [102]),
+        ]
+        assert runtime.calls[0]["hidden"] == [100.0]
+        assert "hit" not in proposer._prefix_hit_blocked
+
+    def test_missing_boundary_fails_closed_without_fresh_mtp_state(self) -> None:
+        runtime = _FakePagedRuntime()
+        runtime.fail_boundary = True
+        proposer = QwenNativeMTPProposer(_runner(runtime=runtime))
+        state = SimpleNamespace(sampling_params=SamplingParams(temperature=0))
+        result = proposer.propose(
+            _ctx(
+                hidden=_hidden(100, 101),
+                prefill_reqs=[_prefill("hit", [100, 101], 100)],
+                prefill_token_ids=[102],
+                prefill_result_modes=["cached_final"],
+                request_states={"hit": state},
+                cu_seqlens=[0, 2],
+            )
+        )
+        assert result is None
+        assert runtime.calls == []
+        assert "hit" in proposer._prefix_hit_blocked
+
+    def test_decode_requests_share_one_mtp_runtime_batch(self) -> None:
+        runtime = _FakePagedRuntime()
+        proposer = QwenNativeMTPProposer(_runner(runtime=runtime))
+        state0 = SimpleNamespace(sampling_params=SamplingParams(temperature=0))
+        state1 = SimpleNamespace(sampling_params=SamplingParams(temperature=0))
+
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(1, 2, 11, 12),
+                prefill_reqs=[
+                    _prefill("r0", [1, 2], 0),
+                    _prefill("r1", [11, 12], 0),
+                ],
+                prefill_token_ids=[0, 0],
+                prefill_result_modes=["intermediate", "intermediate"],
+                request_states={"r0": state0, "r1": state1},
+                cu_seqlens=[0, 2, 4],
+            )
+        )
+        assert runtime.batch_calls[-1] == {
+            "requests": 2,
+            "draft_request_indices": [],
+        }
+
+        proposer.propose(
+            _ctx(
+                hidden=_hidden(3, 13),
+                prefill_reqs=[
+                    _prefill("r0", [3], 2),
+                    _prefill("r1", [13], 2),
+                ],
+                prefill_token_ids=[4, 14],
+                prefill_result_modes=["new_final", "new_final"],
+                request_states={"r0": state0, "r1": state1},
+                cu_seqlens=[0, 1, 2],
+            )
+        )
+
+        runtime.batch_calls.clear()
+        result = proposer.propose(
+            _ctx(
+                hidden=_hidden(4, 14),
+                decode_reqs=[("r0", state0), ("r1", state1)],
+                decode_segments=[
+                    PagedDecodeSegment(
+                        req_id="r0",
+                        input_token_ids=(4,),
+                        start_row=0,
+                        num_query_tokens=1,
+                        draft_token_ids=(),
+                        cache_start_pos=3,
+                        block_ids=((2, 3, 4, 5), (20, 21, 22, 23)),
+                    ),
+                    PagedDecodeSegment(
+                        req_id="r1",
+                        input_token_ids=(14,),
+                        start_row=1,
+                        num_query_tokens=1,
+                        draft_token_ids=(),
+                        cache_start_pos=3,
+                        block_ids=((6, 7, 8, 9), (24, 25, 26, 27)),
+                    ),
+                ],
+                decode_token_ids=[[5], [15]],
+                request_states={"r0": state0, "r1": state1},
+                cu_seqlens=[0, 1, 2],
+            )
+        )
+        assert result is not None
+        assert result.req_ids == ["r0", "r1"]
+        assert result.draft_token_ids == [[6], [16]]
+        assert runtime.batch_calls == [{"requests": 2, "draft_request_indices": [0, 1]}]

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -81,6 +81,18 @@ class ForwardOutputRuntimeStub:
         return None
 
 
+class SpeculativeCommitRuntimeStub:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.materialize_calls = 0
+
+    def commit_speculative_state(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+
+    def materialize_pending_state(self) -> None:
+        self.materialize_calls += 1
+
+
 class PoolingForwardBackendStub:
     def __init__(self, hidden_states: mx.array) -> None:
         self.hidden_states = hidden_states
@@ -134,6 +146,74 @@ class TestDrafterReleaseOnLifecycle:
         )
 
         assert released == [{"done", "paused", "back"}]
+
+
+class TestHybridSpeculativeStatePromotion:
+    @staticmethod
+    def _segment(
+        req_id: str,
+        *,
+        start_row: int,
+        cache_start_pos: int,
+        drafts: tuple[int, ...],
+    ) -> PagedDecodeSegment:
+        return PagedDecodeSegment(
+            req_id=req_id,
+            input_token_ids=(9, *drafts),
+            start_row=start_row,
+            num_query_tokens=1 + len(drafts),
+            draft_token_ids=drafts,
+            cache_start_pos=cache_start_pos,
+            block_ids=((2, 3, 6, 7),),
+        )
+
+    def test_commits_only_speculative_requests_with_sampled_lengths(self) -> None:
+        runner = make_stub_runner(tokenizer=object())
+        runner.model_args = {"full_attention_interval": 2}
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+        runtime = SpeculativeCommitRuntimeStub()
+        runner._paged_attention_runtime = runtime
+        runner._state_block_ids_by_req = {
+            "spec": [[2, 3, 6, 7]],
+            "plain": [[8, 9]],
+        }
+        spec_segment = self._segment(
+            "spec", start_row=0, cache_start_pos=5, drafts=(10, 11)
+        )
+        plain_segment = self._segment(
+            "plain", start_row=3, cache_start_pos=12, drafts=()
+        )
+
+        runner._commit_hybrid_speculative_state(
+            decode_reqs=[("spec", object()), ("plain", object())],
+            decode_segments=(spec_segment, plain_segment),
+            decode_token_ids=[[10, 99], [12]],
+        )
+
+        assert runtime.materialize_calls == 1
+        assert runtime.calls == [
+            {
+                "req_ids": ["spec"],
+                "state_block_ids": [[[2, 3, 6, 7]]],
+                "step_positions": [(5, 3)],
+                "num_sampled_tokens": [2],
+            }
+        ]
+
+    def test_rejects_impossible_verifier_output_length(self) -> None:
+        runner = make_stub_runner(tokenizer=object())
+        runner.model_args = {"full_attention_interval": 2}
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+        runner._paged_attention_runtime = SpeculativeCommitRuntimeStub()
+        runner._state_block_ids_by_req = {"spec": [[2, 3, 6, 7]]}
+        segment = self._segment("spec", start_row=0, cache_start_pos=5, drafts=(10, 11))
+
+        with pytest.raises(RuntimeError, match="emitted 0 tokens"):
+            runner._commit_hybrid_speculative_state(
+                decode_reqs=[("spec", object())],
+                decode_segments=(segment,),
+                decode_token_ids=[[]],
+            )
 
 
 class TestV1MetalModelRunnerGenerate:

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -71,6 +71,12 @@ class PagedAttentionContext:
     # block id / state slab).
     gdn_slot_mapping: list[int] | None = None
     gdn_group_slot_mappings: tuple[list[int], ...] | None = None
+    # Align-mode speculative verification needs one observable GDN state after
+    # every input token. Per group, each request therefore receives a chain
+    # ``[initial, after_token_0, ..., after_token_K]``. Empty request entries
+    # keep the ordinary one-destination path. The runtime safety gate remains
+    # active until the GDN wrapper consumes this contract.
+    gdn_group_state_chains: tuple[list[list[int]], ...] | None = None
     # Number of decode requests packed at the front of the batch.
     # This lets attention wrappers distinguish pure prefill from mixed prefill+decode
     # without reverse-engineering one-token segments from ``cu_seqlens``.

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -68,6 +68,8 @@ class GDNRecurrentDecodeRequest(GDNRecurrentRequest):
     """Inputs for one lazy GDN recurrent decode attempt."""
 
     threadgroup_dv: int = 4
+    # Read from slot_ids while materializing updates into these slots.
+    write_slot_ids: list[int] | None = None
 
 
 @dataclass(frozen=True)
@@ -236,8 +238,13 @@ class GDNLazyKernels:
         state_cache: GDNPagedStateCache,
         cache_idx: int,
         slot_ids: list[int],
+        write_slot_ids: list[int] | None = None,
     ) -> mx.array | None:
-        """Run the lazy GDN conv decode fast path, or return None."""
+        """Run the lazy GDN conv decode fast path, or return None.
+
+        ``slot_ids`` address source state. ``write_slot_ids`` can select
+        different stable-cache destinations for the compact updates.
+        """
         num_requests = len(slot_ids)
         total_tokens = mixed_qkv.shape[1]
         if not (
@@ -250,11 +257,22 @@ class GDNLazyKernels:
         conv_dim = state_cache.conv_dim
         kernel_size = inner.conv_kernel_size
         state_view = state_cache.conv_state_for_decode(cache_idx, slot_ids)
+        destination_slots = slot_ids if write_slot_ids is None else write_slot_ids
+        if len(destination_slots) != num_requests:
+            raise RuntimeError("GDN conv decode destination count mismatch")
+        state_cache.require_allocated_slots(destination_slots)
+        if destination_slots != slot_ids and state_view.uses_compact_state:
+            raise RuntimeError("copyless GDN conv decode requires stable source state")
         conv_state_in = state_view.state
         weight = inner.conv1d.weight
 
         mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
         slot_ids_arr = state_view.cache_slot_ids
+        write_slot_ids_arr = (
+            slot_ids_arr
+            if destination_slots == slot_ids
+            else mx.array(destination_slots, dtype=mx.int32)
+        )
         state_slot_ids_arr = state_view.state_slot_ids
 
         grid_size = num_requests * conv_dim
@@ -282,7 +300,7 @@ class GDNLazyKernels:
             output_shapes=[(num_requests, conv_dim), state_updates_shape],
             output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
         )
-        state_cache.write_conv_rows(cache_idx, conv_state_updates, slot_ids_arr)
+        state_cache.write_conv_rows(cache_idx, conv_state_updates, write_slot_ids_arr)
         if state_view.uses_compact_state:
             state_cache.clear_pending_conv_state(cache_idx)
         return conv_silu_out.reshape(1, total_tokens, conv_dim)
@@ -378,7 +396,27 @@ class GDNLazyKernels:
         state_view = state_cache.recurrent_state_for_decode(
             request.cache_idx, request.slot_ids
         )
+        destination_slots = (
+            request.slot_ids
+            if request.write_slot_ids is None
+            else request.write_slot_ids
+        )
+        if len(destination_slots) != num_requests:
+            raise RuntimeError("GDN recurrent destination count mismatch")
+        state_cache.require_allocated_slots(destination_slots)
+
+        materialize_update = request.write_slot_ids is not None
+        if materialize_update and state_view.uses_compact_state:
+            # A speculative checkpoint write needs both snapshots: publish
+            # the compact source update before the next update supersedes it.
+            state_cache.apply_pending_recurrent_state(request.cache_idx)
+
         state_in = state_view.state
+        write_slot_ids_arr = (
+            state_view.cache_slot_ids
+            if destination_slots == request.slot_ids
+            else mx.array(destination_slots, dtype=mx.int32)
+        )
         state_slot_ids_arr = state_view.state_slot_ids
 
         kernel_inputs = [
@@ -407,20 +445,19 @@ class GDNLazyKernels:
             output_shapes=[(total_tokens, n_hv, d_v), (num_requests, n_hv, d_v, d_k)],
             output_dtypes=[request.output_dtype, mx.float32],
         )
-        # Park the compact update instead of scattering it into the stable
-        # pool.  A steady-state decode chain then reads and writes only
-        # ``num_requests`` slabs per step; without this each step also copies
-        # the update into the pool, doubling recurrent state traffic.
-        #
-        # ``recurrent_state_for_decode`` above already drained any pending
-        # update whose slot order did not match, so the only pending state
-        # that can still be live here is this layer's own previous step —
-        # which ``state_updates`` supersedes.  Clear it rather than letting
-        # ``set_pending_recurrent_state`` scatter that stale slab first.
-        state_cache.clear_pending_recurrent_state(request.cache_idx)
-        state_cache.set_pending_recurrent_state(
-            request.cache_idx, request.slot_ids, state_updates
-        )
+        if materialize_update:
+            state_pool = state_cache.recurrent_states[request.cache_idx]
+            state_pool[write_slot_ids_arr] = state_updates
+            state_cache.store_recurrent_state(request.cache_idx, state_pool)
+        else:
+            # Park the compact update instead of scattering it into the stable
+            # pool. A steady-state decode chain then reads and writes only the
+            # compact request-local slabs. The prior matching pending state was
+            # consumed by this kernel and is superseded by ``state_updates``.
+            state_cache.clear_pending_recurrent_state(request.cache_idx)
+            state_cache.set_pending_recurrent_state(
+                request.cache_idx, request.slot_ids, state_updates
+            )
         return y_out
 
     def try_recurrent_prefill(

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
-from mlx_lm.models.gated_delta import compute_g
+from mlx_lm.models.gated_delta import compute_g, gated_delta_kernel
 
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext, get_context
@@ -45,6 +45,9 @@ class _GDNForwardState:
     total_tokens: int
     slot_ids: list[int]
     num_decode_requests: int
+    # Per request: [initial, after_token_0, ..., after_token_K]. Empty
+    # entries retain the ordinary one-destination path.
+    state_chains: list[list[int]] | None = None
 
 
 @dataclass(frozen=True)
@@ -165,6 +168,25 @@ class GDNPagedAttentionWrapper(nn.Module):
             raise RuntimeError("GDN wrapper requires unique slots per request")
         self._gdn_state_cache.require_allocated_slots(slot_ids)
 
+        state_chains = None
+        if ctx.gdn_group_state_chains is not None:
+            ordinal = self._gdn_state_cache.layer_group_ordinal(self._gdn_cache_idx)
+            state_chains = ctx.gdn_group_state_chains[ordinal]
+            if len(state_chains) != num_requests:
+                raise RuntimeError(
+                    "GDN wrapper requires one speculative state chain per request"
+                )
+            for req_idx, chain in enumerate(state_chains):
+                if not chain:
+                    continue
+                request_tokens = cu_seqlens[req_idx + 1] - cu_seqlens[req_idx]
+                if len(chain) != request_tokens + 1:
+                    raise RuntimeError(
+                        f"GDN request {req_idx} has {request_tokens} input tokens "
+                        f"but a {len(chain)}-entry state chain"
+                    )
+                self._gdn_state_cache.require_allocated_slots(chain)
+
         return _GDNForwardState(
             x=x,
             cu_seqlens=cu_seqlens,
@@ -172,6 +194,7 @@ class GDNPagedAttentionWrapper(nn.Module):
             total_tokens=x.shape[1],
             slot_ids=slot_ids,
             num_decode_requests=ctx.num_decode_requests,
+            state_chains=state_chains,
         )
 
     def _project_inputs(
@@ -209,6 +232,9 @@ class GDNPagedAttentionWrapper(nn.Module):
 
     def _run_conv(self, mixed_qkv: mx.array, state: _GDNForwardState) -> mx.array:
         # === Step 2: Conv1d (per-request, needs conv_state) ===
+        if state.state_chains is not None and any(state.state_chains):
+            return self._run_conv_state_chains(mixed_qkv, state)
+
         inner = self._inner
         state_cache = self._gdn_state_cache
         cache_idx = self._gdn_cache_idx
@@ -262,6 +288,157 @@ class GDNPagedAttentionWrapper(nn.Module):
 
         return mx.concatenate(conv_outputs, axis=1)
 
+    def _one_draft_state_chain_slots(
+        self, state: _GDNForwardState
+    ) -> tuple[list[int], list[int]] | None:
+        """Return rollback/final slots for a pure one-draft verify batch.
+
+        A one-draft chain is ``[initial, after_confirmed, after_draft]``.
+        Align mode intentionally aliases ``initial`` and ``after_confirmed``;
+        the speculative slot is distinct. With merged verify windows every
+        request contributes exactly two packed rows, so the two token
+        positions can be run as two batch-wide decode launches.
+        """
+        chains = state.state_chains
+        if (
+            not self._lazy_kernels_enabled()
+            or chains is None
+            or not chains
+            or state.num_decode_requests != state.num_requests
+            or state.total_tokens != 2 * state.num_requests
+        ):
+            return None
+
+        rollback_slots: list[int] = []
+        speculative_slots: list[int] = []
+        for req_idx, chain in enumerate(chains):
+            start = state.cu_seqlens[req_idx]
+            end = state.cu_seqlens[req_idx + 1]
+            if (
+                end - start != 2
+                or len(chain) != 3
+                or chain[0] != chain[1]
+                or chain[2] == chain[1]
+            ):
+                return None
+            rollback_slots.append(chain[0])
+            speculative_slots.append(chain[2])
+
+        if (
+            len(set(rollback_slots)) != len(rollback_slots)
+            or len(set(speculative_slots)) != len(speculative_slots)
+            or set(rollback_slots) & set(speculative_slots)
+        ):
+            return None
+        return rollback_slots, speculative_slots
+
+    def _try_run_conv_one_draft_state_chains(
+        self, mixed_qkv: mx.array, state: _GDNForwardState
+    ) -> mx.array | None:
+        slots = self._one_draft_state_chain_slots(state)
+        if slots is None:
+            return None
+        rollback_slots, speculative_slots = slots
+
+        first = self._gdn_lazy.try_conv_decode(
+            mixed_qkv[:, 0::2, :],
+            self._inner,
+            self._gdn_state_cache,
+            self._gdn_cache_idx,
+            rollback_slots,
+        )
+        if first is None:
+            return None
+
+        # The first launch leaves the exact post-confirmed state in the
+        # rollback slots. Seed the speculative slots from that state, then
+        # advance every draft token together. This matches mlx-lm's
+        # n_confirmed=1 rollback semantics without per-request Python loops.
+        if isinstance(self._gdn_lazy, GDNLazyKernels):
+            second = self._gdn_lazy.try_conv_decode(
+                mixed_qkv[:, 1::2, :],
+                self._inner,
+                self._gdn_state_cache,
+                self._gdn_cache_idx,
+                rollback_slots,
+                write_slot_ids=speculative_slots,
+            )
+        else:
+            # Preserve the old shape for test doubles and external wrappers.
+            cache_idx = self._gdn_cache_idx
+            pool = self._gdn_state_cache.conv_states[cache_idx]
+            src = mx.array(rollback_slots, dtype=mx.int32)
+            dst = mx.array(speculative_slots, dtype=mx.int32)
+            pool[dst] = pool[src]
+            self._gdn_state_cache.store_conv_state(cache_idx, pool)
+            second = self._gdn_lazy.try_conv_decode(
+                mixed_qkv[:, 1::2, :],
+                self._inner,
+                self._gdn_state_cache,
+                cache_idx,
+                speculative_slots,
+            )
+        if second is None:
+            raise RuntimeError(
+                "one-draft GDN conv fast path became ineligible mid-step"
+            )
+
+        return mx.stack([first[0], second[0]], axis=1).reshape(
+            1, state.total_tokens, self._inner.conv_dim
+        )
+
+    def _run_conv_state_chains(
+        self, mixed_qkv: mx.array, state: _GDNForwardState
+    ) -> mx.array:
+        """Produce an observable conv-state checkpoint after every token.
+
+        One-draft pure-decode batches use two fused batch-wide decode launches;
+        wider or mixed verification shapes retain the correctness-first
+        request/token-sequential fallback below.
+        """
+        fast_path = self._try_run_conv_one_draft_state_chains(mixed_qkv, state)
+        if fast_path is not None:
+            return fast_path
+
+        inner = self._inner
+        state_cache = self._gdn_state_cache
+        cache_idx = self._gdn_cache_idx
+        state_cache.apply_pending_conv_state(cache_idx)
+        pool = state_cache.conv_states[cache_idx]
+        outputs: list[mx.array] = []
+
+        assert state.state_chains is not None
+        for req_idx in range(state.num_requests):
+            start = state.cu_seqlens[req_idx]
+            end = state.cu_seqlens[req_idx + 1]
+            request_qkv = mixed_qkv[:, start:end, :]
+            chain = state.state_chains[req_idx]
+
+            if not chain:
+                slot = state.slot_ids[req_idx]
+                conv_state = pool[slot : slot + 1]
+                conv_input = mx.concatenate([conv_state, request_qkv], axis=1)
+                new_conv = conv_input[:, -(inner.conv_kernel_size - 1) :]
+                pool[slot : slot + 1] = new_conv
+                conv_out = nn.silu(inner.conv1d(conv_input))
+                outputs.append(conv_out[:, -(end - start) :, :])
+                continue
+
+            conv_state = pool[chain[0] : chain[0] + 1]
+            request_outputs: list[mx.array] = []
+            for token_offset, dst in enumerate(chain[1:]):
+                token_qkv = request_qkv[:, token_offset : token_offset + 1, :]
+                conv_input = mx.concatenate([conv_state, token_qkv], axis=1)
+                new_conv = conv_input[:, -(inner.conv_kernel_size - 1) :]
+                pool[dst : dst + 1] = new_conv
+                conv_state = new_conv
+                conv_out = nn.silu(inner.conv1d(conv_input))
+                request_outputs.append(conv_out[:, -1:, :])
+            outputs.append(mx.concatenate(request_outputs, axis=1))
+
+        state_cache.store_conv_state(cache_idx, pool)
+        return mx.concatenate(outputs, axis=1)
+
     def _split_and_normalize(
         self, conv_packed: mx.array, state: _GDNForwardState
     ) -> tuple[mx.array, mx.array, mx.array]:
@@ -304,6 +481,9 @@ class GDNPagedAttentionWrapper(nn.Module):
         state: _GDNForwardState,
     ) -> mx.array:
         # === Step 5: Batched recurrent update ===
+        if state.state_chains is not None and any(state.state_chains):
+            return self._run_recurrent_state_chains(q, k, v, g, beta, state)
+
         if state.num_decode_requests == state.num_requests:
             request = GDNRecurrentDecodeRequest(
                 q=q,
@@ -340,6 +520,135 @@ class GDNPagedAttentionWrapper(nn.Module):
                 return y_flat
         self._gdn_state_cache.apply_pending_recurrent_state(self._gdn_cache_idx)
         return self._run_recurrent_fallback(q, k, v, g, beta, state)
+
+    def _try_run_recurrent_one_draft_state_chains(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        g: mx.array,
+        beta: mx.array,
+        state: _GDNForwardState,
+    ) -> mx.array | None:
+        slots = self._one_draft_state_chain_slots(state)
+        if slots is None:
+            return None
+        rollback_slots, speculative_slots = slots
+
+        def request(
+            rows: slice,
+            slot_ids: list[int],
+            write_slot_ids: list[int] | None = None,
+        ) -> GDNRecurrentDecodeRequest:
+            return GDNRecurrentDecodeRequest(
+                q=q[:, rows],
+                k=k[:, rows],
+                v=v[:, rows],
+                g=g[:, rows],
+                beta=beta[:, rows],
+                state_cache=self._gdn_state_cache,
+                cache_idx=self._gdn_cache_idx,
+                slot_ids=slot_ids,
+                output_dtype=state.x.dtype,
+                threadgroup_dv=self._recurrent_decode_threadgroup_dv(),
+                write_slot_ids=write_slot_ids,
+            )
+
+        first = self._gdn_lazy.try_recurrent_decode(
+            request(slice(0, None, 2), rollback_slots)
+        )
+        if first is None:
+            return None
+
+        if isinstance(self._gdn_lazy, GDNLazyKernels):
+            second = self._gdn_lazy.try_recurrent_decode(
+                request(
+                    slice(1, None, 2),
+                    rollback_slots,
+                    write_slot_ids=speculative_slots,
+                )
+            )
+        else:
+            # Preserve the old shape for test doubles and external wrappers.
+            cache_idx = self._gdn_cache_idx
+            pool = self._gdn_state_cache.recurrent_states[cache_idx]
+            src = mx.array(rollback_slots, dtype=mx.int32)
+            dst = mx.array(speculative_slots, dtype=mx.int32)
+            pool[dst] = pool[src]
+            self._gdn_state_cache.store_recurrent_state(cache_idx, pool)
+            second = self._gdn_lazy.try_recurrent_decode(
+                request(slice(1, None, 2), speculative_slots)
+            )
+        if second is None:
+            raise RuntimeError(
+                "one-draft GDN recurrent fast path became ineligible mid-step"
+            )
+
+        return mx.stack([first, second], axis=1).reshape(
+            state.total_tokens, v.shape[2], v.shape[3]
+        )
+
+    def _run_recurrent_state_chains(
+        self,
+        q: mx.array,
+        k: mx.array,
+        v: mx.array,
+        g: mx.array,
+        beta: mx.array,
+        state: _GDNForwardState,
+    ) -> mx.array:
+        """Produce one recurrent-state snapshot per verification token."""
+        fast_path = self._try_run_recurrent_one_draft_state_chains(
+            q, k, v, g, beta, state
+        )
+        if fast_path is not None:
+            return fast_path
+
+        state_cache = self._gdn_state_cache
+        cache_idx = self._gdn_cache_idx
+        state_cache.apply_pending_recurrent_state(cache_idx)
+        pool = state_cache.recurrent_states[cache_idx]
+        outputs: list[mx.array] = []
+
+        assert state.state_chains is not None
+        for req_idx in range(state.num_requests):
+            start = state.cu_seqlens[req_idx]
+            end = state.cu_seqlens[req_idx + 1]
+            chain = state.state_chains[req_idx]
+
+            if not chain:
+                slot = state.slot_ids[req_idx]
+                request_output, new_state = gated_delta_kernel(
+                    q[:, start:end],
+                    k[:, start:end],
+                    v[:, start:end],
+                    g[:, start:end],
+                    beta[:, start:end],
+                    pool[slot : slot + 1],
+                )
+                pool[slot : slot + 1] = new_state
+                outputs.append(request_output.reshape(end - start, *v.shape[2:]))
+                continue
+
+            recurrent_state = pool[chain[0] : chain[0] + 1]
+            request_outputs: list[mx.array] = []
+            for token_offset, dst in enumerate(chain[1:]):
+                token = start + token_offset
+                token_output, new_state = gated_delta_kernel(
+                    q[:, token : token + 1],
+                    k[:, token : token + 1],
+                    v[:, token : token + 1],
+                    g[:, token : token + 1],
+                    beta[:, token : token + 1],
+                    recurrent_state,
+                )
+                pool[dst : dst + 1] = new_state
+                recurrent_state = new_state
+                request_outputs.append(token_output.reshape(1, *v.shape[2:]))
+            outputs.append(mx.concatenate(request_outputs, axis=0))
+
+        state_cache.store_recurrent_state(cache_idx, pool)
+        return mx.concatenate(outputs, axis=0).astype(state.x.dtype)
 
     def _should_try_recurrent_prefill_containing_lazy(
         self, state: _GDNForwardState

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -335,6 +335,14 @@ class GDNPagedAttentionWrapper(nn.Module):
     def _try_run_conv_one_draft_state_chains(
         self, mixed_qkv: mx.array, state: _GDNForwardState
     ) -> mx.array | None:
+        # The native multi-request two-launch conv chain failed deterministic
+        # request-parity qualification. Keep the C1 latency path, but route C2+
+        # through the exact request/token-sequential implementation until a
+        # real-kernel multi-request regression protects this handoff. The
+        # independent recurrent state chain remains batch-wide.
+        if state.num_requests != 1:
+            return None
+
         slots = self._one_draft_state_chain_slots(state)
         if slots is None:
             return None
@@ -392,9 +400,10 @@ class GDNPagedAttentionWrapper(nn.Module):
     ) -> mx.array:
         """Produce an observable conv-state checkpoint after every token.
 
-        One-draft pure-decode batches use two fused batch-wide decode launches;
-        wider or mixed verification shapes retain the correctness-first
-        request/token-sequential fallback below.
+        A single-request one-draft batch uses two fused decode launches.
+        Multi-request, wider, and mixed verification shapes retain the
+        correctness-first request/token-sequential fallback below; recurrent
+        state still has its independent multi-request batch path.
         """
         fast_path = self._try_run_conv_one_draft_state_chains(mixed_qkv, state)
         if fast_path is not None:

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -35,6 +35,7 @@ from vllm_metal.attention.impls.sdpa_wrapper import (
 from vllm_metal.attention.patching import walk_and_wrap
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
 from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
+from vllm_metal.v1.qwen_mtp_paged import QwenMTPPagedState
 
 logger = init_logger(__name__)
 
@@ -50,6 +51,7 @@ def _build_linear_layer_spec(
     page_size_padded: int | None = None,
     mamba_block_size: int,
     mamba_cache_mode: str = "none",
+    num_speculative_blocks: int = 0,
 ) -> MambaSpec:
     """Build the scheduler-visible GDN state spec.
 
@@ -66,6 +68,7 @@ def _build_linear_layer_spec(
         page_size_padded=page_size_padded,
         mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
         mamba_cache_mode=mamba_cache_mode,
+        num_speculative_blocks=num_speculative_blocks,
     )
 
 
@@ -96,6 +99,10 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         dtype: mx.Dtype,
         # Scheduler-side mamba caching strategy ("none" or "align").
         mamba_cache_mode: str = "none",
+        # One scheduler-owned GDN snapshot block per possible draft token.
+        num_speculative_blocks: int = 0,
+        # Optional native-Qwen MTP cache transaction.
+        qwen_mtp_state: QwenMTPPagedState | None = None,
         # TurboQuant (SDPA layers only)
         turboquant: bool = False,
         k_quant: str | None = None,
@@ -110,6 +117,10 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
                 f"{mamba_cache_mode!r} (only 'none' and 'align')"
             )
         self._mamba_cache_mode = mamba_cache_mode
+        if num_speculative_blocks < 0:
+            raise ValueError("num_speculative_blocks must be non-negative")
+        self._num_speculative_blocks = num_speculative_blocks
+        self._qwen_mtp_state = qwen_mtp_state
 
         # SDPA params
         self._num_kv_heads = num_kv_heads
@@ -181,10 +192,19 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
             dtype=self._dtype,
         )
         self._gdn_state_manager = (
-            AlignGDNStateManager(self._state_cache, self._block_size)
+            AlignGDNStateManager(
+                self._state_cache,
+                self._block_size,
+                self._num_speculative_blocks,
+            )
             if align
             else HybridGDNStateManager(self._state_cache)
         )
+        if self._qwen_mtp_state is not None:
+            self._qwen_mtp_state.initialize(
+                num_blocks=num_blocks,
+                block_size=self._block_size,
+            )
 
         logger.info(
             "Hybrid cache initialized: %d SDPA layers (%d blocks), "
@@ -205,6 +225,8 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         state_group_indices: tuple[int, ...] = (),
         layer_group_ordinals: list[int] | None = None,
         layer_pool_ordinals: list[int] | None = None,
+        mtp_group_index: int | None = None,
+        mtp_block_size: int | None = None,
     ) -> None:
         """Select the vLLM scheduler groups backing this runtime.
 
@@ -223,8 +245,22 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
                 "hybrid paged attention requires the SDPA scheduler group "
                 f"block size to stay {self._block_size}, got {block_size}"
             )
-        self._scheduler_group_indices = (group_index,)
-        self._group_block_sizes = (block_size,)
+        if self._qwen_mtp_state is not None:
+            if mtp_group_index is None or mtp_block_size is None:
+                raise RuntimeError(
+                    "native Qwen MTP runtime is missing its scheduler cache group"
+                )
+            self._qwen_mtp_state.configure_groups(
+                target_group_index=group_index,
+                mtp_group_index=mtp_group_index,
+                target_block_size=block_size,
+                mtp_block_size=mtp_block_size,
+            )
+            self._scheduler_group_indices = (group_index, mtp_group_index)
+            self._group_block_sizes = (block_size, mtp_block_size)
+        else:
+            self._scheduler_group_indices = (group_index,)
+            self._group_block_sizes = (block_size,)
         self._state_group_indices = tuple(state_group_indices)
         if layer_group_ordinals is not None:
             pool_ordinals = (
@@ -311,6 +347,8 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         self.kv_cache.copy_blocks(block_copies)
         if self._mamba_cache_mode == "align":
             self.state_cache.copy_blocks(block_copies)
+        if self._qwen_mtp_state is not None:
+            self._qwen_mtp_state.copy_blocks(block_copies)
 
     def populate_step_context(
         self,
@@ -327,8 +365,93 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
             step_positions=step_positions,
         )
 
+    def commit_speculative_state(
+        self,
+        *,
+        req_ids: list[str],
+        state_block_ids: list[list[list[int]]],
+        step_positions: list[tuple[int, int]],
+        num_sampled_tokens: list[int],
+    ) -> None:
+        if not isinstance(self.gdn_state_manager, AlignGDNStateManager):
+            raise RuntimeError(
+                "scheduler-owned speculative GDN state requires mamba_cache_mode='align'"
+            )
+        self.gdn_state_manager.commit_speculative_state(
+            req_ids=req_ids,
+            state_block_ids=state_block_ids,
+            step_positions=step_positions,
+            num_sampled_tokens=num_sampled_tokens,
+        )
+
+    @property
+    def qwen_mtp_ready(self) -> bool:
+        return self._qwen_mtp_state is not None and self._qwen_mtp_state.ready
+
+    def supports_hybrid_speculative_decode(self) -> bool:
+        return self._mamba_cache_mode == "align" and self.qwen_mtp_ready
+
+    def store_qwen_mtp_target_hidden(
+        self,
+        ctx: PagedAttentionContext,
+        hidden_states: mx.array,
+    ) -> None:
+        if self._qwen_mtp_state is None:
+            return
+        self._qwen_mtp_state.store_target_hidden(ctx, hidden_states)
+
+    def qwen_mtp_boundary_hidden(
+        self,
+        block_ids_by_group: Sequence[Sequence[int]],
+        token_position: int,
+    ) -> mx.array:
+        if self._qwen_mtp_state is None:
+            raise RuntimeError("Qwen MTP boundary state is not installed")
+        return self._qwen_mtp_state.read_boundary_hidden(
+            block_ids_by_group,
+            token_position,
+        )
+
+    def qwen_mtp_run_pairs(
+        self,
+        *,
+        hidden_rows: mx.array,
+        next_token_ids: Sequence[int],
+        block_ids_by_group: Sequence[Sequence[int]],
+        start_pos: int,
+    ) -> int:
+        if self._qwen_mtp_state is None:
+            raise RuntimeError("Qwen MTP paged state is not installed")
+        return self._qwen_mtp_state.run_pairs(
+            hidden_rows=hidden_rows,
+            next_token_ids=next_token_ids,
+            block_ids_by_group=block_ids_by_group,
+            start_pos=start_pos,
+        )
+
+    def qwen_mtp_run_pairs_batch(
+        self,
+        *,
+        hidden_rows_batch: Sequence[mx.array],
+        next_token_ids_batch: Sequence[Sequence[int]],
+        block_ids_by_group_batch: Sequence[Sequence[Sequence[int]]],
+        start_positions: Sequence[int],
+        draft_request_indices: Sequence[int] | None = None,
+    ) -> list[int]:
+        if self._qwen_mtp_state is None:
+            raise RuntimeError("Qwen MTP paged state is not installed")
+        return self._qwen_mtp_state.run_pairs_batch(
+            hidden_rows_batch=hidden_rows_batch,
+            next_token_ids_batch=next_token_ids_batch,
+            block_ids_by_group_batch=block_ids_by_group_batch,
+            start_positions=start_positions,
+            draft_request_indices=draft_request_indices,
+        )
+
     def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:
         self.gdn_state_manager.extend_forward_eval_outputs(outputs)
+        if self._qwen_mtp_state is not None:
+            self._qwen_mtp_state.extend_forward_eval_outputs(outputs)
 
     def release_requests(self, req_ids: set[str]) -> None:
         self.gdn_state_manager.release_requests(req_ids)

--- a/vllm_metal/attention/state/align.py
+++ b/vllm_metal/attention/state/align.py
@@ -42,9 +42,17 @@ if TYPE_CHECKING:
 class AlignGDNStateManager:
     """Drive block-indexed GDN state for align-mode prefix caching."""
 
-    def __init__(self, state_cache: GDNPagedStateCache, block_size: int) -> None:
+    def __init__(
+        self,
+        state_cache: GDNPagedStateCache,
+        block_size: int,
+        num_speculative_blocks: int = 0,
+    ) -> None:
+        if num_speculative_blocks < 0:
+            raise ValueError("num_speculative_blocks must be non-negative")
         self._state_cache = state_cache
         self._block_size = block_size
+        self._num_speculative_blocks = num_speculative_blocks
         self._needs_materialize = False
 
     @property
@@ -101,8 +109,11 @@ class AlignGDNStateManager:
             self._state_cache.ensure_capacity(target)
 
         group_mappings: list[list[int]] = []
+        group_state_chains: list[list[list[int]]] = []
+        has_speculative_chains = False
         for group in range(num_groups):
             dst_ids: list[int] = []
+            request_chains: list[list[int]] = []
             copy_src: list[int] = []
             copy_dst: list[int] = []
             zero_ids: list[int] = []
@@ -113,6 +124,43 @@ class AlignGDNStateManager:
                         f"align GDN state manager: request "
                         f"{req_ids[req_idx]!r} scheduled {num_scheduled} tokens"
                     )
+
+                is_speculative_verify = (
+                    self._num_speculative_blocks > 0
+                    and req_idx < ctx.num_decode_requests
+                    and num_scheduled > 1
+                )
+                if is_speculative_verify:
+                    if num_computed <= 0:
+                        raise RuntimeError(
+                            "speculative GDN verification requires an existing "
+                            "committed state"
+                        )
+                    num_drafts = num_scheduled - 1
+                    if num_drafts > self._num_speculative_blocks:
+                        raise RuntimeError(
+                            f"request {req_ids[req_idx]!r} scheduled {num_drafts} "
+                            "draft tokens but its MambaSpec reserves only "
+                            f"{self._num_speculative_blocks} speculative blocks"
+                        )
+                    state_idx = (num_computed - 1) // self._block_size
+                    end = state_idx + num_scheduled
+                    if end > len(row):
+                        raise RuntimeError(
+                            f"request {req_ids[req_idx]!r} needs GDN state "
+                            f"columns [{state_idx}, {end}) but its mamba block "
+                            f"table has {len(row)} entries"
+                        )
+                    # This mirrors upstream mamba_get_block_table_tensor():
+                    # current state block followed by K speculative blocks.
+                    output_slots = list(row[state_idx:end])
+                    # Token zero reads and overwrites the current private state
+                    # block; each draft writes the following speculative block.
+                    request_chains.append([output_slots[0], *output_slots])
+                    dst_ids.append(output_slots[-1])
+                    has_speculative_chains = True
+                    continue
+
                 dst_idx = (num_computed + num_scheduled - 1) // self._block_size
                 if dst_idx >= len(row):
                     raise RuntimeError(
@@ -123,6 +171,7 @@ class AlignGDNStateManager:
                     )
                 dst = row[dst_idx]
                 dst_ids.append(dst)
+                request_chains.append([])
                 if num_computed == 0:
                     zero_ids.append(dst)
                     continue
@@ -136,8 +185,69 @@ class AlignGDNStateManager:
             self._state_cache.zero_slots(zero_ids, layer_indices)
             self._state_cache.copy_slots(copy_src, copy_dst, layer_indices)
             group_mappings.append(dst_ids)
+            group_state_chains.append(request_chains)
 
         ctx.gdn_group_slot_mappings = tuple(group_mappings)
+        ctx.gdn_group_state_chains = (
+            tuple(group_state_chains) if has_speculative_chains else None
+        )
+        self._needs_materialize = True
+
+    def commit_speculative_state(
+        self,
+        *,
+        req_ids: list[str],
+        state_block_ids: list[list[list[int]]],
+        step_positions: list[tuple[int, int]],
+        num_sampled_tokens: list[int],
+    ) -> None:
+        """Promote the verifier-selected GDN checkpoint.
+
+        A verification window with ``K`` drafts writes state after each of its
+        ``K + 1`` input tokens into consecutive Mamba block-table columns.
+        The verifier emits ``num_sampled`` tokens; upstream's invariant is that
+        the committed recurrent checkpoint is column ``num_sampled - 1``.
+        """
+        if not (
+            len(req_ids)
+            == len(state_block_ids)
+            == len(step_positions)
+            == len(num_sampled_tokens)
+        ):
+            raise RuntimeError("speculative GDN commit metadata length mismatch")
+
+        self._state_cache.apply_pending_states()
+        num_groups = len(state_block_ids[0]) if state_block_ids else 0
+        for group in range(num_groups):
+            copy_src: list[int] = []
+            copy_dst: list[int] = []
+            for req_idx, (num_computed, num_scheduled) in enumerate(step_positions):
+                if num_scheduled <= 1:
+                    continue
+                sampled = num_sampled_tokens[req_idx]
+                if sampled < 1 or sampled > num_scheduled:
+                    raise RuntimeError(
+                        f"request {req_ids[req_idx]!r} sampled {sampled} tokens "
+                        f"for a {num_scheduled}-token verification window"
+                    )
+                row = state_block_ids[req_idx][group]
+                state_idx = (num_computed - 1) // self._block_size
+                selected_idx = state_idx + sampled - 1
+                committed_idx = (num_computed + sampled - 1) // self._block_size
+                if max(selected_idx, committed_idx) >= len(row):
+                    raise RuntimeError(
+                        f"request {req_ids[req_idx]!r} speculative commit "
+                        "exceeds its mamba block table"
+                    )
+                selected = row[selected_idx]
+                committed = row[committed_idx]
+                if selected != committed:
+                    copy_src.append(selected)
+                    copy_dst.append(committed)
+
+            layer_indices = self._state_cache.layers_for_group_ordinal(group)
+            self._state_cache.copy_slots(copy_src, copy_dst, layer_indices)
+
         self._needs_materialize = True
 
     def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -540,12 +540,28 @@ class MetalPlatform(Platform):
                 cache_config.enable_prefix_caching
                 and vllm_config.speculative_config is not None
             ):
-                cls._disable_hybrid_prefix_caching(
-                    vllm_config,
-                    "draft-state rollback across mamba state blocks "
-                    "(num_speculative_blocks) is not implemented for "
-                    "speculative decoding",
+                hf_config = model_config.hf_config
+                get_text_config = getattr(hf_config, "get_text_config", None)
+                text_config = (
+                    get_text_config() if callable(get_text_config) else hf_config
                 )
+                speculative_config = vllm_config.speculative_config
+                native_qwen_mtp = (
+                    getattr(speculative_config, "method", None) == "mtp"
+                    and int(
+                        getattr(speculative_config, "num_speculative_tokens", 0) or 0
+                    )
+                    == 1
+                    and int(getattr(text_config, "mtp_num_hidden_layers", 0)) > 0
+                    and cache_config.mamba_cache_mode == "align"
+                    and config.use_paged_attention
+                )
+                if not native_qwen_mtp:
+                    raise NotImplementedError(
+                        "Hybrid prefix caching plus speculative decoding on "
+                        "Metal is supported only for one-token native Qwen MTP "
+                        "with paged attention and mamba_cache_mode='align'."
+                    )
 
         # Pipeline parallelism is supported on Metal/MLX: each stage runs in its
         # own worker process and the inter-stage activations cross the

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -46,6 +46,10 @@ from vllm_metal.pytorch_backend.tensor_bridge import MLX_TO_TORCH_DTYPE
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPTargetMetadata
 from vllm_metal.v1.model_adapter import ModelAdapter
+from vllm_metal.v1.qwen_mtp_paged import (
+    QwenMTPAttentionSpec,
+    QwenMTPPagedState,
+)
 
 if TYPE_CHECKING:
     from vllm_metal.v1.model_runner import MetalModelRunner
@@ -338,6 +342,74 @@ class ModelCachePolicy:
             and any(window < 0 for window in sliding_windows)
         )
 
+    def _qwen_mtp_metadata(
+        self,
+    ) -> tuple[object, int, int, int, int] | None:
+        spec = self._runner.vllm_config.speculative_config
+        if spec is None or spec.method != "mtp":
+            return None
+        model = self._runner._forward_model
+        if not bool(getattr(model, "supports_mtp", False)):
+            raise ValueError(
+                "method='mtp' was configured but the loaded Qwen checkpoint "
+                "does not contain native MTP weights"
+            )
+        # Qwen3.5's multimodal-compatible MLX wrapper exposes the text model
+        # as ``language_model`` while delegating supports_mtp/mtp_forward at the
+        # top level. Cache ownership needs the text model itself because that is
+        # where the trained MTP module and TextModelArgs live. Dense/text-only
+        # models without the wrapper continue to use the object directly.
+        mtp_model = getattr(model, "language_model", model)
+        mtp = getattr(mtp_model, "mtp", None)
+        args = getattr(mtp_model, "args", None)
+        layers = list(getattr(mtp, "layers", ()))
+        if mtp is None or args is None or not layers:
+            raise ValueError(
+                "native Qwen MTP requires the loaded text model to expose "
+                "mtp.layers and args"
+            )
+        try:
+            num_kv_heads = int(args.num_key_value_heads)
+            head_dim = int(args.head_dim)
+            hidden_size = int(args.hidden_size)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise ValueError(
+                "native Qwen MTP model metadata is missing KV/head dimensions"
+            ) from exc
+        return mtp_model, len(layers), num_kv_heads, head_dim, hidden_size
+
+    def qwen_mtp_aux_bytes_per_block(self) -> int:
+        metadata = self._qwen_mtp_metadata()
+        if metadata is None:
+            return 0
+        _, num_layers, num_kv_heads, head_dim, hidden_size = metadata
+        block_size = self._runner.cache_config.block_size
+        dtype_size = self._require_kv_cache_dtype().size
+        mtp_kv = num_layers * 2 * block_size * num_kv_heads * head_dim * dtype_size
+        # EAGLE recomputes one full hash unit on a warm hit. Only the hidden
+        # checkpoint at the end of each retained target block is durable.
+        boundary_hidden = hidden_size * dtype_size + 1
+        return mtp_kv + boundary_hidden
+
+    def _build_qwen_mtp_state(self) -> QwenMTPPagedState | None:
+        metadata = self._qwen_mtp_metadata()
+        if metadata is None:
+            return None
+        if self._use_turboquant(get_config()):
+            raise NotImplementedError(
+                "native Qwen MTP paged KV currently requires dense KV cache; "
+                "disable TurboQuant KV while using method='mtp'"
+            )
+        model, num_layers, num_kv_heads, head_dim, hidden_size = metadata
+        return QwenMTPPagedState(
+            model=model,
+            num_layers=num_layers,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            hidden_size=hidden_size,
+            dtype=self._require_kv_cache_dtype(),
+        )
+
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """Build the scheduler-visible KV cache specification."""
         pooling_backend = self._runner._pooling_backend
@@ -385,6 +457,7 @@ class ModelCachePolicy:
                     page_size_padded=cache_config.mamba_page_size_padded,
                     mamba_block_size=mamba_block_size,
                     mamba_cache_mode=cache_config.mamba_cache_mode,
+                    num_speculative_blocks=self._num_speculative_blocks(),
                 )
             elif use_turboquant:
                 layer_name = f"layers.{layer_idx}.self_attn"
@@ -430,6 +503,43 @@ class ModelCachePolicy:
         specs.update(
             self._draft_layer_specs(block_size=block_size, torch_dtype=torch_dtype)
         )
+        metadata = self._qwen_mtp_metadata()
+        if metadata is not None:
+            if use_turboquant:
+                raise NotImplementedError(
+                    "native Qwen MTP paged KV does not support TurboQuant KV"
+                )
+            _, num_mtp_layers, mtp_kv_heads, mtp_head_dim, _ = metadata
+            mtp_spec = QwenMTPAttentionSpec(
+                block_size=block_size,
+                # HiddenStateCacheSpec reports one latent tensor. Doubling the
+                # logical head slots makes its page bytes equal the physical
+                # dense K+V arrays owned by MetalPagedKVCache.
+                num_kv_heads=2 * mtp_kv_heads,
+                head_size=mtp_head_dim,
+                dtype=torch_dtype,
+            )
+            target_page = FullAttentionSpec(
+                block_size=block_size,
+                num_kv_heads=self._runner.num_kv_heads,
+                head_size=self._runner.head_dim,
+                dtype=torch_dtype,
+            ).page_size_bytes
+            if mtp_spec.page_size_bytes != target_page:
+                raise NotImplementedError(
+                    "native Qwen MTP requires its KV page size to match the "
+                    "target full-attention page size"
+                )
+            # HiddenStateCacheSpec is vLLM's cache-only grouping path. Put the
+            # custom distinct subtype first so the early uniformity probe sees
+            # its own registered base, fails closed, and reaches cache-only
+            # extraction without reducing every target/GDN group to size one.
+            mtp_specs = {
+                f"mtp.layers.{layer_idx}.self_attn": mtp_spec
+                for layer_idx in range(num_mtp_layers)
+            }
+            specs = {**mtp_specs, **specs}
+
         return specs
 
     def _draft_layer_specs(
@@ -618,6 +728,37 @@ class ModelCachePolicy:
         block_size = kv_cache_config.kv_cache_groups[
             group_index
         ].kv_cache_spec.block_size
+
+        mtp_group_index: int | None = None
+        mtp_block_size: int | None = None
+        metadata = self._qwen_mtp_metadata()
+        if metadata is not None:
+            _, num_mtp_layers, _, _, _ = metadata
+            mtp_names = tuple(
+                f"mtp.layers.{layer_idx}.self_attn"
+                for layer_idx in range(num_mtp_layers)
+            )
+            mtp_group_indices = self._scheduler_group_indices_for_layers(
+                kv_cache_config,
+                mtp_names,
+            )
+            if len(mtp_group_indices) != 1:
+                raise RuntimeError(
+                    "native Qwen MTP layers must share one scheduler cache group"
+                )
+            mtp_group_index = mtp_group_indices[0]
+            if mtp_group_index == group_index:
+                raise RuntimeError(
+                    "native Qwen MTP cache was incorrectly merged into the "
+                    "target SDPA scheduler group"
+                )
+            # vLLM treats method='mtp' as EAGLE. When no group is explicitly
+            # annotated, KVCacheCoordinator conservatively applies the lookahead
+            # drop to every group, preserving one shared prefix lineage across
+            # target SDPA, GDN, and this cache-only MTP group.
+            mtp_group = kv_cache_config.kv_cache_groups[mtp_group_index]
+            mtp_block_size = mtp_group.kv_cache_spec.block_size
+
         # Align mode keys GDN state slabs by scheduler block id.  The engine
         # stripes same-spec linear layers across several mamba cache groups
         # (each group hands every request one block-table row), so the runtime
@@ -701,6 +842,8 @@ class ModelCachePolicy:
             state_group_indices=state_group_indices,
             layer_group_ordinals=layer_group_ordinals,
             layer_pool_ordinals=layer_pool_ordinals,
+            mtp_group_index=mtp_group_index,
+            mtp_block_size=mtp_block_size,
         )
         self._runner.install_paged_attention_runtime(runtime, block_size=block_size)
 
@@ -942,13 +1085,13 @@ class ModelCachePolicy:
         MambaSpec carries ``mamba_page_size_padded`` — an unpadded estimate
         falls short of that requirement by the padding margin.
         """
-        # Mirrors MambaSpec.max_memory_usage_bytes with zero speculative
-        # blocks and mamba_cache_mode "none"; if vLLM's defaults change,
-        # this mirror must follow.
+        # Mirrors MambaSpec.max_memory_usage_bytes in mamba_cache_mode
+        # "none": one live state plus one snapshot per speculative token.
+        multiplier = 1 + self._num_speculative_blocks()
         padded = self._runner.cache_config.mamba_page_size_padded
         if padded is not None:
-            return self._runner.num_linear_layers * padded
-        return self.linear_cache_bytes_per_slot()
+            return self._runner.num_linear_layers * padded * multiplier
+        return self.linear_cache_bytes_per_slot() * multiplier
 
     def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionRuntime:
         config = get_config()
@@ -966,6 +1109,8 @@ class ModelCachePolicy:
             block_size=block_size,
             dtype=self._require_kv_cache_dtype(),
             mamba_cache_mode=self._runner.cache_config.mamba_cache_mode,
+            num_speculative_blocks=self._num_speculative_blocks(),
+            qwen_mtp_state=self._build_qwen_mtp_state(),
             turboquant=config.turboquant,
             k_quant=config.k_quant if config.turboquant else None,
             v_quant=config.v_quant if config.turboquant else None,
@@ -1088,6 +1233,12 @@ class ModelCachePolicy:
             self._runner.num_layers,
         )
         return num_cache_layers, cache_idx_map
+
+    def _num_speculative_blocks(self) -> int:
+        speculative_config = self._runner.vllm_config.speculative_config
+        if speculative_config is None:
+            return 0
+        return int(speculative_config.num_speculative_tokens or 0)
 
     def _require_kv_cache_dtype(self) -> mx.Dtype:
         if self._runner.kv_cache_dtype is None:
@@ -1238,6 +1389,11 @@ class WorkerCachePlanner:
         # replacement materializes, so budget that one-pool overlap too.
         per_block_bytes += self._hybrid_align_state_bytes_per_block()
         per_block_bytes += self._hybrid_align_growth_bytes_per_block()
+        # The MTP cache group shares vLLM's logical block pool, but Metal owns
+        # separate physical arrays for its KV and the target-boundary shadow.
+        # Reserve those bytes in the worker plan so the scheduler round-trips
+        # the same safe block count.
+        per_block_bytes += self._qwen_mtp_aux_bytes_per_block()
         usable_metal = int(metal_limit * fraction)
         base_kv_budget = self.base_kv_budget_bytes(
             metal_limit,
@@ -1327,6 +1483,22 @@ class WorkerCachePlanner:
             reserved_slots=(2 * cushion_slots) - 1,
             max_num_seqs=max_num_seqs,
         )
+
+    def _qwen_mtp_aux_bytes_per_block(self) -> int:
+        """Return optional native-Qwen MTP cache bytes for one block."""
+        reporter = getattr(
+            self._worker.model_runner,
+            "qwen_mtp_aux_bytes_per_block",
+            None,
+        )
+        if not callable(reporter):
+            return 0
+        aux_bytes = int(reporter())
+        if aux_bytes < 0:
+            raise ValueError(
+                "Qwen MTP auxiliary cache bytes per block cannot be negative"
+            )
+        return aux_bytes
 
     def _memory_fraction(self) -> float:
         """Resolve the paged KV memory fraction.

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -433,6 +433,23 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
                 hidden_states=None,
             )
 
+        # Hardened mlx-lm Qwen native-MTP models expose an explicit
+        # return_hidden contract: logits have already passed through the final
+        # RMSNorm, while the hidden state is the pre-final-norm value the vendor
+        # MTP head was trained to consume.
+        if bool(getattr(model, "supports_mtp", False)):
+            output = model(input_ids, cache=cache, return_hidden=True)
+            if not isinstance(output, tuple) or len(output) != 2:
+                raise RuntimeError(
+                    "supports_mtp model must return (logits, hidden_states) "
+                    "when return_hidden=True"
+                )
+            logits, hidden_states = output
+            return TargetModelForwardOutput(
+                logits=self.extract_logits(logits),
+                hidden_states=self._flatten_target_hidden_states(hidden_states),
+            )
+
         hidden_states = self._forward_target_hidden_states(
             model,
             input_ids,

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -108,6 +108,7 @@ from vllm_metal.v1.proposer import (
     Gemma4MTPProposer,
     MetalProposer,
     ProposeContext,
+    QwenNativeMTPProposer,
 )
 from vllm_metal.v1.sampling_batch import (
     GREEDY_TEMPERATURE_EPS,
@@ -512,6 +513,16 @@ class MetalModelRunner:
         max_head_dim = (
             max(head_dims) if head_dims else self.model_config.get_head_size()
         )
+        runtime = self._paged_attention_runtime
+        if (
+            self.is_hybrid
+            and runtime is not None
+            and callable(getattr(runtime, "supports_hybrid_speculative_decode", None))
+            and runtime.supports_hybrid_speculative_decode()
+        ):
+            # The phase-2 GDN wrapper requires one segment per request so it
+            # can emit a recurrent/conv checkpoint after every verify token.
+            return True
         return (
             envs.VLLM_METAL_SPEC_VERIFY_WINDOW
             and not self.is_mla
@@ -841,6 +852,10 @@ class MetalModelRunner:
         """
         return self._cache_policy.get_cache_block_size_bytes()
 
+    def qwen_mtp_aux_bytes_per_block(self) -> int:
+        """Return native-Qwen MTP KV and boundary-hidden bytes per block."""
+        return self._cache_policy.qwen_mtp_aux_bytes_per_block()
+
     def linear_cache_bytes_per_slot(self) -> int:
         """Bytes for one request's linear attention state across all GDN layers."""
         return self._cache_policy.linear_cache_bytes_per_slot()
@@ -971,6 +986,8 @@ class MetalModelRunner:
             return
         if Gemma4MTPAssistantSource.is_gemma4_mtp(spec):
             self._drafter = Gemma4MTPProposer(self)
+        elif spec.method == "mtp":
+            self._drafter = QwenNativeMTPProposer(self)
         elif spec.uses_draft_model():
             from vllm_metal.v1.draft_model_proposer import DraftModelProposer
 
@@ -1004,7 +1021,7 @@ class MetalModelRunner:
         else:
             raise NotImplementedError(
                 f"Speculative method {spec.method!r} is not supported on Metal "
-                "(supported: Gemma4 MTP, draft_model, ngram)."
+                "(supported: Gemma4/Qwen native MTP, draft_model, ngram)."
             )
 
     def estimate_one_sequence_kv_bytes(
@@ -1453,6 +1470,14 @@ class MetalModelRunner:
                     logits = target_output.logits
                     target_hidden_states = target_output.hidden_states
                     del target_output
+
+            if (
+                ctx is not None
+                and runtime is not None
+                and target_hidden_states is not None
+                and bool(getattr(runtime, "qwen_mtp_ready", False))
+            ):
+                runtime.store_qwen_mtp_target_hidden(ctx, target_hidden_states)
         finally:
             clear_context()
 
@@ -1770,6 +1795,16 @@ class MetalModelRunner:
             vocab_size=vocab_size,
         )
 
+        # The target forward has now produced one GDN checkpoint per
+        # verification input token, and the verifier has chosen how many output
+        # tokens to commit. Promote the matching scheduler-owned recurrent state
+        # before request lengths or block ownership advance.
+        self._commit_hybrid_speculative_state(
+            decode_reqs=decode_reqs,
+            decode_segments=decode_segments,
+            decode_token_ids=decode_token_ids,
+        )
+
         # ---- update decode state ----
         for i, (req_id, state) in enumerate(decode_reqs):
             sampled_ids = decode_token_ids[i]
@@ -1958,6 +1993,81 @@ class MetalModelRunner:
                 decode_reqs.append((req_id, state))
         return tuple(decode_reqs)
 
+    def _commit_hybrid_speculative_state(
+        self,
+        *,
+        decode_reqs: list[tuple[str, RequestState]],
+        decode_segments: tuple[PagedDecodeSegment, ...],
+        decode_token_ids: list[list[int]],
+    ) -> None:
+        """Promote verifier-selected state in an align-mode hybrid runtime.
+
+        ``decode_token_ids[i]`` contains the verifier's emitted sequence for
+        request ``i``. Its length is the universal recurrent-state selector:
+        state snapshot ``len(sampled_ids) - 1``.
+        """
+        runtime = self._paged_attention_runtime
+        if runtime is None or not self.is_hybrid:
+            return
+        if not any(segment.draft_token_ids for segment in decode_segments):
+            return
+        if self.cache_config.mamba_cache_mode != "align":
+            raise RuntimeError(
+                "hybrid speculative state promotion requires mamba_cache_mode='align'"
+            )
+        if not (len(decode_reqs) == len(decode_segments) == len(decode_token_ids)):
+            raise RuntimeError("decode speculation metadata length mismatch")
+
+        req_ids: list[str] = []
+        state_block_ids: list[list[list[int]]] = []
+        step_positions: list[tuple[int, int]] = []
+        num_sampled_tokens: list[int] = []
+        for (req_id, _), segment, sampled_ids in zip(
+            decode_reqs, decode_segments, decode_token_ids, strict=True
+        ):
+            if not segment.draft_token_ids:
+                continue
+            if req_id != segment.req_id:
+                raise RuntimeError(
+                    "hybrid speculative state promotion received mismatched "
+                    f"request metadata: {req_id!r} != {segment.req_id!r}"
+                )
+            sampled = len(sampled_ids)
+            if sampled < 1 or sampled > segment.num_query_tokens:
+                raise RuntimeError(
+                    f"request {req_id!r} emitted {sampled} tokens for a "
+                    f"{segment.num_query_tokens}-token verification window"
+                )
+            try:
+                request_state_blocks = self._state_block_ids_by_req[req_id]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"no scheduler-owned GDN block table for {req_id!r}"
+                ) from exc
+
+            req_ids.append(req_id)
+            state_block_ids.append(request_state_blocks)
+            step_positions.append((segment.cache_start_pos, segment.num_query_tokens))
+            num_sampled_tokens.append(sampled)
+
+        if not req_ids:
+            return
+
+        commit = getattr(runtime, "commit_speculative_state", None)
+        if commit is None:
+            raise RuntimeError(
+                "hybrid runtime does not implement speculative GDN state promotion"
+            )
+        commit(
+            req_ids=req_ids,
+            state_block_ids=state_block_ids,
+            step_positions=step_positions,
+            num_sampled_tokens=num_sampled_tokens,
+        )
+        # The promotion copy is a lazy MLX state mutation. Materialize it before
+        # the scheduler can reuse, evict, preempt, or copy those blocks.
+        runtime.materialize_pending_state()
+
     def _validate_spec_decode_supported(
         self,
         scheduler_output: SchedulerOutput,
@@ -1969,6 +2079,17 @@ class MetalModelRunner:
             is_hybrid=self.is_hybrid,
             use_async_scheduling=self.use_async_scheduling,
             speculative_config=self.vllm_config.speculative_config,
+            hybrid_speculative_ready=(
+                self._paged_attention_runtime is not None
+                and callable(
+                    getattr(
+                        self._paged_attention_runtime,
+                        "supports_hybrid_speculative_decode",
+                        None,
+                    )
+                )
+                and self._paged_attention_runtime.supports_hybrid_speculative_decode()
+            ),
         )
 
     def _run_vision_encoders(

--- a/vllm_metal/v1/proposer.py
+++ b/vllm_metal/v1/proposer.py
@@ -157,3 +157,411 @@ class Gemma4MTPProposer:
             req_ids=[seed.req_id for seed in seeds],
             draft_token_ids=draft_token_ids,
         )
+
+
+@dataclass(slots=True)
+class _QwenMTPRequestState:
+    pending_hidden: mx.array | None
+    next_mtp_position: int
+
+
+class QwenNativeMTPProposer:
+    """One-token native Qwen MTP proposer backed by scheduler-owned KV.
+
+    The target hybrid runtime owns both the MTP-head paged KV and a target
+    boundary-hidden shadow. A new request may therefore adopt a scheduler
+    prefix hit without creating a fresh request-local MTP cache.
+
+    vLLM's EAGLE cache group drops one hash unit from a warm hit, so the target
+    recomputes a non-empty suffix. The retained MTP cache is valid through the
+    recompute boundary; drafting resumes *at* ``prefill.start_pos`` rather than
+    overwriting the retained shared tail at ``start_pos - 1``.
+    """
+
+    def __init__(self, runner: MetalModelRunner) -> None:
+        self._runner = runner
+        spec = runner.vllm_config.speculative_config
+        if spec is None or spec.method != "mtp":
+            raise ValueError("QwenNativeMTPProposer requires method='mtp'")
+        width = int(spec.num_speculative_tokens or 0)
+        if width != 1:
+            raise ValueError(
+                "Qwen native MTP on Metal currently supports exactly one "
+                f"speculative token; got {width}."
+            )
+        model = runner._forward_model
+        if not bool(getattr(model, "supports_mtp", False)):
+            raise ValueError(
+                "method='mtp' requires native MTP weights and supports_mtp=True"
+            )
+        if not callable(getattr(model, "mtp_forward", None)):
+            raise ValueError("native MTP model must expose mtp_forward()")
+        self._states: dict[str, _QwenMTPRequestState] = {}
+        self._prefix_hit_blocked: set[str] = set()
+
+    def needs_target_hidden_states(
+        self,
+        decode_segments: Sequence[PagedDecodeSegment],
+        *,
+        has_final_prefill: bool,
+    ) -> bool:
+        del decode_segments, has_final_prefill
+        # Intermediate chunks populate both the MTP KV and the reusable
+        # boundary-hidden shadow, so every Qwen MTP target forward retains them.
+        return True
+
+    def release_requests(self, req_ids: set[str]) -> None:
+        for req_id in req_ids:
+            self._states.pop(req_id, None)
+            self._prefix_hit_blocked.discard(req_id)
+
+    def _runtime(self):
+        runtime = self._runner._paged_attention_runtime
+        if runtime is None or not bool(getattr(runtime, "qwen_mtp_ready", False)):
+            raise RuntimeError(
+                "native Qwen MTP requires the scheduler-owned paged MTP runtime"
+            )
+        return runtime
+
+    def _new_state(self, prefill) -> _QwenMTPRequestState | None:
+        if prefill.start_pos == 0:
+            return _QwenMTPRequestState(
+                pending_hidden=None,
+                next_mtp_position=0,
+            )
+        try:
+            # Validate that the target prefix's durable boundary metadata exists
+            # in the same scheduler-owned block lineage. EAGLE has already
+            # dropped one hash unit, so the MTP KV itself resumes at start_pos.
+            self._runtime().qwen_mtp_boundary_hidden(
+                prefill.block_ids,
+                prefill.start_pos - 1,
+            )
+        except RuntimeError:
+            # Correctness-preserving fallback: target generation continues but
+            # this request drafts nothing. Never combine the restored target
+            # prefix with a fresh or incomplete MTP cache.
+            self._prefix_hit_blocked.add(prefill.req_id)
+            return None
+        return _QwenMTPRequestState(
+            pending_hidden=None,
+            next_mtp_position=prefill.start_pos,
+        )
+
+    def _run_pairs_batch(
+        self,
+        items: Sequence[
+            tuple[
+                _QwenMTPRequestState,
+                mx.array,
+                Sequence[int],
+                Sequence[Sequence[int]],
+                int,
+            ]
+        ],
+        *,
+        draft_request_indices: Sequence[int] | None = None,
+    ) -> list[int]:
+        if not items:
+            return []
+        for state, hidden_rows, next_token_ids, _, start_pos in items:
+            if hidden_rows.shape[0] != len(next_token_ids):
+                raise RuntimeError(
+                    "Qwen MTP hidden/token pair count mismatch: "
+                    f"{hidden_rows.shape[0]} != {len(next_token_ids)}"
+                )
+            if state.next_mtp_position != start_pos:
+                raise RuntimeError(
+                    "Qwen MTP logical position mismatch: "
+                    f"cache expects {state.next_mtp_position}, "
+                    f"caller supplied {start_pos}"
+                )
+
+        drafts = self._runtime().qwen_mtp_run_pairs_batch(
+            hidden_rows_batch=[item[1] for item in items],
+            next_token_ids_batch=[item[2] for item in items],
+            block_ids_by_group_batch=[item[3] for item in items],
+            start_positions=[item[4] for item in items],
+            draft_request_indices=draft_request_indices,
+        )
+        expected_drafts = (
+            len(items) if draft_request_indices is None else len(draft_request_indices)
+        )
+        if len(drafts) != expected_drafts:
+            raise RuntimeError(
+                "Qwen MTP batched draft result count mismatch: "
+                f"{len(drafts)} != {expected_drafts}"
+            )
+        for state, _, next_token_ids, _, _ in items:
+            state.next_mtp_position += len(next_token_ids)
+        return drafts
+
+    def _run_pairs(
+        self,
+        state: _QwenMTPRequestState,
+        hidden_rows: mx.array,
+        next_token_ids: Sequence[int],
+        block_ids_by_group: Sequence[Sequence[int]],
+        *,
+        start_pos: int,
+    ) -> int:
+        drafts = self._run_pairs_batch(
+            [
+                (
+                    state,
+                    hidden_rows,
+                    next_token_ids,
+                    block_ids_by_group,
+                    start_pos,
+                )
+            ]
+        )
+        return drafts[0]
+
+    def _advance_prefill(
+        self,
+        state: _QwenMTPRequestState,
+        hidden_rows: mx.array,
+        input_token_ids: Sequence[int],
+        block_ids_by_group: Sequence[Sequence[int]],
+    ) -> None:
+        if hidden_rows.shape[0] != len(input_token_ids):
+            raise RuntimeError("Qwen MTP prefill hidden/token length mismatch")
+        if not input_token_ids:
+            return
+        pair_hidden: list[mx.array] = []
+        pair_tokens: list[int] = []
+        if state.pending_hidden is not None:
+            pair_hidden.append(state.pending_hidden)
+            pair_tokens.append(int(input_token_ids[0]))
+        if len(input_token_ids) > 1:
+            pair_hidden.append(hidden_rows[:-1])
+            pair_tokens.extend(int(token) for token in input_token_ids[1:])
+        if pair_tokens:
+            self._run_pairs(
+                state,
+                mx.concatenate(pair_hidden, axis=0),
+                pair_tokens,
+                block_ids_by_group,
+                start_pos=state.next_mtp_position,
+            )
+        state.pending_hidden = hidden_rows[-1:]
+
+    def _draft_after_prefill_sample(
+        self,
+        state: _QwenMTPRequestState,
+        sampled_token_id: int,
+        block_ids_by_group: Sequence[Sequence[int]],
+    ) -> int:
+        if state.pending_hidden is None:
+            raise RuntimeError("Qwen MTP final prefill has no boundary hidden state")
+        draft = self._run_pairs(
+            state,
+            state.pending_hidden,
+            [sampled_token_id],
+            block_ids_by_group,
+            start_pos=state.next_mtp_position,
+        )
+        state.pending_hidden = None
+        return draft
+
+    def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
+        if ctx.num_speculative_tokens != 1:
+            raise RuntimeError(
+                "Qwen native MTP proposer received a non-one-token runtime width"
+            )
+        self.release_requests(ctx.finished_req_ids)
+        hidden = ctx.target_hidden_states
+        if hidden is None:
+            return None
+
+        draft_req_ids: list[str] = []
+        drafts: list[list[int]] = []
+        first_stage: list[
+            tuple[
+                _QwenMTPRequestState,
+                mx.array,
+                Sequence[int],
+                Sequence[Sequence[int]],
+                int,
+            ]
+        ] = []
+        decode_indices: list[int] = []
+        decode_req_ids: list[str] = []
+
+        for (req_id, state), segment, sampled_ids in zip(
+            ctx.decode_reqs,
+            ctx.decode_segments,
+            ctx.decode_token_ids,
+            strict=True,
+        ):
+            if (
+                not sampled_ids
+                or not self._runner._spec_decode_controller.can_draft_greedy(
+                    req_id, state
+                )
+            ):
+                continue
+            request_state = self._states.get(req_id)
+            if request_state is None or req_id in self._prefix_hit_blocked:
+                continue
+            if request_state.next_mtp_position != segment.cache_start_pos:
+                raise RuntimeError(
+                    f"Qwen MTP request {req_id!r} expected target position "
+                    f"{request_state.next_mtp_position}, "
+                    f"got {segment.cache_start_pos}"
+                )
+            count = len(sampled_ids)
+            hidden_rows = hidden[segment.start_row : segment.start_row + count]
+            decode_indices.append(len(first_stage))
+            decode_req_ids.append(req_id)
+            first_stage.append(
+                (
+                    request_state,
+                    hidden_rows,
+                    sampled_ids,
+                    segment.block_ids,
+                    segment.cache_start_pos,
+                )
+            )
+
+        pending_hidden_updates: list[tuple[_QwenMTPRequestState, mx.array]] = []
+        final_prefills: list[
+            tuple[str, _QwenMTPRequestState, int, Sequence[Sequence[int]]]
+        ] = []
+
+        for index, (prefill, sampled_token_id, result_mode) in enumerate(
+            zip(
+                ctx.prefill_reqs,
+                ctx.prefill_token_ids,
+                ctx.prefill_result_modes,
+                strict=True,
+            )
+        ):
+            req_id = prefill.req_id
+            request_state = self._states.get(req_id)
+            if request_state is None:
+                request_state = self._new_state(prefill)
+                if request_state is None:
+                    continue
+                self._states[req_id] = request_state
+            if req_id in self._prefix_hit_blocked:
+                continue
+
+            expected_position = prefill.start_pos - int(
+                request_state.pending_hidden is not None
+            )
+            if request_state.next_mtp_position != expected_position:
+                raise RuntimeError(
+                    f"Qwen MTP prefill {req_id!r} expected MTP position "
+                    f"{expected_position}, found "
+                    f"{request_state.next_mtp_position}"
+                )
+
+            start = ctx.cu_seqlens[ctx.num_decode_segments + index]
+            end = ctx.cu_seqlens[ctx.num_decode_segments + index + 1]
+            hidden_rows = hidden[start:end]
+            input_token_ids = prefill.token_ids
+            if hidden_rows.shape[0] != len(input_token_ids):
+                raise RuntimeError("Qwen MTP prefill hidden/token length mismatch")
+            if not input_token_ids:
+                continue
+
+            pair_hidden: list[mx.array] = []
+            pair_tokens: list[int] = []
+            if request_state.pending_hidden is not None:
+                pair_hidden.append(request_state.pending_hidden)
+                pair_tokens.append(int(input_token_ids[0]))
+            if len(input_token_ids) > 1:
+                pair_hidden.append(hidden_rows[:-1])
+                pair_tokens.extend(int(token) for token in input_token_ids[1:])
+            if pair_tokens:
+                first_stage.append(
+                    (
+                        request_state,
+                        mx.concatenate(pair_hidden, axis=0),
+                        pair_tokens,
+                        prefill.block_ids,
+                        request_state.next_mtp_position,
+                    )
+                )
+            pending_hidden_updates.append((request_state, hidden_rows[-1:]))
+
+            if result_mode == "intermediate":
+                continue
+            state = ctx.request_states.get(req_id)
+            if (
+                state is None
+                or not self._runner._spec_decode_controller.can_draft_greedy(
+                    req_id, state
+                )
+            ):
+                continue
+            final_prefills.append(
+                (
+                    req_id,
+                    request_state,
+                    int(sampled_token_id),
+                    prefill.block_ids,
+                )
+            )
+
+        decode_drafts = self._run_pairs_batch(
+            first_stage,
+            draft_request_indices=decode_indices,
+        )
+        for request_state, pending_hidden in pending_hidden_updates:
+            request_state.pending_hidden = pending_hidden
+        for req_id, draft in zip(
+            decode_req_ids,
+            decode_drafts,
+            strict=True,
+        ):
+            draft_req_ids.append(req_id)
+            drafts.append([draft])
+
+        final_stage: list[
+            tuple[
+                _QwenMTPRequestState,
+                mx.array,
+                Sequence[int],
+                Sequence[Sequence[int]],
+                int,
+            ]
+        ] = []
+        final_req_ids: list[str] = []
+        final_states: list[_QwenMTPRequestState] = []
+        for req_id, request_state, sampled_token_id, block_ids in final_prefills:
+            if request_state.pending_hidden is None:
+                raise RuntimeError(
+                    "Qwen MTP final prefill has no boundary hidden state"
+                )
+            final_req_ids.append(req_id)
+            final_states.append(request_state)
+            final_stage.append(
+                (
+                    request_state,
+                    request_state.pending_hidden,
+                    [sampled_token_id],
+                    block_ids,
+                    request_state.next_mtp_position,
+                )
+            )
+
+        final_drafts = self._run_pairs_batch(final_stage)
+        for request_state in final_states:
+            request_state.pending_hidden = None
+        for req_id, draft in zip(
+            final_req_ids,
+            final_drafts,
+            strict=True,
+        ):
+            draft_req_ids.append(req_id)
+            drafts.append([draft])
+
+        if not drafts:
+            return None
+        return DraftTokenIds(
+            req_ids=draft_req_ids,
+            draft_token_ids=drafts,
+        )

--- a/vllm_metal/v1/qwen_mtp_paged.py
+++ b/vllm_metal/v1/qwen_mtp_paged.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler-owned cache transaction for native Qwen MTP on Metal.
+
+The target hybrid runtime owns three pieces of speculative state:
+
+* the ordinary target SDPA/GDN state;
+* a dedicated, scheduler-addressed MTP-head KV cache;
+* one target pre-norm hidden-state checkpoint per completed target cache block.
+
+The MTP group is an EAGLE-style cache group and therefore recomputes a full
+hash unit on a reusable prefix hit. The boundary checkpoint shares the target
+block lifecycle and validates that warm-prefix drafting never combines restored
+target state with a fresh or incomplete MTP cache.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import mlx.core as mx
+from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
+from vllm.v1.kv_cache_interface import HiddenStateCacheSpec
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.attention.context import (
+    PagedAttentionContext,
+    clear_context,
+    prepare_unified,
+)
+from vllm_metal.attention.impls.sdpa_wrapper import patch_sdpa_attention
+
+
+@dataclass(frozen=True, kw_only=True)
+class QwenMTPAttentionSpec(HiddenStateCacheSpec):
+    """A distinct full-attention cache group for the native Qwen MTP head.
+
+    The cache-only marker makes vLLM pull this layer out before hybrid
+    grouping, so a single MTP layer does not collapse every target/GDN group to
+    size one. ``num_kv_heads`` is reported as combined K+V head slots; the
+    inherited latent-page byte formula therefore equals the physical dense
+    K+V page owned by :class:`MetalPagedKVCache`.
+    """
+
+
+# Initialize the built-in registry first, then register this cache-only
+# subtype as its own uniform base. Cache policy inserts it first in the spec
+# map, so vLLM's early uniformity probe cannot absorb it into target attention.
+KVCacheSpecRegistry._ensure_registered()
+KVCacheSpecRegistry.register(
+    QwenMTPAttentionSpec,
+    FullAttentionManager,
+    uniform_type_base_spec=QwenMTPAttentionSpec,
+)
+
+
+class QwenMTPBoundaryHiddenCache:
+    """One pre-final-norm hidden checkpoint per completed target block.
+
+    Prefix-cache adoption is block-aligned. EAGLE drops one hash unit and
+    recomputes it, so only the hidden state at the end of the retained target
+    block is durable state. Keeping one vector per block avoids multiplying the
+    memory cost by ``block_size`` while retaining an exact, fail-closed lineage
+    check.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_blocks: int,
+        block_size: int,
+        hidden_size: int,
+        dtype: mx.Dtype,
+    ) -> None:
+        if num_blocks <= 0 or block_size <= 0 or hidden_size <= 0:
+            raise ValueError("Qwen MTP boundary cache dimensions must be positive")
+        self.num_blocks = num_blocks
+        self.block_size = block_size
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+        self.cache = mx.zeros((num_blocks, hidden_size), dtype=dtype)
+        self.valid = mx.zeros((num_blocks,), dtype=mx.uint8)
+        mx.eval(self.cache, self.valid)
+
+    @property
+    def bytes_per_block(self) -> int:
+        return self.hidden_size * self.dtype.size + mx.uint8.size
+
+    def store(self, slot_mapping: Sequence[int], hidden_states: mx.array) -> None:
+        hidden_states = hidden_states.reshape(-1, self.hidden_size)
+        if len(slot_mapping) != hidden_states.shape[0]:
+            raise RuntimeError(
+                "Qwen MTP boundary-hidden slot/row mismatch: "
+                f"{len(slot_mapping)} != {hidden_states.shape[0]}"
+            )
+        if not slot_mapping:
+            return
+        if any(slot < 0 for slot in slot_mapping):
+            raise RuntimeError("Qwen MTP boundary cache received a negative slot")
+        max_slot = self.num_blocks * self.block_size
+        if any(slot >= max_slot for slot in slot_mapping):
+            raise RuntimeError("Qwen MTP boundary cache slot is out of range")
+
+        # A write to offset zero begins a new physical block lifetime. Clear a
+        # previous occupant's boundary marker before the block can be cached.
+        clear_blocks = sorted(
+            {
+                slot // self.block_size
+                for slot in slot_mapping
+                if slot % self.block_size == 0
+            }
+        )
+        if clear_blocks:
+            clear_ids = mx.array(clear_blocks, dtype=mx.int32)
+            self.valid[clear_ids] = mx.zeros((len(clear_blocks),), dtype=mx.uint8)
+
+        boundary_rows = [
+            row
+            for row, slot in enumerate(slot_mapping)
+            if slot % self.block_size == self.block_size - 1
+        ]
+        if not boundary_rows:
+            return
+        block_ids = mx.array(
+            [slot_mapping[row] // self.block_size for row in boundary_rows],
+            dtype=mx.int32,
+        )
+        row_ids = mx.array(boundary_rows, dtype=mx.int32)
+        self.cache[block_ids] = hidden_states[row_ids].astype(self.dtype)
+        self.valid[block_ids] = mx.ones((len(boundary_rows),), dtype=mx.uint8)
+
+    def read(self, block_ids: Sequence[int], token_position: int) -> mx.array:
+        if token_position < 0:
+            raise RuntimeError("Qwen MTP boundary token position must be non-negative")
+        if token_position % self.block_size != self.block_size - 1:
+            raise RuntimeError(
+                "Qwen MTP warm-prefix boundary is not target-block aligned"
+            )
+        block_index = token_position // self.block_size
+        if block_index >= len(block_ids):
+            raise RuntimeError(
+                "Qwen MTP target prefix is missing the boundary-hidden block"
+            )
+        block_id = int(block_ids[block_index])
+        if block_id < 0 or block_id >= self.num_blocks:
+            raise RuntimeError("Qwen MTP boundary block id is out of range")
+        valid = self.valid[block_id]
+        mx.eval(valid)
+        if int(valid.item()) != 1:
+            raise RuntimeError(
+                "Qwen MTP target prefix has no valid boundary-hidden checkpoint"
+            )
+        value = self.cache[block_id : block_id + 1]
+        mx.eval(value)
+        return value
+
+    def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None:
+        if not block_copies:
+            return
+        src_ids, dst_ids = zip(*block_copies, strict=True)
+        if any(
+            block_id < 0 or block_id >= self.num_blocks
+            for block_id in (*src_ids, *dst_ids)
+        ):
+            raise RuntimeError(
+                "Qwen MTP boundary cache copy contains an out-of-range block id"
+            )
+        src = mx.array(src_ids, dtype=mx.int32)
+        dst = mx.array(dst_ids, dtype=mx.int32)
+        self.cache[dst] = self.cache[src]
+        self.valid[dst] = self.valid[src]
+
+
+class QwenMTPPagedState:
+    """Dedicated paged MTP KV plus target-boundary hidden-state shadow."""
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        num_layers: int,
+        num_kv_heads: int,
+        head_dim: int,
+        hidden_size: int,
+        dtype: mx.Dtype,
+    ) -> None:
+        if num_layers <= 0:
+            raise ValueError("native Qwen MTP requires at least one MTP layer")
+        mtp_module = getattr(model, "mtp", None)
+        if mtp_module is None:
+            raise ValueError("native Qwen MTP model does not expose model.mtp")
+        self.model = model
+        self.mtp_module = mtp_module
+        self.num_layers = num_layers
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+        self.hidden_size = hidden_size
+        self.dtype = dtype
+        self.mtp_cache: MetalPagedKVCache | None = None
+        self.boundary_cache: QwenMTPBoundaryHiddenCache | None = None
+        self._target_group_index: int | None = None
+        self._mtp_group_index: int | None = None
+        self._target_block_size: int | None = None
+        self._mtp_block_size: int | None = None
+
+    def initialize(self, *, num_blocks: int, block_size: int) -> None:
+        self.mtp_cache = MetalPagedKVCache(
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_kv_heads,
+            head_dim=self.head_dim,
+            num_blocks=num_blocks,
+            block_size=block_size,
+            dtype=self.dtype,
+        )
+        self.boundary_cache = QwenMTPBoundaryHiddenCache(
+            num_blocks=num_blocks,
+            block_size=block_size,
+            hidden_size=self.hidden_size,
+            dtype=self.dtype,
+        )
+        patched = patch_sdpa_attention(
+            self.mtp_module,
+            self.mtp_cache,
+            block_size,
+        )
+        if patched != self.num_layers:
+            raise RuntimeError(
+                "Qwen MTP paged runtime patched "
+                f"{patched} attention layers, expected {self.num_layers}"
+            )
+
+    def configure_groups(
+        self,
+        *,
+        target_group_index: int,
+        mtp_group_index: int,
+        target_block_size: int,
+        mtp_block_size: int,
+    ) -> None:
+        if target_group_index == mtp_group_index:
+            raise RuntimeError("Qwen MTP KV must use a distinct scheduler group")
+        if target_block_size != mtp_block_size:
+            raise NotImplementedError(
+                "Qwen MTP currently requires target and MTP groups to use the "
+                "same block size"
+            )
+        cache = self._require_mtp_cache()
+        boundary = self._require_boundary_cache()
+        if (
+            cache.block_size != mtp_block_size
+            or boundary.block_size != target_block_size
+        ):
+            raise RuntimeError("Qwen MTP scheduler block size changed after allocation")
+        self._target_group_index = target_group_index
+        self._mtp_group_index = mtp_group_index
+        self._target_block_size = target_block_size
+        self._mtp_block_size = mtp_block_size
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self.mtp_cache is not None
+            and self.boundary_cache is not None
+            and self._target_group_index is not None
+            and self._mtp_group_index is not None
+        )
+
+    @property
+    def scheduler_group_indices(self) -> tuple[int, int]:
+        self._require_ready()
+        assert self._target_group_index is not None
+        assert self._mtp_group_index is not None
+        return self._target_group_index, self._mtp_group_index
+
+    @property
+    def group_block_sizes(self) -> tuple[int, int]:
+        self._require_ready()
+        assert self._target_block_size is not None
+        assert self._mtp_block_size is not None
+        return self._target_block_size, self._mtp_block_size
+
+    @property
+    def mtp_group_ordinal(self) -> int:
+        # ``HybridPagedAttentionRuntime`` always publishes target first.
+        self._require_ready()
+        return 1
+
+    def store_target_hidden(
+        self,
+        ctx: PagedAttentionContext,
+        hidden_states: mx.array,
+    ) -> None:
+        self._require_ready()
+        if ctx.kv_groups is None or not ctx.kv_groups:
+            slot_mapping = ctx.slot_mapping
+        else:
+            # Runtime-local group zero is the target SDPA group.
+            slot_mapping = ctx.kv_groups[0].slot_mapping
+        self._require_boundary_cache().store(slot_mapping, hidden_states)
+
+    def read_boundary_hidden(
+        self,
+        block_ids_by_group: Sequence[Sequence[int]],
+        token_position: int,
+    ) -> mx.array:
+        self._require_ready()
+        if not block_ids_by_group:
+            raise RuntimeError("Qwen MTP request has no target scheduler blocks")
+        return self._require_boundary_cache().read(
+            block_ids_by_group[0],
+            token_position,
+        )
+
+    def _project_mtp_hidden(self, hidden: mx.array) -> mx.array:
+        """Project only MTP rows whose vocabulary logits are consumed."""
+        args = getattr(self.model, "args", None)
+        inner_model = getattr(self.model, "model", None)
+        embed_tokens = getattr(inner_model, "embed_tokens", None)
+        if bool(getattr(args, "tie_word_embeddings", False)):
+            if embed_tokens is None or not callable(
+                getattr(embed_tokens, "as_linear", None)
+            ):
+                raise RuntimeError("Qwen MTP tied output projection is unavailable")
+            return embed_tokens.as_linear(hidden)
+        lm_head = getattr(self.model, "lm_head", None)
+        if lm_head is None:
+            raise RuntimeError("Qwen MTP model has no output projection")
+        return lm_head(hidden)
+
+    def run_pairs_batch(
+        self,
+        *,
+        hidden_rows_batch: Sequence[mx.array],
+        next_token_ids_batch: Sequence[Sequence[int]],
+        block_ids_by_group_batch: Sequence[Sequence[Sequence[int]]],
+        start_positions: Sequence[int],
+        draft_request_indices: Sequence[int] | None = None,
+    ) -> list[int]:
+        """Advance independent MTP cache segments in one packed forward.
+
+        Varlen scheduler metadata keeps requests isolated. Only segment ends
+        that need a speculative token pay the shared vocabulary projection;
+        prefix-maintenance rows update MTP KV without materializing logits.
+        """
+        self._require_ready()
+        num_requests = len(hidden_rows_batch)
+        if not (
+            num_requests
+            == len(next_token_ids_batch)
+            == len(block_ids_by_group_batch)
+            == len(start_positions)
+        ):
+            raise RuntimeError("Qwen MTP batched request metadata length mismatch")
+        if num_requests == 0:
+            return []
+
+        if draft_request_indices is None:
+            draft_indices = list(range(num_requests))
+        else:
+            draft_indices = [int(index) for index in draft_request_indices]
+        if len(set(draft_indices)) != len(draft_indices) or any(
+            index < 0 or index >= num_requests for index in draft_indices
+        ):
+            raise RuntimeError("Qwen MTP draft request index is out of range")
+
+        ordinal = self.mtp_group_ordinal
+        assert self._mtp_block_size is not None
+        prefill_requests: list[tuple[list[int], int, int]] = []
+        hidden_parts: list[mx.array] = []
+        flat_tokens: list[int] = []
+        segment_end_rows: list[int] = []
+        cursor = 0
+
+        for hidden_rows, next_token_ids, block_ids_by_group, start_pos in zip(
+            hidden_rows_batch,
+            next_token_ids_batch,
+            block_ids_by_group_batch,
+            start_positions,
+            strict=True,
+        ):
+            token_ids = [int(token) for token in next_token_ids]
+            if hidden_rows.shape[0] != len(token_ids):
+                raise RuntimeError(
+                    "Qwen MTP hidden/token pair count mismatch: "
+                    f"{hidden_rows.shape[0]} != {len(token_ids)}"
+                )
+            if not token_ids:
+                raise RuntimeError("Qwen MTP forward requires at least one pair")
+            if ordinal >= len(block_ids_by_group):
+                raise RuntimeError("Qwen MTP request is missing its scheduler KV group")
+            mtp_blocks = list(block_ids_by_group[ordinal])
+            last_pos = int(start_pos) + len(token_ids) - 1
+            if last_pos // self._mtp_block_size >= len(mtp_blocks):
+                raise RuntimeError("Qwen MTP scheduler block table is too short")
+
+            prefill_requests.append((mtp_blocks, len(token_ids), int(start_pos)))
+            hidden_parts.append(hidden_rows)
+            flat_tokens.extend(token_ids)
+            cursor += len(token_ids)
+            segment_end_rows.append(cursor - 1)
+
+        prepare_unified(
+            decode_requests=[],
+            prefill_requests=prefill_requests,
+            block_size=self._mtp_block_size,
+        )
+        cache = self._require_mtp_cache()
+        try:
+            packed_hidden = (
+                hidden_parts[0]
+                if len(hidden_parts) == 1
+                else mx.concatenate(hidden_parts, axis=0)
+            )
+            mtp_hidden = self.mtp_module(
+                packed_hidden[None],
+                mx.array([flat_tokens], dtype=mx.uint32),
+                self.model.model.embed_tokens,
+                [None] * self.num_layers,
+            )
+            if draft_indices:
+                end_rows = mx.array(
+                    [segment_end_rows[index] for index in draft_indices],
+                    dtype=mx.int32,
+                )
+                selected_hidden = mtp_hidden[0, end_rows]
+                selected_logits = self._project_mtp_hidden(selected_hidden)
+                draft_ids = mx.argmax(selected_logits, axis=-1)
+                mx.eval(
+                    draft_ids,
+                    *cache.key_caches,
+                    *cache.value_caches,
+                )
+                return [int(token) for token in draft_ids.tolist()]
+
+            mx.eval(*cache.key_caches, *cache.value_caches)
+            return []
+        finally:
+            clear_context()
+
+    def run_pairs(
+        self,
+        *,
+        hidden_rows: mx.array,
+        next_token_ids: Sequence[int],
+        block_ids_by_group: Sequence[Sequence[int]],
+        start_pos: int,
+    ) -> int:
+        drafts = self.run_pairs_batch(
+            hidden_rows_batch=[hidden_rows],
+            next_token_ids_batch=[next_token_ids],
+            block_ids_by_group_batch=[block_ids_by_group],
+            start_positions=[start_pos],
+        )
+        if len(drafts) != 1:
+            raise RuntimeError("Qwen MTP single-request draft result is missing")
+        return drafts[0]
+
+    def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None:
+        if not self.ready:
+            return
+        self._require_mtp_cache().copy_blocks(block_copies)
+        self._require_boundary_cache().copy_blocks(block_copies)
+
+    def extend_forward_eval_outputs(self, outputs: list[mx.array]) -> None:
+        if self.boundary_cache is not None:
+            outputs.extend([self.boundary_cache.cache, self.boundary_cache.valid])
+
+    def _require_ready(self) -> None:
+        if not self.ready:
+            raise RuntimeError("Qwen MTP paged state is not scheduler-configured")
+
+    def _require_mtp_cache(self) -> MetalPagedKVCache:
+        if self.mtp_cache is None:
+            raise RuntimeError("Qwen MTP paged KV accessed before initialize()")
+        return self.mtp_cache
+
+    def _require_boundary_cache(self) -> QwenMTPBoundaryHiddenCache:
+        if self.boundary_cache is None:
+            raise RuntimeError("Qwen MTP boundary cache accessed before initialize()")
+        return self.boundary_cache

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -120,6 +120,7 @@ class SpeculativeDecodeController:
         is_hybrid: bool,
         use_async_scheduling: bool = False,
         speculative_config: SpeculativeConfig | None = None,
+        hybrid_speculative_ready: bool = False,
     ) -> None:
         """Fail fast for unsupported or inconsistent scheduler handoffs."""
         # All three Metal proposers (draft-model, MTP, n-gram) hand drafts
@@ -150,10 +151,14 @@ class SpeculativeDecodeController:
                 "attention so draft-token rows can share scheduler-assigned "
                 "KV slots."
             )
-        if (active_spec_tokens or has_invalid_spec_tokens) and is_hybrid:
+        if (
+            (active_spec_tokens or has_invalid_spec_tokens)
+            and is_hybrid
+            and not hybrid_speculative_ready
+        ):
             raise NotImplementedError(
-                "Speculative decode verification is not supported for hybrid "
-                "GDN models on Metal yet."
+                "Speculative decode verification for hybrid GDN models requires "
+                "the transactional paged Qwen MTP runtime."
             )
 
         decode_req_ids = {req_id for req_id, _ in decode_reqs}


### PR DESCRIPTION
## Summary

Implements native Qwen MTP speculative decoding for hybrid GDN models on Metal, including scheduler-owned speculative GDN state, a native Qwen MTP proposer, dedicated paged MTP KV, target-boundary hidden-state tracking, fail-closed hybrid prefix-cache reuse, and copyless speculative GDN-state writes.

This PR supersedes the former stacked implementation and remains intentionally **draft/blocked** until reviewed native Qwen MTP support lands on `mlx-lm/main` through `ml-explore/mlx-lm#990` or a review-driven successor or split PR.

The dependency is the landed capability and compatible upstream API—not the lifecycle, branch head, or synthetic merge commit of any individual pull request.

## Current branch state

- feature head: `5c1250161a9de28fa5fd734d922a0df604101eb6`
- original integration base: `150dd3292bd940f2eac1b3442ece21355d8ebf19` (`#620`)
- commits: **2**, both signed off
- changed files: **22**
- GitHub currently reports this PR **not mergeable** with current `main`
- vLLM Metal `main` is currently at `211a1e4bc976cd6c0c961cad8da59d649ea9bd65`, **11 commits** ahead of the original integration base
- the final rebase is deliberately deferred until the reviewed MLX-LM interface lands, so conflict resolution, dependency updates, and validation occur in one controlled rewrite

The second commit is the DCO-corrected form of the physical M5 Max parity repair. It has the same parent and byte-identical code tree as superseded commit `6fe2c51`; only the commit object/sign-off changed.

### Known rebase requirements

Current `main` includes several changes that must be preserved semantically:

- `#630`: scheduler-managed draft-model KV and memory accounting
- `#632`: lazy multi-request GDN prefill without per-layer materialization barriers
- `#634`: in-place `write_conv_rows` / `write_recurrent_rows` GDN state writes
- `#623`: M5 NAX prefill routing in `attention/context.py`
- `#633`: UniProc loopback handling in `platform.py`
- `#636`: token-and-physical-block-lineage validation before reusing speculative KV

`#636` does not add another direct path collision with #618's 22 changed files, but it strengthens the canonical cache-validity contract. Qwen native MTP must not introduce a parallel reuse model that bypasses committed-token identity or scheduler physical-block lineage.

The final rebase must retain #618's separate source and speculative destination slots while routing destination writes through the in-place helpers from `#634`, rather than restoring direct indexed pool assignments.

### Durable handoff artifacts

The exact source revisions and continuation procedure are preserved independently of the live PR branches:

- downstream implementation archive: `PhilipJohnBasile/vllm-metal:archive-pr-618-pre-vacation-20260822` at `5c1250161a9de28fa5fd734d922a0df604101eb6`
- closed #1740 implementation archive: `PhilipJohnBasile/mlx-lm:archive-1740-final-20260822` at `bc1d11414c12372cdf76538e09ce1fbc54b7fc7b`
- current downstream handoff snapshot: `PhilipJohnBasile/vllm-metal:archive-handoff-pr-618-20260822-r2`
- current upstream hardening snapshot: `PhilipJohnBasile/mlx-lm:archive-mtp-native-hardening-handoff-20260822-r2`

Downstream continuation records:

- file-by-file conflict map, invariants, pin changes, and validation sequence:
  https://github.com/PhilipJohnBasile/vllm-metal/blob/archive-handoff-pr-618-20260822-r2/docs/qwen_mtp_handoff_20260822.md
- post-handoff `main` addendum:
  https://github.com/PhilipJohnBasile/vllm-metal/blob/archive-handoff-pr-618-20260822-r2/docs/qwen_mtp_handoff_addendum_20260822_1328Z.md
- machine-readable addendum:
  https://github.com/PhilipJohnBasile/vllm-metal/blob/archive-handoff-pr-618-20260822-r2/docs/qwen_mtp_handoff_addendum_20260822_1328Z.json

For the upstream #1740 carry-forward, the non-PR handoff is based on AirRunner's inspected `feat/mtp-native` head `e8ceeccf118d4a089e22431f28f89d5ffe7d9d2b`:

- semantic carry-forward manifest:
  https://github.com/PhilipJohnBasile/mlx-lm/blob/archive-mtp-native-hardening-handoff-20260822-r2/docs/mtp_native_hardening_handoff_20260822.md
- tests-first acceptance suite:
  https://github.com/PhilipJohnBasile/mlx-lm/blob/archive-mtp-native-hardening-handoff-20260822-r2/tests/test_mtp_hardening_handoff.py
- guarded one-command applicator:
  https://github.com/PhilipJohnBasile/mlx-lm/blob/archive-mtp-native-hardening-handoff-20260822-r2/tools/apply_mtp_hardening_patches.py
- focused patch series:
  https://github.com/PhilipJohnBasile/mlx-lm/tree/archive-mtp-native-hardening-handoff-20260822-r2/patches
- artifact-integrity workflow:
  https://github.com/PhilipJohnBasile/mlx-lm/blob/archive-mtp-native-hardening-handoff-20260822-r2/.github/workflows/mtp-hardening-handoff.yml

These branches open no additional PR and do not alter either live feature head. The guarded applicator is limited to the accepted-token target-log-probability correction and the stateful-processor guard; it deliberately does not choose the disputed transactional-cache / `make_draft_model` architecture.

## Blocking upstream dependency

`ml-explore/mlx-lm#1740` was closed without merge on August 21, 2026, in favor of resolving the requested architectural changes on `ml-explore/mlx-lm#990`.

The live upstream path is therefore:

- `ml-explore/mlx-lm#990` on `AirRunner:feat/mtp-native`; or
- any review-driven successor or split PR that carries that implementation to `mlx-lm/main`

This PR is blocked on the reviewed native-Qwen-MTP capability landing in `mlx-lm/main`. It is not blocked on #1740 reopening or on #990 retaining its current branch structure.

The upstream review may replace the standalone `mtp_generate_step` architecture with a model-provided `make_draft_model` used through the existing speculative-generation path. #618 currently consumes lower-level contracts including `supports_mtp`, `mtp_forward`, pre-final-norm hidden states from `return_hidden=True`, and direct access to the trained MTP module for scheduler-owned paged KV.

After upstream lands, #618 must either consume the canonical landed interface or provide a narrow, documented adapter from that interface to the scheduler-owned paged proposer. Updating only the dependency SHA is not sufficient.

### Hardening to preserve from #1740

AirRunner offered to carry the following #1740 work into `feat/mtp-native` with attribution:

- transactional multi-turn prompt-cache state, including finalization at output limits and generator close
- fail-closed handling when a populated target cache lacks compatible MTP boundary metadata
- cached-versus-uncached multi-turn parity and prompt-cache serialization coverage
- target/verifier distribution log probabilities when a draft token is accepted
- fail-closed guards for models without a usable loaded MTP head
- fail-closed guards for unsupported stateful `logits_processors`, while retaining supported stateless-processor parity
- the focused regression tests associated with those behaviors

Source and attribution record:

https://github.com/PhilipJohnBasile/mlx-lm/commit/bc1d11414c12372cdf76538e09ce1fbc54b7fc7b

These items are considered transferred only when the behavior and corresponding tests are visible in the implementation that lands on `mlx-lm/main`.

### Dependency pins to replace after landing

The exact landed `mlx-lm/main` commit must replace both temporary or pre-MTP references:

- the `pyproject.toml` MLX-LM pin currently at `254d153fdeb6f150edd4fc5a54f9828638481fa8`
- `.github/workflows/qwen-mtp-serving-bench.yml` temporary SHA `ac6aaffd8fdfb8c8e713e17f155d83e3d72b0a0f`
- the benchmark workflow's temporary `PhilipJohnBasile/mlx-lm` installation URL, which must switch to `ml-explore/mlx-lm`

Do not pin the current #990 branch head, the closed #1740 fork head as the production dependency, or a GitHub-generated synthetic merge reference.

## What this adds

- scheduler-owned speculative Mamba/GDN state
- per-token convolution and recurrent-state checkpoints
- verifier-selected checkpoint promotion
- native trained Qwen MTP-head proposal
- correct pre-final-norm target hidden-state handling
- scheduler-visible paged MTP KV cache
- target-boundary hidden-state shadowing for warm prefixes
- atomic, fail-closed prefix-cache and MTP reuse
- chunked-prefill, continuation, cancellation, and prefix-hit handling
- explicit worker budgeting for MTP KV and hidden-state storage
- copyless speculative GDN checkpoint writes

The trained head currently supports exactly **one speculative token**; this PR does not advertise MTP-3 or chained deeper drafting.

## Physical M5 Max correctness repair

A four-request deterministic qualification exposed corruption in the multi-request, one-draft convolution state-chain fast path. The repair in `5c125016`:

- keeps the optimized convolution path for concurrency 1
- routes concurrency 2+ convolution state chains through the exact request/token-sequential path
- retains independent multi-request recurrent batching
- leaves ordinary non-speculative lazy GDN decode unchanged

| Case | Exact parity in this qualification | Native MTP | Throughput | Accepted / drafts | Acceptance |
|---|---:|---:|---:|---:|---:|
| 4 requests × 48 output tokens | yes | yes | 22.13 tok/s | 86 / 103 | 83.50% |
| 4 requests × 128 output tokens | yes | yes | 33.51 tok/s | 242 / 267 | 90.64% |

All four requests matched the non-MTP baseline token-for-token in this implementation and test matrix. This is a qualified path-specific result, not a universal claim that every speculative runtime is bitwise identical under greedy decoding; distribution preservation and floating-point arithmetic identity are distinct guarantees.

## Validation

Full pre-correction exact-head validation: https://github.com/PhilipJohnBasile/vllm-metal/actions/runs/32037507438

- native `_paged_ops` and Metal shader builds passed
- raw MPS and MLX-to-PyTorch bridge preflights passed
- repository-wide Ruff and formatting passed
- mypy passed across 123 source files
- tensor bridge: 21 passed
- remaining non-slow suite: 1,790 passed, 15 skipped, 50 deselected
- **1,811 combined tests passed; zero failures**

The current two-file correction then passed:

- 49 focused GDN/MTP tests
- Ruff lint and format
- `git diff --check`
- physical M5 Max exact-parity gates at 48 and 128 output tokens
- clean server shutdown and listener release

## Performance evidence and current optimization direction

The copyless state path improved geometric-mean MTP throughput by **1.215× (+21.5%)** versus the prior MTP path while preserving output hashes and acceptance. Decision record: `benchmarks/results/qwen_mtp_copyless_promotion_20260817.md`.

Hosted screening still showed native MTP below the non-MTP serving baseline, so this PR makes **no positive net-acceleration claim**.

Independent cross-runtime measurements posted by @janhilgard on an M3 Ultra production Qwen3.8-27B path reinforce that conclusion: at one draft token, RNN snapshotting accounted for 1.8% of step time, while target verification accounted for 69.0% and rejection trim/restore/replay for 19.3%. Increasing chained draft depth from 1 to 2 to 3 raised tokens per step but reduced throughput from 30.4 to 26.8 to 23.4 tok/s as verification cost grew and per-token acceptance fell. Their matched end-to-end path measured MTP at 0.95–0.96× the non-MTP baseline. See `#610` comment: https://github.com/vllm-project/vllm-metal/issues/610#issuecomment-5344860866

Accordingly, the next optimization priority is **verification and rejection/replay cost**, not snapshot-copy work in isolation. The branch remains at one speculative token unless a different verifier design demonstrates a measured net benefit.

## Ready-for-review gate

1. Resolve the requested architecture changes on `ml-explore/mlx-lm#990`, or its review-driven successor PRs.
2. Land native Qwen MTP support on `mlx-lm/main`.
3. Verify that the landed implementation preserves the transactional-cache, accepted-token target-log-probability, usable-head guard, logits-processor guard, and focused regression-test behavior listed above.
4. Reconcile #618 with the landed upstream API, including any move to `make_draft_model`.
5. Rebase onto current vLLM Metal `main`, preserving #630, #632, #633, #634, and #636 semantics.
6. Update the production and benchmark MLX-LM pins to the exact landed upstream commit.
7. Run the final repository-wide suite and physical M5 Max qualification, including token-and-block-lineage reuse failures.
8. Squash to one signed-off commit.
9. Mark ready for review.

Until those steps are complete, this PR should remain draft and should make no new positive net-acceleration claim.

## Suggested review order

1. `vllm_metal/v1/qwen_mtp_paged.py`
2. `vllm_metal/v1/proposer.py`
3. `vllm_metal/v1/model_adapter.py`
4. `vllm_metal/attention/state/align.py`
5. `vllm_metal/attention/impls/linear.py`
6. `vllm_metal/attention/impls/gdn_lazy.py`
7. `vllm_metal/attention/runtime/hybrid.py`
8. `vllm_metal/v1/cache_policy.py`
9. `vllm_metal/v1/model_runner.py`
10. `vllm_metal/v1/spec_decode.py`