### PR TITLE
[Bugfix] Fix paged SDPA compatibility with mlx-lm DeepseekAttention

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -627,6 +627,78 @@ class _PagedRoutingOpsSpy:
 class TestSDPAForward:
     """Tests for ``sdpa_forward`` runtime argument propagation."""
 
+    def test_deepseek_num_kv_heads_naming_reaches_kernel(self) -> None:
+        """DeepSeek exposes ``num_kv_heads``, not ``num_key_value_heads``."""
+        from mlx_lm.models.deepseek import DeepseekAttention, ModelArgs
+
+        args = ModelArgs(
+            model_type="deepseek",
+            vocab_size=32,
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+        )
+        inner = DeepseekAttention(args)
+        x = mx.zeros((1, 2, 16), dtype=mx.float16)
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=2,
+            head_dim=4,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        captured: dict[str, int | float] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self,
+                _keys,
+                _values,
+                key_cache,
+                value_cache,
+                _slot_mapping,
+            ) -> tuple[mx.array, mx.array]:
+                return key_cache, value_cache
+
+            def paged_attention_primitive(
+                self,
+                _query,
+                _key_cache,
+                _value_cache,
+                num_kv_heads,
+                scale,
+                *_args,
+                **_kwargs,
+            ) -> None:
+                captured["num_kv_heads"] = num_kv_heads
+                captured["scale"] = scale
+
+        with (
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((1, 2, 16), dtype=mx.float16),
+            ),
+        ):
+            output, (keys, values) = sdpa_forward(
+                inner,
+                x,
+                _make_ctx(2),
+                cache,
+                layer_idx=0,
+            )
+
+        mx.eval(output, keys, values)
+        assert output.shape == (1, 2, 16)
+        assert keys.shape == (1, 2, 2, 4)
+        assert values.shape == (1, 2, 2, 4)
+        assert captured["num_kv_heads"] == 2
+        assert captured["scale"] == 0.5
+
     def test_mixed_batch_routes_slots_and_page_tables_by_layer_group(self) -> None:
         """Full and sliding layers consume their scheduler-group metadata."""
         layout = MHAKVCacheLayout(

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -530,12 +530,17 @@ def sdpa_forward(
     #   Qwen3/Llama/Gemma/Gemma4: n_heads, n_kv_heads
     #   Qwen3.5 (Qwen3Next):      num_attention_heads, num_key_value_heads
     #   StableLM:                 num_heads, num_key_value_heads
+    #   DeepSeek:                 num_attention_heads, num_kv_heads
     n_heads = (
         getattr(inner, "n_heads", None)
         or getattr(inner, "num_attention_heads", None)
         or inner.num_heads
     )
-    n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
+    n_kv_heads = (
+        getattr(inner, "n_kv_heads", None)
+        or getattr(inner, "num_kv_heads", None)
+        or inner.num_key_value_heads
+    )
 
     # Softmax scale — GPT-OSS names it sm_scale rather than scale.
     attn_scale = getattr(inner, "scale", None)

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -530,7 +530,7 @@ def sdpa_forward(
     #   Qwen3/Llama/Gemma/Gemma4: n_heads, n_kv_heads
     #   Qwen3.5 (Qwen3Next):      num_attention_heads, num_key_value_heads
     #   StableLM:                 num_heads, num_key_value_heads
-    #   DeepSeek:                 num_attention_heads, num_kv_heads
+    #   DeepseekAttention:        num_attention_heads, num_kv_heads
     n_heads = (
         getattr(inner, "n_heads", None)
         or getattr(inner, "num_attention_heads", None)


### PR DESCRIPTION
Fixes #677

## Summary

- recognize `DeepseekAttention.num_kv_heads` in `sdpa_forward`
- document `DeepseekAttention`'s head-count naming convention
- add a regression test using the real mlx-lm `DeepseekAttention` class

## Scope

This is a narrow compatibility fix for
`mlx_lm.models.deepseek.DeepseekAttention` (`model_type: deepseek`). It does
not add or claim support for newer DeepSeek families such as V2, V3, V3.2, or
V4, which use separate model types and attention implementations.

## Problem

mlx-lm's `DeepseekAttention` exposes `num_attention_heads` and
`num_kv_heads`. The SDPA path already supports several other naming
conventions, but its KV-head resolver falls directly from `n_kv_heads` to
`num_key_value_heads`:

```python
n_kv_heads = getattr(inner, "n_kv_heads", None) or inner.num_key_value_heads
```

In mlx-lm v0.31.3, `DeepseekAttention` stores the configured KV-head count as
[`self.num_kv_heads`](https://github.com/ml-explore/mlx-lm/blob/ed1fca4cef15a824c5f1702c80f70b4cffc8e4dd/mlx_lm/models/deepseek.py#L34-L40),
rather than `self.num_key_value_heads`.

As a result, the official `deepseek-ai/deepseek-moe-16b-chat` checkpoint loads
and initializes its paged KV cache, then crashes on the first forward with:

```text
AttributeError: 'DeepseekAttention' object has no attribute 'num_key_value_heads'
```

## Change

Resolve `num_kv_heads` before falling back to `num_key_value_heads`:

```python
n_kv_heads = (
    getattr(inner, "n_kv_heads", None)
    or getattr(inner, "num_kv_heads", None)
    or inner.num_key_value_heads
)
```

The regression test constructs a real, minimal
`mlx_lm.models.deepseek.DeepseekAttention`. It executes the real Q/K/V
projections and RoPE path while replacing only the native Metal operation
boundary, then verifies the projected K/V shapes and the KV-head count passed
to the kernel.

## Tests

```text
pytest -q tests/test_attention_sdpa.py
27 passed

ruff check vllm_metal/attention/impls/sdpa.py tests/test_attention_sdpa.py
All checks passed!

ruff format --check vllm_metal/attention/impls/sdpa.py tests/test_attention_sdpa.py
2 files already formatted

git diff --check
passed
```

A local native-kernel comparison using a minimal DeepSeek attention module
also completed successfully. Its paged output was finite and differed from the
mlx-lm reference by at most `2.06e-4` in FP16.

### Official-checkpoint smoke test

Hardware: 64 GB Apple Silicon Mac  
Checkpoint: `deepseek-ai/deepseek-moe-16b-chat`  
Revision: `eefd8ac7e8dc90e095129fe1a537d5e236b2e57c`  
vLLM: `0.28.0`  
Model dtype: BF16  
Model memory reported by vLLM Metal: `32.75 GB`

Before this change, the first paged forward failed in the KV-head resolver.
After this change, all 28 layers used paged attention and the model completed
prefill plus eight greedy decode steps:

```text
prompt: "Hello"
text: ", my name is [Your Name]."
token_ids: [11, 601, 1210, 317, 825, 7616, 9711, 2986]
```

The non-paged mlx-lm reference matched the first four generated tokens and
then selected `Sarah` instead of `[`. The two candidates were nearly tied at
the divergence step:

| Path | `logp([)` | `logp(Sarah)` | Relative margin |
| --- | ---: | ---: | ---: |
| Paged | -4.1732 | -4.2357 | +0.0625 |
| mlx-lm reference | -4.2713 | -4.2088 | -0.0625 |

This close-call argmax flip is consistent with the rounding-sensitive
paged-vs-MLX behavior documented in `tests/test_paged_deterministic.py`. It is
separate from this change: without the new fallback, DeepSeek never reaches
the kernel.
