### PR TITLE
Optimize pure LoRA prefill routing

### DIFF
--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -92,6 +92,45 @@ def test_punica_handles_fragmented_routing() -> None:
     )
 
 
+def test_punica_output_dtype_matches_base_for_contiguous_and_fragmented() -> None:
+    a_stacked = mx.array(np.array([[[1.0]], [[2.0]]], dtype=np.float32))
+    b_stacked = mx.array(np.array([[[3.0]], [[4.0]]], dtype=np.float32))
+    x = mx.ones((4, 1), dtype=mx.float16)
+    y = mx.zeros((4, 1), dtype=mx.float16)
+
+    for index_mapping in ((11, 11, 22, 22), (11, 22, 11, 22)):
+        wrapper = punica_mod.PunicaWrapperMLX(
+            max_num_batched_tokens=4, max_batches=4, max_loras=2
+        )
+        wrapper.update_metadata(
+            LoRAMapping(index_mapping=index_mapping, prompt_mapping=(11, 22)),
+            lora_index_to_id=[11, 22],
+        )
+
+        out = wrapper.add_lora_linear(y, x, a_stacked, b_stacked, scale=1.0)
+
+        assert out.dtype == y.dtype
+
+
+def test_punica_rejects_routing_row_count_mismatch() -> None:
+    wrapper = punica_mod.PunicaWrapperMLX(
+        max_num_batched_tokens=2, max_batches=2, max_loras=1
+    )
+    wrapper.update_metadata(
+        LoRAMapping(index_mapping=(7, 7), prompt_mapping=(7,)),
+        lora_index_to_id=[7],
+    )
+
+    with pytest.raises(ValueError, match="LoRA routing row count mismatch"):
+        wrapper.add_lora_linear(
+            mx.zeros((1, 1), dtype=mx.float32),
+            mx.ones((1, 1), dtype=mx.float32),
+            mx.ones((1, 1, 1), dtype=mx.float32),
+            mx.ones((1, 1, 1), dtype=mx.float32),
+            scale=1.0,
+        )
+
+
 # MLXLinearWithLoRA wrapper
 
 
@@ -115,6 +154,18 @@ def test_linear_wrapper_set_lora_writes_into_correct_slot() -> None:
     np.testing.assert_array_equal(a_stacked[1, 2:, :], np.zeros((2, 3)))
     np.testing.assert_array_equal(b_stacked[1, :, :2], np.ones((4, 2)))
     np.testing.assert_array_equal(b_stacked[1, :, 2:], np.zeros((4, 2)))
+
+
+def test_linear_wrapper_rank_metadata_is_not_a_module_parameter() -> None:
+    wrapper = layers_mod.MLXLinearWithLoRA(
+        base_layer=nn.Linear(input_dims=3, output_dims=4, bias=False),
+        max_loras=2,
+        max_lora_rank=4,
+        dtype=mx.float32,
+    )
+
+    assert "lora_ranks" not in wrapper.parameters()
+    assert "_lora_ranks" not in wrapper.parameters()
 
 
 def test_linear_wrapper_allocates_only_resident_slots() -> None:

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -45,6 +45,31 @@ def test_punica_add_lora_linear_no_lora_is_a_passthrough() -> None:
     np.testing.assert_array_equal(np.array(out), np.array(y))
 
 
+def test_punica_segmented_path_uses_actual_adapter_rank() -> None:
+    wrapper = punica_mod.PunicaWrapperMLX(
+        max_num_batched_tokens=1, max_batches=1, max_loras=1
+    )
+    wrapper.update_metadata(
+        LoRAMapping(index_mapping=(7,), prompt_mapping=(7,)),
+        lora_index_to_id=[7],
+    )
+    a_stacked = mx.array(
+        np.array([[[1.0], [100.0], [100.0], [100.0]]], dtype=np.float32)
+    )
+    b_stacked = mx.array(np.array([[[1.0, 100.0, 100.0, 100.0]]], dtype=np.float32))
+
+    out = wrapper.add_lora_linear(
+        mx.zeros((1, 1), dtype=mx.float32),
+        mx.ones((1, 1), dtype=mx.float32),
+        a_stacked,
+        b_stacked,
+        scale=1.0,
+        lora_ranks=[1],
+    )
+
+    np.testing.assert_array_equal(np.array(out), [[1.0]])
+
+
 # MLXLinearWithLoRA wrapper
 
 
@@ -68,6 +93,18 @@ def test_linear_wrapper_set_lora_writes_into_correct_slot() -> None:
     np.testing.assert_array_equal(a_stacked[1, 2:, :], np.zeros((2, 3)))
     np.testing.assert_array_equal(b_stacked[1, :, :2], np.ones((4, 2)))
     np.testing.assert_array_equal(b_stacked[1, :, 2:], np.zeros((4, 2)))
