### PR TITLE
[Docs] Add an architecture figure to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 ## Architecture
 
-![vllm-metal in the vLLM stack](docs/assets/architecture.svg)
+Upstream vLLM supplies the API server, scheduler, and paged block manager; mlx_lm supplies the token-wise model layers; vllm-metal owns the request-aware attention path — the paged varlen kernel, M5 NAX prefill, and speculative decoding.
+
+![vllm-metal in the vLLM stack](https://raw.githubusercontent.com/vllm-project/vllm-metal/main/docs/assets/architecture.svg)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 ---
 
+## Architecture
+
+![vllm-metal in the vLLM stack](docs/assets/architecture.svg)
+
 ## Requirements
 
 - macOS 15 (Sequoia) or later, on Apple Silicon

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" role="img" aria-labelledby="figTitle figDesc">
+  <title id="figTitle">vllm-metal in the vLLM stack</title>
+  <desc id="figDesc">A four-layer stack. Client apps speak the OpenAI API to upstream vLLM V1, which contributes the API server, V1 scheduler, paged block manager with prefix caching, and chunked prefill with continuous batching, all used unchanged. vLLM hands the vllm-metal model runner one packed step of queries plus per-request block tables. Inside the runner, mlx_lm's model definitions, weight loading, RMSNorm, linear, MLP and MoE layers are reused unchanged because they are token-wise; vllm-metal adds custom Metal paths for paged varlen attention, M5 NAX prefill, and MTP draft and verify, which need request boundaries from cu_seqlens. Those issue MLX ops and custom Metal kernels down to the MLX runtime, the Apple Silicon GPU, and unified memory holding weights and the paged KV cache.</desc>
+
+  <style>
+    .box { fill: #ffffff; stroke: #cfd8e3; stroke-width: 1.2; }
+    .t   { font: 500 17px system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #1d2939; }
+    .t2  { font: 400 15px system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #6b7686; }
+    .band  { font: 700 20px system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+    .panel { font: 700 16px system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
+    .note { font: 400 15px system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #5a6473; }
+    .h1  { font: 700 27px system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; fill: #101828; }
+  </style>
+
+  <defs>
+    <marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" fill="#8892a4"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1000" height="700" fill="#ffffff"/>
+
+  <!-- ── header ─────────────────────────────────────────────────────── -->
+  <text class="h1"   x="500" y="40" text-anchor="middle">vllm-metal in the vLLM stack</text>
+  <text class="note" x="500" y="63" text-anchor="middle">upstream vLLM schedules · mlx_lm defines the model · vllm-metal owns the attention path</text>
+
+  <!-- ── layer 1: clients ───────────────────────────────────────────── -->
+  <rect x="28" y="84" width="944" height="54" rx="10" fill="#f4f6f9" stroke="#d7dde5" stroke-width="1.4"/>
+  <text class="band" x="48"  y="117" fill="#344054">Client apps</text>
+  <text class="t"    x="176" y="117" fill="#5a6473">coding agents · chat UIs · OpenAI SDKs · curl</text>
+
+  <line x1="500" y1="142" x2="500" y2="170" stroke="#8892a4" stroke-width="2.4" marker-end="url(#ar)"/>
+  <text class="note" x="516" y="162">OpenAI-compatible HTTP</text>
+
+  <!-- ── layer 2: upstream vLLM ─────────────────────────────────────── -->
+  <rect x="28" y="176" width="944" height="120" rx="12" fill="#eef3fb" stroke="#b9cde8" stroke-width="1.5"/>
+  <text class="band" x="48" y="205" fill="#0f2942">Upstream vLLM V1<tspan class="note" dx="10">used unchanged</tspan></text>
+
+  <rect class="box" x="48" y="220" width="214" height="56" rx="8"/>
+  <text class="t"  x="155" y="243" text-anchor="middle">OpenAI API server</text>
+  <text class="t2" x="155" y="263" text-anchor="middle">streaming · tool calls</text>
+
+  <rect class="box" x="277" y="220" width="214" height="56" rx="8"/>
+  <text class="t"  x="384" y="243" text-anchor="middle">V1 scheduler</text>
+  <text class="t2" x="384" y="263" text-anchor="middle">admission · preemption</text>
+
+  <rect class="box" x="506" y="220" width="214" height="56" rx="8"/>
+  <text class="t"  x="613" y="243" text-anchor="middle">paged block manager</text>
+  <text class="t2" x="613" y="263" text-anchor="middle">prefix caching</text>
+
+  <rect class="box" x="735" y="220" width="214" height="56" rx="8"/>
+  <text class="t"  x="842" y="243" text-anchor="middle">chunked prefill</text>
+  <text class="t2" x="842" y="263" text-anchor="middle">continuous batching</text>
+
+  <line x1="500" y1="302" x2="500" y2="330" stroke="#8892a4" stroke-width="2.4" marker-end="url(#ar)"/>
+  <text class="note" x="516" y="322">packed queries [total_q, H, D] · block tables</text>
+
+  <!-- ── layer 3: vllm-metal ────────────────────────────────────────── -->
+  <rect x="28" y="334" width="944" height="216" rx="12" fill="#f7f9ff" stroke="#2a63c8" stroke-width="2.2"/>
+  <text class="band" x="48"  y="365" fill="#12325c">vllm-metal model runner</text>
+  <text class="note" x="952" y="365" text-anchor="end">what this plugin adds</text>
+
+  <!-- reused sub-panel -->
+  <rect x="48" y="384" width="502" height="150" rx="10" fill="#f4f6f9" stroke="#d7dde5" stroke-width="1.4"/>
+  <text class="panel" x="68" y="410" fill="#55637a">reused from mlx_lm<tspan class="t2" dx="9">token-wise · no request boundaries</tspan></text>
+
+  <rect class="box" x="68"  y="422" width="226" height="46" rx="8"/>
+  <text class="t" x="181" y="450" text-anchor="middle">model definitions</text>
+  <rect class="box" x="304" y="422" width="226" height="46" rx="8"/>
+  <text class="t" x="417" y="450" text-anchor="middle">weight loading</text>
+  <rect class="box" x="68"  y="478" width="226" height="46" rx="8"/>
+  <text class="t" x="181" y="506" text-anchor="middle">RMSNorm · linear</text>
+  <rect class="box" x="304" y="478" width="226" height="46" rx="8"/>
+  <text class="t" x="417" y="506" text-anchor="middle">MLP · MoE</text>
+
+  <!-- custom sub-panel -->
+  <rect x="566" y="384" width="386" height="150" rx="10" fill="#eaf1ff" stroke="#2a63c8" stroke-width="1.6"/>
+  <text class="panel" x="586" y="410" fill="#1d4fa8">custom Metal<tspan class="t2" dx="9">consumes cu_seqlens</tspan></text>
+
+  <rect x="586" y="422" width="346" height="46" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
+  <text class="t" x="759" y="450" text-anchor="middle" fill="#12325c">paged varlen attention</text>
+  <rect x="586" y="478" width="168" height="46" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
+  <text class="t" x="670" y="506" text-anchor="middle" fill="#12325c">M5 NAX prefill</text>
+  <rect x="764" y="478" width="168" height="46" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
+  <text class="t" x="848" y="506" text-anchor="middle" fill="#12325c">MTP draft + verify</text>
+
+  <line x1="500" y1="556" x2="500" y2="584" stroke="#8892a4" stroke-width="2.4" marker-end="url(#ar)"/>
+  <text class="note" x="516" y="576">MLX ops · custom Metal kernels</text>
+
+  <!-- ── layer 4: MLX / Metal / hardware ────────────────────────────── -->
+  <rect x="28" y="590" width="944" height="72" rx="12" fill="#eef6ea" stroke="#a9cf9b" stroke-width="1.5"/>
+  <text class="band" x="48" y="632" fill="#14301c">MLX · Metal · Apple Silicon</text>
+
+  <rect x="328" y="602" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
+  <text class="t"  x="428" y="623" text-anchor="middle">MLX runtime</text>
+  <text class="t2" x="428" y="642" text-anchor="middle">GEMMs use M5 NAX</text>
+
+  <rect x="540" y="602" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
+  <text class="t"  x="640" y="623" text-anchor="middle">Apple Silicon GPU</text>
+  <text class="t2" x="640" y="642" text-anchor="middle">M5 adds NAX units</text>
+
+  <rect x="752" y="602" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
+  <text class="t"  x="852" y="623" text-anchor="middle">unified memory</text>
+  <text class="t2" x="852" y="642" text-anchor="middle">weights + paged KV</text>
+
+  <!-- ── legend ─────────────────────────────────────────────────────── -->
+  <rect x="48"  y="678" width="15" height="15" rx="4" fill="#eef3fb" stroke="#b9cde8" stroke-width="1.2"/>
+  <text class="note" x="71" y="690">upstream vLLM · mlx_lm (unchanged)</text>
+
+  <rect x="369" y="678" width="15" height="15" rx="4" fill="#eaf1ff" stroke="#2a63c8" stroke-width="1.4"/>
+  <text class="note" x="392" y="690">added by vllm-metal</text>
+
+  <rect x="576" y="678" width="15" height="15" rx="4" fill="#eef6ea" stroke="#a9cf9b" stroke-width="1.2"/>
+  <text class="note" x="599" y="690">MLX · Metal · hardware</text>
+</svg>

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 680" role="img" aria-labelledby="figTitle figDesc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 688" role="img" aria-labelledby="figTitle figDesc">
   <title id="figTitle">vllm-metal in the vLLM stack</title>
-  <desc id="figDesc">A four-layer stack. Client apps speak the OpenAI API to upstream vLLM V1, which contributes the API server, V1 scheduler, paged block manager with prefix caching, and chunked prefill with continuous batching, all used unchanged. vLLM hands the vllm-metal model runner one packed step of queries plus per-request block tables. Inside the runner, mlx_lm's model definitions, weight loading, RMSNorm, linear, MLP and MoE layers are reused unchanged because they are token-wise; vllm-metal adds custom Metal paths for paged varlen attention, M5 NAX prefill, and MTP draft and verify, which need request boundaries from cu_seqlens. Those issue MLX ops and custom Metal kernels down to the MLX runtime, the Apple Silicon GPU, and unified memory holding weights and the paged KV cache.</desc>
+  <desc id="figDesc">A four-layer stack. Client apps speak the OpenAI API to upstream vLLM V1, which contributes the API server, V1 scheduler, paged block manager with prefix caching, and chunked prefill with continuous batching, all used unchanged. vLLM hands the vllm-metal model runner a SchedulerOutput carrying per-request scheduled-token counts and KV block IDs; the runner packs the token IDs and builds cu_seqlens itself. Inside the runner, model definitions, weight loading, RMSNorm, linear, MLP and MoE layers are built on mlx_lm primitives because they are token-wise. vllm-metal owns the request-aware path: paged varlen attention and M5 NAX prefill are custom Metal kernels taking queries shaped total_q by H by D, and MTP draft and verify is runtime orchestration over them; all three consume cu_seqlens. Those issue MLX ops and custom Metal kernels down to the MLX runtime, the Apple Silicon GPU, and unified memory holding weights and the paged KV cache.</desc>
 
   <style>
     .box { fill: #ffffff; stroke: #cfd8e3; stroke-width: 1.2; }
@@ -18,7 +18,7 @@
     </marker>
   </defs>
 
-  <rect x="0" y="0" width="1000" height="680" fill="#ffffff"/>
+  <rect x="0" y="0" width="1000" height="688" fill="#ffffff"/>
 
   <!-- ── header ─────────────────────────────────────────────────────── -->
   <text class="h1"   x="500" y="40" text-anchor="middle">vllm-metal in the vLLM stack</text>
@@ -53,53 +53,56 @@
   <text class="t2" x="842" y="263" text-anchor="middle">continuous batching</text>
 
   <line x1="500" y1="302" x2="500" y2="330" stroke="#8892a4" stroke-width="2.4" marker-end="url(#ar)"/>
-  <text class="note" x="516" y="322">packed queries [total_q, H, D] · block tables</text>
+  <text class="note" x="516" y="322">SchedulerOutput · scheduled-token counts · KV block IDs</text>
 
   <!-- ── layer 3: vllm-metal ────────────────────────────────────────── -->
-  <rect x="28" y="334" width="944" height="216" rx="12" fill="#f7f9ff" stroke="#2a63c8" stroke-width="2.2"/>
-  <text class="band" x="48"  y="365" fill="#12325c">vllm-metal model runner</text>
+  <rect x="28" y="334" width="944" height="224" rx="12" fill="#f7f9ff" stroke="#2a63c8" stroke-width="2.2"/>
+  <text class="band" x="48"  y="365" fill="#12325c">vllm-metal model runner<tspan class="note" dx="10">packs token IDs · builds cu_seqlens</tspan></text>
 
-  <!-- reused sub-panel -->
-  <rect x="48" y="384" width="502" height="150" rx="10" fill="#f4f6f9" stroke="#d7dde5" stroke-width="1.4"/>
-  <text class="panel" x="68" y="410" fill="#55637a">reused from mlx_lm<tspan class="t2" dx="9">token-wise · no request boundaries</tspan></text>
+  <!-- mlx_lm sub-panel -->
+  <rect x="48" y="384" width="502" height="158" rx="10" fill="#f4f6f9" stroke="#d7dde5" stroke-width="1.4"/>
+  <text class="panel" x="68" y="410" fill="#55637a">built on mlx_lm<tspan class="t2" dx="9">token-wise · no request boundaries</tspan></text>
 
-  <rect class="box" x="68"  y="422" width="226" height="46" rx="8"/>
-  <text class="t" x="181" y="450" text-anchor="middle">model definitions</text>
-  <rect class="box" x="304" y="422" width="226" height="46" rx="8"/>
-  <text class="t" x="417" y="450" text-anchor="middle">weight loading</text>
-  <rect class="box" x="68"  y="478" width="226" height="46" rx="8"/>
-  <text class="t" x="181" y="506" text-anchor="middle">RMSNorm · linear</text>
-  <rect class="box" x="304" y="478" width="226" height="46" rx="8"/>
-  <text class="t" x="417" y="506" text-anchor="middle">MLP · MoE</text>
+  <rect class="box" x="68"  y="422" width="226" height="48" rx="8"/>
+  <text class="t" x="181" y="451" text-anchor="middle">model definitions</text>
+  <rect class="box" x="304" y="422" width="226" height="48" rx="8"/>
+  <text class="t" x="417" y="451" text-anchor="middle">weight loading</text>
+  <rect class="box" x="68"  y="482" width="226" height="48" rx="8"/>
+  <text class="t" x="181" y="511" text-anchor="middle">RMSNorm · linear</text>
+  <rect class="box" x="304" y="482" width="226" height="48" rx="8"/>
+  <text class="t" x="417" y="511" text-anchor="middle">MLP · MoE</text>
 
-  <!-- custom sub-panel -->
-  <rect x="566" y="384" width="386" height="150" rx="10" fill="#eaf1ff" stroke="#2a63c8" stroke-width="1.6"/>
-  <text class="panel" x="586" y="410" fill="#1d4fa8">custom Metal<tspan class="t2" dx="9">consumes cu_seqlens</tspan></text>
+  <!-- vllm-metal-owned sub-panel -->
+  <rect x="566" y="384" width="386" height="158" rx="10" fill="#eaf1ff" stroke="#2a63c8" stroke-width="1.6"/>
+  <text class="panel" x="586" y="410" fill="#1d4fa8">owned by vllm-metal<tspan class="t2" dx="9">consumes cu_seqlens</tspan></text>
 
-  <rect x="586" y="422" width="346" height="46" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
-  <text class="t" x="759" y="450" text-anchor="middle" fill="#12325c">paged varlen attention</text>
-  <rect x="586" y="478" width="168" height="46" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
-  <text class="t" x="670" y="506" text-anchor="middle" fill="#12325c">M5 NAX prefill</text>
-  <rect x="764" y="478" width="168" height="46" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
-  <text class="t" x="848" y="506" text-anchor="middle" fill="#12325c">MTP draft + verify</text>
+  <rect x="586" y="422" width="346" height="48" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
+  <text class="t"  x="759" y="443" text-anchor="middle" fill="#12325c">paged varlen attention</text>
+  <text class="t2" x="759" y="462" text-anchor="middle">Metal kernel · q [total_q, H, D]</text>
+  <rect x="586" y="482" width="158" height="48" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
+  <text class="t"  x="665" y="503" text-anchor="middle" fill="#12325c">M5 NAX prefill</text>
+  <text class="t2" x="665" y="522" text-anchor="middle">Metal kernel</text>
+  <rect x="754" y="482" width="178" height="48" rx="8" fill="#ffffff" stroke="#7ea3e0" stroke-width="1.3"/>
+  <text class="t"  x="843" y="503" text-anchor="middle" fill="#12325c">MTP draft + verify</text>
+  <text class="t2" x="843" y="522" text-anchor="middle">orchestration</text>
 
-  <line x1="500" y1="556" x2="500" y2="584" stroke="#8892a4" stroke-width="2.4" marker-end="url(#ar)"/>
-  <text class="note" x="516" y="576">MLX ops · custom Metal kernels</text>
+  <line x1="500" y1="564" x2="500" y2="592" stroke="#8892a4" stroke-width="2.4" marker-end="url(#ar)"/>
+  <text class="note" x="516" y="584">MLX ops · custom Metal kernels</text>
 
   <!-- ── layer 4: MLX / Metal / hardware ────────────────────────────── -->
-  <rect x="28" y="590" width="944" height="72" rx="12" fill="#eef6ea" stroke="#a9cf9b" stroke-width="1.5"/>
-  <text class="band" x="48" y="632" fill="#14301c">MLX · Metal · Apple Silicon</text>
+  <rect x="28" y="598" width="944" height="72" rx="12" fill="#eef6ea" stroke="#a9cf9b" stroke-width="1.5"/>
+  <text class="band" x="48" y="640" fill="#14301c">MLX · Metal · Apple Silicon</text>
 
-  <rect x="328" y="602" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
-  <text class="t"  x="428" y="623" text-anchor="middle">MLX runtime</text>
-  <text class="t2" x="428" y="642" text-anchor="middle">GEMMs use M5 NAX</text>
+  <rect x="328" y="610" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
+  <text class="t"  x="428" y="631" text-anchor="middle">MLX runtime</text>
+  <text class="t2" x="428" y="650" text-anchor="middle">lazy graph · GEMMs</text>
 
-  <rect x="540" y="602" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
-  <text class="t"  x="640" y="623" text-anchor="middle">Apple Silicon GPU</text>
-  <text class="t2" x="640" y="642" text-anchor="middle">M5 adds NAX units</text>
+  <rect x="540" y="610" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
+  <text class="t"  x="640" y="631" text-anchor="middle">Apple Silicon GPU</text>
+  <text class="t2" x="640" y="650" text-anchor="middle">M5 adds NAX units</text>
 
-  <rect x="752" y="602" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
-  <text class="t"  x="852" y="623" text-anchor="middle">unified memory</text>
-  <text class="t2" x="852" y="642" text-anchor="middle">weights + paged KV</text>
+  <rect x="752" y="610" width="200" height="48" rx="8" fill="#ffffff" stroke="#c3ddb9" stroke-width="1.2"/>
+  <text class="t"  x="852" y="631" text-anchor="middle">unified memory</text>
+  <text class="t2" x="852" y="650" text-anchor="middle">weights + paged KV</text>
 
 </svg>

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 700" role="img" aria-labelledby="figTitle figDesc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 680" role="img" aria-labelledby="figTitle figDesc">
   <title id="figTitle">vllm-metal in the vLLM stack</title>
   <desc id="figDesc">A four-layer stack. Client apps speak the OpenAI API to upstream vLLM V1, which contributes the API server, V1 scheduler, paged block manager with prefix caching, and chunked prefill with continuous batching, all used unchanged. vLLM hands the vllm-metal model runner one packed step of queries plus per-request block tables. Inside the runner, mlx_lm's model definitions, weight loading, RMSNorm, linear, MLP and MoE layers are reused unchanged because they are token-wise; vllm-metal adds custom Metal paths for paged varlen attention, M5 NAX prefill, and MTP draft and verify, which need request boundaries from cu_seqlens. Those issue MLX ops and custom Metal kernels down to the MLX runtime, the Apple Silicon GPU, and unified memory holding weights and the paged KV cache.</desc>
 
@@ -18,7 +18,7 @@
     </marker>
   </defs>
 
-  <rect x="0" y="0" width="1000" height="700" fill="#ffffff"/>
+  <rect x="0" y="0" width="1000" height="680" fill="#ffffff"/>
 
   <!-- ── header ─────────────────────────────────────────────────────── -->
   <text class="h1"   x="500" y="40" text-anchor="middle">vllm-metal in the vLLM stack</text>
@@ -58,7 +58,6 @@
   <!-- ── layer 3: vllm-metal ────────────────────────────────────────── -->
   <rect x="28" y="334" width="944" height="216" rx="12" fill="#f7f9ff" stroke="#2a63c8" stroke-width="2.2"/>
   <text class="band" x="48"  y="365" fill="#12325c">vllm-metal model runner</text>
-  <text class="note" x="952" y="365" text-anchor="end">what this plugin adds</text>
 
   <!-- reused sub-panel -->
   <rect x="48" y="384" width="502" height="150" rx="10" fill="#f4f6f9" stroke="#d7dde5" stroke-width="1.4"/>
@@ -103,13 +102,4 @@
   <text class="t"  x="852" y="623" text-anchor="middle">unified memory</text>
   <text class="t2" x="852" y="642" text-anchor="middle">weights + paged KV</text>
 
-  <!-- ── legend ─────────────────────────────────────────────────────── -->
-  <rect x="48"  y="678" width="15" height="15" rx="4" fill="#eef3fb" stroke="#b9cde8" stroke-width="1.2"/>
-  <text class="note" x="71" y="690">upstream vLLM · mlx_lm (unchanged)</text>
-
-  <rect x="369" y="678" width="15" height="15" rx="4" fill="#eaf1ff" stroke="#2a63c8" stroke-width="1.4"/>
-  <text class="note" x="392" y="690">added by vllm-metal</text>
-
-  <rect x="576" y="678" width="15" height="15" rx="4" fill="#eef6ea" stroke="#a9cf9b" stroke-width="1.2"/>
-  <text class="note" x="599" y="690">MLX · Metal · hardware</text>
 </svg>


### PR DESCRIPTION
Adds a four-layer stack diagram to the README showing that upstream vLLM supplies the server, scheduler, and paged block manager, mlx_lm supplies the token-wise model layers, and vllm-metal owns the attention path.