### PR TITLE
[Spec Decode] Skip re-ingesting accepted draft tokens whose KV the lookahead already wrote (#482 direction 2)

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -154,6 +154,15 @@ the paged decode kernel, sharing KV block loads across its rows like the
 target's verification window; generated tokens are identical either way, and
 single-stream TPOT is within run-to-run noise of the expanded layout.
 
+The ingest also skips re-computing KV it already holds: the lookahead draft
+steps write KV for drafts `d1..d(K-1)`, and when the verifier accepts those
+drafts the next round's ingest starts after them instead of recomputing
+(shrinking the steady-state K+1-token ingest to 2 rows on full acceptance).
+A skipped position requires both its committed token to equal the drafted
+token and the scheduler's block table to still map it to the same physical
+block the speculative write landed in, so rejected drafts, re-allocated
+blocks, and scratch-block writes always fall back to a full re-ingest.
+
 ---
 
 ## N-gram

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -69,10 +69,13 @@ def _request_state(
     committed_block_ids: list[int],
     num_computed_tokens: int = 0,
     sampling_params: SamplingParams | None = None,
+    token_ids: list[int] | None = None,
 ) -> RequestState:
+    if token_ids is None:
+        token_ids = list(range(PROMPT_LEN))
     return RequestState(
-        token_ids=list(range(PROMPT_LEN)),
-        prompt_len=PROMPT_LEN,
+        token_ids=list(token_ids),
+        prompt_len=len(token_ids),
         cache=[],
         sampling_params=sampling_params or SamplingParams(temperature=0.0),
         block_ids=[list(committed_block_ids)],
@@ -275,6 +278,189 @@ def test_scratch_pool_exhaustion_raises() -> None:
             _context("resumed", resumed, request_states, num_speculative_tokens=4)
         )
     assert len(model.block_tables) == calls_before
+
+
+# -- Speculative-KV reuse (#482 direction 2) --------------------------------
+
+
+def _draft_two_rounds(
+    model: _StubDraftModel,
+    proposer: DraftModelProposer,
+    *,
+    second_round_tokens: list[int],
+    second_round_blocks: list[int],
+    num_speculative_tokens: int = 3,
+    first_round_len: int = PROMPT_LEN,
+    first_round_blocks: list[int] | None = None,
+) -> None:
+    """Round 1 drafts from a fresh prompt; round 2 re-proposes after the
+    verifier committed ``second_round_tokens`` (drafts + bonus).
+
+    The stub model argmaxes all-zeros logits to token 0, so every drafted
+    token is 0: "accepted" round-2 tokens are 0s, "rejected" ones are not.
+
+    Returns the index into ``model.input_lens`` of round 2's ingest forward
+    (round 1 contributes one ingest plus K-1 single-token draft steps).
+    """
+    if first_round_blocks is None:
+        first_round_blocks = [0, 1]
+    state1 = _request_state(
+        committed_block_ids=first_round_blocks,
+        token_ids=list(range(first_round_len)),
+    )
+    assert (
+        proposer.propose(
+            _context(
+                "r1",
+                state1,
+                {"r1": state1},
+                num_speculative_tokens=num_speculative_tokens,
+            )
+        )
+        is not None
+    )
+    round2_ingest_index = len(model.input_lens)
+    state2 = _request_state(
+        committed_block_ids=second_round_blocks,
+        token_ids=list(range(first_round_len)) + second_round_tokens,
+    )
+    assert (
+        proposer.propose(
+            _context(
+                "r1",
+                state2,
+                {"r1": state2},
+                num_speculative_tokens=num_speculative_tokens,
+            )
+        )
+        is not None
+    )
+    return round2_ingest_index
+
+
+def test_full_acceptance_skips_reingest_of_drafted_kv() -> None:
+    """On full acceptance the K-1 drafts whose KV the previous round's
+    lookahead steps already wrote are not re-ingested: the steady-state
+    K+1-token ingest shrinks to 2 rows (#482 direction 2)."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+
+    ingest = _draft_two_rounds(
+        model,
+        proposer,
+        second_round_tokens=[0, 0, 0, 5],  # drafts 0,0,0 accepted + bonus
+        second_round_blocks=[0, 1],
+    )
+
+    assert model.input_lens[0] == PROMPT_LEN  # round 1: full prompt
+    assert model.input_lens[ingest] == 2  # round 2: only d_K's slot + bonus
+
+
+def test_rejected_draft_reingests_the_full_committed_range() -> None:
+    """A rejected first draft means the committed token at that position
+    differs from what the speculative KV was written with -- nothing may be
+    skipped."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+
+    ingest = _draft_two_rounds(
+        model,
+        proposer,
+        second_round_tokens=[7, 0, 0, 5],  # first draft rejected
+        second_round_blocks=[0, 1],
+    )
+
+    assert model.input_lens[ingest] == 4  # all K+1 newly committed tokens
+
+
+def test_scratch_block_spec_kv_is_not_reused() -> None:
+    """Speculative KV that landed in a scratch block (lookahead crossed a
+    block boundary) must not be skipped past: the scheduler allocated a
+    different physical block for those positions, so the KV is not where
+    the new block table looks."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+
+    # committed_len 31 with 16-token blocks: lookahead positions 31, 32
+    # land in committed block 1 and scratch block 2 respectively.
+    ingest = _draft_two_rounds(
+        model,
+        proposer,
+        first_round_len=31,
+        first_round_blocks=[0, 1],
+        second_round_tokens=[0, 0, 0, 5],
+        second_round_blocks=[0, 1, 5],  # scheduler's own block 5, not scratch 2
+    )
+
+    # Position 31 (committed block, matching token) is skipped; position 32
+    # (scratch write) is not: 35 - 32 = 3 tokens re-ingested.
+    assert model.input_lens[ingest] == 3
+
+
+def test_reallocated_block_spec_kv_is_not_reused() -> None:
+    """A scheduler re-allocation that swaps the committed block table's
+    physical blocks (tokens still matching) must stop the walk: the
+    speculative KV is not where the new table looks."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+
+    ingest = _draft_two_rounds(
+        model,
+        proposer,
+        second_round_tokens=[0, 0, 0, 5],  # full acceptance: tokens match
+        second_round_blocks=[4, 7],  # but the scheduler remapped the blocks
+    )
+
+    # No position may be skipped: all 4 newly committed tokens re-ingest.
+    assert model.input_lens[ingest] == 4
+
+
+def test_partial_acceptance_never_produces_an_empty_ingest() -> None:
+    """The skip is capped one short of committed_len: the last committed
+    token's row must always run because its logits predict this round's
+    first draft token."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+
+    ingest = _draft_two_rounds(
+        model,
+        proposer,
+        second_round_tokens=[0, 9],  # one draft accepted + bonus
+        second_round_blocks=[0, 1],
+    )
+
+    assert model.input_lens[ingest] == 1
+
+
+def test_spec_kv_ledger_cleared_on_release() -> None:
+    """After release_requests, a request reusing the id cannot skip off a
+    stale ledger -- its KV was never written."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+
+    state1 = _request_state(committed_block_ids=[0, 1])
+    assert (
+        proposer.propose(
+            _context("r1", state1, {"r1": state1}, num_speculative_tokens=3)
+        )
+        is not None
+    )
+    proposer.release_requests({"r1"})
+
+    state2 = _request_state(
+        committed_block_ids=[0, 1],
+        num_computed_tokens=PROMPT_LEN,
+        token_ids=list(range(PROMPT_LEN)) + [0, 0, 0, 5],
+    )
+    ingest = len(model.input_lens)
+    assert (
+        proposer.propose(
+            _context("r1", state2, {"r1": state2}, num_speculative_tokens=3)
+        )
+        is not None
+    )
+
+    assert model.input_lens[ingest] == 4  # no skip: ledger gone
 
 
 # -- Sliding-window / hybrid draft rejection ---------------------------------

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -55,6 +55,20 @@ Each step: ingest advances every row's committed KV to ``committed_len``,
 then ``num_speculative_tokens - 1`` single-token decode steps run for
 drafting rows only. Drafts are handed back via ``take_draft_token_ids`` and
 verified next step by ``SpeculativeDecodeController.verify_greedy``.
+
+**Skipping already-valid speculative KV (#482, direction 2).** The
+lookahead draft steps write KV for drafts ``d1..d(K-1)`` at positions
+``[committed_len, committed_len + K - 1)``. When the next round's committed
+tokens match those drafts (greedy acceptance is a prefix, so accepted drafts
+keep their identities), that KV is exactly what the ingest would recompute
+-- so the ingest skips it (``_speculative_kv_valid_through``), shrinking the
+steady-state K+1-token ingest to 2 rows on full acceptance. A position is
+skipped only when its committed token equals the recorded drafted token AND
+the scheduler's committed-group block table still maps the position to the
+same physical block the speculative write landed in (speculative KV that
+crossed into a scratch block is never reused -- the scheduler allocates its
+own block there). The last committed token is always re-ingested: its
+logits are needed to predict this round's first draft token anyway.
 """
 
 from __future__ import annotations
@@ -106,6 +120,10 @@ class _DraftPlan:
     req_id: str
     block_ids: list[int]
     committed_len: int
+    # Effective start of this step's ingest forward: the position whose KV
+    # is not already valid in the draft cache (either never written, or
+    # written speculatively last round with a token/block that no longer
+    # matches -- see _speculative_kv_valid_through).
     draft_seq_len: int
     ingest_tokens: list[int]
     is_drafting: bool
@@ -155,6 +173,15 @@ class DraftModelProposer:
         # first time a request is seen (see _make_decode_plan), so a
         # resubmitted/shared prefix skips re-ingest (#482).
         self._draft_seq_lens: dict[str, int] = {}
+        # Speculative KV written by past lookahead draft steps, per request:
+        # position -> (block_id, drafted token). Lets the next round's ingest
+        # skip re-ingesting accepted drafts whose KV the lookahead already
+        # wrote (#482 direction 2). Entries are replaced wholesale each time
+        # a request drafts, and survive non-drafting rounds in between --
+        # each position is re-validated against the current committed tokens
+        # and block table before use, so staleness can only cost performance,
+        # never correctness.
+        self._spec_kv_writes: dict[str, dict[int, tuple[int, int]]] = {}
         # Scheduler-owned KV-cache group index for the committed portion.
         # Unknown at construction time -- the physical backend below is
         # built before the scheduler has decided kv_cache_config (see
@@ -300,6 +327,21 @@ class DraftModelProposer:
         mx.eval(drafts)
         rows: list[list[int]] = drafts.tolist()  # type: ignore[assignment]
 
+        # Record the speculative KV this round's lookahead steps wrote, for
+        # next round's ingest skip (see module docstring). Draft step i fed
+        # row[i-1] at position committed_len + i - 1 for i in 1..K-1, writing
+        # its KV there; the K-th draft's KV is never written (no step feeds
+        # it before verification).
+        for plan, row in zip(drafting_plans, rows, strict=True):
+            writes: dict[int, tuple[int, int]] = {}
+            for i in range(num_speculative_tokens - 1):
+                position = plan.committed_len + i
+                writes[position] = (
+                    plan.block_ids[position // self._block_size],
+                    int(row[i]),
+                )
+            self._spec_kv_writes[plan.req_id] = writes
+
         return DraftTokenIds(
             req_ids=[plan.req_id for plan in drafting_plans],
             draft_token_ids=[[int(token) for token in row] for row in rows],
@@ -315,6 +357,7 @@ class DraftModelProposer:
             if blocks is not None:
                 self._scratch_free_blocks.extend(blocks)
             self._draft_seq_lens.pop(req_id, None)
+            self._spec_kv_writes.pop(req_id, None)
 
     # -- internals -----------------------------------------------------------
 
@@ -325,6 +368,9 @@ class DraftModelProposer:
         for req_id in list(self._draft_seq_lens.keys()):
             if req_id not in request_states:
                 del self._draft_seq_lens[req_id]
+        for req_id in list(self._spec_kv_writes.keys()):
+            if req_id not in request_states:
+                del self._spec_kv_writes[req_id]
 
     def _collect_draft_plans(
         self, ctx: ProposeContext, num_speculative_tokens: int
@@ -388,9 +434,26 @@ class DraftModelProposer:
             return None
         is_drafting = req_id in drafting_req_ids
         assert self._committed_group_index is not None
+        committed_group_block_ids = state.block_ids[self._committed_group_index]
+        # Skip the leading accepted drafts whose KV the previous round's
+        # lookahead steps already wrote (#482 direction 2); the walk stops at
+        # the first position whose recorded token or block no longer matches
+        # what is now committed. Capped one short of committed_len: the last
+        # committed token's row must still run (its logits predict this
+        # round's first draft token), so the ingest is never empty.
+        draft_seq_len = min(
+            self._speculative_kv_valid_through(
+                req_id,
+                state.token_ids,
+                committed_group_block_ids,
+                draft_seq_len,
+                committed_len,
+            ),
+            committed_len - 1,
+        )
         block_ids = self._ensure_blocks(
             req_id,
-            committed_group_block_ids=state.block_ids[self._committed_group_index],
+            committed_group_block_ids=committed_group_block_ids,
             total_positions=committed_len
             + (num_speculative_tokens if is_drafting else 0),
         )
@@ -474,6 +537,45 @@ class DraftModelProposer:
             self._scratch_req_blocks.pop(req_id, None)
 
         return list(committed_group_block_ids) + scratch_blocks
+
+    def _speculative_kv_valid_through(
+        self,
+        req_id: str,
+        token_ids: list[int],
+        committed_group_block_ids: list[int],
+        draft_seq_len: int,
+        committed_len: int,
+    ) -> int:
+        """First position in ``[draft_seq_len, committed_len)`` whose committed
+        KV is not already valid in the draft cache.
+
+        Consults the speculative-write ledger from the last round that
+        drafted this request. A position is skippable only when its committed
+        token equals the recorded drafted token AND the position still maps
+        to the same scheduler-owned committed block the speculative write
+        landed in; anything else (rejected draft, scratch-block write,
+        re-allocated block table, no ledger) stops the walk, because the
+        ingest forward must be one contiguous range of positions whose KV is
+        valid up to its start.
+        """
+        writes = self._spec_kv_writes.get(req_id)
+        if not writes:
+            return draft_seq_len
+        position = draft_seq_len
+        while position < committed_len:
+            write = writes.get(position)
+            if write is None:
+                break
+            block_id, drafted_token = write
+            block_index = position // self._block_size
+            if (
+                block_index >= len(committed_group_block_ids)
+                or committed_group_block_ids[block_index] != block_id
+                or token_ids[position] != drafted_token
+            ):
+                break
+            position += 1
+        return position
 
     def _ingest_and_draft_first(
         self, plans: list[_DraftPlan], offset_caches: list[OffsetCache]


### PR DESCRIPTION
## Problem

Issue #482's Problem 2: steady-state propose costs ~1.7–1.9x an entire nospec engine step even at 100% acceptance. The issue names one concrete piece of it: on full acceptance, **K−1 of K+1 ingested tokens recompute KV that the previous round's lookahead draft steps already wrote**. Post-#630 the steady ingest is a 4-token window, so on a full acceptance that is 2 of 4 tokens doing duplicate work.

#502 fixed the routing half of Problem 2 (94 → ~50 ms/step @8k) and **prototyped exactly this skip on top of it — measured ~3 ms, and deliberately left it out of scope** ("rows inside one decode dispatch largely amortize"). This is that follow-on, completed: implemented, tested, and measured with the same-day A/B the prototype lacked.

## Fix

Track the speculative KV each round's lookahead steps wrote, and skip re-ingesting it when the next round's committed tokens prove it still valid:

1. **Record.** After each drafting round, save per request a ledger of `position → (physical block id, drafted token)` for the positions the lookahead steps wrote: `[committed_len, committed_len + K−1)`.
2. **Skip.** The next round's ingest starts at `_speculative_kv_valid_through` — the first position whose committed KV is not already valid in the draft cache. A position is skippable only when:
   - its committed token equals the recorded drafted token, **and**
   - the scheduler's committed-group block table still maps the position to the same physical block the speculative write landed in.

   Anything else — rejected draft, lookahead KV that crossed into a scratch block (the scheduler allocates its own block there), a re-allocated block table, or no ledger — stops the walk, because the ingest forward must be one contiguous range of positions whose KV is valid up to its start.
3. **Cap.** The walk is capped one short of `committed_len`: the last committed token's row must still run — its logits predict this round's first draft token — so the ingest is never empty.

**Result:** on full acceptance, the steady-state 4-token ingest shrinks to **2 tokens**.

## Measurements

Same-day, back-to-back A/B of this branch vs plain `main` (Qwen3-0.6B draft == target, K=3, greedy → 100% acceptance, prefix caching on, steady-state resubmit runs, in-tree harness `tools/benchmark/draft_resubmit_benchmark.py`):

| prefix | propose_median_ms (main → branch) | tpot_ms (main → branch) |
|---|---|---|
| 2k | 47.5 → 47.3 | 18.96 → 18.61 |
| 8k | 75.4 → 73.3 | 30.14 → 29.62 |

- **The skip fires as designed:** steady-state plans ingest 2 tokens on the branch vs 4 on main (23/26 plans per run; the rest are the resubmit-boundary and partial-acceptance plans).
- **Lossless:** generated token sequences are identical branch vs main on all four runs (96 tokens each).
- **Honest caveats:** n=1 run per config (each propose_median is a median of ~26 proposes); the @2k deltas are inside run-to-run noise; the @8k propose delta (−2.1 ms, ~2.8%) is the strongest signal, and tpot is directionally better in all four comparisons. The scale matches #502's prototype (~3 ms): the ceiling is modest because the post-#630 steady ingest was already a 4-token window — this removes its duplicate half, not the kernel cost that dominates the rest.

## Correctness

The ledger survives rounds where a request doesn't draft; every entry is re-validated against the current committed tokens and block table before use, so staleness can only cost performance, never correctness. The ledger is cleared on request release and in the periodic GC, so a reused request id gets no skip.

## Tests & Documentation

- `test_full_acceptance_skips_reingest_of_drafted_kv` — steady-state ingest shrinks to 2 tokens on full acceptance.
- `test_rejected_draft_reingests_the_full_committed_range` — a rejected draft falls back to a full re-ingest.
- `test_scratch_block_spec_kv_is_not_reused` — lookahead KV that landed in a scratch block is not skipped.
- `test_reallocated_block_spec_kv_is_not_reused` — a scheduler re-allocation that swaps the committed block table's physical blocks (tokens still matching) stops the walk; nothing is skipped.
- `test_partial_acceptance_never_produces_an_empty_ingest` — the skip cap keeps the ingest non-empty.
- `test_spec_kv_ledger_cleared_on_release` — releasing a request clears its ledger.
- `docs/speculative_decoding.md` documents the skip conditions and the fallback cases.

Stacks on **#630** (reads committed-group block IDs from the scheduler-owned block table) and **#502** (the 4-token decode-path ingest this trims).

Addresses **#482 direction 2**. Direction 3 (chunked ingest) and the residual Problem 2 items (per-row KV re-read in attention, per-layer block-table hoist) remain open in the issue.
