### PR TITLE
Use loopback for default UniProc rendezvous

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -387,6 +387,25 @@ class TestMetalPlatform:
         with pytest.raises(NotImplementedError, match="single process"):
             MetalPlatform.check_and_update_config(vllm_config)
 
+    @pytest.mark.parametrize(
+        ("configured_ip", "expected_ip"),
+        [(None, "127.0.0.1"), ("192.0.2.1", "192.0.2.1")],
+    )
+    def test_check_and_update_config_sets_uniproc_host_ip(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        configured_ip: str | None,
+        expected_ip: str,
+    ) -> None:
+        if configured_ip is None:
+            monkeypatch.delenv("VLLM_HOST_IP", raising=False)
+        else:
+            monkeypatch.setenv("VLLM_HOST_IP", configured_ip)
+
+        MetalPlatform.check_and_update_config(self._platform_config())
+
+        assert os.environ["VLLM_HOST_IP"] == expected_ip
+
     def test_check_and_update_config_rejects_tensor_parallel(self) -> None:
         """Tensor parallelism is unsupported on Metal yet; reject it at config time."""
         vllm_config = self._platform_config(
@@ -982,7 +1001,6 @@ class TestMetalPlatform:
         """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
-        monkeypatch.delenv("VLLM_HOST_IP", raising=False)
         reset_config()
         try:
             vllm_config = self._platform_config(
@@ -1025,7 +1043,6 @@ class TestMetalPlatform:
             )
             assert vllm_config.parallel_config.distributed_executor_backend == "uni"
             assert vllm_config.parallel_config.disable_custom_all_reduce is True
-            assert os.environ["VLLM_HOST_IP"] == "127.0.0.1"
         finally:
             reset_config()
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -2,6 +2,7 @@
 """Tests for Metal platform."""
 
 import importlib
+import os
 import platform
 import sys
 from types import ModuleType, SimpleNamespace
@@ -981,6 +982,7 @@ class TestMetalPlatform:
         """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        monkeypatch.delenv("VLLM_HOST_IP", raising=False)
         reset_config()
         try:
             vllm_config = self._platform_config(
@@ -1023,6 +1025,7 @@ class TestMetalPlatform:
             )
             assert vllm_config.parallel_config.distributed_executor_backend == "uni"
             assert vllm_config.parallel_config.disable_custom_all_reduce is True
+            assert os.environ["VLLM_HOST_IP"] == "127.0.0.1"
         finally:
             reset_config()
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -406,6 +406,19 @@ class TestMetalPlatform:
 
         assert os.environ["VLLM_HOST_IP"] == expected_ip
 
+    def test_rejected_uniproc_config_does_not_set_host_ip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("VLLM_HOST_IP", raising=False)
+        vllm_config = self._platform_config(
+            cache_config=SimpleNamespace(kv_cache_dtype_skip_layers=["model.layers.0"])
+        )
+
+        with pytest.raises(NotImplementedError, match="heterogeneous KV"):
+            MetalPlatform.check_and_update_config(vllm_config)
+
+        assert "VLLM_HOST_IP" not in os.environ
+
     def test_check_and_update_config_rejects_tensor_parallel(self) -> None:
         """Tensor parallelism is unsupported on Metal yet; reject it at config time."""
         vllm_config = self._platform_config(

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -782,7 +782,7 @@ class MetalPlatform(Platform):
             parallel_config.distributed_executor_backend == "uni"
             and parallel_config.world_size == 1
             and parallel_config.data_parallel_size == 1
-            and "VLLM_HOST_IP" not in os.environ
+            and not os.environ.get("VLLM_HOST_IP")
         ):
             os.environ["VLLM_HOST_IP"] = "127.0.0.1"
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -2,6 +2,7 @@
 """Metal Platform implementation for vLLM."""
 
 import logging
+import os
 import platform as py_platform
 from typing import TYPE_CHECKING
 
@@ -410,6 +411,16 @@ class MetalPlatform(Platform):
             parallel_config.ray_runtime_env = RuntimeEnv(
                 **cls._ray_runtime_env_with_metal_hook(parallel_config.ray_runtime_env)
             )
+
+        # UniProc still initializes gloo locally.  Use loopback so upstream
+        # get_ip() cannot pick a VPN tunnel address that gloo cannot bind.
+        if (
+            parallel_config.distributed_executor_backend == "uni"
+            and parallel_config.world_size == 1
+            and parallel_config.data_parallel_size == 1
+            and "VLLM_HOST_IP" not in os.environ
+        ):
+            os.environ["VLLM_HOST_IP"] = "127.0.0.1"
 
         # Disable features not supported on Metal
         parallel_config.disable_custom_all_reduce = True

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -412,8 +412,10 @@ class MetalPlatform(Platform):
                 **cls._ray_runtime_env_with_metal_hook(parallel_config.ray_runtime_env)
             )
 
