### PR TITLE
[Bugfix] Normalize disabled top_k rows to vocab_size in mixed sampling batches (#646)

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -498,6 +498,38 @@ class TestV1SamplingBatch:
         assert result.token_ids[0] in [2, 3]
         assert result.token_ids[1] == 1  # unconstrained, should pick highest logit
 
+    def test_mixed_disabled_and_enabled_top_k(self) -> None:
+        """Mixed top_k=0 (disabled) and top_k=64 rows must not crash.
+
+        Regression for issue #646: the disabled row reached vLLM's sampler as
+        raw 0, which the PyTorch top-k path interprets as a gather index of
+        vocab_size (out of bounds). It must carry the vocab_size sentinel
+        instead, matching GPUInputBatch. Exercises the real Sampler.forward()
+        path via sample_from_logits (native greedy is unavailable for a mixed
+        batch).
+        """
+        top_k = 64
+        logits = mx.arange(2 * VOCAB_SIZE, dtype=mx.float32).reshape(2, VOCAB_SIZE)
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0),
+                SamplingParams(temperature=1.0, top_k=top_k, top_p=0.95),
+            ],
+            [[1], [2]],
+            [[], []],
+            vocab_size=VOCAB_SIZE,
+        )
+        # Disabled row must be normalized to the vocab_size sentinel.
+        metadata = batch.make_sampling_metadata()
+        assert metadata.top_k is not None
+        assert metadata.top_k.tolist() == [VOCAB_SIZE, top_k]
+
+        result = sample_from_logits(logits, batch, Sampler())
+        # Greedy row samples from the full vocab: argmax of row 0.
+        assert result.token_ids[0] == VOCAB_SIZE - 1
+        # Top-k row stays inside the top-64 candidates (values 960..1023).
+        assert VOCAB_SIZE - top_k <= result.token_ids[1] < VOCAB_SIZE
+
     def test_bad_words_blocks_greedy_token(self) -> None:
         """Greedy + bad_words_token_ids must fall back and block the banned token."""
         logits = mx.array([[10.0, 1.0, 5.0, 1.0]], dtype=mx.float32)

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -219,8 +219,18 @@ class SamplingBatch:
         if self.no_top_k:
             return None
 
+        # Match vLLM's per-row convention: top_k <= 0 (or >= vocab_size)
+        # disables top-k, and the sentinel is vocab_size, not 0. The PyTorch
+        # top-k path computes a gather index of vocab_size - top_k, so a 0
+        # sentinel indexes out of bounds (issue #646). GPUInputBatch and the
+        # v1 sampler states normalize the same way.
         return torch.tensor(
-            [sampling_params.top_k for sampling_params in self.sampling_params_list],
+            [
+                sampling_params.top_k
+                if 0 < sampling_params.top_k < self.vocab_size
+                else self.vocab_size
+                for sampling_params in self.sampling_params_list
+            ],
             dtype=torch.int32,
             device=self.SAMPLER_DEVICE,
         )


### PR DESCRIPTION
This PR is:

- To normalize disabled top_k rows to the vocab_size sentinel in mixed 
- To match vLLM's per-row top_k convention in GPUInputBatch and the v1 sampler 
- To keep disabled rows sampling from the full vocabulary while enabled rows keep their 
- To stop a mixed top_k=0 / top_k=N batch from crashing EngineCore.

Before: _make_top_k() passed raw per-request top_k values to vLLM's sampler, so a disabled row carried 0. The PyTorch top-k path computes a gather index of vocab_size - top_k, indexing out of bounds and terminating EngineCore (issue #646).

After: _make_top_k() sends top_k when 0 < top_k < vocab_size and the vocab_size sentinel otherwise. A regression test covers the mixed batch through the real Sampler.forward() path.
