### PR TITLE
Refuse paged attention for layers with unmanaged per-request state

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -60,6 +60,18 @@ load, since mlx-lm does not read `attention_head_dim` from the
 `nvidia/Nemotron-H-*` configs yet. These values describe default engine
 behavior, not exhaustive per-model benchmarking on Metal.
 
+Hybrid checkpoints route through the state-family table in
+`vllm_metal/attention/runtime/families/`; a hybrid model type with no
+registered family (Falcon-H1, Jamba, PLaMo-2) is refused at startup with a
+clear error ([#655](https://github.com/vllm-project/vllm-metal/issues/655)).
+Paged-attention setup also validates every native cache slot mlx-lm declares
+(`ModelCachePolicy.validate_paged_attention_support`): dense models must
+declare one KV-style cache per layer, and a hybrid family's declaration must
+match its layer plan, so per-request state nothing manages fails loud at
+setup instead of corrupting requests. Supporting a new family means
+registering an owner in the table (the GDN, Nemotron-H, and ShortConv owners
+are the examples).
+
 HF AWQ checkpoints load through mlx-lm's `_transform_awq_weights` repack, with an
 entry-point preflight that normalizes AutoAWQ aliases (`w_bit`, `q_group_size`,
 uppercase `"GEMM"`) and rejects unsupported variants (`gemv`, `bits != 4`,

--- a/tests/test_attention_dispatch.py
+++ b/tests/test_attention_dispatch.py
@@ -295,3 +295,181 @@ def test_mixer_is_probed_only_when_a_family_opts_in() -> None:
 
     assert find_attn_attr(block) is None
     assert find_attn_attr(block, (*DEFAULT_ATTN_ATTR_NAMES, "mixer")) == "mixer"
+
+
+# ---------------------------------------------------------------------------
+# validate_paged_attention_support refuses unmanaged native cache topologies
+# ---------------------------------------------------------------------------
+
+
+def _make_policy_runner(model, *, num_layers: int, hybrid_plan=None, **attrs):
+    """Stub runner around a real mlx_lm model for cache-policy validation."""
+    from tests.stub_runner import make_stub_runner
+
+    return make_stub_runner(
+        model=model,
+        num_layers=num_layers,
+        num_kv_cache_layers=num_layers,
+        num_kv_heads=2,
+        is_hybrid=hybrid_plan is not None,
+        hybrid_runtime_plan=hybrid_plan,
+        **attrs,
+    )
+
+
+def _tiny_gdn_plan(num_layers, attention_indices):
+    """GDN plan with explicit topology; geometry is irrelevant to validation."""
+    from tests.stub_runner import make_gdn_hybrid_plan
+
+    return make_gdn_hybrid_plan(
+        num_layers,
+        attention_indices,
+        conv_kernel_dim=2,
+        conv_dim=4,
+        num_v_heads=1,
+        value_head_dim=4,
+        key_head_dim=32,
+    )
+
+
+def test_validate_rejects_falcon_h1_parallel_mamba():
+    """Falcon-H1 runs a Mamba-2 mixer next to self_attn in every layer (#655).
+
+    mlx-lm declares that topology as a ``CacheList`` per layer; no state
+    family owns it, and the dense paged runtimes manage one KV-style cache
+    per slot, so setup must refuse at validation time rather than crash on
+    the first request.
+    """
+    from mlx_lm.models.falcon_h1 import Model, ModelArgs
+
+    args = ModelArgs(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        mamba_n_heads=4,
+        mamba_d_head=16,
+        mamba_d_ssm=64,
+        mamba_d_state=16,
+        vocab_size=100,
+    )
+    runner = _make_policy_runner(Model(args), num_layers=2)
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        runner.validate_paged_attention_support()
+
+    message = str(excinfo.value)
+    assert "CacheList" in message
+    assert "native cache slot 0" in message
+    assert "VLLM_METAL_USE_PAGED_ATTENTION=0" in message
+
+
+def test_validate_rejects_native_cache_count_mismatch():
+    """A model declaring fewer native slots than KV layers must refuse."""
+    from types import SimpleNamespace
+
+    from mlx_lm.models.cache import KVCache
+
+    model = SimpleNamespace(make_cache=lambda: [KVCache()])
+    runner = _make_policy_runner(model, num_layers=2)
+
+    with pytest.raises(
+        NotImplementedError, match=r"expected 2 native cache slots.*declares 1"
+    ):
+        runner.validate_paged_attention_support()
+
+
+def test_validate_accepts_dense_and_gdn_hybrid_models():
+    """Qwen3 (all KV slots) and Qwen3.5 (matching GDN plan) both pass."""
+    from mlx_lm.models.qwen3 import Model as Qwen3Model
+    from mlx_lm.models.qwen3 import ModelArgs as Qwen3Args
+    from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+
+    dense = _make_policy_runner(
+        Qwen3Model(Qwen3Args(**_QWEN3_ARGS_KWARGS)), num_layers=2
+    )
+    dense.validate_paged_attention_support()
+
+    hybrid = _make_policy_runner(
+        TextModel(TextModelArgs(**_QWEN35_ARGS_KWARGS)),
+        num_layers=4,
+        hybrid_plan=_tiny_gdn_plan(4, [3]),
+    )
+    hybrid.validate_paged_attention_support()
+
+
+def test_validate_accepts_shortconv_and_mamba2_state_families():
+    """LFM2 conv slots and Nemotron-H mixer slots match their family plans.
+
+    Nemotron-H also carries a stateless MLP block ('-'), which mlx-lm skips
+    when declaring caches; validation must line native slots up against the
+    plan's attention and state layers only.
+    """
+    import torch
+    from mlx_lm.models.lfm2 import Model as LFM2Model
+    from mlx_lm.models.lfm2 import ModelArgs as LFM2Args
+    from mlx_lm.models.nemotron_h import Model as NemotronHModel
+    from mlx_lm.models.nemotron_h import ModelArgs as NemotronHArgs
+
+    from tests.stub_runner import NEMOTRON_H_TINY_ARGS, make_nemotron_hybrid_plan
+    from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
+
+    lfm2_args = {
+        "model_type": "lfm2",
+        "vocab_size": 100,
+        "hidden_size": 64,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 512,
+        "norm_eps": 1e-5,
+        "conv_bias": False,
+        "conv_L_cache": 3,
+        "block_dim": 64,
+        "block_ff_dim": 128,
+        "block_multiple_of": 64,
+        "block_ffn_dim_multiplier": 1.0,
+        "block_auto_adjust_ff_dim": False,
+        "layer_types": ["conv", "full_attention"],
+    }
+    lfm2 = _make_policy_runner(
+        LFM2Model(LFM2Args(**lfm2_args)),
+        num_layers=2,
+        hybrid_plan=build_hybrid_runtime_plan(lfm2_args, 2, (torch.float16,)),
+    )
+    lfm2.validate_paged_attention_support()
+
+    nemotron_args = {
+        **NEMOTRON_H_TINY_ARGS,
+        "num_hidden_layers": 3,
+        "hybrid_override_pattern": "M*-",
+    }
+    nemotron = _make_policy_runner(
+        NemotronHModel(NemotronHArgs(**nemotron_args)),
+        num_layers=3,
+        hybrid_plan=make_nemotron_hybrid_plan("M*-"),
+    )
+    nemotron.validate_paged_attention_support()
+
+
+def test_validate_rejects_hybrid_plan_disagreement():
+    """A hybrid whose declared split disagrees with the layer plan refuses.
+
+    The plan expects attention at slots 1 and 3, but the Qwen3.5 model
+    built with ``full_attention_interval=4`` declares ArraysCache at
+    slot 1 -- state the runtime would map to a KV-style cache.
+    """
+    from mlx_lm.models.qwen3_5 import TextModel, TextModelArgs
+
+    runner = _make_policy_runner(
+        TextModel(TextModelArgs(**_QWEN35_ARGS_KWARGS)),
+        num_layers=4,
+        hybrid_plan=_tiny_gdn_plan(4, [1, 3]),
+    )
+
+    with pytest.raises(
+        NotImplementedError, match=r"ArraysCache at native cache slot 1"
+    ):
+        runner.validate_paged_attention_support()

--- a/tests/test_vlm_forward_model.py
+++ b/tests/test_vlm_forward_model.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from tests.stub_runner import make_stub_runner
@@ -45,8 +46,13 @@ class TestValidatePagedAttentionSupport:
                 calls.append((args, num_kv_heads))
 
         model_args = {"num_global_key_value_heads": 8}
+        # Two plain layers: mlx-lm declares one KV-style cache per layer,
+        # which passes the native-cache topology validation.
+        model = SimpleNamespace(layers=[object(), object()])
         runner = make_stub_runner(
             model_args=model_args,
+            model=model,
+            num_kv_cache_layers=2,
             num_kv_heads=8,
             _model_adapter=RecordingAdapter(),
         )

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import mlx.core as mx
 import torch
+from mlx_lm.models import cache as mlx_lm_cache
+from mlx_vlm.models import cache as mlx_vlm_cache
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import (
@@ -30,7 +32,11 @@ from vllm_metal.attention.caches.turboquant import (
     packed_dim,
 )
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
-from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
+from vllm_metal.attention.runtime.hybrid_plan import (
+    ATTENTION_LAYER,
+    STATELESS_LAYER,
+    HybridRuntimePlan,
+)
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.attention.runtime.mla import MLAPagedAttentionRuntime
 from vllm_metal.attention.runtime.protocol import PagedAttentionRuntime
@@ -70,6 +76,13 @@ def _align_state_pool_count(num_linear_layers: int, num_sdpa_layers: int) -> int
 
 
 HYBRID_GDN_GROWTH_CUSHION_SLOTS = 2
+
+
+# Model loading goes through either package (mlx-vlm serves VLM-capable
+# families such as Qwen3.5), and each declares its own parallel cache class
+# hierarchy, so isinstance checks against native caches accept both.
+_STATE_CACHE_CLASSES = (mlx_lm_cache.ArraysCache, mlx_vlm_cache.ArraysCache)
+_STACKED_CACHE_CLASSES = (mlx_lm_cache.CacheList, mlx_vlm_cache.CacheList)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -283,6 +296,7 @@ class ModelCachePolicy:
     def validate_paged_attention_support(self) -> None:
         """Validate that the loaded model can run on the paged-attention path."""
         self._require_supported_per_layer_shapes()
+        self._require_managed_native_caches()
         # ``require_uniform_kv_heads`` is the fail-fast for configs whose
         # ``num_global_key_value_heads`` differs from ``num_key_value_heads``
         # and which would silently fall back to the scalar uniform cache
@@ -296,6 +310,94 @@ class ModelCachePolicy:
                 self._runner.model_args,
                 self._runner.num_kv_heads,
             )
+
+    def _require_managed_native_caches(self) -> None:
+        """Refuse cache topologies no selected paged runtime manages.
+
+        ``make_prompt_cache`` is mlx-lm's declaration of the per-request
+        state each layer keeps.  The dense runtimes replace exactly one
+        KV-style cache per native slot, and a hybrid family's runtime
+        manages exactly the split its layer plan declares; a layer whose
+        declared state is a Mamba/conv ``ArraysCache`` outside that plan
+        or a ``CacheList`` stacking several caches (Falcon-H1, Jamba, ...)
+        would be left running against state nothing manages -- crashing on
+        the first request or silently losing state between decode steps
+        (#655).  Fail loud at setup instead.
+        """
+        runner = self._runner
+        native_caches = mlx_lm_cache.make_prompt_cache(runner._forward_model)
+
+        # Registered hybrid families validate against their layer plan.
+        if runner.is_hybrid:
+            self._validate_hybrid_native_caches(native_caches)
+            return
+
+        expected = runner.num_kv_cache_layers
+        if len(native_caches) != expected:
+            raise NotImplementedError(
+                f"Paged attention expected {expected} native cache slots, "
+                f"but mlx-lm declares {len(native_caches)}. This model uses "
+                "a cache topology the selected paged runtime does not "
+                "manage; set VLLM_METAL_USE_PAGED_ATTENTION=0."
+            )
+
+        unmanaged_classes = _STATE_CACHE_CLASSES + _STACKED_CACHE_CLASSES
+        for slot, cache in enumerate(native_caches):
+            if isinstance(cache, unmanaged_classes):
+                raise NotImplementedError(
+                    f"Paged attention cannot serve this model: mlx-lm "
+                    f"declares {type(cache).__name__} at native cache slot "
+                    f"{slot}, but the selected runtime manages only one "
+                    "KV-style cache per slot. Set "
+                    "VLLM_METAL_USE_PAGED_ATTENTION=0."
+                )
+
+    def _validate_hybrid_native_caches(self, native_caches: list[Any]) -> None:
+        """Check mlx-lm's declared cache layout against the hybrid layer plan.
+
+        A hybrid family's runtime manages one KV-style cache per attention
+        layer and the recurrent/conv state of every state layer; mlx-lm
+        declares that same split as KV-style vs ``ArraysCache`` slots, with
+        no slot for stateless layers (Nemotron-H MLP and MoE blocks).  Any
+        other layout carries state the runtime would not manage.
+        """
+        plan = self._hybrid_plan()
+        label = plan.family.label
+        stateful_layers = [
+            (layer_idx, role)
+            for layer_idx, role in enumerate(plan.layers.layer_roles)
+            if role != STATELESS_LAYER
+        ]
+        if len(native_caches) != len(stateful_layers):
+            raise NotImplementedError(
+                f"Hybrid paged attention expected {len(stateful_layers)} "
+                f"native cache slots (one per attention or state layer), "
+                f"but mlx-lm declares {len(native_caches)}. This model uses "
+                f"a cache topology the {label!r} runtime does not manage; "
+                "set VLLM_METAL_USE_PAGED_ATTENTION=0."
+            )
+        unmanaged_classes = _STATE_CACHE_CLASSES + _STACKED_CACHE_CLASSES
+        for slot, (cache, (layer_idx, role)) in enumerate(
+            zip(native_caches, stateful_layers, strict=True)
+        ):
+            if role == ATTENTION_LAYER:
+                if isinstance(cache, unmanaged_classes):
+                    raise NotImplementedError(
+                        f"Hybrid paged attention cannot serve this model: "
+                        f"mlx-lm declares {type(cache).__name__} at native "
+                        f"cache slot {slot}, but the {label!r} layer plan "
+                        f"maps layer {layer_idx} to attention, which manages "
+                        "only one KV-style cache. Set "
+                        "VLLM_METAL_USE_PAGED_ATTENTION=0."
+                    )
+            elif not isinstance(cache, _STATE_CACHE_CLASSES):
+                raise NotImplementedError(
+                    f"Hybrid paged attention cannot serve this model: mlx-lm "
+                    f"declares {type(cache).__name__} at native cache slot "
+                    f"{slot}, but the {label!r} layer plan maps layer "
+                    f"{layer_idx} to recurrent state, which manages only "
+                    f"{label!r} state. Set VLLM_METAL_USE_PAGED_ATTENTION=0."
+                )
 
     def scheduler_memory_reporting_mode(
         self, *, paged_attention_enabled: bool


### PR DESCRIPTION
## Summary

Serving a model whose layers keep per-request state the paged runtimes do not manage currently loads, warms up, reports healthy, and then kills EngineCore on the first request (#655). This refuses such models at `validate_paged_attention_support` time with a message that names the offending native cache slot and the non-paged fallback, so the failure moves from "500 on first completion" to "engine does not start".

Related: #655, #654, #644. Since this PR was opened, #598 and #710 landed paged serving for LFM2 and Nemotron-H, and #668/#696 moved hybrid geometry behind the state-family table. This revision validates against the table's layer plans and keeps the fail-loud for everything the table does not cover, such as Falcon-H1's per-layer cache stacks, per-request state in models vLLM does not flag as hybrid, and a declaration that drifts from a registered family's plan.

## Approach (revised per review)

Instead of walking model attributes for conv-carrying modules, validate mlx-lm's own cache declaration, as suggested in review: `make_prompt_cache()` is the authoritative statement of what per-request state each layer keeps.

`ModelCachePolicy.validate_paged_attention_support` (`vllm_metal/v1/cache_policy.py:296`) now calls `_require_managed_native_caches` (`cache_policy.py:314`):

- Non-hybrid: the declared slot count must equal `num_kv_cache_layers` (YOCO models declare exactly their unique slots, so Gemma4-style sharing passes), and every slot must be a single KV-style cache. An `ArraysCache` (Mamba/Mamba-2/ShortConv state) or `CacheList` (Falcon-H1's per-layer stack) slot raises `NotImplementedError` naming the slot, the type, and `VLLM_METAL_USE_PAGED_ATTENTION=0`.
- Hybrid: `_validate_hybrid_native_caches` (`cache_policy.py:355`) checks the declared split against `hybrid_runtime_plan.layers`, which serves all three registered families: one KV-style slot per attention layer, one `ArraysCache` per state layer, and no slot for stateless layers (Nemotron-H MLP/MoE blocks, which mlx-lm skips in `make_cache`).
- Cache classes from both `mlx_lm.models.cache` and `mlx_vlm.models.cache` are accepted (`cache_policy.py:84`): the two packages declare parallel hierarchies and Qwen3.5 text serving loads through mlx-vlm, where an `isinstance` against only mlx-lm's classes would misclassify every slot. Both packages are hard dependencies, so the previous `importlib` resolver is now two module imports and two class tuples.

`docs/supported_models.md` points at the state-family table and describes the validation backstop.

## Tests

`tests/test_attention_dispatch.py`, real mlx_lm modules with tiny configs against stub runners:

- Falcon-H1 (`CacheList` at slot 0) and a model declaring fewer slots than the KV plan raise.
- Qwen3 (all KV slots) and Qwen3.5 (matching GDN plan) pass; a hybrid whose declared split disagrees with the layer plan raises.
- LFM2 and Nemotron-H, which the previous revision rejected, now pass through their real family plans built by the family table; the Nemotron-H case uses an `M*-` pattern to cover the stateless-slot skip.
- Hybrid stubs carry `hybrid_runtime_plan` via `make_gdn_hybrid_plan` / `make_nemotron_hybrid_plan` instead of the removed runner attributes.
- `tests/test_vlm_forward_model.py` stub gains real layers so the adapter-delegation test passes the new validation.

## Validation

Apple M1 Pro, 16 GiB, macOS 27.0, Python 3.12.14, vllm 0.28.0+cpu, mlx 0.32.1, mlx_lm 0.32.0, mlx_vlm 0.6.17, source install with `VLLM_METAL_BUILD_FROM_SOURCE=1`.

```
$ pytest tests/ -q -m "not slow"
2156 passed, 15 skipped, 53 deselected in 54.42s
$ pytest tests/test_attention_dispatch.py::test_qwen35_paged_attention_hybrid -q
1 passed in 35.62s
$ ruff check . && ruff format --check . && mypy vllm_metal
Success: no issues found in 137 source files
```

The slow Qwen3.5 E2E exercises the hybrid validation against the real `mlx_vlm` loading path, the same path the `test (macos-15)` smoke failed on after #668 removed `runner.sdpa_layer_indices`.
