### PR TITLE
[Bugfix] Batch nested CacheList caches on the non-paged path

### DIFF
--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -261,3 +261,54 @@ class TestHybridCacheMergeExtract:
         kv_cache = contiguous_cache.KVCache()
         with pytest.raises(TypeError, match="Mixed cache types in a single layer"):
             contiguous_cache._merge_kv_caches([[arrays_cache], [kv_cache]])
+
+    def _make_cache_list(
+        self, *, seq_len: int, kv_value: float, v0: float, v1: float
+    ) -> contiguous_cache.CacheList:
+        # Falcon-H1's per-layer shape: CacheList(ArraysCache(size=2), KVCache()).
+        return contiguous_cache.CacheList(
+            self._make_arrays_cache(v0, v1), self._make_kv_cache(seq_len, kv_value)
+        )
+
+    def test_cache_list_merge_extract_roundtrip(self) -> None:
+        """Nested ``CacheList`` layers merge member-wise and extract back.
+
+        mlx_lm gives a layer that owns several stateful modules (Falcon-H1:
+        parallel Mamba-2 mixer + attention) one ``CacheList`` per layer.  Merging
+        must recurse into each member so batched decode sees a batched cache in
+        every slot, and extraction must rebuild the per-request nesting.
+        """
+        req0 = self._make_cache_list(seq_len=2, kv_value=1.0, v0=3.0, v1=33.0)
+        req1 = self._make_cache_list(seq_len=4, kv_value=2.0, v0=4.0, v1=44.0)
+
+        merged = contiguous_cache._merge_kv_caches([[req0], [req1]])
+
+        assert isinstance(merged[0], contiguous_cache.CacheList)
+        assert isinstance(merged[0][0], contiguous_cache.ArraysCache)
+        assert isinstance(merged[0][1], contiguous_cache.BatchKVCache)
+
+        for idx, src in enumerate((req0, req1)):
+            out = contiguous_cache._extract_kv_cache(merged, idx)[0]
+            assert isinstance(out, contiguous_cache.CacheList)
+            arrays_out, kv_out = out.caches
+            assert isinstance(arrays_out, contiguous_cache.ArraysCache)
+            assert isinstance(kv_out, contiguous_cache.KVCache)
+            assert bool(mx.allclose(arrays_out.state[0], src[0].state[0]))
+            assert bool(mx.allclose(arrays_out.state[1], src[0].state[1]))
+            assert kv_out.offset == src[1].offset
+            assert bool(mx.allclose(kv_out.keys, src[1].keys))
+            assert bool(mx.allclose(kv_out.values, src[1].values))
+
+    def test_cache_list_merge_rejects_width_mismatch(self) -> None:
+        req0 = self._make_cache_list(seq_len=2, kv_value=1.0, v0=3.0, v1=33.0)
+        req1 = contiguous_cache.CacheList(self._make_kv_cache(seq_len=2, value=2.0))
+
+        with pytest.raises(TypeError, match="CacheList width mismatch"):
+            contiguous_cache._merge_kv_caches([[req0], [req1]])
+
+    def test_cache_list_merge_rejects_mixed_layer_types(self) -> None:
+        req0 = self._make_cache_list(seq_len=2, kv_value=1.0, v0=3.0, v1=33.0)
+        req1 = self._make_kv_cache(seq_len=2, value=2.0)
+
+        with pytest.raises(TypeError, match="expected CacheList"):
+            contiguous_cache._merge_kv_caches([[req0], [req1]])

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -8,6 +8,7 @@ from mlx_lm.models.cache import (
     ArraysCache,
     BatchKVCache,
     BatchRotatingKVCache,
+    CacheList,
     KVCache,
     RotatingKVCache,
 )
