### PR TITLE
[Bugfix] Preserve native extension on rebuild failure

### DIFF
--- a/tests/test_metal_build_cache.py
+++ b/tests/test_metal_build_cache.py
@@ -143,6 +143,42 @@ def test_needs_rebuild_swallows_resolution_errors(patched, monkeypatch):
     assert build.needs_rebuild() is True
 
 
+def test_failed_rebuild_preserves_previous_extension(patched, monkeypatch):
+    """A failed linker must not remove the last usable native extension."""
+    py_include = patched.src.parent / "python-include"
+    mlx_include = patched.src.parent / "mlx-include"
+    mlx_lib = patched.src.parent / "mlx-lib"
+    py_include.mkdir()
+    mlx_include.mkdir()
+    mlx_lib.mkdir()
+    (mlx_lib / "libmlx.dylib").write_bytes(b"mlx")
+    spec = dataclasses.replace(
+        patched.spec,
+        mlx_lib=mlx_lib,
+        mlx_include=mlx_include,
+        py_include=str(py_include),
+    )
+    monkeypatch.setattr(build, "_build_spec", lambda: spec)
+
+    previous_extension = b"last-known-good-extension"
+    previous_hash = "last-known-good-hash"
+    patched.out.write_bytes(previous_extension)
+    patched.hsh.write_text(previous_hash)
+
+    def fail_after_clobbering_output(cmd: list[str], _what: str) -> None:
+        output = Path(cmd[cmd.index("-o") + 1])
+        output.unlink(missing_ok=True)
+        raise RuntimeError("link failed")
+
+    monkeypatch.setattr(build, "_run_or_raise", fail_after_clobbering_output)
+
+    with pytest.raises(RuntimeError, match="link failed"):
+        build.build()
+
+    assert patched.out.read_bytes() == previous_extension
+    assert patched.hsh.read_text() == previous_hash
+
+
 # --------------------------------------------------------------------------
 # Path contract (the runtime loader and verify_wheel_artifacts depend on these)
 # --------------------------------------------------------------------------

--- a/vllm_metal/metal/build.py
+++ b/vllm_metal/metal/build.py
@@ -384,7 +384,10 @@ def stale_artifacts() -> list[Path]:
 def build() -> Path:
     """JIT-build the native extension, returning the path to the .so.
 
-    Skips the compile when the prebuilt .so is already current (needs_rebuild)."""
+    Skips the compile when the prebuilt .so is already current (needs_rebuild).
+    A rebuild is compiled beside the installed artifact and promoted only after
+    success, so a linker failure cannot remove the last usable extension.
+    """
     if not needs_rebuild():
         return _OUT
 
@@ -401,7 +404,17 @@ def build() -> Path:
         if not Path(p).exists():
             raise FileNotFoundError(f"{label} not found: {p}")
 
-    _run_or_raise(spec.cmd, "build paged_ops extension")
+    with tempfile.TemporaryDirectory(
+        prefix=".vllm-metal-build-", dir=_OUT.parent
+    ) as tmpdir:
+        tmp_out = Path(tmpdir) / _OUT.name
+        cmd = [str(tmp_out) if arg == str(_OUT) else arg for arg in spec.cmd]
+        # ``clang++ -shared`` derives LC_ID_DYLIB from the output path. Keep the
+        # final artifact identity instead of recording the temporary directory.
+        output_flag = cmd.index("-o")
+        cmd[output_flag:output_flag] = ["-install_name", str(_OUT)]
+        _run_or_raise(cmd, "build paged_ops extension")
+        tmp_out.replace(_OUT)
 
     _HASH.write_text(expected_hash)
     logger.info("Built %s", _OUT)


### PR DESCRIPTION
## Summary

- link the native extension into a same-directory temporary path
- preserve the final Mach-O install name while staging
- atomically promote only a successful build, retaining the prior extension and hash on failure

## Reproduction

On unchanged main (`bcfc199`), Apple clang 17 removes an existing `-o` target before a failing link completes. A missing-library control exits nonzero and leaves the prior output absent. The regression test simulates that linker behavior; on main, `build()` raises and the prior `_paged_ops.so` is gone.

## Validation

- red on unchanged `bcfc199`: focused regression fails because the prior extension was deleted
- exact `f2a6e225`: `scripts/lint.sh`
- exact `f2a6e225`: `scripts/test.sh` (both model smokes passed; `1940 passed, 15 skipped, 52 deselected`)
- real Apple clang 17 failing-link control preserved the prior extension and hash and cleaned staging output
- native extension and all four Metal libraries built; wheel native artifacts target macOS 15; `LC_ID_DYLIB` names the final extension path

## Compatibility and scope

Validated with the repository pins: vLLM 0.28.0, MLX 0.32.0, mlx-lm 0.31.3, and nanobind 2.10.2. The normal no-rebuild path and public APIs are unchanged. This does not add a cross-process build lock; it makes promotion of each completed artifact atomic.