### PR TITLE
Remove per-layer GDN prefill materialization barriers

### DIFF
--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -287,7 +287,6 @@ def _recurrent_prefill_request(
     output_dtype: mx.Dtype = mx.float32,
     compute_dtype: mx.Dtype | None = None,
     defer_state_scatter: bool = False,
-    materialize_outputs: bool = False,
 ) -> GDNRecurrentPrefillRequest:
     return GDNRecurrentPrefillRequest(
         q=q,
@@ -302,7 +301,6 @@ def _recurrent_prefill_request(
         cu_seqlens=cu_seqlens,
         compute_dtype=compute_dtype,
         defer_state_scatter=defer_state_scatter,
-        materialize_outputs=materialize_outputs,
     )
 
 
@@ -1163,7 +1161,7 @@ class TestLazyRecurrentPrefill:
             np.array(cache.recurrent_states[0]), expected_state
         )
 
-    def test_materialized_deferred_prefill_evals_compact_state(
+    def test_deferred_prefill_does_not_materialize_outputs(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Arrange
@@ -1193,7 +1191,6 @@ class TestLazyRecurrentPrefill:
             slot_ids=slot_ids,
             cu_seqlens=[0, 2, 5],
             defer_state_scatter=True,
-            materialize_outputs=True,
         )
 
         # Act
@@ -1206,15 +1203,13 @@ class TestLazyRecurrentPrefill:
 
         # Assert
         assert result is not None
-        assert len(eval_args) == 1
-        assert len(eval_args[0]) == 2
-        assert eval_args[0][1].shape == (2, 2, 3, 32)
-        assert cache.pending_recurrent_state(0, slot_ids) is eval_args[0][1]
+        assert not eval_args
+        assert cache.pending_recurrent_state(0, slot_ids) is not None
         np.testing.assert_array_equal(
             np.array(cache.recurrent_states[0]), np.array(initial_state)
         )
 
-    def test_materialized_scattered_prefill_contiguates_state_pool(
+    def test_scattered_prefill_does_not_force_materialization(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Arrange
@@ -1249,7 +1244,6 @@ class TestLazyRecurrentPrefill:
             slot_ids=slot_ids,
             cu_seqlens=[0, 2, 5],
             defer_state_scatter=False,
-            materialize_outputs=True,
         )
 
         # Act
@@ -1262,10 +1256,8 @@ class TestLazyRecurrentPrefill:
 
         # Assert
         assert result is not None
-        assert len(contiguous_args) == 1
-        assert contiguous_args[0].shape == (4, 2, 3, 32)
-        assert len(eval_args) == 1
-        assert eval_args[0][1] is cache.recurrent_states[0]
+        assert not contiguous_args
+        assert not eval_args
         assert cache.pending_recurrent_state(0, slot_ids) is None
 
     @pytest.mark.parametrize(

--- a/tests/test_gdn_lazy_wrapper.py
+++ b/tests/test_gdn_lazy_wrapper.py
@@ -443,7 +443,6 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         assert result is lazy_out
         assert fake_lazy.prefill_called
         assert fake_lazy.prefill_request is not None
-        assert fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype is None
         assert fake_lazy.prefill_request.defer_state_scatter
 
@@ -510,7 +509,6 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         assert result is lazy_out
         assert fake_lazy.prefill_called
         assert fake_lazy.prefill_request is not None
-        assert fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype == mx.float32
         assert not fake_lazy.prefill_request.defer_state_scatter
 
@@ -618,12 +616,11 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         # Assert
         assert result is lazy_out
         assert fake_lazy.prefill_request is not None
-        assert not fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype is None
         assert not fake_lazy.prefill_request.defer_state_scatter
         assert fake_lazy.prefill_request.slot_ids == [2]
 
-    def test_multi_request_prefill_separate_projection_materializes_compact_conv_state(
+    def test_multi_request_prefill_separate_projection_keeps_conv_state_lazy(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Arrange
@@ -659,9 +656,7 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         # Assert
         pending_state = cache.pending_conv_state(0, [0, 1])
         assert pending_state is not None
-        assert len(eval_args) == 1
-        assert len(eval_args[0]) == 1
-        assert eval_args[0][0] is pending_state
+        assert not eval_args
 
     def test_eager_conv_prefill_fallback_defers_compact_state(self) -> None:
         # Arrange
@@ -901,7 +896,6 @@ class TestGDNPagedAttentionWrapperLazyKernels:
         assert result is lazy_out
         assert fake_lazy.prefill_called
         assert fake_lazy.prefill_request is not None
-        assert not fake_lazy.prefill_request.materialize_outputs
         assert fake_lazy.prefill_request.compute_dtype is None
         assert fake_lazy.prefill_request.defer_state_scatter
 

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -346,13 +346,6 @@ class GDNPagedStateCache:
         """Return whether a layer has deferred conv updates."""
         return self.pending_conv_states[layer_idx] is not None
 
-    def updated_conv_state_array(self, layer_idx: int) -> mx.array:
-        """Return the authoritative conv state array for submission."""
-        pending_state = self.pending_conv_states[layer_idx]
-        return (
-            pending_state if pending_state is not None else self.conv_states[layer_idx]
-        )
-
     def conv_state_for_decode(
         self, layer_idx: int, slot_ids: list[int]
     ) -> GDNDecodeStateView:

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -75,7 +75,6 @@ class GDNRecurrentPrefillRequest(GDNRecurrentRequest):
     """Inputs for one lazy GDN recurrent prefill-containing attempt."""
 
     cu_seqlens: list[int]
-    materialize_outputs: bool = False
     compute_dtype: mx.Dtype | None = None
     defer_state_scatter: bool = False
 
@@ -502,14 +501,8 @@ class GDNLazyKernels:
             request.state_cache.set_pending_recurrent_state(
                 request.cache_idx, request.slot_ids, state_updates
             )
-            state_to_materialize = state_updates
         else:
             state_in[slot_ids_arr] = state_updates
-            if request.materialize_outputs:
-                state_in = mx.contiguous(state_in)
             request.state_cache.store_recurrent_state(request.cache_idx, state_in)
-            state_to_materialize = state_in
         y_out = _astype_if_needed(y_out, request.output_dtype)
-        if request.materialize_outputs:
-            mx.eval(y_out, state_to_materialize)
         return y_out

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -57,7 +57,7 @@ class _GDNLazyPolicy:
 
     - combined QKVZ projection: Qwen3-Next style, cheapest handoff path
     - separate projection with expanded value state: Qwen3.6 style, use the
-      conservative fp32/materialized handoff policy
+      conservative fp32/stable-pool handoff policy
     - separate projection with compact value state: Qwen3.5 style, avoid the
       extra conv-prefill launch but keep lazy recurrent prefill
     """
@@ -79,9 +79,6 @@ class _GDNLazyPolicy:
         if self.uses_conservative_recurrent_prefill_policy():
             return _EXPANDED_RECURRENT_DECODE_THREADGROUP_DV
         return _DEFAULT_RECURRENT_DECODE_THREADGROUP_DV
-
-    def should_materialize_prefill_state(self, num_requests: int) -> bool:
-        return num_requests > 1 and not self.combined_qkvz_projection
 
     def recurrent_prefill_compute_dtype(self) -> mx.Dtype | None:
         if self.uses_conservative_recurrent_prefill_policy():
@@ -228,8 +225,6 @@ class GDNPagedAttentionWrapper(nn.Module):
                 mixed_qkv, inner, state_cache, cache_idx, slot_ids, state.cu_seqlens
             )
             if conv_packed is not None:
-                if self._should_materialize_prefill_state(state):
-                    mx.eval(state_cache.updated_conv_state_array(cache_idx))
                 return conv_packed
 
         state_cache.apply_pending_conv_state(cache_idx)
@@ -264,10 +259,6 @@ class GDNPagedAttentionWrapper(nn.Module):
             state_cache.set_pending_conv_state(
                 cache_idx, slot_ids, mx.concatenate(conv_updates, axis=0)
             )
-            if self._should_materialize_prefill_state(state):
-                mx.eval(state_cache.updated_conv_state_array(cache_idx))
-        elif self._should_materialize_prefill_state(state):
-            mx.eval(state_cache.conv_states[cache_idx])
 
         return mx.concatenate(conv_outputs, axis=1)
 
@@ -341,7 +332,6 @@ class GDNPagedAttentionWrapper(nn.Module):
                 slot_ids=state.slot_ids,
                 output_dtype=state.x.dtype,
                 cu_seqlens=state.cu_seqlens,
-                materialize_outputs=self._should_materialize_prefill_state(state),
                 compute_dtype=self._recurrent_prefill_compute_dtype(),
                 defer_state_scatter=self._should_defer_recurrent_prefill_state(state),
             )
@@ -390,15 +380,6 @@ class GDNPagedAttentionWrapper(nn.Module):
         # Compact separate-projection and combined-QKVZ variants stay on the
         # original launch shape, which benchmarks better for those layouts.
         return self._gdn_lazy_policy.recurrent_decode_threadgroup_dv()
-
-    def _should_materialize_prefill_state(self, state: _GDNForwardState) -> bool:
-        # Separate-projection GDN variants keep more independent state-producing
-        # arrays alive across the lazy prefill graph.  Materializing conv and
-        # recurrent state at each layer bounds the prefill→decode handoff
-        # without penalizing Qwen3-Next's combined QKVZ projection path.
-        return self._gdn_lazy_policy.should_materialize_prefill_state(
-            state.num_requests
-        )
 
     def _recurrent_prefill_compute_dtype(self) -> mx.Dtype | None:
         return self._gdn_lazy_policy.recurrent_prefill_compute_dtype()


### PR DESCRIPTION
## Summary

<img width="2856" height="1661" alt="bench_pr632" src="https://github.com/user-attachments/assets/ed58eb42-5367-405d-ade0-e97f7dc2b53e" />

Multi-request prefill on separate-projection GDN models synchronously evaluates convolution and recurrent state after every GDN layer. This change removes those per-layer evaluations and lets the existing end-of-forward submission evaluate the complete graph.

The GDN recurrence, cache placement, pending-state transitions, and fallback paths are unchanged. Combined-QKVZ models already use the fully lazy path.

## Benchmark

Qwen3.5-0.8B on M5 Pro, Sonnet dataset, 100 prompts, concurrency 16, prefix caching off. Each result is the mean of six runs per branch across three alternating fresh-server sessions; the first run of each session was discarded.

| Input / output | Duration: main | Duration: PR | Δ duration | Mean TTFT: main | Mean TTFT: PR | Δ TTFT |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1024 / 128 | 30.15 ± 2.01 s | 27.85 ± 1.05 s | **−7.6%** | 807.0 ± 54.6 ms | 702.5 ± 34.8 ms | **−13.0%** |
| 1024 / 16 | 14.30 ± 0.58 s | 12.44 ± 0.16 s | **−13.0%** | 789.0 ± 37.3 ms | 685.3 ± 9.1 ms | **−13.1%** |

The prefill-heavy case improves more, consistent with removing 36 `mx.eval` barriers from each prefill-containing step: two per GDN layer across 18 layers. All runs processed the same 101,402 input tokens and fixed output-token counts.

<details>
<summary>Benchmark configuration</summary>

- Base: `bd32be8`
- Hardware: Apple M5 Pro, 64 GB unified memory, macOS 26.6 (25G72)
- Versions: vllm 0.27.0, mlx 0.32.0, mlx-lm 0.31.3
- Server: `VLLM_METAL_USE_PAGED_ATTENTION=1 VLLM_METAL_MEMORY_FRACTION=0.5 vllm serve Qwen/Qwen3.5-0.8B --max-model-len 2048 --no-enable-prefix-caching`
- Client: `vllm bench serve --dataset-name sonnet --sonnet-input-len 1024 --sonnet-output-len {128,16} --num-prompts 100 --request-rate inf --max-concurrency 16 --ignore-eos --temperature 0`
- Scheduler: chunked prefill on, `max_num_batched_tokens=2048`

</details>

## Memory trade-off

Peak prefill graph growth increases from 202 MiB to 432 MiB. This was measured with MLX 0.32.0, 24 layers, four 512-token requests, fp32 state, and the real recurrent prefill kernel. End-of-forward evaluation still bounds the graph.

## Validation

A deterministic Qwen3.5-0.8B A/B probe produced identical token IDs for all five prompts across all four main/PR pairings; same-branch controls were also identical. Instrumentation confirmed that all 18 GDN layers took the affected multi-request prefill path (`prefill_multi=18`, `prefill_single=0`, `max_nreq=5`). An independent GMRID_v3 evaluation (20 stratified examples across 8 classes, two rounds per branch) produced byte-identical main/PR completion text for every example at both 0-shot and 5-shot.

| Revision | 0-shot weighted F1 / EM | 5-shot weighted F1 / EM |
| --- | ---: | ---: |
| main | 0.3900 / 0.4500 | 0.4071 / 0.4500 |
| PR | 0.3900 / 0.4500 | 0.4071 / 0.4500 |
