### PR TITLE
[Bugfix] Honor requested token logprobs

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -15,8 +15,9 @@ for method behavior and configuration details.
 
 All three methods currently have these Metal-specific constraints:
 
-- Only greedy requests (`temperature=0`) are drafted. Other requests run
-  without speculation.
+- Only plain greedy requests (`temperature=0`, without penalties, token
+  constraints, or sample logprobs) are drafted. Other requests run without
+  speculation.
 - Scheduling must be synchronous. The Metal platform disables async scheduling
   when speculative decoding is configured.
 - Pipeline parallelism is not supported with speculative decoding.

--- a/tests/test_native_sampling.py
+++ b/tests/test_native_sampling.py
@@ -28,6 +28,11 @@ class TestNativeRandomEligibility:
 
         assert SamplingBatch.params_allow_native_random(params)
 
+    def test_empty_specific_token_list_is_eligible(self) -> None:
+        assert SamplingBatch.params_allow_native_random(
+            [_random_params(logprob_token_ids=[])]
+        )
+
     @pytest.mark.parametrize(
         ("label", "params_list"),
         [

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -462,6 +462,9 @@ class TestV1SamplingBatch:
             [SamplingParams(temperature=0.0, logprobs=1)]
         ).can_use_native_greedy()
         assert not self._batch(
+            [SamplingParams(temperature=0.0, logprob_token_ids=[1, 2])]
+        ).can_use_native_greedy()
+        assert not self._batch(
             [SamplingParams(temperature=0.0, allowed_token_ids=[1, 2])]
         ).can_use_native_greedy()
         bad_sp = SamplingParams(temperature=0.0)
@@ -672,6 +675,169 @@ class TestV1SamplingBatch:
         assert result.logprobs.logprob_token_ids.shape == (1, 3)
         assert result.logprobs.logprob_token_ids[0, 0] == 2
         assert result.logprobs.sampled_token_ranks.tolist() == [1]
+
+    def test_sample_from_logits_returns_requested_token_logprobs(self) -> None:
+        logits = mx.array([[0.0, 1.0, 4.0, 2.0]], dtype=mx.float32)
+        batch = SamplingBatch(
+            [SamplingParams(temperature=0.0, logprob_token_ids=[0, 3])],
+            [[1, 2, 3]],
+            [[]],
+            vocab_size=4,
+        )
+
+        result = sample_from_logits(logits, batch, Sampler())
+
+        assert result.token_ids == [2]
+        assert result.logprobs is not None
+        assert result.logprobs.logprob_token_ids.tolist() == [[2, 0, 3]]
+        expected = torch.log_softmax(torch.tensor([0.0, 1.0, 4.0, 2.0]), dim=0)
+        assert result.logprobs.logprobs[0].tolist() == pytest.approx(
+            expected[[2, 0, 3]].tolist()
+        )
+        assert result.logprobs.sampled_token_ranks.tolist() == [1]
+
+    def test_empty_requested_token_list_does_not_request_logprobs(self) -> None:
+        params = SamplingParams(temperature=0.0, logprob_token_ids=[])
+        batch = SamplingBatch([params], [[1, 2, 3]], [[]], vocab_size=4)
+
+        assert params.num_logprobs is None
+        assert batch.can_use_native_greedy()
+        assert batch.make_sampling_metadata().logprob_token_ids is None
+        assert (
+            sample_from_logits(
+                mx.array([[0.0, 1.0, 4.0, 2.0]], dtype=mx.float32),
+                batch,
+                Sampler(),
+            ).logprobs
+            is None
+        )
+
+    @pytest.mark.parametrize("specific_row", [0, 1])
+    def test_mixed_specific_and_topk_logprobs_preserve_each_row(
+        self, specific_row: int
+    ) -> None:
+        raw_logits = [[0.0, 1.0, 4.0, 2.0], [5.0, 1.0, 3.0, 2.0]]
+        logits = mx.array(raw_logits, dtype=mx.float32)
+        specific_params = SamplingParams(temperature=0.0, logprob_token_ids=[0, 3])
+        topk_params = SamplingParams(temperature=0.0, logprobs=2)
+        sampling_params = [
+            specific_params if row == specific_row else topk_params for row in range(2)
+        ]
+        batch = SamplingBatch(
+            sampling_params,
+            [[1, 2], [3, 4]],
+            [[], []],
+            vocab_size=4,
+        )
+
+        topk_ids = [[2, 3], [0, 2]]
+        metadata = batch.make_sampling_metadata(torch.tensor(raw_logits))
+        assert metadata.max_num_logprobs is None
+        assert metadata.logprob_token_ids == {
+            specific_row: [0, 3],
+            1 - specific_row: topk_ids[1 - specific_row],
+        }
+
+        result = sample_from_logits(logits, batch, Sampler())
+
+        assert result.token_ids == [2, 0]
+        assert result.logprobs is not None
+        expected_ids = []
+        for row, sampled_token_id in enumerate(result.token_ids):
+            requested_ids = [0, 3] if row == specific_row else topk_ids[row]
+            expected_ids.append([sampled_token_id, *requested_ids])
+        assert result.logprobs.logprob_token_ids.tolist() == expected_ids
+        expected = torch.log_softmax(
+            torch.tensor([[0.0, 1.0, 4.0, 2.0], [5.0, 1.0, 3.0, 2.0]]),
+            dim=1,
+        )
+        for row, token_ids in enumerate(expected_ids):
+            assert result.logprobs.logprobs[row].tolist() == pytest.approx(
+                expected[row, token_ids].tolist()
+            )
+        assert result.logprobs.sampled_token_ranks.tolist() == [1, 1]
+
+    def test_mixed_logprob_metadata_requires_logits(self) -> None:
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0, logprob_token_ids=[0, 3]),
+                SamplingParams(temperature=0.0, logprobs=2),
+            ],
+            [[1, 2], [3, 4]],
+            [[], []],
+            vocab_size=4,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Logits are required when a batch mixes top-k and specific-token",
+        ):
+            batch.make_sampling_metadata()
+
+    def test_same_row_specific_logprobs_override_topk_without_logits(self) -> None:
+        batch = SamplingBatch(
+            [
+                SamplingParams(
+                    temperature=0.0,
+                    logprobs=2,
+                    logprob_token_ids=[0, 3],
+                )
+            ],
+            [[1, 2]],
+            [[]],
+            vocab_size=4,
+        )
+
+        metadata = batch.make_sampling_metadata()
+
+        assert metadata.max_num_logprobs is None
+        assert metadata.logprob_token_ids == {0: [0, 3]}
+
+    def test_mixed_sampled_token_only_and_specific_logprobs_need_no_logits(
+        self,
+    ) -> None:
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0, logprob_token_ids=[0, 3]),
+                SamplingParams(temperature=0.0, logprobs=0),
+            ],
+            [[1, 2], [3, 4]],
+            [[], []],
+            vocab_size=4,
+        )
+
+        metadata = batch.make_sampling_metadata()
+
+        assert metadata.max_num_logprobs is None
+        assert metadata.logprob_token_ids == {0: [0, 3], 1: []}
+
+    def test_mixed_topk_logprobs_preserve_batch_tie_breaking(self) -> None:
+        batch = SamplingBatch(
+            [
+                SamplingParams(temperature=0.0, logprob_token_ids=[0]),
+                SamplingParams(temperature=0.0, logprobs=2),
+                SamplingParams(temperature=0.0, logprobs=5),
+            ],
+            [[1], [2], [3]],
+            [[], [], []],
+            vocab_size=8,
+        )
+        logits = torch.tensor(
+            [
+                [0.0] * 8,
+                [-1.0, -1.0, -1.0, 0.0, -1.0, 1.0, 0.0, 0.0],
+                list(range(8)),
+            ]
+        )
+
+        metadata = batch.make_sampling_metadata(logits)
+
+        assert metadata.max_num_logprobs is None
+        assert metadata.logprob_token_ids == {
+            0: [0],
+            1: [5, 7],
+            2: [7, 6, 5, 4, 3],
+        }
 
     def test_model_runner_output_keeps_logprobs_slot_alignment(self) -> None:
         batch = _ExecutionBatch()

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -356,6 +356,16 @@ class TestGemma4MTPDraftSeeds:
 
 
 class TestVerifyGreedySpecDecode:
+    def test_specific_token_logprobs_are_not_draft_eligible(self) -> None:
+        state = SimpleNamespace(
+            sampling_params=SamplingParams(
+                temperature=0.0,
+                logprob_token_ids=[0, 3],
+            )
+        )
+
+        assert not SpeculativeDecodeController().can_draft_greedy("r0", state)
+
     def test_accepts_all_drafts_and_emits_bonus_token(self) -> None:
         segment = PagedDecodeSegment(
             req_id="r0",

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -112,7 +112,10 @@ class SamplingBatch:
 
     @property
     def needs_logprobs(self) -> bool:
-        return self.max_num_logprobs is not None
+        return any(
+            sampling_params.num_logprobs is not None
+            for sampling_params in self.sampling_params_list
+        )
 
     @staticmethod
     def merge_logprobs_rows(
@@ -186,7 +189,7 @@ class SamplingBatch:
             and sampling_params.frequency_penalty == 0.0
             and sampling_params.presence_penalty == 0.0
             and sampling_params.repetition_penalty == 1.0
-            and sampling_params.logprobs is None
+            and sampling_params.num_logprobs is None
             and not sampling_params.allowed_token_ids
             and not sampling_params.bad_words_token_ids
             for sampling_params in sampling_params_list
@@ -219,8 +222,7 @@ class SamplingBatch:
                 and sp.frequency_penalty == 0.0
                 and sp.presence_penalty == 0.0
                 and sp.repetition_penalty == 1.0
-                and sp.logprobs is None
-                and sp.logprob_token_ids is None
+                and sp.num_logprobs is None
                 and not sp.allowed_token_ids
                 and not sp.bad_words_token_ids
                 for sp in sampling_params_list
@@ -446,13 +448,55 @@ class SamplingBatch:
                 result[i] = sp.bad_words_token_ids
         return result
 
-    def make_sampling_metadata(self) -> SamplingMetadata:
+    def _make_logprob_args(
+        self,
+        logits: torch.Tensor | None,
+    ) -> tuple[int | None, dict[int, list[int]] | None]:
+        """Build mutually exclusive logprob arguments for vLLM's sampler.
+
+        vLLM's compatibility sampler treats any ``logprob_token_ids`` mapping
+        as a batch-wide override of ``max_num_logprobs``. When a batch mixes
+        both request types, materialize the ordinary rows' raw-logit top-k IDs
+        into the mapping and disable the batch-wide top-k argument.
+        """
+        max_num_logprobs = self.max_num_logprobs
+        token_ids_by_row: dict[int, list[int]] = {}
+        for i, sampling_params in enumerate(self.sampling_params_list):
+            if sampling_params.logprob_token_ids:
+                token_ids_by_row[i] = sampling_params.logprob_token_ids
+        if not token_ids_by_row:
+            return max_num_logprobs, None
+
+        topk_requests = [
+            (i, sampling_params.logprobs)
+            for i, sampling_params in enumerate(self.sampling_params_list)
+            if i not in token_ids_by_row and sampling_params.logprobs is not None
+        ]
+        max_topk = max((num_logprobs for _, num_logprobs in topk_requests), default=0)
+        if max_topk > 0:
+            if logits is None:
+                raise ValueError(
+                    "Logits are required when a batch mixes top-k and "
+                    "specific-token logprobs."
+                )
+            topk_token_ids = torch.topk(logits, max_topk, dim=-1).indices
+            for i, num_logprobs in topk_requests:
+                token_ids_by_row[i] = topk_token_ids[i, :num_logprobs].tolist()
+        else:
+            for i, _ in topk_requests:
+                token_ids_by_row[i] = []
+        return None, token_ids_by_row
+
+    def make_sampling_metadata(
+        self, logits: torch.Tensor | None = None
+    ) -> SamplingMetadata:
         """Create vLLM ``SamplingMetadata`` for this batch."""
         (
             frequency_penalties,
             presence_penalties,
             repetition_penalties,
         ) = self._make_penalty_tensors()
+        max_num_logprobs, logprob_token_ids = self._make_logprob_args(logits)
 
         return SamplingMetadata(
             temperature=self._make_temperature(),
@@ -461,7 +505,7 @@ class SamplingBatch:
             top_p=self._make_top_p(),
             top_k=self._make_top_k(),
             generators=self.generators,
-            max_num_logprobs=self.max_num_logprobs,
+            max_num_logprobs=max_num_logprobs,
             prompt_token_ids=self._make_prompt_token_ids(),
             output_token_ids=self.output_token_id_lists,
             frequency_penalties=frequency_penalties,
@@ -471,7 +515,7 @@ class SamplingBatch:
             allowed_token_ids_mask=self._make_allowed_token_ids_mask(),
             bad_words_token_ids=self._make_bad_words_token_ids(),
             logitsprocs=_EMPTY_LOGITSPROCS,
-            logprob_token_ids=None,
+            logprob_token_ids=logprob_token_ids,
         )
 
 
@@ -513,7 +557,7 @@ def sample_from_logits(
     logits_torch = mlx_to_torch(
         logits_2d.astype(mx.float32), device=SamplingBatch.SAMPLER_DEVICE
     )
-    metadata = batch.make_sampling_metadata()
+    metadata = batch.make_sampling_metadata(logits_torch)
     output = sampler.forward(logits_torch, metadata)
     logprobs = (
         output.logprobs_tensors.tolists()

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -419,7 +419,7 @@ class SpeculativeDecodeController:
                 or sampling_params.frequency_penalty != 0.0
                 or sampling_params.presence_penalty != 0.0
                 or sampling_params.repetition_penalty != 1.0
-                or sampling_params.logprobs is not None
+                or sampling_params.num_logprobs is not None
                 or bool(sampling_params.allowed_token_ids)
                 or bool(sampling_params.bad_words_token_ids)
             )


### PR DESCRIPTION
## Summary

- propagate each request's `logprob_token_ids` into vLLM `SamplingMetadata`
- keep every real sample-logprob request off the MLX-native shortcuts and greedy-only speculative drafting, using vLLM's canonical `SamplingParams.num_logprobs` contract
- preserve ordinary per-row top-k logprobs when a neighboring request asks for specific token IDs
- retain `logprob_token_ids=[]` as a no-op, including native sampling eligibility

## Reproduction

On current main (`f61e7a6`), `SamplingParams(temperature=0, logprob_token_ids=[0, 3])` is accepted by the native-greedy gate and `sample_from_logits()` returns the sampled token with `logprobs=None`.

The first candidate exposed a mixed-batch edge case: vLLM 0.28.0 gives a non-empty `logprob_token_ids` mapping batch-wide precedence over `max_num_logprobs`, so a specific-token request could replace an ordinary neighboring row's top-k result. The implementation materializes that ordinary row's raw-logit top-k IDs into the row-indexed mapping before sampling.

A fresh audit of the previous PR head (`5790ece`) found two lifecycle contracts not covered by the initial patch:

- a request with specific-token logprobs remained eligible for greedy speculative drafting, whose verification path returns only token IDs
- an empty requested-token list has `num_logprobs is None` in vLLM but unnecessarily disabled both native sampling paths

Both now have focused regressions.

## Validation

- red on unchanged `f61e7a6`: native eligibility and returned-logprobs assertions fail
- red on initial candidate `119d7ed`: both mixed-batch row orders lose the ordinary row's top-k IDs
- red on previous PR head `5790ece`: the three new native-greedy, native-random, and speculative-lifecycle contracts fail for the intended reasons
- exact `cdd59d9`: reviewer-requested pre-construction helper validated by 14 compile-enabled focused logprob tests and 106 affected sampling/speculative tests
- exact `cdd59d9`: complete non-slow suite in a clean detached worktree (`1,948 passed, 15 skipped, 52 deselected`)
- exact `cdd59d9`: repository Ruff lint/format over 270 files, mypy over 125 source files, compileall, diff and identity checks, and a clean package build
- exact `cdd59d9`: 399 exhaustive metadata cases, 5,000 tie-heavy controls against the previous batch-wide top-k contract, and 300 randomized mixed-batch vs singleton controls
- exact `cdd59d9`: current-main synthetic merge passed all 106 affected tests, Ruff lint/format, mypy, diff checks, and clean-worktree verification
- prior exact `188e1b5`: native extension plus all four Metal shader libraries, wheel artifact, macOS deployment targets, and Qwen3/Qwen3.5 golden-output engine smokes passed
- prior exact `188e1b5`: additional empty, duplicate, reordered, heterogeneous-width, constrained, penalized, seeded, and 128-ID controls passed
- real Qwen3-0.6B engine with n-gram speculation configured returned IDs `0` and `1` for every specific-token logprob row; the neighboring empty-list request returned no logprobs

## Compatibility and limitations

This follows the `SamplingParams.num_logprobs` and row-indexed `SamplingMetadata.logprob_token_ids` contracts in pinned vLLM 0.28.0; the same contracts were checked in current upstream vLLM source. Empty specific-token lists remain no-ops. With speculative decoding configured, requests that need sample logprobs run ordinary non-speculative decode rather than losing their metadata.

The mixed-row compatibility path is validated for the default `raw_logprobs` mode used by `MetalModelRunner`. This PR does not add support for vLLM's non-default processed-logprob modes, which the Metal runner does not currently configure.

