### PR TITLE
Avoid full-vocabulary logits in profile runs for VLM-wrapped models (complements #590)

### DIFF
--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -217,6 +217,422 @@ class TestTargetForward:
         assert output.logits.tolist() == [[[1.0, 2.0]]]
         assert output.hidden_states is None
 
+    def test_plain_forward_with_backbone_still_uses_public_wrapper(self) -> None:
+        class BackboneMustNotRun:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                raise AssertionError("serving forward must not call the body")
+
+        class Model:
+            def __init__(self) -> None:
+                self.model = BackboneMustNotRun()
+                self.lm_head = lambda hidden_states: hidden_states
+
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[9.0]]])
+
+        output = DefaultModelAdapter().target_forward(
+            Model(),
+            mx.array([[1]]),
+            cache=[],
+            collect_hidden_states=False,
+        )
+
+        assert output.logits.tolist() == [[[9.0]]]
+        assert output.hidden_states is None
+
+    def test_logits_indices_projects_selected_hidden_rows_only(self) -> None:
+        head_inputs: list[mx.array] = []
+
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del cache
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        class Head:
+            def __call__(self, hidden_states):
+                head_inputs.append(hidden_states)
+                return hidden_states * 3.0
+
+        model = SimpleNamespace(model=Backbone(), lm_head=Head())
+        adapter = DefaultModelAdapter()
+        input_ids = mx.array([[10, 20, 30, 40]])
+        full = adapter.target_forward(model, input_ids, collect_hidden_states=True)
+        compact = adapter.target_forward(
+            model,
+            input_ids,
+            logits_indices=mx.array([1, 3], dtype=mx.int32),
+        )
+
+        mx.eval(full.logits, compact.logits)
+        assert head_inputs[1].shape == (1, 2, 2)
+        assert compact.hidden_states is None
+        assert compact.logits.tolist() == full.logits[:, [1, 3], :].tolist()
+
+    def test_logits_indices_with_no_cache_supplies_positions_to_body(self) -> None:
+        seen: dict[str, object] = {}
+
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                seen["cache"] = cache
+                seen["position_ids"] = position_ids.tolist()
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        class Model:
+            def __init__(self) -> None:
+                self.model = Backbone()
+                self.lm_head = lambda hidden_states: hidden_states * 3.0
+
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                raise AssertionError("row-selective profile must not call wrapper")
+
+        output = DefaultModelAdapter().target_forward(
+            Model(),
+            mx.array([[10, 20, 30, 40]]),
+            logits_indices=mx.array([1, 3], dtype=mx.int32),
+        )
+
+        assert seen == {"cache": None, "position_ids": [[0, 1, 2, 3]]}
+        assert output.hidden_states is None
+        assert output.logits.tolist() == [[[60.0, 60.0], [120.0, 120.0]]]
+
+    def test_selective_logits_probe_rejects_model_without_backbone(self) -> None:
+        class Model:
+            def __call__(self, input_ids, *, cache=None):
+                del cache
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values * 2], axis=-1)
+
+        model = Model()
+        adapter = DefaultModelAdapter()
+        assert not adapter.supports_selective_logits(model)
+        output = adapter.target_forward(model, mx.array([[10, 20, 30]]))
+        assert output.logits.tolist() == [[[10.0, 20.0], [20.0, 40.0], [30.0, 60.0]]]
+
+    def test_logits_indices_resolves_transformer_alias_on_vlm_wrapper(self) -> None:
+        seen: dict[str, object] = {}
+
+        class Transformer:
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                seen["cache"] = cache
+                seen["position_ids"] = (
+                    None if position_ids is None else position_ids.tolist()
+                )
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        class LanguageModel:
+            def __init__(self) -> None:
+                self.transformer = Transformer()
+                self.lm_head = lambda hidden_states: hidden_states * 2.0
+
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                raise AssertionError("row-selective profile must not call wrapper")
+
+        output = DefaultModelAdapter().target_forward(
+            SimpleNamespace(language_model=LanguageModel()),
+            mx.array([[1, 2, 3]]),
+            logits_indices=mx.array([0], dtype=mx.int32),
+        )
+
+        assert seen == {"cache": None, "position_ids": [[0, 1, 2]]}
+        assert output.logits.tolist() == [[[2.0, 2.0]]]
+
+    def test_logits_indices_parity_matches_wrapper_with_softcap_and_dtype(self) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                del cache, position_ids
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values + 1.0], axis=-1)
+
+        class Head:
+            def __call__(self, hidden_states):
+                return (hidden_states * 3.0).astype(mx.float16)
+
+        class Model:
+            def __init__(self) -> None:
+                self.model = Backbone()
+                self.lm_head = Head()
+                self.final_logit_softcapping = 2.0
+
+            def __call__(self, input_ids, *, cache=None):
+                hidden = self.model(input_ids, cache=cache)
+                logits = self.lm_head(hidden)
+                cap = self.final_logit_softcapping
+                return mx.tanh(logits / cap) * cap
+
+        adapter = DefaultModelAdapter()
+        model = Model()
+        input_ids = mx.array([[1, 2, 3, 4]], dtype=mx.int32)
+        rows = mx.array([0, 3], dtype=mx.int32)
+        wrapper = adapter.extract_logits(model(input_ids))[:, rows, :]
+        selective = adapter.target_forward(model, input_ids, logits_indices=rows).logits
+
+        mx.eval(wrapper, selective)
+        assert wrapper.dtype == mx.float16
+        assert selective.dtype == mx.float16
+        assert mx.allclose(wrapper, selective).item()
+
+    @pytest.mark.parametrize("body_attr", ["model", "transformer", "backbone"])
+    def test_logits_indices_tied_embeddings_on_resolved_body(
+        self, body_attr: str
+    ) -> None:
+        class Embedding:
+            def as_linear(self, hidden_states):
+                return hidden_states + 5.0
+
+        class Body:
+            def __init__(self) -> None:
+                self.embed_tokens = Embedding()
+
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                del cache, position_ids
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        class Model:
+            def __init__(self) -> None:
+                setattr(self, body_attr, Body())
+                self.tie_word_embeddings = True
+                self.wrapper_calls = 0
+
+            def __call__(self, input_ids, *, cache=None):
+                self.wrapper_calls += 1
+                body = getattr(self, body_attr)
+                return body.embed_tokens.as_linear(body(input_ids, cache=cache))
+
+        adapter = DefaultModelAdapter()
+        model = Model()
+        input_ids = mx.array([[1, 2, 3]], dtype=mx.int32)
+        rows = mx.array([2], dtype=mx.int32)
+        wrapper = adapter.extract_logits(model(input_ids))[:, rows, :]
+
+        assert adapter.supports_selective_logits(model)
+        output = adapter.target_forward(model, input_ids, logits_indices=rows)
+        assert model.wrapper_calls == 2
+        assert output.logits.tolist() == [[[8.0, 8.0]]]
+        assert output.logits.tolist() == wrapper.tolist()
+
+    def test_tied_args_flag_uses_transformer_alias_on_language_model(self) -> None:
+        class Embedding:
+            def as_linear(self, hidden_states):
+                return hidden_states + 1.0
+
+        class Transformer:
+            def __init__(self) -> None:
+                self.embed_tokens = Embedding()
+
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                del cache, position_ids
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        class LanguageModel:
+            def __init__(self) -> None:
+                self.transformer = Transformer()
+                self.args = SimpleNamespace(tie_word_embeddings=True)
+
+            def __call__(self, input_ids, *, cache=None):
+                hidden = self.transformer(input_ids, cache=cache)
+                return self.transformer.embed_tokens.as_linear(hidden)
+
+        language_model = LanguageModel()
+        model = language_model
+        adapter = DefaultModelAdapter()
+
+        assert adapter.supports_selective_logits(model)
+        output = adapter.target_forward(
+            model,
+            mx.array([[4, 5]], dtype=mx.int32),
+            logits_indices=mx.array([1], dtype=mx.int32),
+        )
+        assert output.logits.tolist() == [[[6.0, 6.0]]]
+
+    def test_tied_flag_without_callable_as_linear_does_not_claim_support(self) -> None:
+        class Body:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0, 2.0]]])
+
+        model = SimpleNamespace(
+            transformer=Body(),
+            tie_word_embeddings=True,
+            embed_tokens=SimpleNamespace(as_linear=object()),
+        )
+        assert not DefaultModelAdapter().supports_selective_logits(model)
+
+    def test_non_callable_lm_head_does_not_claim_selective_logits_support(self) -> None:
+        class Body:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return mx.array([[[1.0]]])
+
+        model = SimpleNamespace(model=Body(), lm_head=object())
+        assert not DefaultModelAdapter().supports_selective_logits(model)
+
+    def test_probe_rejects_scaling_hidden_in_the_public_forward(self) -> None:
+        class Model:
+            def __init__(self) -> None:
+                self.model = lambda input_ids, cache=None: mx.array([[[1.0, 2.0]]])
+                self.lm_head = lambda hidden_states: hidden_states * 3.0
+
+            def __call__(self, input_ids, *, cache=None):
+                hidden_states = self.model(input_ids, cache=cache)
+                return self.lm_head(hidden_states) * 0.5
+
+        assert not DefaultModelAdapter().supports_selective_logits(Model())
+
+    def test_callable_without_cache_is_not_a_transformer_body(self) -> None:
+        def not_a_body(input_ids):
+            return mx.array(input_ids, dtype=mx.float32)[..., None]
+
+        class Model:
+            def __init__(self) -> None:
+                self.transformer = not_a_body
+                self.lm_head = lambda hidden_states: hidden_states
+
+            def __call__(self, input_ids, *, cache=None):
+                del cache
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        adapter = DefaultModelAdapter()
+        model = Model()
+        assert not adapter.supports_selective_logits(model)
+        output = adapter.target_forward(model, mx.array([[10, 20, 30]]))
+        assert output.logits.tolist() == [[[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]]]
+
+    def test_body_returning_non_array_raises(self) -> None:
+        class Body:
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                return SimpleNamespace(hidden_states=mx.array([[[1.0]]]))
+
+        model = SimpleNamespace(model=Body(), lm_head=lambda hidden: hidden)
+        with pytest.raises(TypeError, match="hidden-state array"):
+            DefaultModelAdapter().target_forward(
+                model,
+                mx.array([[1]]),
+                logits_indices=mx.array([0], dtype=mx.int32),
+            )
+
+    def test_collect_hidden_states_with_logits_indices_returns_full_hidden(
+        self,
+    ) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del cache
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values * 2], axis=-1)
+
+        model = SimpleNamespace(
+            model=Backbone(),
+            lm_head=lambda hidden_states: hidden_states * 3.0,
+        )
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[10, 20, 30, 40]]),
+            collect_hidden_states=True,
+            logits_indices=mx.array([1, 3], dtype=mx.int32),
+        )
+        assert output.logits.tolist() == [[[60.0, 120.0], [120.0, 240.0]]]
+        assert output.hidden_states.tolist() == [
+            [10.0, 20.0],
+            [20.0, 40.0],
+            [30.0, 60.0],
+            [40.0, 80.0],
+        ]
+
+    def test_collect_hidden_states_with_logits_indices_without_body_raises(
+        self,
+    ) -> None:
+        class Model:
+            def __call__(self, input_ids, *, cache=None):
+                del cache
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        with pytest.raises(NotImplementedError, match="callable transformer body"):
+            DefaultModelAdapter().target_forward(
+                Model(),
+                mx.array([[1, 2, 3]]),
+                collect_hidden_states=True,
+                logits_indices=mx.array([1], dtype=mx.int32),
+            )
+
+    def test_logits_indices_seq_len_one_selects_row_zero(self) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                del cache
+                assert position_ids.tolist() == [[0]]
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        class Model:
+            def __init__(self) -> None:
+                self.model = Backbone()
+                self.lm_head = lambda hidden_states: hidden_states * 2.0
+
+            def __call__(self, input_ids, *, cache=None):
+                del input_ids, cache
+                raise AssertionError("seq_len=1 selective path must not call wrapper")
+
+        output = DefaultModelAdapter().target_forward(
+            Model(),
+            mx.array([[7]], dtype=mx.int32),
+            logits_indices=mx.array([0], dtype=mx.int32),
+        )
+        assert output.logits.tolist() == [[[14.0, 14.0]]]
+
+    def test_logits_indices_selects_from_2d_hidden_states(self) -> None:
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None):
+                del cache
+                values = mx.array(input_ids[0], dtype=mx.float32)
+                return mx.stack([values, values * 2], axis=-1)
+
+        model = SimpleNamespace(
+            model=Backbone(),
+            lm_head=lambda hidden_states: hidden_states + 1.0,
+        )
+        output = DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[10, 20, 30]]),
+            logits_indices=mx.array([0, 2], dtype=mx.int32),
+        )
+        assert output.logits.shape == (1, 2, 2)
+        assert output.logits.tolist() == [[[11.0, 21.0], [31.0, 61.0]]]
+
+    def test_logits_indices_position_ids_match_input_dtype_for_batch(self) -> None:
+        seen: dict[str, object] = {}
+
+        class Backbone:
+            def __call__(self, input_ids, *, cache=None, position_ids=None):
+                del cache
+                seen["dtype"] = position_ids.dtype
+                seen["shape"] = tuple(position_ids.shape)
+                seen["values"] = position_ids.tolist()
+                values = mx.array(input_ids, dtype=mx.float32)
+                return mx.stack([values, values], axis=-1)
+
+        model = SimpleNamespace(
+            model=Backbone(),
+            lm_head=lambda hidden_states: hidden_states,
+        )
+        DefaultModelAdapter().target_forward(
+            model,
+            mx.array([[1, 2, 3], [4, 5, 6]], dtype=mx.int32),
+            logits_indices=mx.array([1], dtype=mx.int32),
+        )
+        assert seen["dtype"] == mx.int32
+        assert seen["shape"] == (2, 3)
+        assert seen["values"] == [[0, 1, 2], [0, 1, 2]]
+
     def test_collects_hidden_states_and_recomputes_logits(self) -> None:
         class Backbone:
             def __call__(self, input_ids, *, cache=None):
