### PR TITLE
[Bugfix] Resolve head counts for mlx-lm's num_heads naming convention

### DIFF
--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -486,7 +486,12 @@ def sdpa_forward(
     # Resolve head counts — mlx_lm uses different attribute names:
     #   Qwen3/Llama/Gemma/Gemma4: n_heads, n_kv_heads
     #   Qwen3.5 (Qwen3Next):      num_attention_heads, num_key_value_heads
-    n_heads = getattr(inner, "n_heads", None) or inner.num_attention_heads
+    #   StableLM:                 num_heads, num_key_value_heads
+    n_heads = (
+        getattr(inner, "n_heads", None)
+        or getattr(inner, "num_attention_heads", None)
+        or inner.num_heads
+    )
     n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
 
     # Softmax scale — GPT-OSS names it sm_scale rather than scale.


### PR DESCRIPTION
## Summary

`sdpa_forward` resolves the query-head count by probing two mlx-lm naming conventions — `n_heads` (Qwen3/Llama/Gemma/Gemma4) and `num_attention_heads` (Qwen3.5/Qwen3-Next). mlx-lm has a **third**: `num_heads`. Modules using it raise before any attention runs:

```
File "vllm_metal/attention/impls/sdpa.py", line 489, in sdpa_forward
    n_heads = getattr(inner, "n_heads", None) or inner.num_attention_heads
AttributeError: 'Attention' object has no attribute 'num_attention_heads'
```

This adds `num_heads` as a final fallback.

## Scope — what this does and does not claim

This is a narrow fix to head-count resolution. **It does not make any new model work end-to-end, and I am not claiming StableLM 2 is supported.**

I found this while testing `mlx-community/stablelm-2-zephyr-1_6b-4bit` (`StableLmForCausalLM`, `stablelm.py:49` → `self.num_heads = config.num_attention_heads`). With this change the model gets past head resolution, then hits further gaps that are **out of scope here** and filed separately as #656:

1. **No scale attribute.** StableLM's `Attention` stores neither `scale` nor `sm_scale`; it computes the softmax scale inline at forward time (`stablelm.py:80`, `math.sqrt(1 / queries.shape[-1])`). A fix must *compute* a default, not alias a name — a semantic decision I did not want to bundle into a rename fix.
2. **`q_layernorm` / `k_layernorm` unhandled.** `sdpa.py` applies `q_norm`/`k_norm`; StableLM uses per-head LayerNorm under different names, so its QK normalization would be silently skipped.
3. **No partial-RoPE support.** StableLM rotates only `int(partial_rotary_factor * head_dim)` dims; `sdpa.py` has no partial-rotary handling.

(2) and (3) would produce silently wrong output rather than an error, which is why I stopped rather than patching to "no longer crashes."

## Why the fallback is safe

`num_heads` is overloaded in mlx-lm — `mamba2`, `plamo2:66`, `nemotron_h:94`, `falcon_h1:182`, `rwkv7:239` and `kimi_linear:281` all use it for **SSM/recurrent** head counts. Grabbing one of those would be a silent miscompute, so I traced reachability:

- `sdpa_forward` is called only from `SDPAPagedAttentionWrapper.__call__`.
- That wrapper is constructed only when `is_sdpa(attn)` is true (`runtime/hybrid.py:275`); linear-attention modules route to `GDNPagedAttentionWrapper`, and anything matching neither **raises** rather than passing through unpatched.
- `is_sdpa` gates on projection layout — `q_proj`/`k_proj`/`o_proj` (+ `v_proj` or `use_k_eq_v`), or the packed `qkv_proj` contract — not on head-count names.
- Every overloaded site above lives in an SSM/recurrent mixer carrying `conv1d`/`in_proj` and **no** `q_proj`, so `is_sdpa` is false for all of them.

Two ambiguous cases checked individually:

- **`recurrent_gemma`** has four `num_heads` sites; only `LocalAttentionBlock:230` satisfies `is_sdpa` (it defines `q_proj`/`k_proj`/`v_proj`/`o_proj`), and there `num_heads` *is* the attention head count. The recurrent blocks carry `conv_1d` and no `q_proj`.
- **`phixtral`** uses `Wqkv`, not `qkv_proj`, and defines no `o_proj`/`n_heads`, so it fails both contracts and never reaches this code.

So the only modules that can reach the new fallback are ones already proven to be softmax attention by projection layout, and in every such class in mlx-lm `num_heads` is assigned from `num_attention_heads` (`deepseek_v2`, `deepseek_v3`, `glm4_moe_lite`, `minicpm`, `minicpm3`, `mixtral`, `nanochat`, `phi`, `stablelm`, `youtu_llm`, `falcon_h1:122`, `nemotron_h:241`, `step3p5`).

## Design notes

- **Appended last**, so the change is strictly additive: any module that resolves today resolves to the identical value. Only modules that currently raise are affected.
- **The chain still ends in a bare attribute access**, so an unknown architecture fails loudly — consistent with `is_sdpa`'s "keeping this classifier tight matters" and `walk_and_wrap`'s "there is no silent skip."
- **KV-head line untouched** — `num_key_value_heads` already resolves for the models in question.

## Testing

- Verified the `AttributeError` is gone: the failing path now advances past head resolution to the separately-filed scale gap.
- Environment: Apple M2 / 8 GB, macOS 26.6.2, vllm-metal 0.3.0.dev20260829020049, vllm 0.28.0+cpu, mlx 0.32.0, mlx-lm 0.31.3.

I have **not** run a golden-token parity test for this change, because no model reaches generation through this path yet — that belongs with the follow-up work in #656.