+
+
+def test_linear_wrapper_allocates_only_resident_slots() -> None:
+    wrapper = layers_mod.MLXLinearWithLoRA(
+        base_layer=nn.Linear(input_dims=3, output_dims=4, bias=False),
+        max_loras=2,
+        max_lora_rank=4,
+        dtype=mx.float32,
+    )
+
+    assert wrapper.lora_a_stacked.shape == (2, 4, 3)
+    assert wrapper.lora_b_stacked.shape == (2, 4, 4)
 
 
 @pytest.mark.parametrize(
@@ -263,10 +300,8 @@ def test_lookup_weights_for_module(stored_key, lookup, expected_hit) -> None:
 # Multi-adapter batching
 
 
-def _stack_with_null(*per_slot_a: np.ndarray) -> tuple[mx.array, int, int]:
-    """Stack rank-1 LoRA A weights into ``(slots+1, rank, in)`` with null tail."""
-    null = np.zeros_like(per_slot_a[0])
-    stacked = np.stack([*per_slot_a, null])
+def _stack_adapters(*per_slot_a: np.ndarray) -> tuple[mx.array, int, int]:
+    stacked = np.stack(per_slot_a)
     return mx.array(stacked), int(stacked.shape[1]), int(stacked.shape[2])
 
 
@@ -281,12 +316,11 @@ def test_punica_routes_two_adapters_in_one_batch() -> None:
 
     a0 = np.array([[1.0, 0.0]], dtype=np.float32)  # adapter 11 picks dim 0
     a1 = np.array([[0.0, 1.0]], dtype=np.float32)  # adapter 22 picks dim 1
-    a_stacked, _, _ = _stack_with_null(a0, a1)
+    a_stacked, _, _ = _stack_adapters(a0, a1)
 
     b0 = np.array([[1.0]], dtype=np.float32)  # adapter 11: out scale 1
     b1 = np.array([[10.0]], dtype=np.float32)  # adapter 22: out scale 10
-    b_null = np.zeros_like(b0)
-    b_stacked = mx.array(np.stack([b0, b1, b_null]))
+    b_stacked = mx.array(np.stack([b0, b1]))
 
     x = mx.array(
         np.array([[2.0, 3.0], [2.0, 3.0], [4.0, 5.0], [4.0, 5.0]], dtype=np.float32)
@@ -303,7 +337,7 @@ def test_punica_routes_two_adapters_in_one_batch() -> None:
 
 
 def test_punica_three_adapters_with_no_lora_token() -> None:
-    """Mixed batch: 3 adapters + a base-model token routed to the null slot."""
+    """Mixed batch: 3 adapters + one base-model token."""
     wrapper = punica_mod.PunicaWrapperMLX(
         max_num_batched_tokens=4, max_batches=4, max_loras=3
     )
@@ -311,7 +345,7 @@ def test_punica_three_adapters_with_no_lora_token() -> None:
     wrapper.update_metadata(mapping, lora_index_to_id=[7, 8, 9])
 
     # Three rank-1 adapters that each return a scalar = adapter index + 1.
-    a_stacked, _, _ = _stack_with_null(
+    a_stacked, _, _ = _stack_adapters(
         np.array([[1.0]], dtype=np.float32),
         np.array([[2.0]], dtype=np.float32),
         np.array([[3.0]], dtype=np.float32),
@@ -322,7 +356,6 @@ def test_punica_three_adapters_with_no_lora_token() -> None:
                 np.array([[1.0]], dtype=np.float32),
                 np.array([[1.0]], dtype=np.float32),
                 np.array([[1.0]], dtype=np.float32),
-                np.array([[0.0]], dtype=np.float32),  # null slot
             ]
         )
     )
@@ -332,7 +365,7 @@ def test_punica_three_adapters_with_no_lora_token() -> None:
 
     out = np.array(wrapper.add_lora_linear(y, x, a_stacked, b_stacked, scale=1.0))
 
-    # Adapters add 1, 2, 0 (null), 3 to the base of 100.
+    # Adapters add 1, 2, 0 (no LoRA), 3 to the base of 100.
     np.testing.assert_allclose(out.flatten(), [101.0, 102.0, 100.0, 103.0], rtol=1e-5)
 
 
@@ -350,8 +383,8 @@ def test_punica_batched_matches_per_token_single_adapter_runs() -> None:
         rng.standard_normal((out_dim, rank)).astype(np.float32),
         rng.standard_normal((out_dim, rank)).astype(np.float32),
     )
-    a_stacked = mx.array(np.stack([a0, a1, np.zeros_like(a0)]))
-    b_stacked = mx.array(np.stack([b0, b1, np.zeros_like(b0)]))
+    a_stacked = mx.array(np.stack([a0, a1]))
+    b_stacked = mx.array(np.stack([b0, b1]))
 
     x_np = rng.standard_normal((4, in_dim)).astype(np.float32)
     x = mx.array(x_np)
@@ -388,13 +421,12 @@ def test_punica_update_metadata_reroutes_after_slot_churn() -> None:
     # Adapter 11 picks dim 0 (=> output 1), adapter 22 picks dim 1 (=> output 10).
     a0 = np.array([[1.0, 0.0]], dtype=np.float32)
     a1 = np.array([[0.0, 1.0]], dtype=np.float32)
-    a_stacked = mx.array(np.stack([a0, a1, np.zeros_like(a0)]))
+    a_stacked = mx.array(np.stack([a0, a1]))
     b_stacked = mx.array(
         np.stack(
             [
                 np.array([[1.0]], dtype=np.float32),
                 np.array([[10.0]], dtype=np.float32),
-                np.array([[0.0]], dtype=np.float32),
             ]
         )
     )
@@ -406,20 +438,18 @@ def test_punica_update_metadata_reroutes_after_slot_churn() -> None:
         LoRAMapping(index_mapping=(11, 11), prompt_mapping=(11,)),
         lora_index_to_id=[11, None],
     )
-    assert wrapper.token_slot_indices.tolist() == [0, 0]
     out1 = np.array(wrapper.add_lora_linear(y, x, a_stacked, b_stacked, scale=1.0))
     np.testing.assert_allclose(out1.flatten(), [1.0, 1.0], rtol=1e-5)
 
     # Step 2: adapter 11 moved to slot 1 (because slot 0 now holds 22). The
     # weight stack the manager passes also gets reordered: slot 0 = adapter 22's
     # weights, slot 1 = adapter 11's. Token 0 still requests adapter 11 -> slot 1.
-    a_stacked_swapped = mx.array(np.stack([a1, a0, np.zeros_like(a0)]))
+    a_stacked_swapped = mx.array(np.stack([a1, a0]))
     b_stacked_swapped = mx.array(
         np.stack(
             [
                 np.array([[10.0]], dtype=np.float32),
                 np.array([[1.0]], dtype=np.float32),
-                np.array([[0.0]], dtype=np.float32),
             ]
         )
     )
@@ -427,13 +457,9 @@ def test_punica_update_metadata_reroutes_after_slot_churn() -> None:
         LoRAMapping(index_mapping=(11, 22), prompt_mapping=(11, 22)),
         lora_index_to_id=[22, 11],
     )
-    assert wrapper.token_slot_indices.tolist() == [1, 0]
     out2 = np.array(
         wrapper.add_lora_linear(y, x, a_stacked_swapped, b_stacked_swapped, scale=1.0)
     )
-    # Token 0 (adapter 11, slot 1): a1·[1,1]=1, b·1=1.  No, wait — slot 1 holds adapter 11.
-    # a_swapped[1] = a0 = [1,0]; a0·[1,1] = 1; b_swapped[1] = [[1.0]]; -> 1.0.
-    # Token 1 (adapter 22, slot 0): a_swapped[0] = a1 = [0,1]; a1·[1,1] = 1; b_swapped[0] = [[10.0]]; -> 10.0.
     np.testing.assert_allclose(out2.flatten(), [1.0, 10.0], rtol=1e-5)
 
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -70,6 +70,28 @@ def test_punica_contiguous_run_uses_actual_adapter_rank() -> None:
     np.testing.assert_array_equal(np.array(out), [[1.0]])
 
 