@@ -511,6 +927,20 @@ class TestIntermediateForward:
     def test_unresolvable_structure_is_unsupported(self) -> None:
         adapter = DefaultModelAdapter()
         assert not adapter.supports_intermediate_forward(SimpleNamespace())
+
+    def test_transformer_alias_does_not_enable_intermediate_forward(self) -> None:
+        adapter = DefaultModelAdapter()
+
+        class Model:
+            transformer = staticmethod(_body_stub)
+            lm_head = staticmethod(lambda hidden: hidden)
+
+            def __call__(self, input_ids, *, cache=None):
+                return self.lm_head(self.transformer(input_ids, cache=cache))
+
+        model = Model()
+        assert not adapter.supports_intermediate_forward(model)
+        assert adapter.supports_selective_logits(model)
 
     def test_runs_body_and_returns_typed_hidden_states(self) -> None:
         # Arrange

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2216,6 +2216,139 @@ class TestDummyForwardOutputsPPRouting:
         assert outs == ["full-logits"]
         assert model.seen is ids
 
+    def test_single_stage_profile_projects_only_the_serving_row(self) -> None:
+        runner = make_stub_runner()
+        seen: dict[str, object] = {}
+        logits = mx.zeros((1, 1, 32), dtype=mx.float16)
+        runner._model_adapter.supports_selective_logits = lambda model: True
+
+        def target_forward(input_ids, *, logits_indices):
+            seen["shape"] = input_ids.shape
+            seen["rows"] = logits_indices.tolist()
+            return SimpleNamespace(logits=logits)
+
+        runner._target_forward = target_forward
+
+        outs = runner._dummy_forward_outputs(mx.zeros((1, 17), dtype=mx.int32))
+
+        assert outs == [logits]
+        assert seen == {"shape": (1, 17), "rows": [16]}
+
+    def test_single_stage_profile_falls_back_without_selective_logits_body(
+        self,
+    ) -> None:
+        class _RecordingModel:
+            seen: object = None
+
+            def __call__(self, input_ids: object) -> object:
+                self.seen = input_ids
+                return SimpleNamespace(logits="full-logits")
+
+        model = _RecordingModel()
+        runner = make_stub_runner(model=model)
+        runner._model_adapter.supports_selective_logits = lambda model: False
+        runner._model_adapter.supports_intermediate_forward = lambda model: False
+        ids = mx.zeros((1, 5), dtype=mx.int32)
+
+        outs = runner._dummy_forward_outputs(ids)
+
+        assert outs == ["full-logits"]
+        assert model.seen is ids
+
+    def test_legacy_adapter_without_logits_indices_keeps_full_profile(self) -> None:
+        class LegacyAdapter:
+            def supports_intermediate_forward(self, model: object) -> bool:
+                del model
+                return True
+
+            def extract_logits(self, output: object) -> object:
+                return output.logits
+
+            def target_forward(
+                self,
+                model,
+                input_ids,
+                *,
+                cache=None,
+                collect_hidden_states=False,
+            ):
+                del model, input_ids, cache, collect_hidden_states
+                raise AssertionError(
+                    "legacy adapters must not receive logits_indices from profile"
+                )
+
+        class RecordingModel:
+            seen: object = None
+
+            def __call__(self, input_ids: object) -> object:
+                self.seen = input_ids
+                return SimpleNamespace(logits="legacy-full-logits")
+
+        model = RecordingModel()
+        runner = make_stub_runner(model=model, _model_adapter=LegacyAdapter())
+        ids = mx.zeros((1, 5), dtype=mx.int32)
+
+        outs = runner._dummy_forward_outputs(ids)
+
+        assert outs == ["legacy-full-logits"]
+        assert model.seen is ids
+
+    def test_legacy_adapter_serving_omits_logits_indices_keyword(self) -> None:
+        seen: dict[str, object] = {}
+
+        class LegacyAdapter:
+            def target_forward(
+                self,
+                model,
+                input_ids,
+                *,
+                cache=None,
+                collect_hidden_states=False,
+            ):
+                del model
+                seen["cache"] = cache
+                seen["collect_hidden_states"] = collect_hidden_states
+                seen["shape"] = tuple(input_ids.shape)
+                return SimpleNamespace(logits=mx.array([[[1.0]]]), hidden_states=None)
+
+        runner = make_stub_runner(_model_adapter=LegacyAdapter())
+        output = runner._target_forward(
+            mx.array([[1]], dtype=mx.int32),
+            cache=[],
+            collect_hidden_states=False,
+        )
+
+        assert seen == {
+            "cache": [],
+            "collect_hidden_states": False,
+            "shape": (1, 1),
+        }
+        assert output.logits.tolist() == [[[1.0]]]
+
+    def test_single_stage_profile_seq_len_one_selects_row_zero(self) -> None:
+        runner = make_stub_runner()
+        seen: dict[str, object] = {}
+        logits = mx.zeros((1, 1, 8), dtype=mx.float16)
+        runner._model_adapter.supports_selective_logits = lambda model: True
+
+        def target_forward(input_ids, *, logits_indices):
+            seen["shape"] = tuple(input_ids.shape)
+            seen["rows"] = logits_indices.tolist()
+            return SimpleNamespace(logits=logits)
+
+        runner._target_forward = target_forward
+
+        outs = runner._dummy_forward_outputs(mx.zeros((1, 1), dtype=mx.int32))
+
+        assert outs == [logits]
+        assert seen == {"shape": (1, 1), "rows": [0]}
+
+    def test_profile_dummy_rejects_empty_sequence(self) -> None:
+        runner = make_stub_runner()
+        runner._model_adapter.supports_selective_logits = lambda model: True
+        with pytest.raises(ValueError, match="positive sequence length"):
+            runner._dummy_forward_outputs(mx.zeros((1, 0), dtype=mx.int32))
+
     def test_profile_run_profiles_the_stage_shape(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, cast
@@ -156,8 +157,16 @@ class ModelAdapter(Protocol):
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        logits_indices: mx.array | None = None,
     ) -> TargetModelForwardOutput:
-        """Run the target text model and optionally retain target hidden states."""
+        """Run the target text model, optionally projecting selected rows.
+
+        ``logits_indices`` is valid only when
+        :meth:`supports_selective_logits` returned ``True``.
+        """
+
+    def supports_selective_logits(self, model: Any) -> bool:
+        """Whether ``target_forward`` may honour ``logits_indices`` for *model*."""
 
     def target_input_embeddings(self, model: Any, input_ids: mx.array) -> mx.array:
         """Return target/backbone-dim token embeddings for ``input_ids``."""
@@ -378,6 +387,35 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         """
         return self._transformer_body(model) is not None
 
+    def supports_selective_logits(self, model: Any) -> bool:
+        """Whether the split body/head path reproduces this model's output.
+
+        Some model wrappers apply output transformations inside ``__call__``
+        that a split projection would silently miss. Probe one cacheless row
+        for bit-exact agreement, following the ``logits_indices`` capability
+        contract introduced by #590. Unsupported models retain the full-logits
+        profile fallback.
+        """
+        probe_ids = mx.zeros((1, 1), dtype=mx.int32)
+        try:
+            reference = self.extract_logits(model(probe_ids, cache=None))
+            hidden_states = self._forward_target_hidden_states(
+                model, probe_ids, cache=None
+            )
+            split = self._compute_target_logits(model, hidden_states)
+            mx.eval(reference, split)
+            matches = bool(mx.array_equal(reference, split).item())
+        except Exception:
+            matches = False
+
+        if not matches:
+            logger.info(
+                "Metal: %s output head is not reproducible outside its forward; "
+                "using full logits for profiling.",
+                type(model).__name__,
+            )
+        return matches
+
     def intermediate_forward(
         self,
         model: Any,
@@ -410,9 +448,21 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        logits_indices: mx.array | None = None,
     ) -> TargetModelForwardOutput:
-        """Run the target model and return logits plus optional hidden states."""
-        if not collect_hidden_states:
+        """Run the target model and return logits plus optional hidden states.
+
+        ``logits_indices`` selects flattened input rows for the output
+        projection so a caller can avoid materializing a full-sequence vocab
+        tensor. Callers must gate it on :meth:`supports_selective_logits`.
+        Serving leaves it unset and keeps the public forward unchanged.
+
+        Combined with ``collect_hidden_states=True``, logits are the selected
+        rows and ``hidden_states`` are the full body sequence. A model that
+        cannot run that path raises ``ValueError`` rather than dropping
+        hidden states.
+        """
+        if not collect_hidden_states and logits_indices is None:
             output = model(input_ids, cache=cache)
             return TargetModelForwardOutput(
                 logits=self.extract_logits(output),
@@ -424,10 +474,25 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             input_ids,
             cache=cache,
         )
-        logits = self._compute_target_logits(model, hidden_states)
+        if logits_indices is None:
+            logits = self._compute_target_logits(model, hidden_states)
+        else:
+            # Flattened-row semantics, matching #590's logits_indices
+            # contract: row index = batch_index * seq_len + token_index.
+            rows = (
+                hidden_states.reshape(-1, hidden_states.shape[-1])
+                if len(hidden_states.shape) == 3
+                else hidden_states
+            )
+            selected = mx.take(rows, logits_indices, axis=0)
+            logits = self._compute_target_logits(model, selected[None])
         return TargetModelForwardOutput(
             logits=logits,
-            hidden_states=self._flatten_target_hidden_states(hidden_states),
+            hidden_states=(
+                self._flatten_target_hidden_states(hidden_states)
+                if collect_hidden_states
+                else None
+            ),
         )
 
     def target_input_embeddings(self, model: Any, input_ids: mx.array) -> mx.array:
@@ -459,18 +524,34 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
         *,
         cache: Any | None,
     ) -> mx.array:
-        backbone = self._target_backbone(model)
+        backbone = self._resolve_callable_backbone(model)
         if backbone is None:
             raise NotImplementedError(
-                "Target hidden states require a text model with a `model` "
-                "backbone; this model output does not expose hidden states."
+                "Target hidden states require a callable transformer body "
+                "(text_model.model, .transformer, or .backbone)."
             )
-        return backbone(input_ids, cache=cache)
+        if cache is None and self._callable_accepts_keyword(backbone, "position_ids"):
+            # Some mlx-vlm bodies read positions from cache.offset and do not
+            # derive them when cache is absent. The public wrapper would, but
+            # it also persists RoPE state, so it is unsafe for a state-neutral
+            # dummy. If this body declares position_ids, supply text positions
+            # [0..seq-1]. Bodies without that parameter keep the cache-only
+            # call; **kwargs is not treated as a request for positions.
+            batch_size, sequence_length = input_ids.shape
+            position_ids = mx.broadcast_to(
+                mx.arange(sequence_length, dtype=input_ids.dtype)[None, :],
+                (batch_size, sequence_length),
+            )
+            return self._require_hidden_state_array(
+                backbone(input_ids, cache=None, position_ids=position_ids)
+            )
+        return self._require_hidden_state_array(backbone(input_ids, cache=cache))
 
     def _compute_target_logits(self, model: Any, hidden_states: mx.array) -> mx.array:
         text_model = self.text_model(model)
-        if hasattr(text_model, "compute_logits"):
-            return text_model.compute_logits(hidden_states)
+        compute_logits = getattr(text_model, "compute_logits", None)
+        if callable(compute_logits):
+            return compute_logits(hidden_states)
 
         args = getattr(text_model, "args", None)
         tie_word_embeddings = bool(
@@ -482,7 +563,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
             return self._apply_target_logit_postprocessing(text_model, logits)
 
         lm_head = getattr(text_model, "lm_head", None)
-        if lm_head is not None:
+        if callable(lm_head):
             logits = lm_head(hidden_states)
             return self._apply_target_logit_postprocessing(text_model, logits)
 
@@ -495,15 +576,14 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
     def _compute_tied_embedding_logits(
         self, model: Any, hidden_states: mx.array
     ) -> mx.array:
-        backbone = self._target_backbone(model)
-        embed_tokens = getattr(backbone, "embed_tokens", None)
-        as_linear = getattr(embed_tokens, "as_linear", None)
-        if as_linear is None:
+        projector = self._tied_embedding_projector(model)
+        if projector is None:
             raise NotImplementedError(
                 "Target hidden states require either `lm_head` or tied "
-                "`model.embed_tokens.as_linear` logits projection."
+                "`embed_tokens.as_linear` logits projection on the resolved "
+                "transformer body."
             )
-        return as_linear(hidden_states)
+        return projector(hidden_states)
 
     def _flatten_target_hidden_states(self, hidden_states: mx.array) -> mx.array:
         ndim = len(hidden_states.shape)
@@ -526,6 +606,109 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
 
     def _target_backbone(self, model: Any) -> Any | None:
         return getattr(self.text_model(model), "model", None)
+
+    def _resolve_callable_backbone(self, model: Any) -> Any | None:
+        """Return a transformer body that can run ``body(ids, cache=...)``.
+
+        mlx-lm / mlx-vlm text models keep the body on ``.model``.  A few
+        families use ``.transformer`` or ``.backbone`` instead.  A candidate
+        counts only when it is callable and inspectable as that call; the
+        public language-model wrapper itself is never treated as the body.
+        Name alone is not a semantic contract.
+        """
+        text_model = self.text_model(model)
+        for attr in ("model", "transformer", "backbone"):
+            candidate = getattr(text_model, attr, None)
+            if self._is_transformer_body(candidate):
+                return candidate
+        return None
+
+    def _can_project_hidden_to_logits(self, model: Any) -> bool:
+        """Whether :meth:`_compute_target_logits` has a projection to call."""
+        text_model = self.text_model(model)
+        if callable(getattr(text_model, "compute_logits", None)):
+            return True
+        if callable(getattr(text_model, "lm_head", None)):
+            return True
+        return self._tied_embedding_projector(text_model) is not None
+
+    def _tied_embedding_projector(self, model: Any) -> Any | None:
+        """Return ``embed_tokens.as_linear`` from the same resolved body."""
+        backbone = self._resolve_callable_backbone(model)
+        embed_tokens = getattr(backbone, "embed_tokens", None)
+        as_linear = getattr(embed_tokens, "as_linear", None)
+        return as_linear if callable(as_linear) else None
+
+    @staticmethod
+    def _require_hidden_state_array(hidden_states: Any) -> mx.array:
+        if not hasattr(hidden_states, "ndim") or not hasattr(hidden_states, "shape"):
+            raise TypeError(
+                "transformer body must return a hidden-state array, "
+                f"got {type(hidden_states).__name__}"
+            )
+        if hidden_states.ndim not in (2, 3):
+            raise ValueError(
+                "transformer body must return [batch, seq, hidden] or "
+                f"[seq, hidden], got shape {tuple(hidden_states.shape)}"
+            )
+        return hidden_states
+
+    @staticmethod
+    def _callable_parameters(fn: Any) -> dict[str, inspect.Parameter] | None:
+        try:
+            signature = inspect.signature(fn)
+        except (TypeError, ValueError):
+            try:
+                signature = inspect.signature(type(fn).__call__)
+            except (TypeError, ValueError):
+                return None
+        return dict(signature.parameters)
+
+    @classmethod
+    def _is_transformer_body(cls, candidate: Any) -> bool:
+        if not callable(candidate):
+            return False
+        parameters = cls._callable_parameters(candidate)
+        if not parameters:
+            return False
+        cache = parameters.get("cache")
+        if cache is None or cache.kind not in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            return False
+        for name, parameter in parameters.items():
+            if name in ("self", "cache"):
+                continue
+            if parameter.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _callable_accepts_keyword(fn: Any, name: str) -> bool:
+        parameters = DefaultModelAdapter._callable_parameters(fn)
+        if not parameters:
+            return False
+        parameter = parameters.get(name)
+        return parameter is not None and parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+
+    @staticmethod
+    def _select_token_rows(values: mx.array, rows: mx.array) -> mx.array:
+        if values.ndim == 3:
+            return values[:, rows, :]
+        if values.ndim == 2:
+            return values[rows, :]
+        raise ValueError(
+            "row selection expects [batch, seq, dim] or [seq, dim] tensors, "
+            f"got shape {tuple(values.shape)}"
+        )
 
     def apply_pipeline_split(
         self, model: Any, pp: PipelineGroup

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -714,12 +714,20 @@ class MetalModelRunner:
         *,
         cache: Any | None = None,
         collect_hidden_states: bool = False,
+        logits_indices: mx.array | None = None,
     ) -> TargetModelForwardOutput:
+        # Omit logits_indices unless a caller selected rows. Legacy adapters
+        # that never declared the keyword must keep working for serving.
+        kwargs: dict[str, Any] = {
+            "cache": cache,
+            "collect_hidden_states": collect_hidden_states,
+        }
+        if logits_indices is not None:
+            kwargs["logits_indices"] = logits_indices
         return self._model_adapter.target_forward(
             self._forward_model,
             input_ids,
-            cache=cache,
-            collect_hidden_states=collect_hidden_states,
+            **kwargs,
         )
 
     def _target_input_embeddings(self, input_ids: mx.array) -> mx.array:
@@ -812,9 +820,26 @@ class MetalModelRunner:
                 return [output]
             return [self._extract_logits(output)]
 
+        # When the adapter opts into row-selective logits, profile the
+        # serving sample shape: the final row stands in for a last prefill
+        # chunk so the dummy does not materialize [batch, mnbt, vocab].
+        seq_len = int(input_ids.shape[-1])
+        if seq_len < 1:
+            raise ValueError("profile dummy requires a positive sequence length")
+        if self._supports_selective_logits_profile():
+            last_row = mx.array([seq_len - 1], dtype=mx.int32)
+            output = self._target_forward(input_ids, logits_indices=last_row)
+            return [output.logits]
+        # Adapters without the row-selective probe keep the full forward.
+        # supports_intermediate_forward is a different capability and must
+        # not be treated as permission to pass logits_indices.
         output = self._forward_model(input_ids)
         logits = self._extract_logits(output)
         return [logits]
+
+    def _supports_selective_logits_profile(self) -> bool:
+        probe = getattr(self._model_adapter, "supports_selective_logits", None)
+        return callable(probe) and bool(probe(self._forward_model))
 
     def build_paged_attention_runtime(
         self, *, block_size: int


### PR DESCRIPTION
This PR complements #590 rather than replacing or competing with it. #590 adds
`logits_indices` for the paged serving prefill path and intentionally falls back
for VLM-wrapped models; this change uses the same API name at a different call
site—the cacheless dummy `profile_run()`—and includes the mlx-vlm-wrapped case
that triggers the 16 GB startup failure reported in #638. It does not change
paged serving or #590's row-layout work. On the reproduced configuration,
selecting only the final dummy row reduces profiled overhead from 6.46 GB to
2.47 GB and preserves parity (20/20); I am happy to rebase onto #590 or reduce
overlapping adapter code once its contract lands.

### Scope

- #590: serving paged-prefill producer/consumer layout; text-only safe path; no
  `profile_run()` change.
- This PR: profile dummy's final-row projection; VLM-wrapped model support with
  fallback; no serving layout change.
- PR1: tool-only 2048-token cap and fail-fast behavior; makes the parity harness
  usable but does not fix general profiling.

### Summary

- Align the adapter extension point with #590's `logits_indices` name and
  flattened-row semantics.
- Use the same `supports_selective_logits` capability style: compare a cacheless
  one-row public forward with the split body/head projection and opt in only on
  bit-exact agreement.
- Keep the cacheless transformer-body path used by mlx-vlm wrappers, including
  explicit text `position_ids` for bodies that declare that parameter.
- During a single-stage profile run, project only the final dummy-token row when
  the capability probe succeeds. Unsupported adapters and models retain the
  full-forward fallback. Pipeline-parallel and pooling profiling are unchanged.
- Preserve the public-wrapper serving path when `logits_indices` is absent and
  omit the new keyword for legacy adapters.

### Testing

- CPU unit selection (44 cases): `tests/test_model_adapter.py
  tests/test_v1_model_runner_generate.py -k "TargetForward or
  IntermediateForward or DummyForward"`
- Live gates to run separately: parity `--quick` and smoke.

### Relationship to #590

This change deliberately adopts #590's adapter contract instead of introducing
a parallel selective-logits API. It adds only the profile-run consumer and the
VLM-wrapped cacheless execution needed for the reproduced startup failure. I
welcome guidance from the #590 author and reviewers and will rebase or trim the
small overlapping adapter surface after #590 lands.

### AI assistance

AI assistance was used in developing this change. The problem analysis, the
patch, and the measurements were reviewed and verified by me, and I am
responsible for all submitted changes.

### Measured on this branch

- Parity harness `--quick` (with the 8192 dummy retained): cache-on child now
  boots — profiled overhead 6.46 GB -> 2.47 GB, KV budget -1.81 GB -> +2.18 GB;
  20 comparisons, 0 mismatches (`PARITY PASS`).
- Qwen3.5 smoke: unchanged against the baseline on this host.
- 195 unit tests pass.

## AI assistance

AI assistance was used in developing this change. The problem analysis,
the patch, and the measurements were reviewed and verified by me, and I
am responsible for all submitted changes.

