### PR TITLE
Reserve null block in non-paged scheduler capacity

### DIFF
--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -88,7 +88,7 @@ class TestWorkerRunnerBoundaryDelegation:
         worker.get_cache_block_size_bytes.assert_called_once_with()
 
     def test_determine_available_memory_single_sequence_mode(self) -> None:
-        """Test MLX path returns one max-length sequence estimate (PR #229)."""
+        """MLX path budgets one sequence plus vLLM's reserved null block."""
         model_runner = make_stub_runner(
             num_layers=16,
             num_kv_cache_layers=16,
@@ -100,14 +100,15 @@ class TestWorkerRunnerBoundaryDelegation:
             return_value="single_sequence_estimate"
         )
         worker = _make_worker(model_runner, use_paged_attention=False)
+        model_runner.cache_config.block_size = worker.cache_config.block_size
         worker.model_config = SimpleNamespace(max_model_len=2048)
 
         try:
             available = MetalWorker.determine_available_memory(worker)
 
-            # Should return one max-length sequence KV cache bytes
-            # 2 (K+V) * 16 layers * 2048 tokens * 8 heads * 128 head_dim * 2 bytes
-            expected = 2 * 16 * 2048 * 8 * 128 * 2
+            # Request: 2048 tokens. Reserved null block: 16 tokens.
+            bytes_per_token = 2 * 16 * 8 * 128 * 2
+            expected = bytes_per_token * (2048 + 16)
             assert available == expected
         finally:
             pass

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -1203,10 +1203,15 @@ class WorkerCachePlanner:
             logger.info("Encoder pooling: reporting zero KV-cache bytes")
             return 0
 
-        available = self._worker._one_sequence_kv_bytes()
+        request_bytes = self._worker._one_sequence_kv_bytes()
+        # vLLM's BlockPool permanently reserves one null block. Reporting
+        # exactly one request's bytes therefore leaves one fewer free block
+        # than admission requires and the waiting request is skipped forever.
+        reserved_block_bytes = self._worker.get_cache_block_size_bytes()
+        available = request_bytes + reserved_block_bytes
         logger.info(
             "MLX path: reporting %.2f GB for scheduler admission control "
-            "(one max-length sequence, max_model_len=%d)",
+            "(one max-length sequence + reserved null block, max_model_len=%d)",
             available / 1e9,
             self._worker.model_config.max_model_len,
         )


### PR DESCRIPTION
While testing #644, I found that a max-length request could remain in the waiting queue indefinitely on the non-paged path. `single_sequence_estimate` reports exactly enough block-aligned cache memory for the request, but vLLM's `BlockPool` reserves one physical block as its `null_block`, leaving the scheduler one block short.

This adds one cache block to the reported capacity so the original one-sequence capacity remains available after the null block is reserved. Paged-attention reporting is unchanged. This complements #513, which handled the same reservation during `max_model_len` auto-fit.

I added a focused regression test and ran the worker/platform tests plus the full non-slow suite locally (`1848 passed, 18 skipped, 39 deselected`).
