### PR TITLE
[Bugfix] Fix EXAONE 4.0 32B paged attention

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -614,6 +614,39 @@ class TestExaone4ConfigCompatPatch:
         # Shim stays inert: transformers derives its own sliding/full mix.
         assert "sliding_attention" in config.layer_types
 
+    def test_string_sliding_window_pattern_derives_layer_types(self) -> None:
+        from transformers.models.exaone4.configuration_exaone4 import Exaone4Config
+
+        compat._patch_transformers_exaone4_config()
+        config = Exaone4Config(
+            num_hidden_layers=8,
+            sliding_window=4096,
+            sliding_window_pattern="LLLG",
+        )
+
+        expected_period = [
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ]
+        assert config.layer_types == expected_period * 2
+
+    @pytest.mark.parametrize("pattern", ["", "LLXG", "LLLL", "GGGG"])
+    def test_malformed_string_sliding_window_pattern_is_rejected(
+        self, pattern: str
+    ) -> None:
+        from transformers.models.exaone4.configuration_exaone4 import Exaone4Config
+
+        compat._patch_transformers_exaone4_config()
+
+        with pytest.raises(ValueError, match="both 'L' and 'G'"):
+            Exaone4Config(
+                num_hidden_layers=4,
+                sliding_window=4096,
+                sliding_window_pattern=pattern,
+            )
+
     def test_explicit_layer_types_are_preserved(self) -> None:
         from transformers.models.exaone4.configuration_exaone4 import Exaone4Config
 

