### PR TITLE
Bump vLLM to 0.28.0

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -13,8 +13,10 @@ path. All require synchronous scheduling and greedy sampling.
 
 All three methods:
 
-- Require `--no-async-scheduling` (vLLM auto-disables async for most spec-decode
-  methods; pass it explicitly to be safe).
+- Run with synchronous scheduling. The Metal platform disables async
+  scheduling automatically whenever speculative decoding is configured
+  (vLLM 0.28.0 auto-enables async for draft-model spec decode); passing
+  `--no-async-scheduling` explicitly remains fine.
 - Only accelerate greedy requests (`temperature=0`). Non-greedy requests skip
   drafting silently.
 - Are lossless under greedy decoding.

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Pinned by full URL because no index serves it: PyPI's vllm has no macOS
 # wheel yet. To bump, raise VLLM_VERSION to a release that attaches one —
 # not every release does; v0.26.0 was the first.
-VLLM_VERSION="0.27.1"
+VLLM_VERSION="0.28.0"
 VLLM_WHEEL_URL="https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}%2Bcpu-cp312-cp312-macosx_11_0_arm64.whl"
 
 _cleanup_dirs=()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
     "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
-    # Keep aligned with vLLM 0.27.1's Transformers lower bound.
+    # Keep aligned with vLLM 0.28.0's Transformers lower bound.
     # Temporary cap: transformers 5.13.0 (released 2026-07-03) breaks MLX Metal
     # availability inside the vLLM process on GitHub's macOS runner VMs, so
     # platform resolution falls back to CPU. Verified A/B on the same runner:
@@ -58,12 +58,17 @@ dependencies = [
     "transformers>=5.5.3,<5.13",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
+    # Imported directly (model download/cache paths); keep aligned with vLLM
+    # 0.28.0's lower bound rather than relying on vLLM's transitive install.
+    # Unbounded like upstream's own form: vLLM's requirements/common.txt pins
+    # the effective range in every release and we re-derive it on each bump.
+    "huggingface_hub>=1.27.0",
     # Native Metal extension JIT build
     "nanobind==2.10.2; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Core utilities
     "numpy>=1.24.0",
     "psutil>=5.9.0",
-    # Keep aligned with vLLM 0.27.1's FastAPI/Starlette bounds. vLLM caps fastapi
+    # Keep aligned with vLLM 0.28.0's FastAPI/Starlette bounds. vLLM caps fastapi
     # itself (requirements/common.txt): 0.133.0 is the first release supporting
     # Starlette 1.0, and <0.137.0 avoids the FastAPI 0.137 route-tree change that
     # breaks its handler overrides. The earlier prometheus crash (vllm#45597) is

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -403,38 +403,6 @@ class TestMetalPlatform:
         with pytest.raises(NotImplementedError, match="single process"):
             MetalPlatform.check_and_update_config(vllm_config)
 
-    @pytest.mark.parametrize(
-        ("configured_ip", "expected_ip"),
-        [(None, "127.0.0.1"), ("192.0.2.1", "192.0.2.1")],
-    )
-    def test_check_and_update_config_sets_uniproc_host_ip(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        configured_ip: str | None,
-        expected_ip: str,
-    ) -> None:
-        if configured_ip is None:
-            monkeypatch.delenv("VLLM_HOST_IP", raising=False)
-        else:
-            monkeypatch.setenv("VLLM_HOST_IP", configured_ip)
-
-        MetalPlatform.check_and_update_config(self._platform_config())
-
-        assert os.environ["VLLM_HOST_IP"] == expected_ip
-
-    def test_rejected_uniproc_config_does_not_set_host_ip(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("VLLM_HOST_IP", raising=False)
-        vllm_config = self._platform_config(
-            cache_config=SimpleNamespace(kv_cache_dtype_skip_layers=["model.layers.0"])
-        )
-
-        with pytest.raises(NotImplementedError, match="heterogeneous KV"):
-            MetalPlatform.check_and_update_config(vllm_config)
-
-        assert "VLLM_HOST_IP" not in os.environ
-
     def test_check_and_update_config_rejects_tensor_parallel(self) -> None:
         """Tensor parallelism is unsupported on Metal yet; reject it at config time."""
         vllm_config = self._platform_config(

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1160,67 +1160,111 @@ class TestMetalPlatform:
             ),
         )
 
-    @pytest.mark.parametrize(
-        "paged,cache_config,speculative,err_match",
-        [
-            (
-                "0",
+    @pytest.mark.parametrize("paged", ["0", "1"])
+    def test_check_and_update_config_rejects_hybrid_all_cache_mode(
+        self, paged: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """mamba_cache_mode='all' fails fast on every path, before downgrades."""
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", paged)
+        reset_config()
+        try:
+            # enable_prefix_caching=True so the non-paged parametrization also
+            # pins that the raise fires BEFORE the APC downgrade overwrites
+            # the mode.
+            vllm_config = self._hybrid_vllm_config(
                 SimpleNamespace(
                     block_size=None,
                     kv_cache_dtype_skip_layers=[],
                     enable_prefix_caching=True,
-                    mamba_cache_mode="none",
-                    mamba_ssm_cache_dtype="float32",
-                ),
-                None,
-                "requires paged",
-            ),
-            (
-                "1",
-                SimpleNamespace(
-                    block_size=None,
-                    kv_cache_dtype_skip_layers=[],
-                    enable_prefix_caching=False,
                     mamba_cache_mode="all",
                     mamba_ssm_cache_dtype="float32",
                 ),
-                None,
-                "mamba_cache_mode='all'",
-            ),
+            )
+            with pytest.raises(NotImplementedError, match="mamba_cache_mode='all'"):
+                MetalPlatform.check_and_update_config(vllm_config)
+        finally:
+            reset_config()
+
+    @pytest.mark.parametrize(
+        "paged,speculative",
+        [
+            ("0", None),
             (
                 "1",
-                SimpleNamespace(
-                    block_size=None,
-                    kv_cache_dtype_skip_layers=[],
-                    enable_prefix_caching=True,
-                    mamba_cache_mode="align",
-                    mamba_ssm_cache_dtype="float32",
-                ),
                 SimpleNamespace(
                     use_heterogeneous_vocab=False,
                     num_speculative_tokens=2,
                 ),
-                "speculative decoding",
             ),
         ],
-        ids=["prefix_caching_non_paged", "mamba_cache_mode_all", "prefix_and_sd"],
+        ids=["non_paged", "speculative_decoding"],
     )
-    def test_check_and_update_config_rejects_unsupported_hybrid_cache_modes(
+    def test_check_and_update_config_downgrades_default_hybrid_prefix_caching(
         self,
         paged: str,
-        cache_config: SimpleNamespace,
         speculative: SimpleNamespace | None,
-        err_match: str,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Hybrid combinations Metal cannot serve downgrade APC, not reject.
+
+        vLLM 0.28.0 enables prefix caching by default for hybrid models and
+        resolves mamba_cache_mode='align' / mamba_block_size=block_size before
+        the platform hook runs; failing here would fail every default launch.
+        The downgrade restores the upstream APC-off resolution.
+        """
         self._patch_stt_resolution(monkeypatch, is_stt=False)
         monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", paged)
         reset_config()
         try:
             vllm_config = self._hybrid_vllm_config(
-                cache_config, speculative_config=speculative
+                SimpleNamespace(
+                    block_size=16,
+                    kv_cache_dtype_skip_layers=[],
+                    enable_prefix_caching=True,
+                    mamba_cache_mode="align",
+                    mamba_ssm_cache_dtype="float32",
+                ),
+                speculative_config=speculative,
             )
-            with pytest.raises(NotImplementedError, match=err_match):
+            # Upstream resolves mamba_block_size = block_size AFTER CacheConfig
+            # construction (models/config.py), so user_specified stays False.
+            vllm_config.cache_config.mamba_block_size = 16
+            assert vllm_config.cache_config.user_specified_mamba_block_size is False
+            MetalPlatform.check_and_update_config(vllm_config)
+        finally:
+            reset_config()
+
+        cache_config = vllm_config.cache_config
+        assert cache_config.enable_prefix_caching is False
+        assert cache_config.mamba_cache_mode == "none"
+        assert cache_config.mamba_block_size == 32768
+
+    def test_hybrid_prefix_caching_downgrade_rejects_user_mamba_block_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit --mamba-block-size fails fast when APC must be downgraded.
+
+        Once the hook disables prefix caching, upstream's
+        validate_mamba_block_size (an after-validator) would reject the kept
+        value with a misleading message; the Metal constraint wins instead.
+        """
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+        reset_config()
+        try:
+            vllm_config = self._hybrid_vllm_config(
+                SimpleNamespace(
+                    block_size=16,
+                    kv_cache_dtype_skip_layers=[],
+                    enable_prefix_caching=True,
+                    mamba_cache_mode="align",
+                    mamba_block_size=64,
+                    mamba_ssm_cache_dtype="float32",
+                ),
+            )
+            assert vllm_config.cache_config.user_specified_mamba_block_size is True
+            with pytest.raises(NotImplementedError, match="mamba-block-size"):
                 MetalPlatform.check_and_update_config(vllm_config)
         finally:
             reset_config()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1160,6 +1160,27 @@ class TestMetalPlatform:
             ),
         )
 
+    def test_check_and_update_config_disables_async_scheduling_for_spec_decode(
+        self,
+    ) -> None:
+        """Async scheduling downgrades to synchronous when SD is configured.
+
+        vLLM 0.28.0 auto-enables async scheduling for draft-model SD
+        (vllm#48341) before the platform hook runs; Metal proposers hand
+        drafts back synchronously via take_draft_token_ids().
+        """
+        vllm_config = self._platform_config(
+            speculative_config=SimpleNamespace(
+                use_heterogeneous_vocab=False,
+                num_speculative_tokens=3,
+            ),
+            scheduler_config=SimpleNamespace(async_scheduling=True),
+        )
+
+        MetalPlatform.check_and_update_config(vllm_config)
+
+        assert vllm_config.scheduler_config.async_scheduling is False
+
     @pytest.mark.parametrize("paged", ["0", "1"])
     def test_check_and_update_config_rejects_hybrid_all_cache_mode(
         self, paged: str, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -471,9 +471,11 @@ def test_turboquant_per_layer_shapes_raise_early() -> None:
 
 # --- TurboQuantAttentionSpec (replacement for head_size_v hack) ------------
 #
-# ``TurboQuantAttentionSpec`` subclasses ``FullAttentionSpec`` and overrides
-# ``real_page_size_bytes`` so the scheduler sees the true compressed page size
-# without synthesising a bogus ``head_size_v`` (which used to go negative for
+# ``TurboQuantAttentionSpec`` subclasses ``FullAttentionSpec`` and derives the
+# packed ``state_content_bytes`` in ``__post_init__`` so the scheduler sees the
+# true compressed page size (vLLM 0.28.0 computes ``page_size_bytes`` from that
+# field; ``real_page_size_bytes`` is now just upstream's alias) without
+# synthesising a bogus ``head_size_v`` (which used to go negative for
 # aggressive 2-bit configs).
 
 # Last config is the 2-bit edge case that used to produce a negative
@@ -493,9 +495,16 @@ _TQ_SPEC_CONFIGS = [
     "block_size, num_kv_heads, head_dim, k_quant, v_quant",
     _TQ_SPEC_CONFIGS,
 )
-def test_tq_spec_real_page_size_bytes_matches_helper(
+def test_tq_spec_page_size_bytes_matches_helper(
     block_size, num_kv_heads, head_dim, k_quant, v_quant
 ):
+    """Even a bare construction bills the scheduler the packed page size.
+
+    vLLM 0.28.0 computes ``page_size_bytes`` from the ``state_content_bytes``
+    field (``real_page_size_bytes`` is a dead alias); ``__post_init__``
+    derives the field, so no construction path can fall back to the dense
+    int8 formula.
+    """
     spec = TurboQuantAttentionSpec(
         block_size=block_size,
         num_kv_heads=num_kv_heads,
@@ -511,8 +520,8 @@ def test_tq_spec_real_page_size_bytes_matches_helper(
         k_quant=k_quant,
         v_quant=v_quant,
     )
-    assert spec.real_page_size_bytes == expected
     assert spec.page_size_bytes == expected
+    assert spec.real_page_size_bytes == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -220,6 +220,31 @@ class TestTurboQuantHybridAlignment:
         assert expected_page >= self._MAMBA_PAGE
         assert vllm_config.cache_config.mamba_page_size_padded == expected_page
 
+    def test_realign_resyncs_mamba_block_size_under_align(self, monkeypatch) -> None:
+        """Growing the block size must drag mamba_block_size along under align.
+
+        vLLM 0.28.0 pins mamba_block_size = block_size for align mode before
+        the platform hook runs; without the re-sync the hybrid coordinator's
+        divisibility asserts fail at engine startup.
+        """
+        vllm_config = self._vllm_config(block_size=544)
+        vllm_config.cache_config.mamba_cache_mode = "align"
+        vllm_config.cache_config.mamba_block_size = 544
+        monkeypatch.setattr("vllm_metal.platform.get_config", lambda: _tq_config())
+        self._patch_model_cls(monkeypatch)
+
+        MetalPlatform._realign_hybrid_block_size_for_turboquant(
+            vllm_config,
+            user_block_size=None,
+            hash_block_size=None,
+        )
+
+        assert vllm_config.cache_config.block_size != 544
+        assert (
+            vllm_config.cache_config.mamba_block_size
+            == vllm_config.cache_config.block_size
+        )
+
     def test_realign_noop_without_turboquant(self, monkeypatch) -> None:
         vllm_config = self._vllm_config(block_size=544)
         before_padded = vllm_config.cache_config.mamba_page_size_padded

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -496,6 +496,21 @@ class MetalPlatform(Platform):
                 "1 + num_speculative_tokens, or leave it unset."
             )
 
+        # All three Metal proposers (draft-model, MTP, n-gram) hand drafts back
+        # to the scheduler synchronously via take_draft_token_ids(), so async
+        # scheduling cannot serve speculative decoding. vLLM 0.28.0 auto-enables
+        # async scheduling for draft-model SD (vllm#48341); restore the working
+        # default, the same downgrade shape as the STT scheduler policy.
+        if (
+            speculative_config is not None
+            and vllm_config.scheduler_config.async_scheduling
+        ):
+            vllm_config.scheduler_config.async_scheduling = False
+            logger.warning(
+                "Speculative decoding on Metal requires synchronous "
+                "scheduling; disabled async_scheduling."
+            )
+
         if model_config is not None and model_config.is_hybrid:
             cache_config = vllm_config.cache_config
             if cache_config.mamba_ssm_cache_dtype == "auto":

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -1052,6 +1052,14 @@ class MetalPlatform(Platform):
             )
             cache_config.block_size = attn_block_size
 
+        # vLLM pins mamba_block_size = block_size under align mode before this
+        # hook runs; re-sync it after the TurboQuant realign grows the block
+        # size, or the hybrid KV coordinator's divisibility asserts fail at
+        # startup (mirrors upstream's own re-sync in
+        # Platform.update_block_size_for_backend).
+        if cache_config.mamba_cache_mode == "align":
+            cache_config.mamba_block_size = cache_config.block_size
+
         # Pad mamba page size to exactly match the packed attention page.
         attn_page_size = cache_config.block_size * tq_page_size_1_token
         assert attn_page_size >= mamba_page_size

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -506,29 +506,30 @@ class MetalPlatform(Platform):
                     "--mamba-ssm-cache-dtype float32 because recurrent state is "
                     "stored in fp32."
                 )
-            if cache_config.enable_prefix_caching and not config.use_paged_attention:
-                raise NotImplementedError(
-                    "Prefix caching for hybrid GDN models requires paged "
-                    "attention on Metal (VLLM_METAL_USE_PAGED_ATTENTION=1); "
-                    "the non-paged MLX path has no block-indexed state to "
-                    "restore from."
-                )
             if cache_config.mamba_cache_mode == "all":
+                # Before the downgrades below, which overwrite the mode: an
+                # explicit --mamba-cache-mode all must fail fast on every path.
                 raise NotImplementedError(
                     "mamba_cache_mode='all' is not supported for hybrid GDN "
                     "models on Metal (nor upstream, which falls back to "
                     "'align' for models without SupportsMambaPrefixCaching). "
                     "Use align mode: --enable-prefix-caching resolves to it."
                 )
+            if cache_config.enable_prefix_caching and not config.use_paged_attention:
+                cls._disable_hybrid_prefix_caching(
+                    vllm_config,
+                    "the non-paged MLX path (VLLM_METAL_USE_PAGED_ATTENTION=0) "
+                    "has no block-indexed state to restore from",
+                )
             if (
                 cache_config.enable_prefix_caching
                 and vllm_config.speculative_config is not None
             ):
-                raise NotImplementedError(
-                    "Prefix caching for hybrid GDN models on Metal does not "
-                    "support speculative decoding yet: draft-state rollback "
-                    "across mamba state blocks (num_speculative_blocks) is "
-                    "not implemented. Disable one of the two."
+                cls._disable_hybrid_prefix_caching(
+                    vllm_config,
+                    "draft-state rollback across mamba state blocks "
+                    "(num_speculative_blocks) is not implemented for "
+                    "speculative decoding",
                 )
 
         # Pipeline parallelism is supported on Metal/MLX: each stage runs in its
@@ -834,6 +835,43 @@ class MetalPlatform(Platform):
             f"Metal memory: {total_mem / 1e9:.1f}GB total, "
             f"{available_mem / 1e9:.1f}GB available"
         )
+
+    @staticmethod
+    def _disable_hybrid_prefix_caching(vllm_config: "VllmConfig", reason: str) -> None:
+        """Downgrade default-on prefix caching for a hybrid GDN model.
+
+        vLLM 0.28.0 enables prefix caching by default for hybrid models
+        (vllm#50991) and resolves ``mamba_cache_mode``/``mamba_block_size``
+        for the APC-on case before this platform hook runs. For hybrid
+        combinations Metal cannot serve, restore the APC-off resolution
+        (``mamba_cache_mode='none'``, ``mamba_block_size=max_model_len``)
+        the way upstream's ``MambaModelConfig.verify_and_update_config``
+        else-branch would have, instead of failing a default launch.
+        """
+        cache_config = vllm_config.cache_config
+        if cache_config.user_specified_mamba_block_size:
+            # --mamba-block-size requires prefix caching (upstream's
+            # validate_mamba_block_size rejects it once APC is off), so the
+            # user's two explicit choices conflict; fail with the Metal
+            # constraint before upstream's misleading error fires.
+            raise NotImplementedError(
+                "Prefix caching for hybrid GDN models on Metal cannot serve "
+                f"this configuration ({reason}), and --mamba-block-size "
+                "requires prefix caching. Drop --mamba-block-size or the "
+                "conflicting option."
+            )
+        logger.warning(
+            "Disabling prefix caching for this hybrid GDN model: %s. "
+            "(vLLM enables prefix caching by default for hybrid models; "
+            "pass --no-enable-prefix-caching to make this explicit.)",
+            reason,
+        )
+        cache_config.enable_prefix_caching = False
+        cache_config.mamba_cache_mode = "none"
+        # Restore upstream's APC-off resolution; validate_mamba_block_size
+        # (a pydantic after-validator, so it runs after this hook) rejects
+        # any other value once prefix caching is off.
+        cache_config.mamba_block_size = vllm_config.model_config.max_model_len
 
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -826,18 +826,6 @@ class MetalPlatform(Platform):
         if parallel_config.data_parallel_size > 1:
             cls._register_dp_ray_worker_setup_hook(parallel_config.ray_runtime_env)
 
-        # COMPAT(vLLM 0.27.1): UniProc uses get_ip() for its local gloo
-        # rendezvous. Use loopback so a VPN tunnel address cannot be selected.
-        # Remove after pinned vLLM includes vllm#50999, which uses a file://
-        # store for UniProc rendezvous.
-        if (
-            parallel_config.distributed_executor_backend == "uni"
-            and parallel_config.world_size == 1
-            and parallel_config.data_parallel_size == 1
-            and not os.environ.get("VLLM_HOST_IP")
-        ):
-            os.environ["VLLM_HOST_IP"] = "127.0.0.1"
-
         # Last, after every fail-fast: default the MLX command-buffer memory
         # limit where the memory trade is safe (policy on the class constants
         # above; spawned engine workers inherit the environment).

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -74,28 +74,33 @@ HYBRID_GDN_GROWTH_CUSHION_SLOTS = 2
 class TurboQuantAttentionSpec(FullAttentionSpec):
     """FullAttentionSpec for TurboQuant-compressed KV cache.
 
-    Reports the true packed byte count per page via an override of
-    ``real_page_size_bytes`` so vLLM's scheduler can budget more blocks
-    than the FP16 formula would allow — without lying about ``head_size``
-    (the ``head_size_v`` reverse-engineering trick the previous version
-    used produced negative values for aggressive 2-bit configs).
-
-    Mirrors the upstream pattern of :class:`MLAAttentionSpec` which
-    overrides ``real_page_size_bytes`` for its ``fp8_ds_mla`` cache layout.
+    Publishes the packed per-(head, token) byte count through the base
+    spec's ``state_content_bytes`` field so vLLM's scheduler budgets
+    blocks from the true compressed page size — without lying about
+    ``head_size``. vLLM 0.28.0 computes ``page_size_bytes`` as
+    ``num_heads * storage_block_size * state_content_size_bytes`` and
+    demoted ``real_page_size_bytes`` to an alias, so overriding the
+    latter no longer reaches the scheduler; publishing the field is the
+    same mechanism upstream's ``TurboQuantAttentionBackend.customize_spec``
+    uses for its packed layout.
     """
 
     k_quant: str
     v_quant: str
 
-    @property
-    def real_page_size_bytes(self) -> int:
-        return turboquant_page_size_bytes(
-            block_size=self.block_size,
-            num_kv_heads=self.num_kv_heads,
-            head_dim=self.head_size,
-            k_quant=self.k_quant,
-            v_quant=self.v_quant,
-        )
+    def __post_init__(self) -> None:
+        # Derive the packed per-cell size here, not in the builder, so a
+        # bare construction can never fall back to the dense int8 formula
+        # (the same in-class derivation pattern as the base head_size_v).
+        super().__post_init__()
+        if self.state_content_bytes is None:
+            object.__setattr__(
+                self,
+                "state_content_bytes",
+                turboquant_state_content_bytes(
+                    self.head_size, self.k_quant, self.v_quant
+                ),
+            )
 
     @classmethod
     def merge(cls, specs: Sequence[FullAttentionSpec]) -> TurboQuantAttentionSpec:
@@ -141,18 +146,29 @@ class TurboQuantAttentionSpec(FullAttentionSpec):
         )
 
 
-def turboquant_page_size_bytes(
-    block_size: int, num_kv_heads: int, head_dim: int, k_quant: str, v_quant: str
-) -> int:
-    """Calculate TurboQuant-compressed page size for one layer."""
+def turboquant_state_content_bytes(head_dim: int, k_quant: str, v_quant: str) -> int:
+    """Packed bytes for one (head, token) cell: K + V payload plus scales.
+
+    The scale term is 3 fp16 tensors (k_scale, v_scale, v_bias) per
+    ``TQ_BLOCK_SIZE``-wide group, hence ``3 * scale_groups * 2`` bytes.
+    """
     k_bits = QUANT_PARAMS[k_quant]["bits"]
     v_bits = V_QUANT_PARAMS[v_quant]["bits"]
     k_packed = packed_dim(head_dim, k_bits)
     v_packed = packed_dim(head_dim, v_bits)
-    kv_bytes = block_size * num_kv_heads * (k_packed + v_packed)
     scale_groups = head_dim // TQ_BLOCK_SIZE
-    scale_bytes = 3 * block_size * num_kv_heads * scale_groups * 2
-    return kv_bytes + scale_bytes
+    return k_packed + v_packed + 3 * scale_groups * 2
+
+
+def turboquant_page_size_bytes(
+    block_size: int, num_kv_heads: int, head_dim: int, k_quant: str, v_quant: str
+) -> int:
+    """Calculate TurboQuant-compressed page size for one layer."""
+    return (
+        block_size
+        * num_kv_heads
+        * turboquant_state_content_bytes(head_dim, k_quant, v_quant)
+    )
 
 
 def _build_turboquant_attention_spec(
@@ -164,9 +180,9 @@ def _build_turboquant_attention_spec(
 ) -> TurboQuantAttentionSpec:
     """Build a TurboQuantAttentionSpec for a single attention layer.
 
-    Reports the real compressed page size via ``real_page_size_bytes``
-    override, so the scheduler allocates the right number of blocks and
-    ``head_size`` stays equal to the model's real head_dim.
+    The spec derives its packed ``state_content_bytes`` itself, so the
+    scheduler allocates the right number of blocks and ``head_size``
+    stays equal to the model's real head_dim.
     """
     return TurboQuantAttentionSpec(
         block_size=block_size,
@@ -383,10 +399,11 @@ class ModelCachePolicy:
                 layer_name = f"layers.{layer_idx}.self_attn"
                 # MLA caches a single latent tensor per layer, not separate K
                 # and V (see ``MLAPagedLatentCache``), which is why
-                # ``_kv_factor`` bills it at 1.  ``FullAttentionSpec`` hardcodes
-                # the 2x K/V factor in ``real_page_size_bytes``, so describing
-                # MLA with it makes the engine halve the block count it plans
-                # against relative to the pool actually allocated.
+                # ``_kv_factor`` bills it at 1.  ``FullAttentionSpec`` bakes
+                # the 2x K/V factor into ``page_size_bytes`` (head_size +
+                # head_size_v), so describing MLA with it makes the engine
+                # halve the block count it plans against relative to the pool
+                # actually allocated.
                 if self._runner.is_mla:
                     specs[layer_name] = MLAAttentionSpec(
                         block_size=block_size,
@@ -827,14 +844,14 @@ class ModelCachePolicy:
 
         Derived from the same ``FullAttentionSpec`` objects
         ``_draft_layer_specs`` registers with the scheduler
-        (``real_page_size_bytes``), rather than a parallel hand-rolled
+        (``page_size_bytes``), rather than a parallel hand-rolled
         formula, so the two cannot drift apart. Naturally 0 when no draft is
         configured, since ``_draft_layer_specs`` returns ``{}`` in that case.
         """
         block_size = self._runner.cache_config.block_size
         torch_dtype = MLX_TO_TORCH_DTYPE[self._require_kv_cache_dtype()]
         specs = self._draft_layer_specs(block_size=block_size, torch_dtype=torch_dtype)
-        return sum(spec.real_page_size_bytes for spec in specs.values())
+        return sum(spec.page_size_bytes for spec in specs.values())
 
     def linear_cache_bytes_per_slot(self) -> int:
         """Return bytes for one request's linear-attention state."""


### PR DESCRIPTION
0.28.0 refactored the KV cache page sizing (vllm#51704) and our TurboQuant spec stopped working: real_page_size_bytes is just an alias now, so the scheduler went back to budgeting blocks with the dense int8 formula. I moved the packed page size into the state_content_bytes field, which is how upstream's own TurboQuant backend does it, and made the hybrid realign update mamba_block_size as well, otherwise the coordinator asserts at startup.

The other two changes are new defaults. 0.28.0 turns prefix caching on by default for hybrid models (vllm#50991) and async scheduling on for draft-model spec decode (vllm#48341). Both are resolved before our platform hook sees the config, so if we kept raising like before, a plain vllm serve that worked on 0.27.1 would now die. The hook disables them with a warning instead. An explicit --mamba-block-size still fails fast.

We also get to delete a shim this time. The UniProc VLLM_HOST_IP workaround can go, since 0.28.0 does rendezvous through a file:// store now (vllm#50999). That is the only one: vllm#48724 is still not in, CoreEngineActorManager still calls bare ray.init(), and vLLM still caps fastapi below 0.137, so those all stay. 

I also added huggingface_hub>=1.27.0 to pyproject because we import it directly and vLLM added the floor this release.

For evidence, MetalPlatform resolves after a clean ./install.sh, 1874 non-slow tests pass, both serve smokes return their goldens (the Qwen3.5 one runs with the new APC-on default), a TurboQuant hybrid serve boots, and the n-gram e2e passes 7/7. The slow suite has three failures on my machine (the hybrid APC parity check, the draft-model e2e, and a test-ordering memory issue). I reinstalled the 0.27.1 wheel and they fail the same way there, so they were already broken before this bump.

`vllm bench serve`, Qwen3-0.6B, sonnet, 100 prompts, `--request-rate inf --temperature 0 --ignore-eos --seed 0`, each arm on its own install. The first 0.28.0 session came out slow because it was the first run after a fresh install, so I dropped the first session of both arms and kept two warm ones each. All sessions completed 100 requests with 54256 input and 15000 generated tokens.

| Metric | vLLM 0.27.1 | vLLM 0.28.0 | Delta |
|---|---:|---:|---:|
| Output tok/s | 1068.84 | 1070.41 | +0.1% |
| Total tok/s | 4934.90 | 4942.15 | +0.1% |
| Mean TTFT (ms) | 3752.78 | 3727.07 | -0.7% |
| P99 TTFT (ms) | 6848.13 | 6832.76 | -0.2% |
| Mean TPOT (ms) | 67.58 | 67.62 | +0.1% |
| P99 TPOT (ms) | 85.28 | 85.45 | +0.2% |
| Duration (s) | 14.03 | 14.01 | -0.1% |