@@ -15,8 +16,12 @@ from mlx_lm.models.cache import (
 # Minimum requests to use BatchKVCache for batched decode
 _MIN_BATCH_SIZE_FOR_BATCHING = 2
 
-# Per-layer cache types used by non-paged decode.
-AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache
+# Per-layer cache types used by non-paged decode.  ``CacheList`` is mlx_lm's
+# per-layer container for models whose layer owns several stateful modules,
+# e.g. Falcon-H1's parallel Mamba-2 + attention layer, which ``make_cache``
+# shapes as ``CacheList(ArraysCache(size=2), KVCache())``.
+AnyCache: TypeAlias = KVCache | RotatingKVCache | ArraysCache | CacheList
+BatchedCache: TypeAlias = BatchKVCache | BatchRotatingKVCache | ArraysCache | CacheList
 
 
 def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
@@ -57,80 +62,106 @@ def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
     return extracted
 
 
+def _merge_layer_caches(layer_caches: list[AnyCache]) -> BatchedCache:
+    """Merge one layer's per-request caches into a single batched cache."""
+    first = layer_caches[0]
+    if isinstance(first, CacheList):
+        # Recurse member-wise so each nested cache takes its own merge path
+        # (ArraysCache densification, BatchKVCache left padding, ...), then
+        # rebuild the container the model indexes as ``cache[i]``.
+        cache_lists: list[CacheList] = []
+        for cache in layer_caches:
+            if not isinstance(cache, CacheList):
+                raise TypeError(
+                    "Mixed cache types in a single layer: expected CacheList"
+                )
+            cache_lists.append(cache)
+        width = len(first.caches)
+        for cache_list in cache_lists:
+            if len(cache_list.caches) != width:
+                raise TypeError(
+                    "CacheList width mismatch in a single layer: "
+                    f"expected {width}, got {len(cache_list.caches)}"
+                )
+        return CacheList(
+            *(
+                _merge_layer_caches(
+                    [cache_list.caches[i] for cache_list in cache_lists]
+                )
+                for i in range(width)
+            )
+        )
+    if isinstance(first, ArraysCache):
+        arrays_caches: list[ArraysCache] = []
+        for cache in layer_caches:
+            if not isinstance(cache, ArraysCache):
+                raise TypeError(
+                    "Mixed cache types in a single layer: expected ArraysCache"
+                )
+            arrays_caches.append(cache)
+        return _merge_arrays_caches(arrays_caches)
+    if isinstance(first, RotatingKVCache):
+        rotating_caches: list[RotatingKVCache] = []
+        for cache in layer_caches:
+            if not isinstance(cache, RotatingKVCache):
+                raise TypeError(
+                    "Mixed cache types in a single layer: expected RotatingKVCache"
+                )
+            rotating_caches.append(cache)
+        return BatchRotatingKVCache.merge(rotating_caches)
+    if isinstance(first, KVCache):
+        kv_caches: list[KVCache] = []
+        for cache in layer_caches:
+            if not isinstance(cache, KVCache):
+                raise TypeError("Mixed cache types in a single layer: expected KVCache")
+            kv_caches.append(cache)
+        return BatchKVCache.merge(kv_caches)
+    cache_type = type(first).__name__
+    raise TypeError(f"Unsupported cache type for batching: {cache_type}")
+
+
 def _merge_kv_caches(
     caches_list: list[list[AnyCache]],
-) -> list[BatchKVCache | BatchRotatingKVCache | ArraysCache]:
+) -> list[BatchedCache]:
     """Merge per-request layer caches into batched layer caches."""
     if not caches_list:
         return []
 
     num_layers = len(caches_list[0])