+def test_punica_contiguous_prefill_rank_zero_is_passthrough() -> None:
+    wrapper = punica_mod.PunicaWrapperMLX(
+        max_num_batched_tokens=2, max_batches=1, max_loras=1
+    )
+    wrapper.update_metadata(
+        LoRAMapping(index_mapping=(7, 7), prompt_mapping=(7,), is_prefill=True),
+        lora_index_to_id=[7],
+    )
+
+    y = mx.ones((2, 1), dtype=mx.float32)
+    out = wrapper.add_lora_linear(
+        y,
+        mx.ones((2, 1), dtype=mx.float32),
+        mx.ones((1, 1, 1), dtype=mx.float32),
+        mx.ones((1, 1, 1), dtype=mx.float32),
+        scale=1.0,
+        lora_ranks=[0],
+    )
+
+    assert out is y
+
+
 def test_punica_handles_fragmented_routing() -> None:
     wrapper = punica_mod.PunicaWrapperMLX(
         max_num_batched_tokens=80, max_batches=80, max_loras=2
@@ -1097,26 +1119,40 @@ def test_prepare_step_raises_for_unknown_lora_id() -> None:
 
 
 def test_prepare_step_marks_prefill_mapping() -> None:
-    class CapturingManager:
-        def __init__(self) -> None:
-            self.mapping = None
+    captured = {}
 
-        def set_active_adapters(self, lora_requests, mapping) -> None:
-            self.mapping = mapping
+    def capture_mapping(lora_requests, mapping) -> None:
+        captured["mapping"] = mapping
 
-    class Request:
-        pass
-
-    manager = CapturingManager()
     rt = runtime_mod.MetalLoRARuntime()
-    rt._manager = manager
-    rt._requests_by_id[7] = Request()
+    rt._manager = SimpleNamespace(set_active_adapters=capture_mapping)
+    rt._requests_by_id[7] = object()
 
     rt.prepare_step([(7, 3)])
 
-    assert manager.mapping.index_mapping == (7, 7, 7)
-    assert manager.mapping.prompt_mapping == (7,)
-    assert manager.mapping.is_prefill is True
+    mapping = captured["mapping"]
+    assert mapping.index_mapping == (7, 7, 7)
+    assert mapping.prompt_mapping == (7,)
+    assert mapping.is_prefill is True
+
+
+def test_prepare_step_keeps_mixed_decode_prefill_on_decode_route() -> None:
+    captured = {}
+
+    def capture_mapping(lora_requests, mapping) -> None:
+        captured["mapping"] = mapping
+
+    rt = runtime_mod.MetalLoRARuntime()
+    rt._manager = SimpleNamespace(set_active_adapters=capture_mapping)
+    rt._requests_by_id[7] = object()
+    rt._requests_by_id[8] = object()
+
+    rt.prepare_step([(7, 1), (8, 3)])
+
+    mapping = captured["mapping"]
+    assert mapping.index_mapping == (7, 8, 8, 8)
+    assert mapping.prompt_mapping == (7, 8)
+    assert mapping.is_prefill is False
 
 
 def test_worker_manager_supports_cpu_cache_larger_than_resident_slots() -> None:

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -50,7 +50,7 @@ def test_punica_contiguous_run_uses_actual_adapter_rank() -> None:
         max_num_batched_tokens=1, max_batches=1, max_loras=1
     )
     wrapper.update_metadata(
-        LoRAMapping(index_mapping=(7,), prompt_mapping=(7,)),
+        LoRAMapping(index_mapping=(7,), prompt_mapping=(7,), is_prefill=True),
         lora_index_to_id=[7],
     )
     a_stacked = mx.array(
@@ -72,38 +72,52 @@ def test_punica_contiguous_run_uses_actual_adapter_rank() -> None:
 
 def test_punica_handles_fragmented_routing() -> None:
     wrapper = punica_mod.PunicaWrapperMLX(
-        max_num_batched_tokens=8, max_batches=8, max_loras=2
+        max_num_batched_tokens=80, max_batches=80, max_loras=2
     )
+    index_mapping = tuple(11 if i % 2 == 0 else 22 for i in range(80))
     wrapper.update_metadata(
         LoRAMapping(
-            index_mapping=(11, 22, 11, 22, 11, 22, 11, 22),
+            index_mapping=index_mapping,
             prompt_mapping=(11, 22),
+            is_prefill=True,
         ),
         lora_index_to_id=[11, 22],
     )
     a_stacked = mx.array(np.array([[[1.0, 0.0]], [[0.0, 1.0]]], dtype=np.float32))
     b_stacked = mx.array(np.array([[[1.0]], [[10.0]]], dtype=np.float32))
-    x = mx.array(np.ones((8, 2), dtype=np.float32))
-    y = mx.zeros((8, 1), dtype=mx.float32)
+    x = mx.array(np.ones((80, 2), dtype=np.float32))
+    y = mx.zeros((80, 1), dtype=mx.float32)
 
     out = wrapper.add_lora_linear(y, x, a_stacked, b_stacked, scale=1.0)
     np.testing.assert_array_equal(
-        np.array(out).flatten(), [1.0, 10.0, 1.0, 10.0, 1.0, 10.0, 1.0, 10.0]
+        np.array(out).flatten(),
+        [1.0 if i % 2 == 0 else 10.0 for i in range(80)],
     )
 
 
-def test_punica_output_dtype_matches_base_for_contiguous_and_fragmented() -> None:
-    a_stacked = mx.array(np.array([[[1.0]], [[2.0]]], dtype=np.float32))
-    b_stacked = mx.array(np.array([[[3.0]], [[4.0]]], dtype=np.float32))
-    x = mx.ones((4, 1), dtype=mx.float16)
-    y = mx.zeros((4, 1), dtype=mx.float16)
+def test_punica_output_dtype_matches_base_for_all_routing_paths() -> None:
+    routing_cases = (
+        ((11, 22, 11, 22), False, np.float16),
+        ((11, 11, 11, 11), True, np.float32),
+        (tuple(11 if i % 2 == 0 else 22 for i in range(80)), True, np.float32),
+    )
 
-    for index_mapping in ((11, 11, 22, 22), (11, 22, 11, 22)):
+    for index_mapping, is_prefill, weight_dtype in routing_cases:
+        a_stacked = mx.array(np.array([[[1.0]], [[2.0]]], dtype=weight_dtype))
+        b_stacked = mx.array(np.array([[[3.0]], [[4.0]]], dtype=weight_dtype))
+        x = mx.ones((len(index_mapping), 1), dtype=mx.float16)
+        y = mx.zeros((len(index_mapping), 1), dtype=mx.float16)
         wrapper = punica_mod.PunicaWrapperMLX(
-            max_num_batched_tokens=4, max_batches=4, max_loras=2
+            max_num_batched_tokens=len(index_mapping),
+            max_batches=len(index_mapping),
+            max_loras=2,
         )
         wrapper.update_metadata(
-            LoRAMapping(index_mapping=index_mapping, prompt_mapping=(11, 22)),
+            LoRAMapping(
+                index_mapping=index_mapping,
+                prompt_mapping=(11, 22),
+                is_prefill=is_prefill,
+            ),
             lora_index_to_id=[11, 22],
         )
 
@@ -166,18 +180,6 @@ def test_linear_wrapper_rank_metadata_is_not_a_module_parameter() -> None:
 
     assert "lora_ranks" not in wrapper.parameters()
     assert "_lora_ranks" not in wrapper.parameters()
-
-
-def test_linear_wrapper_allocates_only_resident_slots() -> None:
-    wrapper = layers_mod.MLXLinearWithLoRA(
-        base_layer=nn.Linear(input_dims=3, output_dims=4, bias=False),
-        max_loras=2,
-        max_lora_rank=4,
-        dtype=mx.float32,
-    )
-
-    assert wrapper.lora_a_stacked.shape == (2, 4, 3)
-    assert wrapper.lora_b_stacked.shape == (2, 4, 4)
 
 
 @pytest.mark.parametrize(
@@ -422,6 +424,7 @@ def test_punica_three_adapters_with_no_lora_token() -> None:
         np.array([[1.0]], dtype=np.float32),
         np.array([[2.0]], dtype=np.float32),
         np.array([[3.0]], dtype=np.float32),
+        np.array([[0.0]], dtype=np.float32),
     )
     b_stacked = mx.array(
         np.stack(
@@ -429,6 +432,7 @@ def test_punica_three_adapters_with_no_lora_token() -> None:
                 np.array([[1.0]], dtype=np.float32),
                 np.array([[1.0]], dtype=np.float32),
                 np.array([[1.0]], dtype=np.float32),
+                np.array([[0.0]], dtype=np.float32),
             ]
         )
     )

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -45,7 +45,7 @@ def test_punica_add_lora_linear_no_lora_is_a_passthrough() -> None:
     np.testing.assert_array_equal(np.array(out), np.array(y))
 
 
