### PR TITLE
[Bugfix] Reject non-progressing Whisper audio chunks

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -300,6 +300,74 @@ class TestChunkingPolicy:
         with pytest.raises(ValueError, match="max_audio_clip_s="):
             transcriber.transcribe(short_audio)
 
+    @pytest.mark.parametrize(
+        ("config", "message"),
+        [
+            (
+                SpeechToTextConfig(max_audio_clip_s=0),
+                "max_audio_clip_s must be > 0",
+            ),
+            (
+                SpeechToTextConfig(overlap_chunk_second=-1),
+                "overlap_chunk_second must be >= 0",
+            ),
+            (
+                SpeechToTextConfig(min_energy_split_window_size=0),
+                "min_energy_split_window_size must be > 0",
+            ),
+            (
+                SpeechToTextConfig(
+                    max_audio_clip_s=10,
+                    overlap_chunk_second=10,
+                ),
+                "must be less than max_audio_clip_s",
+            ),
+            (
+                SpeechToTextConfig(
+                    max_audio_clip_s=10,
+                    overlap_chunk_second=11,
+                ),
+                "must be less than max_audio_clip_s",
+            ),
+        ],
+    )
+    def test_prepare_audio_chunks_rejects_invalid_chunking_policy(
+        self,
+        config: SpeechToTextConfig,
+        message: str,
+    ) -> None:
+        transcriber = _ChunkingTestTranscriber(config)
+
+        with pytest.raises(ValueError, match=message):
+            transcriber._prepare_audio_chunks(mx.zeros(1600, dtype=mx.float32))
+
+    def test_prepare_audio_chunks_ignores_quiet_point_inside_overlap(self) -> None:
+        max_clip_s = 2
+        overlap_s = 1
+        window_size = SAMPLE_RATE // 2
+        audio = mx.concatenate(
+            [
+                mx.ones(SAMPLE_RATE // 2, dtype=mx.float32),
+                mx.zeros(SAMPLE_RATE // 2, dtype=mx.float32),
+                mx.ones(2 * SAMPLE_RATE, dtype=mx.float32),
+            ]
+        )
+        transcriber = _ChunkingTestTranscriber(
+            SpeechToTextConfig(
+                max_audio_clip_s=max_clip_s,
+                overlap_chunk_second=overlap_s,
+                min_energy_split_window_size=window_size,
+            )
+        )
+
+        chunks = transcriber._prepare_audio_chunks(audio)
+
+        assert [start for _, start in chunks] == pytest.approx([0.0, 1.0])
+        assert [chunk.shape[0] for chunk, _ in chunks] == [
+            max_clip_s * SAMPLE_RATE,
+            max_clip_s * SAMPLE_RATE,
+        ]
+
 
 class TestGreedyDecode:
     @pytest.fixture()

--- a/vllm_metal/stt/audio.py
+++ b/vllm_metal/stt/audio.py
@@ -406,14 +406,15 @@ def split_audio(
             break
 
         split = _find_split_point(audio, end, window_size)
-        # When the energy search does not find a forward split point,
-        # fall back to the target boundary for stable chunk sizes.
-        if split <= pos:
+        # A split inside the requested overlap would make the next chunk start
+        # at or before this one. Fall back to the target boundary so every
+        # iteration contributes new audio while preserving the overlap.
+        if split <= pos + overlap_samples:
             split = end
         else:
             split = min(split, end)
 
         chunks.append((audio[pos:split], pos / sample_rate))
-        pos = max(split - overlap_samples, pos + 1)
+        pos = split - overlap_samples
 
     return chunks

--- a/vllm_metal/stt/whisper/transcriber.py
+++ b/vllm_metal/stt/whisper/transcriber.py
@@ -175,6 +175,9 @@ class WhisperTranscriber:
                 )
             return [(audio, 0.0)]
 
+        if max_clip_s <= 0:
+            raise ValueError(f"max_audio_clip_s must be > 0, got {max_clip_s}")
+
         if max_clip_s > DEFAULT_SEGMENT_DURATION:
             raise ValueError(
                 f"max_audio_clip_s={max_clip_s} exceeds Whisper's "
@@ -182,10 +185,24 @@ class WhisperTranscriber:
                 "Set max_audio_clip_s <= 30 for Whisper."
             )
 
+        if window_size <= 0:
+            raise ValueError(
+                f"min_energy_split_window_size must be > 0, got {window_size}"
+            )
+
+        overlap_s = self.config.overlap_chunk_second
+        if overlap_s < 0:
+            raise ValueError(f"overlap_chunk_second must be >= 0, got {overlap_s}")
+        if overlap_s >= max_clip_s:
+            raise ValueError(
+                f"overlap_chunk_second={overlap_s} must be less than "
+                f"max_audio_clip_s={max_clip_s} to ensure forward progress"
+            )
+
         return split_audio(
             audio,
             max_clip_s=max_clip_s,
-            overlap_s=self.config.overlap_chunk_second,
+            overlap_s=overlap_s,
             window_size=window_size,
             sample_rate=SAMPLE_RATE,
         )


### PR DESCRIPTION
## Summary

Whisper long-audio chunking accepted active configurations where `overlap_chunk_second >= max_audio_clip_s`. With 30-second clips and 30 seconds of overlap, the previous one-sample recovery could turn a 10-minute, 16 kHz input into approximately 9.12 million chunk iterations.

This change validates reachable `SpeechToTextConfig` constraints in `WhisperTranscriber._prepare_audio_chunks()`: the clip duration and energy window must be positive, the overlap must be nonnegative, and the overlap must be shorter than the clip. The default 30-second clip and 1-second overlap are unchanged.

When energy-based splitting selects a quiet point inside the requested overlap, the splitter uses the target clip boundary. With the validated configuration, each iteration advances strictly and every emitted chunk remains within the configured maximum.

## Validation

Validated at commit `6e8bb6564ef916c80b74fa4c56f45dd4790606ea` on Apple Silicon with macOS 15.6, Python 3.12.13, vLLM 0.28.0, and MLX 0.32.0.

- Focused STT suite: 61 passed
- Complete non-slow suite: 1,888 passed, 15 skipped, 52 deselected
- Shellcheck, Ruff lint, Ruff formatting, and mypy: passed
- Native Metal extension and four shader libraries: built successfully
- Release wheel artifact and macOS 15 deployment-target verification: passed

The real-path regression uses a 2-second clip, 1-second overlap, and an actual low-energy window. The selected quiet point is sample 8,000, inside the 16,000-sample overlap boundary; `_prepare_audio_chunks()` produces two 32,000-sample chunks starting at 0 and 1 seconds.
