### PR TITLE
[Bugfix] Pin torch sampling to CPU to stop random token corruption

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import mlx.core as mx
-import torch
 
 import vllm_metal.v1.model_runner as mr
 from vllm_metal.v1.cache_policy import ModelCachePolicy
@@ -78,7 +77,6 @@ def make_stub_runner(
         "head_dim_per_layer": None,
         "sliding_window_per_layer": None,
         "use_async_scheduling": True,
-        "device": torch.device("cpu"),
         "_sampler": None,
         "_structured_output_applier": MetalStructuredOutputApplier(),
         "_lora": MetalLoRARuntime(),

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -247,7 +247,7 @@ class TestSamplingMetadataWithPenalties:
 
         captured_batches: list = []
 
-        def spy_sample(logits_2d, batch, sampler, device):
+        def spy_sample(logits_2d, batch, sampler):
             captured_batches.append(batch)
             return _SamplingResult([99])
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -283,7 +283,7 @@ class TestV1SeededSamplingGenerator:
         )
 
         sp = SamplingParams(temperature=1.0, seed=123)
-        generator = _create_request_generator(runner.device, sp)
+        generator = _create_request_generator(sp)
         assert generator is not None
 
         state = RequestState(
@@ -304,6 +304,69 @@ class TestV1SeededSamplingGenerator:
         assert not torch.equal(after_second, after_first)
 
 
+class TestSamplerDevicePolicy:
+    """Regression tests for #622: torch sampling must never run on MPS.
+
+    ``exponential_()`` on MPS can return exact zeros, which the vLLM
+    sampler's Gumbel-style division turns into inf/NaN rows whose argmax
+    lands on an arbitrary vocab id.
+    """
+
+    def test_sampling_metadata_tensors_live_on_cpu(self) -> None:
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.8, top_k=20, top_p=0.9),
+                SamplingParams(temperature=1.0, presence_penalty=0.5),
+                SamplingParams(temperature=0.7, allowed_token_ids=[1, 2]),
+            ],
+            [[1, 2], [3], [4]],
+            [[], [], []],
+            vocab_size=VOCAB_SIZE,
+        )
+
+        metadata = batch.make_sampling_metadata()
+
+        assert metadata.temperature is not None
+        assert metadata.temperature.device.type == "cpu"
+        assert metadata.top_k is not None
+        assert metadata.top_k.device.type == "cpu"
+        assert metadata.top_p is not None
+        assert metadata.top_p.device.type == "cpu"
+        assert metadata.prompt_token_ids is not None
+        assert metadata.prompt_token_ids.device.type == "cpu"
+        assert metadata.frequency_penalties.device.type == "cpu"
+        assert metadata.presence_penalties.device.type == "cpu"
+        assert metadata.repetition_penalties.device.type == "cpu"
+        assert metadata.allowed_token_ids_mask is not None
+        assert metadata.allowed_token_ids_mask.device.type == "cpu"
+
+    def test_seeded_generator_lives_on_cpu(self) -> None:
+        generator = _create_request_generator(SamplingParams(temperature=1.0, seed=7))
+
+        assert generator is not None
+        assert generator.device.type == "cpu"
+
+    def test_bridged_logits_reach_sampler_on_cpu(self) -> None:
+        logits = mx.array([[0.0, 1.0, 4.0, 2.0]], dtype=mx.float32)
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.8, top_k=2)],
+            [[1]],
+            [[]],
+            vocab_size=4,
+        )
+        seen_devices: list[torch.device] = []
+
+        class SpySampler(Sampler):
+            def forward(self, logits_torch, sampling_metadata):  # noqa: ANN001
+                seen_devices.append(logits_torch.device)
+                return super().forward(logits_torch, sampling_metadata)
+
+        result = sample_from_logits(logits, batch, SpySampler())
+
+        assert [d.type for d in seen_devices] == ["cpu"]
+        assert 0 <= result.token_ids[0] < 4
+
+
 class TestV1SamplingBatch:
     @staticmethod
     def _batch(params_list: list[SamplingParams]) -> SamplingBatch:
@@ -312,7 +375,6 @@ class TestV1SamplingBatch:
             [[1]] * len(params_list),
             [[]] * len(params_list),
             vocab_size=VOCAB_SIZE,
-            device=torch.device("cpu"),
         )
 
     def test_prefill_requests_share_one_sampler_batch(self, monkeypatch) -> None:
@@ -344,7 +406,6 @@ class TestV1SamplingBatch:
             cu_seqlens=[0, 2, 4, 6],
             num_decode=1,
             sampler=Sampler(),
-            device=torch.device("cpu"),
             vocab_size=4,
         )
 
@@ -368,7 +429,6 @@ class TestV1SamplingBatch:
             cu_seqlens=[0],
             num_decode=0,
             sampler=Sampler(),
-            device=torch.device("cpu"),
             vocab_size=4,
         )
 
@@ -416,9 +476,8 @@ class TestV1SamplingBatch:
             [[1, 2, 3]],
             [[]],
             vocab_size=4,
-            device=torch.device("cpu"),
         )
-        result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+        result = sample_from_logits(logits, batch, Sampler())
         assert result.token_ids[0] in [2, 3]
 
     def test_allowed_token_ids_mixed_batch(self) -> None:
@@ -434,9 +493,8 @@ class TestV1SamplingBatch:
             [[1, 2], [3, 4]],
             [[], []],
             vocab_size=4,
-            device=torch.device("cpu"),
         )
-        result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+        result = sample_from_logits(logits, batch, Sampler())
         assert result.token_ids[0] in [2, 3]
         assert result.token_ids[1] == 1  # unconstrained, should pick highest logit
 
@@ -450,9 +508,8 @@ class TestV1SamplingBatch:
             [[1, 2, 3]],
             [[]],
             vocab_size=4,
-            device=torch.device("cpu"),
         )
-        result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+        result = sample_from_logits(logits, batch, Sampler())
         assert result.token_ids[0] != 0  # token 0 should be blocked
 
     def test_can_use_native_greedy_requires_every_request_to_match(self) -> None:
@@ -486,7 +543,6 @@ class TestV1SamplingBatch:
             [[1, 2, 3], [4, 5], [6]],
             [[], [], []],
             vocab_size=VOCAB_SIZE,
-            device=torch.device("cpu"),
         )
         assert batch.no_penalties
 
@@ -515,7 +571,6 @@ class TestV1SamplingBatch:
             [[1], [2], [3]],
             [[], [], []],
             vocab_size=VOCAB_SIZE,
-            device=torch.device("cpu"),
         )
         assert not batch.no_penalties
 
@@ -532,7 +587,6 @@ class TestV1SamplingBatch:
             [[1, 2, 3]],
             [[]],
             vocab_size=VOCAB_SIZE,
-            device=torch.device("cpu"),
         )
 
         metadata = batch.make_sampling_metadata()
@@ -545,7 +599,6 @@ class TestV1SamplingBatch:
             [[1, 2, 3]],
             [[]],
             vocab_size=VOCAB_SIZE,
-            device=torch.device("cpu"),
         )
 
         with pytest.raises(
@@ -563,7 +616,6 @@ class TestV1SamplingBatch:
             [[1, 2, 3], [4, 5]],
             [[], []],
             vocab_size=VOCAB_SIZE,
-            device=torch.device("cpu"),
         )
 
         with pytest.raises(
@@ -579,10 +631,9 @@ class TestV1SamplingBatch:
             [[1, 2, 3]],
             [[]],
             vocab_size=4,
-            device=torch.device("cpu"),
         )
 
-        result = sample_from_logits(logits, batch, Sampler(), torch.device("cpu"))
+        result = sample_from_logits(logits, batch, Sampler())
 
         assert result.token_ids == [2]
         assert result.logprobs is not None

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -168,7 +168,7 @@ class TestV1MetalModelRunnerGenerate:
         )
 
         with pytest.raises(NotImplementedError, match="custom logits processors"):
