### PR TITLE
[Spec Decode] Register draft-model KV as a scheduler-managed cache group

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -9,7 +9,7 @@ path. All require synchronous scheduling and greedy sampling.
 | Target models | Gemma4 (paged) | Any paged-attention model | Any paged-attention model |
 | Draft source | MTP assistant checkpoint (reads target KV cache) | Separate smaller model (own KV cache) | Prompt/output token history (no model) |
 | `num_speculative_tokens` | 1 | Configurable (3–5 typical) | Configurable (3–5 typical) |
-| Extra memory | None (reads target KV cache) | Second un-budgeted KV cache | None |
+| Extra memory | None (reads target KV cache) | Second scheduler-managed KV cache | None |
 
 All three methods:
 
@@ -126,11 +126,16 @@ Confirm speculative decoding is active: the server log shows
 
 ### Limitations
 
-- **Draft KV cache is un-budgeted.** The draft gets its own KV cache sized to
-  the target's `num_blocks`, allocated after the target KV budget and not
-  subtracted from it. Keep `VLLM_METAL_MEMORY_FRACTION` well below 1.0.
-- **SWA draft models untested.** The draft block allocator assumes full
-  attention.
+- **Draft KV cache is scheduler-managed.** The committed portion of the
+  draft's KV is a scheduler-owned KV-cache group, hashed, matched, admitted,
+  and evicted like the target's own groups and counted against the shared
+  Metal KV budget. Only the speculative lookahead tail
+  (`num_speculative_tokens` positions ahead of the committed length) is a
+  small proposer-local scratch reservation, pre-reserved before the budget is
+  divided.
+- **No sliding-window or hybrid draft models.** The draft block allocator
+  assumes full attention; ``resolve_draft_dims`` rejects draft configs with
+  ``sliding_window`` or mixed ``layer_types`` at startup.
 - **No pipeline parallelism.** `pipeline_parallel_size>1` with speculative
   config raises at startup.
 

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -57,6 +57,7 @@ def make_stub_runner(
         "_multimodal_adapter": None,
         "_gemma4_mtp_assistant": None,
         "_drafter": None,
+        "_draft_dims": None,
         "encoder_cache": None,
         "_paged_attention_runtime": None,
         "_paged_block_size": 0,

--- a/tests/test_draft_cache_policy_gaps.py
+++ b/tests/test_draft_cache_policy_gaps.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests that the scheduler-managed draft KV cache honors the scheduler's
+cache policy -- the gaps a proposer-private draft cache cannot see.
+
+One property per gap named when the proposer-private draft cache was
+rejected (see #500):
+
+- ``cache_salt``: a resubmitted prompt under a different salt must not
+  reuse draft KV.
+- ``skip_reading_prefix_cache``: a request that opts out of cache reads
+  must not reuse draft KV.
+- Allocation limit: the proposer-local scratch reserve is sized to cover
+  every concurrently active request drafting ``num_speculative_tokens``
+  positions, so the draft pool cannot exhaust near the request limit.
+
+The first two run end-to-end in a spawned child process (``spawn`` start
+method -- Metal is not fork-safe) with Qwen3-0.6B draft==target, recording
+each request's first draft plan (``draft_seq_len`` / ingest length) via a
+monkeypatched proposer. The third is stub-level, no weights.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+
+import pytest
+from vllm.utils.math_utils import cdiv
+
+from tests.test_draft_model_proposer import (
+    BLOCK_SIZE,
+    _proposer,
+    _StubDraftModel,
+)
+from tests.test_paged_deterministic import (
+    DEFAULT_PAGED_MEMORY_FRACTION,
+    DEFAULT_USE_PAGED_ATTENTION,
+    MODEL_NAME,
+)
+
+K = 3
+GEN = 8
+
+SALT_PROMPT = (
+    "Once upon a time in a far away kingdom there was a great king "
+    "named Aragorn who ruled the land of Gondor with wisdom and "
+    "grace, and his people loved him dearly because "
+)
+SKIP_PROMPT = (
+    "The engineer examined the trace carefully, noting where the latency "
+    "spiked and which subsystem held the lock the longest before yielding. "
+)
+
+
+def _setenv_default(key: str, default: str) -> None:
+    if os.environ.get(key) is None:
+        os.environ[key] = default
+
+
+def _run_policy_e2e() -> None:
+    """Body of the e2e test -- runs in a spawned child process."""
+    _setenv_default("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    _setenv_default("VLLM_METAL_USE_PAGED_ATTENTION", DEFAULT_USE_PAGED_ATTENTION)
+    _setenv_default("VLLM_METAL_MEMORY_FRACTION", DEFAULT_PAGED_MEMORY_FRACTION)
+
+    if os.environ.get("VLLM_METAL_USE_PAGED_ATTENTION", "0") != "1":
+        return  # non-paged path: nothing to test
+
+    from vllm import LLM, SamplingParams
+
+    from vllm_metal.v1 import draft_model_proposer as dmp
+
+    plans: list[tuple[int, int]] = []
+
+    def _note_plan(plan) -> None:
+        if plan is not None:
+            plans.append((plan.draft_seq_len, len(plan.ingest_tokens)))
+
+    if hasattr(dmp.DraftModelProposer, "_make_plan"):
+        _orig_make_plan = dmp.DraftModelProposer._make_plan
+
+        def _logged_make_plan(self, req_id, state, num_speculative_tokens):
+            plan = _orig_make_plan(self, req_id, state, num_speculative_tokens)
+            _note_plan(plan)
+            return plan
+
+        dmp.DraftModelProposer._make_plan = _logged_make_plan
+    else:
+        _orig_decode = dmp.DraftModelProposer._make_decode_plan
+        _orig_prefill = dmp.DraftModelProposer._make_prefill_plan
+
+        def _logged_decode(self, req_id, state, k, drafting_req_ids):
+            plan = _orig_decode(self, req_id, state, k, drafting_req_ids)
+            _note_plan(plan)
+            return plan
+
+        def _logged_prefill(self, prefill, result_mode, k, drafting_req_ids):
+            plan = _orig_prefill(self, prefill, result_mode, k, drafting_req_ids)
+            _note_plan(plan)
+            return plan
+
+        dmp.DraftModelProposer._make_decode_plan = _logged_decode
+        dmp.DraftModelProposer._make_prefill_plan = _logged_prefill
+
+    llm = LLM(
+        model=MODEL_NAME,
+        max_model_len=1024,
+        max_num_seqs=1,
+        enable_prefix_caching=True,
+        async_scheduling=False,
+        speculative_config={
+            "method": "draft_model",
+            "model": MODEL_NAME,
+            "num_speculative_tokens": K,
+        },
+    )
+    sp = SamplingParams(temperature=0, max_tokens=GEN)
+
+    def first_plan(prompt, sampling_params) -> tuple[int, int] | None:
+        plans.clear()
+        llm.generate([prompt], sampling_params)
+        return plans[0] if plans else None
+
+    # cache_salt: same prompt, different salt must not reuse draft KV.
+    # max_tokens=2 keeps the warm generate short while still running
+    # propose(), which writes the draft group's KV.
+    warm = SamplingParams(temperature=0, max_tokens=2)
+    first_plan({"prompt": SALT_PROMPT, "cache_salt": "a"}, warm)
+    hit_a = first_plan({"prompt": SALT_PROMPT, "cache_salt": "a"}, sp)
+    miss_b = first_plan({"prompt": SALT_PROMPT, "cache_salt": "b"}, sp)
+    if hit_a is None or hit_a[0] == 0:
+        raise AssertionError(f"same cache_salt should reuse draft KV, got {hit_a}")
+    if miss_b is None or miss_b[0] != 0:
+        raise AssertionError(
+            f"different cache_salt must not reuse draft KV, got {miss_b}"
+        )
+    tokens = list(
+        llm.generate([{"prompt": SALT_PROMPT, "cache_salt": "a"}], sp)[0]
+        .outputs[0]
+        .token_ids
+    )
+    if tokens != list(
+        llm.generate([{"prompt": SALT_PROMPT, "cache_salt": "b"}], sp)[0]
+        .outputs[0]
+        .token_ids
+    ):
+        raise AssertionError("cache_salt changed the generated tokens")
+
+    # skip_reading_prefix_cache: opting out of cache reads must not reuse
+    # draft KV, and must not change the generated tokens.
+    first_plan(SKIP_PROMPT, warm)
+    hit = first_plan(SKIP_PROMPT, sp)
+    skip = first_plan(
+        SKIP_PROMPT,
+        SamplingParams(temperature=0, max_tokens=GEN, skip_reading_prefix_cache=True),
+    )
+    if hit is None or hit[0] == 0:
+        raise AssertionError(f"default read should reuse draft KV, got {hit}")
+    if skip is None or skip[0] != 0:
+        raise AssertionError(
+            f"skip_reading_prefix_cache must not reuse draft KV, got {skip}"
+        )
+    tokens = list(llm.generate([SKIP_PROMPT], sp)[0].outputs[0].token_ids)
+    skipped = list(
+        llm.generate(
+            [SKIP_PROMPT],
+            SamplingParams(
+                temperature=0, max_tokens=GEN, skip_reading_prefix_cache=True
+            ),
+        )[0]
+        .outputs[0]
+        .token_ids
+    )
+    if tokens != skipped:
+        raise AssertionError("skip_reading_prefix_cache changed the generated tokens")
+
+
+@pytest.mark.slow
+def test_draft_cache_honors_scheduler_cache_policy_e2e() -> None:
+    ctx = mp.get_context("spawn")
+    proc = ctx.Process(target=_run_policy_e2e)
+    proc.start()
+    proc.join()
+    if proc.exitcode != 0:
+        raise AssertionError(
+            "Draft cache-policy e2e test failed in spawned child "
+            f"(exit code: {proc.exitcode})"
+        )
+
+
+def test_scratch_reserve_covers_max_concurrency() -> None:
+    """The reserve formula fits every concurrent drafter at full concurrency.
+
+    Each request's committed allocation covers its committed length (one
+    block for 16 tokens here); the lookahead to ``committed_len + K - 1``
+    then needs exactly ``cdiv(K, block_size)`` scratch block(s) per request.
+    ``max_num_seqs`` requests must fit in ``max_num_seqs * cdiv(K, BLOCK_SIZE)``
+    scratch blocks, and one block short must exhaust.
+    """
+    num_speculative_tokens = 4
+    max_num_seqs = 3
+    reserve = max_num_seqs * cdiv(num_speculative_tokens, BLOCK_SIZE)
+
+    from vllm.sampling_params import SamplingParams
+
+    from vllm_metal.v1.model_runner import RequestState
+    from vllm_metal.v1.proposer import ProposeContext
+
+    def _state() -> RequestState:
+        return RequestState(
+            token_ids=list(range(16)),
+            prompt_len=16,
+            cache=[],
+            sampling_params=SamplingParams(temperature=0.0),
+            block_ids=[[0]],
+            num_computed_tokens=0,
+        )
+
+    def _context_for(states: dict[str, RequestState]) -> ProposeContext:
+        return ProposeContext(
+            target_hidden_states=None,
+            decode_reqs=list(states.items()),
+            decode_segments=[],
+            decode_token_ids=[[state.token_ids[-1]] for state in states.values()],
+            prefill_reqs=[],
+            prefill_token_ids=[],
+            prefill_result_modes=[],
+            request_states=states,
+            cu_seqlens=[],
+            num_decode_segments=1,
+            num_speculative_tokens=num_speculative_tokens,
+            finished_req_ids=set(),
+        )
+
+    states = {f"r{i}": _state() for i in range(max_num_seqs)}
+
+    model = _StubDraftModel()
+    proposer = _proposer(model, committed_num_blocks=1, scratch_reserve_blocks=reserve)
+    drafts = proposer.propose(_context_for(states))
+    assert drafts is not None
+
+    model = _StubDraftModel()
+    starved = _proposer(
+        model, committed_num_blocks=1, scratch_reserve_blocks=reserve - 1
+    )
+    with pytest.raises(RuntimeError, match="scratch pool exhausted"):
+        starved.propose(_context_for(states))

--- a/tests/test_draft_ingest_routing.py
+++ b/tests/test_draft_ingest_routing.py
@@ -36,7 +36,8 @@ def _proposer(model, **kwargs) -> DraftModelProposer:
     return DraftModelProposer(
         model=model,
         block_size=BLOCK_SIZE,
-        num_blocks=64,
+        committed_num_blocks=64,
+        scratch_reserve_blocks=0,
         num_layers=1,
         controller=None,
         extract_logits=lambda logits: logits,
@@ -53,6 +54,7 @@ def _plan(n_ingest: int, draft_seq_len: int) -> _DraftPlan:
         committed_len=committed,
         draft_seq_len=draft_seq_len,
         ingest_tokens=list(range(100, 100 + n_ingest)),
+        is_drafting=True,
     )
 
 

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -1,8 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the draft-model proposer's draft KV block pool.
+"""Tests for the draft-model proposer's committed/scratch block split.
 
-A stub draft model returns logits of the right shape, so the block allocator and
-the release path run through ``propose`` without loading any weights.
+A stub draft model returns logits of the right shape, so ingest, drafting,
+and the release path run through ``propose`` without loading any weights.
+The committed portion of the block table is scheduler-assigned (as it would
+be by a real KVCacheManager for the draft's registered KV-cache group, see
+``cache_policy.ModelCachePolicy._draft_layer_specs``); these tests simulate
+that assignment directly on ``RequestState.block_ids`` rather than driving a
+real scheduler.
 """
 
 from __future__ import annotations
@@ -13,14 +18,15 @@ from vllm.sampling_params import SamplingParams
 
 from vllm_metal.attention.context import OffsetCache, get_context
 from vllm_metal.v1.draft_model_proposer import DraftModelProposer
-from vllm_metal.v1.model_runner import RequestState
+from vllm_metal.v1.model_runner import PrefillRequest, RequestState
 from vllm_metal.v1.proposer import ProposeContext
 from vllm_metal.v1.spec_decode import SpeculativeDecodeController
 
 BLOCK_SIZE = 16
-NUM_BLOCKS = 2
+COMMITTED_GROUP_INDEX = 0
+COMMITTED_NUM_BLOCKS = 2
+SCRATCH_RESERVE_BLOCKS = 2
 VOCAB_SIZE = 8
-# Long enough that one request plus its drafted position spans the whole pool.
 PROMPT_LEN = 20
 
 
@@ -29,31 +35,48 @@ class _StubDraftModel:
 
     def __init__(self) -> None:
         self.block_tables: list[list[list[int]]] = []
+        self.input_lens: list[int] = []
 
     def __call__(self, input_ids: mx.array, *, cache: list[OffsetCache]) -> mx.array:
         ctx = get_context()
         assert ctx is not None
         self.block_tables.append([list(block_ids) for block_ids in ctx.block_tables])
+        self.input_lens.append(int(input_ids.shape[1]))
         return mx.zeros((1, int(input_ids.shape[1]), VOCAB_SIZE), dtype=mx.float32)
 
 
-def _proposer(model: _StubDraftModel) -> DraftModelProposer:
-    return DraftModelProposer(
+def _proposer(
+    model: _StubDraftModel,
+    *,
+    committed_num_blocks: int = COMMITTED_NUM_BLOCKS,
+    scratch_reserve_blocks: int = SCRATCH_RESERVE_BLOCKS,
+) -> DraftModelProposer:
+    proposer = DraftModelProposer(
         model=model,
         block_size=BLOCK_SIZE,
-        num_blocks=NUM_BLOCKS,
+        committed_num_blocks=committed_num_blocks,
+        scratch_reserve_blocks=scratch_reserve_blocks,
         num_layers=1,
         controller=SpeculativeDecodeController(),
         extract_logits=lambda output: output,
     )
+    proposer.adopt_committed_group(COMMITTED_GROUP_INDEX)
+    return proposer
 
 
-def _request_state() -> RequestState:
+def _request_state(
+    *,
+    committed_block_ids: list[int],
+    num_computed_tokens: int = 0,
+    sampling_params: SamplingParams | None = None,
+) -> RequestState:
     return RequestState(
         token_ids=list(range(PROMPT_LEN)),
         prompt_len=PROMPT_LEN,
         cache=[],
-        sampling_params=SamplingParams(temperature=0.0),
+        sampling_params=sampling_params or SamplingParams(temperature=0.0),
+        block_ids=[list(committed_block_ids)],
+        num_computed_tokens=num_computed_tokens,
     )
 
 
@@ -61,6 +84,8 @@ def _context(
     req_id: str,
     state: RequestState,
     request_states: dict[str, RequestState],
+    *,
+    num_speculative_tokens: int = 1,
 ) -> ProposeContext:
     return ProposeContext(
         target_hidden_states=None,
@@ -73,7 +98,7 @@ def _context(
         request_states=request_states,
         cu_seqlens=[],
         num_decode_segments=1,
-        num_speculative_tokens=1,
+        num_speculative_tokens=num_speculative_tokens,
         finished_req_ids=set(),
     )
 
@@ -83,38 +108,236 @@ def _drafting_blocks(model: _StubDraftModel, forward_index: int) -> set[int]:
     return set(block_ids)
 
 
-def test_release_requests_returns_draft_blocks_to_the_free_pool() -> None:
+def test_propose_before_adopt_committed_group_raises() -> None:
+    model = _StubDraftModel()
+    proposer = DraftModelProposer(
+        model=model,
+        block_size=BLOCK_SIZE,
+        committed_num_blocks=COMMITTED_NUM_BLOCKS,
+        scratch_reserve_blocks=SCRATCH_RESERVE_BLOCKS,
+        num_layers=1,
+        controller=SpeculativeDecodeController(),
+        extract_logits=lambda output: output,
+    )
+    state = _request_state(committed_block_ids=[0, 1])
+    with pytest.raises(RuntimeError, match="adopt_committed_group"):
+        proposer.propose(_context("r1", state, {"r1": state}))
+
+
+def test_committed_blocks_come_from_scheduler_assignment() -> None:
+    """The committed portion of the block table is exactly what the
+    scheduler assigned on RequestState.block_ids, not a proposer-owned pool."""
     model = _StubDraftModel()
     proposer = _proposer(model)
-    waiting, resumed = _request_state(), _request_state()
-    # A preempted request keeps its RequestState, so the finished-request sweep
-    # inside propose() never reclaims its blocks.
+    state = _request_state(committed_block_ids=[1, 0])  # order matters
+    drafts = proposer.propose(_context("r1", state, {"r1": state}))
+
+    assert drafts is not None
+    used = model.block_tables[0][0]
+    assert used[:2] == [1, 0]
+
+
+def test_lookahead_tail_draws_from_scratch_pool_beyond_committed() -> None:
+    """A request whose committed blocks exactly cover its prompt still needs
+    a scratch block for the speculative lookahead position(s)."""
+    model = _StubDraftModel()
+    proposer = _proposer(model, committed_num_blocks=1)
+    state = _request_state(committed_block_ids=[0])
+    drafts = proposer.propose(
+        _context("r1", state, {"r1": state}, num_speculative_tokens=4)
+    )
+
+    assert drafts is not None
+    used = model.block_tables[0][0]
+    assert used[0] == 0  # committed block, scheduler-assigned
+    assert used[1] >= 1  # scratch block, drawn from the offset range
+
+
+def test_cache_hit_seeds_draft_seq_len_from_scheduler_boundary() -> None:
+    """A resubmitted/shared prefix reported via num_computed_tokens must not
+    be re-ingested -- this is #482's core fix."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    state = _request_state(
+        committed_block_ids=[0, 1], num_computed_tokens=PROMPT_LEN - 1
+    )
+    drafts = proposer.propose(_context("r1", state, {"r1": state}))
+
+    assert drafts is not None
+    assert model.input_lens[0] == 1
+
+
+def test_no_cache_hit_ingests_the_whole_committed_range() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    state = _request_state(committed_block_ids=[0, 1], num_computed_tokens=0)
+    drafts = proposer.propose(_context("r1", state, {"r1": state}))
+
+    assert drafts is not None
+    assert model.input_lens[0] == PROMPT_LEN
+
+
+def test_non_greedy_request_ingests_but_never_drafts() -> None:
+    """Non-greedy requests must still keep the committed group's KV in sync
+    (the scheduler advances num_computed_tokens for them regardless), but
+    must never receive draft tokens."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    state = _request_state(
+        committed_block_ids=[0, 1], sampling_params=SamplingParams(temperature=1.0)
+    )
+    drafts = proposer.propose(_context("r1", state, {"r1": state}))
+
+    assert drafts is None  # nothing to draft for
+    assert len(model.block_tables) == 1  # but ingest still ran
+
+
+def test_intermediate_prefill_chunk_ingests_without_drafting() -> None:
+    """An intermediate (not-yet-final) prefill chunk must ingest its
+    scheduled slice so the committed group's KV stays in sync, but must not
+    produce draft tokens (mirrors non-greedy: keep pace, never draft)."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    prefill = PrefillRequest(
+        req_id="r1",
+        token_ids=list(range(16)),
+        sampling_params=SamplingParams(temperature=0.0),
+        block_ids=[[0]],
+        generator=None,
+        prompt_len=None,
+        start_pos=0,
+        full_prompt_token_ids=None,
+    )
+    state = _request_state(committed_block_ids=[0])
+    ctx = ProposeContext(
+        target_hidden_states=None,
+        decode_reqs=[],
+        decode_segments=[],
+        decode_token_ids=[],
+        prefill_reqs=[prefill],
+        prefill_token_ids=[],
+        prefill_result_modes=["intermediate"],
+        request_states={"r1": state},
+        cu_seqlens=[],
+        num_decode_segments=0,
+        num_speculative_tokens=1,
+        finished_req_ids=set(),
+    )
+    drafts = proposer.propose(ctx)
+
+    assert drafts is None
+    assert len(model.block_tables) == 1
+
+
+def test_release_requests_returns_scratch_blocks_to_the_free_pool() -> None:
+    model = _StubDraftModel()
+    proposer = _proposer(model, committed_num_blocks=1)
+    waiting = _request_state(committed_block_ids=[0])
+    resumed = _request_state(committed_block_ids=[0])
     request_states = {"waiting": waiting, "resumed": resumed}
 
-    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+    assert (
+        proposer.propose(
+            _context("waiting", waiting, request_states, num_speculative_tokens=4)
+        )
+        is not None
+    )
     pool = _drafting_blocks(model, 0)
-    assert len(pool) == NUM_BLOCKS
 
     proposer.release_requests({"waiting"})
 
-    drafts = proposer.propose(_context("resumed", resumed, request_states))
+    drafts = proposer.propose(
+        _context("resumed", resumed, request_states, num_speculative_tokens=4)
+    )
 
     assert drafts is not None
     assert list(drafts.req_ids) == ["resumed"]
     assert _drafting_blocks(model, 1) == pool
 
 
-def test_draft_blocks_stay_pinned_without_release() -> None:
+def test_scratch_pool_exhaustion_raises() -> None:
     model = _StubDraftModel()
-    proposer = _proposer(model)
-    waiting, resumed = _request_state(), _request_state()
+    proposer = _proposer(model, committed_num_blocks=1, scratch_reserve_blocks=1)
+    waiting = _request_state(committed_block_ids=[0])
+    resumed = _request_state(committed_block_ids=[0])
     request_states = {"waiting": waiting, "resumed": resumed}
 
-    assert proposer.propose(_context("waiting", waiting, request_states)) is not None
+    assert (
+        proposer.propose(
+            _context("waiting", waiting, request_states, num_speculative_tokens=4)
+        )
+        is not None
+    )
 
-    with pytest.raises(RuntimeError) as excinfo:
-        proposer.propose(_context("resumed", resumed, request_states))
+    calls_before = len(model.block_tables)
+    with pytest.raises(RuntimeError, match="scratch pool exhausted"):
+        proposer.propose(
+            _context("resumed", resumed, request_states, num_speculative_tokens=4)
+        )
+    assert len(model.block_tables) == calls_before
 
-    assert "'resumed'" in str(excinfo.value)
-    # Allocation fails before any draft forward runs.
-    assert len(model.block_tables) == 1
+
+# -- Sliding-window / hybrid draft rejection ---------------------------------
+
+
+class _FakeModelConfig:
+    """Minimal mock of ``vllm.config.ModelConfig`` for config-only checks."""
+
+    def __init__(
+        self,
+        *,
+        sliding_window: int | None = None,
+        layer_types: list[str] | None = None,
+    ) -> None:
+        self._sliding_window = sliding_window
+        # hf_text_config is where layer_types and sliding_window live
+        self.hf_text_config = type("_HFConfig", (), {})()
+        if layer_types is not None:
+            self.hf_text_config.layer_types = layer_types
+
+    def get_sliding_window(self) -> int | None:
+        return self._sliding_window
+
+    def get_total_num_hidden_layers(self) -> int:
+        return 4
+
+    def get_num_kv_heads(self, parallel_config: object) -> int:
+        return 2
+
+    def get_head_size(self) -> int:
+        return 64
+
+
+def test_sliding_window_draft_rejected() -> None:
+    """A draft model with sliding_window must be rejected at config time."""
+    from vllm_metal.v1.draft_model_proposer import _require_full_attention_draft
+
+    cfg = _FakeModelConfig(sliding_window=4096)
+    with pytest.raises(NotImplementedError, match="sliding_window=4096"):
+        _require_full_attention_draft(cfg)
+
+
+def test_hybrid_layer_types_draft_rejected() -> None:
+    """A draft model with mixed layer types (e.g. Gemma4) must be rejected."""
+    from vllm_metal.v1.draft_model_proposer import _require_full_attention_draft
+
+    cfg = _FakeModelConfig(
+        layer_types=["sliding_attention", "full_attention"] * 2,
+    )
+    with pytest.raises(NotImplementedError, match="non-full-attention layer types"):
+        _require_full_attention_draft(cfg)
+
+
+def test_full_attention_draft_accepted() -> None:
+    """A plain full-attention draft model must pass the check."""
+    from vllm_metal.v1.draft_model_proposer import _require_full_attention_draft
+
+    # No sliding window, no layer_types at all (standard transformer)
+    cfg_plain = _FakeModelConfig()
+    _require_full_attention_draft(cfg_plain)  # should not raise
+
+    # Explicit full_attention layer_types only
+    cfg_explicit = _FakeModelConfig(
+        layer_types=["full_attention"] * 4,
+    )
+    _require_full_attention_draft(cfg_explicit)  # should not raise

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -328,6 +328,7 @@ class TestPagedAttentionPlanDiagnostics:
             scheduler_config=SimpleNamespace(max_num_seqs=2),
             cache_config=SimpleNamespace(mamba_cache_mode="none"),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
+            draft_scratch_reserve_bytes=MagicMock(return_value=0),
         )
         worker = _make_worker(runner, use_paged_attention=True)
         worker.metal_config.is_auto_memory = False
@@ -368,6 +369,7 @@ class TestPagedAttentionPlanDiagnostics:
             scheduler_config=SimpleNamespace(max_num_seqs=256),
             cache_config=SimpleNamespace(mamba_cache_mode="none"),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
+            draft_scratch_reserve_bytes=MagicMock(return_value=0),
         )
         planner = self._make_planner(
             runner,
@@ -409,6 +411,7 @@ class TestPagedAttentionPlanDiagnostics:
             scheduler_config=SimpleNamespace(max_num_seqs=1),
             cache_config=SimpleNamespace(mamba_cache_mode="none"),
             linear_cache_bytes_per_slot=MagicMock(return_value=64_400_000),
+            draft_scratch_reserve_bytes=MagicMock(return_value=0),
         )
         planner = self._make_planner(
             runner,
@@ -444,6 +447,7 @@ class TestPagedAttentionPlanDiagnostics:
             # produces six physical pools: 600 steady bytes per block plus
             # one 100-byte old pool retained during growth.
             linear_cache_bytes_per_slot=MagicMock(return_value=1_800),
+            draft_scratch_reserve_bytes=MagicMock(return_value=0),
         )
         planner = self._make_planner(
             runner,
@@ -472,7 +476,10 @@ class TestPagedAttentionPlanDiagnostics:
         assert plan.num_blocks == 10
 
     def test_non_hybrid_oom_error_omits_gdn_reservation(self, monkeypatch) -> None:
-        runner = SimpleNamespace(is_hybrid=False)
+        runner = SimpleNamespace(
+            is_hybrid=False,
+            draft_scratch_reserve_bytes=MagicMock(return_value=0),
+        )
         planner = self._make_planner(runner, memory_fraction=0.1)
         monkeypatch.setattr(
             WorkerCachePlanner,

--- a/tools/benchmark/draft_resubmit_benchmark.py
+++ b/tools/benchmark/draft_resubmit_benchmark.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark for draft-model KV cache cross-request reuse and losslessness.
+
+Two things are measured on a *single* tree (no cross-tree comparison):
+
+**Reuse.** Two speculative-decode generates of the same prompt, under fresh
+request ids each time:
+
+  gen1_cold      -- fresh request, cold draft cache
+  gen2_resubmit  -- identical prompt, new request id
+
+A tree without cross-request reuse re-ingests the full prompt into the draft
+model's KV inside every first propose; with the scheduler-managed draft cache
+the resubmit reuses the committed prefix blocks and ingests only the uncached
+suffix. Greedy throughout.
+
+**Losslessness.** A separate non-speculative reference generate of the same
+prompt establishes ground-truth output tokens. The two spec-decode runs are
+compared against it; ``lossless`` is ``true`` when the token ids match exactly.
+This proves the spec-decode path does not alter greedy output without relying
+on a comparison across different code trees (where a broken base path can
+produce degenerate output, making the comparison meaningless).
+
+Structural numbers come from monkeypatching ``DraftModelProposer``'s plan
+construction: ``first_plan_reused_tokens`` / ``first_plan_ingest_tokens`` are
+the first plan's ``draft_seq_len`` (where existing KV starts) and its ingest
+length, read directly from internal proposer state.
+
+Notes on methodology:
+
+- Requires ``VLLM_ENABLE_V1_MULTIPROCESSING=0`` so the monkeypatch reaches
+  the engine; the script sets it if unset. Set ``VLLM_METAL_MEMORY_FRACTION``
+  as needed for the machine (0.4 is a reasonable default).
+- The warm 1-token generate heats the *target* prefix cache only on trees
+  where ``propose()`` is skipped for prefill-only steps. On the
+  scheduler-managed tree the runner calls ``propose()`` every step, so the
+  warm request also ingests draft KV and gen1_cold is draft-warm there. Use
+  ``--skip-warm`` for a draft-cold gen1.
+- ``propose_first_ms`` times the first ``propose()`` call, which on the
+  scheduler-managed tree can be an empty call that precedes the first plan;
+  prefer the plan columns and wall/tpot for conclusions.
+- The reference run creates a separate non-speculative ``LLM`` instance.
+  Pass ``--skip-lossless`` to skip it if memory is tight.
+
+Output: one JSON object with ``reference`` (or ``null``) and ``spec_runs``
+(array of per-generate records), prefixed with ``RESULT ``.
+
+Usage:
+
+    VLLM_METAL_MEMORY_FRACTION=0.4 \\
+        python tools/benchmark/draft_resubmit_benchmark.py --prefix 8192
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+from vllm import LLM, SamplingParams  # noqa: E402
+
+from vllm_metal.v1 import draft_model_proposer as dmp  # noqa: E402
+
+DURS: list[float] = []
+PLANS: list[tuple[int, int]] = []  # (draft_seq_len, n_ingest) per plan
+
+_orig_propose = dmp.DraftModelProposer.propose
+
+
+def _timed_propose(self, ctx):
+    t0 = time.perf_counter()
+    r = _orig_propose(self, ctx)  # self-evals its drafts before returning
+    DURS.append(time.perf_counter() - t0)
+    return r
+
+
+def _note_plan(plan) -> None:
+    if plan is not None:
+        PLANS.append((plan.draft_seq_len, len(plan.ingest_tokens)))
+
+
+if hasattr(dmp.DraftModelProposer, "_make_plan"):
+    # Single plan constructor (pre-scheduler-cache trees).
+    _orig_make_plan = dmp.DraftModelProposer._make_plan
+
+    def _logged_make_plan(self, req_id, state, num_speculative_tokens):
+        plan = _orig_make_plan(self, req_id, state, num_speculative_tokens)
+        _note_plan(plan)
+        return plan
+
+    dmp.DraftModelProposer._make_plan = _logged_make_plan
+else:
+    # Plan construction split into decode/prefill variants (scheduler-managed
+    # cache tree).
+    _orig_decode = dmp.DraftModelProposer._make_decode_plan
+    _orig_prefill = dmp.DraftModelProposer._make_prefill_plan
+
+    def _logged_decode(self, req_id, state, k, drafting_req_ids):
+        plan = _orig_decode(self, req_id, state, k, drafting_req_ids)
+        _note_plan(plan)
+        return plan
+
+    def _logged_prefill(self, prefill, result_mode, k, drafting_req_ids):
+        plan = _orig_prefill(self, prefill, result_mode, k, drafting_req_ids)
+        _note_plan(plan)
+        return plan
+
+    dmp.DraftModelProposer._make_decode_plan = _logged_decode
+    dmp.DraftModelProposer._make_prefill_plan = _logged_prefill
+
+dmp.DraftModelProposer.propose = _timed_propose
+
+
+def _build_prompt(model: str, prefix: int) -> str:
+    """Build a deterministic prompt of exactly ``prefix`` tokens."""
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model)
+    unit = (
+        "The engineer examined the trace carefully, noting where the latency "
+        "spiked and which subsystem held the lock the longest before yielding. "
+    )
+    prompt = unit
+    while len(tok.encode(prompt)) < prefix:
+        prompt += unit
+    prompt = tok.decode(tok.encode(prompt)[:prefix])
+    return prompt
+
+
+def _run_reference(args, prompt: str) -> dict | None:
+    """Generate without speculative decoding to establish ground truth."""
+    sys.stderr.write("=== reference (no spec) start ===\n")
+    sys.stderr.flush()
+    llm = LLM(
+        model=args.model,
+        max_model_len=args.prefix + 256,
+        max_num_seqs=1,
+        enable_prefix_caching=True,
+        async_scheduling=False,
+    )
+    sp = SamplingParams(temperature=0, max_tokens=args.gen)
+    t0 = time.perf_counter()
+    out = llm.generate([prompt], sp)
+    dt = time.perf_counter() - t0
+    ids = list(out[0].outputs[0].token_ids)
+    del llm
+    gc.collect()
+    sys.stderr.write("=== reference done ===\n")
+    sys.stderr.flush()
+    return {
+        "label": "reference",
+        "gen": len(ids),
+        "wall_s": round(dt, 3),
+        "tpot_ms": round(dt / max(len(ids), 1) * 1000, 2),
+        "token_ids": ids,
+    }
+
+
+def _run_spec(args, prompt: str, reference_ids: list[int] | None) -> list[dict]:
+    """Run speculative-decode generates, comparing against reference."""
+    llm = LLM(
+        model=args.model,
+        max_model_len=args.prefix + 256,
+        max_num_seqs=1,
+        enable_prefix_caching=True,
+        async_scheduling=False,
+        speculative_config={
+            "method": "draft_model",
+            "model": args.model,
+            "num_speculative_tokens": args.num_speculative_tokens,
+        },
+    )
+
+    if not args.skip_warm:
+        llm.generate(
+            [prompt], SamplingParams(temperature=0, max_tokens=1)
+        )  # warm target
+
+    results = []
+    sp = SamplingParams(temperature=0, max_tokens=args.gen)
+    for label in ("gen1_cold", "gen2_resubmit"):
+        DURS.clear()
+        PLANS.clear()
+        t0 = time.perf_counter()
+        out = llm.generate([prompt], sp)
+        dt = time.perf_counter() - t0
+        ids = list(out[0].outputs[0].token_ids)
+        ms = sorted(d * 1000 for d in DURS)
+        first_plan = PLANS[0] if PLANS else (None, None)
+        lossless = (ids == reference_ids) if reference_ids is not None else None
+        results.append(
+            {
+                "label": label,
+                "prefix": args.prefix,
+                "gen": len(ids),
+                "wall_s": round(dt, 3),
+                "tpot_ms": round(dt / max(len(ids), 1) * 1000, 2),
+                "propose_calls": len(ms),
+                "propose_first_ms": round(DURS[0] * 1000, 1) if DURS else None,
+                "propose_median_ms": round(ms[len(ms) // 2], 1) if ms else None,
+                "first_plan_reused_tokens": first_plan[0],
+                "first_plan_ingest_tokens": first_plan[1],
+                "lossless": lossless,
+                "token_ids": ids,
+            }
+        )
+        sys.stderr.write(f"=== {label} done ===\n")
+        sys.stderr.flush()
+
+    del llm
+    gc.collect()
+    return results
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prefix", type=int, default=8192)
+    ap.add_argument("--gen", type=int, default=96)
+    ap.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    ap.add_argument("--num-speculative-tokens", type=int, default=3)
+    ap.add_argument("--skip-warm", action="store_true")
+    ap.add_argument(
+        "--skip-lossless",
+        action="store_true",
+        help="Skip the non-speculative reference run (saves memory/time).",
+    )
+    args = ap.parse_args()
+
+    prompt = _build_prompt(args.model, args.prefix)
+
+    # -- Reference: no speculative decoding ------------------------------------
+    reference = None
+    reference_ids = None
+    if not args.skip_lossless:
+        reference = _run_reference(args, prompt)
+        reference_ids = reference["token_ids"]
+
+    # -- Spec-decode runs with instrumentation ---------------------------------
+    spec_runs = _run_spec(args, prompt, reference_ids)
+
+    output = {"reference": reference, "spec_runs": spec_runs}
+    print("RESULT " + json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/benchmark/draft_resubmit_benchmark.py
+++ b/tools/benchmark/draft_resubmit_benchmark.py
@@ -39,8 +39,12 @@ Notes on methodology:
 - ``propose_first_ms`` times the first ``propose()`` call, which on the
   scheduler-managed tree can be an empty call that precedes the first plan;
   prefer the plan columns and wall/tpot for conclusions.
-- The reference run creates a separate non-speculative ``LLM`` instance.
-  Pass ``--skip-lossless`` to skip it if memory is tight.
+- The reference run executes in its own subprocess: an in-process
+  ``del llm`` / ``gc.collect()`` does not release Metal memory
+  (``mx.clear_cache()`` neither, and ``gpu_memory_utilization`` has no
+  effect on this backend), so the reference's KV would still be resident
+  when the spec run profiles its budget. The subprocess exit releases
+  everything. Pass ``--skip-lossless`` to skip it if memory is tight.
 
 Output: one JSON object with ``reference`` (or ``null``) and ``spec_runs``
 (array of per-generate records), prefixed with ``RESULT ``.
@@ -57,6 +61,7 @@ import argparse
 import gc
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -148,8 +153,6 @@ def _run_reference(args, prompt: str) -> dict | None:
     out = llm.generate([prompt], sp)
     dt = time.perf_counter() - t0
     ids = list(out[0].outputs[0].token_ids)
-    del llm
-    gc.collect()
     sys.stderr.write("=== reference done ===\n")
     sys.stderr.flush()
     return {
@@ -159,6 +162,39 @@ def _run_reference(args, prompt: str) -> dict | None:
         "tpot_ms": round(dt / max(len(ids), 1) * 1000, 2),
         "token_ids": ids,
     }
+
+
+def _run_reference_subprocess(args) -> dict:
+    """Run the reference generate in its own process.
+
+    The reference's Metal allocations (weights + KV) are only guaranteed
+    released once its process exits; in-process teardown of the ``LLM``
+    object does not free them before the spec run profiles its KV budget,
+    so on tight ``VLLM_METAL_MEMORY_FRACTION`` values the spec run would
+    see a reduced or negative ``kv_budget`` and fail.
+    """
+    cmd = [
+        sys.executable,
+        __file__,
+        "--reference-only",
+        "--model",
+        args.model,
+        "--prefix",
+        str(args.prefix),
+        "--gen",
+        str(args.gen),
+    ]
+    # stderr passes through so the child's progress markers stay visible.
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"reference subprocess failed with exit code {proc.returncode}"
+            " (see its stderr above)"
+        )
+    for line in proc.stdout.splitlines():
+        if line.startswith("RESULT "):
+            return json.loads(line[len("RESULT") :].lstrip())
+    raise RuntimeError("reference subprocess produced no RESULT line")
 
 
 def _run_spec(args, prompt: str, reference_ids: list[int] | None) -> list[dict]:
@@ -229,15 +265,26 @@ def main() -> None:
         action="store_true",
         help="Skip the non-speculative reference run (saves memory/time).",
     )
+    ap.add_argument(
+        "--reference-only",
+        action="store_true",
+        help=argparse.SUPPRESS,  # internal: spawned by the parent process
+    )
     args = ap.parse_args()
 
     prompt = _build_prompt(args.model, args.prefix)
 
+    if args.reference_only:
+        print("RESULT " + json.dumps(_run_reference(args, prompt)))
+        return
+
     # -- Reference: no speculative decoding ------------------------------------
+    # In its own subprocess so its Metal memory is fully released before the
+    # spec run profiles the KV budget.
     reference = None
     reference_ids = None
     if not args.skip_lossless:
-        reference = _run_reference(args, prompt)
+        reference = _run_reference_subprocess(args)
         reference_ids = reference["token_ids"]
 
     # -- Spec-decode runs with instrumentation ---------------------------------

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 import mlx.core as mx
 import torch
 from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -409,7 +410,33 @@ class ModelCachePolicy:
                         dtype=torch_dtype,
                     )
 
+        specs.update(
+            self._draft_layer_specs(block_size=block_size, torch_dtype=torch_dtype)
+        )
         return specs
+
+    def _draft_layer_specs(
+        self, *, block_size: int, torch_dtype: torch.dtype
+    ) -> dict[str, KVCacheSpec]:
+        """Scheduler-visible spec for the draft model's committed-KV group.
+
+        Draft models must be plain transformers (no sliding window / MLA /
+        hybrid) -- enforced at startup by ``resolve_draft_dims`` -- so a
+        uniform ``FullAttentionSpec`` per layer under distinct synthetic names
+        is enough to let the scheduler size the draft's KV cache.
+        """
+        draft_dims = self._runner._draft_dims
+        if draft_dims is None:
+            return {}
+        return {
+            f"draft_layers.{layer_idx}.self_attn": FullAttentionSpec(
+                block_size=block_size,
+                num_kv_heads=draft_dims.num_kv_heads,
+                head_size=draft_dims.head_dim,
+                dtype=torch_dtype,
+            )
+            for layer_idx in range(draft_dims.num_layers)
+        }
 
     def _build_mha_attention_spec(
         self,
@@ -447,6 +474,7 @@ class ModelCachePolicy:
         upstream config is also the source of truth for scheduler KV groups, so
         adopt its grouping before serving.
         """
+        self._adopt_draft_scheduler_group(kv_cache_config)
         runtime = self._runner.paged_attention_runtime
         pooling_backend = self._runner._pooling_backend
         if (
@@ -659,6 +687,45 @@ class ModelCachePolicy:
         )
         self._runner.install_paged_attention_runtime(runtime, block_size=block_size)
 
+    def _adopt_draft_scheduler_group(self, kv_cache_config: KVCacheConfig) -> None:
+        """Tell the drafter which scheduler KV group owns its committed KV.
+
+        The draft model's own physical backend is already built by this
+        point (``install_drafter``, called from ``determine_available_memory``
+        -- before the engine has computed ``kv_cache_config``, so it cannot
+        know its group index at construction time). This runs after, once
+        ``kv_cache_config.kv_cache_groups`` exists, and resolves which group
+        the synthetic ``draft_layers.*`` names from
+        ``ModelCachePolicy._draft_layer_specs`` landed in -- mirroring
+        ``_adopt_mha_layout``'s resolution for the target. No-op without a
+        draft model configured.
+        """
+        draft_dims = self._runner._draft_dims
+        if draft_dims is None:
+            return
+        layer_names = tuple(
+            f"draft_layers.{layer_idx}.self_attn"
+            for layer_idx in range(draft_dims.num_layers)
+        )
+        group_indices = self._scheduler_group_indices_for_layers(
+            kv_cache_config, layer_names
+        )
+        if len(group_indices) != 1:
+            raise NotImplementedError(
+                "draft-model speculative decoding requires all draft layers "
+                "to share one scheduler KV cache group"
+            )
+
+        from vllm_metal.v1.draft_model_proposer import DraftModelProposer
+
+        drafter = self._runner._drafter
+        if not isinstance(drafter, DraftModelProposer):
+            raise RuntimeError(
+                "draft KV-cache spec registered but no DraftModelProposer is "
+                f"installed (got {type(drafter).__name__})"
+            )
+        drafter.adopt_committed_group(group_indices[0])
+
     def _scheduler_group_indices_for_layers(
         self,
         kv_cache_config: KVCacheConfig,
@@ -687,7 +754,13 @@ class ModelCachePolicy:
         """Return the byte size of one cache block.
 
         For per-layer shapes, sums each layer's contribution individually.
-        For uniform shapes, reduces to the existing product formula.
+        For uniform shapes, reduces to the existing product formula. Adds the
+        draft model's own per-block bytes when one is configured (see
+        ``_draft_cache_block_size_bytes``), so every caller of this method --
+        scheduler capacity reporting and the local budget-to-num_blocks
+        division alike -- sizes against the true combined cost of one block
+        index, which now has real storage in both the target's and the
+        draft's KV-cache groups.
         """
         self._require_supported_per_layer_shapes()
         block_size = self._runner.cache_config.block_size
@@ -697,15 +770,71 @@ class ModelCachePolicy:
         # TurboQuant uses quantized KV cache with different byte layout
         config = get_config()
         if self._use_turboquant(config):
-            return num_kv_layers * turboquant_page_size_bytes(
-                block_size=block_size,
-                num_kv_heads=self._runner.num_kv_heads,
-                head_dim=self._runner.head_dim,
-                k_quant=config.k_quant,
-                v_quant=config.v_quant,
+            return (
+                num_kv_layers
+                * turboquant_page_size_bytes(
+                    block_size=block_size,
+                    num_kv_heads=self._runner.num_kv_heads,
+                    head_dim=self._runner.head_dim,
+                    k_quant=config.k_quant,
+                    v_quant=config.v_quant,
+                )
+                + self._draft_cache_block_size_bytes()
             )
 
-        return self._kv_factor() * block_size * dtype_size * self._kv_layer_size_sum()
+        return (
+            self._kv_factor() * block_size * dtype_size * self._kv_layer_size_sum()
+            + self._draft_cache_block_size_bytes()
+        )
+
+    def draft_scratch_reserve_blocks(self) -> int:
+        """Blocks reserved for the draft model's speculative lookahead tail.
+
+        The committed portion of the draft's KV is a normal scheduler-owned
+        group (see ``_draft_layer_specs``), so the scheduler owns every block
+        id in ``[0, num_blocks)`` for it. The *speculative* tail -- positions
+        drafted ahead of a request's committed length, not yet verified --
+        has no scheduler concept (no group is ever "ahead" of committed
+        tokens), so it stays a small proposer-local reservation sized to the
+        worst case: every concurrently active request drafting
+        ``num_speculative_tokens`` positions at once. Zero without a draft
+        model. See ``DraftModelProposer``'s split of committed vs. scratch
+        block ids, and ``WorkerCachePlanner.setup_paged_attention`` for how
+        this over-provisions the draft's *physical* backend beyond the
+        scheduler-visible block count.
+        """
+        spec = self._runner.vllm_config.speculative_config
+        if self._runner._draft_dims is None or spec is None:
+            return 0
+        block_size = self._runner.cache_config.block_size
+        extra_per_req = cdiv(spec.num_speculative_tokens, block_size)
+        return self._runner.scheduler_config.max_num_seqs * extra_per_req
+
+    def draft_scratch_reserve_bytes(self) -> int:
+        """Bytes held out of the KV budget for the draft's scratch tail.
+
+        Subtracted before dividing by the (target + draft) combined
+        per-block cost, so ``num_blocks`` leaves this much headroom in the
+        draft's own physical pool without it being scheduler-visible or
+        counted against the target's budget.
+        """
+        return (
+            self.draft_scratch_reserve_blocks() * self._draft_cache_block_size_bytes()
+        )
+
+    def _draft_cache_block_size_bytes(self) -> int:
+        """Byte size of one draft-model cache block, or 0 without a draft.
+
+        Derived from the same ``FullAttentionSpec`` objects
+        ``_draft_layer_specs`` registers with the scheduler
+        (``real_page_size_bytes``), rather than a parallel hand-rolled
+        formula, so the two cannot drift apart. Naturally 0 when no draft is
+        configured, since ``_draft_layer_specs`` returns ``{}`` in that case.
+        """
+        block_size = self._runner.cache_config.block_size
+        torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
+        specs = self._draft_layer_specs(block_size=block_size, torch_dtype=torch_dtype)
+        return sum(spec.real_page_size_bytes for spec in specs.values())
 
     def linear_cache_bytes_per_slot(self) -> int:
         """Return bytes for one request's linear-attention state."""
@@ -1100,7 +1229,8 @@ class WorkerCachePlanner:
             overhead,
         )
         reservation = self._hybrid_gdn_reservation()
-        kv_budget = base_kv_budget - reservation.total_bytes
+        draft_scratch_bytes = self._worker.model_runner.draft_scratch_reserve_bytes()
+        kv_budget = base_kv_budget - reservation.total_bytes - draft_scratch_bytes
         plan = _PagedAttentionPlan(
             block_size=block_size,
             fraction=fraction,

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -2,41 +2,59 @@
 """Draft-model speculative decoding proposer for the Metal paged path.
 
 A :class:`DraftModelProposer` drafts with a *separate* full model (vLLM
-``method="draft_model"``). It owns:
+``method="draft_model"``). Its KV is split into two parts with different
+ownership, matching where cross-request cache *reuse* actually happens
+(#482):
 
-- its own MLX draft model (loaded independently of the target),
-- its own physical :class:`MetalPagedKVCache`, sized to the *target's*
-  ``num_blocks`` (a second KV store), and
-- its own block allocator over that ``num_blocks`` pool. The draft *cannot*
-  reuse the target's scheduler-allocated ``block_ids``: it drafts
-  ``num_speculative_tokens`` positions AHEAD of the committed length, while the
-  target's block table is exact-fit for that committed length and runs out at
-  the next block boundary (regression-pinned by
-  ``test_long_prompt_crosses_block_boundary``). K/V values still line up
-  position-for-position across the two caches; only the block table is owned
-  separately.
+- The **committed** portion (``[0, committed_len)`` per request) is a real
+  scheduler-owned KV-cache group (``cache_policy.ModelCachePolicy.
+  _draft_layer_specs``), registered and sized exactly like the target's own
+  groups. The scheduler hashes, matches, admits, and evicts it -- so
+  ``cache_salt``, per-request cache-read rules (``skip_reading_prefix_cache``),
+  and the real admission/allocation limit all apply to it automatically,
+  the same way they already apply to the target. This is where content-based
+  reuse across requests lives.
+- The **speculative lookahead** tail (positions drafted ahead of a request's
+  committed length, not yet verified) has no scheduler concept -- no
+  registered group is ever "ahead" of a request's committed tokens -- so it
+  stays a small, proposer-local scratch reservation
+  (``committed_num_blocks + scratch_reserve_blocks``, see
+  ``DraftModelProposer.build`` and ``ModelCachePolicy.
+  draft_scratch_reserve_blocks``). It never claims cross-request reuse, so
+  none of the scheduler-owned group's guarantees are needed there.
 
-Each scheduler step ``propose()`` runs, batched over the dynamic mixed batch
-with the scheduler-selected speculative token count:
+**Block-alignment note.** When ``committed_len`` is not a multiple of
+``block_size``, the last committed block is only partially filled with
+scheduler-owned KV.  The lookahead draft steps write their speculative KV
+into the remaining slots of that same scheduler-owned block (and into scratch
+blocks beyond it, if needed).  This is safe because ingest rewrites every
+position in ``[draft_seq_len, committed_len)`` *before* the block can be
+hashed: the scheduler only content-hashes a block once it is fully filled,
+and by that point a future ingest step will have overwritten the speculative
+slots with the correct committed KV.  No stale draft KV can leak into a
+prefix-cache match.
 
-1. **Ingest** — for every drafting request, run the draft model over the
-   committed-token suffix it has not yet written into the draft cache
-   (``token_ids[draft_seq_len:committed_len]``) as one batched prefill. This
-   advances the draft cache to the committed length and overwrites any stale
-   KV left by rejected drafts from the previous step. The last row per request
-   yields the first draft token.
-2. **Decode** — ``num_speculative_tokens - 1`` batched single-token steps, each
-   feeding the previous draft token to produce the next.
+**Why every active row ingests, not just drafting-eligible ones.** The
+scheduler advances a request's ``num_computed_tokens`` and marks the
+committed group's blocks "cached" based on its own per-step bookkeeping,
+trusting that whatever it scheduled, the worker actually computed -- for
+*every* registered group, uniformly, every step. But
+``SpeculativeDecodeController.draft_eligible_requests`` intentionally
+excludes non-greedy requests and intermediate prefill chunks from
+*drafting*. If those rows also skipped *ingest*, the scheduler would believe
+their committed-group blocks hold real KV when they never did, and a later,
+unrelated request whose prompt happens to hash-match that prefix could be
+handed those blocks as a "cache hit" -- silent data corruption, not just a
+missed optimization. So ``propose()`` ingests every decode and prefill row
+(chunked or not, greedy or not) to keep the committed group's physical KV
+genuinely in sync with what the scheduler believes, and only *drafts*
+(produces returned token ids, runs the extra lookahead decode steps) for the
+eligible subset.
 
-The verify half is unchanged: drafts are handed back via ``take_draft_token_ids``
-and verified next step by ``SpeculativeDecodeController.verify_greedy``.
-
-KV-budget note: the draft cache is a second store with the *same block count*
-as the target's cache but sized for the draft model's (smaller) dimensions — so
-it is materially smaller than the target's KV cache for a small draft. It is
-allocated *after* the target budget is computed, so it is not subtracted from
-the target KV budget. This is safe only with headroom
-(``VLLM_METAL_MEMORY_FRACTION`` well below 1.0); a budget split is a follow-up.
+Each step: ingest advances every row's committed KV to ``committed_len``,
+then ``num_speculative_tokens - 1`` single-token decode steps run for
+drafting rows only. Drafts are handed back via ``take_draft_token_ids`` and
+verified next step by ``SpeculativeDecodeController.verify_greedy``.
 """
 
 from __future__ import annotations
@@ -47,6 +65,7 @@ from typing import TYPE_CHECKING, Any
 import mlx.core as mx
 from mlx_lm import load as mlx_lm_load
 from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
 from vllm.v1.outputs import DraftTokenIds
 
 from vllm_metal import envs
@@ -61,11 +80,12 @@ from vllm_metal.utils import get_model_download_path
 from vllm_metal.v1.mlx_lm_paths import mlx_lm_compatible_model_path
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
+    from vllm.config import ParallelConfig
     from vllm.config.speculative import SpeculativeConfig
 
-    from vllm_metal.v1.model_runner import RequestState
+    from vllm_metal.v1.model_runner import PrefillRequest, RequestState
     from vllm_metal.v1.proposer import ProposeContext
     from vllm_metal.v1.spec_decode import SpeculativeDecodeController
 
@@ -73,7 +93,7 @@ logger = init_logger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
-class _DraftDims:
+class DraftDims:
     num_layers: int
     num_kv_heads: int
     head_dim: int
@@ -88,6 +108,7 @@ class _DraftPlan:
     committed_len: int
     draft_seq_len: int
     ingest_tokens: list[int]
+    is_drafting: bool
 
 
 # Ingests at or below this size are submitted as expanded decode rows instead
@@ -105,7 +126,8 @@ class DraftModelProposer:
         *,
         model: Any,
         block_size: int,
-        num_blocks: int,
+        committed_num_blocks: int,
+        scratch_reserve_blocks: int,
         num_layers: int,
         controller: SpeculativeDecodeController,
         extract_logits: Callable[[Any], mx.array],
@@ -127,14 +149,30 @@ class DraftModelProposer:
         # real per-request offsets come from the paged context, so these carry
         # no state — allocate once and reuse across steps, not per propose().
         self._offset_caches = [OffsetCache(0) for _ in range(num_layers)]
-        # Committed positions written into the draft cache, per request.
+        # Committed positions actually written into the draft cache, per
+        # request. Self-tracked so it only advances when we actually ran a
+        # forward pass; seeded from the scheduler's cache-hit boundary the
+        # first time a request is seen (see _make_decode_plan), so a
+        # resubmitted/shared prefix skips re-ingest (#482).
         self._draft_seq_lens: dict[str, int] = {}
-        # The draft owns its block allocation: it drafts K positions AHEAD of
-        # what the target has committed, so it cannot reuse the target's
-        # block_ids (those exactly fit the committed length and run out at the
-        # next block boundary). Each request draws draft blocks from this pool.
-        self._free_blocks: list[int] = list(range(num_blocks))
-        self._req_blocks: dict[str, list[int]] = {}
+        # Scheduler-owned KV-cache group index for the committed portion.
+        # Unknown at construction time -- the physical backend below is
+        # built before the scheduler has decided kv_cache_config (see
+        # ModelCachePolicy._adopt_draft_scheduler_group) -- so this is set
+        # later via adopt_committed_group().
+        self._committed_group_index: int | None = None
+        self._committed_num_blocks = committed_num_blocks
+        # The speculative lookahead tail draws from block ids the scheduler
+        # never assigns: [committed_num_blocks, committed_num_blocks +
+        # scratch_reserve_blocks). The physical backend (see `build`) is
+        # over-provisioned to cover this range.
+        self._scratch_free_blocks: list[int] = list(
+            range(
+                committed_num_blocks,
+                committed_num_blocks + scratch_reserve_blocks,
+            )
+        )
+        self._scratch_req_blocks: dict[str, list[int]] = {}
 
     # -- construction --------------------------------------------------------
 
@@ -143,13 +181,16 @@ class DraftModelProposer:
         cls,
         *,
         speculative_config: SpeculativeConfig,
+        parallel_config: ParallelConfig,
         controller: SpeculativeDecodeController,
         extract_logits: Callable[[Any], mx.array],
-        num_blocks: int,
+        committed_num_blocks: int,
+        scratch_reserve_blocks: int,
         block_size: int,
         dtype: mx.Dtype,
     ) -> DraftModelProposer:
-        model, dims = _load_draft_model(speculative_config)
+        model, dims = _load_draft_model(speculative_config, parallel_config)
+        total_blocks = committed_num_blocks + scratch_reserve_blocks
         backend = MHAPagedAttentionRuntime(
             num_layers=dims.num_layers,
             num_kv_heads=dims.num_kv_heads,
@@ -157,22 +198,25 @@ class DraftModelProposer:
             block_size=block_size,
             dtype=dtype,
         )
-        backend.initialize(num_blocks)
+        backend.initialize(total_blocks)
         n_patched = backend.patch_model(model)
         logger.info(
             "Draft model loaded for speculative decoding: %s "
-            "(layers=%d, kv_heads=%d, head_dim=%d, patched=%d, num_blocks=%d)",
+            "(layers=%d, kv_heads=%d, head_dim=%d, patched=%d, "
+            "committed_blocks=%d, scratch_blocks=%d)",
             speculative_config.draft_model_config.model,
             dims.num_layers,
             dims.num_kv_heads,
             dims.head_dim,
             n_patched,
-            num_blocks,
+            committed_num_blocks,
+            scratch_reserve_blocks,
         )
         return cls(
             model=model,
             block_size=block_size,
-            num_blocks=num_blocks,
+            committed_num_blocks=committed_num_blocks,
+            scratch_reserve_blocks=scratch_reserve_blocks,
             num_layers=dims.num_layers,
             controller=controller,
             extract_logits=extract_logits,
@@ -184,6 +228,16 @@ class DraftModelProposer:
             # head_dim.  Only the decode kernel's head bound remains.
             merge_ingest_windows=dims.head_dim <= PA_WINDOW_MAX_HEAD_SIZE,
         )
+
+    def adopt_committed_group(self, group_index: int) -> None:
+        """Record which scheduler KV-cache group owns the committed portion.
+
+        Called from ``ModelCachePolicy._adopt_draft_scheduler_group`` once
+        ``kv_cache_config`` exists -- after this proposer is built, since the
+        physical backend above is sized before the scheduler has decided
+        groups.
+        """
+        self._committed_group_index = group_index
 
     # -- MetalProposer protocol ---------------------------------------------
 
@@ -201,54 +255,73 @@ class DraftModelProposer:
         num_speculative_tokens = ctx.num_speculative_tokens
         if num_speculative_tokens <= 0:
             return None
+        if self._committed_group_index is None:
+            raise RuntimeError(
+                "DraftModelProposer.propose() called before "
+                "adopt_committed_group() -- initialize_kv_cache() must run "
+                "before the first speculative decode step"
+            )
 
         self._prune_finished(ctx.request_states)
         plans = self._collect_draft_plans(ctx, num_speculative_tokens)
         if not plans:
             return None
 
-        # Step 1: ingest committed suffixes; first draft token per request.
-        draft_cols: list[mx.array] = [
-            self._ingest_and_draft_first(plans, self._offset_caches)
-        ]
-        # Steps 2..K: single-token decode per request.
-        for draft_index in range(1, num_speculative_tokens):
-            draft_cols.append(
-                self._draft_step(
-                    plans, draft_cols[-1], draft_index, self._offset_caches
-                )
-            )
+        # Ingest every active row (see module docstring); predicts a first
+        # token per row, used below only for drafting rows.
+        first_tokens = self._ingest_and_draft_first(plans, self._offset_caches)
 
-        drafts = mx.stack(draft_cols, axis=1)  # [num_plans, K]
-        mx.eval(drafts)
-        rows: list[list[int]] = drafts.tolist()  # type: ignore[assignment]
-
-        # The draft cache now holds KV through committed_len for each request.
+        # The committed group now holds KV through committed_len for every
+        # row that ingested this step, drafting or not.
         for plan in plans:
             self._draft_seq_lens[plan.req_id] = plan.committed_len
 
+        drafting_plans = [plan for plan in plans if plan.is_drafting]
+        if not drafting_plans:
+            return None
+
+        drafting_indices = mx.array(
+            [i for i, plan in enumerate(plans) if plan.is_drafting],
+            dtype=mx.int32,
+        )
+        draft_cols: list[mx.array] = [mx.take(first_tokens, drafting_indices, axis=0)]
+        # Steps 2..K: single-token decode per drafting row.
+        for draft_index in range(1, num_speculative_tokens):
+            draft_cols.append(
+                self._draft_step(
+                    drafting_plans,
+                    draft_cols[-1],
+                    draft_index,
+                    self._offset_caches,
+                )
+            )
+
+        drafts = mx.stack(draft_cols, axis=1)  # [num_drafting, K]
+        mx.eval(drafts)
+        rows: list[list[int]] = drafts.tolist()  # type: ignore[assignment]
+
         return DraftTokenIds(
-            req_ids=[plan.req_id for plan in plans],
+            req_ids=[plan.req_id for plan in drafting_plans],
             draft_token_ids=[[int(token) for token in row] for row in rows],
         )
 
     def release_requests(self, req_ids: set[str]) -> None:
-        # Return a preempted/evicted request's draft KV blocks to the free pool
-        # and drop its committed-length bookkeeping, so it does not pin draft
-        # cache while it waits; a resumed request re-ingests from the paged
-        # context. Mirrors _prune_finished for an explicit lifecycle set.
+        # Only the speculative lookahead tail is proposer-owned; the
+        # committed portion's lifecycle (finish/evict/refcount) belongs to
+        # the scheduler now, like any other KV-cache group. Mirrors
+        # _prune_finished for an explicit lifecycle set.
         for req_id in req_ids:
-            blocks = self._req_blocks.pop(req_id, None)
+            blocks = self._scratch_req_blocks.pop(req_id, None)
             if blocks is not None:
-                self._free_blocks.extend(blocks)
+                self._scratch_free_blocks.extend(blocks)
             self._draft_seq_lens.pop(req_id, None)
 
     # -- internals -----------------------------------------------------------
 
-    def _prune_finished(self, request_states: Any) -> None:
-        for req_id in list(self._req_blocks.keys()):
+    def _prune_finished(self, request_states: Mapping[str, RequestState]) -> None:
+        for req_id in list(self._scratch_req_blocks.keys()):
             if req_id not in request_states:
-                self._free_blocks.extend(self._req_blocks.pop(req_id))
+                self._scratch_free_blocks.extend(self._scratch_req_blocks.pop(req_id))
         for req_id in list(self._draft_seq_lens.keys()):
             if req_id not in request_states:
                 del self._draft_seq_lens[req_id]
@@ -256,38 +329,70 @@ class DraftModelProposer:
     def _collect_draft_plans(
         self, ctx: ProposeContext, num_speculative_tokens: int
     ) -> list[_DraftPlan]:
-        # Eligibility filter (greedy + non-intermediate prefill + greedy-only
-        # sampling) is shared with every greedy drafter; this step then builds
-        # per-request ingest plans and drops any row with no newly-committed
-        # tokens to ingest.
-        eligible = self._controller.draft_eligible_requests(
-            ctx.decode_reqs,
-            ctx.decode_token_ids,
-            ctx.prefill_reqs,
-            ctx.prefill_result_modes,
-            ctx.request_states,
-        )
+        # can_draft_greedy/draft_eligible_requests decide *drafting*
+        # eligibility only here (greedy + non-intermediate prefill +
+        # greedy-only sampling); ingest itself runs for every active row
+        # regardless -- see module docstring.
+        drafting_req_ids = {
+            req_id
+            for req_id, _ in self._controller.draft_eligible_requests(
+                ctx.decode_reqs,
+                ctx.decode_token_ids,
+                ctx.prefill_reqs,
+                ctx.prefill_result_modes,
+                ctx.request_states,
+            )
+        }
         plans: list[_DraftPlan] = []
-        for req_id, state in eligible:
-            plan = self._make_plan(req_id, state, num_speculative_tokens)
+        for req_id, state in ctx.decode_reqs:
+            plan = self._make_decode_plan(
+                req_id, state, num_speculative_tokens, drafting_req_ids
+            )
+            if plan is not None:
+                plans.append(plan)
+
+        seen = {plan.req_id for plan in plans}
+        for prefill, result_mode in zip(
+            ctx.prefill_reqs, ctx.prefill_result_modes, strict=True
+        ):
+            if prefill.req_id in seen:
+                continue
+            seen.add(prefill.req_id)
+            plan = self._make_prefill_plan(
+                prefill, result_mode, num_speculative_tokens, drafting_req_ids
+            )
             if plan is not None:
                 plans.append(plan)
         return plans
 
-    def _make_plan(
-        self, req_id: str, state: RequestState, num_speculative_tokens: int
+    def _make_decode_plan(
+        self,
+        req_id: str,
+        state: RequestState,
+        num_speculative_tokens: int,
+        drafting_req_ids: set[str],
     ) -> _DraftPlan | None:
+        # state.token_ids already reflects this step's sampled token(s) by
+        # the time propose() runs (mirrors the runner's own decode-state
+        # update), so this is valid for decode -- unlike prefill, where
+        # token_ids is pre-populated with the whole future prompt and
+        # committed_len must come from the scheduled chunk instead (see
+        # _make_prefill_plan).
         committed_len = len(state.token_ids)
-        draft_seq_len = self._draft_seq_lens.get(req_id, 0)
+        draft_seq_len = self._draft_seq_lens.setdefault(
+            req_id, state.num_computed_tokens
+        )
         if draft_seq_len >= committed_len:
             # No newly committed tokens to ingest (should not happen for an
-            # accepted decode step or a finalized prefill); skip rather than
-            # emit an empty forward.
+            # accepted decode step); skip rather than emit an empty forward.
             return None
-        # Draft positions reach committed_len + K - 1; size the draft block
-        # table to cover them from the draft's own pool.
-        block_ids = self._ensure_draft_blocks(
-            req_id, committed_len + num_speculative_tokens
+        is_drafting = req_id in drafting_req_ids
+        assert self._committed_group_index is not None
+        block_ids = self._ensure_blocks(
+            req_id,
+            committed_group_block_ids=state.block_ids[self._committed_group_index],
+            total_positions=committed_len
+            + (num_speculative_tokens if is_drafting else 0),
         )
         return _DraftPlan(
             req_id=req_id,
@@ -295,22 +400,80 @@ class DraftModelProposer:
             committed_len=committed_len,
             draft_seq_len=draft_seq_len,
             ingest_tokens=list(state.token_ids[draft_seq_len:committed_len]),
+            is_drafting=is_drafting,
         )
 
-    def _ensure_draft_blocks(self, req_id: str, num_positions: int) -> list[int]:
-        """Grow this request's draft block table to cover ``num_positions``."""
-        needed = (num_positions + self._block_size - 1) // self._block_size
-        blocks = self._req_blocks.setdefault(req_id, [])
-        while len(blocks) < needed:
-            if not self._free_blocks:
+    def _make_prefill_plan(
+        self,
+        prefill: PrefillRequest,
+        result_mode: str,
+        num_speculative_tokens: int,
+        drafting_req_ids: set[str],
+    ) -> _DraftPlan | None:
+        if not prefill.token_ids:
+            return None
+        req_id = prefill.req_id
+        committed_len = prefill.start_pos + len(prefill.token_ids)
+        is_drafting = result_mode != "intermediate" and req_id in drafting_req_ids
+        assert self._committed_group_index is not None
+        block_ids = self._ensure_blocks(
+            req_id,
+            committed_group_block_ids=prefill.block_ids[self._committed_group_index],
+            total_positions=committed_len
+            + (num_speculative_tokens if is_drafting else 0),
+        )
+        plan = _DraftPlan(
+            req_id=req_id,
+            block_ids=block_ids,
+            committed_len=committed_len,
+            draft_seq_len=prefill.start_pos,
+            ingest_tokens=list(prefill.token_ids),
+            is_drafting=is_drafting,
+        )
+        return plan
+
+    def _ensure_blocks(
+        self,
+        req_id: str,
+        *,
+        committed_group_block_ids: list[int],
+        total_positions: int,
+    ) -> list[int]:
+        """Scheduler-assigned committed blocks + this request's scratch tail.
+
+        The committed prefix comes straight from the scheduler's own
+        allocation for the draft KV-cache group -- never grown or freed
+        here. Only the tail beyond it (the speculative lookahead, when
+        drafting) is drawn from the local scratch pool, grown or shrunk to
+        exactly what this step needs.
+
+        When ``committed_len`` is not block-aligned, ``total_positions``
+        extends into the last committed block's unfilled tail.  The
+        lookahead draft steps write speculative KV into those slots of a
+        scheduler-owned block.  This is safe: ingest always rewrites the
+        committed range before the scheduler can hash the block (see
+        module docstring, "Block-alignment note").
+        """
+        needed_total = cdiv(total_positions, self._block_size)
+        scratch_needed = max(0, needed_total - len(committed_group_block_ids))
+
+        scratch_blocks = self._scratch_req_blocks.setdefault(req_id, [])
+        if len(scratch_blocks) > scratch_needed:
+            self._scratch_free_blocks.extend(scratch_blocks[scratch_needed:])
+            del scratch_blocks[scratch_needed:]
+        while len(scratch_blocks) < scratch_needed:
+            if not self._scratch_free_blocks:
                 raise RuntimeError(
-                    f"Draft KV cache exhausted: request {req_id!r} needs "
-                    f"{needed} blocks but the draft pool is empty "
-                    f"({len(self._req_blocks)} active requests). "
-                    "Lower --max-num-seqs or raise VLLM_METAL_MEMORY_FRACTION."
+                    f"Draft KV scratch pool exhausted: request {req_id!r} "
+                    f"needs {scratch_needed} lookahead block(s) but none are "
+                    "free. Lower --max-num-seqs or raise "
+                    "VLLM_METAL_MEMORY_FRACTION."
                 )
-            blocks.append(self._free_blocks.pop())
-        return blocks
+            scratch_blocks.append(self._scratch_free_blocks.pop())
+        if not scratch_blocks:
+            self._scratch_req_blocks.pop(req_id, None)
+
+        return list(committed_group_block_ids) + scratch_blocks
 
     def _ingest_and_draft_first(
         self, plans: list[_DraftPlan], offset_caches: list[OffsetCache]
@@ -383,14 +546,81 @@ class DraftModelProposer:
         return mx.argmax(logits[0], axis=-1)
 
 
-def _load_draft_model(
+def resolve_draft_dims(
     speculative_config: SpeculativeConfig,
-) -> tuple[Any, _DraftDims]:
+    parallel_config: ParallelConfig,
+) -> DraftDims:
+    """Resolve the draft model's cache shape from its HF config alone.
+
+    Config-only and weight-free, so this can run early in the runner
+    lifecycle (before ``determine_available_memory()``/``get_kv_cache_spec()``)
+    to size a scheduler-visible KV-cache group for the draft model, well
+    before its MLX weights are actually loaded in ``_load_draft_model``.
+
+    Delegates to ``ModelConfig``'s own accessors rather than re-deriving GQA
+    head-count and head-size fallbacks from raw ``hf_config`` fields --
+    ``get_head_size()``/``get_num_kv_heads()`` already handle those (and the
+    MLA-becomes-MQA case), the same way upstream's own
+    ``SpecDecodeBaseProposer`` reads them off its ``draft_model_config``.
+
+    Raises :class:`NotImplementedError` if the draft model uses sliding-window
+    or hybrid attention.  ``_draft_layer_specs`` unconditionally emits
+    ``FullAttentionSpec`` for every draft layer, so a sliding-window draft
+    would silently get the wrong spec and corrupt KV cache sizing.
+    """
     draft_model_config = speculative_config.draft_model_config
     if draft_model_config is None:
         raise ValueError(
             "draft_model speculative decoding requires a draft_model_config"
         )
+    _require_full_attention_draft(draft_model_config)
+    return DraftDims(
+        num_layers=draft_model_config.get_total_num_hidden_layers(),
+        num_kv_heads=draft_model_config.get_num_kv_heads(parallel_config),
+        head_dim=draft_model_config.get_head_size(),
+    )
+
+
+def _require_full_attention_draft(draft_model_config: Any) -> None:
+    """Reject draft models that are not plain full-attention transformers.
+
+    The scheduler-managed draft KV cache (``_draft_layer_specs``) registers
+    every draft layer as a ``FullAttentionSpec``.  A draft model whose HF
+    config declares sliding-window attention or mixed layer types (e.g.
+    Gemma4's ``sliding_attention`` / ``full_attention`` hybrid) would be
+    silently misrepresented, leading to incorrect KV cache sizing and
+    potential data corruption.  Fail fast instead.
+    """
+    # 1) Global or per-model sliding window
+    sliding_window = draft_model_config.get_sliding_window()
+    if sliding_window is not None:
+        raise NotImplementedError(
+            f"Draft model has sliding_window={sliding_window}, but the "
+            "draft KV cache only supports full-attention transformers. "
+            "Sliding-window draft models are not supported."
+        )
+    # 2) Hybrid layer types (e.g. Gemma4 sliding_attention + full_attention)
+    hf_text_config = getattr(draft_model_config, "hf_text_config", None)
+    layer_types = (
+        getattr(hf_text_config, "layer_types", None) if hf_text_config else None
+    )
+    if layer_types is not None:
+        non_full = [lt for lt in layer_types if lt != "full_attention"]
+        if non_full:
+            raise NotImplementedError(
+                f"Draft model has non-full-attention layer types "
+                f"{set(non_full)}, but the draft KV cache only supports "
+                "plain full-attention transformers."
+            )
+
+
+def _load_draft_model(
+    speculative_config: SpeculativeConfig,
+    parallel_config: ParallelConfig,
+) -> tuple[Any, DraftDims]:
+    dims = resolve_draft_dims(speculative_config, parallel_config)
+    draft_model_config = speculative_config.draft_model_config
+    assert draft_model_config is not None  # resolve_draft_dims already checked
 
     # Its own instance (patched to its own draft KV cache, so it must not alias
     # the target). AWQ / variable-head-dim drafts aren't handled here yet
@@ -399,13 +629,4 @@ def _load_draft_model(
     with mlx_lm_compatible_model_path(model_path) as compatible_path:
         model, _ = mlx_lm_load(str(compatible_path))
 
-    hf = draft_model_config.hf_config
-    num_layers = int(hf.num_hidden_layers)
-    num_attention_heads = int(hf.num_attention_heads)
-    num_kv_heads = int(getattr(hf, "num_key_value_heads", num_attention_heads))
-    head_dim = int(getattr(hf, "head_dim", 0) or hf.hidden_size // num_attention_heads)
-    return model, _DraftDims(
-        num_layers=num_layers,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-    )
+    return model, dims

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -14,7 +14,7 @@ Key contracts:
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
-from typing import Any, Literal, NamedTuple, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias, cast
 
 import mlx.core as mx
 import numpy as np
@@ -124,6 +124,13 @@ from vllm_metal.v1.spec_decode import (
 )
 from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
+if TYPE_CHECKING:
+    # Kept out of the runtime import graph: draft_model_proposer.py pulls in
+    # mlx_lm's model loader at module scope, which should only load when
+    # draft_model speculative decoding is actually configured (see the lazy
+    # runtime import in __init__ and in install_drafter).
+    from vllm_metal.v1.draft_model_proposer import DraftDims
+
 logger = init_logger(__name__)
 
 
@@ -182,6 +189,12 @@ class RequestState:
     # Decode reconstructs M-RoPE positions as
     # ``len(token_ids) - 1 + mrope_position_delta``; ``None`` for text-only.
     mrope_position_delta: int | None = None
+    # Scheduler-reconciled prefix-cache-hit boundary (the same value used to
+    # resume the target's own paged prefill, see `_add_new_requests`).
+    # DraftModelProposer reuses this as the committed-KV group's ingest
+    # boundary instead of self-tracking it, so a cache hit shared across
+    # requests skips re-ingest for the draft's KV too (#482).
+    num_computed_tokens: int = 0
 
 
 class PrefillRequest(NamedTuple):
@@ -356,6 +369,16 @@ class MetalModelRunner:
         self._multimodal_adapter: MultimodalRuntimeAdapter | None = None
         self._gemma4_mtp_assistant: Gemma4MTPAssistantRuntime | None = None
         self._drafter: MetalProposer | None = None
+        # Resolved eagerly (config-only, no weights) so `ModelCachePolicy`
+        # can size a scheduler-visible KV-cache group for the draft model
+        # before `determine_available_memory()`/`get_kv_cache_spec()` run.
+        # The draft's MLX weights load later, in `install_drafter`.
+        self._draft_dims: DraftDims | None = None
+        spec = vllm_config.speculative_config
+        if spec is not None and spec.uses_draft_model():
+            from vllm_metal.v1.draft_model_proposer import resolve_draft_dims
+
+            self._draft_dims = resolve_draft_dims(spec, vllm_config.parallel_config)
         self.encoder_cache: EncoderCache | None = None
 
         # Request state cache for incremental decoding
@@ -755,6 +778,14 @@ class MetalModelRunner:
         """Bytes for one request's linear attention state across all GDN layers."""
         return self._cache_policy.linear_cache_bytes_per_slot()
 
+    def draft_scratch_reserve_blocks(self) -> int:
+        """Blocks reserved for the draft model's speculative lookahead tail."""
+        return self._cache_policy.draft_scratch_reserve_blocks()
+
+    def draft_scratch_reserve_bytes(self) -> int:
+        """Bytes held out of the KV budget for the draft's scratch tail."""
+        return self._cache_policy.draft_scratch_reserve_bytes()
+
     def profile_run(self) -> int:
         """Measure MLX buffer-cache footprint of one forward pass and cap the allocator.
 
@@ -876,24 +907,24 @@ class MetalModelRunner:
         elif spec.uses_draft_model():
             from vllm_metal.v1.draft_model_proposer import DraftModelProposer
 
+            # `num_blocks` is the scheduler-visible committed-KV capacity for
+            # the draft group (see cache_policy._draft_layer_specs); the
+            # physical backend needs `scratch_reserve_blocks` on top of that
+            # for the speculative lookahead tail, which the scheduler never
+            # sees or assigns (see draft_scratch_reserve_blocks). The KV
+            # budget already reserved this many blocks' worth of bytes off
+            # the top (WorkerCachePlanner._paged_attention_plan), so this is
+            # guaranteed to fit.
             self._drafter = DraftModelProposer.build(
                 speculative_config=spec,
+                parallel_config=self.vllm_config.parallel_config,
                 controller=self._spec_decode_controller,
                 extract_logits=self._model_adapter.extract_logits,
-                num_blocks=num_blocks,
+                committed_num_blocks=num_blocks,
+                scratch_reserve_blocks=self.draft_scratch_reserve_blocks(),
                 block_size=block_size,
                 dtype=self.kv_cache_dtype,
             )
-            max_num_seqs = self.scheduler_config.max_num_seqs
-            extra_per_req = (spec.num_speculative_tokens + block_size - 1) // block_size
-            if num_blocks < max_num_seqs * extra_per_req:
-                raise ValueError(
-                    f"Draft KV cache too small: {num_blocks} blocks cannot "
-                    f"support {max_num_seqs} concurrent requests each needing "
-                    f"{extra_per_req} extra block(s) for "
-                    f"{spec.num_speculative_tokens} speculative tokens. "
-                    "Raise VLLM_METAL_MEMORY_FRACTION or lower --max-num-seqs."
-                )
         elif spec.method == "ngram":
             from vllm_metal.v1.ngram_proposer import NgramProposer
 
@@ -1702,6 +1733,7 @@ class MetalModelRunner:
                     block_ids=prefill.block_ids,
                     lora_id=prefill.lora_id,
                     mrope_position_delta=mm_delta,
+                    num_computed_tokens=prefill.start_pos,
                 )
                 continue
 
@@ -2207,6 +2239,7 @@ class MetalModelRunner:
                         generated_tokens=0,
                         block_ids=sched_block_ids,
                         lora_id=lora_id,
+                        num_computed_tokens=computed_tokens,
                     )
                 continue
 


### PR DESCRIPTION
CC: @ricky-chaoju 

### Problem
`method="draft_model"` speculative decoding re-prefills a request's entire prompt into the draft model's KV on every new request. The proposer's private block allocator has no content-based reuse, so even a resubmitted identical prompt pays a full draft prefill again (#482). PR #500 fixed this with a proposer-private prefix cache (vLLM's BlockPool for hashing, refcounting, and eviction), but was closed: the cache lived in the proposer/worker path while the real cache policy, `cache_salt`, per-request cache-read rules (`skip_reading_prefix_cache`), and the actual scheduler admission/allocation limit live in the scheduler/request layer, which a proposer-private allocator structurally cannot see.

### Fix
Split the draft model's KV by where cross-request reuse actually happens:

- **Committed portion (`[0, committed_len)`)**: Registered as a real second scheduler-owned `KVCacheSpec` group (`cache_policy.py::_draft_layer_specs`), sized and budgeted alongside the target's own groups. The scheduler hashes, matches, admits, and evicts it exactly like the target's, so `cache_salt`, `skip_reading_prefix_cache`, and the real admission limit apply automatically. `draft_model_proposer.py`'s `_make_decode_plan` and `_make_prefill_plan` read block IDs straight off `state.block_ids[self._committed_group_index]` (the scheduler's own assignment) rather than a private pool.
- **Speculative lookahead tail**: Positions drafted ahead of `committed_len` (not yet verified) have no scheduler concept, so it stays a small proposer-local scratch reservation over-provisioned into the draft's physical backend beyond the scheduler-visible block count.
- **Validation fail-fast**: `resolve_draft_dims` now rejects draft models with sliding-window or hybrid attention (e.g., Gemma4) at config-resolution time, since `_draft_layer_specs` unconditionally emits `FullAttentionSpec` and a mismatch would silently corrupt KV cache sizing.
- **Ingest alignment**: `DraftModelProposer` now ingests every active decode and prefill row each step (chunked or not, greedy-eligible or not), not just drafting-eligible ones. The scheduler advances `num_computed_tokens` and marks committed-group blocks "cached" uniformly per step, trusting whatever it scheduled was actually computed; skipping ingest for excluded rows would leave the scheduler believing blocks hold real KV that was never written. Only drafting (producing returned tokens, running extra lookahead steps) stays restricted to the greedy-eligible, non-intermediate subset.

### Behavior Changes
The draft cache's memory is now counted against the shared Metal KV budget rather than allocated after the target's budget was computed and left untracked. Concretely, each scheduler block now reserves room for the draft layers as well, so `per_block_bytes` doubles (1,835,008 -> 3,670,016 on a 128 GB Mac) and `num_blocks` halves (30,398 -> 15,189) for the same `VLLM_METAL_MEMORY_FRACTION`. This is a hard requirement, not a latent risk: on base at 0.5 the target takes the entire budget (`kv_budget` 55.78 GB, `num_blocks` 30,398) and drafting dies with a Metal out-of-memory inside `mx.eval(drafts)` — it only fits at 0.3. With this PR the same 0.5 fraction works end to end. `RequestState` gains a `num_computed_tokens` field set at request creation from the scheduler's own reconciled cache-hit boundary.


### Verification
Same methodology as the original #500 validation thread (`Qwen/Qwen3-0.6B` draft==target, greedy, resubmitting an identical prompt under a fresh request ID). The resubmit's first draft plan goes from full-prompt ingest with zero reuse to ingest 16 / reuse 8176 at 8k (ingest 16 / reuse 2032 at 2k); first propose drops from 3525 ms to 111 ms and e2e from 66.8 to 31.2 ms/tok at 8k (438 to 64 ms and 21.9 to 19.5 at 2k).

Losslessness is shown by comparing spec-decode output against a non-speculative reference run on the same tree (rather than cross-tree SHA comparison, which is unreliable when the base path is broken). The validation harness is in-tree at `tools/benchmark/draft_resubmit_benchmark.py`.

### Tests & Documentation
- E2E coverage that the draft group honors `cache_salt` and `skip_reading_prefix_cache` (the cache-policy gaps named when the proposer-private draft cache was rejected).
- Stub-level unit test that the scratch reserve covers `max_num_seqs` concurrent drafters.
- Regression tests verifying sliding-window and hybrid-attention draft models are rejected at config resolution time.
- Updated `docs/speculative_decoding.md`: documents scheduler-managed/budgeted draft KV cache, SWA/hybrid draft rejection at startup, and the block-alignment safety invariant for lookahead writes into scheduler-owned blocks.

Addresses #482 direction 1 (per-request re-ingest). The steady-state proposer overhead (#482 Problem 2) is unaffected and left as a follow-up.

Credits:
@KrxGu  for the first PR #500 