### PR TITLE
Write align-mode GDN state rows in place with a Metal kernel

### DIFF
--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -710,7 +710,10 @@ class TestLazyConvPrefill:
         # Assert
         assert result is not None
         assert cache.pending_conv_state(0, [3, 1]) is None
-        assert decode_kernel.state_input is cache.conv_states[0]
+        # The kernel must read the stable pool, not the compact pending rows.
+        # Object identity no longer distinguishes them: the in-place scatter
+        # mints a fresh handle onto the same buffer, so compare shape.
+        assert decode_kernel.state_input.shape == cache.conv_states[0].shape
         mx.eval(cache.conv_states[0], decode_kernel.slot_mapping)
         np.testing.assert_array_equal(np.array(decode_kernel.slot_mapping), [1, 3])
         expected_state = np.array(initial_state)

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -204,29 +204,27 @@ class TestGDNPagedStateCache:
         np.testing.assert_array_equal(np.array(view.cache_slot_ids), [3, 1])
         np.testing.assert_array_equal(np.array(view.state_slot_ids), [0, 1])
 
-    def test_pending_states_batch_matches_per_layer_drain(self) -> None:
-        # The batched drain must land exactly what draining each layer in turn
-        # would have landed.
-        def build() -> GDNPagedStateCache:
-            cache = _make_state_cache(num_layers=2, max_seqs=4)
-            cache.set_layer_layout([0, 1], [0, 0])
-            cache.set_pending_conv_state(
-                0, [1], mx.full((1, 2, 4), 4, dtype=mx.float32)
-            )
-            cache.set_pending_conv_state(
-                1, [3], mx.full((1, 2, 4), 6, dtype=mx.float32)
-            )
-            return cache
+    def test_copy_slots_gathers_overlapping_sources_before_writing(self) -> None:
+        cache = _make_state_cache(
+            max_seqs=4,
+            conv_kernel_dim=2,
+            conv_dim=1,
+            value_head_dim=1,
+            key_head_dim=1,
+        )
+        cache.conv_states[0] = mx.arange(4, dtype=mx.float32).reshape(4, 1, 1)
+        cache.recurrent_states[0] = mx.arange(4, dtype=mx.float32).reshape(4, 1, 1, 1)
 
-        batched = build()
-        batched.apply_pending_conv_states()
-
-        per_layer = build()
-        per_layer.apply_pending_conv_state(0)
-        per_layer.apply_pending_conv_state(1)
+        # Destination 2 is also the second source. Both source rows must be
+        # gathered before the in-place writes begin.
+        cache.copy_slots([1, 2], [2, 3], [0])
+        mx.eval(cache.conv_states[0], cache.recurrent_states[0])
 
         np.testing.assert_array_equal(
-            np.array(batched.conv_states[0]), np.array(per_layer.conv_states[0])
+            np.array(cache.conv_states[0]).reshape(-1), [0.0, 1.0, 1.0, 2.0]
+        )
+        np.testing.assert_array_equal(
+            np.array(cache.recurrent_states[0]).reshape(-1), [0.0, 1.0, 1.0, 2.0]
         )
 
     def test_identity_layout_still_drains_every_layer(self) -> None:

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -1938,37 +1938,21 @@ class TestNativeGDNStateScatter:
 
         np.testing.assert_array_equal(np.array(updated[2]), 5.0)
 