-            mr.MetalModelRunner(vllm_config, torch.device("cpu"))
+            mr.MetalModelRunner(vllm_config)
 
     def test_warm_up_propagates_dummy_forward_failure(self) -> None:
         runner = self._make_runner()
@@ -1201,8 +1201,8 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         )
         sampled_rows = []
 
-        def fake_sample_from_logits(logits_2d, batch, sampler, device):
-            del sampler, device
+        def fake_sample_from_logits(logits_2d, batch, sampler):
+            del sampler
             sampled_rows.append(logits_2d.tolist())
             assert [sp.temperature for sp in batch.sampling_params_list] == [0.7]
             return mr._SamplingResult([4])

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -144,7 +144,6 @@ def _lora_id_from_request_data(new_req: NewRequestData) -> int | None:
 
 
 def _create_request_generator(
-    device: torch.device,
     sampling_params: SamplingParams,
 ) -> torch.Generator | None:
     """Create a per-request generator for seeded sampling.
@@ -156,7 +155,7 @@ def _create_request_generator(
         return None
     if sampling_params.temperature < GREEDY_TEMPERATURE_EPS:
         return None
-    generator = torch.Generator(device=device)
+    generator = torch.Generator(device=SamplingBatch.SAMPLER_DEVICE)
     generator.manual_seed(sampling_params.seed)
     return generator
 
@@ -314,16 +313,11 @@ class MetalModelRunner:
     Uses true batched decode with BatchKVCache for efficient parallel processing.
     """
 
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        device: torch.device,
-    ):
+    def __init__(self, vllm_config: VllmConfig):
         """Initialize model runner.
 
         Args:
             vllm_config: vLLM configuration
-            device: PyTorch device (CPU for Metal interop)
         """
         if vllm_config.model_config.logits_processors or entry_points(
             group=LOGITSPROCS_GROUP
@@ -337,7 +331,6 @@ class MetalModelRunner:
         self.cache_config = vllm_config.cache_config
         self.scheduler_config = vllm_config.scheduler_config
         self.use_async_scheduling = bool(self.scheduler_config.async_scheduling)
-        self.device = device
         self.metal_config = get_config()
         self._model_adapter: ModelAdapter = DefaultModelAdapter()
         self._cache_policy = ModelCachePolicy(self, self._model_adapter)
@@ -951,7 +944,6 @@ class MetalModelRunner:
             prompt_token_id_lists,
             output_token_id_lists,
             vocab_size=self._vocab_size,
-            device=self.device,
             generators=generators,
         ).make_sampling_metadata()
 
@@ -987,10 +979,9 @@ class MetalModelRunner:
             [token_ids],
             [[]],
             vocab_size=vocab_size,
-            device=self.device,
             generators=generators,
         )
-        result = sample_from_logits(last_logits, batch, self._sampler, self.device)
+        result = sample_from_logits(last_logits, batch, self._sampler)
         [next_token] = result.token_ids
         mx.eval(*[c.state for c in cache])
 
@@ -1048,12 +1039,9 @@ class MetalModelRunner:
             prompt_token_ids_list,
             output_tokens_list,
             vocab_size=vocab_size,
-            device=self.device,
             generators=generators,
         )
-        result = sample_from_logits(
-            next_token_logits, batch, self._sampler, self.device
-        )
+        result = sample_from_logits(next_token_logits, batch, self._sampler)
         next_tokens = result.token_ids
 
         # Extract updated caches back to individual requests
@@ -1095,10 +1083,9 @@ class MetalModelRunner:
                 [state.token_ids[: state.prompt_len]],
                 [state.token_ids[state.prompt_len :]],
                 vocab_size=vocab_size,
-                device=self.device,
                 generators=generators,
             )
-            result = sample_from_logits(last_logits, batch, self._sampler, self.device)
+            result = sample_from_logits(last_logits, batch, self._sampler)
             [next_token] = result.token_ids
 
             next_tokens.append(next_token)