-def test_punica_segmented_path_uses_actual_adapter_rank() -> None:
+def test_punica_contiguous_run_uses_actual_adapter_rank() -> None:
     wrapper = punica_mod.PunicaWrapperMLX(
         max_num_batched_tokens=1, max_batches=1, max_loras=1
     )
@@ -68,6 +68,28 @@ def test_punica_segmented_path_uses_actual_adapter_rank() -> None:
     )
 
     np.testing.assert_array_equal(np.array(out), [[1.0]])
+
+
+def test_punica_handles_fragmented_routing() -> None:
+    wrapper = punica_mod.PunicaWrapperMLX(
+        max_num_batched_tokens=8, max_batches=8, max_loras=2
+    )
+    wrapper.update_metadata(
+        LoRAMapping(
+            index_mapping=(11, 22, 11, 22, 11, 22, 11, 22),
+            prompt_mapping=(11, 22),
+        ),
+        lora_index_to_id=[11, 22],
+    )
+    a_stacked = mx.array(np.array([[[1.0, 0.0]], [[0.0, 1.0]]], dtype=np.float32))
+    b_stacked = mx.array(np.array([[[1.0]], [[10.0]]], dtype=np.float32))
+    x = mx.array(np.ones((8, 2), dtype=np.float32))
+    y = mx.zeros((8, 1), dtype=mx.float32)
+
+    out = wrapper.add_lora_linear(y, x, a_stacked, b_stacked, scale=1.0)
+    np.testing.assert_array_equal(
+        np.array(out).flatten(), [1.0, 10.0, 1.0, 10.0, 1.0, 10.0, 1.0, 10.0]
+    )
 
 
 # MLXLinearWithLoRA wrapper

--- a/tests/test_qlora.py
+++ b/tests/test_qlora.py
@@ -261,7 +261,7 @@ def test_qlora_wrapper_no_lora_passthrough_with_punica() -> None:
     punica = PunicaWrapperMLX(max_num_batched_tokens=2, max_batches=1, max_loras=1)
     w.set_mapping(punica)
 
-    # no_lora=True (null mapping, all slots empty)
+    # no_lora=True because no adapter id maps to a resident slot.
     mapping = LoRAMapping(index_mapping=(0, 0), prompt_mapping=(0,))
     punica.update_metadata(mapping, lora_index_to_id=[None])
 
@@ -323,7 +323,7 @@ def test_qlora_mixed_batch_base_model_tokens_unaffected() -> None:
     b0 = rng.standard_normal((32, 1)).astype(np.float32)
     w.set_lora(0, mx.array(a0), mx.array(b0))
 
-    # Token 0 -> no-LoRA (null slot), tokens 1/2 -> adapter 55
+    # Token 0 -> no-LoRA, tokens 1/2 -> adapter 55.
     mapping = LoRAMapping(index_mapping=(0, 55, 55), prompt_mapping=(0, 55))
     punica.update_metadata(mapping, lora_index_to_id=[55])
 

--- a/vllm_metal/v1/lora/layers.py
+++ b/vllm_metal/v1/lora/layers.py
@@ -66,9 +66,9 @@ class _LoRALinearBase(nn.Module):
         self.base_layer = base_layer
         self.max_loras, self.max_lora_rank = max_loras, max_lora_rank
         self.input_size, self.output_size = input_size, output_size
-        slots = max_loras + 1  # Trailing null slot; see punica_wrapper.
-        self.lora_a_stacked = mx.zeros((slots, max_lora_rank, input_size), dtype)
-        self.lora_b_stacked = mx.zeros((slots, output_size, max_lora_rank), dtype)
+        self.lora_a_stacked = mx.zeros((max_loras, max_lora_rank, input_size), dtype)
+        self.lora_b_stacked = mx.zeros((max_loras, output_size, max_lora_rank), dtype)
+        self.lora_ranks = [0] * max_loras
         self.punica_wrapper: PunicaWrapperMLX | None = None
 
     def set_mapping(self, punica_wrapper: PunicaWrapperMLX) -> None:
@@ -120,14 +120,18 @@ class _LoRALinearBase(nn.Module):
 
     def set_lora(self, slot: int, lora_a: mx.array, lora_b: mx.array) -> None:
         prepared = self.prepare_lora_weights(slot, lora_a, lora_b)
-        self.set_prepared_lora(slot, *prepared)
+        self.set_prepared_lora(slot, *prepared, rank=int(lora_a.shape[0]))
 
-    def set_prepared_lora(self, slot: int, lora_a: mx.array, lora_b: mx.array) -> None:
+    def set_prepared_lora(
+        self, slot: int, lora_a: mx.array, lora_b: mx.array, *, rank: int
+    ) -> None:
         self.lora_a_stacked[slot], self.lora_b_stacked[slot] = lora_a, lora_b
+        self.lora_ranks[slot] = rank
 
     def reset_lora(self, slot: int) -> None:
         self.lora_a_stacked[slot] = mx.zeros_like(self.lora_a_stacked[slot])
         self.lora_b_stacked[slot] = mx.zeros_like(self.lora_b_stacked[slot])
+        self.lora_ranks[slot] = 0
 
 
 class MLXLinearWithLoRA(_LoRALinearBase):
@@ -165,7 +169,12 @@ class MLXLinearWithLoRA(_LoRALinearBase):
             else (x, y)
         )
         out = self.punica_wrapper.add_lora_linear(
-            y2, x2, self.lora_a_stacked, self.lora_b_stacked, scale=1.0
+            y2,
+            x2,
+            self.lora_a_stacked,
+            self.lora_b_stacked,
+            scale=1.0,
+            lora_ranks=self.lora_ranks,
         )
         return out if out is y else out.reshape(shape)
 
@@ -216,6 +225,7 @@ class MLXQuantizedLinearWithLoRA(_LoRALinearBase):
             self.lora_a_stacked,
             self.lora_b_stacked,
             scale=1.0,