--- a/tests/test_exaone4_paged.py
+++ b/tests/test_exaone4_paged.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Paged-attention regressions for EXAONE 4.0."""
+
+import mlx.core as mx
+from mlx_lm.models.exaone4 import Attention, ModelArgs
+
+from vllm_metal.attention.context import PagedAttentionContext
+from vllm_metal.attention.impls.sdpa import prepare_sdpa_qkv
+from vllm_metal.v1.model_adapter import DefaultModelAdapter
+
+
+def _model_args(*, num_hidden_layers: int = 4) -> ModelArgs:
+    return ModelArgs(
+        model_type="exaone4",
+        hidden_size=8,
+        num_hidden_layers=num_hidden_layers,
+        intermediate_size=16,
+        num_attention_heads=2,
+        rms_norm_eps=1e-5,
+        vocab_size=32,
+        num_key_value_heads=1,
+        max_position_embeddings=32_768,
+        rope_theta=1_000_000.0,
+        head_dim=4,
+        tie_word_embeddings=False,
+        rope_scaling={},
+        sliding_window=4_096,
+        sliding_window_pattern="LLLG",
+    )
+
+
+def test_string_pattern_drives_per_layer_sliding_window_policy() -> None:
+    """EXAONE's retained MLX pattern must drive Metal cache geometry."""
+    args = _model_args(num_hidden_layers=8)
+
+    sliding_windows = DefaultModelAdapter().build_sliding_window_per_layer(
+        vars(args), args.num_hidden_layers
+    )
+
+    assert sliding_windows == [4_096, 4_096, 4_096, -1] * 2
+
+
+def test_global_attention_preserves_unrotated_qk() -> None:
+    """EXAONE 4.0 32B's global layers explicitly omit RoPE."""
+    args = _model_args()
+    attention = Attention(args, is_local=False)
+    assert attention.use_rope is False
+
+    attention.q_proj.weight = (
+        mx.arange(64).reshape(8, 8).astype(mx.float32) / 31.0 - 1.0
+    )
+    attention.k_proj.weight = (
+        mx.arange(32).reshape(4, 8).astype(mx.float32) / 19.0 - 0.75
+    )
+    attention.v_proj.weight = mx.ones((4, 8), dtype=mx.float32)
+    x = mx.arange(24).reshape(1, 3, 8).astype(mx.float32) / 11.0 - 1.0
+
+    expected_q = attention.q_norm(attention.q_proj(x).reshape(1, 3, 2, 4)).transpose(
+        0, 2, 1, 3
+    )
+    expected_k = attention.k_norm(attention.k_proj(x).reshape(1, 3, 1, 4)).transpose(
+        0, 2, 1, 3
+    )
+    context = PagedAttentionContext(
+        slot_mapping=[17, 18, 19],
+        block_tables=[[0, 1]],
+        context_lens=[20],
+        offsets=[17],
+        cu_seqlens=[0, 3],
+    )
+
+    queries, keys, _, _, _ = prepare_sdpa_qkv(
+        attention,
+        x,
+        context,
+        attention.n_heads,
+        attention.n_kv_heads,
+    )
+    mx.eval(queries, keys, expected_q, expected_k)
+
+    assert mx.array_equal(queries, expected_q).item()
+    assert mx.array_equal(keys, expected_k).item()

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -296,8 +296,9 @@ def prepare_sdpa_qkv(
           the caller can forward them to the next YOCO layer.
 
     Raises:
-        NotImplementedError: If ``inner`` has neither ``rope`` nor
-            ``rotary_emb`` (only RoPE-based models are supported).
+        NotImplementedError: If no precomputed rotary embeddings are provided,
+            and ``inner`` has neither ``rope`` nor ``rotary_emb`` and does not
+            explicitly disable RoPE.
     """
     B, L, _ = x.shape  # noqa: N806
     norm_placement = attention_contract.qk_norm_placement

--- a/vllm_metal/attention/impls/varlen_rope_compat.py
+++ b/vllm_metal/attention/impls/varlen_rope_compat.py
@@ -141,12 +141,20 @@ def apply_attention_rope(
     positions: list[mx.array | None] | None = None,
     position_embeddings: tuple[mx.array, mx.array] | None = None,
 ) -> tuple[mx.array, mx.array]:
-    """Apply the attention module's RoPE contract to packed Q/K tensors."""
+    """Apply the attention module's RoPE contract to packed Q/K tensors.
+
+    Without caller-precomputed embeddings, modules that explicitly set
+    ``use_rope`` to ``False`` keep Q/K unchanged. A missing rotary
+    implementation without that opt-out remains an error.
+    """
     if position_embeddings is not None:
         rotated_q, rotated_k = apply_precomputed_mrope(
             attn_module, queries, keys, position_embeddings
         )
         return rotated_q, (rotated_k if apply_keys else keys)
+
+    if getattr(attn_module, "use_rope", None) is False:
+        return queries, keys
 
     if not hasattr(attn_module, "rope") and not hasattr(attn_module, "rotary_emb"):
         raise NotImplementedError(

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 _APPLIED = False
 _QWEN35_FP8_BLOCK_SIZE = 128
+_EXAONE4_LAYER_TYPE = {"L": "sliding_attention", "G": "full_attention"}
 
 
 def apply_compat_patches() -> None:
@@ -88,24 +89,43 @@ def ensure_vllm_auto_fit_null_block_patch() -> None:
     logger.debug("Installed vLLM auto-fit null-block reservation patch")
 
 
+def _exaone4_layer_types_from_pattern(
+    pattern: str, num_hidden_layers: int
+) -> list[str]:
+    """Expand mlx-lm's repeating EXAONE ``L`` / ``G`` attention pattern.
+
+    mlx-lm selects representative local and global caches with ``index()``, so
+    both layer kinds are required whenever a pattern is present.
+    """
+    if not pattern or set(pattern) != set(_EXAONE4_LAYER_TYPE):
+        raise ValueError(
+            "EXAONE 4.0 sliding_window_pattern must be a non-empty "
+            "string containing both 'L' and 'G' and no other characters."
+        )
+    return [
+        _EXAONE4_LAYER_TYPE[pattern[i % len(pattern)]] for i in range(num_hidden_layers)
+    ]
+
+
 def _patch_transformers_exaone4_config() -> None:
-    """Guard ``Exaone4Config`` against a div-by-zero on no-sliding-window configs.
+    """Guard ``Exaone4Config`` against invalid layer-type derivation.
 
     transformers' ``Exaone4Config.__post_init__`` sets
     ``sliding_window_pattern = 0`` when ``sliding_window is None`` (EXAONE 4.0
     checkpoints without a sliding window, e.g. ``EXAONE-4.0-1.2B``), then derives
     ``layer_types`` via ``(i + 1) % sliding_window_pattern`` — a
-    ``ZeroDivisionError``. The config, and therefore the whole model, fails to
-    load through ``AutoConfig`` / ``mlx_lm`` / vLLM before any forward runs.
+    ``ZeroDivisionError``. It also applies the same modulo to string patterns
+    such as ``mlx-community/EXAONE-4.0-32B-4bit``'s ``"LLLG"``, raising
+    ``TypeError`` when ``layer_types`` is absent. vLLM's ``AutoConfig`` step then
+    fails before vllm-metal can invoke mlx-lm or run a forward pass.
 
     Pre-populate ``layer_types`` as all ``"full_attention"`` (the real layout of
-    a no-sliding-window model) so the original ``__post_init__`` skips the
-    crashing derivation. The wrapper only fires on the exact crash condition
-    (``layer_types is None and sliding_window is None``), so sliding-window
-    variants (e.g. the 32B) keep transformers' own derivation untouched.
+    a no-sliding-window model), or expand an ``L`` / ``G`` string pattern to the
+    corresponding sliding / full attention sequence. Integer patterns and
+    explicit ``layer_types`` keep transformers' own behavior.
 
-    TODO: remove once the supported transformers release no longer divides by a
-    zero ``sliding_window_pattern`` (tracked upstream in transformers).
+    TODO: remove once the supported transformers release handles zero and string
+    ``sliding_window_pattern`` values (tracked upstream in transformers).
     """
     try:
         from transformers.models.exaone4 import configuration_exaone4
@@ -122,11 +142,15 @@ def _patch_transformers_exaone4_config() -> None:
     def _patched_post_init(self: Any, **kwargs: Any) -> Any:
         if self.layer_types is None and self.sliding_window is None:
             self.layer_types = ["full_attention"] * self.num_hidden_layers
+        elif self.layer_types is None and isinstance(self.sliding_window_pattern, str):
+            self.layer_types = _exaone4_layer_types_from_pattern(
+                self.sliding_window_pattern, self.num_hidden_layers
+            )
         return original_post_init(self, **kwargs)
 
     config_cls.__post_init__ = _patched_post_init
     config_cls._vllm_metal_exaone4_patched = True
-    logger.debug("Installed Exaone4 no-sliding-window config compatibility patch")
+    logger.debug("Installed Exaone4 config compatibility patch")
 
 
 def _metal_ray_local_gpu_ids(

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -754,17 +754,28 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
     def build_sliding_window_per_layer(
         self, args: dict[str, Any], num_layers: int
     ) -> list[int] | None:
-        """Return per-layer sliding window sizes for Gemma4, else None.
+        """Return model-authoritative per-layer sliding window sizes.
 
-        Gemma4 sliding-attention layers enforce a local window
-        (``config.sliding_window``); full-attention layers attend to the
-        entire context (represented as ``-1``).  Models without
-        ``layer_types`` or ``sliding_window`` in their config return
-        ``None``, keeping the current disabled-everywhere behavior.
+        Explicit ``layer_types`` identify sliding and full layers directly.
+        mlx-lm filters that field out of EXAONE's ``ModelArgs``, so for EXAONE
+        derive the same cyclic layout its model constructor uses from the
+        retained ``sliding_window_pattern``. Full-attention layers use ``-1``.
+        Models without either authoritative layout or ``sliding_window`` return
+        ``None``, keeping window enforcement disabled everywhere.
         """
-        layer_types: list[str] = args.get("layer_types", [])
         sliding_window = args.get("sliding_window")
-        if len(layer_types) != num_layers or not sliding_window:
+        if not sliding_window:
+            return None
+
+        layer_types = args.get("layer_types")
+        if layer_types is None and args.get("model_type") == "exaone4":
+            pattern = args.get("sliding_window_pattern")
+            if isinstance(pattern, str):
+                from vllm_metal.compat import _exaone4_layer_types_from_pattern
+
+                layer_types = _exaone4_layer_types_from_pattern(pattern, num_layers)
+
+        if layer_types is None or len(layer_types) != num_layers:
             return None
 
         sw = int(sliding_window)


### PR DESCRIPTION
## Summary

EXAONE 4.0 32B currently crosses three incompatible assumptions on the paged path:

- `mlx-community/EXAONE-4.0-32B-4bit` stores `sliding_window_pattern: "LLLG"` without `layer_types`, while pinned Transformers applies integer modulo to the string and raises `TypeError` during config loading.
- mlx-lm filters `layer_types` out of EXAONE's `ModelArgs` even when the source config contains it. Without reconstructing the retained string pattern, Metal defaults every layer to full-attention cache policy instead of the model's 48 sliding / 16 global layout.
- Pinned mlx-lm intentionally sets `use_rope=False` and omits `rope` on every global layer, while the paged Q/K preparation path rejects any attention module without a rotary object.

Use one validated `L` / `G` pattern expansion for both Transformers layer types and loaded MLX cache metadata, and preserve Q/K unchanged when an attention module explicitly disables RoPE. Integer patterns, explicit layer types, caller-precomputed embeddings, and the existing fail-loud behavior for modules with no rotary contract remain unchanged.

## Validation

Red controls on unchanged `07f1987` reproduced the config `TypeError` and the real pinned global `mlx_lm.models.exaone4.Attention` `NotImplementedError`. A fresh audit then found the cache-metadata handoff: the initial PR head returned `None` for a real EXAONE `ModelArgs`, while the corrected head returns `[4096, 4096, 4096, -1]` cyclically and matches mlx-lm layer locality.

Exact commit `5637e0ef08dc55563c35900b400b958fe6c2ba66`:

- `262 passed, 3 skipped, 1 deselected` across EXAONE config/paged regressions and the surrounding model-adapter, lifecycle, SDPA, cache, and native sliding-window suites.
- `1955 passed, 15 skipped, 53 deselected` across all practical non-slow tests. The one excluded GGUF entry-point test was previously reproduced identically on unchanged main in this reused environment.
- Ruff lint/format, full mypy, and ShellCheck pass.
- The native extension and all four metallibs build successfully. A CPython 3.12 release-style wheel contains matching CPython 3.12 native extensions, every metallib, and both extensions target macOS 15.
- The real 64-layer checkpoint resolves 48 sliding / 16 global layers. On an M4 / 32 GB / macOS 15.6, all layers were wrapped and greedy paged output matched mlx-lm for the tested two-token continuation (`[1655, 375]`). This smoke used `max_model_len=64`, one prompt, and prefix caching disabled; native window-parity tests separately cover contexts beyond the configured window. No performance claim is made.

Pinned compatibility matrix: vLLM 0.28.0, MLX 0.32.0, mlx-lm `254d153fdeb6f150edd4fc5a54f9828638481fa8`, Transformers 5.12.1.