@@ -1614,14 +1601,10 @@ class MetalModelRunner:
                     prompt_token_ids_list,
                     output_tokens_list,
                     vocab_size=vocab_size,
-                    device=self.device,
                     generators=generators,
                 )
                 plain_result = sample_from_logits(
-                    plain_logits,
-                    plain_batch,
-                    self._sampler,
-                    self.device,
+                    plain_logits, plain_batch, self._sampler
                 )
                 for plain_index, (decode_index, _, _) in enumerate(plain_items):
                     decode_token_ids[decode_index] = [
@@ -1638,7 +1621,6 @@ class MetalModelRunner:
                 decode_reqs,
                 num_decode_tokens,
                 self._sampler,
-                self.device,
                 vocab_size=vocab_size,
             )
             decode_token_ids = [[token_id] for token_id in decode_result.token_ids]
@@ -1649,7 +1631,6 @@ class MetalModelRunner:
             cu_seqlens,
             num_decode_segments,
             self._sampler,
-            self.device,
             vocab_size=vocab_size,
         )
 
@@ -2159,7 +2140,7 @@ class MetalModelRunner:
                 batch.add_output(req_id, [0])
                 continue
 
-            generator = _create_request_generator(self.device, sampling_params)
+            generator = _create_request_generator(sampling_params)
 
             if self._paged_attention_runtime is not None:
                 sched_block_ids = self._copy_paged_block_ids(new_req.block_ids)

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -6,6 +6,7 @@ Pure functions: logits in, token IDs out.  No model runner state accessed.
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import ClassVar
 
 import mlx.core as mx
 import numpy as np
@@ -41,6 +42,12 @@ class SamplingBatch:
     Today it owns only the sampling-side state for one step.
     """
 
+    # The torch sampler always runs on CPU. ``Tensor.exponential_()`` on MPS
+    # can return exact zeros, and the Gumbel-style ``probs.div(q).argmax()``
+    # in vLLM's sampler maps a zero draw to an inf/NaN row whose argmax picks
+    # an arbitrary vocab id (issue #622).
+    SAMPLER_DEVICE: ClassVar[torch.device] = torch.device("cpu")
+
     def __init__(
         self,
         sampling_params_list: Sequence[SamplingParams],
@@ -48,7 +55,6 @@ class SamplingBatch:
         output_token_id_lists: Sequence[list[int]],
         *,
         vocab_size: int,
-        device: torch.device,
         generators: dict[int, torch.Generator] | None = None,
     ) -> None:
         batch_size = len(sampling_params_list)
@@ -69,7 +75,6 @@ class SamplingBatch:
         self.prompt_token_id_lists = list(prompt_token_id_lists)
         self.output_token_id_lists = list(output_token_id_lists)
         self.vocab_size = vocab_size
-        self.device = device
         self.generators = {} if generators is None else generators
         self.all_greedy = all(
             sampling_params.temperature < GREEDY_TEMPERATURE_EPS
@@ -197,7 +202,7 @@ class SamplingBatch:
                 for sampling_params in self.sampling_params_list
             ],
             dtype=torch.float32,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
 
     def _make_top_p(self) -> torch.Tensor | None:
@@ -207,7 +212,7 @@ class SamplingBatch:
         return torch.tensor(
             [sampling_params.top_p for sampling_params in self.sampling_params_list],
             dtype=torch.float32,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
 
     def _make_top_k(self) -> torch.Tensor | None:
@@ -217,7 +222,7 @@ class SamplingBatch:
         return torch.tensor(
             [sampling_params.top_k for sampling_params in self.sampling_params_list],
             dtype=torch.int32,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
 
     def _make_prompt_token_ids(self) -> torch.Tensor | None:
@@ -227,7 +232,7 @@ class SamplingBatch:
         return make_tensor_with_pad(
             self.prompt_token_id_lists,
             pad=self.vocab_size,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
             dtype=torch.int64,
             pin_memory=False,
         )
@@ -243,7 +248,7 @@ class SamplingBatch:
         avoid allocating ``batch_size`` tensors three times every step.
         """
         if self.no_penalties:
