### PR TITLE
Use loopback for the single-process rendezvous address

### DIFF
--- a/tests/test_uniproc_loopback_rendezvous.py
+++ b/tests/test_uniproc_loopback_rendezvous.py
@@ -1,0 +1,123 @@
+"""Tests for the single-process loopback rendezvous patch (vllm-metal#625)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vllm_metal.compat import (
+    _install_uniproc_loopback_rendezvous,
+    ensure_vllm_uniproc_loopback_rendezvous_patch,
+)
+
+uniproc_executor = pytest.importorskip("vllm.v1.executor.uniproc_executor")
+
+
+ORIGINAL_URI = "tcp://192.168.12.165:65334"
+
+
+def _make_executor(
+    cls: type,
+    *,
+    world_size: int = 1,
+    backend: str | None = "uni",
+) -> Any:
+    """A stand-in carrying only the attributes the patch inspects."""
+    obj = object.__new__(cls)
+    obj.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            world_size=world_size,
+            distributed_executor_backend=backend,
+        )
+    )
+    return obj
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Apply the patch over a stub ``_distributed_args`` returning a routable IP."""
+    monkeypatch.setattr(
+        uniproc_executor.UniProcExecutor,
+        "_distributed_args",
+        lambda self: (ORIGINAL_URI, 0, 0),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        uniproc_executor, "_vllm_metal_uniproc_loopback_patched", False, raising=False
+    )
+    monkeypatch.delenv("VLLM_HOST_IP", raising=False)
+    _install_uniproc_loopback_rendezvous(uniproc_executor)
+
+
+def _call(obj: Any) -> tuple[str, int, int]:
+    return uniproc_executor.UniProcExecutor._distributed_args(obj)
+
+
+def test_rewrites_to_loopback_preserving_port(patched: None) -> None:
+    method, rank, local_rank = _call(_make_executor(uniproc_executor.UniProcExecutor))
+    assert method == "tcp://127.0.0.1:65334"
+    assert (rank, local_rank) == (0, 0)
+
+
+def test_explicit_vllm_host_ip_is_preserved(
+    patched: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VLLM_HOST_IP", "10.0.0.5")
+    method, _, _ = _call(_make_executor(uniproc_executor.UniProcExecutor))
+    assert method == ORIGINAL_URI
+
+
+@pytest.mark.parametrize(
+    ("world_size", "backend"),
+    [(2, "uni"), (1, "ray"), (1, "mp"), (1, "external_launcher")],
+)
+def test_untouched_outside_single_process_uni(
+    patched: None, world_size: int, backend: str
+) -> None:
+    obj = _make_executor(
+        uniproc_executor.UniProcExecutor, world_size=world_size, backend=backend
+    )
+    assert _call(obj)[0] == ORIGINAL_URI
+
+
+def test_external_launcher_subclass_untouched(patched: None) -> None:
+    """``ExecutorWithExternalLauncher`` must keep its own ``env://`` rendezvous."""
+    obj = _make_executor(uniproc_executor.ExecutorWithExternalLauncher)
+    assert _call(obj)[0] == ORIGINAL_URI
+
+
+def test_patch_is_idempotent(patched: None) -> None:
+    _install_uniproc_loopback_rendezvous(uniproc_executor)
+    _install_uniproc_loopback_rendezvous(uniproc_executor)
+    assert _call(_make_executor(uniproc_executor.UniProcExecutor))[0] == (
+        "tcp://127.0.0.1:65334"
+    )
+
+
+def test_hook_installs_when_module_already_imported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the module already in sys.modules, patch it directly rather than
+    installing a redundant meta_path finder."""
+    import sys
+
+    monkeypatch.setattr(
+        uniproc_executor.UniProcExecutor,
+        "_distributed_args",
+        lambda self: (ORIGINAL_URI, 0, 0),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        uniproc_executor, "_vllm_metal_uniproc_loopback_patched", False, raising=False
+    )
+    monkeypatch.delenv("VLLM_HOST_IP", raising=False)
+    before = len(sys.meta_path)
+
+    ensure_vllm_uniproc_loopback_rendezvous_patch()
+
+    assert len(sys.meta_path) == before
+    assert _call(_make_executor(uniproc_executor.UniProcExecutor))[0] == (
+        "tcp://127.0.0.1:65334"
+    )

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -8,8 +8,11 @@ diagnosable.
 
 from __future__ import annotations
 
+import importlib.abc
 import json
 import logging
+import os
+import sys
 from collections.abc import Callable, Mapping
 from functools import lru_cache
 from pathlib import Path
@@ -32,6 +35,7 @@ def apply_compat_patches() -> None:
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
     _patch_transformers_exaone4_config()
+    ensure_vllm_uniproc_loopback_rendezvous_patch()
 
 
 def _apply_bytelevel_patch_during_registration() -> None:
@@ -889,3 +893,103 @@ def _wrap_model_sanitize(
     setattr(_patched_sanitize, sentinel_attr, True)
     model_cls.sanitize = _patched_sanitize
     return True
+
+
+def _install_uniproc_loopback_rendezvous(uniproc_executor: Any) -> None:
+    """Wrap ``UniProcExecutor._distributed_args`` to use a loopback rendezvous."""
+    if getattr(uniproc_executor, "_vllm_metal_uniproc_loopback_patched", False):
+        return
+
+    from vllm.utils.network_utils import get_tcp_uri
+
+    original = uniproc_executor.UniProcExecutor._distributed_args
+
+    def _distributed_args(self: Any) -> tuple[str, int, int]:
+        method, rank, local_rank = original(self)
+        if type(self) is not uniproc_executor.UniProcExecutor:
+            return method, rank, local_rank
+        if os.environ.get("VLLM_HOST_IP"):
+            return method, rank, local_rank
+        parallel = getattr(self.vllm_config, "parallel_config", None)
+        if parallel is None or getattr(parallel, "world_size", 1) != 1:
+            return method, rank, local_rank
+        if getattr(parallel, "distributed_executor_backend", None) not in (None, "uni"):
+            return method, rank, local_rank
+        try:
+            port = int(method.rsplit(":", 1)[1])
+        except (IndexError, ValueError):
+            return method, rank, local_rank
+        return get_tcp_uri("127.0.0.1", port), rank, local_rank
+
+    uniproc_executor.UniProcExecutor._distributed_args = _distributed_args  # type: ignore[method-assign]
+    uniproc_executor._vllm_metal_uniproc_loopback_patched = True
+
+
+def ensure_vllm_uniproc_loopback_rendezvous_patch() -> None:
+    """Use loopback for the single-process rendezvous address.
+
+    ``get_ip()`` resolves the local address by opening a UDP socket toward
+    8.8.8.8 and returning ``getsockname()``. With a VPN active that yields the
+    tunnel interface, which gloo cannot bind for its local rendezvous, so
+    startup retries forever emitting only ``The server socket on [...] has timed
+    out, will retry.`` -- no error and no exit, so it reads as a slow model load
+    (vllm-metal#625).
+
+    A single-process engine has no peer to reach, so the rendezvous address only
+    needs to be bindable locally. The rewrite applies only when the executor is
+    exactly ``UniProcExecutor``, ``world_size == 1``, the executor backend is
+    ``uni`` or unset, and ``VLLM_HOST_IP`` is unset -- an explicit address always
+    wins. ``ExecutorWithExternalLauncher`` overrides ``_distributed_args`` with
+    ``env://`` and never reaches this code; Ray and multiproc executors build
+    their init method in their own modules. Ray, pipeline-parallel,
+    data-parallel and multi-node behaviour are unchanged.
+
+    Installed through a post-import hook rather than directly, because plugin
+    registration runs before ``vllm.v1.executor`` is importable (circular import
+    via ``vllm.utils.torch_utils``) and the executor is constructed in the
+    EngineCore subprocess, which does not re-run ``check_and_update_config``.
+    The hook fires when the module is first imported in whichever process needs
+    it. Patching ``network_utils.get_ip`` instead does not work: it is called
+    outside any ``set_current_vllm_config`` context, so the guard conditions
+    cannot be evaluated there.
+    """
+    module_name = "vllm.v1.executor.uniproc_executor"
+
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        _install_uniproc_loopback_rendezvous(existing)
+        return
+
+    if any(getattr(f, "_vllm_metal_uniproc_hook", False) for f in sys.meta_path):
+        return
+
+    class _UniprocLoopbackFinder(importlib.abc.MetaPathFinder):
+        _vllm_metal_uniproc_hook = True
+
+        def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
+            if fullname != module_name:
+                return None
+            for finder in sys.meta_path:
+                if finder is self:
+                    continue
+                spec = finder.find_spec(fullname, path, target)
+                if spec is not None:
+                    break
+            else:
+                return None
+            loader = spec.loader
+            if loader is None:
+                return spec
+            original_exec = loader.exec_module
+
+            def exec_module(module: Any) -> None:
+                original_exec(module)
+                try:
+                    _install_uniproc_loopback_rendezvous(module)
+                except Exception as exc:  # noqa: BLE001 - never block the import
+                    logger.debug("Loopback rendezvous patch failed: %s", exc)
+
+            loader.exec_module = exec_module  # type: ignore[method-assign]
+            return spec
+
+    sys.meta_path.insert(0, _UniprocLoopbackFinder())


### PR DESCRIPTION
Fixes #625.

## Problem

`get_ip()` resolves the local address by opening a UDP socket toward `8.8.8.8` and returning `getsockname()`. With a VPN active that yields the **tunnel interface**, which gloo cannot bind for its local rendezvous. Startup then retries forever, emitting only:

```
The server socket on [::ffff:10.4.6.40]:52437 has timed out, will retry.
```

No error, no exit — so it reads as a slow model load rather than a failure.

## Change

A single-process engine has no peer to reach, so the rendezvous address only has to be bindable locally. This wraps `UniProcExecutor._distributed_args` to rewrite the host to `127.0.0.1`, preserving the chosen port.

The wrapper is installed through a **post-import hook** on `vllm.v1.executor.uniproc_executor`. Three simpler placements were tried first and each provably fails:

1. **Directly at `apply_compat_patches()`** — plugin registration runs while vLLM is partially initialized, so the import raises and the patch silently skips:
   ```
   cannot import name 'is_quantized_kv_cache' from partially initialized module
   'vllm.utils.torch_utils' (most likely due to a circular import)
   ```
2. **Re-ensuring in `MetalPlatform.check_and_update_config`** — that runs in the **APIServer** process, but the executor is constructed in the **EngineCore** subprocess, which does not re-run it. Confirmed by logging the install site: `(APIServer pid=15257) ... patch INSTALLED`, while the rendezvous was computed under `(EngineCore ...)`.
3. **Patching `network_utils.get_ip`** — it is called **outside** any `set_current_vllm_config()` context, so the guard conditions cannot be evaluated there:
   ```
   Current vLLM config is not set. This typically means get_current_vllm_config()
   was called outside of a set_current_vllm_config() context
   ```
   The config is only reachable as `self.vllm_config` inside `_distributed_args`.

The hook fires in whichever process imports the module, before the class is used, and keeps `self.vllm_config` in scope for the guards. If the module is already imported, it patches directly and installs no `sys.meta_path` entry.

## Scope

Per the guidance on #625, the rewrite applies only when **all** of these hold:

- the executor is **exactly** `UniProcExecutor`
- `world_size == 1`
- executor backend is `uni` or unset
- `VLLM_HOST_IP` is unset — an explicit address always wins

Nothing else can reach it:

| Path | Why unaffected |
|---|---|
| `ExecutorWithExternalLauncher` (torchrun / multi-node) | subclasses `UniProcExecutor` but **overrides** `_distributed_args` to return `env://` — never reaches this code |
| Ray | builds its init method in `ray_executor.py` |
| Multiproc (PP / DP / TP) | builds its init method in `multiproc_executor.py` |

Ray, pipeline-parallel, data-parallel and multi-node behaviour are unchanged.

## Verification — end to end, against a live VPN

Host on a tunnel interface (`inet 10.4.6.40`), model `HuggingFaceTB/SmolLM2-135M-Instruct`:

| Condition | `distributed_init_method` | Result |
|---|---|---|
| Unpatched | `tcp://10.4.6.40:52437` | retry loop — **#625 reproduced on demand** |
| **Patched** | **`tcp://127.0.0.1:58367`** | **clean start, 0 retry lines** |
| Patched + explicit `VLLM_HOST_IP=10.4.6.40` | `tcp://10.4.6.40:59191` | operator's address honored, not overridden |

**Control** (before enabling the VPN): unpatched starts cleanly on the LAN address, `tcp://192.168.12.165:49892`, 0 retries — so the hang is attributable to the VPN rather than the model, the port, or the build.

## Tests

`tests/test_uniproc_loopback_rendezvous.py` — 9 cases: the rewrite and port preservation, explicit `VLLM_HOST_IP` passthrough, each excluded backend (`ray`, `mp`, `external_launcher`) and `world_size > 1`, the `ExecutorWithExternalLauncher` subclass, idempotency, and the already-imported path installing no finder.

```
9 passed
```

## Checks

- `ruff check` — clean
- `ruff format --check` — clean
- `mypy vllm_metal/compat.py` — reports 4 errors, **all pre-existing and unrelated to this PR**. They are in `vllm_metal/gguf/mlx_native.py` (`GGMLQuantizationType` "not valid as a type", lines 81 and 145), reached via import following. Verified identical on an unmodified checkout at `4edfe6a` by stashing this change and re-running. This PR touches neither that file nor its imports.

Environment: `vllm-metal 0.3.0.dev20260817081527`, `vllm 0.27.1`, macOS 26.5.2 arm64, Apple M4 Max.