### PR TITLE
[Bugfix] Honor attention logit softcapping in paged SDPA

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -758,8 +758,14 @@ class TestSDPAForward:
 
         assert captured["num_kv_heads"] == actual_kv_heads
 
-    def test_gpt_oss_scale_and_sinks_reach_kernel(self) -> None:
-        """GPT-OSS exposes ``sm_scale`` and per-head attention sinks."""
+    @pytest.mark.parametrize(
+        ("softcap", "expected_softcap"),
+        [(50.0, 50.0), (None, 0.0)],
+    )
+    def test_scale_softcap_and_sinks_reach_kernel(
+        self, softcap: float | None, expected_softcap: float
+    ) -> None:
+        """Per-module attention parameters reach the paged kernel."""
         cache = MetalPagedKVCache(
             num_layers=1,
             num_kv_heads=_N_KV_HEADS,
@@ -775,6 +781,7 @@ class TestSDPAForward:
             num_key_value_heads=_N_KV_HEADS,
             sm_scale=expected_scale,
             sinks=fp16_sinks,
+            attn_logit_softcapping=softcap,
             o_proj=lambda out: out,
         )
         ctx = _make_ctx(_SEQ_LEN)
@@ -802,11 +809,13 @@ class TestSDPAForward:
                 _value_cache,
                 _num_kv_heads,
                 scale,
+                received_softcap,
                 *_args,
                 sinks=None,
                 **_kwargs,
             ) -> None:
                 captured["scale"] = scale
+                captured["softcap"] = received_softcap
                 captured["sinks"] = sinks
 
         with (
@@ -826,6 +835,7 @@ class TestSDPAForward:
 
         sinks = captured["sinks"]
         assert captured["scale"] == expected_scale
+        assert captured["softcap"] == expected_softcap
         assert isinstance(sinks, mx.array)
         assert sinks.dtype == mx.float32
 

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -542,6 +542,13 @@ def sdpa_forward(
     if attn_scale is None:
         attn_scale = inner.sm_scale
 
+    # Gemma 2 exposes attention-logit softcapping on each Attention module.
+    # Other architectures omit it (or may explicitly set it to None); the
+    # Metal kernel uses 0.0 to select its disabled fast path.
+    attn_softcap = getattr(inner, "attn_logit_softcapping", None)
+    if attn_softcap is None:
+        attn_softcap = 0.0
+
     # Attention sinks: a learned per-head logit that joins the softmax
     # denominator without contributing a value row (GPT-OSS). Models without
     # sinks leave this None and the kernel keeps its plain-softmax path.
@@ -740,7 +747,7 @@ def sdpa_forward(
             kernel_v_cache,
             cache_kv_heads,
             attn_scale,
-            0.0,  # softcap (0 = disabled)
+            attn_softcap,
             block_tables,
             seq_lens,
             cu_seqlens_q,
@@ -768,7 +775,7 @@ def sdpa_forward(
             kernel_v_cache,
             cache_kv_heads,
             attn_scale,
-            0.0,  # softcap (0 = disabled)
+            attn_softcap,
             block_tables,
             seq_lens,
             cu_seqlens_q,


### PR DESCRIPTION
## Summary

- read the existing `attn_logit_softcapping` value from each wrapped attention module
- pass it to both the dense and TurboQuant paged-attention kernel calls
- preserve the current disabled fast path (`0.0`) when the attribute is absent or `None`
- add regression coverage for Gemma 2-style `50.0` propagation and the disabled fallback

No new model or wrapper attribute is introduced.

Fixes #665

## Testing

- `pytest -q tests/test_attention_sdpa.py tests/test_model_adapter.py` (103 passed)
- `ruff check vllm_metal/attention/impls/sdpa.py tests/test_attention_sdpa.py`
- `ruff format --check vllm_metal/attention/impls/sdpa.py tests/test_attention_sdpa.py`
- `git diff --check`

Broader native-kernel tests were not usable in this checkout because its prebuilt Metal artifacts are stale relative to the source timestamps. This change does not modify Metal or C++ sources.