### PR TITLE
Keep GDN prefill state handoff compact and lazy

### DIFF
--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -312,7 +312,6 @@ def _recurrent_prefill_request(
     output_dtype: mx.Dtype = mx.float32,
     compute_dtype: mx.Dtype | None = None,
     defer_state_scatter: bool = False,
-    materialize_outputs: bool = False,
 ) -> GDNRecurrentPrefillRequest:
     return GDNRecurrentPrefillRequest(
         q=q,
@@ -327,7 +326,6 @@ def _recurrent_prefill_request(
         cu_seqlens=cu_seqlens,
         compute_dtype=compute_dtype,
         defer_state_scatter=defer_state_scatter,
-        materialize_outputs=materialize_outputs,
     )
 
 
@@ -1240,7 +1238,7 @@ class TestLazyRecurrentPrefill:
             np.array(cache.recurrent_states[0]), np.array(initial_state)
         )
 
-    def test_materialized_deferred_prefill_evals_compact_state(
+    def test_deferred_prefill_does_not_materialize_outputs(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Arrange
@@ -1270,7 +1268,6 @@ class TestLazyRecurrentPrefill:
             slot_ids=slot_ids,
             cu_seqlens=[0, 2, 5],
             defer_state_scatter=True,
-            materialize_outputs=True,
         )
 
         # Act
@@ -1283,15 +1280,13 @@ class TestLazyRecurrentPrefill:
 
         # Assert
         assert result is not None
-        assert len(eval_args) == 1
-        assert len(eval_args[0]) == 2
-        assert eval_args[0][1].shape == (2, 2, 3, 32)
-        assert cache.pending_recurrent_state(0, slot_ids) is eval_args[0][1]
+        assert not eval_args
+        assert cache.pending_recurrent_state(0, slot_ids) is not None
         np.testing.assert_array_equal(
             np.array(cache.recurrent_states[0]), np.array(initial_state)
         )
 
-    def test_materialized_scattered_prefill_contiguates_state_pool(
+    def test_scattered_prefill_does_not_force_materialization(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Arrange
@@ -1326,7 +1321,6 @@ class TestLazyRecurrentPrefill:
             slot_ids=slot_ids,
             cu_seqlens=[0, 2, 5],
             defer_state_scatter=False,
-            materialize_outputs=True,
         )
 
         # Act
@@ -1339,10 +1333,8 @@ class TestLazyRecurrentPrefill:
 
         # Assert
         assert result is not None
-        assert len(contiguous_args) == 1
-        assert contiguous_args[0].shape == (4, 2, 3, 32)
-        assert len(eval_args) == 1
-        assert eval_args[0][1] is cache.recurrent_states[0]
+        assert not contiguous_args
+        assert not eval_args
         assert cache.pending_recurrent_state(0, slot_ids) is None
 
     @pytest.mark.parametrize(

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -178,7 +178,7 @@ class TestGDNPagedStateCache:
         )
 
         # Act
-        view = cache.recurrent_state_for_decode(0, [0, 2])
+        view = cache.recurrent_state_for_update(0, [0, 2], allow_compact=True)
 
         # Assert
         assert not view.uses_compact_state
@@ -189,7 +189,7 @@ class TestGDNPagedStateCache:
         np.testing.assert_array_equal(np.array(view.state), expected_state)
         np.testing.assert_array_equal(np.array(view.state_slot_ids), [0, 2])
 
-    def test_decode_state_view_owns_compact_slot_mapping(self) -> None:
+    def test_state_view_owns_compact_slot_mapping(self) -> None:
         # Arrange
         cache = _make_state_cache(max_seqs=4, conv_kernel_dim=3, conv_dim=4)
         pending = mx.full((2, 2, 4), 9, dtype=mx.float32)

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -168,7 +168,10 @@ class TestGDNPagedStateCache:
             np.array(pending_state), np.full((2, 1, 4, 32), 9)
         )
 
-    def test_recurrent_decode_view_drains_mismatched_pending_state(self) -> None:
+    @pytest.mark.parametrize("slot_ids", [[0, 2], [1, 3]])
+    def test_recurrent_state_view_drains_mismatched_pending_state(
+        self, slot_ids: list[int]
+    ) -> None:
         # Arrange
         cache = _make_state_cache(max_seqs=4)
         initial_state = mx.arange(4 * 1 * 4 * 32, dtype=mx.float32).reshape(4, 1, 4, 32)
@@ -178,7 +181,7 @@ class TestGDNPagedStateCache:
         )
 
         # Act