-    merged: list[BatchKVCache | BatchRotatingKVCache | ArraysCache] = []
-
-    for layer_idx in range(num_layers):
-        layer_caches = [caches[layer_idx] for caches in caches_list]
-        if isinstance(layer_caches[0], ArraysCache):
-            arrays_caches: list[ArraysCache] = []
-            for cache in layer_caches:
-                if not isinstance(cache, ArraysCache):
-                    raise TypeError(
-                        "Mixed cache types in a single layer: expected ArraysCache"
-                    )
-                arrays_caches.append(cache)
-            batch_cache = _merge_arrays_caches(arrays_caches)
-        elif isinstance(layer_caches[0], RotatingKVCache):
-            rotating_caches: list[RotatingKVCache] = []
-            for cache in layer_caches:
-                if not isinstance(cache, RotatingKVCache):
-                    raise TypeError(
-                        "Mixed cache types in a single layer: expected RotatingKVCache"
-                    )
-                rotating_caches.append(cache)
-            batch_cache = BatchRotatingKVCache.merge(rotating_caches)
-        elif isinstance(layer_caches[0], KVCache):
-            kv_caches: list[KVCache] = []
-            for cache in layer_caches:
-                if not isinstance(cache, KVCache):
-                    raise TypeError(
-                        "Mixed cache types in a single layer: expected KVCache"
-                    )
-                kv_caches.append(cache)
-            batch_cache = BatchKVCache.merge(kv_caches)
-        else:
-            cache_type = type(layer_caches[0]).__name__
-            raise TypeError(f"Unsupported cache type for batching: {cache_type}")
-        merged.append(batch_cache)
-
-    return merged
+    return [
+        _merge_layer_caches([caches[layer_idx] for caches in caches_list])
+        for layer_idx in range(num_layers)
+    ]
 
 
-def _extract_kv_cache(
-    batch_caches: list[BatchKVCache | BatchRotatingKVCache | ArraysCache], idx: int
-) -> list[AnyCache]:
+def _extract_layer_cache(cache: BatchedCache, idx: int) -> AnyCache:
+    """Extract one request's cache for a single layer."""
+    if isinstance(cache, CacheList):
+        return CacheList(*(_extract_layer_cache(sub, idx) for sub in cache.caches))
+    if isinstance(cache, ArraysCache):
+        return _extract_arrays_cache(cache, idx)
+    c = cache.extract(idx)
+    # Pad sliced rotating buffers so later decode can update in place.
+    if (
+        isinstance(c, RotatingKVCache)
+        and c.keys is not None
+        and c.offset > c.max_size
+        and c.keys.shape[2] < c.max_size
+    ):
+        pad = c.max_size - c.keys.shape[2]
+        z_k = mx.zeros(
+            (1, c.keys.shape[1], pad, c.keys.shape[3]),
+            dtype=c.keys.dtype,
+        )
+        z_v = mx.zeros(
+            (1, c.values.shape[1], pad, c.values.shape[3]),
+            dtype=c.values.dtype,
+        )
+        c.keys = mx.concatenate([c.keys, z_k], axis=2)
+        c.values = mx.concatenate([c.values, z_v], axis=2)
+    return c
+
+
+def _extract_kv_cache(batch_caches: list[BatchedCache], idx: int) -> list[AnyCache]:
     """Extract one request's layer caches from batched layer caches."""
-    extracted: list[AnyCache] = []
-    for cache in batch_caches:
-        if isinstance(cache, ArraysCache):
-            extracted.append(_extract_arrays_cache(cache, idx))
-        else:
-            c = cache.extract(idx)
-            # Pad sliced rotating buffers so later decode can update in place.
-            if (
-                isinstance(c, RotatingKVCache)
-                and c.keys is not None
-                and c.offset > c.max_size
-                and c.keys.shape[2] < c.max_size
-            ):
-                pad = c.max_size - c.keys.shape[2]
-                z_k = mx.zeros(
-                    (1, c.keys.shape[1], pad, c.keys.shape[3]),
-                    dtype=c.keys.dtype,
-                )
-                z_v = mx.zeros(
-                    (1, c.values.shape[1], pad, c.values.shape[3]),
-                    dtype=c.values.dtype,
-                )
-                c.keys = mx.concatenate([c.keys, z_k], axis=2)
-                c.values = mx.concatenate([c.values, z_v], axis=2)
-            extracted.append(c)
-    return extracted
+    return [_extract_layer_cache(cache, idx) for cache in batch_caches]