-        # UniProc still initializes gloo locally.  Use loopback so upstream
-        # get_ip() cannot pick a VPN tunnel address that gloo cannot bind.
+        # COMPAT(vLLM 0.27.1): UniProc uses get_ip() for its local gloo
+        # rendezvous. Use loopback so a VPN tunnel address cannot be selected.
+        # Remove after pinned vLLM includes vllm#50999, which uses a file://
+        # store for UniProc rendezvous.
         if (
             parallel_config.distributed_executor_backend == "uni"
             and parallel_config.world_size == 1

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -412,18 +412,6 @@ class MetalPlatform(Platform):
                 **cls._ray_runtime_env_with_metal_hook(parallel_config.ray_runtime_env)
             )
 
-        # COMPAT(vLLM 0.27.1): UniProc uses get_ip() for its local gloo
-        # rendezvous. Use loopback so a VPN tunnel address cannot be selected.
-        # Remove after pinned vLLM includes vllm#50999, which uses a file://
-        # store for UniProc rendezvous.
-        if (
-            parallel_config.distributed_executor_backend == "uni"
-            and parallel_config.world_size == 1
-            and parallel_config.data_parallel_size == 1
-            and "VLLM_HOST_IP" not in os.environ
-        ):
-            os.environ["VLLM_HOST_IP"] = "127.0.0.1"
-
         # Disable features not supported on Metal
         parallel_config.disable_custom_all_reduce = True
 
@@ -785,6 +773,18 @@ class MetalPlatform(Platform):
         # executor-level ray_runtime_env hook does not propagate on the DP path).
         if parallel_config.data_parallel_size > 1:
             cls._register_dp_ray_worker_setup_hook(parallel_config.ray_runtime_env)
+
+        # COMPAT(vLLM 0.27.1): UniProc uses get_ip() for its local gloo
+        # rendezvous. Use loopback so a VPN tunnel address cannot be selected.
+        # Remove after pinned vLLM includes vllm#50999, which uses a file://
+        # store for UniProc rendezvous.
+        if (
+            parallel_config.distributed_executor_backend == "uni"
+            and parallel_config.world_size == 1
+            and parallel_config.data_parallel_size == 1
+            and "VLLM_HOST_IP" not in os.environ
+        ):
+            os.environ["VLLM_HOST_IP"] = "127.0.0.1"
 
         # Log memory configuration
         total_mem = cls.get_device_total_memory()


### PR DESCRIPTION
This PR is:

- To avoid VPN-selected tunnel IPs during default single-process Metal startup.
- To set `VLLM_HOST_IP=127.0.0.1` only for `uni`, `world_size=1`, and `data_parallel_size=1` when the user did not configure it.
- To preserve explicit `VLLM_HOST_IP` and leave mp, Ray, PP, DP, and multi-node paths unchanged.

Note:

This fixes issue #625. Pinned vLLM 0.27.1 still uses `get_ip()` for UniProc gloo rendezvous, which can select a VPN tunnel address and hang startup. The workaround is marked for removal after the pinned vLLM includes vLLM #50999.