-        view = cache.recurrent_state_for_update(0, [0, 2], allow_compact=True)
+        view = cache.recurrent_state_for_update(0, slot_ids, allow_compact=True)
 
         # Assert
         assert not view.uses_compact_state
@@ -187,7 +190,29 @@ class TestGDNPagedStateCache:
         expected_state = np.array(initial_state)
         expected_state[[3, 1]] = 7
         np.testing.assert_array_equal(np.array(view.state), expected_state)
-        np.testing.assert_array_equal(np.array(view.state_slot_ids), [0, 2])
+        np.testing.assert_array_equal(np.array(view.state_slot_ids), slot_ids)
+
+    def test_recurrent_state_view_drains_matching_pending_when_disallowed(
+        self,
+    ) -> None:
+        # Arrange
+        cache = _make_state_cache(max_seqs=4)
+        slot_ids = [3, 1]
+        cache.set_pending_recurrent_state(
+            0, slot_ids, mx.full((2, 1, 4, 32), 7, dtype=mx.float32)
+        )
+
+        # Act
+        view = cache.recurrent_state_for_update(0, slot_ids, allow_compact=False)
+
+        # Assert
+        assert not view.uses_compact_state
+        assert not cache.has_pending_recurrent_state(0)
+        mx.eval(view.state, view.state_slot_ids)
+        expected_state = np.zeros((4, 1, 4, 32), dtype=np.float32)
+        expected_state[slot_ids] = 7
+        np.testing.assert_array_equal(np.array(view.state), expected_state)
+        np.testing.assert_array_equal(np.array(view.state_slot_ids), slot_ids)
 
     def test_state_view_owns_compact_slot_mapping(self) -> None:
         # Arrange
