### PR TITLE
Defer the GDN recurrent decode state scatter

### DIFF
--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -168,6 +168,27 @@ class TestGDNPagedStateCache:
             np.array(pending_state), np.full((2, 1, 4, 32), 9)
         )
 
+    def test_recurrent_decode_view_drains_mismatched_pending_state(self) -> None:
+        # Arrange
+        cache = _make_state_cache(max_seqs=4)
+        initial_state = mx.arange(4 * 1 * 4 * 32, dtype=mx.float32).reshape(4, 1, 4, 32)
+        cache.recurrent_states[0] = mx.array(initial_state)
+        cache.set_pending_recurrent_state(
+            0, [3, 1], mx.full((2, 1, 4, 32), 7, dtype=mx.float32)
+        )
+
+        # Act
+        view = cache.recurrent_state_for_decode(0, [0, 2])
+
+        # Assert
+        assert not view.uses_compact_state
+        assert not cache.has_pending_recurrent_state(0)
+        mx.eval(view.state, view.state_slot_ids)
+        expected_state = np.array(initial_state)
+        expected_state[[3, 1]] = 7
+        np.testing.assert_array_equal(np.array(view.state), expected_state)
+        np.testing.assert_array_equal(np.array(view.state_slot_ids), [0, 2])
+
     def test_decode_state_view_owns_compact_slot_mapping(self) -> None:
         # Arrange
         cache = _make_state_cache(max_seqs=4, conv_kernel_dim=3, conv_dim=4)
@@ -812,33 +833,32 @@ class TestLazyRecurrentDecode:
             conv_kernel=_RaisingKernel(),
             recurrent_decode_kernel=decode_kernel,
         )
-
-        def decode() -> None:
-            assert (
-                kernels.try_recurrent_decode(
-                    _recurrent_request(
-                        q=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
-                        k=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
-                        v=mx.zeros((1, 2, 2, 3), dtype=mx.float32),
-                        g=mx.zeros((1, 2, 2), dtype=mx.float32),
-                        beta=mx.zeros((1, 2, 2), dtype=mx.float32),
-                        cache=cache,
-                        slot_ids=slot_ids,
-                    )
-                )
-                is not None
-            )
+        request = _recurrent_request(
+            q=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+            k=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+            v=mx.zeros((1, 2, 2, 3), dtype=mx.float32),
+            g=mx.zeros((1, 2, 2), dtype=mx.float32),
+            beta=mx.zeros((1, 2, 2), dtype=mx.float32),
+            cache=cache,
+            slot_ids=slot_ids,
+        )
 
         # Act
-        decode()
-        decode()
-        decode()
+        for _ in range(2):
+            assert kernels.try_recurrent_decode(request) is not None
 
         # Assert: each step fed the previous step's compact update straight
         # back into the kernel, so the pool still holds its pre-decode bytes.
         assert decode_kernel.state_input is not None
         assert decode_kernel.state_input.shape == (2, 2, 3, 32)
