### PR TITLE
[Bugfix] Plumb attn_logit_softcapping into the paged attention kernel (Gemma 2)

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -829,6 +829,90 @@ class TestSDPAForward:
         assert isinstance(sinks, mx.array)
         assert sinks.dtype == mx.float32
 
+    def _run_capturing_softcap(self, inner: SimpleNamespace) -> float:
+        """Drive ``sdpa_forward`` and return the softcap the kernel received."""
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
+        queries = mx.ones((_BATCH, _N_HEADS, _SEQ_LEN, _HEAD_DIM))
+        keys = mx.ones((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        values = mx.ones((_BATCH, _N_KV_HEADS, _SEQ_LEN, _HEAD_DIM))
+        captured: dict[str, float] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self,
+                _key,
+                _value,
+                key_cache,
+                value_cache,
+                _slot_mapping,
+            ) -> tuple[mx.array, mx.array]:
+                return key_cache, value_cache
+
+            def paged_attention_primitive(
+                self,
+                _query,
+                _key_cache,
+                _value_cache,
+                _num_kv_heads,
+                _scale,
+                softcap,
+                *_args,
+                **_kwargs,
+            ) -> None:
+                captured["softcap"] = softcap
+
+        with (
+            patch.object(
+                sdpa_mod,
+                "prepare_sdpa_qkv",
+                return_value=(queries, keys, values, None, (keys, values)),
+            ),
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)),
+            ),
+        ):
+            sdpa_forward(inner, x, ctx, cache, layer_idx=0)
+
+        return captured["softcap"]
+
+    def test_attn_logit_softcapping_reaches_kernel(self) -> None:
+        """Gemma 2 caps pre-softmax scores; the kernel must receive the value."""
+        inner = SimpleNamespace(
+            n_heads=_N_HEADS,
+            n_kv_heads=_N_KV_HEADS,
+            scale=_HEAD_DIM**-0.5,
+            attn_logit_softcapping=50.0,
+            o_proj=lambda out: out,
+        )
+        assert self._run_capturing_softcap(inner) == 50.0
+
+    def test_softcap_defaults_to_disabled_without_the_attribute(self) -> None:
+        """Architectures without the attribute keep the uncapped kernel path.
+
+        The kernel treats any value <= 0 as disabled, so this is the
+        regression guard that plumbing the value changed nothing for the
+        models that were already working.
+        """
+        inner = SimpleNamespace(
+            n_heads=_N_HEADS,
+            n_kv_heads=_N_KV_HEADS,
+            scale=_HEAD_DIM**-0.5,
+            o_proj=lambda out: out,
+        )
+        assert self._run_capturing_softcap(inner) == 0.0
+
     def test_shared_kv_path_does_not_rebind_cache_arrays(self) -> None:
         """Shared-KV attention must read the existing cache without writing."""
         cache = MetalPagedKVCache(

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -494,6 +494,13 @@ def sdpa_forward(
     if attn_scale is None:
         attn_scale = inner.sm_scale
 
+    # Attention logit softcapping (Gemma 2: ``attn_logit_softcapping``).
+    # mlx_lm applies ``tanh(qk / cap) * cap`` to the pre-softmax scores; the
+    # Metal kernel implements the same clamp and treats any value <= 0 as
+    # disabled, so architectures that do not define the attribute keep the
+    # previous uncapped path unchanged.
+    attn_softcap = float(getattr(inner, "attn_logit_softcapping", None) or 0.0)
+
     # Attention sinks: a learned per-head logit that joins the softmax
     # denominator without contributing a value row (GPT-OSS). Models without
     # sinks leave this None and the kernel keeps its plain-softmax path.
@@ -691,7 +698,7 @@ def sdpa_forward(
             kernel_v_cache,
             cache_kv_heads,
             attn_scale,
-            0.0,  # softcap (0 = disabled)
+            attn_softcap,
             block_tables,
             seq_lens,
             cu_seqlens_q,
@@ -719,7 +726,7 @@ def sdpa_forward(
             kernel_v_cache,
             cache_kv_heads,
             attn_scale,
-            0.0,  # softcap (0 = disabled)
+            attn_softcap,
             block_tables,
             seq_lens,
             cu_seqlens_q,


### PR DESCRIPTION
## Summary

`sdpa_forward` passed the attention softcap to the Metal kernel as a hardcoded `0.0` at both call sites, so architectures that set `attn_logit_softcapping` ran without it. Gemma 2 sets it to `50.0` and `mlx_lm` applies `tanh(qk / cap) * cap` to the pre-softmax scores. This reads the value off the attention module and passes it through.

**This fixes a real correctness gap**: the kernel now receives and applies a value that was previously discarded — confirmed at the shader level and by measurable logprob deltas (below).

**It does not resolve the token divergence reported in #665.** That divergence remains open and unexplained: both diverging prompts still diverge byte-identically with this change applied. Softcapping was never the cause — with softcap disabled in `mlx_lm`, the diverging prompt's output is unchanged there, so the two are independent.

Related to #665 — deliberately not `Fixes #665`. This PR closes the softcap plumbing bug documented in that issue, but the token-4 divergence documented alongside it is a separate, still-unexplained problem that this change does not address (both diverging prompts still diverge byte-identically with it applied). The issue should stay open after this merges.

**No observable token-level change on the 2B checkpoint** across 96 sampled positions (4 prompts × 24 greedy tokens). The cap never binds at this model's score magnitudes: measured pre-softcap `|scores|` max **16.16** against a cap of **50.0**, `0/26` layers exceeding it. `tanh(x/50)*50` is close to identity in that range.

**9B and 27B are unmeasured.** Attention logits grow with model width and context length; if scores approach 50 there the cap starts to bind and this stops being invisible. I could not test them (8 GB machine).

## The change

```diff
+    attn_softcap = float(getattr(inner, "attn_logit_softcapping", None) or 0.0)
```
```diff
             attn_scale,
-            0.0,  # softcap (0 = disabled)
+            attn_softcap,
```

Applied at both call sites — the TurboQuant/quantized-cache branch and the plain branch. Reading the value off `inner` follows the existing convention in this function for `scale` and `sinks`.

## Verification

### The shaders already implement it

All three paged-attention kernels apply the same clamp and treat `<= 0` as disabled, which is why the previous hardcoded `0.0` was a silent no-op rather than an error:

```
pagedattention.metal:1120        if (softcapping > 0.0f) { qk = tanh(qk / softcapping) * softcapping; }
pagedattention_tiled.metal:382   s = softcapping * precise::tanh(s_orig / softcapping) * M_LOG2E_F;
pagedattention_nax.metal:282     s = softcapping * precise::tanh(s_orig / softcapping)
```

`paged_ops.cpp` already threads the parameter through to `enc.set_bytes(softcap, 10)`. Only the Python call sites were missing.

### The value reaches the kernel

Spying on `paged_attention_primitive` during a real Gemma 2 forward:

```
KERNEL_ARGS: ('softcap_arg', 50.0, 'scale_arg', 0.0625)
KERNEL_ARGS: ('softcap_arg', 50.0, 'scale_arg', 0.0625)
```

(`scale = 0.0625 = query_pre_attn_scalar ** -0.5 = 256 ** -0.5`, as expected for Gemma 2.)

### The kernel acts on it

Top-5 logprobs for one prompt, single greedy step, with and without the change:

| token | with fix | without fix | delta |
| --- | --- | --- | --- |
| 651 | -0.076241 | -0.077614 | +0.001373 |
| 219715 | -3.094187 | -3.074394 | -0.019793 |
| 10716 | -4.665764 | -4.648836 | -0.016928 |
| 10940 | -5.074399 | -5.049919 | -0.024480 |
| 102164 | -5.301066 | -5.296119 | -0.004947 |

The distribution shifts, confirming the shader consumes the value. The shift is too small to reorder the top-1 at this model size, which is consistent with the cap not binding.

### Negative control

With the change stashed, the new test fails exactly as expected:

```
E   assert 0.0 == 50.0
```

## Scope

Only `mlx_lm/models/gemma2.py` defines `self.attn_logit_softcapping`, and `Gemma2ForCausalLM` is in vLLM 0.28.0's registry. The one other softcap-shaped attribute in mlx-lm, `laguna.py`'s `self.softcap`, is a **MoE router** cap (`moe_router_logit_softcapping`) applied inside the expert gate — unrelated to attention and untouched here.

Architectures without the attribute resolve to `0.0`, which is the kernel's existing disabled sentinel, so their behaviour is bit-identical to before.

## Tests

Two tests in `tests/test_attention_sdpa.py`, following the kernel-argument spy pattern already used by `test_gpt_oss_scale_and_sinks_reach_kernel`:

- `test_attn_logit_softcapping_reaches_kernel` — a module exposing `attn_logit_softcapping=50.0` must deliver `50.0` to the kernel. Fails without the change (`assert 0.0 == 50.0`).
- `test_softcap_defaults_to_disabled_without_the_attribute` — a module without it must still deliver `0.0`. This one passes with and without the change by design; it is a regression guard that plumbing the value did not alter the models that already worked.

```
pytest tests/test_attention_sdpa.py -q            ->  28 passed
pytest tests/ -m "not slow" -q                    ->  1842 passed, 7 failed, 18 skipped
```

The 7 failures are pre-existing and unrelated (`test_transcribe.py`, `test_gguf_vllm_integration.py` — they need the `stt` / `gguf` extras, which are not installed here). They fail identically with this change reverted.

## Environment

Apple M2 / 8 GB, macOS 26.6.2, Python 3.12.2 (arm64), vllm 0.28.0+cpu, mlx 0.32.0, mlx-lm 0.31.3, on `main` @ `f61e7a6` (imported from the source tree, not the release wheel). Checkpoint `mlx-community/gemma-2-2b-it-4bit` @ `2c715097ff9c081a6ac1e5cd239e2ac756b5bd99`.