### PR DESCRIPTION
## Summary

Fixes #679.

Falcon-H1 (`mlx-community/Falcon-H1-1.5B-Instruct-4bit`) on the non-paged MLX path (`VLLM_METAL_USE_PAGED_ATTENTION=0`) serves a single request correctly, but the first step that batches two or more decode requests kills EngineCore:

```
File "vllm_metal/v1/model_runner.py", line 1117, in _batched_decode
TypeError: Unsupported cache type for batching: CacheList
```

This teaches the non-paged merge/extract helpers about mlx_lm's `CacheList`, so models whose layer owns several stateful modules can take batched decode. Related: #655 (the paged-path crash for the same model stays open; that needs the Mamba-2 paged state work tracked in #644).

## Root cause

`mlx_lm.models.falcon_h1.Model.make_cache` returns `CacheList(ArraysCache(size=2), KVCache())` per layer, because every Falcon-H1 layer runs a Mamba-2 mixer and attention in parallel and indexes `cache[0]` / `cache[1]`. `vllm_metal/v1/contiguous_cache.py` dispatched on `ArraysCache`, `RotatingKVCache` and `KVCache` only, so `_merge_kv_caches` raised for the container type. Other mlx_lm models with the same shape: `deepseek_v32`, `longcat_flash`, `baichuan_m1`.

## Changes

- `_merge_layer_caches` / `_extract_layer_cache`: per-layer dispatch factored out of the loops; a `CacheList` recurses member-wise (width-checked, type-checked) so each nested cache keeps its own batching path (`ArraysCache` densification, `BatchKVCache` left padding) and extraction rebuilds the per-request nesting.
- `AnyCache` / `BatchedCache` aliases include `CacheList`.
- Tests: round-trip through a `CacheList(ArraysCache, KVCache)` layer with unequal sequence lengths, plus rejection of width mismatch and mixed layer types.

## Validation

Apple M1 Pro, 16 GiB, macOS 27.0, Python 3.12.14, vllm 0.28.0+cpu, mlx 0.32.0, mlx_lm 0.31.3, source install with `VLLM_METAL_BUILD_FROM_SOURCE=1`.

```
$ pytest tests/test_prefix_cache.py -q
12 passed in 2.48s
$ pytest -m "not slow" tests/ -q
1952 passed, 15 skipped, 52 deselected in 30.23s
$ ruff check . && ruff format --check . && mypy vllm_metal
Success: no issues found in 126 source files
```

Serving `mlx-community/Falcon-H1-1.5B-Instruct-4bit@6f5e4f68` with `VLLM_METAL_USE_PAGED_ATTENTION=0 VLLM_METAL_MEMORY_FRACTION=auto vllm serve ... --max-model-len 8192` (large enough that two requests fit; with `--max-model-len 512` the hybrid block alignment leaves one block and the request waits forever, which is #672):

- Before: two concurrent `/v1/completions` requests -> HTTP 500, EngineCore dead with the traceback above.
- After: both return 200; with `logprobs=2` and greedy sampling the per-token logprobs of the batched run are identical to the solo run for all three prompts (40 tokens each, `/metrics` shows `num_requests_running` reaching 2, no preemptions).
- The solo output matches a plain `mlx_lm` greedy loop (`model(...)` with `make_prompt_cache`) token for token on the same prompt ids.
- Teacher-forced in-process check mirroring `_batched_decode` (merge, one batched forward, extract, every step) with requests joining and leaving the batch: bit-identical logprobs to sequential decode for the unpadded request; a left-padded request can pick up fp16-level differences from the masked SDPA kernel (first seen as a 1e-3 deviation at one layer with bit-identical q/k/v), the same behaviour dense models and `mlx_lm.batch_generate` show today, so not introduced here.