-        mx.eval(cache.recurrent_states[0], decode_kernel.slot_mapping)
+        mx.eval(
+            cache.recurrent_states[0],
+            decode_kernel.state_input,
+            decode_kernel.slot_mapping,
+        )
+        np.testing.assert_array_equal(
+            np.array(decode_kernel.state_input), np.full((2, 2, 3, 32), 7)
+        )
         np.testing.assert_array_equal(np.array(decode_kernel.slot_mapping), [0, 1])
         np.testing.assert_array_equal(
             np.array(cache.recurrent_states[0]), np.array(initial_state)
@@ -848,59 +868,6 @@ class TestLazyRecurrentDecode:
         mx.eval(cache.recurrent_states[0])
         expected_state = np.array(initial_state)
         expected_state[slot_ids] = 7
-        np.testing.assert_array_equal(
-            np.array(cache.recurrent_states[0]), expected_state
-        )
-
-    def test_decode_slot_order_change_drains_pending_into_pool(self) -> None:
-        # Arrange
-        decode_kernel = _RecordingStateKernel(
-            mx.ones((2, 2, 3), dtype=mx.float32),
-            mx.full((2, 2, 3, 32), 7, dtype=mx.float32),
-            state_input_index=5,
-            slot_mapping_index=6,
-        )
-        cache = _make_state_cache(
-            max_seqs=4,
-            num_v_heads=2,
-            value_head_dim=3,
-            key_head_dim=32,
-        )
-        initial_state = mx.arange(4 * 2 * 3 * 32, dtype=mx.float32).reshape(4, 2, 3, 32)
-        cache.recurrent_states[0] = mx.array(initial_state)
-        kernels = GDNLazyKernels(
-            enabled=True,
-            conv_kernel=_RaisingKernel(),
-            recurrent_decode_kernel=decode_kernel,
-        )
-
-        def decode(slot_ids: list[int]) -> None:
-            assert (
-                kernels.try_recurrent_decode(
-                    _recurrent_request(
-                        q=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
-                        k=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
-                        v=mx.zeros((1, 2, 2, 3), dtype=mx.float32),
-                        g=mx.zeros((1, 2, 2), dtype=mx.float32),
-                        beta=mx.zeros((1, 2, 2), dtype=mx.float32),
-                        cache=cache,
-                        slot_ids=slot_ids,
-                    )
-                )
-                is not None
-            )
-
-        # Act: the second step's slot order does not match the parked update,
-        # so the parked slabs must be published before it reads the pool.
-        decode([3, 1])
-        decode([0, 2])
-
-        # Assert
-        assert decode_kernel.slot_mapping is not None
-        mx.eval(cache.recurrent_states[0], decode_kernel.slot_mapping)
-        np.testing.assert_array_equal(np.array(decode_kernel.slot_mapping), [0, 2])
-        expected_state = np.array(initial_state)
-        expected_state[[3, 1]] = 7
         np.testing.assert_array_equal(
             np.array(cache.recurrent_states[0]), expected_state
         )

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -779,9 +779,128 @@ class TestLazyRecurrentDecode:
         assert fake_kernel.grid == (32, 3, 4)
         assert fake_kernel.threadgroup == (32, 4, 1)
         assert fake_kernel.output_shapes == [(2, 2, 3), (2, 2, 3, 32)]
+        # Decode defers its compact update; draining it must land the new state
+        # on the active slots and leave every other slot untouched.
+        assert cache.pending_recurrent_state(0, slot_ids) is not None
+        cache.apply_pending_recurrent_state(0)
         mx.eval(cache.recurrent_states[0])
         expected_state = np.array(initial_state)
         expected_state[slot_ids] = 9
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), expected_state
+        )
+
+    def test_consecutive_decodes_never_touch_the_stable_pool(self) -> None:
+        # Arrange
+        decode_kernel = _RecordingStateKernel(
+            mx.ones((2, 2, 3), dtype=mx.float32),
+            mx.full((2, 2, 3, 32), 7, dtype=mx.float32),
+            state_input_index=5,
+            slot_mapping_index=6,
+        )
+        cache = _make_state_cache(
+            max_seqs=4,
+            num_v_heads=2,
+            value_head_dim=3,
+            key_head_dim=32,
+        )
+        initial_state = mx.arange(4 * 2 * 3 * 32, dtype=mx.float32).reshape(4, 2, 3, 32)
+        cache.recurrent_states[0] = mx.array(initial_state)
+        slot_ids = [3, 1]
+        kernels = GDNLazyKernels(
+            enabled=True,
+            conv_kernel=_RaisingKernel(),
+            recurrent_decode_kernel=decode_kernel,
+        )
+
+        def decode() -> None:
+            assert (
+                kernels.try_recurrent_decode(
+                    _recurrent_request(
+                        q=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+                        k=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+                        v=mx.zeros((1, 2, 2, 3), dtype=mx.float32),
+                        g=mx.zeros((1, 2, 2), dtype=mx.float32),
+                        beta=mx.zeros((1, 2, 2), dtype=mx.float32),
+                        cache=cache,
+                        slot_ids=slot_ids,
+                    )
+                )
+                is not None
+            )
+
+        # Act
+        decode()
+        decode()
+        decode()
+
+        # Assert: each step fed the previous step's compact update straight
+        # back into the kernel, so the pool still holds its pre-decode bytes.
+        assert decode_kernel.state_input is not None
+        assert decode_kernel.state_input.shape == (2, 2, 3, 32)
+        mx.eval(cache.recurrent_states[0], decode_kernel.slot_mapping)
+        np.testing.assert_array_equal(np.array(decode_kernel.slot_mapping), [0, 1])
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), np.array(initial_state)
+        )
+        # Draining once publishes the latest update to the active slots.
+        cache.apply_pending_recurrent_state(0)
+        mx.eval(cache.recurrent_states[0])
+        expected_state = np.array(initial_state)
+        expected_state[slot_ids] = 7
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), expected_state
+        )
+
+    def test_decode_slot_order_change_drains_pending_into_pool(self) -> None:
+        # Arrange
+        decode_kernel = _RecordingStateKernel(
+            mx.ones((2, 2, 3), dtype=mx.float32),
+            mx.full((2, 2, 3, 32), 7, dtype=mx.float32),
+            state_input_index=5,
+            slot_mapping_index=6,
+        )
+        cache = _make_state_cache(
+            max_seqs=4,
+            num_v_heads=2,
+            value_head_dim=3,
+            key_head_dim=32,
+        )
+        initial_state = mx.arange(4 * 2 * 3 * 32, dtype=mx.float32).reshape(4, 2, 3, 32)
+        cache.recurrent_states[0] = mx.array(initial_state)
+        kernels = GDNLazyKernels(
+            enabled=True,
+            conv_kernel=_RaisingKernel(),
+            recurrent_decode_kernel=decode_kernel,
+        )
+
+        def decode(slot_ids: list[int]) -> None:
+            assert (
+                kernels.try_recurrent_decode(
+                    _recurrent_request(
+                        q=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+                        k=mx.zeros((1, 2, 1, 32), dtype=mx.float32),
+                        v=mx.zeros((1, 2, 2, 3), dtype=mx.float32),
+                        g=mx.zeros((1, 2, 2), dtype=mx.float32),
+                        beta=mx.zeros((1, 2, 2), dtype=mx.float32),
+                        cache=cache,
+                        slot_ids=slot_ids,
+                    )
+                )
+                is not None
+            )
+
+        # Act: the second step's slot order does not match the parked update,
+        # so the parked slabs must be published before it reads the pool.
+        decode([3, 1])
+        decode([0, 2])
+
+        # Assert
+        assert decode_kernel.slot_mapping is not None
+        mx.eval(cache.recurrent_states[0], decode_kernel.slot_mapping)
+        np.testing.assert_array_equal(np.array(decode_kernel.slot_mapping), [0, 2])
+        expected_state = np.array(initial_state)
+        expected_state[[3, 1]] = 7
         np.testing.assert_array_equal(
             np.array(cache.recurrent_states[0]), expected_state
         )
