### PR TITLE
Keep the hybrid APC parity harness bootable on 16 GB hosts

### DIFF
--- a/tools/hybrid_apc_parity_matrix.py
+++ b/tools/hybrid_apc_parity_matrix.py
@@ -49,7 +49,9 @@ import argparse
 import json
 import multiprocessing as mp
 import os
+import queue as queue_mod
 import sys
+import time
 
 MODEL_DEFAULT = os.environ.get("QWEN35_MODEL_PATH", "Qwen/Qwen3.5-0.8B")
 
@@ -144,9 +146,15 @@ def run_child(model, enable_prefix_caching, mnbt, shared_corpus, quick, queue):
             "max_model_len": 2048,
             "max_num_seqs": 4,
             "enable_prefix_caching": enable_prefix_caching,
+            # profile_run builds a single (1, max_num_batched_tokens) dummy
+            # sequence. Without a cap the LLM-class default (8192) makes that
+            # dummy four times longer than max_model_len, and its full-vocab
+            # logits alone can push the measured overhead past the KV budget
+            # on 16 GB hosts (negative kv_budget -> startup rejection). Keep
+            # the profile within the shapes this harness actually runs.
+            "max_num_batched_tokens": 2048 if mnbt is None else mnbt,
         }
         if mnbt is not None:
-            kwargs["max_num_batched_tokens"] = mnbt
             kwargs["enable_chunked_prefill"] = True
         llm = LLM(**kwargs)
         cache_config = llm.llm_engine.vllm_config.cache_config
@@ -189,7 +197,25 @@ def run_pair(model, mnbt, shared_corpus, quick=False):
         )
         proc.start()
         try:
-            per_mode[enable] = queue.get(timeout=1500)
+            # Poll instead of a single long get: if the child dies during
+            # engine startup (e.g. a capacity rejection) it never reaches
+            # queue.put, and a bare get(timeout=1500) would sit for 25
+            # minutes before surfacing an unrelated queue.Empty. Fail fast
+            # with the child's exit code instead.
+            deadline = time.monotonic() + 1500
+            while True:
+                try:
+                    per_mode[enable] = queue.get(timeout=5)
+                    break
+                except queue_mod.Empty:
+                    if proc.exitcode is not None:
+                        raise RuntimeError(
+                            f"child (prefix_caching={enable}) exited with "
+                            f"{proc.exitcode} before reporting results; "
+                            "see its traceback above"
+                        ) from None
+                    if time.monotonic() >= deadline:
+                        raise
         finally:
             proc.join(timeout=60)
             if proc.is_alive():


### PR DESCRIPTION
Fixes #638.

## Summary

The `--quick` gate (and the defaults arm in general) passed no
`max_num_batched_tokens`. `LLM()` therefore took the 8192 LLM-class default,
and `profile_run()` evaluated a single `(1, 8192)` dummy. In the reproduced
configuration on the tested 16 GB M-series Mac, the cache-on child's
profiled overhead reached 6.46 GB, its KV budget reached -1.81 GB, and it
died during `LLM()` initialization. The cache-off child on the same revision
initialized with 2.38 GB of overhead.

This change is limited to `tools/hybrid_apc_parity_matrix.py`:

- The defaults arm now passes `max_num_batched_tokens=2048`, matching its
  existing `max_model_len`. The arm no longer exercises the LLM-class 8192
  default. That default was not needed by the short parity prompts; it made
  the profile dummy four times longer than any legal sequence in this
  harness. The explicit `mnbt1088` arm is unchanged.
- The parent polls the queue in five-second intervals and fails immediately
  with the child exit code if the child terminates before `queue.put()`,
  instead of waiting up to 1500 seconds and then raising `queue.Empty`.

This PR changes no serving behavior or library default. A serving-shaped
profile path is separate work being discussed in RFC #525 and #590.
#585/#586 concerned the former MLX per-buffer default; #637's proposed
conditional default does not apply below 50 GiB usable memory and is not
involved on the tested host.

## Testing

- `python tools/hybrid_apc_parity_matrix.py --quick` — 20 comparisons,
  0 mismatches, `PARITY PASS`
- Cache-on profile: overhead 6.46 GB -> 0.73 GB; KV budget -1.81 GB ->
  +3.92 GB
- Cache-off bounded profile: overhead 0.76 GB; final KV budget +3.83 GB

The end-to-end wrapper is marked `slow`, is not run in CI, and requires
local Qwen/Qwen3.5-0.8B weights.

## AI assistance

AI assistance was used in developing this change. The problem analysis,
the patch, and the measurements were reviewed and verified by me, and I
am responsible for all submitted changes.