-            empty = torch.empty(0, dtype=torch.float32, device=self.device)
+            empty = torch.empty(0, dtype=torch.float32, device=self.SAMPLER_DEVICE)
             return empty, empty, empty
 
         frequency_penalties = torch.tensor(
@@ -252,7 +257,7 @@ class SamplingBatch:
                 for sampling_params in self.sampling_params_list
             ],
             dtype=torch.float32,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
         presence_penalties = torch.tensor(
             [
@@ -260,7 +265,7 @@ class SamplingBatch:
                 for sampling_params in self.sampling_params_list
             ],
             dtype=torch.float32,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
         repetition_penalties = torch.tensor(
             [
@@ -268,7 +273,7 @@ class SamplingBatch:
                 for sampling_params in self.sampling_params_list
             ],
             dtype=torch.float32,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
         return frequency_penalties, presence_penalties, repetition_penalties
 
@@ -284,7 +289,7 @@ class SamplingBatch:
             len(self.sampling_params_list),
             self.vocab_size,
             dtype=torch.bool,
-            device=self.device,
+            device=self.SAMPLER_DEVICE,
         )
         for i, sp in enumerate(self.sampling_params_list):
             if sp.allowed_token_ids:
@@ -347,14 +352,14 @@ def sample_from_logits(
     logits_2d: mx.array,
     batch: SamplingBatch,
     sampler: Sampler,
-    device: torch.device,
 ) -> _SamplingResult:
     """Sample tokens from pre-sliced 2D logits ``(batch_size, vocab)``.
 
     Single entry point for all sampling paths.  Chooses native MLX greedy
-    when possible, otherwise bridges to the vLLM torch sampler. Requests that
-    need sample logprobs must use the vLLM sampler so ``ModelRunnerOutput`` can
-    satisfy the OpenAI serving contract.
+    when possible, otherwise bridges to the vLLM torch sampler on
+    ``SamplingBatch.SAMPLER_DEVICE``. Requests that need sample logprobs must
+    use the vLLM sampler so ``ModelRunnerOutput`` can satisfy the OpenAI
+    serving contract.
     """
     if batch.can_use_native_greedy() and not batch.needs_logprobs:
         tokens = mlx_greedy_tokens(logits_2d)
@@ -364,7 +369,9 @@ def sample_from_logits(
         return _SamplingResult(tokens.tolist())  # type: ignore[arg-type]
 
     mx.eval(logits_2d)
-    logits_torch = mlx_to_torch(logits_2d.astype(mx.float32), device=device)
+    logits_torch = mlx_to_torch(
+        logits_2d.astype(mx.float32), device=SamplingBatch.SAMPLER_DEVICE
+    )
     metadata = batch.make_sampling_metadata()
     output = sampler.forward(logits_torch, metadata)
     logprobs = (
@@ -380,7 +387,6 @@ def sample_decode_tokens(
     decode_reqs: list[tuple[str, object]],
     num_decode: int,
     sampler: Sampler,
-    device: torch.device,
     *,
     vocab_size: int,
 ) -> _SamplingResult:
@@ -391,7 +397,6 @@ def sample_decode_tokens(
         decode_reqs: ``(req_id, RequestState)`` pairs for decode requests.
         num_decode: Number of decode requests (prefix of the token dimension).
         sampler: vLLM Sampler instance.
-        device: PyTorch device for the torch bridge path.
         vocab_size: Model vocabulary size.
     Returns:
         Sampled token IDs and optional logprobs, one row per decode request.
@@ -419,10 +424,9 @@ def sample_decode_tokens(
         prompt_token_ids_list,
         output_tokens_list,
         vocab_size=vocab_size,
-        device=device,
         generators=generators,
     )
-    return sample_from_logits(decode_logits, batch, sampler, device)
+    return sample_from_logits(decode_logits, batch, sampler)
 
 
 def sample_prefill_tokens(
@@ -431,7 +435,6 @@ def sample_prefill_tokens(
     cu_seqlens: list[int],
     num_decode: int,
     sampler: Sampler,
-    device: torch.device,
     *,
     vocab_size: int,
 ) -> _SamplingResult:
@@ -443,7 +446,6 @@ def sample_prefill_tokens(
         cu_seqlens: Cumulative sequence lengths for logit position lookup.
         num_decode: Number of decode requests (offset into cu_seqlens).
         sampler: vLLM Sampler instance.
-        device: PyTorch device for the torch bridge path.
         vocab_size: Model vocabulary size.
     Returns:
         Sampled token IDs and optional logprobs, one row per prefill request.
@@ -474,11 +476,10 @@ def sample_prefill_tokens(
         prompt_token_id_lists,
         output_token_id_lists,
         vocab_size=vocab_size,
-        device=device,
         generators={
             j: pr.generator
             for j, pr in enumerate(prefill_reqs)
             if pr.generator is not None
         },
     )
-    return sample_from_logits(last_logits, batch, sampler, device)
+    return sample_from_logits(last_logits, batch, sampler)

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -125,10 +125,10 @@ class MetalWorker(WorkerBase):
         logger.info(f"MLX device set to: {mx.default_device()}")
         set_wired_limit()
 
-        # Use MetalPlatform.get_torch_device() to properly support MPS when available.
-        # This ensures consistency with the platform's device selection logic and
-        # allows using MPS for PyTorch operations (like vLLM's sampler) when supported,
-        # while falling back to CPU if MPS is not available.
+        # ``self.device`` is the upstream WorkerBase contract field for the
+        # torch device. Torch sampling deliberately does not follow it: the
+        # sampler is pinned to ``SamplingBatch.SAMPLER_DEVICE`` (CPU) because
+        # MPS ``exponential_()`` can corrupt sampled tokens (#622).
         self.device = MetalPlatform.get_torch_device(0)
         logger.info(f"PyTorch device set to: {self.device}")
 
@@ -187,10 +187,7 @@ class MetalWorker(WorkerBase):
         else:
             from vllm_metal.v1.model_runner import MetalModelRunner
 
-            self.model_runner = MetalModelRunner(
-                vllm_config=self.vllm_config,
-                device=self.device,
-            )
+            self.model_runner = MetalModelRunner(vllm_config=self.vllm_config)
             # Hand the pipeline group to the runner so its forward path can pipe
             # activations stage-to-stage. None on the default single-stage path.
             self.model_runner.pp = self.pp


### PR DESCRIPTION
Fixes #622. With `temperature > 0`, about 10% of completions came back with one garbage CJK token dropped into otherwise normal text, while greedy was clean. The cause is the vLLM torch sampler running on MPS: torch's `exponential_()` on MPS sometimes returns exact zeros (I counted 873 in 29 billion draws on an M1 Ultra; CPU gives none), and the sampler computes `probs.div(q).argmax()`, so a zero draw becomes inf or NaN and argmax lands on a random vocab id. That also matches the `top_k=1` result in the issue thread, since masked positions turn into `0/0 = NaN`. In a synthetic harness, the zero draws and the bad tokens matched 1:1, and clamping just the zeros made every violation disappear, so this is the whole mechanism.

The fix pins the torch sampling path to CPU. `SamplingBatch` owns the device as a class constant and the device parameters are deleted from the sampling entry points, so nothing can route sampling back to MPS. Greedy stays on native MLX. Seeded outputs change because the CPU RNG stream differs from MPS. This also stops an EngineCore abort seen with Metal API validation enabled, where torch's MPS radix sort kernel trips an assertion on the first non-greedy request.

For evidence, replaying the reporter's request shape on `mlx-community/Qwen3.8-27B-4bit` at temperature 0.7, 60 completions per run: 6/60 corrupted before, 0/60 after. Sampling on CPU is also slightly faster since it skips the per-step MPS transfer. `vllm bench latency --batch-size 1 --input-len 32 --output-len 128` on the same model:

| | avg latency |
|---|---:|
| main | 6.14 s |
| this PR | 5.86 s |