@@ -866,6 +985,9 @@ class TestLazyRecurrentDecode:
 
         # Assert
         assert lazy_out is not None
+        # The lazy decode path parks its state update; drain it so the pool
+        # can be compared against the C++ oracle's in-place pool.
+        cache_lazy.apply_pending_recurrent_state(0)
         mx.eval(lazy_out, cache_lazy.recurrent_states[0])
 
         q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k))
@@ -1057,9 +1179,15 @@ class TestLazyRecurrentPrefill:
         # Assert
         assert prefill_out is not None
         assert decode_out is not None
-        assert cache.pending_recurrent_state(0, slot_ids) is None
+        # Decode consumed the prefill's compact update in place of the pool and
+        # replaced it with its own, so the pool is never touched in between.
+        pending = cache.pending_recurrent_state(0, slot_ids)
+        assert pending is not None
+        mx.eval(pending)
+        np.testing.assert_array_equal(np.array(pending), np.full((2, 2, 3, 32), 7))
         assert decode_kernel.state_input is not None
         assert decode_kernel.state_input.shape == (2, 2, 3, 32)
+        cache.apply_pending_recurrent_state(0)
         mx.eval(cache.recurrent_states[0], decode_kernel.slot_mapping)
         np.testing.assert_array_equal(np.array(decode_kernel.slot_mapping), [0, 1])
         expected_state = np.array(initial_state)

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -85,11 +85,11 @@ class GDNLazyKernels:
 
     The fast path uses ``mx.fast.metal_kernel`` source snippets from
     ``kernels_v2``.  Unlike the legacy recurrent C++ path, these kernels