+            lora_ranks=self.lora_ranks,
         )
         out = out.astype(y.dtype)
         return out if out.shape == shape else out.reshape(shape)

--- a/vllm_metal/v1/lora/layers.py
+++ b/vllm_metal/v1/lora/layers.py
@@ -66,10 +66,11 @@ class _LoRALinearBase(nn.Module):
         self.base_layer = base_layer
         self.max_loras, self.max_lora_rank = max_loras, max_lora_rank
         self.input_size, self.output_size = input_size, output_size
-        self.lora_a_stacked = mx.zeros((max_loras, max_lora_rank, input_size), dtype)
-        self.lora_b_stacked = mx.zeros((max_loras, output_size, max_lora_rank), dtype)
+        slots = max_loras + 1
+        self.lora_a_stacked = mx.zeros((slots, max_lora_rank, input_size), dtype)
+        self.lora_b_stacked = mx.zeros((slots, output_size, max_lora_rank), dtype)
         # MLX tracks lists assigned through Module.__setattr__; ranks are metadata.
-        object.__setattr__(self, "_lora_ranks", [0] * max_loras)
+        object.__setattr__(self, "_lora_ranks", [0] * slots)
         self.punica_wrapper: PunicaWrapperMLX | None = None
 
     def set_mapping(self, punica_wrapper: PunicaWrapperMLX) -> None:

--- a/vllm_metal/v1/lora/layers.py
+++ b/vllm_metal/v1/lora/layers.py
@@ -68,7 +68,7 @@ class _LoRALinearBase(nn.Module):
         self.input_size, self.output_size = input_size, output_size
         self.lora_a_stacked = mx.zeros((max_loras, max_lora_rank, input_size), dtype)
         self.lora_b_stacked = mx.zeros((max_loras, output_size, max_lora_rank), dtype)
-        self.lora_ranks = [0] * max_loras
+        object.__setattr__(self, "_lora_ranks", [0] * max_loras)
         self.punica_wrapper: PunicaWrapperMLX | None = None
 
     def set_mapping(self, punica_wrapper: PunicaWrapperMLX) -> None:
@@ -126,12 +126,12 @@ class _LoRALinearBase(nn.Module):
         self, slot: int, lora_a: mx.array, lora_b: mx.array, *, rank: int
     ) -> None:
         self.lora_a_stacked[slot], self.lora_b_stacked[slot] = lora_a, lora_b
-        self.lora_ranks[slot] = rank
+        self._lora_ranks[slot] = rank
 
     def reset_lora(self, slot: int) -> None:
         self.lora_a_stacked[slot] = mx.zeros_like(self.lora_a_stacked[slot])
         self.lora_b_stacked[slot] = mx.zeros_like(self.lora_b_stacked[slot])
-        self.lora_ranks[slot] = 0
+        self._lora_ranks[slot] = 0
 
 
 class MLXLinearWithLoRA(_LoRALinearBase):
@@ -174,7 +174,7 @@ class MLXLinearWithLoRA(_LoRALinearBase):
             self.lora_a_stacked,
             self.lora_b_stacked,
             scale=1.0,
-            lora_ranks=self.lora_ranks,
+            lora_ranks=self._lora_ranks,
         )
         return out if out is y else out.reshape(shape)
 
@@ -225,7 +225,7 @@ class MLXQuantizedLinearWithLoRA(_LoRALinearBase):
             self.lora_a_stacked,
             self.lora_b_stacked,
             scale=1.0,
-            lora_ranks=self.lora_ranks,
+            lora_ranks=self._lora_ranks,
         )
         out = out.astype(y.dtype)
         return out if out.shape == shape else out.reshape(shape)

--- a/vllm_metal/v1/lora/layers.py
+++ b/vllm_metal/v1/lora/layers.py
@@ -68,6 +68,7 @@ class _LoRALinearBase(nn.Module):
         self.input_size, self.output_size = input_size, output_size
         self.lora_a_stacked = mx.zeros((max_loras, max_lora_rank, input_size), dtype)
         self.lora_b_stacked = mx.zeros((max_loras, output_size, max_lora_rank), dtype)
+        # MLX tracks lists assigned through Module.__setattr__; ranks are metadata.
         object.__setattr__(self, "_lora_ranks", [0] * max_loras)
         self.punica_wrapper: PunicaWrapperMLX | None = None
 

--- a/vllm_metal/v1/lora/model_manager.py
+++ b/vllm_metal/v1/lora/model_manager.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _WrappedModule = MLXLinearWithLoRA | MLXQuantizedLinearWithLoRA
-_PreparedLoRAWeights = tuple[mx.array, mx.array]
+_PreparedLoRAWeights = tuple[mx.array, mx.array, int]
 _PreparedModuleUpdate = tuple[_WrappedModule, _PreparedLoRAWeights | None]
 
 
@@ -306,14 +306,15 @@ class MLXLoRAModelManager:
                 updates.append((module, None))
                 continue
             loaded += 1
+            lora_a, lora_b = module.prepare_lora_weights(
+                slot,
+                weights.lora_a,
+                weights.lora_b * weights.scaling,
+            )
             updates.append(
                 (
                     module,
-                    module.prepare_lora_weights(
-                        slot,
-                        weights.lora_a,
-                        weights.lora_b * weights.scaling,
-                    ),
+                    (lora_a, lora_b, int(weights.lora_a.shape[0])),
                 )
             )
         if loaded == 0:
@@ -335,8 +336,8 @@ class MLXLoRAModelManager:
             if weights is None:
                 module.reset_lora(slot)
                 continue
-            lora_a, lora_b = weights
-            module.set_prepared_lora(slot, lora_a, lora_b)
+            lora_a, lora_b, rank = weights
+            module.set_prepared_lora(slot, lora_a, lora_b, rank=rank)
         self.lora_index_to_id[slot] = lora_id
         self._last_mapping = None
 

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -14,11 +14,17 @@ if TYPE_CHECKING:
     from vllm.lora.layers import LoRAMapping
 
 
+# Contiguous runs avoid gather/scatter for common prefill layouts. Grouping wins
+# once routing alternates heavily because it reduces matmul launches.
+MAX_CONTIGUOUS_RUNS_PER_SLOT = 2
+
+
 class PunicaWrapperMLX:
     def __init__(self, max_num_batched_tokens: int, max_batches: int, max_loras: int):
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_batches = max_batches
         self.max_loras = max_loras
+        self._runs: tuple[tuple[int | None, int, int], ...] = ()
         self._token_indices_by_slot: tuple[tuple[int, mx.array], ...] = ()
         self._no_lora = True
 
@@ -30,16 +36,38 @@ class PunicaWrapperMLX:
         self, mapping: LoRAMapping, lora_index_to_id: list[int | None]
     ) -> None:
         slot_of = {aid: i for i, aid in enumerate(lora_index_to_id) if aid is not None}
+        runs: list[tuple[int | None, int, int]] = []
         token_indices_by_slot: dict[int, list[int]] = {}
