### PR TITLE
Correctly log dense KV cache size from previously allocated array nbytes

### DIFF
--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -52,26 +51,6 @@ def config_from_vllm_groups(
         available = groups[0].kv_cache_spec.page_size_bytes * num_blocks * group_size
     return get_kv_cache_config_from_groups(
         vllm_config_for_kv_grouping(), groups, available
-    )
-
-
-def logged_kv_cache_mb(caplog: pytest.LogCaptureFixture) -> float:
-    """Return the MB figure from the single ``KV cache:`` startup log line."""
-    messages = [
-        record.message
-        for record in caplog.records
-        if record.message.startswith("KV cache:")
-    ]
-    assert len(messages) == 1, messages
-    match = re.search(r"KV cache: ([\d.]+) MB", messages[0])
-    assert match is not None, messages[0]
-    return float(match.group(1))
-
-
-def allocated_cache_bytes(cache: MetalPagedKVCache) -> int:
-    """Return the bytes held by a cache's per-layer key/value arrays."""
-    return sum(array.nbytes for array in cache.key_caches) + sum(
-        array.nbytes for array in cache.value_caches
     )
 
 
@@ -176,79 +155,30 @@ class TestMetalPagedKVCachePerLayer:
                 kv_heads_per_layer=[8, 8, 8],
             )
 