-    materialize compact conv/recurrent state updates.  Decode scatters updates
-    back into the stable cache pool; eligible prefill may defer compact
-    conv/recurrent updates until the next decode, fallback, materialize, or release
-    boundary.  Callers fall back to the legacy path when a request shape is
-    ineligible.
+    materialize compact conv/recurrent state updates.  Conv decode scatters
+    updates back into the stable cache pool; recurrent decode and eligible
+    prefill defer compact updates until the next slot-order change, fallback,
+    materialize, or release boundary.  Callers fall back to the legacy path
+    when a request shape is ineligible.
     """
 
     _shared: ClassVar[GDNLazyKernels | None] = None
@@ -382,8 +382,6 @@ class GDNLazyKernels:
             request.cache_idx, request.slot_ids
         )
         state_in = state_view.state
-        state_pool = state_cache.recurrent_states[request.cache_idx]
-        slot_ids_arr = state_view.cache_slot_ids
         state_slot_ids_arr = state_view.state_slot_ids
 
         kernel_inputs = [
@@ -412,10 +410,20 @@ class GDNLazyKernels:
             output_shapes=[(total_tokens, n_hv, d_v), (num_requests, n_hv, d_v, d_k)],
             output_dtypes=[request.output_dtype, mx.float32],
         )
-        state_pool[slot_ids_arr] = state_updates
-        state_cache.store_recurrent_state(request.cache_idx, state_pool)
-        if state_view.uses_compact_state:
-            state_cache.clear_pending_recurrent_state(request.cache_idx)
+        # Park the compact update instead of scattering it into the stable
+        # pool.  A steady-state decode chain then reads and writes only
+        # ``num_requests`` slabs per step; without this each step also copies
+        # the update into the pool, doubling recurrent state traffic.
+        #
+        # ``recurrent_state_for_decode`` above already drained any pending
+        # update whose slot order did not match, so the only pending state
+        # that can still be live here is this layer's own previous step —
+        # which ``state_updates`` supersedes.  Clear it rather than letting
+        # ``set_pending_recurrent_state`` scatter that stale slab first.
+        state_cache.clear_pending_recurrent_state(request.cache_idx)
+        state_cache.set_pending_recurrent_state(
+            request.cache_idx, request.slot_ids, state_updates
+        )
         return y_out
 
     def try_recurrent_prefill(


### PR DESCRIPTION
## Summary

Keep each GDN recurrent decode update in its compact buffer and feed it directly into the next decode step when the request slot order is unchanged.

Previously, every decode layer copied that update back into the stable state pool. The pool is still updated before any operation that needs it: slot-order changes, prefill or fallback execution, materialization, release, and align-mode step planning.

```
Old:
kernel output
  → scatter into stable pool
  → clear consumed pending input

New:
kernel output
  → discard the consumed pending input
  → register the output as the new authoritative pending state
```

## Why

For Qwen3.5-0.8B, one recurrent-state slab is 1 MiB per request per GDN layer (`16 × 128 × 128 × fp32`), across 18 GDN layers. Avoiding the extra per-token scatter reduces state traffic without changing the recurrent computation.

## Performance

Serving benchmark on M5 Pro, `Qwen/Qwen3.5-0.8B`, paged path, `mamba_cache_mode=none`. Sonnet 1024-token input / 128-token output, 100 prompts, request rate 10, `--max-num-seqs 32`. Two independent passes per arm; values below are the mean of both.

Concurrency 32:

| metric | main | this PR | change |
|---|---:|---:|---:|
| Output token throughput (tok/s) | 398.9 | 431.7 | +8.2% |
| Total token throughput (tok/s) | 3635 | 3908 | +7.5% |
| Mean TPOT (ms) | 66.6 | 59.6 | -10.4% |
| P99 TPOT (ms) | 83.0 | 74.0 | -10.8% |
| Benchmark duration (s) | 31.3 | 29.2 | -6.9% |

Concurrency 8:

| metric | main | this PR | change |
|---|---:|---:|---:|
| Output token throughput (tok/s) | 266.6 | 286.9 | +7.6% |
| Total token throughput (tok/s) | 2428 | 2610 | +7.5% |
| Mean TPOT (ms) | 25.9 | 23.6 | -8.9% |
| P99 TPOT (ms) | 30.3 | 29.3 | -3.4% |
| Benchmark duration (s) | 46.9 | 43.7 | -6.9% |

TTFT is unaffected. Prefill cannot reach this path, which requires `total_tokens == num_requests`. Median TTFT differs by 0.9% at concurrency 32; at concurrency 8 the two `main` passes alone span 374-504 ms, bracketing this PR's 489 ms.

The end-to-end gain is smaller than the decode-only delta because this workload is prefill-heavy at 1024 in / 128 out. Isolating decode on the same machine gives roughly 1.4x at batch 32.

Align mode still publishes pending state at the start of every step, so it does not receive the full steady-state benefit.

<details>
<summary>Raw output, concurrency 32</summary>

**main**

```
============ Serving Benchmark Result ============
Successful requests:                     100
Maximum request concurrency:             32
Benchmark duration (s):                  31.36
Total input tokens:                      101402
Total generated tokens:                  12478
Request throughput (req/s):              3.19
Output token throughput (tok/s):         397.85
Total token throughput (tok/s):          3630.95
---------------Time to First Token----------------
Mean TTFT (ms):                          610.44
Median TTFT (ms):                        623.06
P99 TTFT (ms):                           1076.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          66.67
Median TPOT (ms):                        69.86
P99 TPOT (ms):                           90.93
---------------Inter-token Latency----------------
Mean ITL (ms):                           66.32
Median ITL (ms):                         43.87
P99 ITL (ms):                            280.05
==================================================
```

**this PR**

```
============ Serving Benchmark Result ============
Successful requests:                     100
Maximum request concurrency:             32
Benchmark duration (s):                  29.17
Total input tokens:                      101402
Total generated tokens:                  12656
Request throughput (req/s):              3.43
Output token throughput (tok/s):         433.89
Total token throughput (tok/s):          3910.30
---------------Time to First Token----------------
Mean TTFT (ms):                          642.88
Median TTFT (ms):                        622.21
P99 TTFT (ms):                           1047.37
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          59.18
Median TPOT (ms):                        63.29
P99 TPOT (ms):                           78.32
---------------Inter-token Latency----------------
Mean ITL (ms):                           59.09
Median ITL (ms):                         35.39
P99 ITL (ms):                            285.98
==================================================
```
</details>

<details>
<summary>Benchmark configuration</summary>

- Hardware: Apple M5 Pro, 64 GB
- Model: `Qwen/Qwen3.5-0.8B` (18 GDN layers + 6 SDPA layers)
- Server: `VLLM_METAL_USE_PAGED_ATTENTION=1`, `VLLM_METAL_MEMORY_FRACTION=0.5`, `--max-model-len 2048 --max-num-seqs 32`
- Client: `vllm bench serve --dataset-name sonnet --sonnet-input-len 1024 --sonnet-output-len 128 --num-prompts 100 --request-rate 10 --max-concurrency {8,32} --seed 0`
- Arms: `main` at `a8b7e75`, this PR at `8a7caaa`
</details>

## Validation

- `tests/test_gdn_lazy_kernels.py`: 37 passed, including C++ parity and pending-state transitions.
- Paged output matched MLX inline-cache output with lazy GDN kernels enabled and disabled.
- Uneven batched generation matched batch-1 goldens at `max_num_seqs=8` and `32`.
- Hybrid prefix-caching parity passed both 40-case configurations with zero mismatches and confirmed an aligned restore.

`VLLM_METAL_GDN_LAZY_KERNELS=0` continues to bypass this path.

