### PR TITLE
[Release] Retain only the latest dev release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-${{ github.ref }}
+
 jobs:
   build-and-release:
     runs-on: macos-15

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -141,6 +141,13 @@ main() {
   fi
 
   if [ "$channel" = "dev" ]; then
+    local main_sha
+    main_sha=$(git ls-remote --exit-code origin refs/heads/main | cut -f1)
+    if [ "$(git rev-parse HEAD)" != "$main_sha" ]; then
+      echo "Skipping stale dev release: checkout is no longer the tip of main."
+      exit 0
+    fi
+
     previous_dev_tag=$(gh release list --limit 30 --json tagName \
       --jq '[.[] | select(.tagName | contains(".dev"))][0].tagName // ""')
   fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,7 +123,7 @@ main() {
   fi
   verify_wheel_artifacts "${wheels[0]}"
 
-  local tag
+  local tag previous_dev_tag=""
   tag="v${version}"
   echo "Generated tag: $tag"
 
@@ -139,7 +139,17 @@ main() {
   if [ "$prerelease" -eq 1 ]; then
     release_args+=(--prerelease)
   fi
+
+  if [ "$channel" = "dev" ]; then
+    previous_dev_tag=$(gh release list --limit 30 --json tagName \
+      --jq '[.[] | select(.tagName | contains(".dev"))][0].tagName // ""')
+  fi
+
   gh release create "$tag" "${release_args[@]}" dist/*.whl
+
+  if [ -n "$previous_dev_tag" ]; then
+    gh release delete "$previous_dev_tag" --yes
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## Problem

Automated development prereleases accumulate on the GitHub Releases page even though only the newest wheel is installed.

## Change

- Serialize release publication per Git ref so overlapping `main` runs cannot race during cleanup.
- Remember the current `.dev` release before publishing its replacement.
- Delete the previous Release record only after the replacement release and wheel are published successfully, while retaining its Git tag.
- Leave the stable release path and installer unchanged.

## Manual cleanup on the release page

- I plan to clean the Releases page manually and retain one representative release for each previous version line: `v0.1.0`, `v0.2.0`, and `v0.3.0`.

I'll do it now if you agree @LxYuan0420

## Validation

- `./scripts/lint.sh`
- The live release selector resolves the current development prerelease.