-
-class TestDenseCacheLogging:
-    """The dense startup log must report the bytes actually allocated."""
-
-    def test_heterogeneous_log_matches_allocation(
+    def test_heterogeneous_dense_log_reports_per_layer_bytes(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """Mixed-width layers are logged per layer, not all at the widest."""
-        # Gemma 4 E4B's 24 unique cache layers: 20 sliding (256) + 4 full (512),
-        # every layer carrying 2 KV heads.  The scalar head_dim is the widened
-        # dispatch shape (512), which is what the old log billed all 24 at.
+        """E4B-shaped unique layers log 2.8 MB, not the old all-512 4.7 MB."""
         head_dims = [512 if (index + 1) % 6 == 0 else 256 for index in range(24)]
-        kv_heads = [2] * 24
-        num_blocks = 3
-        block_size = 16
-
         with caplog.at_level(logging.INFO):
-            cache = MetalPagedKVCache(
-                num_layers=len(head_dims),
-                num_kv_heads=kv_heads[0],
-                head_dim=max(head_dims),
-                num_blocks=num_blocks,
-                block_size=block_size,
+            MetalPagedKVCache(
+                num_layers=24,
+                num_kv_heads=2,
+                head_dim=512,
+                num_blocks=3,
+                block_size=16,
                 dtype=mx.bfloat16,
-                kv_heads_per_layer=kv_heads,
+                kv_heads_per_layer=[2] * 24,
                 head_dim_per_layer=head_dims,
             )
-
-        allocated = allocated_cache_bytes(cache)
-        scalar_product = (
-            len(head_dims)
-            * num_blocks
-            * block_size
-            * kv_heads[0]
-            * max(head_dims)
-            * 2
-            * mx.bfloat16.size
-        )
-        assert allocated == 2_752_512
-        assert scalar_product == 4_718_592  # 12/7 of the real allocation
-        assert logged_kv_cache_mb(caplog) == round(allocated / 1e6, 1)
-
-    def test_uniform_log_matches_allocation(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Uniform models keep the byte total the scalar product produced."""
-        num_layers = 4
-        num_kv_heads = 8
-        head_dim = 128
-        num_blocks = 64
-        block_size = 16
-
-        with caplog.at_level(logging.INFO):
-            cache = MetalPagedKVCache(
-                num_layers=num_layers,
-                num_kv_heads=num_kv_heads,
-                head_dim=head_dim,
-                num_blocks=num_blocks,
-                block_size=block_size,
-                dtype=mx.bfloat16,
-            )
-
-        allocated = allocated_cache_bytes(cache)
-        assert allocated == (
-            num_layers
-            * num_blocks
-            * block_size
-            * num_kv_heads
-            * head_dim
-            * 2
-            * mx.bfloat16.size
-        )
-        assert logged_kv_cache_mb(caplog) == round(allocated / 1e6, 1)
+        messages = [
+            record.message
+            for record in caplog.records
+            if record.message.startswith("KV cache:")
+        ]
+        assert len(messages) == 1, messages
+        assert "KV cache: 2.8 MB" in messages[0]
+        assert "4.7 MB" not in messages[0]
 
 
 class TestMHABackendPerLayer:
@@ -471,21 +401,6 @@ class TestMHAKVCacheLayout:
         assert layout.total_bytes == sum(
             tensor.size for tensor in config.kv_cache_tensors
         )
-
-    def test_layout_log_reports_physical_bytes(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Layout logging stays on total_bytes; per-layer views double-count."""
-        config, names = self._mixed_mha_config()
-        layout = MHAKVCacheLayout.from_config(config, names)
-
-        with caplog.at_level(logging.INFO):
-            cache = MetalPagedKVCache.from_layout(layout, mx.bfloat16)
-
-        # Four logical layers are reshaped views over two physical slot pairs,
-        # so summing the per-layer arrays here would report twice the memory.
-        assert allocated_cache_bytes(cache) > layout.total_bytes
-        assert logged_kv_cache_mb(caplog) == round(layout.total_bytes / 1e6, 1)
 
     def test_allocates_shared_slots_from_layout(self) -> None:
         config, names = self._mixed_mha_config()

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import logging
+import re
 from types import SimpleNamespace
 
 import mlx.core as mx
@@ -50,6 +52,26 @@ def config_from_vllm_groups(
         available = groups[0].kv_cache_spec.page_size_bytes * num_blocks * group_size
     return get_kv_cache_config_from_groups(
         vllm_config_for_kv_grouping(), groups, available
+    )
+
+
+def logged_kv_cache_mb(caplog: pytest.LogCaptureFixture) -> float:
+    """Return the MB figure from the single ``KV cache:`` startup log line."""
+    messages = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("KV cache:")
+    ]
+    assert len(messages) == 1, messages
+    match = re.search(r"KV cache: ([\d.]+) MB", messages[0])
+    assert match is not None, messages[0]
+    return float(match.group(1))
+
+
+def allocated_cache_bytes(cache: MetalPagedKVCache) -> int:
+    """Return the bytes held by a cache's per-layer key/value arrays."""
+    return sum(array.nbytes for array in cache.key_caches) + sum(
+        array.nbytes for array in cache.value_caches
     )
 
 
@@ -153,6 +175,80 @@ class TestMetalPagedKVCachePerLayer:
                 block_size=16,
                 kv_heads_per_layer=[8, 8, 8],
             )
+
+
+class TestDenseCacheLogging:
+    """The dense startup log must report the bytes actually allocated."""
+
+    def test_heterogeneous_log_matches_allocation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Mixed-width layers are logged per layer, not all at the widest."""
+        # Gemma 4 E4B's 24 unique cache layers: 20 sliding (256) + 4 full (512),
+        # every layer carrying 2 KV heads.  The scalar head_dim is the widened
+        # dispatch shape (512), which is what the old log billed all 24 at.
+        head_dims = [512 if (index + 1) % 6 == 0 else 256 for index in range(24)]
+        kv_heads = [2] * 24
+        num_blocks = 3
+        block_size = 16
+
+        with caplog.at_level(logging.INFO):
+            cache = MetalPagedKVCache(
+                num_layers=len(head_dims),
+                num_kv_heads=kv_heads[0],
+                head_dim=max(head_dims),
+                num_blocks=num_blocks,
+                block_size=block_size,
+                dtype=mx.bfloat16,
+                kv_heads_per_layer=kv_heads,
+                head_dim_per_layer=head_dims,
+            )
+
+        allocated = allocated_cache_bytes(cache)
+        scalar_product = (
+            len(head_dims)
+            * num_blocks
+            * block_size
+            * kv_heads[0]
+            * max(head_dims)
+            * 2
+            * mx.bfloat16.size
+        )
+        assert allocated == 2_752_512
+        assert scalar_product == 4_718_592  # 12/7 of the real allocation
+        assert logged_kv_cache_mb(caplog) == round(allocated / 1e6, 1)
+
+    def test_uniform_log_matches_allocation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Uniform models keep the byte total the scalar product produced."""
+        num_layers = 4
+        num_kv_heads = 8
+        head_dim = 128
+        num_blocks = 64
+        block_size = 16
+
+        with caplog.at_level(logging.INFO):
+            cache = MetalPagedKVCache(
+                num_layers=num_layers,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                num_blocks=num_blocks,
+                block_size=block_size,
+                dtype=mx.bfloat16,
+            )
+
+        allocated = allocated_cache_bytes(cache)
+        assert allocated == (
+            num_layers
+            * num_blocks
+            * block_size
+            * num_kv_heads
+            * head_dim
+            * 2
+            * mx.bfloat16.size
+        )
+        assert logged_kv_cache_mb(caplog) == round(allocated / 1e6, 1)
 
 
 class TestMHABackendPerLayer:
@@ -375,6 +471,21 @@ class TestMHAKVCacheLayout:
         assert layout.total_bytes == sum(
             tensor.size for tensor in config.kv_cache_tensors
         )
+
+    def test_layout_log_reports_physical_bytes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Layout logging stays on total_bytes; per-layer views double-count."""
+        config, names = self._mixed_mha_config()
+        layout = MHAKVCacheLayout.from_config(config, names)
+
+        with caplog.at_level(logging.INFO):
+            cache = MetalPagedKVCache.from_layout(layout, mx.bfloat16)
+
+        # Four logical layers are reshaped views over two physical slot pairs,
+        # so summing the per-layer arrays here would report twice the memory.
+        assert allocated_cache_bytes(cache) > layout.total_bytes
+        assert logged_kv_cache_mb(caplog) == round(layout.total_bytes / 1e6, 1)
 
     def test_allocates_shared_slots_from_layout(self) -> None:
         config, names = self._mixed_mha_config()

--- a/vllm_metal/attention/caches/kv_cache.py
+++ b/vllm_metal/attention/caches/kv_cache.py
@@ -155,7 +155,7 @@ class MetalPagedKVCache:
         if not turboquant:
             if layout is None:
                 self._allocate_dense_caches(dtype)
-                self._log_dense_cache(dtype)
+                self._log_dense_cache()
             else:
                 self._allocate_layout_caches(layout, dtype)
                 self._log_layout_cache(layout)
@@ -255,15 +255,13 @@ class MetalPagedKVCache:
                 )
             )
 
-    def _log_dense_cache(self, dtype: mx.Dtype) -> None:
-        kv_bytes = (
-            self.num_layers
-            * self.num_blocks
-            * self.block_size
-            * self.num_kv_heads
-            * self.head_dim
-            * 2
-            * self._dtype_size(dtype)
+    def _log_dense_cache(self) -> None:
+        # Sum the allocated arrays instead of multiplying the scalar
+        # ``num_kv_heads``/``head_dim``: heterogeneous layers are sized from
+        # ``kv_heads_per_layer``/``head_dim_per_layer`` while the scalars carry
+        # the widened dispatch shape, so the product over-bills narrow layers.
+        kv_bytes = sum(cache.nbytes for cache in self.key_caches) + sum(
+            cache.nbytes for cache in self.value_caches
         )
         logger.info(
             f"KV cache: {kv_bytes / 1e6:.1f} MB "


### PR DESCRIPTION
Tl;DR: Gemma 4 E2B and E4B mix the 256-wide sliding window KV with 512-wide global KV. The manually calculated logger assumed every unique layer as 512-wide, so it overstated E4B by 12/7 and E2B by 5/3. Allocation was already right. The log now dynamically sums the allocated arrays' nbytes. No allocation changes made.

## Summary
Gemma 4 unique cache layers are not one width. Sliding layers store K/V at `head_dim=256`; global/full layers store `global_head_dim=512`. E4B YOCO keeps 24 unique layers (20 sliding + 4 full). E2B keeps 15 (12 + 3). `_allocate_dense_caches` already builds each layer from `kv_heads_per_layer` / `head_dim_per_layer`.

`_log_dense_cache` ignored those lists and multiplied `num_layers × blocks × 16 × num_kv_heads × self.head_dim × 2 × dtype`. `self.head_dim` is `max(256, 512) = 512` from `resolve_max_head_dim` (kernel dispatch, not sizing). Every unique layer was billed at 4096 bytes/token. Real E4B is `20×2048 + 4×4096` per token (12/7). Real E2B is 5/3. The planner's `get_cache_block_size_bytes()` / `_kv_layer_size_sum()` already matched allocation, so serving size was fine; only the startup `KV cache: … MB` line was wrong.

The logger now sums `key_caches` and `value_caches` `.nbytes` after allocate, so it follows the arrays instead of a second formula. The `dtype` argument is gone because nbytes already includes element size. `_log_layout_cache` still uses `layout.total_bytes`: those per-layer entries are views over shared slots, and summing nbytes would double-count. Default 12B/26B/31B take that layout path and were not on the bad line.

## Tests
- `test_heterogeneous_log_matches_allocation` — E4B-shaped 24 layers, 3 blocks: log 2,752,512 B, not the old 4,718,592 B product
- `test_uniform_log_matches_allocation` — uniform models still match the old product
- `test_layout_log_reports_physical_bytes` — layout path still logs `layout.total_bytes`, not the per-layer nbytes sum

No model or kernel change; no performance claim. CONTRIBUTING golden-token and benchmark checks do not apply.

Checked and fixed with AI assistance (GPT-5.6 Sol, Opus 5, Grok 4.6). I first raised the issue and reviewed the patch and take responsibility for it. Fixes #628.