### PR TITLE
Support Hugging Face config sources for local GGUF weights

### DIFF
--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from huggingface_hub import snapshot_download
+
 try:
     import gguf
 except ImportError as exc:
@@ -41,6 +43,7 @@ _PLAIN_GGUF_TYPES = frozenset(
     }
 )
 _ALLOWED_WEIGHT_TYPES = frozenset(MLX_NATIVE_GGUF_TYPES) | _PLAIN_GGUF_TYPES
+_CONFIG_ALLOW_PATTERNS = ("config.json", "generation_config.json", "*.py")
 
 
 GGUFWrapper = GGUFLinear | GGUFEmbedding
@@ -85,7 +88,14 @@ class GGUFModelLoader:
     ) -> None:
         self._gguf_path = Path(gguf_path)
         self._config_dir = Path(config_dir)
-        self._tokenizer_dir = Path(tokenizer_dir or config_dir)
+        if not self._config_dir.exists() and not self._config_dir.is_absolute():
+            self._config_dir = Path(
+                snapshot_download(
+                    str(config_dir),
+                    allow_patterns=list(_CONFIG_ALLOW_PATTERNS),
+                )
+            )
+        self._tokenizer_dir = str(tokenizer_dir or config_dir)
         self._target_dtype = target_dtype
         self._tokenizer_config = dict(tokenizer_config or {})
 

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -43,7 +43,7 @@ _PLAIN_GGUF_TYPES = frozenset(
     }
 )
 _ALLOWED_WEIGHT_TYPES = frozenset(MLX_NATIVE_GGUF_TYPES) | _PLAIN_GGUF_TYPES
-_CONFIG_ALLOW_PATTERNS = ("config.json", "generation_config.json", "*.py")
+_CONFIG_ALLOW_PATTERNS = ("config.json", "generation_config.json")
 
 
 GGUFWrapper = GGUFLinear | GGUFEmbedding


### PR DESCRIPTION
This PR is:

- To support serving local `.gguf` weights with a Hugging Face config/tokenizer source.
- To resolve non-local GGUF config sources before building the MLX model skeleton.
- To keep existing local config-directory GGUF loading unchanged.

This enables the normal GGUF serve shape:

```bash
vllm serve /path/to/Qwen3-0.6B-Q8_0.gguf \
  --tokenizer Qwen/Qwen3-0.6B
```

Before this change, the GGUF loader treated `Qwen/Qwen3-0.6B` as a local directory and failed while looking for:

```text
Qwen/Qwen3-0.6B/config.json
```

After this change, the loader downloads only the config files needed to build the MLX model skeleton. Tokenizer loading continues through the existing MLX-LM tokenizer path.

Validation:

- `tests/test_gguf_loader.py`: 42 passed.
- Ruff, compileall, and `git diff --check` passed.
- Real smoke: local `Qwen3-0.6B-Q8_0.gguf` weights with `Qwen/Qwen3-0.6B` config/tokenizer loaded successfully.