@@ -1161,6 +1186,58 @@ class TestLazyRecurrentPrefill:
         expected_state[slot_ids] = 7
         np.testing.assert_array_equal(
             np.array(cache.recurrent_states[0]), expected_state
+        )
+
+    def test_deferred_prefill_state_is_consumed_by_next_prefill(self) -> None:
+        # Arrange
+        state_updates = mx.full((2, 2, 3, 32), 9, dtype=mx.float32)
+        prefill_kernel = _RecordingStateKernel(
+            mx.ones((5, 2, 3), dtype=mx.float32),
+            state_updates,
+            state_input_index=5,
+            slot_mapping_index=7,
+        )
+        cache = _make_state_cache(
+            max_seqs=4,
+            num_v_heads=2,
+            value_head_dim=3,
+            key_head_dim=32,
+        )
+        initial_state = mx.arange(4 * 2 * 3 * 32, dtype=mx.float32).reshape(4, 2, 3, 32)
+        cache.recurrent_states[0] = mx.array(initial_state)
+        slot_ids = [3, 1]
+        request = _recurrent_prefill_request(
+            q=mx.zeros((1, 5, 1, 32), dtype=mx.float32),
+            k=mx.zeros((1, 5, 1, 32), dtype=mx.float32),
+            v=mx.zeros((1, 5, 2, 3), dtype=mx.float32),
+            g=mx.zeros((1, 5, 2), dtype=mx.float32),
+            beta=mx.zeros((1, 5, 2), dtype=mx.float32),
+            cache=cache,
+            slot_ids=slot_ids,
+            cu_seqlens=[0, 2, 5],
+            defer_state_scatter=True,
+        )
+        kernels = GDNLazyKernels(
+            enabled=True,
+            conv_kernel=_RaisingKernel(),
+            recurrent_decode_kernel=_RaisingKernel(),
+            recurrent_prefill_kernel=prefill_kernel,
+        )
+
+        # Act
+        assert kernels.try_recurrent_prefill(request) is not None
+        assert kernels.try_recurrent_prefill(request) is not None
+
+        # Assert
+        assert prefill_kernel.state_input is state_updates
+        assert prefill_kernel.slot_mapping is not None
+        assert cache.pending_recurrent_state(0, slot_ids) is state_updates
+        mx.eval(cache.recurrent_states[0], prefill_kernel.slot_mapping)
+        np.testing.assert_array_equal(
+            np.array(prefill_kernel.slot_mapping), np.array([0, 1])
+        )
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]), np.array(initial_state)
         )
 
     def test_materialized_deferred_prefill_evals_compact_state(

--- a/tests/test_gdn_lazy_wrapper.py
+++ b/tests/test_gdn_lazy_wrapper.py
@@ -443,7 +443,6 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         assert result is lazy_out
         assert fake_lazy.prefill_called
         assert fake_lazy.prefill_request is not None
-        assert fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype is None
         assert fake_lazy.prefill_request.defer_state_scatter
 
@@ -510,7 +509,6 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         assert result is lazy_out
         assert fake_lazy.prefill_called
         assert fake_lazy.prefill_request is not None
-        assert fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype == mx.float32
         assert not fake_lazy.prefill_request.defer_state_scatter
 
@@ -618,12 +616,11 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         # Assert
         assert result is lazy_out
         assert fake_lazy.prefill_request is not None
-        assert not fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype is None
         assert not fake_lazy.prefill_request.defer_state_scatter
         assert fake_lazy.prefill_request.slot_ids == [2]
 
-    def test_multi_request_prefill_separate_projection_materializes_compact_conv_state(
+    def test_multi_request_prefill_separate_projection_keeps_conv_state_lazy(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Arrange
@@ -659,9 +656,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         # Assert
         pending_state = cache.pending_conv_state(0, [0, 1])
         assert pending_state is not None
-        assert len(eval_args) == 1
-        assert len(eval_args[0]) == 1
-        assert eval_args[0][0] is pending_state
+        assert not eval_args
 
     def test_eager_conv_prefill_fallback_defers_compact_state(self) -> None:
         # Arrange
@@ -901,7 +896,6 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         assert result is lazy_out
         assert fake_lazy.prefill_called
         assert fake_lazy.prefill_request is not None
-        assert not fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype is None
         assert fake_lazy.prefill_request.defer_state_scatter
 

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -346,13 +346,6 @@ class GDNPagedStateCache:
         """Return whether a layer has deferred conv updates."""
         return self.pending_conv_states[layer_idx] is not None
 
-    def updated_conv_state_array(self, layer_idx: int) -> mx.array:
-        """Return the authoritative conv state array for submission."""
-        pending_state = self.pending_conv_states[layer_idx]
-        return (
-            pending_state if pending_state is not None else self.conv_states[layer_idx]
-        )
-
     def conv_state_for_decode(
         self, layer_idx: int, slot_ids: list[int]
     ) -> GDNStateView:
@@ -418,23 +411,19 @@ class GDNPagedStateCache:
         state_updates: mx.array,
         *,
         defer: bool,
-        make_contiguous: bool = False,
-    ) -> mx.array:
-        """Publish or defer a recurrent update and return authoritative state."""
+    ) -> None:
+        """Publish or defer a recurrent state update."""
         if defer:
             if state_view.uses_compact_state:
                 self.clear_pending_recurrent_state(layer_idx)
             self.set_pending_recurrent_state(layer_idx, slot_ids, state_updates)
-            return state_updates
+            return
 
         if state_view.uses_compact_state:
             raise RuntimeError("cannot scatter through a compact recurrent state view")
         recurrent_state = state_view.state
         recurrent_state[state_view.state_slot_ids] = state_updates
-        if make_contiguous:
-            recurrent_state = mx.contiguous(recurrent_state)
         self.store_recurrent_state(layer_idx, recurrent_state)
-        return recurrent_state
 
     def _state_view(
         self,

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -19,8 +19,8 @@ Pending state handoff:
     layer.
   - A recurrent update may consume that compact state directly only when its
     caller permits compact input and the active slot order exactly matches.
-  - Slot-order mismatches, fallback execution, new prefill work, or slot release
-    must scatter the pending update into the stable state pool first.
+  - Slot-order mismatches, fallback execution, or slot release must scatter the
+    pending update into the stable state pool first.
 """
 
 from __future__ import annotations
@@ -373,7 +373,7 @@ class GDNPagedStateCache:
     def set_pending_recurrent_state(
         self, layer_idx: int, slot_ids: list[int], state_updates: mx.array
     ) -> None:
-        """Store compact recurrent updates to be consumed by the next decode."""
+        """Store compact recurrent updates for the next eligible state consumer."""
         self.require_allocated_slots(slot_ids)
         if self.has_pending_recurrent_state(layer_idx):
             self.apply_pending_recurrent_state(layer_idx)

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -17,8 +17,8 @@ on request admission and never exceeds that cap.
 Pending state handoff:
   - At most one compact pending conv or recurrent update may exist per linear
     layer.
-  - Lazy decode may consume that compact update directly only when the active
-    slot order exactly matches the pending slot order.
+  - A recurrent update may consume that compact state directly only when its
+    caller permits compact input and the active slot order exactly matches.
   - Slot-order mismatches, fallback execution, new prefill work, or slot release
     must scatter the pending update into the stable state pool first.
 """
@@ -32,8 +32,8 @@ import mlx.core as mx
 
 
 @dataclass(frozen=True)
-class GDNDecodeStateView:
-    """State array and slot mappings for one lazy decode kernel launch."""
+class GDNStateView:
+    """State array and slot mappings for one lazy stateful kernel launch."""
 
     state: mx.array
     state_slot_ids: mx.array
@@ -355,20 +355,18 @@ class GDNPagedStateCache:
 
     def conv_state_for_decode(
         self, layer_idx: int, slot_ids: list[int]
-    ) -> GDNDecodeStateView:
+    ) -> GDNStateView:
         """Return authoritative conv state and slot ids for a decode kernel."""
         self.require_allocated_slots(slot_ids)
         if not self.has_pending_conv_state(layer_idx):
-            return self._decode_state_view(
+            return self._state_view(
                 self.conv_states[layer_idx], slot_ids, uses_compact_state=False
             )
         pending_state = self.pending_conv_state(layer_idx, slot_ids)
         if pending_state is not None:
-            return self._decode_state_view(
-                pending_state, slot_ids, uses_compact_state=True
-            )
+            return self._state_view(pending_state, slot_ids, uses_compact_state=True)
         self.apply_pending_conv_state(layer_idx)
-        return self._decode_state_view(
+        return self._state_view(
             self.conv_states[layer_idx], slot_ids, uses_compact_state=False
         )
 
@@ -391,32 +389,60 @@ class GDNPagedStateCache:
             return None
         return self.pending_recurrent_states[layer_idx]
 
-    def recurrent_state_for_decode(
-        self, layer_idx: int, slot_ids: list[int]
-    ) -> GDNDecodeStateView:
-        """Return authoritative recurrent state and slot ids for a decode kernel."""
+    def recurrent_state_for_update(
+        self,
+        layer_idx: int,
+        slot_ids: list[int],
+        *,
+        allow_compact: bool,
+    ) -> GDNStateView:
+        """Return authoritative recurrent state for one lazy kernel update."""
         self.require_allocated_slots(slot_ids)
         if not self.has_pending_recurrent_state(layer_idx):
-            return self._decode_state_view(
+            return self._state_view(
                 self.recurrent_states[layer_idx], slot_ids, uses_compact_state=False
             )
         pending_state = self.pending_recurrent_state(layer_idx, slot_ids)
-        if pending_state is not None:
-            return self._decode_state_view(
-                pending_state, slot_ids, uses_compact_state=True
-            )
+        if allow_compact and pending_state is not None:
+            return self._state_view(pending_state, slot_ids, uses_compact_state=True)
         self.apply_pending_recurrent_state(layer_idx)
-        return self._decode_state_view(
+        return self._state_view(
             self.recurrent_states[layer_idx], slot_ids, uses_compact_state=False
         )
 
-    def _decode_state_view(
+    def finish_recurrent_state_update(
+        self,
+        layer_idx: int,
+        slot_ids: list[int],
+        state_view: GDNStateView,
+        state_updates: mx.array,
+        *,
+        defer: bool,
+        make_contiguous: bool = False,
+    ) -> mx.array:
+        """Publish or defer a recurrent update and return authoritative state."""
+        if defer:
+            if state_view.uses_compact_state:
+                self.clear_pending_recurrent_state(layer_idx)
+            self.set_pending_recurrent_state(layer_idx, slot_ids, state_updates)
+            return state_updates
+
+        if state_view.uses_compact_state:
+            raise RuntimeError("cannot scatter through a compact recurrent state view")
+        recurrent_state = state_view.state
+        recurrent_state[state_view.state_slot_ids] = state_updates
+        if make_contiguous:
+            recurrent_state = mx.contiguous(recurrent_state)
+        self.store_recurrent_state(layer_idx, recurrent_state)
+        return recurrent_state
+
+    def _state_view(
         self,
         state: mx.array,
         slot_ids: list[int],
         *,
         uses_compact_state: bool,
-    ) -> GDNDecodeStateView:
+    ) -> GDNStateView:
         cache_slot_ids = mx.array(slot_ids, dtype=mx.int32)
         compact_order = list(range(len(slot_ids)))
         state_slot_ids = (
@@ -424,7 +450,7 @@ class GDNPagedStateCache:
             if uses_compact_state and slot_ids != compact_order
             else cache_slot_ids
         )
-        return GDNDecodeStateView(
+        return GDNStateView(
             state=state,
             state_slot_ids=state_slot_ids,
             cache_slot_ids=cache_slot_ids,

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -463,7 +463,9 @@ class GDNLazyKernels:
 
         state_cache = request.state_cache
         state_view = state_cache.recurrent_state_for_update(
-            request.cache_idx, request.slot_ids, allow_compact=False
+            request.cache_idx,
+            request.slot_ids,
+            allow_compact=request.defer_state_scatter,
         )
         state_in = state_view.state
         slot_ids_arr = state_view.state_slot_ids

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -75,7 +75,6 @@ class GDNRecurrentPrefillRequest(GDNRecurrentRequest):
     """Inputs for one lazy GDN recurrent prefill-containing attempt."""
 
     cu_seqlens: list[int]
-    materialize_outputs: bool = False
     compute_dtype: mx.Dtype | None = None
     defer_state_scatter: bool = False
 
@@ -504,15 +503,12 @@ class GDNLazyKernels:
             output_shapes=[(total_tokens, n_hv, d_v), (num_requests, n_hv, d_v, d_k)],
             output_dtypes=[kernel_dtype, state_dtype],
         )
-        state_to_materialize = state_cache.finish_recurrent_state_update(
+        state_cache.finish_recurrent_state_update(
             request.cache_idx,
             request.slot_ids,
             state_view,
             state_updates,
             defer=request.defer_state_scatter,
-            make_contiguous=request.materialize_outputs,
         )
         y_out = _astype_if_needed(y_out, request.output_dtype)
-        if request.materialize_outputs:
-            mx.eval(y_out, state_to_materialize)
         return y_out

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -378,8 +378,8 @@ class GDNLazyKernels:
             return None
 
         state_cache = request.state_cache
-        state_view = state_cache.recurrent_state_for_decode(
-            request.cache_idx, request.slot_ids
+        state_view = state_cache.recurrent_state_for_update(
+            request.cache_idx, request.slot_ids, allow_compact=True
         )
         state_in = state_view.state
         state_slot_ids_arr = state_view.state_slot_ids
@@ -415,14 +415,17 @@ class GDNLazyKernels:
         # ``num_requests`` slabs per step; without this each step also copies
         # the update into the pool, doubling recurrent state traffic.
         #
-        # ``recurrent_state_for_decode`` above already drained any pending
+        # ``recurrent_state_for_update`` above already drained any pending
         # update whose slot order did not match, so the only pending state
         # that can still be live here is this layer's own previous step —
         # which ``state_updates`` supersedes.  Clear it rather than letting
         # ``set_pending_recurrent_state`` scatter that stale slab first.
-        state_cache.clear_pending_recurrent_state(request.cache_idx)
-        state_cache.set_pending_recurrent_state(
-            request.cache_idx, request.slot_ids, state_updates
+        state_cache.finish_recurrent_state_update(
+            request.cache_idx,
+            request.slot_ids,
+            state_view,
+            state_updates,
+            defer=True,
         )
         return y_out
 
@@ -459,10 +462,11 @@ class GDNLazyKernels:
             return None
 
         state_cache = request.state_cache
-        if state_cache.has_pending_recurrent_state(request.cache_idx):
-            state_cache.apply_pending_recurrent_state(request.cache_idx)
-        state_in = state_cache.recurrent_states[request.cache_idx]
-        slot_ids_arr = mx.array(request.slot_ids, dtype=mx.int32)
+        state_view = state_cache.recurrent_state_for_update(
+            request.cache_idx, request.slot_ids, allow_compact=False
+        )
+        state_in = state_view.state
+        slot_ids_arr = state_view.state_slot_ids
         cu_seqlens_arr = mx.array(request.cu_seqlens, dtype=mx.int32)
         kernel_dtype = request.compute_dtype or request.output_dtype
         state_dtype = state_in.dtype
@@ -498,17 +502,14 @@ class GDNLazyKernels:
             output_shapes=[(total_tokens, n_hv, d_v), (num_requests, n_hv, d_v, d_k)],
             output_dtypes=[kernel_dtype, state_dtype],
         )
-        if request.defer_state_scatter:
-            request.state_cache.set_pending_recurrent_state(
-                request.cache_idx, request.slot_ids, state_updates
-            )
-            state_to_materialize = state_updates
-        else:
-            state_in[slot_ids_arr] = state_updates
-            if request.materialize_outputs:
-                state_in = mx.contiguous(state_in)
-            request.state_cache.store_recurrent_state(request.cache_idx, state_in)
-            state_to_materialize = state_in
+        state_to_materialize = state_cache.finish_recurrent_state_update(
+            request.cache_idx,
+            request.slot_ids,
+            state_view,
+            state_updates,
+            defer=request.defer_state_scatter,
+            make_contiguous=request.materialize_outputs,
+        )
         y_out = _astype_if_needed(y_out, request.output_dtype)
         if request.materialize_outputs:
             mx.eval(y_out, state_to_materialize)

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -57,7 +57,7 @@ class _GDNLazyPolicy:
 
     - combined QKVZ projection: Qwen3-Next style, cheapest handoff path
     - separate projection with expanded value state: Qwen3.6 style, use the
-      conservative fp32/materialized handoff policy
+      conservative fp32/stable-pool handoff policy
     - separate projection with compact value state: Qwen3.5 style, avoid the
       extra conv-prefill launch but keep lazy recurrent prefill
     """
@@ -79,9 +79,6 @@ class _GDNLazyPolicy:
         if self.uses_conservative_recurrent_prefill_policy():
             return _EXPANDED_RECURRENT_DECODE_THREADGROUP_DV
         return _DEFAULT_RECURRENT_DECODE_THREADGROUP_DV
-
-    def should_materialize_prefill_state(self, num_requests: int) -> bool:
-        return num_requests > 1 and not self.combined_qkvz_projection
 
     def recurrent_prefill_compute_dtype(self) -> mx.Dtype | None:
         if self.uses_conservative_recurrent_prefill_policy():
@@ -228,8 +225,6 @@ class GDNPagedAttentionWrapper(nn.Module):
                 mixed_qkv, inner, state_cache, cache_idx, slot_ids, state.cu_seqlens
             )
             if conv_packed is not None:
-                if self._should_materialize_prefill_state(state):
-                    mx.eval(state_cache.updated_conv_state_array(cache_idx))
                 return conv_packed
 
         state_cache.apply_pending_conv_state(cache_idx)
@@ -264,10 +259,6 @@ class GDNPagedAttentionWrapper(nn.Module):
             state_cache.set_pending_conv_state(
                 cache_idx, slot_ids, mx.concatenate(conv_updates, axis=0)
             )
-            if self._should_materialize_prefill_state(state):
-                mx.eval(state_cache.updated_conv_state_array(cache_idx))
-        elif self._should_materialize_prefill_state(state):
-            mx.eval(state_cache.conv_states[cache_idx])
 
         return mx.concatenate(conv_outputs, axis=1)
 
@@ -341,7 +332,6 @@ class GDNPagedAttentionWrapper(nn.Module):
                 slot_ids=state.slot_ids,
                 output_dtype=state.x.dtype,
                 cu_seqlens=state.cu_seqlens,
-                materialize_outputs=self._should_materialize_prefill_state(state),
                 compute_dtype=self._recurrent_prefill_compute_dtype(),
                 defer_state_scatter=self._should_defer_recurrent_prefill_state(state),
             )
@@ -390,15 +380,6 @@ class GDNPagedAttentionWrapper(nn.Module):
         # Compact separate-projection and combined-QKVZ variants stay on the
         # original launch shape, which benchmarks better for those layouts.
         return self._gdn_lazy_policy.recurrent_decode_threadgroup_dv()
-
-    def _should_materialize_prefill_state(self, state: _GDNForwardState) -> bool:
-        # Separate-projection GDN variants keep more independent state-producing
-        # arrays alive across the lazy prefill graph.  Materializing conv and
-        # recurrent state at each layer bounds the prefill→decode handoff
-        # without penalizing Qwen3-Next's combined QKVZ projection path.
-        return self._gdn_lazy_policy.should_materialize_prefill_state(
-            state.num_requests
-        )
 
     def _recurrent_prefill_compute_dtype(self) -> mx.Dtype | None:
         return self._gdn_lazy_policy.recurrent_prefill_compute_dtype()


### PR DESCRIPTION
## Summary

Multi-request GDN prefill can leave recurrent state in a compact active-request buffer. The next prefill on `main` scatters that buffer into the stable pool and immediately reads the same rows back. Separate-projection models also force convolution and recurrent state with `mx.eval` at each GDN layer.

This change:

- moves recurrent state acquisition and publication into `GDNPagedStateCache`;
- feeds matching deferred state directly into the next prefill-containing kernel;
- removes the per-layer state materialization policy.

## Correctness

Compact state is used only when the active slot list matches exactly and the current update will remain deferred. Slot changes, fallback execution, non-deferred updates, and release boundaries still publish pending state to the stable pool first.

Batched greedy token IDs remained bitwise identical across the change. The hybrid APC parity matrix passed all 80 cases.

## Performance

Agent-split serving used Qwen3.5-0.8B on M5 Pro at concurrency 16, measured back-to-back in the same session.

| Metric | `main` | This branch |
| --- | ---: | ---: |
| Wall time | 77.4 s | 63.1 s |
| Output throughput | 70.1 tok/s | 90.2 tok/s |

Compact pending consumption reduced wall time by 16% in isolation. Removing the materialization barriers reduced it by 4% to 7%. Peak GPU allocation increased from 28.7 GB to 29.2 GB because the larger graph remains lazy.

## Validation

- 175 focused kernel, wrapper, state-manager, and model-runner tests passed with current Metal sources.
- Ruff lint and format checks passed.
- mypy passed for the changed modules and focused tests.

## Commit structure

1. Refactor recurrent state handoff behind cache-owned views without changing dispatch behavior.
2. Enable compact pending consumption for eligible prefill-containing updates.
3. Remove per-layer GDN prefill state materialization barriers.