+        run_slot: int | None = None
+        run_start = 0
         for token_index, adapter_id in enumerate(mapping.index_mapping):
             slot = slot_of.get(adapter_id)
             if slot is not None:
                 token_indices_by_slot.setdefault(slot, []).append(token_index)
-        self._token_indices_by_slot = tuple(
-            (slot, mx.array(indices, dtype=mx.int32))
-            for slot, indices in sorted(token_indices_by_slot.items())
+            if token_index == 0:
+                run_slot = slot
+                continue
+            if slot != run_slot:
+                runs.append((run_slot, run_start, token_index))
+                run_slot = slot
+                run_start = token_index
+        if mapping.index_mapping:
+            runs.append((run_slot, run_start, len(mapping.index_mapping)))
+
+        active_slot_count = len(token_indices_by_slot)
+        use_runs = active_slot_count > 0 and len(runs) <= (
+            MAX_CONTIGUOUS_RUNS_PER_SLOT * active_slot_count
         )
-        self._no_lora = not self._token_indices_by_slot
+        self._runs = tuple(runs) if use_runs else ()
+        self._token_indices_by_slot = (
+            ()
+            if use_runs
+            else tuple(
+                (slot, mx.array(indices, dtype=mx.int32))
+                for slot, indices in sorted(token_indices_by_slot.items())
+            )
+        )
+        self._no_lora = active_slot_count == 0
 
     def add_lora_linear(
         self,
@@ -55,6 +83,25 @@ class PunicaWrapperMLX:
             return y
         max_rank = int(lora_a_stacked.shape[1])
         ranks = lora_ranks or [max_rank] * self.max_loras
+
+        if self._runs:
+            outputs: list[mx.array] = []
+            for slot, start, end in self._runs:
+                y_run = y[start:end]
+                if slot is None:
+                    outputs.append(y_run)
+                    continue
+                rank = ranks[slot]
+                if rank == 0:
+                    outputs.append(y_run)
+                    continue
+                lora_a = lora_a_stacked[slot, :rank]
+                lora_b = lora_b_stacked[slot, :, :rank]
+                x_run = x[start:end]
+                delta = mx.matmul(mx.matmul(x_run, lora_a.T), lora_b.T)
+                outputs.append(y_run + delta * scale)
+            return mx.concatenate(outputs, axis=0)
+
         output = y
         for slot, token_indices in self._token_indices_by_slot:
             rank = ranks[slot]

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX PunicaWrapper — gather + batched matmul for the rank-r LoRA delta.
+"""MLX PunicaWrapper — grouped matmuls for the rank-r LoRA delta.
 
-Slot ``max_loras`` is the permanently-zero null slot: no-LoRA tokens are
-remapped to it so the kernel runs branch-free.
+No-LoRA tokens are passed through without indexing a weight slot.
 """
 
 from __future__ import annotations
@@ -20,25 +19,27 @@ class PunicaWrapperMLX:
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_batches = max_batches
         self.max_loras = max_loras
-        self._token_slot_indices: mx.array | None = None
+        self._token_indices_by_slot: tuple[tuple[int, mx.array], ...] = ()
         self._no_lora = True
 
     @property
     def no_lora(self) -> bool:
         return self._no_lora
 
-    @property
-    def token_slot_indices(self) -> mx.array | None:
-        return self._token_slot_indices
-
     def update_metadata(
         self, mapping: LoRAMapping, lora_index_to_id: list[int | None]
     ) -> None:
-        null = self.max_loras
         slot_of = {aid: i for i, aid in enumerate(lora_index_to_id) if aid is not None}
-        tok = [slot_of.get(t, null) for t in mapping.index_mapping]
-        self._token_slot_indices = mx.array(tok, dtype=mx.int32)
-        self._no_lora = all(s == null for s in tok)
+        token_indices_by_slot: dict[int, list[int]] = {}
+        for token_index, adapter_id in enumerate(mapping.index_mapping):
+            slot = slot_of.get(adapter_id)
+            if slot is not None:
+                token_indices_by_slot.setdefault(slot, []).append(token_index)
+        self._token_indices_by_slot = tuple(
+            (slot, mx.array(indices, dtype=mx.int32))
+            for slot, indices in sorted(token_indices_by_slot.items())
+        )
+        self._no_lora = not self._token_indices_by_slot
 
     def add_lora_linear(
         self,
@@ -47,13 +48,21 @@ class PunicaWrapperMLX:
         lora_a_stacked: mx.array,
         lora_b_stacked: mx.array,
         scale: float,
+        lora_ranks: list[int] | None = None,
     ) -> mx.array:
-        """``y += (B[idx] @ A[idx] @ x) * scale``  per token."""
-        if self._no_lora or self._token_slot_indices is None:
+        """Apply LoRA deltas once per active adapter slot."""
+        if self._no_lora:
             return y
-        idx = self._token_slot_indices
-        a, b = (
-            mx.take(lora_a_stacked, idx, axis=0),
-            mx.take(lora_b_stacked, idx, axis=0),
-        )
-        return y + mx.matmul(b, mx.matmul(a, x[:, :, None])).squeeze(-1) * scale
+        max_rank = int(lora_a_stacked.shape[1])
+        ranks = lora_ranks or [max_rank] * self.max_loras
+        output = y
+        for slot, token_indices in self._token_indices_by_slot:
+            rank = ranks[slot]
+            if rank == 0:
+                continue
+            lora_a = lora_a_stacked[slot, :rank]
+            lora_b = lora_b_stacked[slot, :, :rank]
+            x_for_slot = mx.take(x, token_indices, axis=0)
+            delta = mx.matmul(mx.matmul(x_for_slot, lora_a.T), lora_b.T)
+            output = output.at[token_indices].add(delta * scale)
+        return output

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -14,17 +14,12 @@ if TYPE_CHECKING:
     from vllm.lora.layers import LoRAMapping
 
 
-# Contiguous runs avoid gather/scatter for common prefill layouts. Grouping wins
-# once routing alternates heavily because it reduces matmul launches.
-MAX_CONTIGUOUS_RUNS_PER_SLOT = 2
-
-
 class PunicaWrapperMLX:
     def __init__(self, max_num_batched_tokens: int, max_batches: int, max_loras: int):
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_batches = max_batches
         self.max_loras = max_loras
-        self._runs: tuple[tuple[int | None, int, int], ...] = ()
+        self._contiguous_runs: tuple[tuple[int | None, int, int], ...] = ()
         self._token_indices_by_slot: tuple[tuple[int, mx.array], ...] = ()
         self._no_lora = True
 
@@ -55,13 +50,11 @@ class PunicaWrapperMLX:
             runs.append((run_slot, run_start, len(mapping.index_mapping)))
 
         active_slot_count = len(token_indices_by_slot)
-        use_runs = active_slot_count > 0 and len(runs) <= (
-            MAX_CONTIGUOUS_RUNS_PER_SLOT * active_slot_count
-        )
-        self._runs = tuple(runs) if use_runs else ()
+        use_contiguous_runs = active_slot_count > 0 and len(runs) <= active_slot_count
+        self._contiguous_runs = tuple(runs) if use_contiguous_runs else ()
         self._token_indices_by_slot = (
             ()
-            if use_runs
+            if use_contiguous_runs
             else tuple(
                 (slot, mx.array(indices, dtype=mx.int32))
                 for slot, indices in sorted(token_indices_by_slot.items())
@@ -84,9 +77,9 @@ class PunicaWrapperMLX:
         max_rank = int(lora_a_stacked.shape[1])
         ranks = lora_ranks or [max_rank] * self.max_loras
 
-        if self._runs:
+        if self._contiguous_runs:
             outputs: list[mx.array] = []
-            for slot, start, end in self._runs:
+            for slot, start, end in self._contiguous_runs:
                 y_run = y[start:end]
                 if slot is None:
                     outputs.append(y_run)

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -118,7 +118,7 @@ class PunicaWrapperMLX:
 
         if self._contiguous_runs:
             outputs: list[mx.array] = []
-            applied_delta = False
+            has_lora_delta = False
             for slot, start, end in self._contiguous_runs:
                 y_run = y[start:end]
                 if slot is None:
@@ -136,9 +136,9 @@ class PunicaWrapperMLX:
                     delta = delta * scale
                 if delta.dtype != y.dtype:
                     delta = delta.astype(y.dtype)
-                applied_delta = True
+                has_lora_delta = True
                 outputs.append(y_run + delta)
-            if not applied_delta:
+            if not has_lora_delta:
                 return y
             return outputs[0] if len(outputs) == 1 else mx.concatenate(outputs, axis=0)
 

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -21,6 +21,7 @@ class PunicaWrapperMLX:
         self.max_loras = max_loras
         self._contiguous_runs: tuple[tuple[int | None, int, int], ...] = ()
         self._token_indices_by_slot: tuple[tuple[int, mx.array], ...] = ()
+        self._num_tokens = 0
         self._no_lora = True
 
     @property
@@ -49,8 +50,12 @@ class PunicaWrapperMLX:
         if mapping.index_mapping:
             runs.append((run_slot, run_start, len(mapping.index_mapping)))
 
+        self._num_tokens = len(mapping.index_mapping)
         active_slot_count = len(token_indices_by_slot)
-        use_contiguous_runs = active_slot_count > 0 and len(runs) <= active_slot_count
+        lora_run_count = sum(1 for slot, _, _ in runs if slot is not None)
+        use_contiguous_runs = (
+            active_slot_count > 0 and lora_run_count <= active_slot_count
+        )
         self._contiguous_runs = tuple(runs) if use_contiguous_runs else ()
         self._token_indices_by_slot = (
             ()
@@ -74,8 +79,13 @@ class PunicaWrapperMLX:
         """Apply LoRA deltas once per active adapter slot."""
         if self._no_lora:
             return y
+        if int(x.shape[0]) != self._num_tokens or int(y.shape[0]) != self._num_tokens:
+            raise ValueError(
+                "LoRA routing row count mismatch: "
+                f"metadata={self._num_tokens}, x={x.shape[0]}, y={y.shape[0]}"
+            )
         max_rank = int(lora_a_stacked.shape[1])
-        ranks = lora_ranks or [max_rank] * self.max_loras
+        ranks = lora_ranks if lora_ranks is not None else [max_rank] * self.max_loras
 
         if self._contiguous_runs:
             outputs: list[mx.array] = []
@@ -92,7 +102,7 @@ class PunicaWrapperMLX:
                 lora_b = lora_b_stacked[slot, :, :rank]
                 x_run = x[start:end]
                 delta = mx.matmul(mx.matmul(x_run, lora_a.T), lora_b.T)
-                outputs.append(y_run + delta * scale)
+                outputs.append(y_run + (delta * scale).astype(y.dtype))
             return mx.concatenate(outputs, axis=0)
 
         output = y
@@ -104,5 +114,5 @@ class PunicaWrapperMLX:
             lora_b = lora_b_stacked[slot, :, :rank]
             x_for_slot = mx.take(x, token_indices, axis=0)
             delta = mx.matmul(mx.matmul(x_for_slot, lora_a.T), lora_b.T)
-            output = output.at[token_indices].add(delta * scale)
+            output = output.at[token_indices].add((delta * scale).astype(y.dtype))
         return output

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX PunicaWrapper — grouped matmuls for the rank-r LoRA delta.
+"""MLX PunicaWrapper — route LoRA deltas by adapter slot.
 
-No-LoRA tokens are passed through without indexing a weight slot.
+Prefill batches avoid per-token weight expansion; decode keeps the compact
+batched path that works best for small token counts.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ class PunicaWrapperMLX:
         self.max_loras = max_loras
         self._contiguous_runs: tuple[tuple[int | None, int, int], ...] = ()
         self._token_indices_by_slot: tuple[tuple[int, mx.array], ...] = ()
+        self._expanded_slot_indices: mx.array | None = None
         self._num_tokens = 0
         self._no_lora = True
 
@@ -32,6 +34,20 @@ class PunicaWrapperMLX:
         self, mapping: LoRAMapping, lora_index_to_id: list[int | None]
     ) -> None:
         slot_of = {aid: i for i, aid in enumerate(lora_index_to_id) if aid is not None}
+        self._num_tokens = len(mapping.index_mapping)
+
+        if not mapping.is_prefill:
+            null_slot = self.max_loras
+            token_slots = [
+                slot_of.get(adapter_id, null_slot)
+                for adapter_id in mapping.index_mapping
+            ]
+            self._expanded_slot_indices = mx.array(token_slots, dtype=mx.int32)
+            self._contiguous_runs = ()
+            self._token_indices_by_slot = ()
+            self._no_lora = all(slot == null_slot for slot in token_slots)
+            return
+
         runs: list[tuple[int | None, int, int]] = []
         active_slots: set[int] = set()
         run_slot: int | None = None
@@ -50,13 +66,15 @@ class PunicaWrapperMLX:
         if mapping.index_mapping:
             runs.append((run_slot, run_start, len(mapping.index_mapping)))
 
-        self._num_tokens = len(mapping.index_mapping)
         lora_run_count = sum(1 for slot, _, _ in runs if slot is not None)
         use_contiguous_runs = bool(active_slots) and lora_run_count <= len(active_slots)
-        self._contiguous_runs = tuple(runs) if use_contiguous_runs else ()
         if use_contiguous_runs:
+            self._expanded_slot_indices = None
+            self._contiguous_runs = tuple(runs)
             self._token_indices_by_slot = ()
         else:
+            self._expanded_slot_indices = None
+            self._contiguous_runs = ()
             token_indices_by_slot: dict[int, list[int]] = {}
             for token_index, adapter_id in enumerate(mapping.index_mapping):
                 slot = slot_of.get(adapter_id)
@@ -85,6 +103,16 @@ class PunicaWrapperMLX:
                 "LoRA routing row count mismatch: "
                 f"metadata={self._num_tokens}, x={x.shape[0]}, y={y.shape[0]}"
             )
+
+        if self._expanded_slot_indices is not None:
+            lora_a = mx.take(lora_a_stacked, self._expanded_slot_indices, axis=0)
+            lora_b = mx.take(lora_b_stacked, self._expanded_slot_indices, axis=0)
+            return (
+                y
+                + mx.matmul(lora_b, mx.matmul(lora_a, x[:, :, None])).squeeze(-1)
+                * scale
+            )
+
         max_rank = int(lora_a_stacked.shape[1])
         ranks = lora_ranks if lora_ranks is not None else [max_rank] * self.max_loras
 
@@ -103,7 +131,11 @@ class PunicaWrapperMLX:
                 lora_b = lora_b_stacked[slot, :, :rank]
                 x_run = x[start:end]
                 delta = mx.matmul(mx.matmul(x_run, lora_a.T), lora_b.T)
-                outputs.append(y_run + (delta * scale).astype(y.dtype))
+                if scale != 1.0:
+                    delta = delta * scale
+                if delta.dtype != y.dtype:
+                    delta = delta.astype(y.dtype)
+                outputs.append(y_run + delta)
             return mx.concatenate(outputs, axis=0)
 
         output = y
@@ -115,5 +147,9 @@ class PunicaWrapperMLX:
             lora_b = lora_b_stacked[slot, :, :rank]
             x_for_slot = mx.take(x, token_indices, axis=0)
             delta = mx.matmul(mx.matmul(x_for_slot, lora_a.T), lora_b.T)
-            output = output.at[token_indices].add((delta * scale).astype(y.dtype))
+            if scale != 1.0:
+                delta = delta * scale
+            if delta.dtype != y.dtype:
+                delta = delta.astype(y.dtype)
+            output = output.at[token_indices].add(delta)
         return output

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -118,6 +118,7 @@ class PunicaWrapperMLX:
 
         if self._contiguous_runs:
             outputs: list[mx.array] = []
+            applied_delta = False
             for slot, start, end in self._contiguous_runs:
                 y_run = y[start:end]
                 if slot is None:
@@ -135,8 +136,11 @@ class PunicaWrapperMLX:
                     delta = delta * scale
                 if delta.dtype != y.dtype:
                     delta = delta.astype(y.dtype)
+                applied_delta = True
                 outputs.append(y_run + delta)
-            return mx.concatenate(outputs, axis=0)
+            if not applied_delta:
+                return y
+            return outputs[0] if len(outputs) == 1 else mx.concatenate(outputs, axis=0)
 
         output = y
         for slot, token_indices in self._token_indices_by_slot:

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -33,13 +33,13 @@ class PunicaWrapperMLX:
     ) -> None:
         slot_of = {aid: i for i, aid in enumerate(lora_index_to_id) if aid is not None}
         runs: list[tuple[int | None, int, int]] = []
-        token_indices_by_slot: dict[int, list[int]] = {}
+        active_slots: set[int] = set()
         run_slot: int | None = None
         run_start = 0
         for token_index, adapter_id in enumerate(mapping.index_mapping):
             slot = slot_of.get(adapter_id)
             if slot is not None:
-                token_indices_by_slot.setdefault(slot, []).append(token_index)
+                active_slots.add(slot)
             if token_index == 0:
                 run_slot = slot
                 continue
@@ -51,21 +51,22 @@ class PunicaWrapperMLX:
             runs.append((run_slot, run_start, len(mapping.index_mapping)))
 
         self._num_tokens = len(mapping.index_mapping)
-        active_slot_count = len(token_indices_by_slot)
         lora_run_count = sum(1 for slot, _, _ in runs if slot is not None)
-        use_contiguous_runs = (
-            active_slot_count > 0 and lora_run_count <= active_slot_count
-        )
+        use_contiguous_runs = bool(active_slots) and lora_run_count <= len(active_slots)
         self._contiguous_runs = tuple(runs) if use_contiguous_runs else ()
-        self._token_indices_by_slot = (
-            ()
-            if use_contiguous_runs
-            else tuple(
+        if use_contiguous_runs:
+            self._token_indices_by_slot = ()
+        else:
+            token_indices_by_slot: dict[int, list[int]] = {}
+            for token_index, adapter_id in enumerate(mapping.index_mapping):
+                slot = slot_of.get(adapter_id)
+                if slot is not None:
+                    token_indices_by_slot.setdefault(slot, []).append(token_index)
+            self._token_indices_by_slot = tuple(
                 (slot, mx.array(indices, dtype=mx.int32))
                 for slot, indices in sorted(token_indices_by_slot.items())
             )
-        )
-        self._no_lora = active_slot_count == 0
+        self._no_lora = not active_slots
 
     def add_lora_linear(
         self,

--- a/vllm_metal/v1/lora/runtime.py
+++ b/vllm_metal/v1/lora/runtime.py
@@ -24,16 +24,20 @@ class _LoRAMappingBuilder:
     def __init__(self) -> None:
         self._idx: list[int] = []
         self._prompt: list[int] = []
-        self._is_prefill = False
+        self._use_prefill_routing = True
 
     def add_request(self, lora_id: int | None, num_tokens: int) -> None:
         token_id = 0 if lora_id is None else int(lora_id)
         self._idx += [token_id] * num_tokens
         self._prompt.append(token_id)
-        self._is_prefill |= num_tokens > 1
+        self._use_prefill_routing &= num_tokens > 1
 
     def build(self) -> LoRAMapping:
-        return LoRAMapping(tuple(self._idx), tuple(self._prompt), self._is_prefill)
+        return LoRAMapping(
+            tuple(self._idx),
+            tuple(self._prompt),
+            self._use_prefill_routing,
+        )
 
     def is_empty(self) -> bool:
         return not self._idx


### PR DESCRIPTION
This PR is:

- To optimize pure LoRA prefill by applying adapter deltas per active slot instead of expanding LoRA weights per token.
- To reduce long-prompt prefill latency and temporary adapter-weight traffic.
- To keep decode and mixed decode/prefill batches on the existing routing path.

Before: each LoRA token gathered full A/B adapter matrices, so prefill copied the same adapter weights once per token.

After: pure prefill groups rows by adapter slot and reuses each adapter A/B matrix for the whole row range or row group.

Scope note: this intentionally optimizes pure prefill only. If any one-token decode row is present, the batch keeps the existing expanded route to avoid decode regression.

Local hot-path microbenchmark, lower ms is better:

| Tokens | Before old expanded route | After pure-prefill route | Speedup |
|---:|---:|---:|---:|
| 64 | 0.773 ms | 0.563 ms | 1.37x |
| 512 | 1.006 ms | 0.260 ms | 3.87x |
| 2048 | 1.175 ms | 0.406 ms | 2.90x |
| 4096 | 2.490 ms | 0.449 ms | 5.54x |