### PR TITLE
Own hybrid geometry behind a family owner

### DIFF
--- a/tests/attention/test_align_gdn_state_manager.py
+++ b/tests/attention/test_align_gdn_state_manager.py
@@ -138,7 +138,7 @@ class TestAlignGDNStateManager:
 class TestHybridAlignRuntime:
     def _make_runtime(self) -> HybridPagedAttentionRuntime:
         return HybridPagedAttentionRuntime(
-            plan=make_gdn_hybrid_plan(
+            hybrid_plan=make_gdn_hybrid_plan(
                 4,
                 range(1, 4, 2),
                 conv_kernel_dim=2,

--- a/tests/attention/test_align_gdn_state_manager.py
+++ b/tests/attention/test_align_gdn_state_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import mlx.core as mx
 import numpy as np
 
+from tests.stub_runner import make_gdn_hybrid_plan
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
@@ -137,16 +138,18 @@ class TestAlignGDNStateManager:
 class TestHybridAlignRuntime:
     def _make_runtime(self) -> HybridPagedAttentionRuntime:
         return HybridPagedAttentionRuntime(
-            num_layers=4,
-            full_attention_interval=2,
+            plan=make_gdn_hybrid_plan(
+                4,
+                range(1, 4, 2),
+                conv_kernel_dim=2,
+                conv_dim=4,
+                num_v_heads=1,
+                value_head_dim=4,
+                key_head_dim=32,
+            ),
             max_num_seqs=2,
             num_kv_heads=1,
             head_dim=4,
-            linear_num_v_heads=1,
-            linear_key_head_dim=32,
-            linear_value_head_dim=4,
-            linear_conv_kernel_dim=2,
-            linear_conv_dim=4,
             block_size=BLOCK,
             dtype=mx.float32,
             mamba_cache_mode="align",

--- a/tests/attention/test_hybrid_gdn_state_manager.py
+++ b/tests/attention/test_hybrid_gdn_state_manager.py
@@ -229,7 +229,7 @@ class TestHybridGDNStateManager:
 class TestHybridPagedAttentionRuntime:
     def test_initialize_wires_gdn_state_manager_delegation(self) -> None:
         runtime = HybridPagedAttentionRuntime(
-            plan=make_gdn_hybrid_plan(
+            hybrid_plan=make_gdn_hybrid_plan(
                 2,
                 range(1, 2, 2),
                 conv_kernel_dim=2,

--- a/tests/attention/test_hybrid_gdn_state_manager.py
+++ b/tests/attention/test_hybrid_gdn_state_manager.py
@@ -5,6 +5,7 @@ import mlx.core as mx
 import numpy as np
 import pytest
 
+from tests.stub_runner import make_gdn_hybrid_plan
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.context import PagedAttentionContext
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
@@ -228,16 +229,18 @@ class TestHybridGDNStateManager:
 class TestHybridPagedAttentionRuntime:
     def test_initialize_wires_gdn_state_manager_delegation(self) -> None:
         runtime = HybridPagedAttentionRuntime(
-            num_layers=2,
-            full_attention_interval=2,
+            plan=make_gdn_hybrid_plan(
+                2,
+                range(1, 2, 2),
+                conv_kernel_dim=2,
+                conv_dim=4,
+                num_v_heads=1,
+                value_head_dim=4,
+                key_head_dim=32,
+            ),
             max_num_seqs=2,
             num_kv_heads=1,
             head_dim=4,
-            linear_num_v_heads=1,
-            linear_key_head_dim=32,
-            linear_value_head_dim=4,
-            linear_conv_kernel_dim=2,
-            linear_conv_dim=4,
             block_size=4,
             dtype=mx.float32,
         )

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -62,8 +62,8 @@ class _FakeModel(nn.Module):
     def __init__(self, roles: str) -> None:
         super().__init__()
         self.layers = [
-            _Layer(_FakeGDN() if k == "s" else _FakeSDPA(), linear=(k == "s"))
-            for k in roles
+            _Layer(_FakeGDN() if role == "s" else _FakeSDPA(), linear=(role == "s"))
+            for role in roles
         ]
 
 
@@ -119,15 +119,6 @@ class TestGdnPlanDecision:
         assert plan.geometry.num_v_heads == 4
         assert plan.geometry.value_head_dim == 16
         assert plan.geometry.key_head_dim == 32
-
-    def test_family_policy_matches_the_gdn_runtime_contract(self) -> None:
-        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
-
-        assert plan.family.label == "gdn"
-        assert plan.family.wrapper_cls is GDNPagedAttentionWrapper
-        assert plan.family.mamba_type is MambaAttentionBackendEnum.GDN_ATTN
-        assert plan.family.recurrent_dtype is torch.float32
-        assert plan.family.supported_cache_modes == ("none", "align")
 
 
 class TestGdnPlanRejection:

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -82,7 +82,7 @@ def _make_tiny_plan() -> HybridRuntimePlan:
 
 def _make_runtime() -> HybridPagedAttentionRuntime:
     return HybridPagedAttentionRuntime(
-        plan=_make_tiny_plan(),
+        hybrid_plan=_make_tiny_plan(),
         max_num_seqs=2,
         num_kv_heads=1,
         head_dim=4,
@@ -93,10 +93,8 @@ def _make_runtime() -> HybridPagedAttentionRuntime:
 
 class TestGdnPlanDecision:
     def test_topology_follows_the_interval_rule(self) -> None:
-        # Arrange / Act
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
 
-        # Assert
         assert plan.layers.attention_indices == (3, 7)
         assert plan.layers.state_indices == (0, 1, 2, 4, 5, 6)
         assert plan.layers.num_attention == 2
@@ -113,10 +111,9 @@ class TestGdnPlanDecision:
         )
 
     def test_geometry_packs_qk_and_v_into_the_conv_stream(self) -> None:
-        # Arrange / Act
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
 
-        # Assert — conv_dim = 2*32*2 + 4*16 = 192, hand-written.
+        # conv_dim = 2*32*2 + 4*16 = 192, hand-written.
         assert plan.geometry.conv_kernel_dim == 3
         assert plan.geometry.conv_dim == 192
         assert plan.geometry.num_v_heads == 4
@@ -124,10 +121,8 @@ class TestGdnPlanDecision:
         assert plan.geometry.key_head_dim == 32
 
     def test_family_policy_matches_the_gdn_runtime_contract(self) -> None:
-        # Arrange / Act
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
 
-        # Assert
         assert plan.family.label == "gdn"
         assert plan.family.wrapper_cls is GDNPagedAttentionWrapper
         assert plan.family.mamba_type is MambaAttentionBackendEnum.GDN_ATTN
@@ -140,53 +135,34 @@ class TestGdnPlanRejection:
         "missing", ["linear_num_key_heads", "linear_conv_kernel_dim"]
     )
     def test_omitted_linear_dim_rejects_with_the_key_name(self, missing: str) -> None:
-        # Arrange
         args = {k: v for k, v in GDN_ARGS.items() if k != missing}
         expected = f"GDN hybrid model args are missing a usable {missing!r}: got None."
 
-        # Act / Assert
         with pytest.raises(ValueError) as excinfo:
             build_gdn_hybrid_plan(args, 8)
         assert str(excinfo.value) == expected
 
     def test_non_positive_layer_count_rejects(self) -> None:
-        # Arrange
-        expected = "GDN hybrid requires a positive layer count, got 0."
-
-        # Act / Assert
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="positive layer count"):
             build_gdn_hybrid_plan(GDN_ARGS, 0)
-        assert str(excinfo.value) == expected
 
 
 class TestLayerPlanDispatch:
-    def test_kind_of_rejects_out_of_range_layers(self) -> None:
-        # Arrange
+    def test_layer_kind_rejects_out_of_range_layers(self) -> None:
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
-        expected = "hybrid layer plan covers layers 0..7, got layer 8"
 
-        # Act / Assert
-        with pytest.raises(ValueError) as excinfo:
-            plan.layers.kind_of(8)
-        assert str(excinfo.value) == expected
+        with pytest.raises(ValueError, match="got layer 8"):
+            plan.layers.layer_kind(8)
 
     def test_cache_index_rejects_the_wrong_kind(self) -> None:
-        # Arrange — layer 0 is a state layer.
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
-        expected = (
-            "hybrid layer plan has no attention cache index for layer 0; "
-            "attention layers are (3, 7)"
-        )
 
-        # Act / Assert
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError, match="no attention cache index for layer 0"):
             plan.layers.attention_cache_index(0)
-        assert str(excinfo.value) == expected
 
 
 class TestStateCacheSpec:
     def test_spec_threads_geometry_family_and_mode(self) -> None:
-        # Arrange
         plan = make_gdn_hybrid_plan(
             4,
             [1, 3],
@@ -205,30 +181,25 @@ class TestStateCacheSpec:
             mamba_cache_mode="align",
         )
 
-        # Act
         spec = plan.state_cache_spec(
             conv_dtype=torch.float16,
             mamba_block_size=2048,
             mamba_cache_mode="align",
         )
 
-        # Assert
         assert spec == expected
 
 
 class TestRuntimeUsesThePlan:
     def test_unsupported_cache_mode_rejects_with_the_family_label(self) -> None:
-        # Arrange
-        plan = _make_tiny_plan()
         expected = (
             "hybrid paged attention does not support mamba_cache_mode='all' "
             "for the 'gdn' state family (supported: ('none', 'align'))"
         )
 
-        # Act / Assert
         with pytest.raises(NotImplementedError) as excinfo:
             HybridPagedAttentionRuntime(
-                plan=plan,
+                hybrid_plan=_make_tiny_plan(),
                 max_num_seqs=2,
                 num_kv_heads=1,
                 head_dim=4,
@@ -239,13 +210,10 @@ class TestRuntimeUsesThePlan:
         assert str(excinfo.value) == expected
 
     def test_state_cache_is_sized_from_the_plan_geometry(self) -> None:
-        # Arrange
         runtime = _make_runtime()
 
-        # Act
         runtime.initialize(num_blocks=2)
 
-        # Assert
         state_cache = runtime.state_cache
         assert state_cache.num_layers == 2
         assert state_cache.conv_kernel_dim == 2
@@ -257,15 +225,12 @@ class TestRuntimeUsesThePlan:
 
 class TestHybridPatchModel:
     def test_installs_family_wrappers_at_plan_cache_indices(self) -> None:
-        # Arrange — layers 1 and 3 are attention, 0 and 2 are state.
         runtime = _make_runtime()
         runtime.initialize(num_blocks=2)
         model = _FakeModel("sasa")
 
-        # Act
         patched = runtime.patch_model(model)
 
-        # Assert
         assert patched == 4
         sdpa_1 = model.layers[1].self_attn
         sdpa_3 = model.layers[3].self_attn
@@ -283,7 +248,6 @@ class TestHybridPatchModel:
         assert gdn_2._gdn_state_cache is runtime.state_cache
 
     def test_repatch_rebinds_cached_wrappers_through_owner_methods(self) -> None:
-        # Arrange — patch once, then a fresh runtime repatches the same model.
         runtime_a = _make_runtime()
         runtime_a.initialize(num_blocks=2)
         model = _FakeModel("sasa")
@@ -292,10 +256,8 @@ class TestHybridPatchModel:
         runtime_b = _make_runtime()
         runtime_b.initialize(num_blocks=2)
 
-        # Act
         patched = runtime_b.patch_model(model)
 
-        # Assert — same wrapper object, refreshed state cache ref.
         assert patched == 4
         assert model.layers[0].linear_attn is wrapper_before
         assert wrapper_before._gdn_state_cache is runtime_b.state_cache
@@ -303,7 +265,6 @@ class TestHybridPatchModel:
         assert wrapper_before._gdn_cache_idx == 0
 
     def test_unclassifiable_layer_rejects_with_the_family_label(self) -> None:
-        # Arrange
         runtime = _make_runtime()
         runtime.initialize(num_blocks=2)
 
@@ -312,13 +273,6 @@ class TestHybridPatchModel:
 
         model = _FakeModel("sasa")
         model.layers[2] = _Layer(_Mystery(), linear=True)
-        expected = (
-            "Hybrid patch_model: layer 2 attention _Mystery is neither SDPA "
-            "nor 'gdn' state; refusing to leave it unpatched (it would "
-            "silently run unpaged)."
-        )
 
-        # Act / Assert
-        with pytest.raises(RuntimeError) as excinfo:
+        with pytest.raises(RuntimeError, match="neither SDPA nor 'gdn' state"):
             runtime.patch_model(model)
-        assert str(excinfo.value) == expected

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -169,12 +169,6 @@ class TestLayerPlanDispatch:
         with pytest.raises(ValueError, match="got layer 8"):
             plan.layers.layer_role(8)
 
-    def test_cache_index_rejects_the_wrong_role(self) -> None:
-        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
-
-        with pytest.raises(ValueError, match="no attention cache index for layer 0"):
-            plan.layers.attention_cache_index(0)
-
 
 class TestStateCacheSpec:
     def test_spec_threads_geometry_family_and_mode(self) -> None:
@@ -289,5 +283,5 @@ class TestHybridPatchModel:
         model = _FakeModel("sasa")
         model.layers[2] = _Layer(_Mystery(), linear=True)
 
-        with pytest.raises(RuntimeError, match="neither SDPA nor 'gdn' state"):
+        with pytest.raises(RuntimeError, match="is not a 'gdn' state module"):
             runtime.patch_model(model)

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -162,14 +162,6 @@ class TestGdnPlanRejection:
         assert str(excinfo.value) == expected
 
 
-class TestLayerPlanDispatch:
-    def test_layer_role_rejects_out_of_range_layers(self) -> None:
-        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
-
-        with pytest.raises(ValueError, match="got layer 8"):
-            plan.layers.layer_role(8)
-
-
 class TestStateCacheSpec:
     def test_spec_threads_geometry_family_and_mode(self) -> None:
         plan = make_gdn_hybrid_plan(

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -142,9 +142,24 @@ class TestGdnPlanRejection:
             build_gdn_hybrid_plan(args, 8)
         assert str(excinfo.value) == expected
 
-    def test_non_positive_layer_count_rejects(self) -> None:
-        with pytest.raises(ValueError, match="positive layer count"):
-            build_gdn_hybrid_plan(GDN_ARGS, 0)
+    @pytest.mark.parametrize(
+        ("interval", "num_layers"),
+        [(1, 8), (9, 8)],
+        ids=["no_state_layers", "no_attention_layers"],
+    )
+    def test_interval_dropping_a_layer_role_rejects(
+        self, interval: int, num_layers: int
+    ) -> None:
+        args = {**GDN_ARGS, "full_attention_interval": interval}
+        expected = (
+            "GDN hybrid requires 2 <= full_attention_interval <= num_layers so "
+            "the model keeps both attention and state layers, got "
+            f"full_attention_interval={interval} with num_layers={num_layers}."
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            build_gdn_hybrid_plan(args, num_layers)
+        assert str(excinfo.value) == expected
 
 
 class TestLayerPlanDispatch:

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -59,11 +59,11 @@ class _Layer(nn.Module):
 
 
 class _FakeModel(nn.Module):
-    def __init__(self, kinds: str) -> None:
+    def __init__(self, roles: str) -> None:
         super().__init__()
         self.layers = [
             _Layer(_FakeGDN() if k == "s" else _FakeSDPA(), linear=(k == "s"))
-            for k in kinds
+            for k in roles
         ]
 
 
@@ -99,7 +99,7 @@ class TestGdnPlanDecision:
         assert plan.layers.state_indices == (0, 1, 2, 4, 5, 6)
         assert plan.layers.num_attention == 2
         assert plan.layers.num_state == 6
-        assert plan.layers.kinds == (
+        assert plan.layers.layer_roles == (
             STATE_LAYER,
             STATE_LAYER,
             STATE_LAYER,
@@ -148,13 +148,13 @@ class TestGdnPlanRejection:
 
 
 class TestLayerPlanDispatch:
-    def test_layer_kind_rejects_out_of_range_layers(self) -> None:
+    def test_layer_role_rejects_out_of_range_layers(self) -> None:
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
 
         with pytest.raises(ValueError, match="got layer 8"):
-            plan.layers.layer_kind(8)
+            plan.layers.layer_role(8)
 
-    def test_cache_index_rejects_the_wrong_kind(self) -> None:
+    def test_cache_index_rejects_the_wrong_role(self) -> None:
         plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
 
         with pytest.raises(ValueError, match="no attention cache index for layer 0"):

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -185,6 +185,7 @@ class TestStateCacheSpec:
         spec = plan.state_cache_spec(
             conv_dtype=torch.float16,
             mamba_block_size=2048,
+            page_size_padded=None,
             mamba_cache_mode="align",
         )
 

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -127,7 +127,7 @@ class TestGdnPlanRejection:
     )
     def test_omitted_linear_dim_rejects_with_the_key_name(self, missing: str) -> None:
         args = {k: v for k, v in GDN_ARGS.items() if k != missing}
-        expected = f"GDN hybrid model args are missing a usable {missing!r}: got None."
+        expected = f"GDN hybrid model args are missing required {missing!r}."
 
         with pytest.raises(ValueError) as excinfo:
             build_gdn_hybrid_plan(args, 8)

--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for the hybrid runtime plan and its GDN family owner."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+import torch
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from tests.stub_runner import make_gdn_hybrid_plan
+from vllm_metal.attention.impls.linear import GDNPagedAttentionWrapper
+from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
+from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
+from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
+from vllm_metal.attention.runtime.hybrid_plan import (
+    ATTENTION_LAYER,
+    STATE_LAYER,
+    HybridRuntimePlan,
+)
+
+GDN_ARGS = {
+    "full_attention_interval": 4,
+    "linear_num_key_heads": 2,
+    "linear_num_value_heads": 4,
+    "linear_key_head_dim": 32,
+    "linear_value_head_dim": 16,
+    "linear_conv_kernel_dim": 3,
+}
+
+
+class _FakeSDPA(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.q_proj = nn.Linear(4, 4)
+        self.k_proj = nn.Linear(4, 4)
+        self.v_proj = nn.Linear(4, 4)
+        self.o_proj = nn.Linear(4, 4)
+
+
+class _FakeGDN(nn.Module):
+    num_k_heads = 1
+    num_v_heads = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1d = nn.Conv1d(4, 4, 2)
+
+
+class _Layer(nn.Module):
+    def __init__(self, attn: nn.Module, linear: bool) -> None:
+        super().__init__()
+        if linear:
+            self.linear_attn = attn
+        else:
+            self.self_attn = attn
+
+
+class _FakeModel(nn.Module):
+    def __init__(self, kinds: str) -> None:
+        super().__init__()
+        self.layers = [
+            _Layer(_FakeGDN() if k == "s" else _FakeSDPA(), linear=(k == "s"))
+            for k in kinds
+        ]
+
+
+def _make_tiny_plan() -> HybridRuntimePlan:
+    """Four layers, attention at 1 and 3, geometry sized for the fakes."""
+    return make_gdn_hybrid_plan(
+        4,
+        [1, 3],
+        conv_kernel_dim=2,
+        conv_dim=4,
+        num_v_heads=1,
+        value_head_dim=4,
+        key_head_dim=32,
+    )
+
+
+def _make_runtime() -> HybridPagedAttentionRuntime:
+    return HybridPagedAttentionRuntime(
+        plan=_make_tiny_plan(),
+        max_num_seqs=2,
+        num_kv_heads=1,
+        head_dim=4,
+        block_size=4,
+        dtype=mx.float32,
+    )
+
+
+class TestGdnPlanDecision:
+    def test_topology_follows_the_interval_rule(self) -> None:
+        # Arrange / Act
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+
+        # Assert
+        assert plan.layers.attention_indices == (3, 7)
+        assert plan.layers.state_indices == (0, 1, 2, 4, 5, 6)
+        assert plan.layers.num_attention == 2
+        assert plan.layers.num_state == 6
+        assert plan.layers.kinds == (
+            STATE_LAYER,
+            STATE_LAYER,
+            STATE_LAYER,
+            ATTENTION_LAYER,
+            STATE_LAYER,
+            STATE_LAYER,
+            STATE_LAYER,
+            ATTENTION_LAYER,
+        )
+
+    def test_geometry_packs_qk_and_v_into_the_conv_stream(self) -> None:
+        # Arrange / Act
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+
+        # Assert — conv_dim = 2*32*2 + 4*16 = 192, hand-written.
+        assert plan.geometry.conv_kernel_dim == 3
+        assert plan.geometry.conv_dim == 192
+        assert plan.geometry.num_v_heads == 4
+        assert plan.geometry.value_head_dim == 16
+        assert plan.geometry.key_head_dim == 32
+
+    def test_family_policy_matches_the_gdn_runtime_contract(self) -> None:
+        # Arrange / Act
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+
+        # Assert
+        assert plan.family.label == "gdn"
+        assert plan.family.wrapper_cls is GDNPagedAttentionWrapper
+        assert plan.family.mamba_type is MambaAttentionBackendEnum.GDN_ATTN
+        assert plan.family.recurrent_dtype is torch.float32
+        assert plan.family.supported_cache_modes == ("none", "align")
+
+
+class TestGdnPlanRejection:
+    @pytest.mark.parametrize(
+        "missing", ["linear_num_key_heads", "linear_conv_kernel_dim"]
+    )
+    def test_omitted_linear_dim_rejects_with_the_key_name(self, missing: str) -> None:
+        # Arrange
+        args = {k: v for k, v in GDN_ARGS.items() if k != missing}
+        expected = f"GDN hybrid model args are missing a usable {missing!r}: got None."
+
+        # Act / Assert
+        with pytest.raises(ValueError) as excinfo:
+            build_gdn_hybrid_plan(args, 8)
+        assert str(excinfo.value) == expected
+
+    def test_non_positive_layer_count_rejects(self) -> None:
+        # Arrange
+        expected = "GDN hybrid requires a positive layer count, got 0."
+
+        # Act / Assert
+        with pytest.raises(ValueError) as excinfo:
+            build_gdn_hybrid_plan(GDN_ARGS, 0)
+        assert str(excinfo.value) == expected
+
+
+class TestLayerPlanDispatch:
+    def test_kind_of_rejects_out_of_range_layers(self) -> None:
+        # Arrange
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+        expected = "hybrid layer plan covers layers 0..7, got layer 8"
+
+        # Act / Assert
+        with pytest.raises(ValueError) as excinfo:
+            plan.layers.kind_of(8)
+        assert str(excinfo.value) == expected
+
+    def test_cache_index_rejects_the_wrong_kind(self) -> None:
+        # Arrange — layer 0 is a state layer.
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+        expected = (
+            "hybrid layer plan has no attention cache index for layer 0; "
+            "attention layers are (3, 7)"
+        )
+
+        # Act / Assert
+        with pytest.raises(ValueError) as excinfo:
+            plan.layers.attention_cache_index(0)
+        assert str(excinfo.value) == expected
+
+
+class TestStateCacheSpec:
+    def test_spec_threads_geometry_family_and_mode(self) -> None:
+        # Arrange
+        plan = make_gdn_hybrid_plan(
+            4,
+            [1, 3],
+            conv_kernel_dim=3,
+            conv_dim=192,
+            num_v_heads=4,
+            value_head_dim=16,
+            key_head_dim=32,
+        )
+        expected = MambaSpec(
+            shapes=((2, 192), (4, 16, 32)),
+            dtypes=(torch.float16, torch.float32),
+            block_size=2048,
+            page_size_padded=None,
+            mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+            mamba_cache_mode="align",
+        )
+
+        # Act
+        spec = plan.state_cache_spec(
+            conv_dtype=torch.float16,
+            mamba_block_size=2048,
+            mamba_cache_mode="align",
+        )
+
+        # Assert
+        assert spec == expected
+
+
+class TestRuntimeUsesThePlan:
+    def test_unsupported_cache_mode_rejects_with_the_family_label(self) -> None:
+        # Arrange
+        plan = _make_tiny_plan()
+        expected = (
+            "hybrid paged attention does not support mamba_cache_mode='all' "
+            "for the 'gdn' state family (supported: ('none', 'align'))"
+        )
+
+        # Act / Assert
+        with pytest.raises(NotImplementedError) as excinfo:
+            HybridPagedAttentionRuntime(
+                plan=plan,
+                max_num_seqs=2,
+                num_kv_heads=1,
+                head_dim=4,
+                block_size=4,
+                dtype=mx.float32,
+                mamba_cache_mode="all",
+            )
+        assert str(excinfo.value) == expected
+
+    def test_state_cache_is_sized_from_the_plan_geometry(self) -> None:
+        # Arrange
+        runtime = _make_runtime()
+
+        # Act
+        runtime.initialize(num_blocks=2)
+
+        # Assert
+        state_cache = runtime.state_cache
+        assert state_cache.num_layers == 2
+        assert state_cache.conv_kernel_dim == 2
+        assert state_cache.conv_dim == 4
+        assert state_cache.num_v_heads == 1
+        assert state_cache.value_head_dim == 4
+        assert state_cache.key_head_dim == 32
+
+
+class TestHybridPatchModel:
+    def test_installs_family_wrappers_at_plan_cache_indices(self) -> None:
+        # Arrange — layers 1 and 3 are attention, 0 and 2 are state.
+        runtime = _make_runtime()
+        runtime.initialize(num_blocks=2)
+        model = _FakeModel("sasa")
+
+        # Act
+        patched = runtime.patch_model(model)
+
+        # Assert
+        assert patched == 4
+        sdpa_1 = model.layers[1].self_attn
+        sdpa_3 = model.layers[3].self_attn
+        gdn_0 = model.layers[0].linear_attn
+        gdn_2 = model.layers[2].linear_attn
+        assert isinstance(sdpa_1, SDPAPagedAttentionWrapper)
+        assert isinstance(sdpa_3, SDPAPagedAttentionWrapper)
+        assert isinstance(gdn_0, GDNPagedAttentionWrapper)
+        assert isinstance(gdn_2, GDNPagedAttentionWrapper)
+        assert sdpa_1._mk_cache_idx == 0
+        assert sdpa_3._mk_cache_idx == 1
+        assert gdn_0._gdn_cache_idx == 0
+        assert gdn_2._gdn_cache_idx == 1
+        assert gdn_0._gdn_state_cache is runtime.state_cache
+        assert gdn_2._gdn_state_cache is runtime.state_cache
+
+    def test_repatch_rebinds_cached_wrappers_through_owner_methods(self) -> None:
+        # Arrange — patch once, then a fresh runtime repatches the same model.
+        runtime_a = _make_runtime()
+        runtime_a.initialize(num_blocks=2)
+        model = _FakeModel("sasa")
+        runtime_a.patch_model(model)
+        wrapper_before = model.layers[0].linear_attn
+        runtime_b = _make_runtime()
+        runtime_b.initialize(num_blocks=2)
+
+        # Act
+        patched = runtime_b.patch_model(model)
+
+        # Assert — same wrapper object, refreshed state cache ref.
+        assert patched == 4
+        assert model.layers[0].linear_attn is wrapper_before
+        assert wrapper_before._gdn_state_cache is runtime_b.state_cache
+        assert wrapper_before._gdn_state_cache is not runtime_a.state_cache
+        assert wrapper_before._gdn_cache_idx == 0
+
+    def test_unclassifiable_layer_rejects_with_the_family_label(self) -> None:
+        # Arrange
+        runtime = _make_runtime()
+        runtime.initialize(num_blocks=2)
+
+        class _Mystery(nn.Module):
+            pass
+
+        model = _FakeModel("sasa")
+        model.layers[2] = _Layer(_Mystery(), linear=True)
+        expected = (
+            "Hybrid patch_model: layer 2 attention _Mystery is neither SDPA "
+            "nor 'gdn' state; refusing to leave it unpatched (it would "
+            "silently run unpaged)."
+        )
+
+        # Act / Assert
+        with pytest.raises(RuntimeError) as excinfo:
+            runtime.patch_model(model)
+        assert str(excinfo.value) == expected

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -247,7 +247,7 @@ def make_gdn_hybrid_plan(
         ATTENTION_LAYER if i in attention else STATE_LAYER for i in range(num_layers)
     )
     return HybridRuntimePlan(
-        layers=HybridLayerPlan.from_kinds(kinds),
+        layers=HybridLayerPlan(kinds=kinds),
         family=_GDN_FAMILY_SPEC,
         geometry=RecurrentStateGeometry(
             conv_kernel_dim=conv_kernel_dim,

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -214,20 +214,18 @@ def make_gemma4_mixed_mha_runner(
     )
 
 
-# The production family spec, resolved once through the public builder (the
-# args are a minimal valid sentinel; only the family policy is kept).  Tests
-# reuse it so they cannot drift from the wrapper, detector and dtype policy
-# production installs.
+# Production family policy, resolved through the public builder from the
+# smallest valid hybrid layout so tests cannot drift from what production installs.
 _GDN_FAMILY_SPEC = build_gdn_hybrid_plan(
     {
-        "full_attention_interval": 1,
+        "full_attention_interval": 2,
         "linear_num_key_heads": 1,
         "linear_num_value_heads": 1,
         "linear_key_head_dim": 1,
         "linear_value_head_dim": 1,
         "linear_conv_kernel_dim": 1,
     },
-    1,
+    2,
 ).family
 
 

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -243,11 +243,11 @@ def make_gdn_hybrid_plan(
 ) -> HybridRuntimePlan:
     """Build a GDN hybrid plan with explicit topology and geometry."""
     attention = frozenset(attention_indices)
-    kinds = tuple(
+    layer_roles = tuple(
         ATTENTION_LAYER if i in attention else STATE_LAYER for i in range(num_layers)
     )
     return HybridRuntimePlan(
-        layers=HybridLayerPlan(kinds=kinds),
+        layers=HybridLayerPlan(layer_roles=layer_roles),
         family=_GDN_FAMILY_SPEC,
         geometry=RecurrentStateGeometry(
             conv_kernel_dim=conv_kernel_dim,

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -3,12 +3,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from types import SimpleNamespace
 from typing import Any
 
 import mlx.core as mx
 
 import vllm_metal.v1.model_runner as mr
+from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
+from vllm_metal.attention.runtime.hybrid_plan import (
+    ATTENTION_LAYER,
+    STATE_LAYER,
+    HybridLayerPlan,
+    HybridRuntimePlan,
+    RecurrentStateGeometry,
+)
 from vllm_metal.v1.cache_policy import ModelCachePolicy
 from vllm_metal.v1.decode_pipeline import DecodePipeline
 from vllm_metal.v1.lora import MetalLoRARuntime
@@ -60,6 +69,7 @@ def make_stub_runner(
         "_draft_dims": None,
         "encoder_cache": None,
         "_paged_attention_runtime": None,
+        "hybrid_runtime_plan": None,
         "_paged_block_size": 0,
         "_paged_scheduler_group_indices": (),
         "_paged_group_block_sizes": (),
@@ -201,4 +211,49 @@ def make_gemma4_mixed_mha_runner(
         kv_heads_per_layer=kv_heads_per_layer,
         head_dim_per_layer=head_dim_per_layer,
         sliding_window_per_layer=sliding_windows,
+    )
+
+
+# The production family spec, resolved once through the public builder (the
+# args are a minimal valid sentinel; only the family policy is kept).  Tests
+# reuse it so they cannot drift from the wrapper, detector and dtype policy
+# production installs.
+_GDN_FAMILY_SPEC = build_gdn_hybrid_plan(
+    {
+        "full_attention_interval": 1,
+        "linear_num_key_heads": 1,
+        "linear_num_value_heads": 1,
+        "linear_key_head_dim": 1,
+        "linear_value_head_dim": 1,
+        "linear_conv_kernel_dim": 1,
+    },
+    1,
+).family
+
+
+def make_gdn_hybrid_plan(
+    num_layers: int,
+    attention_indices: Iterable[int],
+    *,
+    conv_kernel_dim: int,
+    conv_dim: int,
+    num_v_heads: int,
+    value_head_dim: int,
+    key_head_dim: int,
+) -> HybridRuntimePlan:
+    """Build a GDN hybrid plan with explicit topology and geometry."""
+    attention = frozenset(attention_indices)
+    kinds = tuple(
+        ATTENTION_LAYER if i in attention else STATE_LAYER for i in range(num_layers)
+    )
+    return HybridRuntimePlan(
+        layers=HybridLayerPlan.from_kinds(kinds),
+        family=_GDN_FAMILY_SPEC,
+        geometry=RecurrentStateGeometry(
+            conv_kernel_dim=conv_kernel_dim,
+            conv_dim=conv_dim,
+            num_v_heads=num_v_heads,
+            value_head_dim=value_head_dim,
+            key_head_dim=key_head_dim,
+        ),
     )

--- a/tests/test_kv_cache_spec_capacity.py
+++ b/tests/test_kv_cache_spec_capacity.py
@@ -11,7 +11,7 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.core.kv_cache_utils import get_uniform_page_size
 from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec, MLAAttentionSpec
 
-from tests.stub_runner import make_stub_runner
+from tests.stub_runner import make_gdn_hybrid_plan, make_stub_runner
 
 BLOCK_SIZE = 16
 DTYPE = torch.bfloat16
@@ -104,9 +104,15 @@ def test_hybrid_mamba_spec_reserves_one_state_block_per_request() -> None:
             max_model_len=max_model_len,
         ),
         num_layers=2,
-        num_sdpa_layers=1,
-        num_linear_layers=1,
-        sdpa_layer_indices={1},
+        hybrid_runtime_plan=make_gdn_hybrid_plan(
+            2,
+            [1],
+            conv_kernel_dim=4,
+            conv_dim=64,
+            num_v_heads=1,
+            value_head_dim=64,
+            key_head_dim=64,
+        ),
         num_kv_heads=1,
         head_dim=128,
         kv_cache_dtype=mx.float16,
@@ -116,11 +122,6 @@ def test_hybrid_mamba_spec_reserves_one_state_block_per_request() -> None:
             mamba_block_size=max_model_len,
             mamba_cache_mode="none",
         ),
-        linear_conv_kernel_dim=4,
-        linear_conv_dim=64,
-        linear_num_v_heads=1,
-        linear_value_head_dim=64,
-        linear_key_head_dim=64,
     )
 
     spec = runner._cache_policy.get_kv_cache_spec()["layers.0.linear_attn"]

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -16,7 +16,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 
-from tests.stub_runner import make_stub_runner
+from tests.stub_runner import make_gdn_hybrid_plan, make_stub_runner
 from vllm_metal.config import MetalConfig
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import (
@@ -46,10 +46,15 @@ def _hybrid_runner():
     return make_stub_runner(
         model_args={"full_attention_interval": 4},
         num_layers=NUM_LAYERS,
-        full_attention_interval=4,
-        sdpa_layer_indices=set(SDPA_LAYERS),
-        num_sdpa_layers=len(SDPA_LAYERS),
-        num_linear_layers=NUM_LAYERS - len(SDPA_LAYERS),
+        hybrid_runtime_plan=make_gdn_hybrid_plan(
+            NUM_LAYERS,
+            SDPA_LAYERS,
+            conv_kernel_dim=4,
+            conv_dim=1024,
+            num_v_heads=16,
+            value_head_dim=64,
+            key_head_dim=64,
+        ),
         num_kv_heads=KV_HEADS,
         head_dim=HEAD_DIM,
         kv_cache_dtype=mx.float16,
@@ -60,11 +65,6 @@ def _hybrid_runner():
             mamba_cache_mode="none",
         ),
         scheduler_config=SimpleNamespace(max_num_seqs=4),
-        linear_conv_kernel_dim=4,
-        linear_conv_dim=1024,
-        linear_num_v_heads=16,
-        linear_value_head_dim=64,
-        linear_key_head_dim=64,
     )
 
 
@@ -106,10 +106,15 @@ class TestHybridTurboQuantCachePolicy:
             runner = make_stub_runner(
                 model_args={"full_attention_interval": 4},
                 num_layers=NUM_LAYERS,
-                full_attention_interval=4,
-                sdpa_layer_indices=set(sdpa_layers),
-                num_sdpa_layers=len(sdpa_layers),
-                num_linear_layers=NUM_LAYERS - len(sdpa_layers),
+                hybrid_runtime_plan=make_gdn_hybrid_plan(
+                    NUM_LAYERS,
+                    sdpa_layers,
+                    conv_kernel_dim=4,
+                    conv_dim=1024,
+                    num_v_heads=16,
+                    value_head_dim=64,
+                    key_head_dim=64,
+                ),
                 num_kv_heads=KV_HEADS,
                 head_dim=HEAD_DIM,
                 kv_cache_dtype=mx.float16,
@@ -120,11 +125,6 @@ class TestHybridTurboQuantCachePolicy:
                     mamba_cache_mode="none",
                 ),
                 scheduler_config=SimpleNamespace(max_num_seqs=4),
-                linear_conv_kernel_dim=4,
-                linear_conv_dim=1024,
-                linear_num_v_heads=16,
-                linear_value_head_dim=64,
-                linear_key_head_dim=64,
             )
             with patch(
                 "vllm_metal.v1.cache_policy.get_config", return_value=_tq_config()

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -12,6 +12,7 @@ import pytest
 pytest.importorskip("vllm", reason="vllm not installed")
 
 from tests.stub_runner import make_gdn_hybrid_plan, make_stub_runner  # noqa: E402
+from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
 from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
@@ -442,20 +443,10 @@ class TestPagedAttentionPlanDiagnostics:
         runner = SimpleNamespace(
             is_hybrid=True,
             cache_config=SimpleNamespace(mamba_cache_mode="align"),
-            num_layers=24,
-            hybrid_runtime_plan=make_gdn_hybrid_plan(
-                24,
-                range(6),
-                conv_kernel_dim=2,
-                conv_dim=1,
-                num_v_heads=1,
-                value_head_dim=1,
-                key_head_dim=1,
-            ),
-            # 18 logical GDN layers at 100 bytes per layer/slot. Striping
-            # produces six physical pools: 600 steady bytes per block plus
-            # one 100-byte old pool retained during growth.
-            linear_cache_bytes_per_slot=MagicMock(return_value=1_800),
+            # Six striped pools: 600 steady bytes per block plus one 100-byte
+            # old pool retained during growth.
+            hybrid_align_state_bytes_per_block=MagicMock(return_value=600),
+            hybrid_align_growth_bytes_per_block=MagicMock(return_value=100),
             draft_scratch_reserve_bytes=MagicMock(return_value=0),
         )
         planner = self._make_planner(
@@ -536,6 +527,42 @@ class TestPagedAttentionPlanDiagnostics:
         fraction = WorkerCachePlanner(worker)._memory_fraction()
 
         assert fraction == expected_fraction
+
+
+class TestAlignStateSizing:
+    @staticmethod
+    def _make_align_runner() -> mr.MetalModelRunner:
+        """Qwen-shaped 24-layer GDN plan: 18 state layers striped over 6 SDPA."""
+        return make_stub_runner(
+            model_args={"full_attention_interval": 4},
+            kv_cache_dtype=mx.float16,
+            hybrid_runtime_plan=build_gdn_hybrid_plan(
+                {
+                    "full_attention_interval": 4,
+                    "linear_num_key_heads": 1,
+                    "linear_num_value_heads": 1,
+                    "linear_key_head_dim": 1,
+                    "linear_value_head_dim": 1,
+                    "linear_conv_kernel_dim": 2,
+                },
+                24,
+            ),
+        )
+
+    def test_align_state_bytes_per_block_stripes_pools(self) -> None:
+        runner = self._make_align_runner()
+        # Hand-written: conv (2-1)*3 fp16 values = 6 B plus 1*1*1 fp32 = 4 B
+        # per layer, one pool per SDPA layer -> 10 B * 6 pools.
+        expected = 60
+
+        assert runner.hybrid_align_state_bytes_per_block() == expected
+
+    def test_align_growth_bytes_retain_one_pool(self) -> None:
+        runner = self._make_align_runner()
+        # Hand-written: one old pool holds one layer's 10 B.
+        expected = 10
+
+        assert runner.hybrid_align_growth_bytes_per_block() == expected
 
 
 class TestHybridPlanGuard:

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -11,7 +11,7 @@ import pytest
 
 pytest.importorskip("vllm", reason="vllm not installed")
 
-from tests.stub_runner import make_stub_runner  # noqa: E402
+from tests.stub_runner import make_gdn_hybrid_plan, make_stub_runner  # noqa: E402
 from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
@@ -140,16 +140,18 @@ class TestOneSequenceKvBytes:
     def test_hybrid_adds_linear_state(self) -> None:
         model_runner = make_stub_runner(
             model_args={"full_attention_interval": 2},
-            num_sdpa_layers=8,
             num_kv_heads=4,
             head_dim=256,
             kv_cache_dtype=mx.float16,
-            linear_conv_kernel_dim=3,
-            linear_conv_dim=5,
-            linear_num_v_heads=2,
-            linear_value_head_dim=7,
-            linear_key_head_dim=11,
-            num_linear_layers=3,
+            hybrid_runtime_plan=make_gdn_hybrid_plan(
+                11,
+                range(8),
+                conv_kernel_dim=3,
+                conv_dim=5,
+                num_v_heads=2,
+                value_head_dim=7,
+                key_head_dim=11,
+            ),
         )
         worker = _make_worker(model_runner, use_paged_attention=False)
         worker.model_config = SimpleNamespace(max_model_len=2048)
@@ -175,16 +177,18 @@ class TestOneSequenceKvBytes:
         padded_page = 4096
         model_runner = make_stub_runner(
             model_args={"full_attention_interval": 2},
-            num_sdpa_layers=8,
             num_kv_heads=4,
             head_dim=256,
             kv_cache_dtype=mx.float16,
-            linear_conv_kernel_dim=3,
-            linear_conv_dim=5,
-            linear_num_v_heads=2,
-            linear_value_head_dim=7,
-            linear_key_head_dim=11,
-            num_linear_layers=3,
+            hybrid_runtime_plan=make_gdn_hybrid_plan(
+                11,
+                range(8),
+                conv_kernel_dim=3,
+                conv_dim=5,
+                num_v_heads=2,
+                value_head_dim=7,
+                key_head_dim=11,
+            ),
             cache_config=SimpleNamespace(mamba_page_size_padded=padded_page),
         )
         worker = _make_worker(model_runner, use_paged_attention=False)
@@ -206,25 +210,19 @@ class TestOneSequenceKvBytes:
         runner._model_adapter = DefaultModelAdapter()
         runner._cache_policy = ModelCachePolicy(runner, runner._model_adapter)
         runner.kv_cache_dtype = mx.float16
-        runner.linear_conv_kernel_dim = 3
-        runner.linear_conv_dim = 5
-        runner.linear_num_v_heads = 2
-        runner.linear_value_head_dim = 7
-        runner.linear_key_head_dim = 11
-        runner.num_linear_layers = 3
+        runner.hybrid_runtime_plan = make_gdn_hybrid_plan(
+            11,
+            range(8),
+            conv_kernel_dim=3,
+            conv_dim=5,
+            num_v_heads=2,
+            value_head_dim=7,
+            key_head_dim=11,
+        )
 
-        conv_bytes = (
-            (runner.linear_conv_kernel_dim - 1)
-            * runner.linear_conv_dim
-            * mx.float16.size
-        )
-        recurrent_bytes = (
-            runner.linear_num_v_heads
-            * runner.linear_value_head_dim
-            * runner.linear_key_head_dim
-            * mx.float32.size
-        )
-        expected = runner.num_linear_layers * (conv_bytes + recurrent_bytes)
+        # Hand-written from the plan above: conv (3-1)*5 fp16 values = 20 B,
+        # recurrent 2*7*11 fp32 values = 616 B, over 3 state layers.
+        expected = 3 * (20 + 616)
 
         assert runner.linear_cache_bytes_per_slot() == expected
 
@@ -445,7 +443,15 @@ class TestPagedAttentionPlanDiagnostics:
             is_hybrid=True,
             cache_config=SimpleNamespace(mamba_cache_mode="align"),
             num_layers=24,
-            sdpa_layer_indices=list(range(6)),
+            hybrid_runtime_plan=make_gdn_hybrid_plan(
+                24,
+                range(6),
+                conv_kernel_dim=2,
+                conv_dim=1,
+                num_v_heads=1,
+                value_head_dim=1,
+                key_head_dim=1,
+            ),
             # 18 logical GDN layers at 100 bytes per layer/slot. Striping
             # produces six physical pools: 600 steady bytes per block plus
             # one 100-byte old pool retained during growth.
@@ -530,3 +536,19 @@ class TestPagedAttentionPlanDiagnostics:
         fraction = WorkerCachePlanner(worker)._memory_fraction()
 
         assert fraction == expected_fraction
+
+
+class TestHybridPlanGuard:
+    def test_hybrid_sizing_without_plan_rejects(self) -> None:
+        # Arrange — is_hybrid derives from model_args; the stub leaves
+        # hybrid_runtime_plan at its None default.
+        runner = make_stub_runner(model_args={"full_attention_interval": 2})
+        expected = (
+            "hybrid model has no resolved hybrid_runtime_plan; "
+            "ModelLifecycle.resolve_model_dims must run before cache sizing"
+        )
+
+        # Act / Assert
+        with pytest.raises(RuntimeError) as excinfo:
+            runner.linear_cache_bytes_per_slot()
+        assert str(excinfo.value) == expected

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -540,15 +540,8 @@ class TestPagedAttentionPlanDiagnostics:
 
 class TestHybridPlanGuard:
     def test_hybrid_sizing_without_plan_rejects(self) -> None:
-        # Arrange — is_hybrid derives from model_args; the stub leaves
-        # hybrid_runtime_plan at its None default.
+        # is_hybrid derives from model_args; the stub leaves the plan at None.
         runner = make_stub_runner(model_args={"full_attention_interval": 2})
-        expected = (
-            "hybrid model has no resolved hybrid_runtime_plan; "
-            "ModelLifecycle.resolve_model_dims must run before cache sizing"
-        )
 
-        # Act / Assert
-        with pytest.raises(RuntimeError) as excinfo:
+        with pytest.raises(RuntimeError, match="no resolved hybrid_runtime_plan"):
             runner.linear_cache_bytes_per_slot()
-        assert str(excinfo.value) == expected

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -123,6 +123,13 @@ class GDNPagedAttentionWrapper(nn.Module):
         object.__setattr__(self, "_gdn_lazy", GDNLazyKernels.shared())
         object.__setattr__(self, "_gdn_lazy_policy", _GDNLazyPolicy.from_module(inner))
 
+    def rebind_state_cache(
+        self, state_cache: GDNPagedStateCache, *, cache_idx: int
+    ) -> None:
+        """Refresh pooled state refs in place (cached model reuse)."""
+        object.__setattr__(self, "_gdn_cache_idx", cache_idx)
+        object.__setattr__(self, "_gdn_state_cache", state_cache)
+
     def __call__(
         self,
         x: mx.array,

--- a/vllm_metal/attention/runtime/families/__init__.py
+++ b/vllm_metal/attention/runtime/families/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""State-family owners for the hybrid paged runtime."""

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -71,6 +71,30 @@ class GDNHybridConfig:
                 f"{', '.join(invalid_fields)}."
             )
 
+    def layer_roles(self, num_layers: int) -> tuple[LayerRole, ...]:
+        interval = self.full_attention_interval
+        if not 2 <= interval <= num_layers:
+            raise ValueError(
+                "GDN hybrid requires 2 <= full_attention_interval <= num_layers so "
+                "the model keeps both attention and state layers, got "
+                f"full_attention_interval={interval} with num_layers={num_layers}."
+            )
+        return tuple(
+            ATTENTION_LAYER if (i + 1) % interval == 0 else STATE_LAYER
+            for i in range(num_layers)
+        )
+
+    def state_geometry(self) -> RecurrentStateGeometry:
+        return RecurrentStateGeometry(
+            conv_kernel_dim=self.conv_kernel_dim,
+            # GDN packs q/k at key_dim and v at value_dim into one conv stream.
+            conv_dim=self.num_key_heads * self.key_head_dim * 2
+            + self.num_value_heads * self.value_head_dim,
+            num_v_heads=self.num_value_heads,
+            value_head_dim=self.value_head_dim,
+            key_head_dim=self.key_head_dim,
+        )
+
 
 _GDN_FAMILY = StateFamilySpec(
     label="gdn",
@@ -89,27 +113,8 @@ def build_gdn_hybrid_plan(
 ) -> HybridRuntimePlan:
     """Resolve GDN layer topology and recurrent geometry from model args."""
     gdn_config = GDNHybridConfig.from_model_args(model_args)
-    interval = gdn_config.full_attention_interval
-    if not 2 <= interval <= num_layers:
-        raise ValueError(
-            "GDN hybrid requires 2 <= full_attention_interval <= num_layers so "
-            "the model keeps both attention and state layers, got "
-            f"full_attention_interval={interval} with num_layers={num_layers}."
-        )
-    layer_roles: tuple[LayerRole, ...] = tuple(
-        ATTENTION_LAYER if (i + 1) % interval == 0 else STATE_LAYER
-        for i in range(num_layers)
-    )
     return HybridRuntimePlan(
-        layers=HybridLayerPlan(layer_roles=layer_roles),
+        layers=HybridLayerPlan(layer_roles=gdn_config.layer_roles(num_layers)),
         family=_GDN_FAMILY,
-        geometry=RecurrentStateGeometry(
-            conv_kernel_dim=gdn_config.conv_kernel_dim,
-            # GDN packs q/k at key_dim and v at value_dim into one conv stream.
-            conv_dim=gdn_config.num_key_heads * gdn_config.key_head_dim * 2
-            + gdn_config.num_value_heads * gdn_config.value_head_dim,
-            num_v_heads=gdn_config.num_value_heads,
-            value_head_dim=gdn_config.value_head_dim,
-            key_head_dim=gdn_config.key_head_dim,
-        ),
+        geometry=gdn_config.state_geometry(),
     )

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -76,14 +76,15 @@ def build_gdn_hybrid_plan(
 ) -> HybridRuntimePlan:
     """Resolve GDN layer topology and recurrent geometry from model args."""
     gdn_config = GDNHybridConfig.from_model_args(model_args)
-    if num_layers <= 0:
+    interval = gdn_config.full_attention_interval
+    if not 2 <= interval <= num_layers:
         raise ValueError(
-            f"GDN hybrid requires a positive layer count, got {num_layers}."
+            "GDN hybrid requires 2 <= full_attention_interval <= num_layers so "
+            "the model keeps both attention and state layers, got "
+            f"full_attention_interval={interval} with num_layers={num_layers}."
         )
     layer_roles: tuple[LayerRole, ...] = tuple(
-        ATTENTION_LAYER
-        if (i + 1) % gdn_config.full_attention_interval == 0
-        else STATE_LAYER
+        ATTENTION_LAYER if (i + 1) % interval == 0 else STATE_LAYER
         for i in range(num_layers)
     )
     return HybridRuntimePlan(

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GDN linear-attention state family (Qwen3.5 / Qwen3.6, Qwen3-Next)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+
+from vllm_metal.attention.impls.linear import (
+    GDNPagedAttentionWrapper,
+    is_linear_attention,
+)
+from vllm_metal.attention.runtime.hybrid_plan import (
+    ATTENTION_LAYER,
+    STATE_LAYER,
+    HybridLayerPlan,
+    HybridRuntimePlan,
+    LayerKind,
+    RecurrentStateGeometry,
+    StateFamilySpec,
+)
+
+_INTERVAL_KEY = "full_attention_interval"
+# Scheduler-side mamba caching strategies the GDN state path implements.
+_SUPPORTED_CACHE_MODES = ("none", "align")
+
+
+def build_gdn_hybrid_plan(
+    model_args: Mapping[str, Any], num_layers: int
+) -> HybridRuntimePlan:
+    """Resolve GDN layer topology and recurrent geometry from model args."""
+    interval = _require_positive_int(model_args, _INTERVAL_KEY)
+    if num_layers <= 0:
+        raise ValueError(
+            f"GDN hybrid requires a positive layer count, got {num_layers}."
+        )
+    kinds: tuple[LayerKind, ...] = tuple(
+        ATTENTION_LAYER if (i + 1) % interval == 0 else STATE_LAYER
+        for i in range(num_layers)
+    )
+    return HybridRuntimePlan(
+        layers=HybridLayerPlan.from_kinds(kinds),
+        family=_GDN_FAMILY,
+        geometry=_gdn_geometry(model_args),
+    )
+
+
+_GDN_FAMILY = StateFamilySpec(
+    label="gdn",
+    wrapper_cls=GDNPagedAttentionWrapper,
+    is_state_module=is_linear_attention,
+    mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+    # Match the fp32 recurrent pool used for kernel accumulation.
+    recurrent_dtype=torch.float32,
+    supported_cache_modes=_SUPPORTED_CACHE_MODES,
+)
+
+
+def _gdn_geometry(model_args: Mapping[str, Any]) -> RecurrentStateGeometry:
+    num_k_heads = _require_positive_int(model_args, "linear_num_key_heads")
+    num_v_heads = _require_positive_int(model_args, "linear_num_value_heads")
+    key_head_dim = _require_positive_int(model_args, "linear_key_head_dim")
+    value_head_dim = _require_positive_int(model_args, "linear_value_head_dim")
+    return RecurrentStateGeometry(
+        conv_kernel_dim=_require_positive_int(model_args, "linear_conv_kernel_dim"),
+        # GDN packs q/k at key_dim and v at value_dim into one conv stream.
+        conv_dim=num_k_heads * key_head_dim * 2 + num_v_heads * value_head_dim,
+        num_v_heads=num_v_heads,
+        value_head_dim=value_head_dim,
+        key_head_dim=key_head_dim,
+    )
+
+
+def _require_positive_int(model_args: Mapping[str, Any], key: str) -> int:
+    value = model_args.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(
+            f"GDN hybrid model args are missing a usable {key!r}: got {value!r}."
+        )
+    return int(value)

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 import torch
@@ -23,31 +24,6 @@ from vllm_metal.attention.runtime.hybrid_plan import (
     StateFamilySpec,
 )
 
-_INTERVAL_KEY = "full_attention_interval"
-# Scheduler-side mamba caching strategies the GDN state path implements.
-_SUPPORTED_CACHE_MODES = ("none", "align")
-
-
-def build_gdn_hybrid_plan(
-    model_args: Mapping[str, Any], num_layers: int
-) -> HybridRuntimePlan:
-    """Resolve GDN layer topology and recurrent geometry from model args."""
-    interval = _require_positive_int(model_args, _INTERVAL_KEY)
-    if num_layers <= 0:
-        raise ValueError(
-            f"GDN hybrid requires a positive layer count, got {num_layers}."
-        )
-    kinds: tuple[LayerKind, ...] = tuple(
-        ATTENTION_LAYER if (i + 1) % interval == 0 else STATE_LAYER
-        for i in range(num_layers)
-    )
-    return HybridRuntimePlan(
-        layers=HybridLayerPlan.from_kinds(kinds),
-        family=_GDN_FAMILY,
-        geometry=_gdn_geometry(model_args),
-    )
-
-
 _GDN_FAMILY = StateFamilySpec(
     label="gdn",
     wrapper_cls=GDNPagedAttentionWrapper,
@@ -55,29 +31,69 @@ _GDN_FAMILY = StateFamilySpec(
     mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
     # Match the fp32 recurrent pool used for kernel accumulation.
     recurrent_dtype=torch.float32,
-    supported_cache_modes=_SUPPORTED_CACHE_MODES,
+    # Scheduler-side mamba caching strategies the GDN state path implements.
+    supported_cache_modes=("none", "align"),
 )
 
 
-def _gdn_geometry(model_args: Mapping[str, Any]) -> RecurrentStateGeometry:
-    num_k_heads = _require_positive_int(model_args, "linear_num_key_heads")
-    num_v_heads = _require_positive_int(model_args, "linear_num_value_heads")
-    key_head_dim = _require_positive_int(model_args, "linear_key_head_dim")
-    value_head_dim = _require_positive_int(model_args, "linear_value_head_dim")
-    return RecurrentStateGeometry(
-        conv_kernel_dim=_require_positive_int(model_args, "linear_conv_kernel_dim"),
-        # GDN packs q/k at key_dim and v at value_dim into one conv stream.
-        conv_dim=num_k_heads * key_head_dim * 2 + num_v_heads * value_head_dim,
-        num_v_heads=num_v_heads,
-        value_head_dim=value_head_dim,
-        key_head_dim=key_head_dim,
-    )
+@dataclass(frozen=True, slots=True)
+class GDNHybridConfig:
+    """GDN dims parsed once from the third-party model args boundary."""
 
+    full_attention_interval: int
+    num_key_heads: int
+    num_value_heads: int
+    key_head_dim: int
+    value_head_dim: int
+    conv_kernel_dim: int
 
-def _require_positive_int(model_args: Mapping[str, Any], key: str) -> int:
-    value = model_args.get(key)
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise ValueError(
-            f"GDN hybrid model args are missing a usable {key!r}: got {value!r}."
+    @classmethod
+    def from_model_args(cls, model_args: Mapping[str, Any]) -> GDNHybridConfig:
+        require = cls._require_positive_int
+        return cls(
+            full_attention_interval=require(model_args, "full_attention_interval"),
+            num_key_heads=require(model_args, "linear_num_key_heads"),
+            num_value_heads=require(model_args, "linear_num_value_heads"),
+            key_head_dim=require(model_args, "linear_key_head_dim"),
+            value_head_dim=require(model_args, "linear_value_head_dim"),
+            conv_kernel_dim=require(model_args, "linear_conv_kernel_dim"),
         )
-    return int(value)
+
+    @staticmethod
+    def _require_positive_int(model_args: Mapping[str, Any], key: str) -> int:
+        value = model_args.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(
+                f"GDN hybrid model args are missing a usable {key!r}: got {value!r}."
+            )
+        return int(value)
+
+
+def build_gdn_hybrid_plan(
+    model_args: Mapping[str, Any], num_layers: int
+) -> HybridRuntimePlan:
+    """Resolve GDN layer topology and recurrent geometry from model args."""
+    config = GDNHybridConfig.from_model_args(model_args)
+    if num_layers <= 0:
+        raise ValueError(
+            f"GDN hybrid requires a positive layer count, got {num_layers}."
+        )
+    kinds: tuple[LayerKind, ...] = tuple(
+        ATTENTION_LAYER
+        if (i + 1) % config.full_attention_interval == 0
+        else STATE_LAYER
+        for i in range(num_layers)
+    )
+    return HybridRuntimePlan(
+        layers=HybridLayerPlan(kinds=kinds),
+        family=_GDN_FAMILY,
+        geometry=RecurrentStateGeometry(
+            conv_kernel_dim=config.conv_kernel_dim,
+            # GDN packs q/k at key_dim and v at value_dim into one conv stream.
+            conv_dim=config.num_key_heads * config.key_head_dim * 2
+            + config.num_value_heads * config.value_head_dim,
+            num_v_heads=config.num_value_heads,
+            value_head_dim=config.value_head_dim,
+            key_head_dim=config.key_head_dim,
+        ),
+    )

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -19,7 +19,7 @@ from vllm_metal.attention.runtime.hybrid_plan import (
     STATE_LAYER,
     HybridLayerPlan,
     HybridRuntimePlan,
-    LayerKind,
+    LayerRole,
     RecurrentStateGeometry,
     StateFamilySpec,
 )
@@ -73,27 +73,27 @@ def build_gdn_hybrid_plan(
     model_args: Mapping[str, Any], num_layers: int
 ) -> HybridRuntimePlan:
     """Resolve GDN layer topology and recurrent geometry from model args."""
-    config = GDNHybridConfig.from_model_args(model_args)
+    gdn_config = GDNHybridConfig.from_model_args(model_args)
     if num_layers <= 0:
         raise ValueError(
             f"GDN hybrid requires a positive layer count, got {num_layers}."
         )
-    kinds: tuple[LayerKind, ...] = tuple(
+    layer_roles: tuple[LayerRole, ...] = tuple(
         ATTENTION_LAYER
-        if (i + 1) % config.full_attention_interval == 0
+        if (i + 1) % gdn_config.full_attention_interval == 0
         else STATE_LAYER
         for i in range(num_layers)
     )
     return HybridRuntimePlan(
-        layers=HybridLayerPlan(kinds=kinds),
+        layers=HybridLayerPlan(layer_roles=layer_roles),
         family=_GDN_FAMILY,
         geometry=RecurrentStateGeometry(
-            conv_kernel_dim=config.conv_kernel_dim,
+            conv_kernel_dim=gdn_config.conv_kernel_dim,
             # GDN packs q/k at key_dim and v at value_dim into one conv stream.
-            conv_dim=config.num_key_heads * config.key_head_dim * 2
-            + config.num_value_heads * config.value_head_dim,
-            num_v_heads=config.num_value_heads,
-            value_head_dim=config.value_head_dim,
-            key_head_dim=config.key_head_dim,
+            conv_dim=gdn_config.num_key_heads * gdn_config.key_head_dim * 2
+            + gdn_config.num_value_heads * gdn_config.value_head_dim,
+            num_v_heads=gdn_config.num_value_heads,
+            value_head_dim=gdn_config.value_head_dim,
+            key_head_dim=gdn_config.key_head_dim,
         ),
     )

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -36,6 +36,16 @@ _GDN_FAMILY = StateFamilySpec(
 )
 
 
+def _read_positive_int(model_args: Mapping[str, Any], key: str) -> int:
+    """Read one GDN dimension from model args, rejecting anything unusable."""
+    value = model_args.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(
+            f"GDN hybrid model args are missing a usable {key!r}: got {value!r}."
+        )
+    return value
+
+
 @dataclass(frozen=True, slots=True)
 class GDNHybridConfig:
     """GDN dims parsed once from the third-party model args boundary."""
@@ -49,24 +59,16 @@ class GDNHybridConfig:
 
     @classmethod
     def from_model_args(cls, model_args: Mapping[str, Any]) -> GDNHybridConfig:
-        require = cls._require_positive_int
         return cls(
-            full_attention_interval=require(model_args, "full_attention_interval"),
-            num_key_heads=require(model_args, "linear_num_key_heads"),
-            num_value_heads=require(model_args, "linear_num_value_heads"),
-            key_head_dim=require(model_args, "linear_key_head_dim"),
-            value_head_dim=require(model_args, "linear_value_head_dim"),
-            conv_kernel_dim=require(model_args, "linear_conv_kernel_dim"),
+            full_attention_interval=_read_positive_int(
+                model_args, "full_attention_interval"
+            ),
+            num_key_heads=_read_positive_int(model_args, "linear_num_key_heads"),
+            num_value_heads=_read_positive_int(model_args, "linear_num_value_heads"),
+            key_head_dim=_read_positive_int(model_args, "linear_key_head_dim"),
+            value_head_dim=_read_positive_int(model_args, "linear_value_head_dim"),
+            conv_kernel_dim=_read_positive_int(model_args, "linear_conv_kernel_dim"),
         )
-
-    @staticmethod
-    def _require_positive_int(model_args: Mapping[str, Any], key: str) -> int:
-        value = model_args.get(key)
-        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-            raise ValueError(
-                f"GDN hybrid model args are missing a usable {key!r}: got {value!r}."
-            )
-        return int(value)
 
 
 def build_gdn_hybrid_plan(

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -24,27 +24,6 @@ from vllm_metal.attention.runtime.hybrid_plan import (
     StateFamilySpec,
 )
 
-_GDN_FAMILY = StateFamilySpec(
-    label="gdn",
-    wrapper_cls=GDNPagedAttentionWrapper,
-    is_state_module=is_linear_attention,
-    mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
-    # Match the fp32 recurrent pool used for kernel accumulation.
-    recurrent_dtype=torch.float32,
-    # Scheduler-side mamba caching strategies the GDN state path implements.
-    supported_cache_modes=("none", "align"),
-)
-
-
-def _read_positive_int(model_args: Mapping[str, Any], key: str) -> int:
-    """Read one GDN dimension from model args, rejecting anything unusable."""
-    value = model_args.get(key)
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise ValueError(
-            f"GDN hybrid model args are missing a usable {key!r}: got {value!r}."
-        )
-    return value
-
 
 @dataclass(frozen=True, slots=True)
 class GDNHybridConfig:
@@ -59,16 +38,50 @@ class GDNHybridConfig:
 
     @classmethod
     def from_model_args(cls, model_args: Mapping[str, Any]) -> GDNHybridConfig:
-        return cls(
-            full_attention_interval=_read_positive_int(
-                model_args, "full_attention_interval"
-            ),
-            num_key_heads=_read_positive_int(model_args, "linear_num_key_heads"),
-            num_value_heads=_read_positive_int(model_args, "linear_num_value_heads"),
-            key_head_dim=_read_positive_int(model_args, "linear_key_head_dim"),
-            value_head_dim=_read_positive_int(model_args, "linear_value_head_dim"),
-            conv_kernel_dim=_read_positive_int(model_args, "linear_conv_kernel_dim"),
-        )
+        try:
+            return cls(
+                full_attention_interval=model_args["full_attention_interval"],
+                num_key_heads=model_args["linear_num_key_heads"],
+                num_value_heads=model_args["linear_num_value_heads"],
+                key_head_dim=model_args["linear_key_head_dim"],
+                value_head_dim=model_args["linear_value_head_dim"],
+                conv_kernel_dim=model_args["linear_conv_kernel_dim"],
+            )
+        except KeyError as exc:
+            raise ValueError(
+                f"GDN hybrid model args are missing required {exc.args[0]!r}."
+            ) from exc
+
+    def __post_init__(self) -> None:
+        invalid_fields = [
+            f"{name}={value!r}"
+            for name, value in (
+                ("full_attention_interval", self.full_attention_interval),
+                ("linear_num_key_heads", self.num_key_heads),
+                ("linear_num_value_heads", self.num_value_heads),
+                ("linear_key_head_dim", self.key_head_dim),
+                ("linear_value_head_dim", self.value_head_dim),
+                ("linear_conv_kernel_dim", self.conv_kernel_dim),
+            )
+            if type(value) is not int or value <= 0
+        ]
+        if invalid_fields:
+            raise ValueError(
+                "GDN hybrid model args must be positive integers; invalid "
+                f"{', '.join(invalid_fields)}."
+            )
+
+
+_GDN_FAMILY = StateFamilySpec(
+    label="gdn",
+    wrapper_cls=GDNPagedAttentionWrapper,
+    is_state_module=is_linear_attention,
+    mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+    # Match the fp32 recurrent pool used for kernel accumulation.
+    recurrent_dtype=torch.float32,
+    # Scheduler-side mamba caching strategies the GDN state path implements.
+    supported_cache_modes=("none", "align"),
+)
 
 
 def build_gdn_hybrid_plan(

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -27,7 +27,7 @@ from vllm_metal.attention.impls.sdpa_wrapper import (
 )
 from vllm_metal.attention.patching import walk_and_wrap
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
-from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
+from vllm_metal.attention.runtime.hybrid_plan import STATE_LAYER, HybridRuntimePlan
 from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
 
 logger = init_logger(__name__)
@@ -196,29 +196,31 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         state_family = self._hybrid_plan.family
 
         def wrap_layer(layer_idx: int, attn: Any) -> Any:
+            if layer_plan.layer_role(layer_idx) == STATE_LAYER:
+                cache_idx = layer_plan.state_cache_index(layer_idx)
+                if isinstance(attn, state_family.wrapper_cls):
+                    attn.rebind_state_cache(state_cache, cache_idx=cache_idx)
+                    return attn
+                if state_family.is_state_module(attn):
+                    return state_family.wrapper_cls(
+                        attn, layer_idx, cache_idx, state_cache
+                    )
+                raise RuntimeError(
+                    f"Hybrid patch_model: layer {layer_idx} is a state layer in "
+                    f"the hybrid plan but {type(attn).__name__} is not a "
+                    f"{state_family.label!r} state module."
+                )
+            cache_idx = layer_plan.attention_cache_index(layer_idx)
             if isinstance(attn, SDPAPagedAttentionWrapper):
-                # Already patched (cached model reuse) — refresh cache refs.
-                cache_idx = layer_plan.attention_cache_index(layer_idx)
                 attn.rebind_cache(kv_cache, self._block_size, cache_idx=cache_idx)
                 return attn
-            if isinstance(attn, state_family.wrapper_cls):
-                # Already patched — refresh state cache ref.
-                cache_idx = layer_plan.state_cache_index(layer_idx)
-                attn.rebind_state_cache(state_cache, cache_idx=cache_idx)
-                return attn
             if is_sdpa(attn):
-                cache_idx = layer_plan.attention_cache_index(layer_idx)
                 return SDPAPagedAttentionWrapper(
                     attn, layer_idx, kv_cache, self._block_size, cache_idx=cache_idx
                 )
-            if state_family.is_state_module(attn):
-                cache_idx = layer_plan.state_cache_index(layer_idx)
-                return state_family.wrapper_cls(attn, layer_idx, cache_idx, state_cache)
             raise RuntimeError(
-                f"Hybrid patch_model: layer {layer_idx} attention "
-                f"{type(attn).__name__} is neither SDPA nor "
-                f"{state_family.label!r} state; refusing to leave it unpatched "
-                "(it would silently run unpaged)."
+                f"Hybrid patch_model: layer {layer_idx} is an attention layer in "
+                f"the hybrid plan but {type(attn).__name__} is not SDPA."
             )
 
         return walk_and_wrap(model, wrap_layer)

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -80,11 +80,6 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         self._k_quant = k_quant
         self._v_quant = v_quant
 
-        # Layer topology is owned by the plan; alias its index tuples here
-        # instead of re-deriving them from config math.
-        self._sdpa_indices = self._hybrid_plan.layers.attention_indices
-        self._linear_indices = self._hybrid_plan.layers.state_indices
-
         self._cache = None
         self._state_cache: GDNPagedStateCache | None = None
         self._gdn_state_manager: HybridGDNStateManager | AlignGDNStateManager | None = (
@@ -95,7 +90,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
 
     def initialize(self, num_blocks: int) -> None:
         self._cache = MetalPagedKVCache(
-            num_layers=len(self._sdpa_indices),
+            num_layers=self._hybrid_plan.layers.num_attention,
             num_kv_heads=self._num_kv_heads,
             head_dim=self._head_dim,
             num_blocks=num_blocks,
@@ -120,7 +115,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         state_slots = num_blocks if align else self._max_num_seqs
         state_geometry = self._hybrid_plan.geometry
         self._state_cache = GDNPagedStateCache(
-            num_layers=len(self._linear_indices),
+            num_layers=self._hybrid_plan.layers.num_state,
             max_seqs=state_slots,
             conv_kernel_dim=state_geometry.conv_kernel_dim,
             conv_dim=state_geometry.conv_dim,
@@ -139,9 +134,9 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         logger.info(
             "Hybrid cache initialized: %d SDPA layers (%d blocks), "
             "%d linear layers (%d/%d GDN slots allocated, mamba_cache_mode=%s)",
-            len(self._sdpa_indices),
+            self._hybrid_plan.layers.num_attention,
             num_blocks,
-            len(self._linear_indices),
+            self._hybrid_plan.layers.num_state,
             self._state_cache.allocated_seqs,
             self._state_cache.max_seqs,
             self._mamba_cache_mode,
@@ -196,9 +191,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
 
     def patch_model(self, model: nn.Module) -> int:
         kv_cache = self._require_initialized("patch_model")
-        if self._state_cache is None:
-            raise RuntimeError("patch_model() called before initialize()")
-        state_cache = self._state_cache
+        state_cache = self.state_cache
         layer_plan = self._hybrid_plan.layers
         state_family = self._hybrid_plan.family
 

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -27,7 +27,7 @@ from vllm_metal.attention.impls.sdpa_wrapper import (
 )
 from vllm_metal.attention.patching import walk_and_wrap
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
-from vllm_metal.attention.runtime.hybrid_plan import STATE_LAYER, HybridRuntimePlan
+from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
 from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
 
 logger = init_logger(__name__)
@@ -196,7 +196,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         state_family = self._hybrid_plan.family
 
         def wrap_layer(layer_idx: int, attn: Any) -> Any:
-            if layer_plan.layer_role(layer_idx) == STATE_LAYER:
+            if layer_plan.is_state_layer(layer_idx):
                 cache_idx = layer_plan.state_cache_index(layer_idx)
                 if isinstance(attn, state_family.wrapper_cls):
                     attn.rebind_state_cache(state_cache, cache_idx=cache_idx)

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -16,57 +16,21 @@ from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
-import torch
 from vllm.logger import init_logger
-from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
-from vllm.v1.kv_cache_interface import MambaSpec
 
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.context import PagedAttentionContext
-from vllm_metal.attention.impls.linear import (
-    GDNPagedAttentionWrapper,
-    is_linear_attention,
-)
 from vllm_metal.attention.impls.sdpa import is_sdpa
 from vllm_metal.attention.impls.sdpa_wrapper import (
     SDPAPagedAttentionWrapper,
 )
 from vllm_metal.attention.patching import walk_and_wrap
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
+from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
 from vllm_metal.attention.state import AlignGDNStateManager, HybridGDNStateManager
 
 logger = init_logger(__name__)
-
-
-def _build_linear_layer_spec(
-    *,
-    conv_kernel_dim: int,
-    conv_dim: int,
-    num_v_heads: int,
-    value_head_dim: int,
-    key_head_dim: int,
-    torch_dtype: torch.dtype,
-    page_size_padded: int | None = None,
-    mamba_block_size: int,
-    mamba_cache_mode: str = "none",
-) -> MambaSpec:
-    """Build the scheduler-visible GDN state spec.
-
-    A max-length Mamba block gives each request one block in ``none`` mode.
-    """
-    return MambaSpec(
-        shapes=(
-            (conv_kernel_dim - 1, conv_dim),
-            (num_v_heads, value_head_dim, key_head_dim),
-        ),
-        # Match the fp32 recurrent pool used for kernel accumulation.
-        dtypes=(torch_dtype, torch.float32),
-        block_size=mamba_block_size,
-        page_size_padded=page_size_padded,
-        mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
-        mamba_cache_mode=mamba_cache_mode,
-    )
 
 
 class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
@@ -79,35 +43,30 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
     def __init__(
         self,
         *,
-        num_layers: int,
-        full_attention_interval: int,
+        plan: HybridRuntimePlan,
         max_num_seqs: int,
         # SDPA dims
         num_kv_heads: int,
         head_dim: int,
-        # GDN dims
-        linear_num_v_heads: int,
-        linear_key_head_dim: int,
-        linear_value_head_dim: int,
-        linear_conv_kernel_dim: int,
-        linear_conv_dim: int,
         # Common
         block_size: int,
         dtype: mx.Dtype,
-        # Scheduler-side mamba caching strategy ("none" or "align").
+        # Scheduler-side mamba caching strategy.
         mamba_cache_mode: str = "none",
         # TurboQuant (SDPA layers only)
         turboquant: bool = False,
         k_quant: str | None = None,
         v_quant: str | None = None,
     ) -> None:
+        self._plan = plan
         self._max_num_seqs = max_num_seqs
         self._block_size = block_size
         self._dtype = dtype
-        if mamba_cache_mode not in ("none", "align"):
+        if mamba_cache_mode not in plan.family.supported_cache_modes:
             raise NotImplementedError(
                 f"hybrid paged attention does not support mamba_cache_mode="
-                f"{mamba_cache_mode!r} (only 'none' and 'align')"
+                f"{mamba_cache_mode!r} for the {plan.family.label!r} state "
+                f"family (supported: {plan.family.supported_cache_modes})"
             )
         self._mamba_cache_mode = mamba_cache_mode
 
@@ -115,26 +74,15 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         self._num_kv_heads = num_kv_heads
         self._head_dim = head_dim
 
-        # GDN params
-        self._linear_num_v_heads = linear_num_v_heads
-        self._linear_key_head_dim = linear_key_head_dim
-        self._linear_value_head_dim = linear_value_head_dim
-        self._linear_conv_kernel_dim = linear_conv_kernel_dim
-        self._linear_conv_dim = linear_conv_dim
-
         # TurboQuant params (only applies to SDPA layers)
         self._turboquant = turboquant
         self._k_quant = k_quant
         self._v_quant = v_quant
 
-        # Classify layers
-        self._sdpa_indices: list[int] = []
-        self._linear_indices: list[int] = []
-        for i in range(num_layers):
-            if (i + 1) % full_attention_interval == 0:
-                self._sdpa_indices.append(i)
-            else:
-                self._linear_indices.append(i)
+        # Layer topology is owned by the plan; alias its index tuples here
+        # instead of re-deriving them from config math.
+        self._sdpa_indices = plan.layers.attention_indices
+        self._linear_indices = plan.layers.state_indices
 
         self._cache = None
         self._state_cache: GDNPagedStateCache | None = None
@@ -169,14 +117,15 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         # None mode keeps one slab per resident request and grows on demand.
         align = self._mamba_cache_mode == "align"
         state_slots = num_blocks if align else self._max_num_seqs
+        geometry = self._plan.geometry
         self._state_cache = GDNPagedStateCache(
             num_layers=len(self._linear_indices),
             max_seqs=state_slots,
-            conv_kernel_dim=self._linear_conv_kernel_dim,
-            conv_dim=self._linear_conv_dim,
-            num_v_heads=self._linear_num_v_heads,
-            value_head_dim=self._linear_value_head_dim,
-            key_head_dim=self._linear_key_head_dim,
+            conv_kernel_dim=geometry.conv_kernel_dim,
+            conv_dim=geometry.conv_dim,
+            num_v_heads=geometry.num_v_heads,
+            value_head_dim=geometry.value_head_dim,
+            key_head_dim=geometry.key_head_dim,
             initial_seqs=0,
             dtype=self._dtype,
         )
@@ -249,40 +198,33 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         if self._state_cache is None:
             raise RuntimeError("patch_model() called before initialize()")
         state_cache = self._state_cache
-
-        sdpa_cache_map = {
-            layer_idx: cache_idx
-            for cache_idx, layer_idx in enumerate(self._sdpa_indices)
-        }
-        linear_cache_map = {
-            layer_idx: cache_idx
-            for cache_idx, layer_idx in enumerate(self._linear_indices)
-        }
+        plan = self._plan
+        family = plan.family
 
         def wrap_layer(layer_idx: int, attn: Any) -> Any:
             if isinstance(attn, SDPAPagedAttentionWrapper):
                 # Already patched (cached model reuse) — refresh cache refs.
-                cache_idx = sdpa_cache_map.get(layer_idx, layer_idx)
+                cache_idx = plan.layers.attention_cache_index(layer_idx)
                 attn.rebind_cache(kv_cache, self._block_size, cache_idx=cache_idx)
                 return attn
-            if isinstance(attn, GDNPagedAttentionWrapper):
+            if isinstance(attn, family.wrapper_cls):
                 # Already patched — refresh state cache ref.
-                cache_idx = linear_cache_map.get(layer_idx, layer_idx)
-                object.__setattr__(attn, "_gdn_cache_idx", cache_idx)
-                object.__setattr__(attn, "_gdn_state_cache", state_cache)
+                cache_idx = plan.layers.state_cache_index(layer_idx)
+                attn.rebind_state_cache(state_cache, cache_idx=cache_idx)
                 return attn
             if is_sdpa(attn):
-                cache_idx = sdpa_cache_map.get(layer_idx, layer_idx)
+                cache_idx = plan.layers.attention_cache_index(layer_idx)
                 return SDPAPagedAttentionWrapper(
                     attn, layer_idx, kv_cache, self._block_size, cache_idx=cache_idx
                 )
-            if is_linear_attention(attn):
-                cache_idx = linear_cache_map.get(layer_idx, layer_idx)
-                return GDNPagedAttentionWrapper(attn, layer_idx, cache_idx, state_cache)
+            if family.is_state_module(attn):
+                cache_idx = plan.layers.state_cache_index(layer_idx)
+                return family.wrapper_cls(attn, layer_idx, cache_idx, state_cache)
             raise RuntimeError(
                 f"Hybrid patch_model: layer {layer_idx} attention "
-                f"{type(attn).__name__} is neither SDPA nor linear attention; "
-                "refusing to leave it unpatched (it would silently run unpaged)."
+                f"{type(attn).__name__} is neither SDPA nor "
+                f"{family.label!r} state; refusing to leave it unpatched "
+                "(it would silently run unpaged)."
             )
 
         return walk_and_wrap(model, wrap_layer)

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -43,7 +43,7 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
     def __init__(
         self,
         *,
-        plan: HybridRuntimePlan,
+        hybrid_plan: HybridRuntimePlan,
         max_num_seqs: int,
         # SDPA dims
         num_kv_heads: int,
@@ -58,15 +58,16 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         k_quant: str | None = None,
         v_quant: str | None = None,
     ) -> None:
-        self._plan = plan
+        self._hybrid_plan = hybrid_plan
         self._max_num_seqs = max_num_seqs
         self._block_size = block_size
         self._dtype = dtype
-        if mamba_cache_mode not in plan.family.supported_cache_modes:
+        state_family = self._hybrid_plan.family
+        if mamba_cache_mode not in state_family.supported_cache_modes:
             raise NotImplementedError(
                 f"hybrid paged attention does not support mamba_cache_mode="
-                f"{mamba_cache_mode!r} for the {plan.family.label!r} state "
-                f"family (supported: {plan.family.supported_cache_modes})"
+                f"{mamba_cache_mode!r} for the {state_family.label!r} state "
+                f"family (supported: {state_family.supported_cache_modes})"
             )
         self._mamba_cache_mode = mamba_cache_mode
 
@@ -81,8 +82,8 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
 
         # Layer topology is owned by the plan; alias its index tuples here
         # instead of re-deriving them from config math.
-        self._sdpa_indices = plan.layers.attention_indices
-        self._linear_indices = plan.layers.state_indices
+        self._sdpa_indices = self._hybrid_plan.layers.attention_indices
+        self._linear_indices = self._hybrid_plan.layers.state_indices
 
         self._cache = None
         self._state_cache: GDNPagedStateCache | None = None
@@ -117,15 +118,15 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         # None mode keeps one slab per resident request and grows on demand.
         align = self._mamba_cache_mode == "align"
         state_slots = num_blocks if align else self._max_num_seqs
-        geometry = self._plan.geometry
+        state_geometry = self._hybrid_plan.geometry
         self._state_cache = GDNPagedStateCache(
             num_layers=len(self._linear_indices),
             max_seqs=state_slots,
-            conv_kernel_dim=geometry.conv_kernel_dim,
-            conv_dim=geometry.conv_dim,
-            num_v_heads=geometry.num_v_heads,
-            value_head_dim=geometry.value_head_dim,
-            key_head_dim=geometry.key_head_dim,
+            conv_kernel_dim=state_geometry.conv_kernel_dim,
+            conv_dim=state_geometry.conv_dim,
+            num_v_heads=state_geometry.num_v_heads,
+            value_head_dim=state_geometry.value_head_dim,
+            key_head_dim=state_geometry.key_head_dim,
             initial_seqs=0,
             dtype=self._dtype,
         )
@@ -198,32 +199,32 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
         if self._state_cache is None:
             raise RuntimeError("patch_model() called before initialize()")
         state_cache = self._state_cache
-        plan = self._plan
-        family = plan.family
+        layer_plan = self._hybrid_plan.layers
+        state_family = self._hybrid_plan.family
 
         def wrap_layer(layer_idx: int, attn: Any) -> Any:
             if isinstance(attn, SDPAPagedAttentionWrapper):
                 # Already patched (cached model reuse) — refresh cache refs.
-                cache_idx = plan.layers.attention_cache_index(layer_idx)
+                cache_idx = layer_plan.attention_cache_index(layer_idx)
                 attn.rebind_cache(kv_cache, self._block_size, cache_idx=cache_idx)
                 return attn
-            if isinstance(attn, family.wrapper_cls):
+            if isinstance(attn, state_family.wrapper_cls):
                 # Already patched — refresh state cache ref.
-                cache_idx = plan.layers.state_cache_index(layer_idx)
+                cache_idx = layer_plan.state_cache_index(layer_idx)
                 attn.rebind_state_cache(state_cache, cache_idx=cache_idx)
                 return attn
             if is_sdpa(attn):
-                cache_idx = plan.layers.attention_cache_index(layer_idx)
+                cache_idx = layer_plan.attention_cache_index(layer_idx)
                 return SDPAPagedAttentionWrapper(
                     attn, layer_idx, kv_cache, self._block_size, cache_idx=cache_idx
                 )
-            if family.is_state_module(attn):
-                cache_idx = plan.layers.state_cache_index(layer_idx)
-                return family.wrapper_cls(attn, layer_idx, cache_idx, state_cache)
+            if state_family.is_state_module(attn):
+                cache_idx = layer_plan.state_cache_index(layer_idx)
+                return state_family.wrapper_cls(attn, layer_idx, cache_idx, state_cache)
             raise RuntimeError(
                 f"Hybrid patch_model: layer {layer_idx} attention "
                 f"{type(attn).__name__} is neither SDPA nor "
-                f"{family.label!r} state; refusing to leave it unpatched "
+                f"{state_family.label!r} state; refusing to leave it unpatched "
                 "(it would silently run unpaged)."
             )
 

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed carriers for the hybrid paged runtime.
+
+``HybridLayerPlan`` owns layer topology, ``RecurrentStateGeometry`` owns
+state dimensions and ``StateFamilySpec`` owns per-family policy; a family
+owner in ``families/`` builds all three into one ``HybridRuntimePlan``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol, TypeAlias
+
+import mlx.nn as nn
+import torch
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
+
+LayerKind: TypeAlias = Literal["attention", "state"]
+
+ATTENTION_LAYER: LayerKind = "attention"
+STATE_LAYER: LayerKind = "state"
+
+
+class PagedStateWrapper(Protocol):
+    """Construction and rebind contract for a state-family wrapper class."""
+
+    def __init__(
+        self,
+        inner: nn.Module,
+        layer_idx: int,
+        cache_idx: int,
+        state_cache: GDNPagedStateCache,
+    ) -> None: ...
+
+    def rebind_state_cache(
+        self, state_cache: GDNPagedStateCache, *, cache_idx: int
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class HybridLayerPlan:
+    """Which model layers own paged attention KV pages and which own state."""
+
+    kinds: tuple[LayerKind, ...]
+    attention_indices: tuple[int, ...]
+    state_indices: tuple[int, ...]
+
+    @classmethod
+    def from_kinds(cls, kinds: tuple[LayerKind, ...]) -> HybridLayerPlan:
+        """Build a plan, deriving the per-kind index tuples once."""
+        if not kinds:
+            raise ValueError("hybrid layer plan requires at least one layer")
+        return cls(
+            kinds=kinds,
+            attention_indices=tuple(
+                i for i, kind in enumerate(kinds) if kind == ATTENTION_LAYER
+            ),
+            state_indices=tuple(
+                i for i, kind in enumerate(kinds) if kind == STATE_LAYER
+            ),
+        )
+
+    @property
+    def num_attention(self) -> int:
+        return len(self.attention_indices)
+
+    @property
+    def num_state(self) -> int:
+        return len(self.state_indices)
+
+    def kind_of(self, layer_idx: int) -> LayerKind:
+        """Return the kind owning ``layer_idx``; consumers dispatch on it."""
+        if not 0 <= layer_idx < len(self.kinds):
+            raise ValueError(
+                f"hybrid layer plan covers layers 0..{len(self.kinds) - 1}, "
+                f"got layer {layer_idx}"
+            )
+        return self.kinds[layer_idx]
+
+    def attention_cache_index(self, layer_idx: int) -> int:
+        """Return the compact KV cache ordinal owned by an attention layer."""
+        return self._cache_index(self.attention_indices, layer_idx, ATTENTION_LAYER)
+
+    def state_cache_index(self, layer_idx: int) -> int:
+        """Return the compact state ordinal owned by a state layer."""
+        return self._cache_index(self.state_indices, layer_idx, STATE_LAYER)
+
+    @staticmethod
+    def _cache_index(indices: tuple[int, ...], layer_idx: int, kind: LayerKind) -> int:
+        try:
+            return indices.index(layer_idx)
+        except ValueError:
+            raise ValueError(
+                f"hybrid layer plan has no {kind} cache index for layer "
+                f"{layer_idx}; {kind} layers are {indices}"
+            ) from None
+
+
+@dataclass(frozen=True, slots=True)
+class RecurrentStateGeometry:
+    """Per-layer recurrent state dimensions shared by conv and SSM pools."""
+
+    conv_kernel_dim: int
+    conv_dim: int
+    num_v_heads: int
+    value_head_dim: int
+    key_head_dim: int
+
+
+@dataclass(frozen=True, slots=True)
+class StateFamilySpec:
+    """Per-family policy: how state layers are detected, wrapped and typed."""
+
+    label: str
+    wrapper_cls: type[PagedStateWrapper]
+    is_state_module: Callable[[Any], bool]
+    mamba_type: MambaAttentionBackendEnum
+    recurrent_dtype: torch.dtype
+    supported_cache_modes: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class HybridRuntimePlan:
+    """Everything the hybrid runtime and cache sizing need for one model."""
+
+    layers: HybridLayerPlan
+    family: StateFamilySpec
+    geometry: RecurrentStateGeometry
+
+    def state_cache_spec(
+        self,
+        *,
+        conv_dtype: torch.dtype,
+        mamba_block_size: int,
+        page_size_padded: int | None = None,
+        mamba_cache_mode: str = "none",
+    ) -> MambaSpec:
+        """Build the scheduler-visible state spec for one state layer."""
+        geometry = self.geometry
+        return MambaSpec(
+            shapes=(
+                (geometry.conv_kernel_dim - 1, geometry.conv_dim),
+                (
+                    geometry.num_v_heads,
+                    geometry.value_head_dim,
+                    geometry.key_head_dim,
+                ),
+            ),
+            dtypes=(conv_dtype, self.family.recurrent_dtype),
+            block_size=mamba_block_size,
+            page_size_padded=page_size_padded,
+            mamba_type=self.family.mamba_type,
+            mamba_cache_mode=mamba_cache_mode,
+        )

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -86,23 +86,11 @@ class HybridLayerPlan:
 
     def attention_cache_index(self, layer_idx: int) -> int:
         """Return the compact KV cache ordinal owned by an attention layer."""
-        attention_indices = self.attention_indices
-        if layer_idx not in attention_indices:
-            raise ValueError(
-                f"hybrid layer plan has no attention cache index for layer "
-                f"{layer_idx}; attention layers are {attention_indices}"
-            )
-        return attention_indices.index(layer_idx)
+        return self.attention_indices.index(layer_idx)
 
     def state_cache_index(self, layer_idx: int) -> int:
         """Return the compact state ordinal owned by a state layer."""
-        state_indices = self.state_indices
-        if layer_idx not in state_indices:
-            raise ValueError(
-                f"hybrid layer plan has no state cache index for layer "
-                f"{layer_idx}; state layers are {state_indices}"
-            )
-        return state_indices.index(layer_idx)
+        return self.state_indices.index(layer_idx)
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -79,6 +79,10 @@ class HybridLayerPlan:
         """Return the role owning ``layer_idx``; consumers dispatch on it."""
         return self.layer_roles[layer_idx]
 
+    def is_state_layer(self, layer_idx: int) -> bool:
+        """Return whether ``layer_idx`` is owned by the state runtime."""
+        return self.layer_roles[layer_idx] == STATE_LAYER
+
     def attention_cache_index(self, layer_idx: int) -> int:
         """Return the compact KV cache ordinal owned by an attention layer."""
         return self.attention_indices.index(layer_idx)

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -86,21 +86,23 @@ class HybridLayerPlan:
 
     def attention_cache_index(self, layer_idx: int) -> int:
         """Return the compact KV cache ordinal owned by an attention layer."""
-        return self._cache_index(self.attention_indices, layer_idx, ATTENTION_LAYER)
+        attention_indices = self.attention_indices
+        if layer_idx not in attention_indices:
+            raise ValueError(
+                f"hybrid layer plan has no attention cache index for layer "
+                f"{layer_idx}; attention layers are {attention_indices}"
+            )
+        return attention_indices.index(layer_idx)
 
     def state_cache_index(self, layer_idx: int) -> int:
         """Return the compact state ordinal owned by a state layer."""
-        return self._cache_index(self.state_indices, layer_idx, STATE_LAYER)
-
-    @staticmethod
-    def _cache_index(indices: tuple[int, ...], layer_idx: int, role: LayerRole) -> int:
-        try:
-            return indices.index(layer_idx)
-        except ValueError:
+        state_indices = self.state_indices
+        if layer_idx not in state_indices:
             raise ValueError(
-                f"hybrid layer plan has no {role} cache index for layer "
-                f"{layer_idx}; {role} layers are {indices}"
-            ) from None
+                f"hybrid layer plan has no state cache index for layer "
+                f"{layer_idx}; state layers are {state_indices}"
+            )
+        return state_indices.index(layer_idx)
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -124,8 +124,8 @@ class HybridRuntimePlan:
         *,
         conv_dtype: torch.dtype,
         mamba_block_size: int,
-        page_size_padded: int | None = None,
-        mamba_cache_mode: str = "none",
+        page_size_padded: int | None,
+        mamba_cache_mode: str,
     ) -> MambaSpec:
         """Build the scheduler-visible state spec for one state layer."""
         geometry = self.geometry

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -123,6 +123,20 @@ class HybridRuntimePlan:
     family: StateFamilySpec
     geometry: RecurrentStateGeometry
 
+    def state_bytes_per_layer(self, conv_dtype_size: int) -> int:
+        """Bytes one request holds in one recurrent state layer."""
+        geometry = self.geometry
+        conv_bytes = (
+            (geometry.conv_kernel_dim - 1) * geometry.conv_dim * conv_dtype_size
+        )
+        recurrent_bytes = (
+            geometry.num_v_heads
+            * geometry.value_head_dim
+            * geometry.key_head_dim
+            * self.family.recurrent_dtype.itemsize
+        )
+        return conv_bytes + recurrent_bytes
+
     def state_cache_spec(
         self,
         *,

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -19,10 +19,10 @@ from vllm.v1.kv_cache_interface import MambaSpec
 
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
 
-LayerKind: TypeAlias = Literal["attention", "state"]
+LayerRole: TypeAlias = Literal["attention", "state"]
 
-ATTENTION_LAYER: LayerKind = "attention"
-STATE_LAYER: LayerKind = "state"
+ATTENTION_LAYER: LayerRole = "attention"
+STATE_LAYER: LayerRole = "state"
 
 
 class PagedStateWrapper(Protocol):
@@ -45,23 +45,27 @@ class PagedStateWrapper(Protocol):
 class HybridLayerPlan:
     """Which model layers own paged attention KV pages and which own state.
 
-    ``kinds`` is the single source of truth; index tuples and counts are
-    derived from it on access.
+    ``layer_roles`` is the single source of truth; index tuples and counts
+    are derived from it on access.
     """
 
-    kinds: tuple[LayerKind, ...]
+    layer_roles: tuple[LayerRole, ...]
 
     def __post_init__(self) -> None:
-        if not self.kinds:
+        if not self.layer_roles:
             raise ValueError("hybrid layer plan requires at least one layer")
 
     @property
     def attention_indices(self) -> tuple[int, ...]:
-        return tuple(i for i, kind in enumerate(self.kinds) if kind == ATTENTION_LAYER)
+        return tuple(
+            i for i, role in enumerate(self.layer_roles) if role == ATTENTION_LAYER
+        )
 
     @property
     def state_indices(self) -> tuple[int, ...]:
-        return tuple(i for i, kind in enumerate(self.kinds) if kind == STATE_LAYER)
+        return tuple(
+            i for i, role in enumerate(self.layer_roles) if role == STATE_LAYER
+        )
 
     @property
     def num_attention(self) -> int:
@@ -71,14 +75,14 @@ class HybridLayerPlan:
     def num_state(self) -> int:
         return len(self.state_indices)
 
-    def layer_kind(self, layer_idx: int) -> LayerKind:
-        """Return the kind owning ``layer_idx``; consumers dispatch on it."""
-        if not 0 <= layer_idx < len(self.kinds):
+    def layer_role(self, layer_idx: int) -> LayerRole:
+        """Return the role owning ``layer_idx``; consumers dispatch on it."""
+        if not 0 <= layer_idx < len(self.layer_roles):
             raise ValueError(
-                f"hybrid layer plan covers layers 0..{len(self.kinds) - 1}, "
+                f"hybrid layer plan covers layers 0..{len(self.layer_roles) - 1}, "
                 f"got layer {layer_idx}"
             )
-        return self.kinds[layer_idx]
+        return self.layer_roles[layer_idx]
 
     def attention_cache_index(self, layer_idx: int) -> int:
         """Return the compact KV cache ordinal owned by an attention layer."""
@@ -89,13 +93,13 @@ class HybridLayerPlan:
         return self._cache_index(self.state_indices, layer_idx, STATE_LAYER)
 
     @staticmethod
-    def _cache_index(indices: tuple[int, ...], layer_idx: int, kind: LayerKind) -> int:
+    def _cache_index(indices: tuple[int, ...], layer_idx: int, role: LayerRole) -> int:
         try:
             return indices.index(layer_idx)
         except ValueError:
             raise ValueError(
-                f"hybrid layer plan has no {kind} cache index for layer "
-                f"{layer_idx}; {kind} layers are {indices}"
+                f"hybrid layer plan has no {role} cache index for layer "
+                f"{layer_idx}; {role} layers are {indices}"
             ) from None
 
 

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -43,26 +43,25 @@ class PagedStateWrapper(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class HybridLayerPlan:
-    """Which model layers own paged attention KV pages and which own state."""
+    """Which model layers own paged attention KV pages and which own state.
+
+    ``kinds`` is the single source of truth; index tuples and counts are
+    derived from it on access.
+    """
 
     kinds: tuple[LayerKind, ...]
-    attention_indices: tuple[int, ...]
-    state_indices: tuple[int, ...]
 
-    @classmethod
-    def from_kinds(cls, kinds: tuple[LayerKind, ...]) -> HybridLayerPlan:
-        """Build a plan, deriving the per-kind index tuples once."""
-        if not kinds:
+    def __post_init__(self) -> None:
+        if not self.kinds:
             raise ValueError("hybrid layer plan requires at least one layer")
-        return cls(
-            kinds=kinds,
-            attention_indices=tuple(
-                i for i, kind in enumerate(kinds) if kind == ATTENTION_LAYER
-            ),
-            state_indices=tuple(
-                i for i, kind in enumerate(kinds) if kind == STATE_LAYER
-            ),
-        )
+
+    @property
+    def attention_indices(self) -> tuple[int, ...]:
+        return tuple(i for i, kind in enumerate(self.kinds) if kind == ATTENTION_LAYER)
+
+    @property
+    def state_indices(self) -> tuple[int, ...]:
+        return tuple(i for i, kind in enumerate(self.kinds) if kind == STATE_LAYER)
 
     @property
     def num_attention(self) -> int:
@@ -72,7 +71,7 @@ class HybridLayerPlan:
     def num_state(self) -> int:
         return len(self.state_indices)
 
-    def kind_of(self, layer_idx: int) -> LayerKind:
+    def layer_kind(self, layer_idx: int) -> LayerKind:
         """Return the kind owning ``layer_idx``; consumers dispatch on it."""
         if not 0 <= layer_idx < len(self.kinds):
             raise ValueError(

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -77,11 +77,6 @@ class HybridLayerPlan:
 
     def layer_role(self, layer_idx: int) -> LayerRole:
         """Return the role owning ``layer_idx``; consumers dispatch on it."""
-        if not 0 <= layer_idx < len(self.layer_roles):
-            raise ValueError(
-                f"hybrid layer plan covers layers 0..{len(self.layer_roles) - 1}, "
-                f"got layer {layer_idx}"
-            )
         return self.layer_roles[layer_idx]
 
     def attention_cache_index(self, layer_idx: int) -> int:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -376,70 +376,99 @@ class ModelCachePolicy:
             num_spec_layers, _ = self._runner._yoco_cache_mapping
         specs: dict[str, KVCacheSpec] = {}
         use_deferred_mha_layout = self._uses_deferred_mha_layout()
-        hybrid_plan = self._hybrid_plan() if self._runner.is_hybrid else None
-        for layer_idx in range(num_spec_layers):
-            layer_role = (
-                hybrid_plan.layers.layer_role(layer_idx)
-                if hybrid_plan is not None
-                else None
+
+        def attention_spec(layer_idx: int) -> KVCacheSpec:
+            return self._attention_layer_spec(
+                layer_idx,
+                block_size=block_size,
+                num_kv_heads=kv_heads[layer_idx],
+                head_dim=head_dims[layer_idx],
+                torch_dtype=torch_dtype,
+                use_turboquant=use_turboquant,
+                config=config,
+                use_deferred_mha_layout=use_deferred_mha_layout,
             )
-            if hybrid_plan is not None and layer_role == STATE_LAYER:
-                layer_name = f"layers.{layer_idx}.linear_attn"
-                cache_config = self._runner.cache_config
-                mamba_block_size = cache_config.mamba_block_size
-                # Upstream resolves this during config setup and asserts it here.
-                assert mamba_block_size is not None
-                specs[layer_name] = hybrid_plan.state_cache_spec(
-                    conv_dtype=torch_dtype,
-                    mamba_block_size=mamba_block_size,
-                    page_size_padded=cache_config.mamba_page_size_padded,
-                    mamba_cache_mode=cache_config.mamba_cache_mode,
-                )
-            elif use_turboquant:
-                layer_name = f"layers.{layer_idx}.self_attn"
-                specs[layer_name] = _build_turboquant_attention_spec(
-                    block_size=block_size,
-                    num_kv_heads=self._runner.num_kv_heads,
-                    head_dim=self._runner.head_dim,
-                    k_quant=config.k_quant,
-                    v_quant=config.v_quant,
-                )
-            else:
-                layer_name = f"layers.{layer_idx}.self_attn"
-                # MLA caches a single latent tensor per layer, not separate K
-                # and V (see ``MLAPagedLatentCache``), which is why
-                # ``_kv_factor`` bills it at 1.  ``FullAttentionSpec`` bakes
-                # the 2x K/V factor into ``page_size_bytes`` (head_size +
-                # head_size_v), so describing MLA with it makes the engine
-                # halve the block count it plans against relative to the pool
-                # actually allocated.
-                if self._runner.is_mla:
-                    specs[layer_name] = MLAAttentionSpec(
-                        block_size=block_size,
-                        num_kv_heads=kv_heads[layer_idx],
-                        head_size=head_dims[layer_idx],
-                        dtype=torch_dtype,
-                    )
-                elif use_deferred_mha_layout:
-                    specs[layer_name] = self._build_mha_attention_spec(
-                        layer_idx=layer_idx,
-                        block_size=block_size,
-                        num_kv_heads=kv_heads[layer_idx],
-                        head_dim=head_dims[layer_idx],
-                        torch_dtype=torch_dtype,
-                    )
+
+        if self._runner.is_hybrid:
+            hybrid_plan = self._hybrid_plan()
+            state_spec = self._state_layer_spec(hybrid_plan, torch_dtype)
+            for layer_idx in range(num_spec_layers):
+                if hybrid_plan.layers.layer_role(layer_idx) == STATE_LAYER:
+                    specs[f"layers.{layer_idx}.linear_attn"] = state_spec
                 else:
-                    specs[layer_name] = FullAttentionSpec(
-                        block_size=block_size,
-                        num_kv_heads=kv_heads[layer_idx],
-                        head_size=head_dims[layer_idx],
-                        dtype=torch_dtype,
-                    )
+                    specs[f"layers.{layer_idx}.self_attn"] = attention_spec(layer_idx)
+        else:
+            for layer_idx in range(num_spec_layers):
+                specs[f"layers.{layer_idx}.self_attn"] = attention_spec(layer_idx)
 
         specs.update(
             self._draft_layer_specs(block_size=block_size, torch_dtype=torch_dtype)
         )
         return specs
+
+    def _state_layer_spec(
+        self, hybrid_plan: HybridRuntimePlan, torch_dtype: torch.dtype
+    ) -> MambaSpec:
+        """Build the scheduler-visible spec shared by every state layer."""
+        cache_config = self._runner.cache_config
+        mamba_block_size = cache_config.mamba_block_size
+        # Upstream resolves this during config setup and asserts it here.
+        assert mamba_block_size is not None
+        return hybrid_plan.state_cache_spec(
+            conv_dtype=torch_dtype,
+            mamba_block_size=mamba_block_size,
+            page_size_padded=cache_config.mamba_page_size_padded,
+            mamba_cache_mode=cache_config.mamba_cache_mode,
+        )
+
+    def _attention_layer_spec(
+        self,
+        layer_idx: int,
+        *,
+        block_size: int,
+        num_kv_heads: int,
+        head_dim: int,
+        torch_dtype: torch.dtype,
+        use_turboquant: bool,
+        config: MetalConfig,
+        use_deferred_mha_layout: bool,
+    ) -> KVCacheSpec:
+        """Build the scheduler-visible spec for one attention layer."""
+        if use_turboquant:
+            return _build_turboquant_attention_spec(
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                k_quant=config.k_quant,
+                v_quant=config.v_quant,
+            )
+        # MLA caches a single latent tensor per layer, not separate K and V
+        # (see ``MLAPagedLatentCache``), which is why ``_kv_factor`` bills it
+        # at 1.  ``FullAttentionSpec`` bakes the 2x K/V factor into
+        # ``page_size_bytes`` (head_size + head_size_v), so describing MLA with
+        # it makes the engine halve the block count it plans against relative
+        # to the pool actually allocated.
+        if self._runner.is_mla:
+            return MLAAttentionSpec(
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+                head_size=head_dim,
+                dtype=torch_dtype,
+            )
+        if use_deferred_mha_layout:
+            return self._build_mha_attention_spec(
+                layer_idx=layer_idx,
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                torch_dtype=torch_dtype,
+            )
+        return FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=num_kv_heads,
+            head_size=head_dim,
+            dtype=torch_dtype,
+        )
 
     def _draft_layer_specs(
         self, *, block_size: int, torch_dtype: torch.dtype
@@ -611,11 +640,13 @@ class ModelCachePolicy:
                 "hybrid cache config requires HybridPagedAttentionRuntime"
             )
 
+        hybrid_plan = self._hybrid_plan()
+        layer_plan = hybrid_plan.layers
         group_indices = self._scheduler_group_indices_for_layers(
             kv_cache_config,
             tuple(
                 f"layers.{layer_idx}.self_attn"
-                for layer_idx in self._hybrid_plan().layers.attention_indices
+                for layer_idx in layer_plan.attention_indices
             ),
         )
         if len(group_indices) != 1:
@@ -639,9 +670,7 @@ class ModelCachePolicy:
         if self._runner.cache_config.mamba_cache_mode == "align":
             cache_idx_by_name = {
                 f"layers.{layer_idx}.linear_attn": cache_idx
-                for cache_idx, layer_idx in enumerate(
-                    self._hybrid_plan().layers.state_indices
-                )
+                for cache_idx, layer_idx in enumerate(layer_plan.state_indices)
             }
             mamba_group_ids = [
                 index
@@ -694,8 +723,7 @@ class ModelCachePolicy:
                     "layer; cannot derive state pools"
                 )
             budgeted = _align_state_pool_count(
-                len(cache_idx_by_name),
-                self._hybrid_plan().layers.num_attention,
+                len(cache_idx_by_name), layer_plan.num_attention
             )
             if pools_used > budgeted:
                 raise RuntimeError(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -891,34 +891,25 @@ class ModelCachePolicy:
         if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
         hybrid_plan = self._hybrid_plan()
-        return hybrid_plan.layers.num_state * self._state_bytes_per_layer(hybrid_plan)
+        return hybrid_plan.layers.num_state * hybrid_plan.state_bytes_per_layer(
+            self._require_kv_cache_dtype().size
+        )
 
     def hybrid_align_state_bytes_per_block(self) -> int:
         """Per-pool-block linear-state bytes under align-mode prefix caching."""
         hybrid_plan = self._hybrid_plan()
         layer_plan = hybrid_plan.layers
         pools = _align_state_pool_count(layer_plan.num_state, layer_plan.num_attention)
-        return self._state_bytes_per_layer(hybrid_plan) * pools
+        return (
+            hybrid_plan.state_bytes_per_layer(self._require_kv_cache_dtype().size)
+            * pools
+        )
 
     def hybrid_align_growth_bytes_per_block(self) -> int:
         """One old physical state pool retained during align-cache growth."""
-        return self._state_bytes_per_layer(self._hybrid_plan())
-
-    def _state_bytes_per_layer(self, hybrid_plan: HybridRuntimePlan) -> int:
-        """Bytes one request holds in one state layer: conv tail plus SSM state."""
-        state_geometry = hybrid_plan.geometry
-        conv_bytes = (
-            (state_geometry.conv_kernel_dim - 1)
-            * state_geometry.conv_dim
-            * self._require_kv_cache_dtype().size
+        return self._hybrid_plan().state_bytes_per_layer(
+            self._require_kv_cache_dtype().size
         )
-        recurrent_bytes = (
-            state_geometry.num_v_heads
-            * state_geometry.value_head_dim
-            * state_geometry.key_head_dim
-            * hybrid_plan.family.recurrent_dtype.itemsize
-        )
-        return conv_bytes + recurrent_bytes
 
     def build_paged_attention_runtime(
         self, *, block_size: int

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -379,7 +379,7 @@ class ModelCachePolicy:
         hybrid_plan = self._hybrid_plan() if self._runner.is_hybrid else None
         for layer_idx in range(num_spec_layers):
             layer_role = (
-                hybrid_plan.layers.layer_kind(layer_idx)
+                hybrid_plan.layers.layer_role(layer_idx)
                 if hybrid_plan is not None
                 else None
             )

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -30,10 +30,7 @@ from vllm_metal.attention.caches.turboquant import (
     packed_dim,
 )
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
-from vllm_metal.attention.runtime.hybrid_plan import (
-    STATE_LAYER,
-    HybridRuntimePlan,
-)
+from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.attention.runtime.mla import MLAPagedAttentionRuntime
 from vllm_metal.attention.runtime.protocol import PagedAttentionRuntime
@@ -393,7 +390,7 @@ class ModelCachePolicy:
             hybrid_plan = self._hybrid_plan()
             state_spec = self._state_layer_spec(hybrid_plan, torch_dtype)
             for layer_idx in range(num_spec_layers):
-                if hybrid_plan.layers.layer_role(layer_idx) == STATE_LAYER:
+                if hybrid_plan.layers.is_state_layer(layer_idx):
                     specs[f"layers.{layer_idx}.linear_attn"] = state_spec
                 else:
                     specs[f"layers.{layer_idx}.self_attn"] = attention_spec(layer_idx)

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -29,9 +29,11 @@ from vllm_metal.attention.caches.turboquant import (
     V_QUANT_PARAMS,
     packed_dim,
 )
-from vllm_metal.attention.runtime.hybrid import (
-    HybridPagedAttentionRuntime,
-    _build_linear_layer_spec,
+from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
+from vllm_metal.attention.runtime.hybrid_plan import (
+    ATTENTION_LAYER,
+    STATE_LAYER,
+    HybridRuntimePlan,
 )
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.attention.runtime.mla import MLAPagedAttentionRuntime
@@ -65,6 +67,17 @@ def _align_state_pool_count(num_linear_layers: int, num_sdpa_layers: int) -> int
     if num_sdpa_layers > 0 and num_linear_layers % num_sdpa_layers == 0:
         return num_sdpa_layers
     return num_linear_layers
+
+
+def _require_runner_hybrid_plan(runner: MetalModelRunner) -> HybridRuntimePlan:
+    """Return the resolved hybrid plan, failing fast if lifecycle skipped it."""
+    plan = runner.hybrid_runtime_plan
+    if plan is None:
+        raise RuntimeError(
+            "hybrid model has no resolved hybrid_runtime_plan; "
+            "ModelLifecycle.resolve_model_dims must run before cache sizing"
+        )
+    return plan
 
 
 HYBRID_GDN_GROWTH_CUSHION_SLOTS = 2
@@ -316,6 +329,9 @@ class ModelCachePolicy:
             return "paged_attention_capacity"
         return "single_sequence_estimate"
 
+    def _require_hybrid_plan(self) -> HybridRuntimePlan:
+        return _require_runner_hybrid_plan(self._runner)
+
     def _uses_deferred_mha_layout(self) -> bool:
         """Return whether vLLM's grouped MHA config must own allocation."""
         kv_heads = self._runner.kv_heads_per_layer
@@ -365,26 +381,32 @@ class ModelCachePolicy:
             num_spec_layers, _ = self._runner._yoco_cache_mapping
         specs: dict[str, KVCacheSpec] = {}
         use_deferred_mha_layout = self._uses_deferred_mha_layout()
+        hybrid_plan = self._require_hybrid_plan() if self._runner.is_hybrid else None
         for layer_idx in range(num_spec_layers):
             if (
-                self._runner.is_hybrid
-                and layer_idx not in self._runner.sdpa_layer_indices
+                hybrid_plan is not None
+                and hybrid_plan.layers.kind_of(layer_idx) == STATE_LAYER
             ):
                 layer_name = f"layers.{layer_idx}.linear_attn"
                 cache_config = self._runner.cache_config
                 mamba_block_size = cache_config.mamba_block_size
                 # Upstream resolves this during config setup and asserts it here.
                 assert mamba_block_size is not None
-                specs[layer_name] = _build_linear_layer_spec(
-                    conv_kernel_dim=self._runner.linear_conv_kernel_dim,
-                    conv_dim=self._runner.linear_conv_dim,
-                    num_v_heads=self._runner.linear_num_v_heads,
-                    value_head_dim=self._runner.linear_value_head_dim,
-                    key_head_dim=self._runner.linear_key_head_dim,
-                    torch_dtype=torch_dtype,
-                    page_size_padded=cache_config.mamba_page_size_padded,
+                specs[layer_name] = hybrid_plan.state_cache_spec(
+                    conv_dtype=torch_dtype,
                     mamba_block_size=mamba_block_size,
+                    page_size_padded=cache_config.mamba_page_size_padded,
                     mamba_cache_mode=cache_config.mamba_cache_mode,
+                )
+            elif (
+                hybrid_plan is not None
+                and hybrid_plan.layers.kind_of(layer_idx) != ATTENTION_LAYER
+            ):
+                # Unreachable while LayerKind is the closed two-member
+                # Literal; fail-fast for when a future family adds a kind.
+                raise NotImplementedError(
+                    f"hybrid cache sizing has no spec for layer {layer_idx} "
+                    f"of kind {hybrid_plan.layers.kind_of(layer_idx)!r}"
                 )
             elif use_turboquant:
                 layer_name = f"layers.{layer_idx}.self_attn"
@@ -606,7 +628,7 @@ class ModelCachePolicy:
             kv_cache_config,
             tuple(
                 f"layers.{layer_idx}.self_attn"
-                for layer_idx in sorted(self._runner.sdpa_layer_indices)
+                for layer_idx in self._require_hybrid_plan().layers.attention_indices
             ),
         )
         if len(group_indices) != 1:
@@ -631,9 +653,7 @@ class ModelCachePolicy:
             cache_idx_by_name = {
                 f"layers.{layer_idx}.linear_attn": cache_idx
                 for cache_idx, layer_idx in enumerate(
-                    layer_idx
-                    for layer_idx in range(self._runner.num_layers)
-                    if layer_idx not in self._runner.sdpa_layer_indices
+                    self._require_hybrid_plan().layers.state_indices
                 )
             }
             mamba_group_ids = [
@@ -687,7 +707,8 @@ class ModelCachePolicy:
                     "layer; cannot derive state pools"
                 )
             budgeted = _align_state_pool_count(
-                len(cache_idx_by_name), len(self._runner.sdpa_layer_indices)
+                len(cache_idx_by_name),
+                self._require_hybrid_plan().layers.num_attention,
             )
             if pools_used > budgeted:
                 raise RuntimeError(
@@ -857,20 +878,18 @@ class ModelCachePolicy:
         """Return bytes for one request's linear-attention state."""
         if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
+        plan = self._require_hybrid_plan()
+        geometry = plan.geometry
         dtype_size = self._require_kv_cache_dtype().size
-        recurrent_dtype_size = mx.float32.size
-        conv_bytes = (
-            (self._runner.linear_conv_kernel_dim - 1)
-            * self._runner.linear_conv_dim
-            * dtype_size
-        )
+        recurrent_dtype_size = plan.family.recurrent_dtype.itemsize
+        conv_bytes = (geometry.conv_kernel_dim - 1) * geometry.conv_dim * dtype_size
         recurrent_bytes = (
-            self._runner.linear_num_v_heads
-            * self._runner.linear_value_head_dim
-            * self._runner.linear_key_head_dim
+            geometry.num_v_heads
+            * geometry.value_head_dim
+            * geometry.key_head_dim
             * recurrent_dtype_size
         )
-        return self._runner.num_linear_layers * (conv_bytes + recurrent_bytes)
+        return plan.layers.num_state * (conv_bytes + recurrent_bytes)
 
     def build_paged_attention_runtime(
         self, *, block_size: int
@@ -947,22 +966,16 @@ class ModelCachePolicy:
         # this mirror must follow.
         padded = self._runner.cache_config.mamba_page_size_padded
         if padded is not None:
-            return self._runner.num_linear_layers * padded
+            return self._require_hybrid_plan().layers.num_state * padded
         return self.linear_cache_bytes_per_slot()
 
     def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionRuntime:
         config = get_config()
         return HybridPagedAttentionRuntime(
-            num_layers=self._runner.num_layers,
-            full_attention_interval=self._runner.full_attention_interval,
+            plan=self._require_hybrid_plan(),
             max_num_seqs=self._runner.scheduler_config.max_num_seqs,
             num_kv_heads=self._runner.num_kv_heads,
             head_dim=self._runner.head_dim,
-            linear_num_v_heads=self._runner.linear_num_v_heads,
-            linear_key_head_dim=self._runner.linear_key_head_dim,
-            linear_value_head_dim=self._runner.linear_value_head_dim,
-            linear_conv_kernel_dim=self._runner.linear_conv_kernel_dim,
-            linear_conv_dim=self._runner.linear_conv_dim,
             block_size=block_size,
             dtype=self._require_kv_cache_dtype(),
             mamba_cache_mode=self._runner.cache_config.mamba_cache_mode,
@@ -1064,7 +1077,7 @@ class ModelCachePolicy:
 
     def _num_kv_cache_layers(self) -> int:
         if self._runner.is_hybrid:
-            return self._runner.num_sdpa_layers
+            return self._require_hybrid_plan().layers.num_attention
         return self._runner.num_kv_cache_layers
 
     def _use_turboquant(self, config: MetalConfig) -> bool:
@@ -1292,8 +1305,9 @@ class WorkerCachePlanner:
             return 0
         if runner.cache_config.mamba_cache_mode != "align":
             return 0
-        num_linear = runner.num_layers - len(runner.sdpa_layer_indices)
-        pools = _align_state_pool_count(num_linear, len(runner.sdpa_layer_indices))
+        plan = _require_runner_hybrid_plan(runner)
+        num_linear = plan.layers.num_state
+        pools = _align_state_pool_count(num_linear, plan.layers.num_attention)
         return runner.linear_cache_bytes_per_slot() * pools // num_linear
 
     def _hybrid_align_growth_bytes_per_block(self) -> int:
@@ -1303,7 +1317,7 @@ class WorkerCachePlanner:
             return 0
         if runner.cache_config.mamba_cache_mode != "align":
             return 0
-        num_linear = runner.num_layers - len(runner.sdpa_layer_indices)
+        num_linear = _require_runner_hybrid_plan(runner).layers.num_state
         return runner.linear_cache_bytes_per_slot() // num_linear
 
     def _hybrid_gdn_reservation(self) -> _HybridGDNReservation:

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -31,7 +31,6 @@ from vllm_metal.attention.caches.turboquant import (
 )
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
 from vllm_metal.attention.runtime.hybrid_plan import (
-    ATTENTION_LAYER,
     STATE_LAYER,
     HybridRuntimePlan,
 )
@@ -67,17 +66,6 @@ def _align_state_pool_count(num_linear_layers: int, num_sdpa_layers: int) -> int
     if num_sdpa_layers > 0 and num_linear_layers % num_sdpa_layers == 0:
         return num_sdpa_layers
     return num_linear_layers
-
-
-def _require_runner_hybrid_plan(runner: MetalModelRunner) -> HybridRuntimePlan:
-    """Return the resolved hybrid plan, failing fast if lifecycle skipped it."""
-    plan = runner.hybrid_runtime_plan
-    if plan is None:
-        raise RuntimeError(
-            "hybrid model has no resolved hybrid_runtime_plan; "
-            "ModelLifecycle.resolve_model_dims must run before cache sizing"
-        )
-    return plan
 
 
 HYBRID_GDN_GROWTH_CUSHION_SLOTS = 2
@@ -329,8 +317,15 @@ class ModelCachePolicy:
             return "paged_attention_capacity"
         return "single_sequence_estimate"
 
-    def _require_hybrid_plan(self) -> HybridRuntimePlan:
-        return _require_runner_hybrid_plan(self._runner)
+    def _hybrid_plan(self) -> HybridRuntimePlan:
+        """Return the resolved hybrid plan, failing fast if lifecycle skipped it."""
+        plan = self._runner.hybrid_runtime_plan
+        if plan is None:
+            raise RuntimeError(
+                "hybrid model has no resolved hybrid_runtime_plan; "
+                "ModelLifecycle.resolve_model_dims must run before cache sizing"
+            )
+        return plan
 
     def _uses_deferred_mha_layout(self) -> bool:
         """Return whether vLLM's grouped MHA config must own allocation."""
@@ -381,12 +376,14 @@ class ModelCachePolicy:
             num_spec_layers, _ = self._runner._yoco_cache_mapping
         specs: dict[str, KVCacheSpec] = {}
         use_deferred_mha_layout = self._uses_deferred_mha_layout()
-        hybrid_plan = self._require_hybrid_plan() if self._runner.is_hybrid else None
+        hybrid_plan = self._hybrid_plan() if self._runner.is_hybrid else None
         for layer_idx in range(num_spec_layers):
-            if (
-                hybrid_plan is not None
-                and hybrid_plan.layers.kind_of(layer_idx) == STATE_LAYER
-            ):
+            layer_role = (
+                hybrid_plan.layers.layer_kind(layer_idx)
+                if hybrid_plan is not None
+                else None
+            )
+            if hybrid_plan is not None and layer_role == STATE_LAYER:
                 layer_name = f"layers.{layer_idx}.linear_attn"
                 cache_config = self._runner.cache_config
                 mamba_block_size = cache_config.mamba_block_size
@@ -397,16 +394,6 @@ class ModelCachePolicy:
                     mamba_block_size=mamba_block_size,
                     page_size_padded=cache_config.mamba_page_size_padded,
                     mamba_cache_mode=cache_config.mamba_cache_mode,
-                )
-            elif (
-                hybrid_plan is not None
-                and hybrid_plan.layers.kind_of(layer_idx) != ATTENTION_LAYER
-            ):
-                # Unreachable while LayerKind is the closed two-member
-                # Literal; fail-fast for when a future family adds a kind.
-                raise NotImplementedError(
-                    f"hybrid cache sizing has no spec for layer {layer_idx} "
-                    f"of kind {hybrid_plan.layers.kind_of(layer_idx)!r}"
                 )
             elif use_turboquant:
                 layer_name = f"layers.{layer_idx}.self_attn"
@@ -628,7 +615,7 @@ class ModelCachePolicy:
             kv_cache_config,
             tuple(
                 f"layers.{layer_idx}.self_attn"
-                for layer_idx in self._require_hybrid_plan().layers.attention_indices
+                for layer_idx in self._hybrid_plan().layers.attention_indices
             ),
         )
         if len(group_indices) != 1:
@@ -653,7 +640,7 @@ class ModelCachePolicy:
             cache_idx_by_name = {
                 f"layers.{layer_idx}.linear_attn": cache_idx
                 for cache_idx, layer_idx in enumerate(
-                    self._require_hybrid_plan().layers.state_indices
+                    self._hybrid_plan().layers.state_indices
                 )
             }
             mamba_group_ids = [
@@ -708,7 +695,7 @@ class ModelCachePolicy:
                 )
             budgeted = _align_state_pool_count(
                 len(cache_idx_by_name),
-                self._require_hybrid_plan().layers.num_attention,
+                self._hybrid_plan().layers.num_attention,
             )
             if pools_used > budgeted:
                 raise RuntimeError(
@@ -878,7 +865,7 @@ class ModelCachePolicy:
         """Return bytes for one request's linear-attention state."""
         if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
-        plan = self._require_hybrid_plan()
+        plan = self._hybrid_plan()
         geometry = plan.geometry
         dtype_size = self._require_kv_cache_dtype().size
         recurrent_dtype_size = plan.family.recurrent_dtype.itemsize
@@ -966,13 +953,13 @@ class ModelCachePolicy:
         # this mirror must follow.
         padded = self._runner.cache_config.mamba_page_size_padded
         if padded is not None:
-            return self._require_hybrid_plan().layers.num_state * padded
+            return self._hybrid_plan().layers.num_state * padded
         return self.linear_cache_bytes_per_slot()
 
     def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionRuntime:
         config = get_config()
         return HybridPagedAttentionRuntime(
-            plan=self._require_hybrid_plan(),
+            hybrid_plan=self._hybrid_plan(),
             max_num_seqs=self._runner.scheduler_config.max_num_seqs,
             num_kv_heads=self._runner.num_kv_heads,
             head_dim=self._runner.head_dim,
@@ -1077,7 +1064,7 @@ class ModelCachePolicy:
 
     def _num_kv_cache_layers(self) -> int:
         if self._runner.is_hybrid:
-            return self._require_hybrid_plan().layers.num_attention
+            return self._hybrid_plan().layers.num_attention
         return self._runner.num_kv_cache_layers
 
     def _use_turboquant(self, config: MetalConfig) -> bool:
@@ -1305,10 +1292,14 @@ class WorkerCachePlanner:
             return 0
         if runner.cache_config.mamba_cache_mode != "align":
             return 0
-        plan = _require_runner_hybrid_plan(runner)
+        # linear_cache_bytes_per_slot routes through ModelCachePolicy, whose
+        # _hybrid_plan() enforces the plan-resolved invariant.
+        bytes_per_slot = runner.linear_cache_bytes_per_slot()
+        plan = runner.hybrid_runtime_plan
+        assert plan is not None
         num_linear = plan.layers.num_state
         pools = _align_state_pool_count(num_linear, plan.layers.num_attention)
-        return runner.linear_cache_bytes_per_slot() * pools // num_linear
+        return bytes_per_slot * pools // num_linear
 
     def _hybrid_align_growth_bytes_per_block(self) -> int:
         """One old physical state pool retained during align-cache growth."""
@@ -1317,8 +1308,12 @@ class WorkerCachePlanner:
             return 0
         if runner.cache_config.mamba_cache_mode != "align":
             return 0
-        num_linear = _require_runner_hybrid_plan(runner).layers.num_state
-        return runner.linear_cache_bytes_per_slot() // num_linear
+        # linear_cache_bytes_per_slot routes through ModelCachePolicy, whose
+        # _hybrid_plan() enforces the plan-resolved invariant.
+        bytes_per_slot = runner.linear_cache_bytes_per_slot()
+        plan = runner.hybrid_runtime_plan
+        assert plan is not None
+        return bytes_per_slot // plan.layers.num_state
 
     def _hybrid_gdn_reservation(self) -> _HybridGDNReservation:
         """Return lazy GDN headroom reserved outside the paged KV pool."""

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -893,18 +893,35 @@ class ModelCachePolicy:
         """Return bytes for one request's linear-attention state."""
         if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
-        plan = self._hybrid_plan()
-        geometry = plan.geometry
-        dtype_size = self._require_kv_cache_dtype().size
-        recurrent_dtype_size = plan.family.recurrent_dtype.itemsize
-        conv_bytes = (geometry.conv_kernel_dim - 1) * geometry.conv_dim * dtype_size
-        recurrent_bytes = (
-            geometry.num_v_heads
-            * geometry.value_head_dim
-            * geometry.key_head_dim
-            * recurrent_dtype_size
+        hybrid_plan = self._hybrid_plan()
+        return hybrid_plan.layers.num_state * self._state_bytes_per_layer(hybrid_plan)
+
+    def hybrid_align_state_bytes_per_block(self) -> int:
+        """Per-pool-block linear-state bytes under align-mode prefix caching."""
+        hybrid_plan = self._hybrid_plan()
+        layer_plan = hybrid_plan.layers
+        pools = _align_state_pool_count(layer_plan.num_state, layer_plan.num_attention)
+        return self._state_bytes_per_layer(hybrid_plan) * pools
+
+    def hybrid_align_growth_bytes_per_block(self) -> int:
+        """One old physical state pool retained during align-cache growth."""
+        return self._state_bytes_per_layer(self._hybrid_plan())
+
+    def _state_bytes_per_layer(self, hybrid_plan: HybridRuntimePlan) -> int:
+        """Bytes one request holds in one state layer: conv tail plus SSM state."""
+        state_geometry = hybrid_plan.geometry
+        conv_bytes = (
+            (state_geometry.conv_kernel_dim - 1)
+            * state_geometry.conv_dim
+            * self._require_kv_cache_dtype().size
         )
-        return plan.layers.num_state * (conv_bytes + recurrent_bytes)
+        recurrent_bytes = (
+            state_geometry.num_v_heads
+            * state_geometry.value_head_dim
+            * state_geometry.key_head_dim
+            * hybrid_plan.family.recurrent_dtype.itemsize
+        )
+        return conv_bytes + recurrent_bytes
 
     def build_paged_attention_runtime(
         self, *, block_size: int
@@ -1320,14 +1337,7 @@ class WorkerCachePlanner:
             return 0
         if runner.cache_config.mamba_cache_mode != "align":
             return 0
-        # linear_cache_bytes_per_slot routes through ModelCachePolicy, whose
-        # _hybrid_plan() enforces the plan-resolved invariant.
-        bytes_per_slot = runner.linear_cache_bytes_per_slot()
-        plan = runner.hybrid_runtime_plan
-        assert plan is not None
-        num_linear = plan.layers.num_state
-        pools = _align_state_pool_count(num_linear, plan.layers.num_attention)
-        return bytes_per_slot * pools // num_linear
+        return runner.hybrid_align_state_bytes_per_block()
 
     def _hybrid_align_growth_bytes_per_block(self) -> int:
         """One old physical state pool retained during align-cache growth."""
@@ -1336,12 +1346,7 @@ class WorkerCachePlanner:
             return 0
         if runner.cache_config.mamba_cache_mode != "align":
             return 0
-        # linear_cache_bytes_per_slot routes through ModelCachePolicy, whose
-        # _hybrid_plan() enforces the plan-resolved invariant.
-        bytes_per_slot = runner.linear_cache_bytes_per_slot()
-        plan = runner.hybrid_runtime_plan
-        assert plan is not None
-        return bytes_per_slot // plan.layers.num_state
+        return runner.hybrid_align_growth_bytes_per_block()
 
     def _hybrid_gdn_reservation(self) -> _HybridGDNReservation:
         """Return lazy GDN headroom reserved outside the paged KV pool."""

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -14,6 +14,7 @@ from mlx_vlm import load as mlx_vlm_load
 from vllm.logger import init_logger
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
+from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
 from vllm_metal.compat import apply_compat_patches
 from vllm_metal.compiled_mlp import CompiledMLPBlocks
 from vllm_metal.gguf.source import GGUFLoadSource
@@ -190,7 +191,7 @@ class ModelLifecycle:
         self._install_yoco_cache_mapping(args)
         self._install_per_layer_attention_metadata(args, default_head_dim)
         self._reject_pipeline_parallel_with_per_layer_metadata()
-        self._install_hybrid_attention_dims(args)
+        self._install_hybrid_state_plan(args)
 
     def _load_encoder_pooling(self) -> LoadedEncoderBackend | None:
         runner = self._runner
@@ -490,27 +491,11 @@ class ModelLifecycle:
                 "head dims, e.g. Gemma4)."
             )
 
-    def _install_hybrid_attention_dims(self, args: dict[str, Any]) -> None:
-        """Install hybrid linear-attention dimensions for GDN-style models."""
+    def _install_hybrid_state_plan(self, args: dict[str, Any]) -> None:
+        """Resolve the state family that owns this model's hybrid layers."""
         if self._runner.is_hybrid:
-            fai = int(args["full_attention_interval"])
-            self._runner.full_attention_interval = fai
-            self._runner.sdpa_layer_indices = frozenset(
-                i for i in range(self._runner.num_layers) if (i + 1) % fai == 0
-            )
-            self._runner.num_sdpa_layers = len(self._runner.sdpa_layer_indices)
-            self._runner.num_linear_layers = (
-                self._runner.num_layers - self._runner.num_sdpa_layers
-            )
-            self._runner.linear_num_k_heads = int(args["linear_num_key_heads"])
-            self._runner.linear_num_v_heads = int(args["linear_num_value_heads"])
-            self._runner.linear_key_head_dim = int(args["linear_key_head_dim"])
-            self._runner.linear_value_head_dim = int(args["linear_value_head_dim"])
-            self._runner.linear_conv_kernel_dim = int(args["linear_conv_kernel_dim"])
-            # Qwen3.5 GDN packs q/k at key_dim and v at value_dim.
-            self._runner.linear_conv_dim = (
-                self._runner.linear_num_k_heads * self._runner.linear_key_head_dim * 2
-                + self._runner.linear_num_v_heads * self._runner.linear_value_head_dim
+            self._runner.hybrid_runtime_plan = build_gdn_hybrid_plan(
+                args, self._runner.num_layers
             )
 
     def _install_runtime_extensions(

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -840,6 +840,14 @@ class MetalModelRunner:
         """Bytes for one request's linear attention state across all GDN layers."""
         return self._cache_policy.linear_cache_bytes_per_slot()
 
+    def hybrid_align_state_bytes_per_block(self) -> int:
+        """Per-pool-block linear-state bytes under align-mode prefix caching."""
+        return self._cache_policy.hybrid_align_state_bytes_per_block()
+
+    def hybrid_align_growth_bytes_per_block(self) -> int:
+        """One old physical state pool retained during align-cache growth."""
+        return self._cache_policy.hybrid_align_growth_bytes_per_block()
+
     def draft_scratch_reserve_blocks(self) -> int:
         """Blocks reserved for the draft model's speculative lookahead tail."""
         return self._cache_policy.draft_scratch_reserve_blocks()

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -53,6 +53,7 @@ from vllm_metal.attention.context import (
     prepare_grouped,
 )
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
+from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
 from vllm_metal.attention.runtime.protocol import PagedAttentionRuntime
 from vllm_metal.config import get_config
 from vllm_metal.distributed import (
@@ -459,6 +460,11 @@ class MetalModelRunner:
         # present: it is consulted on the KV-sizing path, which runs for every
         # model, not only the YOCO ones that install a real mapping.
         self._yoco_cache_mapping: tuple[int, dict[int, int]] | None = None
+        # Hybrid layer split and state family, resolved once by ModelLifecycle
+        # from the loaded model args.  None for every non-hybrid model; cache
+        # sizing and the hybrid runtime read it instead of re-deriving the
+        # split from full_attention_interval.
+        self.hybrid_runtime_plan: HybridRuntimePlan | None = None
 
         # Whether the adapter can run projection-free intermediate forwards
         # for the loaded model; resolved once in load_model().

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -460,10 +460,7 @@ class MetalModelRunner:
         # present: it is consulted on the KV-sizing path, which runs for every
         # model, not only the YOCO ones that install a real mapping.
         self._yoco_cache_mapping: tuple[int, dict[int, int]] | None = None
-        # Hybrid layer split and state family, resolved once by ModelLifecycle
-        # from the loaded model args.  None for every non-hybrid model; cache
-        # sizing and the hybrid runtime read it instead of re-deriving the
-        # split from full_attention_interval.
+        # Resolved by ModelLifecycle at load; None for non-hybrid models.
         self.hybrid_runtime_plan: HybridRuntimePlan | None = None
 
         # Whether the adapter can run projection-free intermediate forwards


### PR DESCRIPTION
Groundwork for the Nemotron-H stack in #644, PR 1 of 4. The hybrid runtime's geometry is currently ten undeclared attributes that lifecycle mutates onto the runner, and `cache_policy` sizes the linear side as `num_layers` minus the SDPA count. That arithmetic breaks as soon as a model has a third kind of layer. On the 52-layer Nemotron checkpoint it reports 46 recurrent layers when only 23 are.

Because of that, this PR moves the geometry behind one owner, a typed layer plan built by `families/gdn.py`, in the same shape as the encoder pooling loaders from #608. Lifecycle shrinks to a four-line route. The loader table comes with the next PR, so lifecycle imports the GDN builder directly for now.

For evidence, the main one is an interleaved A/B on `Qwen/Qwen3.5-0.8B`. Greedy token ids are bit-identical and `per_block_bytes` is identical. `num_blocks` wobbles a few blocks on both arms since overhead is measured at profile time. The full suite gives 1921 passed with 15 new tests, and error messages on malformed configs got stricter, each pinned by a full-string test.

#598 and #607 both touch these hunks, and #607 passes constructor kwargs this PR deletes, so whichever lands second rebases. Happy to be the one who does. The `MambaSpec` shape and the attention-side wiring stay put until the table lands.