-    def test_cache_drain_agrees_with_the_mlx_fallback(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # The whole point of the primitive is to be a drop-in for the MLX
-        # path, so the two must land identical pools.
-        from vllm_metal.attention.caches import gdn_cache as gdn_cache_mod
-
-        scatter = self._scatter_fn()
-
-        def build() -> GDNPagedStateCache:
-            cache = _make_state_cache(num_layers=2, max_seqs=4)
-            cache.set_layer_layout([0, 1], [0, 0])
-            cache.set_pending_recurrent_state(
-                0, [0], mx.full((1, 1, 4, 32), 3, dtype=mx.float32)
-            )
-            cache.set_pending_recurrent_state(
-                1, [2], mx.full((1, 1, 4, 32), 7, dtype=mx.float32)
-            )
-            return cache
-
-        monkeypatch.setattr(gdn_cache_mod, "_native_row_scatter", lambda: None)
-        fallback = build()
-        fallback.apply_pending_recurrent_states()
-        mx.eval(fallback.recurrent_states[0])
-
-        monkeypatch.setattr(gdn_cache_mod, "_native_row_scatter", lambda: scatter)
-        native = build()
-        native.apply_pending_recurrent_states()
-        mx.eval(native.recurrent_states[0])
-
-        np.testing.assert_array_equal(
-            np.array(native.recurrent_states[0]),
-            np.array(fallback.recurrent_states[0]),
+    def test_shared_cache_drain_chains_native_scatters(self) -> None:
+        self._scatter_fn()  # skip when the primitive is unavailable
+        cache = _make_state_cache(num_layers=2, max_seqs=4)
+        cache.set_layer_layout([0, 1], [0, 0])
+        cache.set_pending_recurrent_state(
+            0, [0], mx.full((1, 1, 4, 32), 3, dtype=mx.float32)
         )
+        cache.set_pending_recurrent_state(
+            1, [2], mx.full((1, 1, 4, 32), 7, dtype=mx.float32)
+        )
+
+        cache.apply_pending_recurrent_states()
+        mx.eval(cache.recurrent_states[0])
+
+        expected = np.zeros(cache.recurrent_states[0].shape, dtype=np.float32)
+        expected[0] = 3
+        expected[2] = 7
+        np.testing.assert_array_equal(np.array(cache.recurrent_states[0]), expected)

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -1781,11 +1781,7 @@ class TestNativeGDNStateScatter:
 
     @staticmethod
     def _scatter_fn() -> Any:
-        ops = _get_native_ops_or_skip()
-        fn = getattr(ops, "gdn_state_scatter", None)
-        if fn is None:
-            pytest.skip("native extension predates gdn_state_scatter")
-        return fn
+        return _get_native_ops_or_skip().gdn_state_scatter
 
     @pytest.mark.parametrize(
         ("shape", "dtype", "slots"),

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -1881,6 +1881,49 @@ class TestNativeGDNStateScatter:
                 mx.ones((1, 3, 2), dtype=mx.float32),
                 mx.array([0], dtype=mx.int32),
             )
+        with pytest.raises(RuntimeError, match="row shape does not match"):
+            scatter(
+                pool,
+                mx.array(1, dtype=mx.float32),
+                mx.array([0], dtype=mx.int32),
+            )
+
+    def test_rejects_unsupported_pool_dtype(self) -> None:
+        scatter = self._scatter_fn()
+        with pytest.raises(RuntimeError, match="pool dtype must be"):
+            scatter(
+                mx.zeros((4, 2), dtype=mx.int32),
+                mx.ones((1, 2), dtype=mx.int32),
+                mx.array([0], dtype=mx.int32),
+            )
+
+    def test_materializes_noncontiguous_source_and_ids(self) -> None:
+        scatter = self._scatter_fn()
+        pool = mx.zeros((4, 2), dtype=mx.float32)
+        rows = mx.arange(8, dtype=mx.float32).reshape(2, 4)[:, ::2]
+        ids = mx.array([0, 3, 1, 3], dtype=mx.int32)[::2]
+
+        updated = scatter(pool, rows, ids)
+        mx.eval(updated)
+
+        np.testing.assert_array_equal(np.array(updated[:2]), [[0.0, 2.0], [4.0, 6.0]])
+
+    def test_materializes_noncontiguous_pool(self) -> None:
+        scatter = self._scatter_fn()
+        base = mx.arange(8, dtype=mx.float32).reshape(2, 4)
+        mx.eval(base)
+        pool = base.T
+        updated = scatter(
+            pool,
+            mx.array([[9.0, 10.0]], dtype=mx.float32),
+            mx.array([1], dtype=mx.int32),
+        )
+        mx.eval(updated)
+
+        np.testing.assert_array_equal(
+            np.array(updated),
+            [[0.0, 4.0], [9.0, 10.0], [2.0, 6.0], [3.0, 7.0]],
+        )
 
     def test_converts_source_dtype_like_mlx_does(self) -> None:
         # MLX's indexed assignment converts the source implicitly, so callers

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -1797,6 +1797,10 @@ class TestNativeGDNStateScatter:
             ((8, 3, 4), mx.float16, [3]),
             ((8, 3, 4), mx.bfloat16, [6, 0]),
             ((16, 2, 6144), mx.float32, [15, 4, 9]),
+            # row lengths not divisible by 4 take the scalar kernel
+            ((8, 3), mx.float32, [0, 5]),
+            ((8, 7), mx.float16, [2]),
+            ((8, 5, 3), mx.bfloat16, [6, 1]),
         ],
     )
     def test_matches_mlx_indexed_assignment(

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -204,6 +204,48 @@ class TestGDNPagedStateCache:
         np.testing.assert_array_equal(np.array(view.cache_slot_ids), [3, 1])
         np.testing.assert_array_equal(np.array(view.state_slot_ids), [0, 1])
 
+    def test_pending_states_batch_matches_per_layer_drain(self) -> None:
+        # The batched drain must land exactly what draining each layer in turn
+        # would have landed.
+        def build() -> GDNPagedStateCache:
+            cache = _make_state_cache(num_layers=2, max_seqs=4)
+            cache.set_layer_layout([0, 1], [0, 0])
+            cache.set_pending_conv_state(
+                0, [1], mx.full((1, 2, 4), 4, dtype=mx.float32)
+            )
+            cache.set_pending_conv_state(
+                1, [3], mx.full((1, 2, 4), 6, dtype=mx.float32)
+            )
+            return cache
+
+        batched = build()
+        batched.apply_pending_conv_states()
+
+        per_layer = build()
+        per_layer.apply_pending_conv_state(0)
+        per_layer.apply_pending_conv_state(1)
+
+        np.testing.assert_array_equal(
+            np.array(batched.conv_states[0]), np.array(per_layer.conv_states[0])
+        )
+
+    def test_identity_layout_still_drains_every_layer(self) -> None:
+        # mamba_cache_mode="none" never calls set_layer_layout: every layer is
+        # its own pool and must still be drained.
+        cache = _make_state_cache(num_layers=3, max_seqs=4)
+        for layer_idx in range(3):
+            cache.set_pending_recurrent_state(
+                layer_idx, [layer_idx], mx.full((1, 1, 4, 32), 2, dtype=mx.float32)
+            )
+
+        cache.apply_pending_recurrent_states()
+
+        for layer_idx in range(3):
+            assert not cache.has_pending_recurrent_state(layer_idx)
+            np.testing.assert_array_equal(
+                np.array(cache.recurrent_states[layer_idx][layer_idx]), 2.0
+            )
+
 
 def _require_metal() -> None:
     try:
@@ -229,6 +271,7 @@ def _get_native_ops_or_skip() -> Any:
 
 def _make_state_cache(
     *,
+    num_layers: int = 1,
     max_seqs: int = 3,
     conv_kernel_dim: int = 3,
     conv_dim: int = 4,
@@ -237,7 +280,7 @@ def _make_state_cache(
     key_head_dim: int = 32,
 ) -> GDNPagedStateCache:
     return GDNPagedStateCache(
-        num_layers=1,
+        num_layers=num_layers,
         max_seqs=max_seqs,
         conv_kernel_dim=conv_kernel_dim,
         conv_dim=conv_dim,
@@ -1730,3 +1773,154 @@ class TestGDNLazySharedOwner:
             "gdn_recurrent_decode_v2",
             "gdn_recurrent_prefill_v2",
         ]
+
+
+class TestNativeGDNStateScatter:
+    """The in-place row scatter that replaces MLX's whole-pool copy."""
+
+    @staticmethod
+    def _scatter_fn() -> Any:
+        ops = _get_native_ops_or_skip()
+        fn = getattr(ops, "gdn_state_scatter", None)
+        if fn is None:
+            pytest.skip("native extension predates gdn_state_scatter")
+        return fn
+
+    @pytest.mark.parametrize(
+        ("shape", "dtype", "slots"),
+        [
+            ((8, 3, 4), mx.float32, [0, 5, 2]),
+            ((8, 1, 4, 32), mx.float32, [7, 1]),
+            ((8, 3, 4), mx.float16, [3]),
+            ((8, 3, 4), mx.bfloat16, [6, 0]),
+            ((16, 2, 6144), mx.float32, [15, 4, 9]),
+        ],
+    )
+    def test_matches_mlx_indexed_assignment(
+        self, shape: tuple[int, ...], dtype: mx.Dtype, slots: list[int]
+    ) -> None:
+        scatter = self._scatter_fn()
+        rng = np.random.default_rng(0)
+        pool_np = rng.standard_normal(shape).astype(np.float32)
+        rows_np = rng.standard_normal((len(slots), *shape[1:])).astype(np.float32)
+        ids = mx.array(slots, dtype=mx.int32)
+
+        reference = mx.array(pool_np).astype(dtype)
+        reference[ids] = mx.array(rows_np).astype(dtype)
+        mx.eval(reference)
+
+        pool = mx.array(pool_np).astype(dtype)
+        mx.eval(pool)
+        out = scatter(pool, mx.array(rows_np).astype(dtype), ids)
+        mx.eval(out)
+
+        np.testing.assert_array_equal(
+            np.array(out.astype(mx.float32)), np.array(reference.astype(mx.float32))
+        )
+
+    def test_writes_through_the_original_buffer(self) -> None:
+        # The output aliases the pool buffer -- that is what avoids the copy,
+        # and what makes the caller's rebind mandatory.
+        scatter = self._scatter_fn()
+        pool = mx.zeros((4, 2, 2), dtype=mx.float32)
+        mx.eval(pool)
+        out = scatter(
+            pool, mx.ones((1, 2, 2), dtype=mx.float32), mx.array([2], mx.int32)
+        )
+        mx.eval(out)
+        np.testing.assert_array_equal(np.array(pool[2]), 1.0)
+
+    def test_empty_update_leaves_the_pool_alone(self) -> None:
+        scatter = self._scatter_fn()
+        pool = mx.ones((4, 2, 2), dtype=mx.float32)
+        mx.eval(pool)
+        out = scatter(
+            pool,
+            mx.zeros((0, 2, 2), dtype=mx.float32),
+            mx.array([], dtype=mx.int32),
+        )
+        mx.eval(out)
+        np.testing.assert_array_equal(np.array(out), 1.0)
+
+    def test_rejects_mismatched_inputs(self) -> None:
+        scatter = self._scatter_fn()
+        pool = mx.zeros((4, 2, 2), dtype=mx.float32)
+        mx.eval(pool)
+        with pytest.raises(RuntimeError, match="dtypes differ"):
+            scatter(
+                pool,
+                mx.ones((1, 2, 2), dtype=mx.float16),
+                mx.array([0], dtype=mx.int32),
+            )
+        with pytest.raises(RuntimeError, match="dst_ids must be int32"):
+            scatter(
+                pool,
+                mx.ones((1, 2, 2), dtype=mx.float32),
+                mx.array([0], dtype=mx.int64),
+            )
+        with pytest.raises(RuntimeError, match="one dst id per src row"):
+            scatter(
+                pool,
+                mx.ones((2, 2, 2), dtype=mx.float32),
+                mx.array([0], dtype=mx.int32),
+            )
+        with pytest.raises(RuntimeError, match="must be mlx.core.array"):
+            # inst_ptr on a non-array is undefined behaviour; this used to
+            # segfault rather than raise.
+            scatter(pool, mx.ones((1, 2, 2), dtype=mx.float32), [0])
+        with pytest.raises(RuntimeError, match="row shape does not match"):
+            scatter(
+                pool,
+                mx.ones((1, 3, 2), dtype=mx.float32),
+                mx.array([0], dtype=mx.int32),
+            )
+
+    def test_converts_source_dtype_like_mlx_does(self) -> None:
+        # MLX's indexed assignment converts the source implicitly, so callers
+        # pass int literals into fp32 pools; the primitive demands an exact
+        # match, so the cache helper must convert before dispatching.
+        self._scatter_fn()  # skip when the primitive is unavailable
+        cache = _make_state_cache(max_seqs=4, conv_kernel_dim=3, conv_dim=4)
+        pool = cache.conv_states[0]
+        rows = mx.full((1, 2, 4), 5)  # int32, unlike the fp32 pool
+        assert rows.dtype != pool.dtype
+
+        updated = cache._scatter_rows(pool, rows, mx.array([2], dtype=mx.int32))
+        mx.eval(updated)
+
+        np.testing.assert_array_equal(np.array(updated[2]), 5.0)
+
+    def test_cache_drain_agrees_with_the_mlx_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The whole point of the primitive is to be a drop-in for the MLX
+        # path, so the two must land identical pools.
+        from vllm_metal.attention.caches import gdn_cache as gdn_cache_mod
+
+        scatter = self._scatter_fn()
+
+        def build() -> GDNPagedStateCache:
+            cache = _make_state_cache(num_layers=2, max_seqs=4)
+            cache.set_layer_layout([0, 1], [0, 0])
+            cache.set_pending_recurrent_state(
+                0, [0], mx.full((1, 1, 4, 32), 3, dtype=mx.float32)
+            )
+            cache.set_pending_recurrent_state(
+                1, [2], mx.full((1, 1, 4, 32), 7, dtype=mx.float32)
+            )
+            return cache
+
+        monkeypatch.setattr(gdn_cache_mod, "_native_row_scatter", lambda: None)
+        fallback = build()
+        fallback.apply_pending_recurrent_states()
+        mx.eval(fallback.recurrent_states[0])
+
+        monkeypatch.setattr(gdn_cache_mod, "_native_row_scatter", lambda: scatter)
+        native = build()
+        native.apply_pending_recurrent_states()
+        mx.eval(native.recurrent_states[0])
+
+        np.testing.assert_array_equal(
+            np.array(native.recurrent_states[0]),
+            np.array(fallback.recurrent_states[0]),
+        )

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -444,36 +444,14 @@ class GDNPagedStateCache:
         return arrays
 
     def _scatter_rows(self, pool: mx.array, rows: mx.array, ids: mx.array) -> mx.array:
-        """Write ``rows`` into ``pool`` at row ids ``ids``; return the new pool.
-
-        MLX's indexed assignment routes through ``copy_gpu``, which donates
-        the source buffer only when it holds the sole reference to it
-        (``is_donatable`` in ``mlx/backend/common/utils.h``).  A state pool is
-        aliased into every one of its sibling layers by
-        :meth:`store_conv_state`, so that never holds and each write rewrites
-        the whole pool -- which, under align-mode prefix caching, grows with
-        cache occupancy.  The native primitive writes only the named rows in
-        place and returns an array aliasing the same buffer, so callers must
-        rebind through :meth:`store_conv_state` /
-        :meth:`store_recurrent_state`.
-
-        Destination slots must be distinct; duplicates race in the kernel
-        where the MLX path would be last-writer-wins.
-        """
+        """Write distinct rows in place and return the rebound pool handle."""
         # MLX's indexed assignment converts the source implicitly and callers
         # rely on it; the primitive requires an exact match.  ``astype`` is a
         # no-op when the dtypes already agree, and O(rows) otherwise.
         return _native_row_scatter()(pool, rows.astype(pool.dtype), ids)
 
     def write_conv_rows(self, layer_idx: int, rows: mx.array, ids: mx.array) -> None:
-        """Write conv rows into a layer's pool and rebind its sibling aliases.
-
-        The single write path for a conv pool.  Writing the pool directly with
-        MLX's indexed assignment rewrites all of it (see :meth:`_scatter_rows`),
-        and the aliasing that makes that unavoidable is also what makes the
-        rebind mandatory -- doing both here keeps the two from drifting apart.
-        This is graph construction only; nothing is evaluated.
-        """
+        """Write conv rows and rebind every sibling to the returned handle."""
         self.store_conv_state(
             layer_idx, self._scatter_rows(self.conv_states[layer_idx], rows, ids)
         )
@@ -481,7 +459,7 @@ class GDNPagedStateCache:
     def write_recurrent_rows(
         self, layer_idx: int, rows: mx.array, ids: mx.array
     ) -> None:
-        """Write recurrent rows into a layer's pool and rebind its aliases."""
+        """Write recurrent rows and rebind siblings to the returned handle."""
         self.store_recurrent_state(
             layer_idx,
             self._scatter_rows(self.recurrent_states[layer_idx], rows, ids),

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -30,40 +30,14 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import mlx.core as mx
-from vllm.logger import init_logger
-
-logger = init_logger(__name__)
 
 
 @functools.cache
-def _native_row_scatter() -> Callable[..., mx.array] | None:
-    """Return the in-place row-scatter primitive, or ``None`` for the MLX path.
+def _native_row_scatter() -> Callable[..., mx.array]:
+    """Return the required in-place row-scatter primitive."""
+    from vllm_metal.metal import get_ops
 
-    Resolved once per process.  The fallback exists for an extension that
-    predates the primitive -- a prebuilt wheel artifact in a source checkout --
-    and warns, because silently taking the slow path loses the whole point of
-    the primitive with no signal.
-    """
-    try:
-        from vllm_metal.metal import get_ops
-
-        scatter = getattr(get_ops(), "gdn_state_scatter", None)
-    except (ImportError, RuntimeError) as exc:
-        logger.warning(
-            "Native gdn_state_scatter is unavailable (%s); GDN state writes "
-            "fall back to MLX's indexed assignment, which rewrites the whole "
-            "state pool per write.",
-            exc,
-        )
-        return None
-    if scatter is None:
-        logger.warning(
-            "The native extension predates gdn_state_scatter; GDN state "
-            "writes fall back to MLX's indexed assignment, which rewrites "
-            "the whole state pool per write. Rebuild with "
-            "`python -m vllm_metal.metal.build` to restore the fast path."
-        )
-    return scatter
+    return get_ops().gdn_state_scatter
 
 
 @dataclass(frozen=True)
@@ -486,14 +460,10 @@ class GDNPagedStateCache:
         Destination slots must be distinct; duplicates race in the kernel
         where the MLX path would be last-writer-wins.
         """
-        native = _native_row_scatter()
-        if native is None:
-            pool[ids] = rows
-            return pool
         # MLX's indexed assignment converts the source implicitly and callers
         # rely on it; the primitive requires an exact match.  ``astype`` is a
         # no-op when the dtypes already agree, and O(rows) otherwise.
-        return native(pool, rows.astype(pool.dtype), ids)
+        return _native_row_scatter()(pool, rows.astype(pool.dtype), ids)
 
     def write_conv_rows(self, layer_idx: int, rows: mx.array, ids: mx.array) -> None:
         """Write conv rows into a layer's pool and rebind its sibling aliases.

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -224,14 +224,7 @@ class GDNPagedStateCache:
         """Clear state for one allocated slot before it is reused."""
         self.require_allocated_slots([slot])
         self.apply_pending_states()
-        for layer_idx in self._canonical_layers:
-            conv = self.conv_states[layer_idx]
-            conv[slot] = mx.zeros_like(conv[slot])
-            self.store_conv_state(layer_idx, conv)
-
-            recurrent = self.recurrent_states[layer_idx]
-            recurrent[slot] = mx.zeros_like(recurrent[slot])
-            self.store_recurrent_state(layer_idx, recurrent)
+        self.zero_slots([slot], self._canonical_layers)
 
     def set_layer_layout(
         self, group_ordinals: list[int], pool_ordinals: list[int]
@@ -307,13 +300,10 @@ class GDNPagedStateCache:
             # Gather first (its output is O(rows)), then write the rows back.
             # Reading the sources into their own array keeps the copy atomic
             # when one pair's destination is another pair's source.
-            conv = self.conv_states[layer_idx]
-            conv = self._scatter_rows(conv, conv[src], dst)
-            self.store_conv_state(layer_idx, conv)
-
-            recurrent = self.recurrent_states[layer_idx]
-            recurrent = self._scatter_rows(recurrent, recurrent[src], dst)
-            self.store_recurrent_state(layer_idx, recurrent)
+            self.write_conv_rows(layer_idx, self.conv_states[layer_idx][src], dst)
+            self.write_recurrent_rows(
+                layer_idx, self.recurrent_states[layer_idx][src], dst
+            )
 
     def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None:
         """Apply scheduler copy-on-write operations to every physical pool."""
@@ -348,13 +338,8 @@ class GDNPagedStateCache:
             dtype=self.recurrent_states[0].dtype,
         )
         for layer_idx in layer_indices:
-            conv = self._scatter_rows(self.conv_states[layer_idx], conv_zeros, ids)
-            self.store_conv_state(layer_idx, conv)
-
-            recurrent = self._scatter_rows(
-                self.recurrent_states[layer_idx], recurrent_zeros, ids
-            )
-            self.store_recurrent_state(layer_idx, recurrent)
+            self.write_conv_rows(layer_idx, conv_zeros, ids)
+            self.write_recurrent_rows(layer_idx, recurrent_zeros, ids)
 
     def set_pending_conv_state(
         self, layer_idx: int, slot_ids: list[int], state_updates: mx.array
@@ -510,6 +495,28 @@ class GDNPagedStateCache:
         # no-op when the dtypes already agree, and O(rows) otherwise.
         return native(pool, rows.astype(pool.dtype), ids)
 
+    def write_conv_rows(self, layer_idx: int, rows: mx.array, ids: mx.array) -> None:
+        """Write conv rows into a layer's pool and rebind its sibling aliases.
+
+        The single write path for a conv pool.  Writing the pool directly with
+        MLX's indexed assignment rewrites all of it (see :meth:`_scatter_rows`),
+        and the aliasing that makes that unavoidable is also what makes the
+        rebind mandatory -- doing both here keeps the two from drifting apart.
+        This is graph construction only; nothing is evaluated.
+        """
+        self.store_conv_state(
+            layer_idx, self._scatter_rows(self.conv_states[layer_idx], rows, ids)
+        )
+
+    def write_recurrent_rows(
+        self, layer_idx: int, rows: mx.array, ids: mx.array
+    ) -> None:
+        """Write recurrent rows into a layer's pool and rebind its aliases."""
+        self.store_recurrent_state(
+            layer_idx,
+            self._scatter_rows(self.recurrent_states[layer_idx], rows, ids),
+        )
+
     def apply_pending_conv_state(self, layer_idx: int) -> None:
         """Scatter deferred conv updates into the stable state pool."""
         pending_state = self.pending_conv_states[layer_idx]
@@ -518,12 +525,9 @@ class GDNPagedStateCache:
             return
         self.require_allocated_slots(pending_slots)
 
-        conv_state = self._scatter_rows(
-            self.conv_states[layer_idx],
-            pending_state,
-            mx.array(pending_slots, dtype=mx.int32),
+        self.write_conv_rows(
+            layer_idx, pending_state, mx.array(pending_slots, dtype=mx.int32)
         )
-        self.store_conv_state(layer_idx, conv_state)
         self.clear_pending_conv_state(layer_idx)
 
     def apply_pending_conv_states(self) -> None:
@@ -539,12 +543,9 @@ class GDNPagedStateCache:
             return
         self.require_allocated_slots(pending_slots)
 
-        recurrent_state = self._scatter_rows(
-            self.recurrent_states[layer_idx],
-            pending_state,
-            mx.array(pending_slots, dtype=mx.int32),
+        self.write_recurrent_rows(
+            layer_idx, pending_state, mx.array(pending_slots, dtype=mx.int32)
         )
-        self.store_recurrent_state(layer_idx, recurrent_state)
         self.clear_pending_recurrent_state(layer_idx)
 
     def apply_pending_recurrent_states(self) -> None:

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -25,10 +25,45 @@ Pending state handoff:
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import functools
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import mlx.core as mx
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@functools.cache
+def _native_row_scatter() -> Callable[..., mx.array] | None:
+    """Return the in-place row-scatter primitive, or ``None`` for the MLX path.
+
+    Resolved once per process.  The fallback exists for an extension that
+    predates the primitive -- a prebuilt wheel artifact in a source checkout --
+    and warns, because silently taking the slow path loses the whole point of
+    the primitive with no signal.
+    """
+    try:
+        from vllm_metal.metal import get_ops
+
+        scatter = getattr(get_ops(), "gdn_state_scatter", None)
+    except (ImportError, RuntimeError) as exc:
+        logger.warning(
+            "Native gdn_state_scatter is unavailable (%s); GDN state writes "
+            "fall back to MLX's indexed assignment, which rewrites the whole "
+            "state pool per write.",
+            exc,
+        )
+        return None
+    if scatter is None:
+        logger.warning(
+            "The native extension predates gdn_state_scatter; GDN state "
+            "writes fall back to MLX's indexed assignment, which rewrites "
+            "the whole state pool per write. Rebuild with "
+            "`python -m vllm_metal.metal.build` to restore the fast path."
+        )
+    return scatter
 
 
 @dataclass(frozen=True)
@@ -269,12 +304,15 @@ class GDNPagedStateCache:
         src = mx.array(src_ids, dtype=mx.int32)
         dst = mx.array(dst_ids, dtype=mx.int32)
         for layer_idx in layer_indices:
+            # Gather first (its output is O(rows)), then write the rows back.
+            # Reading the sources into their own array keeps the copy atomic
+            # when one pair's destination is another pair's source.
             conv = self.conv_states[layer_idx]
-            conv[dst] = conv[src]
+            conv = self._scatter_rows(conv, conv[src], dst)
             self.store_conv_state(layer_idx, conv)
 
             recurrent = self.recurrent_states[layer_idx]
-            recurrent[dst] = recurrent[src]
+            recurrent = self._scatter_rows(recurrent, recurrent[src], dst)
             self.store_recurrent_state(layer_idx, recurrent)
 
     def copy_blocks(self, block_copies: Sequence[tuple[int, int]]) -> None:
@@ -310,12 +348,12 @@ class GDNPagedStateCache:
             dtype=self.recurrent_states[0].dtype,
         )
         for layer_idx in layer_indices:
-            conv = self.conv_states[layer_idx]
-            conv[ids] = conv_zeros
+            conv = self._scatter_rows(self.conv_states[layer_idx], conv_zeros, ids)
             self.store_conv_state(layer_idx, conv)
 
-            recurrent = self.recurrent_states[layer_idx]
-            recurrent[ids] = recurrent_zeros
+            recurrent = self._scatter_rows(
+                self.recurrent_states[layer_idx], recurrent_zeros, ids
+            )
             self.store_recurrent_state(layer_idx, recurrent)
 
     def set_pending_conv_state(
@@ -446,6 +484,32 @@ class GDNPagedStateCache:
         arrays.extend(p for p in self.pending_recurrent_states if p is not None)
         return arrays
 
+    def _scatter_rows(self, pool: mx.array, rows: mx.array, ids: mx.array) -> mx.array:
+        """Write ``rows`` into ``pool`` at row ids ``ids``; return the new pool.
+
+        MLX's indexed assignment routes through ``copy_gpu``, which donates
+        the source buffer only when it holds the sole reference to it
+        (``is_donatable`` in ``mlx/backend/common/utils.h``).  A state pool is
+        aliased into every one of its sibling layers by
+        :meth:`store_conv_state`, so that never holds and each write rewrites
+        the whole pool -- which, under align-mode prefix caching, grows with
+        cache occupancy.  The native primitive writes only the named rows in
+        place and returns an array aliasing the same buffer, so callers must
+        rebind through :meth:`store_conv_state` /
+        :meth:`store_recurrent_state`.
+
+        Destination slots must be distinct; duplicates race in the kernel
+        where the MLX path would be last-writer-wins.
+        """
+        native = _native_row_scatter()
+        if native is None:
+            pool[ids] = rows
+            return pool
+        # MLX's indexed assignment converts the source implicitly and callers
+        # rely on it; the primitive requires an exact match.  ``astype`` is a
+        # no-op when the dtypes already agree, and O(rows) otherwise.
+        return native(pool, rows.astype(pool.dtype), ids)
+
     def apply_pending_conv_state(self, layer_idx: int) -> None:
         """Scatter deferred conv updates into the stable state pool."""
         pending_state = self.pending_conv_states[layer_idx]
@@ -454,9 +518,11 @@ class GDNPagedStateCache:
             return
         self.require_allocated_slots(pending_slots)
 
-        slot_ids_arr = mx.array(pending_slots, dtype=mx.int32)
-        conv_state = self.conv_states[layer_idx]
-        conv_state[slot_ids_arr] = pending_state
+        conv_state = self._scatter_rows(
+            self.conv_states[layer_idx],
+            pending_state,
+            mx.array(pending_slots, dtype=mx.int32),
+        )
         self.store_conv_state(layer_idx, conv_state)
         self.clear_pending_conv_state(layer_idx)
 
@@ -473,9 +539,11 @@ class GDNPagedStateCache:
             return
         self.require_allocated_slots(pending_slots)
 
-        slot_ids_arr = mx.array(pending_slots, dtype=mx.int32)
-        recurrent_state = self.recurrent_states[layer_idx]
-        recurrent_state[slot_ids_arr] = pending_state
+        recurrent_state = self._scatter_rows(
+            self.recurrent_states[layer_idx],
+            pending_state,
+            mx.array(pending_slots, dtype=mx.int32),
+        )
         self.store_recurrent_state(layer_idx, recurrent_state)
         self.clear_pending_recurrent_state(layer_idx)
 

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -251,7 +251,6 @@ class GDNLazyKernels:
         kernel_size = inner.conv_kernel_size
         state_view = state_cache.conv_state_for_decode(cache_idx, slot_ids)
         conv_state_in = state_view.state
-        state_pool = state_cache.conv_states[cache_idx]
         weight = inner.conv1d.weight
 
         mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
@@ -283,8 +282,7 @@ class GDNLazyKernels:
             output_shapes=[(num_requests, conv_dim), state_updates_shape],
             output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
         )
-        state_pool[slot_ids_arr] = conv_state_updates
-        state_cache.store_conv_state(cache_idx, state_pool)
+        state_cache.write_conv_rows(cache_idx, conv_state_updates, slot_ids_arr)
         if state_view.uses_compact_state:
             state_cache.clear_pending_conv_state(cache_idx)
         return conv_silu_out.reshape(1, total_tokens, conv_dim)
@@ -502,7 +500,8 @@ class GDNLazyKernels:
                 request.cache_idx, request.slot_ids, state_updates
             )
         else:
-            state_in[slot_ids_arr] = state_updates
-            request.state_cache.store_recurrent_state(request.cache_idx, state_in)
+            request.state_cache.write_recurrent_rows(
+                request.cache_idx, state_updates, slot_ids_arr
+            )
         y_out = _astype_if_needed(y_out, request.output_dtype)
         return y_out

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -247,9 +247,9 @@ class GDNPagedAttentionWrapper(nn.Module):
             if defer_conv_state:
                 conv_updates.append(new_conv)
             else:
-                cs = state_cache.conv_states[cache_idx]
-                cs[slot : slot + 1] = new_conv
-                state_cache.store_conv_state(cache_idx, cs)
+                state_cache.write_conv_rows(
+                    cache_idx, new_conv, mx.array([slot], dtype=mx.int32)
+                )
 
             conv_out = nn.silu(inner.conv1d(conv_input))
             # Take only the output tokens (not the conv state prefix)

--- a/vllm_metal/metal/__init__.py
+++ b/vllm_metal/metal/__init__.py
@@ -76,6 +76,7 @@ def _build_gdn_source() -> str:
     parts = [
         _read_metal_source(_KERNELS_V2_DIR / "utils.metal"),
         _read_metal_source(_KERNELS_V2_DIR / "gdn_linear_attention.metal"),
+        _read_metal_source(_KERNELS_V2_DIR / "gdn_state_scatter.metal"),
     ]
     return "\n".join(parts)
 

--- a/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
@@ -18,9 +18,6 @@ template <typename T>
     device const int &row_elems [[buffer(3)]],
     uint2 gid [[thread_position_in_grid]]) {
   const int i = int(gid.x);
-  if (i >= row_elems) {
-    return;
-  }
   const int64_t row = int64_t(gid.y);
   const int64_t dst = int64_t(dst_ids[gid.y]) * row_elems;
   pool[dst + i] = src[row * row_elems + i];
@@ -36,9 +33,6 @@ template <typename T>
     device const int &row_vec4s [[buffer(3)]],
     uint2 gid [[thread_position_in_grid]]) {
   const int i = int(gid.x);
-  if (i >= row_vec4s) {
-    return;
-  }
   const int64_t row = int64_t(gid.y);
   const int64_t dst = int64_t(dst_ids[gid.y]) * row_vec4s;
   reinterpret_cast<device vec<T, 4> *>(pool)[dst + i] =

--- a/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
@@ -11,6 +11,13 @@ using namespace metal;
 //
 // A 2D grid walks elements on x and update rows on y. Destination slots must
 // be distinct because duplicate rows would race between threadgroups.
+//
+// Both kernels assume an exact-size grid and therefore carry no bounds check:
+// the host dispatches through MLX's dispatch_threads, which maps to Metal's
+// non-uniform dispatchThreads and launches exactly grid_dims threads. Moving
+// to dispatch_threadgroups -- the style the rest of paged_ops.cpp uses --
+// would round the grid up to whole threadgroups and write past the end of a
+// row. Add the bounds checks back first if you ever change the dispatch.
 template <typename T>
 [[kernel]] void gdn_state_scatter_rows(
     device T *pool [[buffer(0)]], const device T *src [[buffer(1)]],

--- a/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
@@ -9,19 +9,8 @@ using namespace metal;
 //   src:     [n, row_elems]           compact update rows
 //   dst_ids: [n]                      destination slot for each update row
 //
-// A 2D thread grid: x walks the row, y selects the update. One threadgroup
-// per row would leave the GPU idle -- a recurrent row is 16x128x128 floats,
-// so a single 256-wide threadgroup would run 1024 scalar iterations while
-// most of the machine sits unused.
-//
-// MLX's own indexed assignment cannot be used on this path because it donates
-// the destination buffer only when it holds the sole reference to it, and a
-// state pool is aliased into every sibling layer that shares it -- so each
-// write rewrites the whole pool, which under align-mode prefix caching grows
-// with cache occupancy.
-//
-// Destination slots must be distinct: two update rows naming the same slot
-// would race.  Callers enforce that (pool siblings own disjoint block ids).
+// A 2D grid walks elements on x and update rows on y. Destination slots must
+// be distinct because duplicate rows would race between threadgroups.
 template <typename T>
 [[kernel]] void gdn_state_scatter_rows(
     device T *pool [[buffer(0)]], const device T *src [[buffer(1)]],

--- a/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
@@ -1,0 +1,44 @@
+#include "utils.metal"
+#include <metal_stdlib>
+
+using namespace metal;
+
+// Scatter compact update rows into a slot-indexed GDN state pool, in place.
+//
+//   pool:    [num_slots, row_elems]   flattened; written in place
+//   src:     [n, row_elems]           compact update rows
+//   dst_ids: [n]                      destination slot for each update row
+//
+// One threadgroup per update row, threads striding the row.  Cost is
+// O(n * row_elems).  MLX's own indexed assignment cannot be used on this path
+// because it donates the destination buffer only when it holds the sole
+// reference to it, and a state pool is aliased into every sibling layer that
+// shares it -- so each write rewrites the whole pool, which under align-mode
+// prefix caching grows with cache occupancy.
+//
+// Destination slots must be distinct: two update rows naming the same slot
+// would race.  Callers enforce that (pool siblings own disjoint block ids).
+template <typename T>
+[[kernel]] void gdn_state_scatter_rows(
+    device T *pool [[buffer(0)]], const device T *src [[buffer(1)]],
+    const device int *dst_ids [[buffer(2)]],
+    device const int &row_elems [[buffer(3)]],
+    uint gid [[threadgroup_position_in_grid]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint threads_per_threadgroup [[threads_per_threadgroup]]) {
+  const int64_t src_off = static_cast<int64_t>(gid) * row_elems;
+  const int64_t dst_off = static_cast<int64_t>(dst_ids[gid]) * row_elems;
+  for (int i = tid; i < row_elems; i += threads_per_threadgroup) {
+    pool[dst_off + i] = src[src_off + i];
+  }
+}
+
+#define instantiate_gdn_state_scatter_rows(type)                          \
+  template [[host_name("gdn_state_scatter_rows_" #type)]] [[kernel]] void \
+  gdn_state_scatter_rows<type>(                                           \
+      device type *, const device type *, const device int *,             \
+      device const int &, uint, uint, uint);
+
+instantiate_gdn_state_scatter_rows(float);
+instantiate_gdn_state_scatter_rows(bfloat16_t);
+instantiate_gdn_state_scatter_rows(half);

--- a/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_state_scatter.metal
@@ -9,12 +9,16 @@ using namespace metal;
 //   src:     [n, row_elems]           compact update rows
 //   dst_ids: [n]                      destination slot for each update row
 //
-// One threadgroup per update row, threads striding the row.  Cost is
-// O(n * row_elems).  MLX's own indexed assignment cannot be used on this path
-// because it donates the destination buffer only when it holds the sole
-// reference to it, and a state pool is aliased into every sibling layer that
-// shares it -- so each write rewrites the whole pool, which under align-mode
-// prefix caching grows with cache occupancy.
+// A 2D thread grid: x walks the row, y selects the update. One threadgroup
+// per row would leave the GPU idle -- a recurrent row is 16x128x128 floats,
+// so a single 256-wide threadgroup would run 1024 scalar iterations while
+// most of the machine sits unused.
+//
+// MLX's own indexed assignment cannot be used on this path because it donates
+// the destination buffer only when it holds the sole reference to it, and a
+// state pool is aliased into every sibling layer that shares it -- so each
+// write rewrites the whole pool, which under align-mode prefix caching grows
+// with cache occupancy.
 //
 // Destination slots must be distinct: two update rows naming the same slot
 // would race.  Callers enforce that (pool siblings own disjoint block ids).
@@ -23,21 +27,44 @@ template <typename T>
     device T *pool [[buffer(0)]], const device T *src [[buffer(1)]],
     const device int *dst_ids [[buffer(2)]],
     device const int &row_elems [[buffer(3)]],
-    uint gid [[threadgroup_position_in_grid]],
-    uint tid [[thread_position_in_threadgroup]],
-    uint threads_per_threadgroup [[threads_per_threadgroup]]) {
-  const int64_t src_off = static_cast<int64_t>(gid) * row_elems;
-  const int64_t dst_off = static_cast<int64_t>(dst_ids[gid]) * row_elems;
-  for (int i = tid; i < row_elems; i += threads_per_threadgroup) {
-    pool[dst_off + i] = src[src_off + i];
+    uint2 gid [[thread_position_in_grid]]) {
+  const int i = int(gid.x);
+  if (i >= row_elems) {
+    return;
   }
+  const int64_t row = int64_t(gid.y);
+  const int64_t dst = int64_t(dst_ids[gid.y]) * row_elems;
+  pool[dst + i] = src[row * row_elems + i];
+}
+
+// Same, four elements per thread. Selected by the host when row_elems is a
+// multiple of 4 -- true for every GDN state layout in practice (a conv row is
+// (kernel-1)*conv_dim, a recurrent row is heads*d_v*d_k).
+template <typename T>
+[[kernel]] void gdn_state_scatter_rows_vec4(
+    device T *pool [[buffer(0)]], const device T *src [[buffer(1)]],
+    const device int *dst_ids [[buffer(2)]],
+    device const int &row_vec4s [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]]) {
+  const int i = int(gid.x);
+  if (i >= row_vec4s) {
+    return;
+  }
+  const int64_t row = int64_t(gid.y);
+  const int64_t dst = int64_t(dst_ids[gid.y]) * row_vec4s;
+  reinterpret_cast<device vec<T, 4> *>(pool)[dst + i] =
+      reinterpret_cast<const device vec<T, 4> *>(src)[row * row_vec4s + i];
 }
 
 #define instantiate_gdn_state_scatter_rows(type)                          \
   template [[host_name("gdn_state_scatter_rows_" #type)]] [[kernel]] void \
   gdn_state_scatter_rows<type>(                                           \
       device type *, const device type *, const device int *,             \
-      device const int &, uint, uint, uint);
+      device const int &, uint2);                                         \
+  template [[host_name("gdn_state_scatter_rows_vec4_" #type)]] [[kernel]] \
+  void gdn_state_scatter_rows_vec4<type>(                                 \
+      device type *, const device type *, const device int *,             \
+      device const int &, uint2);
 
 instantiate_gdn_state_scatter_rows(float);
 instantiate_gdn_state_scatter_rows(bfloat16_t);

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1250,11 +1250,10 @@ class GDNStateScatterPrimitive : public Primitive {
       std::vector<array>& outputs) override {
     // inputs:  0=pool_in, 1=src_rows, 2=dst_ids
     // outputs: 0=pool_out (aliases pool_in; the kernel writes in place)
-    outputs[0].copy_shared_buffer(inputs[0]);
-
     const array& pool    = inputs[0];
     const array& src     = inputs[1];
     const array& dst_ids = inputs[2];
+    outputs[0].copy_shared_buffer(pool);
 
     int n = static_cast<int>(dst_ids.size());
     if (n == 0) {
@@ -1304,6 +1303,12 @@ static array gdn_state_scatter_primitive_fn(
     throw std::runtime_error(
         "gdn_state_scatter: pool must be [num_slots, ...]");
   }
+  if (pool.dtype() != float16 &&
+      pool.dtype() != bfloat16 &&
+      pool.dtype() != float32) {
+    throw std::runtime_error(
+        "gdn_state_scatter: pool dtype must be float16, bfloat16 or float32");
+  }
   if (src.dtype() != pool.dtype()) {
     throw std::runtime_error("gdn_state_scatter: src and pool dtypes differ");
   }
@@ -1313,10 +1318,6 @@ static array gdn_state_scatter_primitive_fn(
   if (dst_ids.ndim() != 1) {
     throw std::runtime_error("gdn_state_scatter: dst_ids must be 1-D");
   }
-  if (static_cast<size_t>(src.shape(0)) != dst_ids.size()) {
-    throw std::runtime_error(
-        "gdn_state_scatter: one dst id per src row required");
-  }
   if (src.ndim() != pool.ndim() ||
       !std::equal(
           pool.shape().begin() + 1, pool.shape().end(),
@@ -1324,10 +1325,21 @@ static array gdn_state_scatter_primitive_fn(
     throw std::runtime_error(
         "gdn_state_scatter: src row shape does not match pool row shape");
   }
+  if (static_cast<size_t>(src.shape(0)) != dst_ids.size()) {
+    throw std::runtime_error(
+        "gdn_state_scatter: one dst id per src row required");
+  }
+  // The Metal kernel flattens all three inputs. Make strided views contiguous
+  // inside the MLX graph. The returned handle aliases this materialized pool,
+  // so callers must rebind it even when the input pool was already contiguous.
+  auto contiguous_pool = contiguous(pool);
+  auto contiguous_src = contiguous(src);
+  auto contiguous_ids = contiguous(dst_ids);
   auto prim = std::make_shared<GDNStateScatterPrimitive>(
       default_stream(Device::gpu));
   return array::make_arrays(
-      {pool.shape()}, {pool.dtype()}, prim, {pool, src, dst_ids})[0];
+      {pool.shape()}, {pool.dtype()}, prim,
+      {contiguous_pool, contiguous_src, contiguous_ids})[0];
 }
 
 // ---------------------------------------------------------------------------
@@ -1778,9 +1790,10 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("pool"), nb::arg("src"), nb::arg("dst_ids"),
         "In-place row scatter into a slot-indexed GDN state pool. Writes "
         "src[i] into pool[dst_ids[i]] without MLX's whole-pool copy preamble; "
-        "the returned array aliases the pool buffer, so the caller MUST "
-        "rebind its pool reference to it. dst_ids must be distinct int32 "
-        "slots; src is [n, *pool.shape[1:]] with pool's dtype.");
+        "strided inputs are materialized first, and the returned array aliases "
+        "the resulting pool buffer, so the caller MUST rebind its pool "
+        "reference. dst_ids must be distinct int32 slots; src is "
+        "[n, *pool.shape[1:]] with pool's dtype.");
 
   // Paged attention primitive (read-only): dispatches paged_attention_v2_online.
   // Cache writes are handled by MLX-native scatter upstream.

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1215,9 +1215,11 @@ void init_gdn_library(const std::string& src) {
   d.get_library("gdn_kern", [&]() { return gdn_source_; });
 }
 
-// gdn_state_scatter writes selected rows in place and returns a distinct graph
-// handle for the resulting pool buffer. Callers must rebind that handle so
-// later operations depend on the write. Destination slots must be distinct.
+// MLX Scatter/SliceUpdate copy their destination unless it is donatable; GDN
+// pools are aliased across sibling layers, so pool[ids] = rows copies the full
+// pool. mx.fast.metal_kernel allocates fresh outputs, so this Primitive aliases
+// the pool with copy_shared_buffer; callers rebind the output so downstream
+// readers depend on the write. Destination slots must be distinct.
 
 class GDNStateScatterPrimitive : public Primitive {
  public:

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1262,10 +1262,16 @@ class GDNStateScatterPrimitive : public Primitive {
     }
     int row_elems = static_cast<int>(pool.size() / pool.shape(0));
 
+    // Four elements per thread when the row divides evenly, which every GDN
+    // state layout does; the scalar kernel is the general fallback.
+    bool vec4 = (row_elems % 4) == 0;
+    int lanes = vec4 ? row_elems / 4 : row_elems;
+
     auto s = stream();
     auto& d = metal::device(s.device);
     auto dt = dtype_to_metal(pool.dtype());
-    std::string kname = "gdn_state_scatter_rows_" + dt;
+    std::string kname =
+        std::string("gdn_state_scatter_rows_") + (vec4 ? "vec4_" : "") + dt;
     auto* lib = d.get_library("gdn_kern");
     auto* kernel = d.get_kernel(kname, lib, kname, {});
 
@@ -1274,12 +1280,15 @@ class GDNStateScatterPrimitive : public Primitive {
     enc.set_output_array(outputs[0], 0);
     enc.set_input_array(src,         1);
     enc.set_input_array(dst_ids,     2);
-    enc.set_bytes(row_elems,         3);
+    enc.set_bytes(lanes,             3);
 
-    int tg = std::min(row_elems, 256);
-    enc.dispatch_threadgroups(
-        MTL::Size::Make(n, 1, 1),
-        MTL::Size::Make(tg, 1, 1));
+    // 2D thread grid: x walks the row, y selects the update row. One
+    // threadgroup per row leaves most of the GPU idle on a 1 MiB slab.
+    int tg_x = std::min<int>(
+        lanes, static_cast<int>(kernel->maxTotalThreadsPerThreadgroup()));
+    enc.dispatch_threads(
+        MTL::Size::Make(lanes, n, 1),
+        MTL::Size::Make(tg_x, 1, 1));
   }
 
   const char* name() const override { return "GDNStateScatter"; }

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1267,6 +1267,11 @@ class GDNStateScatterPrimitive : public Primitive {
 
     // 2D thread grid: x walks the row, y selects the update row. One
     // threadgroup per row leaves most of the GPU idle on a 1 MiB slab.
+    //
+    // dispatch_threads maps to Metal's non-uniform dispatchThreads, so exactly
+    // `lanes` threads run along x and the kernels need no bounds check. This is
+    // the only dispatch_threads call in this file; the others round up through
+    // dispatch_threadgroups, which here would write past the end of a row.
     int tg_x = std::min<int>(
         lanes, static_cast<int>(kernel->maxTotalThreadsPerThreadgroup()));
     enc.dispatch_threads(

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1216,6 +1216,112 @@ void init_gdn_library(const std::string& src) {
 }
 
 // ---------------------------------------------------------------------------
+// gdn_state_scatter — in-place row scatter into a GDN state pool
+//
+// Replaces `pool[mx.array(slot_ids)] = rows` on the state-drain path.  MLX's
+// Scatter::eval_gpu (mlx/backend/metal/indexing.cpp) routes through copy_gpu,
+// which donates the source buffer only when it holds the sole reference to it
+// (is_donatable, mlx/backend/common/utils.h).  A GDN state pool is aliased
+// into every one of its sibling layers, so that never holds and each write
+// rewrites the whole pool.  Under align-mode prefix caching the pool is
+// indexed by scheduler block id and grows with cache occupancy, so that
+// rewrite — not the update itself — dominates the step.
+//
+// This primitive writes the rows in place: the output aliases the pool buffer
+// via copy_shared_buffer, giving the write a distinct graph identity (the same
+// provenance pattern as TQEncodePrimitive / ReshapeAndCachePrimitive) while
+// touching only the rows named by dst_ids.  The caller MUST rebind its pool
+// reference to the returned array so later ops depend on this primitive.
+//
+// Destination slots must be distinct; duplicates would race between
+// threadgroups.  Callers enforce that invariant.
+// ---------------------------------------------------------------------------
+
+class GDNStateScatterPrimitive : public Primitive {
+ public:
+  explicit GDNStateScatterPrimitive(Stream stream) : Primitive(stream) {}
+
+  void eval_cpu(const std::vector<array>&, std::vector<array>&) override {
+    throw std::runtime_error("GDNStateScatterPrimitive only supports GPU");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    // inputs:  0=pool_in, 1=src_rows, 2=dst_ids
+    // outputs: 0=pool_out (aliases pool_in; the kernel writes in place)
+    outputs[0].copy_shared_buffer(inputs[0]);
+
+    const array& pool    = inputs[0];
+    const array& src     = inputs[1];
+    const array& dst_ids = inputs[2];
+
+    int n = static_cast<int>(dst_ids.size());
+    if (n == 0) {
+      return;
+    }
+    int row_elems = static_cast<int>(pool.size() / pool.shape(0));
+
+    auto s = stream();
+    auto& d = metal::device(s.device);
+    auto dt = dtype_to_metal(pool.dtype());
+    std::string kname = "gdn_state_scatter_rows_" + dt;
+    auto* lib = d.get_library("gdn_kern");
+    auto* kernel = d.get_kernel(kname, lib, kname, {});
+
+    auto& enc = metal::get_command_encoder(s);
+    enc.set_compute_pipeline_state(kernel);
+    enc.set_output_array(outputs[0], 0);
+    enc.set_input_array(src,         1);
+    enc.set_input_array(dst_ids,     2);
+    enc.set_bytes(row_elems,         3);
+
+    int tg = std::min(row_elems, 256);
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(n, 1, 1),
+        MTL::Size::Make(tg, 1, 1));
+  }
+
+  const char* name() const override { return "GDNStateScatter"; }
+
+  bool is_equivalent(const Primitive& other) const override {
+    return dynamic_cast<const GDNStateScatterPrimitive*>(&other) != nullptr;
+  }
+};
+
+static array gdn_state_scatter_primitive_fn(
+    const array& pool, const array& src, const array& dst_ids) {
+  if (pool.ndim() < 2) {
+    throw std::runtime_error(
+        "gdn_state_scatter: pool must be [num_slots, ...]");
+  }
+  if (src.dtype() != pool.dtype()) {
+    throw std::runtime_error("gdn_state_scatter: src and pool dtypes differ");
+  }
+  if (dst_ids.dtype() != int32) {
+    throw std::runtime_error("gdn_state_scatter: dst_ids must be int32");
+  }
+  if (dst_ids.ndim() != 1) {
+    throw std::runtime_error("gdn_state_scatter: dst_ids must be 1-D");
+  }
+  if (static_cast<size_t>(src.shape(0)) != dst_ids.size()) {
+    throw std::runtime_error(
+        "gdn_state_scatter: one dst id per src row required");
+  }
+  if (src.ndim() != pool.ndim() ||
+      !std::equal(
+          pool.shape().begin() + 1, pool.shape().end(),
+          src.shape().begin() + 1)) {
+    throw std::runtime_error(
+        "gdn_state_scatter: src row shape does not match pool row shape");
+  }
+  auto prim = std::make_shared<GDNStateScatterPrimitive>(
+      default_stream(Device::gpu));
+  return array::make_arrays(
+      {pool.shape()}, {pool.dtype()}, prim, {pool, src, dst_ids})[0];
+}
+
+// ---------------------------------------------------------------------------
 // MLA paged attention (RFC #360)
 // ---------------------------------------------------------------------------
 
@@ -1631,6 +1737,41 @@ NB_MODULE(_paged_ops, m) {
         "kv_cache.<cache>[layer_idx] to the returned value. key/value are "
         "[num_tokens, num_kv_heads, head_size]; caches are "
         "[num_blocks, block_size, num_kv_heads, head_size].");
+
+  m.def("gdn_state_scatter",
+        [](nb::handle pool_h, nb::handle src_h, nb::handle ids_h) {
+          // inst_ptr<array> on a non-array is undefined behaviour, so check
+          // before dereferencing: a wrong type must raise, not crash.
+          nb::object mx_array_cls =
+              nb::module_::import_("mlx.core").attr("array");
+          for (nb::handle h : {pool_h, src_h, ids_h}) {
+            if (!nb::isinstance(h, mx_array_cls)) {
+              throw std::runtime_error(
+                  "gdn_state_scatter: pool, src and dst_ids must be "
+                  "mlx.core.array");
+            }
+          }
+          auto result = gdn_state_scatter_primitive_fn(
+              *nb::inst_ptr<array>(pool_h),
+              *nb::inst_ptr<array>(src_h),
+              *nb::inst_ptr<array>(ids_h));
+
+          // Same placeholder dance as tq_encode / reshape_and_cache: mint an
+          // mx.core.array and overwrite_descriptor to bypass cross-module
+          // nanobind RTTI.
+          nb::object mx_core  = nb::module_::import_("mlx.core");
+          nb::object arr_cls  = mx_core.attr("array");
+          nb::object zero_arg = nb::int_(0);
+          nb::object out      = arr_cls(zero_arg);
+          nb::inst_ptr<array>(out)->overwrite_descriptor(result);
+          return out;
+        },
+        nb::arg("pool"), nb::arg("src"), nb::arg("dst_ids"),
+        "In-place row scatter into a slot-indexed GDN state pool. Writes "
+        "src[i] into pool[dst_ids[i]] without MLX's whole-pool copy preamble; "
+        "the returned array aliases the pool buffer, so the caller MUST "
+        "rebind its pool reference to it. dst_ids must be distinct int32 "
+        "slots; src is [n, *pool.shape[1:]] with pool's dtype.");
 
   // Paged attention primitive (read-only): dispatches paged_attention_v2_online.
   // Cache writes are handled by MLX-native scatter upstream.

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -1215,27 +1215,9 @@ void init_gdn_library(const std::string& src) {
   d.get_library("gdn_kern", [&]() { return gdn_source_; });
 }
 
-// ---------------------------------------------------------------------------
-// gdn_state_scatter — in-place row scatter into a GDN state pool
-//
-// Replaces `pool[mx.array(slot_ids)] = rows` on the state-drain path.  MLX's
-// Scatter::eval_gpu (mlx/backend/metal/indexing.cpp) routes through copy_gpu,
-// which donates the source buffer only when it holds the sole reference to it
-// (is_donatable, mlx/backend/common/utils.h).  A GDN state pool is aliased
-// into every one of its sibling layers, so that never holds and each write
-// rewrites the whole pool.  Under align-mode prefix caching the pool is
-// indexed by scheduler block id and grows with cache occupancy, so that
-// rewrite — not the update itself — dominates the step.
-//
-// This primitive writes the rows in place: the output aliases the pool buffer
-// via copy_shared_buffer, giving the write a distinct graph identity (the same
-// provenance pattern as TQEncodePrimitive / ReshapeAndCachePrimitive) while
-// touching only the rows named by dst_ids.  The caller MUST rebind its pool
-// reference to the returned array so later ops depend on this primitive.
-//
-// Destination slots must be distinct; duplicates would race between
-// threadgroups.  Callers enforce that invariant.
-// ---------------------------------------------------------------------------
+// gdn_state_scatter writes selected rows in place and returns a distinct graph
+// handle for the resulting pool buffer. Callers must rebind that handle so
+// later operations depend on the write. Destination slots must be distinct.
 
 class GDNStateScatterPrimitive : public Primitive {
  public:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -678,6 +678,16 @@ class ModelCachePolicy:
                     f"the memory plan budgeted {budgeted}; refusing to "
                     "exceed the paged memory budget"
                 )
+            # Record the derived layout next to the budget it was checked
+            # against.
+            logger.info(
+                "Align-mode GDN state: %d linear layers over %d physical "
+                "state pools (budgeted %d), %d mamba cache groups",
+                len(cache_idx_by_name),
+                pools_used,
+                budgeted,
+                len(mamba_group_ids),
+            )
         runtime.adopt_scheduler_group(
             group_index,
             block_size,

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -678,16 +678,6 @@ class ModelCachePolicy:
                     f"the memory plan budgeted {budgeted}; refusing to "
                     "exceed the paged memory budget"
                 )
-            # Record the derived layout next to the budget it was checked
-            # against.
-            logger.info(
-                "Align-mode GDN state: %d linear layers over %d physical "
-                "state pools (budgeted %d), %d mamba cache groups",
-                len(cache_idx_by_name),
-                pools_used,
-                budgeted,
-                len(mamba_group_ids),
-            )
         runtime.adopt_scheduler_group(
             group_index,
             block_size,


### PR DESCRIPTION
## Summary

Prefix caching should help when requests share a prefix and add essentially no cost when they do not. On hybrid GDN models, `main` did neither: shared-prefix traffic improved by only 1.03×, while traffic without shared prefixes became 2.24× slower.

Qwen3.5+ prefix caching `align` will be the default in the next vllm version (currently it's off by default): https://github.com/vllm-project/vllm/pull/50991

This PR makes it behave like prefix caching:

| Model / mode | Shared prefix | No shared prefix |
| --- | ---: | ---: |
| Qwen3-0.6B, dense reference | **1.32× faster** | 1.02×, effectively free |
| Qwen3.5-0.8B, align, `main` | 1.03×, barely faster | **2.24× slower** |
| Qwen3.5-0.8B, align, this PR | **1.26× faster** | 0.98×, effectively free |

The dense row is the behavioral control: shared prefixes help, while unrelated traffic stays neutral. The PR restores that behavior for the hybrid model.

<details>
<summary>Benchmark setting</summary>

Each cell compares APC enabled with disabled for the same model and workload in the same benchmark session. All runs use 100 prompts, concurrency 16, request rate `inf`, 2304 input tokens, 128 output tokens, `--ignore-eos`, and seed 1234. The shared-prefix workload uses 10 repeated 2048-token prefixes with 256-token suffixes, producing a 61% cache-hit rate; the no-sharing workload uses random prompts.

The server runs on an Apple M5 Pro with 64 GB unified memory, macOS 26.2, vllm 0.27.0, mlx 0.32.0, `--max-model-len 4096`, paged attention enabled, and `VLLM_METAL_MEMORY_FRACTION=0.5`.

Each cell is one run. Repeat `main` runs for the no-sharing workload were 153.10 s and 156.73 s, so changes within approximately 3% should be treated as noise.

</details>


## Roadmap

* #584 prototype of align-mode GDN prefix caching
* #634 align mode kernel: after this PR, prefix caching becomes actually very useful, if you have enough memory. 
* future work: fix kv cache double count issue. 
* then we can mark this feature as support (currently experimental)
* future work: extend the support to LFM
* not planned: `all` mode prefix caching

## What was wrong & Why we need a `Primitive` metal kernel

Under `mamba_cache_mode="align"`, 18 linear layers share 6 physical state pools indexed by scheduler block id. At 1650+ cached blocks, each recurrent pool is about 1.6 GiB.

Every state write used MLX assignment. The available MLX 0.32.0 paths behave as follows:

| Write path | What `eval_gpu` does | Result for this pool |
| --- | --- | --- |
| `pool[ids] = rows` | [`Scatter`](https://github.com/ml-explore/mlx/blob/7a1d4f5c12ac82f4b4d0a6e71538d89ca0605247/mlx/backend/metal/indexing.cpp#L247-L256) calls `copy_gpu(pool, out)` before scattering | Full-pool copy when donation fails |
| `pool[a:b] = rows` | [`SliceUpdate`](https://github.com/ml-explore/mlx/blob/7a1d4f5c12ac82f4b4d0a6e71538d89ca0605247/mlx/backend/metal/indexing.cpp#L731-L764) calls the same `copy_gpu` path before copying the slice | Same full-pool copy |
| `mx.fast.metal_kernel` | [`CustomKernel`](https://github.com/ml-explore/mlx/blob/7a1d4f5c12ac82f4b4d0a6e71538d89ca0605247/mlx/backend/metal/custom_kernel.cpp#L21-L38) creates fresh output storage | Cannot express an aliased pool write |
| This PR: MLX `Primitive` | Aliases the pool with `copy_shared_buffer`, then writes selected rows | No full-pool pre-copy, with a graph dependency |

For a contiguous pool, `copy_gpu` avoids the copy only by donating the source buffer. [`array::is_donatable()`](https://github.com/ml-explore/mlx/blob/7a1d4f5c12ac82f4b4d0a6e71538d89ca0605247/mlx/array.h#L293-L296) requires both the array descriptor and its data buffer to have `use_count() == 1`. `store_conv_state` and `store_recurrent_state` alias each physical pool across its sibling layers, so donation is unavailable. A row update therefore rewrote up to all 1650+ rows.

The cache owned three affected paths: the deferred-state drain, `zero_slots`, and `copy_slots`. Three more writers reached into the pools directly. The hot one was `gdn_lazy.try_conv_decode`, which wrote the conv pool once per linear layer on every pure-decode step. This made a fresh request slower as unrelated requests filled the prefix cache (9.2 ms to 112.5 ms decode ITL).

## What changed

- Add `gdn_state_scatter`, an MLX `Primitive` that aliases the pool, writes only selected rows with a 2D/vectorized Metal kernel, and returns the post-write graph handle.
- Route all six writers through `write_conv_rows` or `write_recurrent_rows`, which scatter the rows and rebind every sibling layer to that handle.

This adds no `mx.eval` barriers. Recurrence, cache placement, and pending-state transitions are unchanged.

## Validation

- `tools/hybrid_apc_parity_matrix.py` on Qwen/Qwen3.5-0.8B: 6 runs, 480 comparisons, 0 mismatches. The matrix covers engine defaults and `max_num_batched_tokens=1088` to force aligned chunked splits.
- Focused GDN kernel, wrapper, and state-manager tests: 92 passed.

## Build

This changes C++ and Metal sources. Run `python -m vllm_metal.metal.build` to refresh prebuilt artifacts, or set `VLLM_METAL_BUILD_FROM_SOURCE=1` for a source build.

## Scope

This changes state-write traffic, not align-mode memory usage. The remaining 1.7% no-sharing overhead and the 8.2 ms versus 6.5 ms decode gap are not addressed here.
