### PR TITLE
Add KV cache offloading for the Metal backend

### DIFF
--- a/docs/kv_offloading.md
+++ b/docs/kv_offloading.md
@@ -1,0 +1,139 @@
+# KV Cache Offloading
+
+vllm-metal supports vLLM's KV cache offloading. Blocks evicted from the wired
+Metal KV cache spill to host memory and, optionally, to disk, so a prefix that
+no longer fits can be restored instead of recomputed. The flags are vLLM's own,
+so a command that works on CUDA works here.
+
+Two things prefix caching cannot do and offloading can: serve a prefix after it
+has been evicted, and serve one after the server restarts.
+
+## Quick Start
+
+```bash
+VLLM_METAL_USE_PAGED_ATTENTION=1 vllm serve mlx-community/Qwen2.5-32B-Instruct-4bit \
+  --kv-offloading-size 32
+```
+
+That gives the host-memory tier. On Apple Silicon it is the same physical RAM
+as the wired cache, so it buys capacity beyond the wired cap rather than a
+faster medium.
+
+For persistence, which is where the benefit is largest, add a disk tier:
+
+```bash
+PYTHONHASHSEED=0 \
+VLLM_METAL_USE_PAGED_ATTENTION=1 vllm serve mlx-community/Qwen2.5-32B-Instruct-4bit \
+  --kv-offloading-size 32 \
+  --kv-transfer-config '{"kv_connector_extra_config":
+    {"secondary_tiers": [{"type": "fs", "root_dir": "/path/to/kv-store"}]}}'
+```
+
+Paged attention is required. Offloading is off by default.
+
+## Configuration
+
+| Flag | Description |
+|---|---|
+| `--kv-offloading-size N` | Host pool size in GiB. Enables offloading. |
+| `--kv-offloading-backend` | Must be `native`. |
+| `--kv-transfer-config` | Secondary tiers, as JSON. Only `fs` is supported. |
+
+Tier keys:
+
+| Key | Default | Description |
+|---|---|---|
+| `type` | required | `fs`. `p2p` needs NVLink, `obj` needs NIXL, which has no macOS build. |
+| `root_dir` | required | Where block files live. Nothing removes them; see Disk usage. |
+| `enable_kv_events` | auto | Set for you when KV events are on globally. |
+
+### `PYTHONHASHSEED` is required for reuse across restarts
+
+Block filenames are content hashes, and Python seeds its hash per process.
+Without `PYTHONHASHSEED=0` a restarted server cannot find what the previous one
+wrote, so the disk tier silently gives you nothing on the case it exists for.
+The server warns at startup when a persistent tier is configured and the seed
+is unset.
+
+## Sizing
+
+**The host pool should be larger than the wired KV cache.** If it is smaller,
+the pool's own LRU drops blocks before the wired cache would have re-requested
+them, so restores mostly miss and the tier costs more than it saves. The
+server logs a warning when this happens and no disk tier is configured.
+Behind a disk tier a small pool is the expected shape.
+
+**Offloading only helps once the working set overflows the wired cache.**
+Below that point prefix caching already serves every request and there is
+nothing to restore. Anyone validating the feature has to size the memory
+fraction so the traffic actually evicts, or offloading and no offloading
+read the same.
+
+The wired cache size is `VLLM_METAL_MEMORY_FRACTION` of the recommended working
+set, minus the model weights. It is printed at startup as
+`max_tokens_cached=`. Note the tension: at a high memory fraction there is no
+room left for a pool larger than the cache, and the disk tier is then the only
+secondary tier that adds real capacity.
+
+The host pool is pageable memory and comes out of the same RAM as the weights
+and the wired cache, so it is taken out of the `VLLM_METAL_MEMORY_FRACTION`
+budget: a larger pool means a smaller wired cache, and the fraction stays the
+bound on total resident memory. The startup log shows it as
+`kv_offload_pool=` in the memory breakdown. A pool above half of physical RAM
+is refused outright.
+
+## Disk usage
+
+**Nothing evicts block files.** The store grows to whatever the workload
+touches and stays there until you delete `root_dir` yourself. A workload with
+no prefix reuse writes every evicted block and reads none of them back; on a
+32B model that reached 84 GB in one benchmark run.
+
+Blocks live under a `blocks.noindex` subdirectory so Spotlight does not index
+them, and files are `0600` under a `0700` root because prompt content is
+recoverable from them. The store is not excluded from Time Machine for you.
+Run `tmutil addexclusion /path/to/kv-store` if it is on a backed-up volume.
+
+## KV-aware routing
+
+A KV-aware router places requests by knowing which instance already holds
+a prefix. It learns that from the `BlockStored` events the offload tier
+publishes, so the events have to be turned on:
+
+```bash
+PYTHONHASHSEED=0 \
+VLLM_METAL_USE_PAGED_ATTENTION=1 vllm serve <model> \
+  --kv-offloading-size 32 \
+  --kv-events-config '{"enable_kv_cache_events": true, "publisher": "zmq",
+    "endpoint": "tcp://*:5557"}' \
+  --kv-transfer-config '{"kv_connector_extra_config":
+    {"secondary_tiers": [{"type": "fs", "root_dir": "/path/to/kv-store"}]}}'
+```
+
+`enable_kv_events` on the tier is set automatically when
+`--kv-events-config` enables events globally. Setting it on the tier *without*
+enabling events globally is refused at startup, because the tier would publish
+nothing and the router would silently route as if this instance held no
+prefixes.
+
+## Not supported
+
+Rejected at startup with a specific message, rather than failing later.
+
+- Hybrid and sliding-window models. A single uniform full-attention KV cache
+  group only.
+- Draft-model speculative decoding, which puts the draft KV in the same cache
+  group.
+- Multiple workers. Offloading needs the single-process executor, because the
+  host pool is shared between the scheduler and the worker in one process.
+- The `p2p` and `obj` tiers.
+
+## Known limitations
+
+Block files carry no checksum, matching upstream's on-disk format so a store
+written here is readable by an upstream `fs` tier and the reverse. A torn write
+or bit rot therefore produces a right-sized file whose contents are wrong, and
+it is restored without complaint. Only truncation is caught.
+
+Deleting block files does not immediately return disk space, because APFS local
+snapshots are volume-wide and have no per-path exclusion.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -73,6 +73,7 @@ nav:
     - Text Pooling: text_embedding_pooling.md
     - Speech-to-Text: stt.md
     - Turboquant: turboquant.md
+    - KV Cache Offloading: kv_offloading.md
     - GPU Profiling: profiling.md
     - Distributed (Ray): distributed.md
   - Contributing: CONTRIBUTING.md

--- a/tests/kv_offload_helpers.py
+++ b/tests/kv_offload_helpers.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared helpers for the KV offloading tests.
+
+The snapshot/zero helpers mirror the cache kernels' write-then-rebind idiom
+(see vllm_metal/attention/caches/kv_cache.py): mutate through the current
+list entry, then rebind it, so later readers get provenance.
+"""
+
+import mmap
+import uuid
+
+import mlx.core as mx
+import numpy as np
+from vllm.v1.kv_offload.base import GPULoadStoreSpec
+
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+from vllm_metal.v1.kv_offload.worker import CACHE_ATTRS, MetalKVOffloadWorker
+
+
+def make_cache(dtype: mx.Dtype = mx.float16, **kwargs) -> MetalPagedKVCache:
+    kwargs.setdefault("num_layers", 2)
+    kwargs.setdefault("num_kv_heads", 2)
+    kwargs.setdefault("head_dim", 32)
+    kwargs.setdefault("num_blocks", 8)
+    kwargs.setdefault("block_size", 4)
+    return MetalPagedKVCache(dtype=dtype, **kwargs)
+
+
+def gpu_block_bytes(cache: MetalPagedKVCache) -> int:
+    """Bytes of one GPU block summed across every cache array."""
+    total = 0
+    for attr in CACHE_ATTRS:
+        for arr in getattr(cache, attr):
+            total += int(np.prod(arr.shape[1:])) * arr.dtype.size
+    return total
+
+
+def make_region(
+    cache: MetalPagedKVCache,
+    *,
+    block_size_factor: int,
+    num_cpu_blocks: int,
+    rank: int | None = 0,
+    engine_id: str | None = None,
+) -> MetalSharedOffloadRegion:
+    """One attachment to a shared region sized for ``cache``.
+
+    Rows are rounded up to the page size, as upstream's SharedOffloadRegion
+    does. Pass the same ``engine_id`` twice (rank 0 and rank None) to get
+    the worker-side and scheduler-side views of one region."""
+    raw_row = gpu_block_bytes(cache) * block_size_factor
+    aligned_row = -(-raw_row // mmap.PAGESIZE) * mmap.PAGESIZE
+    return MetalSharedOffloadRegion(
+        engine_id=engine_id or f"test-{uuid.uuid4().hex[:8]}",
+        num_blocks=num_cpu_blocks,
+        rank=rank,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+
+
+def make_worker(
+    cache: MetalPagedKVCache,
+    *,
+    block_size_factor: int = 1,
+    num_cpu_blocks: int = 4,
+    **kwargs,
+) -> MetalKVOffloadWorker:
+    """A worker over a fresh region; ``kwargs`` pass through."""
+    region = make_region(
+        cache, block_size_factor=block_size_factor, num_cpu_blocks=num_cpu_blocks
+    )
+    return MetalKVOffloadWorker(
+        cache,
+        block_size_factor=block_size_factor,
+        num_cpu_blocks=num_cpu_blocks,
+        region=region,
+        **kwargs,
+    )
+
+
+def randomize(cache: MetalPagedKVCache, seed: int = 0) -> None:
+    """Fill every cache array with distinct values."""
+    mx.random.seed(seed)
+    for attr in CACHE_ATTRS:
+        arrays = getattr(cache, attr)
+        for i, arr in enumerate(arrays):
+            if arr.dtype in (mx.float16, mx.bfloat16, mx.float32):
+                arrays[i] = mx.random.normal(arr.shape).astype(arr.dtype)
+            else:
+                arrays[i] = mx.random.randint(0, 255, arr.shape).astype(arr.dtype)
+        mx.eval(*arrays)
+
+
+def snapshot_blocks(cache: MetalPagedKVCache, block_ids: list[int]) -> list[np.ndarray]:
+    """Copy the given blocks of every cache array to numpy (bf16 as uint16)."""
+    out = []
+    for attr in CACHE_ATTRS:
+        for arr in getattr(cache, attr):
+            sl = mx.take(arr, mx.array(block_ids), axis=0)
+            if sl.dtype == mx.bfloat16:
+                sl = mx.view(sl, mx.uint16)
+            out.append(np.array(sl))
+    return out
+
+
+def zero_blocks(cache: MetalPagedKVCache, block_ids: list[int]) -> None:
+    for attr in CACHE_ATTRS:
+        arrays = getattr(cache, attr)
+        for i, arr in enumerate(arrays):
+            arr[mx.array(block_ids)] = mx.zeros(
+                (len(block_ids), *arr.shape[1:]), dtype=arr.dtype
+            )
+            arrays[i] = arr
+            mx.eval(arr)
+
+
+def gpu_spec(block_ids: list[int], block_index: int = 0) -> GPULoadStoreSpec:
+    return GPULoadStoreSpec(
+        block_ids, group_sizes=[len(block_ids)], block_indices=[block_index]
+    )

--- a/tests/test_decode_pipeline.py
+++ b/tests/test_decode_pipeline.py
@@ -160,6 +160,7 @@ def _submit_step(
             entries=tuple(entries),
             batch=batch,
             scheduler_output=_make_scheduler_output(req_ids),
+            kv_connector_output=None,
         )
     )
     return handle, states, batch

--- a/tests/test_kv_offload_config.py
+++ b/tests/test_kv_offload_config.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Config-time tests for the KV offloading platform wiring.
+
+MetalPlatform.check_and_update_config performs the --kv-offloading-size ->
+kv_transfer_config translation itself (it runs before vLLM's own translation,
+which would force-set a connector this platform cannot serve) and routes the
+connector/spec lookups to the Metal classes.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_metal.config import reset_config
+from vllm_metal.platform import MetalPlatform
+
+
+def _base_config(**cache_overrides) -> SimpleNamespace:
+    cache_config = SimpleNamespace(
+        block_size=None,
+        enable_prefix_caching=False,
+        kv_offloading_size=None,
+        kv_offloading_backend="native",
+        # Read by _pick_mb_buffer_default (#637).
+        gpu_memory_utilization=0.9,
+        # Populated by --kv-cache-dtype turboquant_*; Metal rejects it up
+        # front (TurboQuant runs off --additional-config).
+        kv_cache_dtype_skip_layers=[],
+    )
+    for key, value in cache_overrides.items():
+        setattr(cache_config, key, value)
+    return SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            worker_cls="auto",
+            distributed_executor_backend="auto",
+            pipeline_parallel_size=1,
+            tensor_parallel_size=1,
+            data_parallel_size=1,
+            disable_custom_all_reduce=False,
+        ),
+        cache_config=cache_config,
+        speculative_config=None,
+        model_config=SimpleNamespace(
+            model="test-model",
+            disable_cascade_attn=False,
+            tokenizer=None,
+            max_model_len=4096,
+            multimodal_config=None,
+            hf_config=SimpleNamespace(model_type="qwen3"),
+            is_hybrid=False,
+        ),
+        scheduler_config=SimpleNamespace(
+            async_scheduling=False,
+            enable_chunked_prefill=True,
+            max_num_batched_tokens=2048,
+            max_num_scheduled_tokens=None,
+        ),
+        kv_transfer_config=None,
+        # Real VllmConfig always carries this; the events path reads it.
+        kv_events_config=None,
+        # The platform hook reads this directly (vllm-metal #604 dropped the
+        # getattr fallback in favour of trusting vLLM's typed config).
+        additional_config=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _paged_attention(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+    monkeypatch.setattr(
+        "vllm_metal.platform.MetalPlatform._is_stt_model",
+        staticmethod(lambda *_: False),
+        raising=False,
+    )
+    reset_config()
+    yield
+    reset_config()
+
+
+def test_offloading_size_translates_to_metal_connector() -> None:
+    vllm_config = _base_config(kv_offloading_size=2.0)
+    MetalPlatform.check_and_update_config(vllm_config)
+
+    ktc = vllm_config.kv_transfer_config
+    assert ktc is not None
+    assert ktc.kv_connector == "MetalOffloadingConnector"
+    assert ktc.kv_connector_module_path == "vllm_metal.v1.kv_offload.connector"
+    assert ktc.kv_role == "kv_both"
+    extra = ktc.kv_connector_extra_config
+    assert extra["cpu_bytes_to_use"] == 2 * (1 << 30)
+    # One spec serves both the plain host pool and secondary tiers.
+    assert extra["spec_name"] == "MetalTieringOffloadingSpec"
+    assert extra["spec_module_path"] == "vllm_metal.v1.kv_offload.spec"
+    # Upstream translation must be disarmed (it would force-set a connector
+    # name after this hook has run).
+    assert vllm_config.cache_config.kv_offloading_size is None
+
+
+def test_secondary_tiers_select_tiering_spec() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={
+            "secondary_tiers": [{"type": "fs", "root_dir": "/tmp/kv"}]
+        },
+    )
+    MetalPlatform.check_and_update_config(vllm_config)
+
+    extra = vllm_config.kv_transfer_config.kv_connector_extra_config
+    assert extra["spec_name"] == "MetalTieringOffloadingSpec"
+
+
+def test_offloading_requires_uni_executor() -> None:
+    """The host pool is anonymous RAM shared within one process, so a
+    multi-process executor would give the worker a disjoint pool."""
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.parallel_config.distributed_executor_backend = "mp"
+    with pytest.raises(NotImplementedError, match="single-process executor"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_inert_kv_transfer_config_passes_through() -> None:
+    """A kv_transfer_config with no connector and no offloading request was
+    inert upstream and must stay untouched (no guards, no spec injection)."""
+    vllm_config = _base_config()
+    inert = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role="kv_both",
+        kv_connector_extra_config={},
+    )
+    vllm_config.kv_transfer_config = inert
+    MetalPlatform.check_and_update_config(vllm_config)
+
+    assert vllm_config.kv_transfer_config is inert
+    assert inert.kv_connector is None
+    assert inert.kv_connector_module_path is None
+    assert inert.kv_connector_extra_config == {}
+
+
+def test_unsupported_connector_rejected() -> None:
+    vllm_config = _base_config()
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector="NixlConnector",
+        kv_connector_module_path=None,
+        kv_role="kv_both",
+        kv_connector_extra_config={},
+    )
+    with pytest.raises(NotImplementedError, match="NixlConnector"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_explicit_connector_without_size_rejected() -> None:
+    vllm_config = _base_config()
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector="OffloadingConnector",
+        kv_connector_module_path=None,
+        kv_role="kv_both",
+        kv_connector_extra_config={},
+    )
+    with pytest.raises(NotImplementedError, match="--kv-offloading-size"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_unknown_spec_name_rejected() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={"spec_name": "ARCOffloadingSpec"},
+    )
+    with pytest.raises(NotImplementedError, match="ARCOffloadingSpec"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_simple_kv_offload_env_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("vllm.envs.VLLM_USE_SIMPLE_KV_OFFLOAD", True, raising=False)
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    with pytest.raises(NotImplementedError, match="VLLM_USE_SIMPLE_KV_OFFLOAD"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_offloading_requires_paged_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "0")
+    reset_config()
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    with pytest.raises(NotImplementedError, match="paged attention"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_lmcache_backend_rejected() -> None:
+    vllm_config = _base_config(kv_offloading_size=1.0, kv_offloading_backend="lmcache")
+    with pytest.raises(NotImplementedError, match="lmcache"):
+        MetalPlatform.check_and_update_config(vllm_config)
+
+
+def test_validate_metal_support_guards() -> None:
+    """The single-group / uniform-attention guard that keeps hybrid and
+    non-attention KV layouts off the offload path (e2e-validated on gemma-4;
+    unit-pinned here)."""
+    from types import SimpleNamespace
+
+    import pytest
+    from vllm.v1.kv_cache_interface import AttentionSpec
+
+    from vllm_metal.v1.kv_offload.spec import validate_metal_support
+
+    def group(spec, layer_names=("layer0",)):
+        return SimpleNamespace(kv_cache_spec=spec, layer_names=layer_names)
+
+    with pytest.raises(NotImplementedError, match="single KV cache group"):
+        validate_metal_support(
+            SimpleNamespace(kv_cache_groups=[group(None), group(None)])
+        )
+    with pytest.raises(NotImplementedError, match="hybrid/sliding-window"):
+        validate_metal_support(SimpleNamespace(kv_cache_groups=[group(object())]))
+
+    # vllm-metal #630 puts the draft model's KV in this same group, so a
+    # non-uniform spec here usually means spec decode, not a hybrid model.
+    # Saying "hybrid/sliding-window" sends the user after the wrong thing.
+    with pytest.raises(NotImplementedError, match="speculative decoding"):
+        validate_metal_support(
+            SimpleNamespace(
+                kv_cache_groups=[
+                    group(object(), ("layer0", "draft_layers.0.self_attn"))
+                ]
+            )
+        )
+
+    class _FakeAttention(AttentionSpec):
+        pass
+
+    ok = _FakeAttention.__new__(_FakeAttention)
+    validate_metal_support(SimpleNamespace(kv_cache_groups=[group(ok)]))  # no raise
+
+
+def test_secondary_tier_gate_is_idempotent() -> None:
+    """check_and_update_config runs again in the engine core process, on a
+    config MetalTieringOffloadingSpec has already rewritten to name the Metal
+    tier class. The gate has to accept its own rewrite or the engine dies at
+    startup with 'tier type MetalFileSystemTierManager is not supported'."""
+    from vllm_metal.v1.kv_offload.spec import route_fs_tiers_to_metal
+
+    tiers = [{"type": "fs", "root_dir": "/tmp/unused"}]
+    config = _base_config(
+        kv_offloading_size=8,
+    )
+    config.kv_transfer_config = SimpleNamespace(
+        kv_connector="OffloadingConnector",
+        kv_role=None,
+        kv_connector_module_path=None,
+        kv_connector_extra_config={"secondary_tiers": tiers},
+    )
+    MetalPlatform.check_and_update_config(config)
+
+    # The spec rewrites the tier in place, exactly as it does at runtime.
+    route_fs_tiers_to_metal(config.kv_transfer_config.kv_connector_extra_config)
+    assert tiers[0]["type"] == "MetalFileSystemTierManager"
+
+    # Second pass over the rewritten config must not raise.
+    MetalPlatform.check_and_update_config(config)
+
+
+def test_kv_events_enable_the_tier_switch() -> None:
+    """A KV-aware router consumes the BlockStored events the tier emits, and
+    the tier only emits them when its own enable_kv_events is set AND events
+    are on globally. Set them up for the user rather than making them line up
+    two switches by hand."""
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.kv_events_config = SimpleNamespace(enable_kv_cache_events=True)
+    tiers = [{"type": "fs", "root_dir": "/tmp/kv"}]
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={"secondary_tiers": tiers},
+    )
+    MetalPlatform.check_and_update_config(vllm_config)
+    assert tiers[0]["enable_kv_events"] is True
+
+
+def test_tier_events_without_global_events_rejected() -> None:
+    """The reverse combination emits nothing and only warns mid-startup,
+    which looks exactly like a broken router. Refuse it at config time."""
+    vllm_config = _base_config(kv_offloading_size=1.0)
+    vllm_config.kv_events_config = None
+    vllm_config.kv_transfer_config = SimpleNamespace(
+        kv_connector=None,
+        kv_connector_module_path=None,
+        kv_role=None,
+        kv_connector_extra_config={
+            "secondary_tiers": [
+                {"type": "fs", "root_dir": "/tmp/kv", "enable_kv_events": True}
+            ]
+        },
+    )
+    with pytest.raises(NotImplementedError, match="kv-events-config"):
+        MetalPlatform.check_and_update_config(vllm_config)

--- a/tests/test_kv_offload_connector_step_order.py
+++ b/tests/test_kv_offload_connector_step_order.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Step-to-step ordering of the KV connector context on the pipelined path.
+
+Upstream's store fencing depends on an ordering across step boundaries. Step
+k's context close runs ``prepare_store_kv``, which queues that step's store
+jobs; step k+1's ``handle_preemptions`` then submits them, and ``submit_store``
+performs the copy synchronously. If step k's context is still open at that
+point its jobs are not queued yet, so the copy runs a step later, against
+blocks the intervening forward has overwritten. That is a silent wrong-KV
+write into the offload pool, so the ordering is a correctness contract.
+
+Two levels are covered. ``execute_model`` is driven for real, far enough to
+record that it handles preemptions before opening the step, then stopped with
+a deliberate raise; that pins the call order itself. The cross-step tests then
+drive the runner's helpers in that same order to pin the lifecycle across a
+step boundary, which no single ``execute_model`` call can show.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
+
+import vllm_metal.v1.model_runner as mr
+from tests.stub_runner import make_stub_runner
+
+
+class _ConnectorSpy:
+    """Records the connector lifecycle and enforces upstream's invariants.
+
+    Mirrors the two things upstream does that this test is about: metadata is
+    bound on enter and cleared on the no-forward path, and ``get_finished``
+    asserts the metadata is still bound when the context closes.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.metadata_bound = False
+        self.step = "?"
+
+    # -- the runner's collaborators -------------------------------------
+    def handle_preemptions(self, metadata) -> None:
+        del metadata
+        self.events.append(f"preempt:{self.step}")
+
+    def no_forward(self, *args, **kwargs):
+        del args, kwargs
+        self.events.append(f"no_forward:{self.step}")
+        self.metadata_bound = False  # upstream clears on this path
+        return mr.EMPTY_MODEL_RUNNER_OUTPUT
+
+    @contextmanager
+    def step_context(self, scheduler_output, *args, **kwargs):
+        del scheduler_output, args, kwargs
+        self.metadata_bound = True
+        self.events.append(f"open:{self.step}")
+        output = KVConnectorOutput()
+        try:
+            yield output
+        finally:
+            if not self.metadata_bound:
+                raise AssertionError(
+                    "connector step closed after its metadata was cleared"
+                )
+            self.events.append(f"close:{self.step}")
+            output.finished_recving = {f"r-{self.step}"}
+
+
+@pytest.fixture
+def spy(monkeypatch) -> _ConnectorSpy:
+    connector = _ConnectorSpy()
+    monkeypatch.setattr(mr, "has_kv_transfer_group", lambda: True)
+    monkeypatch.setattr(mr, "get_kv_transfer_group", lambda: connector)
+    monkeypatch.setattr(mr, "set_forward_context", lambda *a, **k: nullcontext())
+    monkeypatch.setattr(
+        mr.KVConnectorModelRunnerMixin,
+        "_get_kv_connector_output",
+        staticmethod(connector.step_context),
+    )
+    monkeypatch.setattr(
+        mr.KVConnectorModelRunnerMixin,
+        "kv_connector_no_forward",
+        staticmethod(connector.no_forward),
+    )
+    return connector
+
+
+def _scheduler_output(req_ids: list[str]) -> SchedulerOutput:
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens=dict.fromkeys(req_ids, 1),
+        total_num_scheduled_tokens=len(req_ids),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+        num_invalid_spec_tokens=None,
+        num_spec_tokens_to_schedule=0,
+    )
+    scheduler_output.kv_connector_metadata = SimpleNamespace()
+    return scheduler_output
+
+
+def _drive_execute_model_prologue(runner, scheduler_output) -> None:
+    """Run the real execute_model until just past the connector step opening.
+
+    _handle_new_requests is the first statement after the step opens, so
+    raising there stops the drive without a forward, a device, or a live
+    connector, while still exercising execute_model's own ordering.
+    """
+
+    def stop(*args, **kwargs):
+        raise RuntimeError("stop after the connector step opened")
+
+    runner._handle_new_requests = stop
+    with pytest.raises(RuntimeError, match="stop after"):
+        runner.execute_model(scheduler_output)
+
+
+def test_execute_model_handles_preemptions_before_opening_the_step(spy):
+    """The store fence depends on this order inside execute_model itself."""
+    runner = make_stub_runner(model=SimpleNamespace())
+    spy.step = "1"
+
+    _drive_execute_model_prologue(runner, _scheduler_output(["r0"]))
+
+    assert spy.events == ["preempt:1", "open:1"]
+
+
+def test_zero_token_step_still_handles_preemptions(spy):
+    """A step with no forward must still let KV transfers progress."""
+    runner = make_stub_runner(model=SimpleNamespace())
+    spy.step = "1"
+
+    runner.execute_model(_scheduler_output([]))
+
+    assert spy.events == ["preempt:1", "no_forward:1"]
+
+
+def _pipelined_decode_step(runner, spy, tag: str) -> None:
+    """One pipeline-eligible decode step, in execute_model's own order."""
+    spy.step = tag
+    scheduler_output = _scheduler_output(["r0"])
+
+    # execute_model: preemptions are handled BEFORE the step context opens.
+    spy.handle_preemptions(None)
+    runner._kv_connector_start_step(scheduler_output)
+
+    state = mr.RequestState(
+        token_ids=[3, 9],
+        prompt_len=1,
+        cache=[],
+        sampling_params=SamplingParams(temperature=0.0),
+        generator=None,
+        generated_tokens=1,
+    )
+    runner._paged_request_seq_lens = {"r0": 1}
+    runner._execute_model_state = mr._PagedForwardState(
+        batch=mr._ExecutionBatch(),
+        prefill_reqs=[],
+        decode_reqs=[("r0", state)],
+        scheduler_output=scheduler_output,
+        logits=mx.array([[[0.0, 10.0, 0.0, 0.0]]]),
+        target_hidden_states=None,
+        pooling_hidden_states=None,
+        cu_seqlens=[0, 1],
+        logits_cu_seqlens=[0, 1],
+        decode_segments=[],
+        num_decode_tokens=1,
+        mm_prefill_deltas={},
+    )
+    runner._decode_pipeline.begin_step(
+        mr.PipelineGateDecision(eligible=True, reason="eligible")
+    )
+    runner.sample_tokens(grammar_output=None)
+
+
+def test_step_context_closes_before_the_next_step_handles_preemptions(spy):
+    """close(k) must precede preempt(k+1), or the flush fence is a no-op."""
+    runner = make_stub_runner(model=SimpleNamespace())
+
+    _pipelined_decode_step(runner, spy, "1")
+    _pipelined_decode_step(runner, spy, "2")
+
+    assert spy.events == [
+        "preempt:1",
+        "open:1",
+        "close:1",
+        "preempt:2",
+        "open:2",
+        "close:2",
+    ]
+
+
+def test_zero_token_step_after_a_pipelined_step_does_not_crash(spy):
+    """A leaked context plus a zero-token step kills engine core upstream.
+
+    The no-forward path clears the connector metadata, so a later close of the
+    still-open previous context trips get_finished's metadata assertion."""
+    runner = make_stub_runner(model=SimpleNamespace())
+
+    _pipelined_decode_step(runner, spy, "1")
+
+    # Step 2 schedules nothing: execute_model takes the no-forward path and
+    # sample_tokens is never called.
+    spy.step = "2"
+    spy.handle_preemptions(None)
+    spy.no_forward(_scheduler_output([]), runner.vllm_config)
+
+    # Step 3 opens its own context. With step 1 leaked, the recovery close
+    # would run against cleared metadata and raise.
+    spy.step = "3"
+    runner._kv_connector_start_step(_scheduler_output(["r0"]))
+
+    assert "close:1" in spy.events
+    assert spy.events.index("close:1") < spy.events.index("no_forward:2")

--- a/tests/test_kv_offload_cuda_parity.py
+++ b/tests/test_kv_offload_cuda_parity.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Functional parity of the Metal offload path with vLLM's CUDA path.
+
+The scheduler side needs no parity testing: it *is* the upstream code
+(asserted below by function identity). The worker-side worker is the one
+reimplemented piece, so its observable contract — which bytes land in which
+host-pool slot for a given TransferSpec — is checked here against upstream's
+own placement arithmetic: ``compute_sub_block_ptrs`` from
+``vllm/v1/kv_offload/cpu/gpu_worker.py``, the exact function the CUDA DMA
+path uses to build its copy descriptors (it is pure numpy/torch pointer math
+and runs on any platform).
+
+For every transfer the CUDA worker copies GPU block ``i`` to the byte range
+``[ptrs[i], ptrs[i] + page_size)`` of the CPU tensor, where ``ptrs`` comes
+from ``compute_sub_block_ptrs`` over the CPU tensor with the transfer's
+``skip = block_index % block_size_factor``. The Metal worker must place the
+same bytes at the same offsets of its host pool, per cache array.
+"""
+
+import numpy as np
+import pytest
+import torch
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.gpu_worker import compute_sub_block_ptrs
+
+from tests.kv_offload_helpers import (
+    gpu_spec,
+    make_cache,
+    make_worker,
+    randomize,
+    snapshot_blocks,
+    zero_blocks,
+)
+
+NUM_CPU_BLOCKS = 4
+
+CASES = [
+    pytest.param(1, [5, 2, 7], [0, 1, 3], 0, id="factor1"),
+    pytest.param(2, [1, 2, 3, 4], [0, 2], 0, id="factor2-aligned"),
+    pytest.param(2, [5], [2], 3, id="factor2-unaligned"),
+    pytest.param(4, [1, 2, 3], [0, 3], 6, id="factor4-unaligned-spanning"),
+]
+
+
+def _expected_offsets(
+    pool: np.ndarray, factor: int, cpu_blocks: list[int], skip: int, count: int
+) -> np.ndarray:
+    """Byte offsets into ``pool`` where upstream CUDA would place each block.
+
+    ``pool`` is one cache array's host pool, shape
+    (num_cpu_blocks, factor, *block_shape). Upstream sees it as the
+    (num_cpu_blocks, row_bytes) int8 CPU tensor it computes pointers over;
+    the reshape keeps the region's row stride, so the pointers are the real
+    ones.
+    """
+    rows = pool.reshape(NUM_CPU_BLOCKS, -1).view(np.int8)
+    cpu_tensor = torch.from_numpy(rows)
+    ptrs = np.empty(count, dtype=np.uint64)
+    compute_sub_block_ptrs(
+        np.asarray(cpu_blocks), factor, ptrs, cpu_tensor, skip_count=skip
+    )
+    return (ptrs - np.uint64(cpu_tensor.data_ptr())).astype(np.int64)
+
+
+@pytest.mark.parametrize(("factor", "gpu_blocks", "cpu_blocks", "block_index"), CASES)
+@pytest.mark.parametrize("turboquant", [False, True], ids=["fp16", "turboquant"])
+def test_store_placement_matches_cuda(
+    factor: int,
+    gpu_blocks: list[int],
+    cpu_blocks: list[int],
+    block_index: int,
+    turboquant: bool,
+) -> None:
+    if turboquant:
+        cache = make_cache(head_dim=64, turboquant=True, k_quant="q8_0", v_quant="q3_0")
+    else:
+        cache = make_cache()
+    worker = make_worker(cache, block_size_factor=factor, num_cpu_blocks=NUM_CPU_BLOCKS)
+    randomize(cache)
+    original = snapshot_blocks(cache, gpu_blocks)
+
+    assert worker.submit_store(
+        1, gpu_spec(gpu_blocks, block_index), CPULoadStoreSpec(cpu_blocks)
+    )
+    assert [r.job_id for r in worker.get_finished()] == [1]
+
+    skip = block_index % factor
+    # ref.cpu is a strided view into the region (rows are page-aligned, as
+    # upstream lays them out), so read the placement off the region itself
+    # rather than a flattened copy.
+    region_bytes = (
+        np.asarray(worker.region.create_kv_memoryview()).reshape(-1).view(np.uint8)
+    )
+    region_ptr = region_bytes.ctypes.data
+    for ref, blocks in zip(worker._refs, original, strict=True):
+        pool_bytes = region_bytes[ref.cpu.ctypes.data - region_ptr :]
+        block_bytes = blocks.reshape(len(gpu_blocks), -1).view(np.uint8)
+        page = block_bytes.shape[1]
+        offsets = _expected_offsets(ref.cpu, factor, cpu_blocks, skip, len(gpu_blocks))
+        for i, off in enumerate(offsets):
+            np.testing.assert_array_equal(
+                pool_bytes[off : off + page],
+                block_bytes[i],
+                err_msg=f"gpu block {gpu_blocks[i]} not at CUDA offset {off}",
+            )
+
+    # Load back through the Metal worker from the CUDA-verified layout, so
+    # both directions are pinned to the same placement.
+    zero_blocks(cache, gpu_blocks)
+    assert worker.submit_load(
+        2, CPULoadStoreSpec(cpu_blocks), gpu_spec(gpu_blocks, block_index)
+    )
+    assert [r.job_id for r in worker.get_finished()] == [2]
+    for a, b in zip(original, snapshot_blocks(cache, gpu_blocks), strict=True):
+        np.testing.assert_array_equal(a, b)
+
+
+def test_scheduler_side_is_upstream_code() -> None:
+    """The scheduler-facing surface is upstream's own functions, not ports."""
+    from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
+        OffloadingConnector,
+    )
+
+    from vllm_metal.v1.kv_offload.connector import MetalOffloadingConnector
+
+    # The connector overrides only worker-side KV-cache registration; every
+    # scheduler-side hook is inherited.
+    overridden = {
+        name for name in vars(MetalOffloadingConnector) if not name.startswith("_")
+    }
+    assert overridden == {"register_kv_caches"}, overridden
+    for name in (
+        "get_num_new_matched_tokens",
+        "update_state_after_alloc",
+        "build_connector_meta",
+        "request_finished",
+        "take_events",
+    ):
+        assert getattr(MetalOffloadingConnector, name) is getattr(
+            OffloadingConnector, name
+        ), name

--- a/tests/test_kv_offload_decode_pipeline.py
+++ b/tests/test_kv_offload_decode_pipeline.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV connector step lifecycle on the pipelined (deferred) decode path.
+
+``sample_tokens`` has three exits. The two synchronous ones close the KV
+connector step and stamp its ``KVConnectorOutput`` onto the returned
+``ModelRunnerOutput``. The deferred exit returns a
+``MetalAsyncModelRunnerOutput`` and the real output is built one step later
+inside ``DecodePipeline._resolve_pending``. These tests pin the two things
+the scheduler depends on for that exit: the resolved output carries the
+connector output, and the step context does not leak into the next step.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
+from vllm.v1.outputs import KVConnectorOutput
+
+import vllm_metal.v1.model_runner as mr
+from tests.stub_runner import make_stub_runner
+
+FINISHED_RECVING = {"r1"}
+INVALID_BLOCK_IDS = {7, 11}
+
+
+def _scheduler_output(req_ids: list[str]) -> SchedulerOutput:
+    return SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData.make_empty(),
+        num_scheduled_tokens=dict.fromkeys(req_ids, 1),
+        total_num_scheduled_tokens=len(req_ids),
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+        num_invalid_spec_tokens=None,
+        num_spec_tokens_to_schedule=0,
+    )
+
+
+def _decode_state() -> mr.RequestState:
+    return mr.RequestState(
+        token_ids=[3, 9],
+        prompt_len=1,
+        cache=[],
+        sampling_params=SamplingParams(temperature=0.0),
+        generator=None,
+        generated_tokens=1,
+    )
+
+
+def _paged_state(decode_reqs, scheduler_output) -> mr._PagedForwardState:
+    return mr._PagedForwardState(
+        batch=mr._ExecutionBatch(),
+        prefill_reqs=[],
+        decode_reqs=list(decode_reqs),
+        scheduler_output=scheduler_output,
+        logits=mx.array([[[0.0, 10.0, 0.0, 0.0]] * len(decode_reqs)]),
+        target_hidden_states=None,
+        pooling_hidden_states=None,
+        cu_seqlens=list(range(len(decode_reqs) + 1)),
+        # Pure decode projects every row, so the logits boundaries are the
+        # packed ones (#590).
+        logits_cu_seqlens=list(range(len(decode_reqs) + 1)),
+        decode_segments=[],
+        num_decode_tokens=len(decode_reqs),
+        mm_prefill_deltas={},
+    )
+
+
+class _ConnectorEnv:
+    """Fake connector step whose output is tagged per step."""
+
+    def __init__(self) -> None:
+        self.tag = "s0"
+
+
+@pytest.fixture
+def connector_env(monkeypatch) -> _ConnectorEnv:
+    """Make the runner's connector-step helpers runnable off-device.
+
+    ``_kv_connector_start_step`` runs for real, since it owns the ExitStack
+    whose lifetime is under test. Only its two collaborators are faked: the
+    forward context needs a real VllmConfig, and the upstream mixin needs a
+    registered transfer group and live GPU caches. Neither is available to a
+    stub runner, and neither is what these tests are about.
+
+    The fake populates its fields on EXIT, mirroring the upstream mixin
+    (vllm/v1/worker/kv_connector_model_runner_mixin.py). Upstream sets more
+    fields than these three; the whole object is handed over by reference, so
+    the extra fields ride along untouched.
+    """
+    env = _ConnectorEnv()
+    monkeypatch.setattr(mr, "has_kv_transfer_group", lambda: True)
+    monkeypatch.setattr(mr, "set_forward_context", lambda *a, **k: nullcontext())
+
+    @contextmanager
+    def fake_get_kv_connector_output(scheduler_output, *args, **kwargs):
+        del scheduler_output, args, kwargs
+        output = KVConnectorOutput()
+        try:
+            yield output
+        finally:
+            output.finished_sending = {env.tag}
+            output.finished_recving = set(FINISHED_RECVING)
+            output.invalid_block_ids = set(INVALID_BLOCK_IDS)
+
+    monkeypatch.setattr(
+        mr.KVConnectorModelRunnerMixin,
+        "_get_kv_connector_output",
+        staticmethod(fake_get_kv_connector_output),
+    )
+    return env
+
+
+def _arm_eligible_step(runner, scheduler_output) -> None:
+    """Put an existing runner on a pipeline-eligible pure-decode step."""
+    state = _decode_state()
+    runner._paged_request_seq_lens = {"r0": 1}
+    runner._execute_model_state = _paged_state([("r0", state)], scheduler_output)
+    runner._decode_pipeline.begin_step(
+        mr.PipelineGateDecision(eligible=True, reason="eligible")
+    )
+
+
+def _runner_on_eligible_step(scheduler_output) -> mr.MetalModelRunner:
+    runner = make_stub_runner(model=SimpleNamespace())
+    _arm_eligible_step(runner, scheduler_output)
+    return runner
+
+
+class TestDeferredDecodeCarriesConnectorOutput:
+    """The deferred exit must not drop the connector's step results."""
+
+    def test_resolved_output_carries_kv_connector_output(self, connector_env):
+        # Arrange — a KV connector step is open for a pipeline-eligible
+        # pure-decode step, exactly as execute_model leaves it.
+        scheduler_output = _scheduler_output(["r0"])
+        runner = _runner_on_eligible_step(scheduler_output)
+        runner._kv_connector_start_step(scheduler_output)
+
+        # Act — the engine takes the async output and resolves it a step later.
+        async_output = runner.sample_tokens(grammar_output=None)
+        assert isinstance(async_output, mr.MetalAsyncModelRunnerOutput)
+        output = async_output.get_output()
+
+        # Assert — the scheduler reads finished/invalid sets off this output.
+        assert output.kv_connector_output is not None
+        assert output.kv_connector_output.finished_sending == {connector_env.tag}
+        assert output.kv_connector_output.finished_recving == FINISHED_RECVING
+        assert output.kv_connector_output.invalid_block_ids == INVALID_BLOCK_IDS
+
+    def test_step_context_is_closed_once_the_deferred_step_is_submitted(
+        self, connector_env
+    ):
+        # Arrange
+        scheduler_output = _scheduler_output(["r0"])
+        runner = _runner_on_eligible_step(scheduler_output)
+        runner._kv_connector_start_step(scheduler_output)
+
+        # Act
+        runner.sample_tokens(grammar_output=None)
+
+        # Assert - the deferred step left no context open for the next step
+        # to find. Asserted directly rather than via the leak log, which is
+        # wording that can change.
+        assert runner._kv_connector_stack is None
+
+    def test_each_pipelined_step_carries_its_own_connector_output(self, connector_env):
+        """Two steps in flight must not swap or share their connector output."""
+        runner = make_stub_runner(model=SimpleNamespace())
+
+        outputs = []
+        for step in ("a", "b"):
+            connector_env.tag = step
+            scheduler_output = _scheduler_output(["r0"])
+            _arm_eligible_step(runner, scheduler_output)
+            runner._kv_connector_start_step(scheduler_output)
+            outputs.append(runner.sample_tokens(grammar_output=None))
+
+        resolved = [o.get_output().kv_connector_output for o in outputs]
+        assert [r.finished_sending for r in resolved] == [{"a"}, {"b"}]

--- a/tests/test_kv_offload_fs_tier.py
+++ b/tests/test_kv_offload_fs_tier.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the macOS-tuned fs secondary tier (vllm_metal/v1/kv_offload/fs_tier.py).
+
+The io functions must keep upstream's semantics (byte-identical on-disk format,
+atomic replace, dedup on existing files) while adding the macOS integrations:
+F_NOCACHE, 0o600 files, 0o700 directories, and .noindex nesting.
+"""
+
+import os
+import stat
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from vllm_metal.v1.kv_offload.fs_tier import (
+    NOINDEX_DIRNAME,
+    MetalFileSystemTierManager,
+    load_block,
+    prepare_root_dir,
+    store_block,
+)
+
+BLOCK = 4096
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_store_load_roundtrip(tmp_path: Path) -> None:
+    data = np.random.default_rng(0).integers(0, 256, BLOCK * 2, dtype=np.uint8)
+    dest = tmp_path / "ab" / "cd_g0" / "hash.bin"
+
+    store_block(str(dest), memoryview(data), BLOCK, BLOCK)
+
+    assert _mode(dest) == 0o600
+    assert [p.name for p in dest.parent.iterdir()] == ["hash.bin"]  # no .tmp left
+
+    out = np.zeros(BLOCK * 2, dtype=np.uint8)
+    load_block(str(dest), memoryview(out), BLOCK, BLOCK)
+    np.testing.assert_array_equal(out[BLOCK:], data[BLOCK:])
+    np.testing.assert_array_equal(out[:BLOCK], 0)
+
+
+def test_store_skips_existing(tmp_path: Path) -> None:
+    """Content-hash dedup parity with upstream: existing files are kept."""
+    dest = tmp_path / "hash.bin"
+    first = np.full(BLOCK, 1, dtype=np.uint8)
+    second = np.full(BLOCK, 2, dtype=np.uint8)
+
+    store_block(str(dest), memoryview(first), 0, BLOCK)
+    store_block(str(dest), memoryview(second), 0, BLOCK)
+
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    load_block(str(dest), memoryview(out), 0, BLOCK)
+    np.testing.assert_array_equal(out, first)
+
+
+def test_load_removes_unreadable_file(tmp_path: Path) -> None:
+    dest = tmp_path / "short.bin"
+    dest.write_bytes(b"x" * (BLOCK // 2))
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    with pytest.raises(OSError, match="Short read"):
+        load_block(str(dest), memoryview(out), 0, BLOCK)
+    assert not dest.exists()
+
+
+def test_load_missing_file_raises_without_cleanup(tmp_path: Path) -> None:
+    """A transient-style failure (here: file vanished) propagates as-is —
+    load_block must not attempt deletion when it never validated the file."""
+    out = np.zeros(BLOCK, dtype=np.uint8)
+    with pytest.raises(FileNotFoundError):
+        load_block(str(tmp_path / "gone.bin"), memoryview(out), 0, BLOCK)
+
+
+def test_prepare_root_dir(tmp_path: Path) -> None:
+    root = tmp_path / "kv-store"
+    store_dir = prepare_root_dir(str(root))
+
+    assert store_dir == str(root / NOINDEX_DIRNAME)
+    assert _mode(root) == 0o700
+    assert _mode(Path(store_dir)) == 0o700
+    # Idempotent against an existing store.
+    assert prepare_root_dir(str(root)) == store_dir
+
+
+def test_prepare_root_dir_respects_noindex_name(tmp_path: Path) -> None:
+    root = tmp_path / "kv-store.noindex"
+    assert prepare_root_dir(str(root)) == str(root)
+    assert _mode(root) == 0o700
+
+
+def test_fs_tier_config_routes_to_metal_class() -> None:
+    """An 'fs' tier config is rewritten to load the Metal class through
+    upstream's out-of-tree module_path hook, and upstream resolves it.
+
+    Without this the tier silently falls back to upstream's: buffered I/O,
+    0o644 block files, and nothing logged."""
+    from vllm.v1.kv_offload.tiering.factory import SecondaryTierFactory
+
+    from vllm_metal.v1.kv_offload.spec import route_fs_tiers_to_metal
+
+    extra = {"secondary_tiers": [{"type": "fs", "root_dir": "/tmp/unused"}]}
+    route_fs_tiers_to_metal(extra)
+    tier = extra["secondary_tiers"][0]
+    assert tier["module_path"] == "vllm_metal.v1.kv_offload.fs_tier"
+    assert SecondaryTierFactory.get_tier_class(tier) is MetalFileSystemTierManager
+    # Untouched: the registry is upstream's and stays that way.
+    assert "MetalFileSystemTierManager" not in SecondaryTierFactory._registry
+
+
+def test_metal_region_swapped_only_within_scope() -> None:
+    """The shared region has no out-of-tree hook upstream, so it is still
+    rebound. Pin that it is restored."""
+    import vllm.v1.kv_offload.tiering.spec as tiering_spec_module
+
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+    from vllm_metal.v1.kv_offload.spec import _metal_tiering_classes
+
+    original = tiering_spec_module.SharedOffloadRegion
+    assert original is not MetalSharedOffloadRegion
+    with _metal_tiering_classes():
+        assert tiering_spec_module.SharedOffloadRegion is MetalSharedOffloadRegion
+    assert tiering_spec_module.SharedOffloadRegion is original
+
+
+def test_metric_definitions_resolve_metal_tier_classes(monkeypatch) -> None:
+    """build_metric_definitions runs at stat-logger construction, before any
+    spec instance exists, so it has to route the tier config itself or a
+    Metal tier's metrics silently never register (then KeyError at first
+    observation)."""
+    from vllm_metal.v1.kv_offload.spec import MetalTieringOffloadingSpec
+
+    sentinel = {"metal_fs_metric": object()}
+    monkeypatch.setattr(
+        MetalFileSystemTierManager,
+        "build_metric_definitions",
+        classmethod(lambda cls, cfg: sentinel),
+    )
+    metrics = MetalTieringOffloadingSpec.build_metric_definitions(
+        {"secondary_tiers": [{"type": "fs", "root_dir": "/tmp/unused"}]}
+    )
+    assert "metal_fs_metric" in metrics
+
+
+def test_region_alignment_matches_upstream_snapshot() -> None:
+    """TieringOffloadingSpec snapshots SharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+    at import time; a Metal override of the class attr would never be seen by
+    that snapshot, so pin the two to be equal."""
+    from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
+
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+    assert (
+        MetalSharedOffloadRegion.BLOCK_SIZE_ALIGNMENT
+        == TieringOffloadingSpec.BLOCK_SIZE_ALIGNMENT
+    )
+
+
+def test_layout_signature_discriminates_turboquant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TurboQuant settings must produce disjoint store paths.
+
+    Everything else upstream's FileMapper already hashes into the path, so
+    the signature is empty unless TurboQuant is on."""
+    from types import SimpleNamespace
+
+    from vllm_metal.v1.kv_offload import fs_tier
+
+    def config(turboquant, k_quant="q8_0", v_quant="q3_0"):
+        cfg = SimpleNamespace(turboquant=turboquant, k_quant=k_quant, v_quant=v_quant)
+        monkeypatch.setattr(fs_tier, "get_config", lambda: cfg)
+
+    config(False)
+    assert fs_tier.layout_signature() == ""
+
+    config(True)
+    tq = fs_tier.layout_signature()
+    config(True, k_quant="q5_0")
+    tq_k = fs_tier.layout_signature()
+    config(True, v_quant="q2_0")
+    tq_v = fs_tier.layout_signature()
+
+    assert len({"", tq, tq_k, tq_v}) == 4  # all disjoint
+
+    config(True)
+    assert fs_tier.layout_signature() == tq  # deterministic
+
+
+def test_make_private_dir_does_not_chmod_existing(tmp_path: Path) -> None:
+    """Pointing root_dir at a pre-existing (e.g. shared) directory must not
+    strip other users' permissions."""
+    from vllm_metal.v1.kv_offload.fs_tier import _make_private_dir
+
+    pre = tmp_path / "shared"
+    pre.mkdir()
+    os.chmod(pre, 0o755)
+    _make_private_dir(str(pre))
+    assert _mode(pre) == 0o755  # untouched (warning logged instead)
+
+    fresh = tmp_path / "fresh"
+    _make_private_dir(str(fresh))
+    assert _mode(fresh) == 0o700
+
+
+def _fake_spec(block_bytes: int):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        blocks_per_chunk=1,
+        kv_bytes_per_chunk=block_bytes,
+        # Read by upstream's __init__ only when enable_kv_events is set.
+        kv_events_config=SimpleNamespace(enable_kv_cache_events=True),
+        config=SimpleNamespace(
+            engine_id="test-engine",
+            replicated_layout=False,
+            canonical_layout=False,
+            extra_config={},
+            model=SimpleNamespace(name="test-model", dtype="float16"),
+            cache=SimpleNamespace(tokens_per_hash=16, blocks_per_chunk=1),
+            parallel=SimpleNamespace(
+                tp_size=1,
+                pp_size=1,
+                pcp_size=1,
+                dcp_size=1,
+                rank=0,
+                is_parallelism_agnostic=True,
+            ),
+            groups=(SimpleNamespace(tokens_per_block=16, layer_names=("layer0",)),),
+        ),
+    )
+
+
+def _await_lookup(tier, key, ctx, timeout: float = 10.0):
+    """Drive the async lookup loop (lookup -> flush -> drain) to a verdict."""
+    import time as _time
+
+    from vllm.v1.kv_offload.base import LookupResult, ScheduleEndContext
+
+    deadline = _time.monotonic() + timeout
+    while _time.monotonic() < deadline:
+        result = tier.lookup(key, ctx)
+        if result is not LookupResult.RETRY:
+            return result
+        tier.on_schedule_end(ScheduleEndContext(set(), set()))
+        _time.sleep(0.05)
+    raise TimeoutError("lookup never resolved")
+
+
+def test_manager_end_to_end_and_livelock_guard(tmp_path: Path) -> None:
+    """Constructs the real MetalFileSystemTierManager and pins: store/load
+    round-trip, lookup hit, and upstream's failed-load negative cache
+    (vllm#49328) still reaching through this subclass's submit_load."""
+    import time as _time
+
+    import numpy as np
+    from vllm.v1.kv_offload.base import LookupResult, ReqContext
+    from vllm.v1.kv_offload.tiering.base import TransferJob
+
+    num_blocks, block_bytes = 4, 4096
+    pool = np.zeros((num_blocks, block_bytes), dtype=np.uint8)
+    tier = MetalFileSystemTierManager(
+        offloading_spec=_fake_spec(block_bytes),
+        primary_kv_view=memoryview(pool),
+        tier_type="fs",
+        root_dir=str(tmp_path / "kv-store"),
+        n_read_threads=2,
+        n_write_threads=2,
+    )
+    try:
+        import hashlib
+
+        key = hashlib.sha256(b"block-A").digest() + (0).to_bytes(4, "big")
+        path = Path(tier.file_mapper.get_file_name(key))
+
+        # Store block 0.
+        pool[0] = 7
+        tier.submit_store(
+            TransferJob(
+                job_id=1,
+                keys=[key],
+                block_ids=np.array([0]),
+                is_promotion=False,
+                req_context=ReqContext(req_id="r-store"),
+            )
+        )
+        tier.drain_jobs()
+        results = list(tier.get_finished_jobs())
+        assert [(r.job_id, r.success) for r in results] == [(1, True)]
+        assert path.stat().st_size == block_bytes
+
+        ctx1 = ReqContext(req_id="r-1")
+        assert _await_lookup(tier, key, ctx1, timeout=15) is LookupResult.HIT
+        tier.on_request_finished(ctx1)
+
+        # Livelock guard: cache a True verdict, THEN corrupt, then fail the
+        # load. The failed load must override the stale True, or the same
+        # doomed promotion is re-issued every step. vLLM 0.28.0 does this
+        # upstream (vllm#49328) off _load_job_keys, which submit_load fills.
+        ctx3 = ReqContext(req_id="r-3")
+        assert _await_lookup(tier, key, ctx3, timeout=15) is LookupResult.HIT
+        path.write_bytes(b"x" * 10)  # corrupt AFTER the cached True
+        tier.submit_load(
+            TransferJob(
+                job_id=2,
+                keys=[key],
+                block_ids=np.array([1]),
+                is_promotion=True,
+                req_context=ctx3,
+            )
+        )
+        tier.drain_jobs()
+        _time.sleep(0.1)
+        results = list(tier.get_finished_jobs())
+        assert [(r.job_id, r.success) for r in results] == [(2, False)]
+        assert tier.lookup(key, ctx3) is LookupResult.MISS  # stale HIT overridden
+        tier.on_request_finished(ctx3)
+
+        # A fresh store restores the block, and the key hits again.
+        pool[0] = 7
+        tier.submit_store(
+            TransferJob(
+                job_id=3,
+                keys=[key],
+                block_ids=np.array([0]),
+                is_promotion=False,
+                req_context=ReqContext(req_id="r-restore"),
+            )
+        )
+        tier.drain_jobs()
+        assert [(r.job_id, r.success) for r in tier.get_finished_jobs()] == [(3, True)]
+        ctx4 = ReqContext(req_id="r-4")
+        assert _await_lookup(tier, key, ctx4, timeout=15) is LookupResult.HIT
+        tier.on_request_finished(ctx4)
+    finally:
+        tier.shutdown()
+
+
+def _tier(tmp_path, block_bytes=4096, num_blocks=4, **kwargs):
+    """A real MetalFileSystemTierManager over a numpy pool."""
+    pool = np.zeros((num_blocks, block_bytes), dtype=np.uint8)
+    return MetalFileSystemTierManager(
+        offloading_spec=_fake_spec(block_bytes),
+        primary_kv_view=memoryview(pool),
+        tier_type="fs",
+        root_dir=str(tmp_path / "kv-store"),
+        n_read_threads=2,
+        n_write_threads=2,
+        **kwargs,
+    )
+
+
+def test_store_emits_block_stored_event(tmp_path: Path) -> None:
+    """The tier must announce what it stored.
+
+    Upstream builds the BlockStored event from _store_job_keys, populated in
+    submit_store. An override that omits it stores blocks and never announces
+    them, so a KV-aware router never learns this instance holds them and
+    routes prefix matches elsewhere. Silent, and it defeats the disk tier in
+    a routed deployment."""
+    import hashlib
+
+    from vllm.v1.kv_offload.base import ReqContext
+    from vllm.v1.kv_offload.tiering.base import TransferJob
+
+    tier = _tier(tmp_path, enable_kv_events=True)
+    try:
+        assert tier.events is not None, "fake spec did not enable events"
+        key = hashlib.sha256(b"evented").digest() + (0).to_bytes(4, "big")
+        tier.submit_store(
+            TransferJob(
+                job_id=1,
+                keys=[key],
+                block_ids=[0],
+                req_context=ReqContext(req_id="r-ev"),
+                is_promotion=False,
+            )
+        )
+        tier.drain_jobs()
+        assert [(r.job_id, r.success) for r in tier.get_finished_jobs()] == [(1, True)]
+        events = list(tier.take_events())
+        assert events, "no BlockStored event emitted for a successful store"
+        assert key in events[0].keys
+    finally:
+        tier.shutdown()
+
+
+def test_empty_job_completes_without_hanging(tmp_path: Path) -> None:
+    """A keyless job must not wedge drain_jobs().
+
+    Enqueueing zero tasks increments the pool's in-flight count and nothing
+    ever decrements it, because completion is driven by task callbacks.
+    drain_jobs() waits on that count with no timeout, so one empty job hangs
+    reset_cache and sleep/wake for good."""
+    import threading
+
+    from vllm.v1.kv_offload.base import ReqContext
+    from vllm.v1.kv_offload.tiering.base import TransferJob
+
+    tier = _tier(tmp_path)
+    try:
+        tier.submit_store(
+            TransferJob(
+                job_id=7,
+                keys=[],
+                block_ids=[],
+                req_context=ReqContext(req_id="r-e"),
+                is_promotion=False,
+            )
+        )
+        done = threading.Event()
+        threading.Thread(
+            target=lambda: (tier.drain_jobs(), done.set()), daemon=True
+        ).start()
+        assert done.wait(timeout=10), "drain_jobs() hung on a keyless job"
+        assert (7, True) in [(r.job_id, r.success) for r in tier.get_finished_jobs()]
+    finally:
+        tier.shutdown()
+
+
+def test_empty_job_leaves_no_bookkeeping(tmp_path: Path) -> None:
+    """A keyless job must complete and leave no bookkeeping behind.
+
+    Upstream enqueues exactly one task per job, so an empty job still has a
+    task to complete and the pool's in-flight count comes back down. Pinned
+    because an earlier per-block fan-out enqueued zero tasks here and wedged
+    drain_jobs() forever."""
+    from vllm.v1.kv_offload.base import ReqContext
+    from vllm.v1.kv_offload.tiering.base import TransferJob
+
+    tier = _tier(tmp_path)
+    try:
+        for job_id in range(5):
+            for promotion in (False, True):
+                job = TransferJob(
+                    job_id=job_id * 2 + promotion,
+                    keys=[],
+                    block_ids=[],
+                    req_context=ReqContext(req_id=f"r-{job_id}"),
+                    is_promotion=promotion,
+                )
+                if promotion:
+                    tier.submit_load(job)
+                else:
+                    tier.submit_store(job)
+        tier.drain_jobs()
+        list(tier.get_finished_jobs())
+        assert tier._store_job_keys == {}
+        assert tier._load_job_keys == {}
+    finally:
+        tier.shutdown()

--- a/tests/test_kv_offload_tiering.py
+++ b/tests/test_kv_offload_tiering.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the tiering (shared-region) variant of Metal KV offloading.
+
+The tiering worker carves its host pool out of a MetalSharedOffloadRegion —
+anonymous RAM shared between the scheduler-side manager and the worker-side
+worker within one process — so that secondary tiers (disk) can address whole
+CPU blocks as raw byte rows via ``create_kv_memoryview``. These tests
+exercise the worker round-trip through the region and the byte-level
+contract the fs tier relies on: store via the worker, read/write the same
+block through the memoryview, load back via the worker.
+"""
+
+import mmap
+import uuid
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+from tests.kv_offload_helpers import (
+    gpu_block_bytes,
+    gpu_spec,
+    make_cache,
+    randomize,
+    snapshot_blocks,
+    zero_blocks,
+)
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+NUM_CPU_BLOCKS = 4
+FACTOR = 2
+
+
+def _region_geometry(cache: MetalPagedKVCache) -> tuple[int, int]:
+    raw_row = gpu_block_bytes(cache) * FACTOR
+    aligned_row = -(-raw_row // mmap.PAGESIZE) * mmap.PAGESIZE
+    return aligned_row, raw_row
+
+
+def _make_regions(
+    cache: MetalPagedKVCache,
+) -> tuple[MetalSharedOffloadRegion, MetalSharedOffloadRegion]:
+    """Worker-rank and scheduler-rank attachments to one shared region."""
+    aligned_row, raw_row = _region_geometry(cache)
+    instance = f"test-{uuid.uuid4().hex[:8]}"
+    worker = MetalSharedOffloadRegion(
+        engine_id=instance,
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=0,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    scheduler = MetalSharedOffloadRegion(
+        engine_id=instance,
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=None,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    return worker, scheduler
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_region_backed_roundtrip(dtype: mx.Dtype) -> None:
+    cache = make_cache(dtype)
+    worker_region, scheduler_region = _make_regions(cache)
+    worker = MetalKVOffloadWorker(
+        cache,
+        block_size_factor=FACTOR,
+        num_cpu_blocks=NUM_CPU_BLOCKS,
+        region=worker_region,
+    )
+    try:
+        randomize(cache)
+        original = snapshot_blocks(cache, [1, 2, 5, 6])
+
+        assert worker.submit_store(1, gpu_spec([1, 2, 5, 6]), CPULoadStoreSpec([0, 2]))
+        assert len(worker.get_finished()) == 1
+
+        zero_blocks(cache, [1, 2, 5, 6])
+        assert worker.submit_load(2, CPULoadStoreSpec([0, 2]), gpu_spec([1, 2, 5, 6]))
+        assert len(worker.get_finished()) == 1
+
+        restored = snapshot_blocks(cache, [1, 2, 5, 6])
+        for a, b in zip(original, restored, strict=True):
+            np.testing.assert_array_equal(a, b)
+    finally:
+        worker.shutdown()
+        scheduler_region.cleanup()
+
+
+def test_memoryview_sees_worker_stores_and_feeds_loads() -> None:
+    """Byte-level contract used by the fs tier: whole-block rows round-trip
+    through the scheduler-side memoryview."""
+    cache = make_cache()
+    worker_region, scheduler_region = _make_regions(cache)
+    worker = MetalKVOffloadWorker(
+        cache,
+        block_size_factor=FACTOR,
+        num_cpu_blocks=NUM_CPU_BLOCKS,
+        region=worker_region,
+    )
+    view = scheduler_region.create_kv_memoryview()
+    flat = view.cast("B")
+    try:
+        randomize(cache)
+        original = snapshot_blocks(cache, [3, 4])
+
+        # Handler stores GPU blocks 3,4 into CPU block 1...
+        assert worker.submit_store(1, gpu_spec([3, 4]), CPULoadStoreSpec([1]))
+        worker.get_finished()
+
+        # ...the scheduler-side view of CPU block 1 must carry those bytes.
+        # Address it exactly like the fs tier does (tiering/fs/io.py): flat
+        # byte cast, block b at [b * strides[0], (b + 1) * strides[0]).
+        assert view.strides is not None
+        row_stride = view.strides[0]
+        stored_bytes = bytes(flat[row_stride : 2 * row_stride])
+        assert any(stored_bytes)  # not all zero
+
+        # Simulate the fs tier: persist the row, scribble over the CPU
+        # block, then restore the row through the same memoryview.
+        flat[row_stride : 2 * row_stride] = b"\x00" * row_stride
+        assert not any(bytes(flat[row_stride : 2 * row_stride]))
+        flat[row_stride : 2 * row_stride] = stored_bytes
+
+        # A worker load from that CPU block must reproduce the GPU blocks.
+        zero_blocks(cache, [3, 4])
+        assert worker.submit_load(2, CPULoadStoreSpec([1]), gpu_spec([3, 4]))
+        worker.get_finished()
+
+        restored = snapshot_blocks(cache, [3, 4])
+        for a, b in zip(original, restored, strict=True):
+            np.testing.assert_array_equal(a, b)
+    finally:
+        del flat, view
+        worker.shutdown()
+        scheduler_region.cleanup()
+
+
+def test_region_registry_shares_and_releases() -> None:
+    """Two attachments to one instance id share bytes; distinct ids do not;
+    cleanup releases the registry entry only when the last ref drops."""
+    cache = make_cache()
+    aligned_row, raw_row = _region_geometry(cache)
+    instance = f"test-{uuid.uuid4().hex[:8]}"
+
+    def attach(rank):
+        return MetalSharedOffloadRegion(
+            engine_id=instance,
+            num_blocks=NUM_CPU_BLOCKS,
+            rank=rank,
+            kv_bytes_per_block=aligned_row,
+            cpu_page_size=raw_row,
+        )
+
+    a = attach(0)
+    b = attach(None)
+    a._base[0] = 42
+    assert int(b._base[0]) == 42, "attachments must share the same buffer"
+
+    other = MetalSharedOffloadRegion(
+        engine_id=f"other-{uuid.uuid4().hex[:8]}",
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=None,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    assert int(other._base[0]) == 0, "distinct instance ids must not share"
+    other.cleanup()
+
+    a.cleanup()
+    # Buffer still alive through b.
+    assert int(b._base[0]) == 42
+    b.cleanup()
+
+    # A fresh attachment after full release gets a new zeroed buffer.
+    c = attach(None)
+    assert int(c._base[0]) == 0
+    c.cleanup()
+
+
+def test_region_geometry_mismatch_rejected() -> None:
+    cache = make_cache()
+    aligned_row, raw_row = _region_geometry(cache)
+    instance = f"test-{uuid.uuid4().hex[:8]}"
+    a = MetalSharedOffloadRegion(
+        engine_id=instance,
+        num_blocks=NUM_CPU_BLOCKS,
+        rank=0,
+        kv_bytes_per_block=aligned_row,
+        cpu_page_size=raw_row,
+    )
+    try:
+        with pytest.raises(AssertionError, match="mismatched geometry"):
+            MetalSharedOffloadRegion(
+                engine_id=instance,
+                num_blocks=NUM_CPU_BLOCKS + 1,
+                rank=None,
+                kv_bytes_per_block=aligned_row,
+                cpu_page_size=raw_row,
+            )
+    finally:
+        a.cleanup()
+
+
+def test_region_backed_roundtrip_turboquant() -> None:
+    """TurboQuant packed + scale/zero arrays through the shared region and
+    the byte-level memoryview contract the disk tier relies on — the region
+    carve is most fragile exactly here (mixed dtypes, packed layouts)."""
+    cache = make_cache(head_dim=64, turboquant=True, k_quant="q8_0", v_quant="q3_0")
+    worker_region, scheduler_region = _make_regions(cache)
+    worker = MetalKVOffloadWorker(
+        cache,
+        block_size_factor=FACTOR,
+        num_cpu_blocks=NUM_CPU_BLOCKS,
+        region=worker_region,
+    )
+    randomize(cache)
+    gpu_blocks = [1, 2, 3, 4]
+    original = snapshot_blocks(cache, gpu_blocks)
+    assert worker.submit_store(1, gpu_spec(gpu_blocks), CPULoadStoreSpec([0, 2]))
+    worker.get_finished()
+
+    # Byte-level round trip through the scheduler-side memoryview (what the
+    # fs tier reads/writes): copy row bytes out and back, then restore.
+    # Access exactly as the fs tier does (io.py): flat byte cast + slice.
+    mv = scheduler_region.create_kv_memoryview().cast("B")
+    row_bytes = (
+        scheduler_region.row_stride
+        if hasattr(scheduler_region, "row_stride")
+        else len(mv) // NUM_CPU_BLOCKS
+    )
+    row_copy = bytes(mv[0:row_bytes])
+    mv[0:row_bytes] = b"\x00" * row_bytes
+    mv[0:row_bytes] = row_copy
+
+    zero_blocks(cache, gpu_blocks)
+    assert worker.submit_load(2, CPULoadStoreSpec([0, 2]), gpu_spec(gpu_blocks))
+    worker.get_finished()
+    for a, b in zip(original, snapshot_blocks(cache, gpu_blocks), strict=True):
+        np.testing.assert_array_equal(a, b)
+    worker.shutdown()
+    scheduler_region.cleanup()
+
+
+def _offloading_config(
+    blocks_per_chunk: int = 1,
+    tokens_per_block: int = 16,
+    extra_config: dict | None = None,
+    enable_kv_cache_events: bool = False,
+):
+    """A real ``OffloadingConfig``, as vLLM hands to an offloading spec.
+
+    Built directly rather than through ``build_offloading_config`` so the test
+    needs no model download; the dataclass is upstream's, so a field rename
+    still breaks this.
+    """
+    from vllm.v1.kv_offload.config import (
+        OffloadingCacheConfig,
+        OffloadingConfig,
+        OffloadingGroupConfig,
+        OffloadingModelConfig,
+        OffloadingParallelConfig,
+    )
+
+    return OffloadingConfig(
+        groups=(
+            OffloadingGroupConfig(
+                tokens_per_block=tokens_per_block, layer_names=("l0",)
+            ),
+        ),
+        worker_kv_bytes_per_block=1 << 14,
+        enable_kv_cache_events=enable_kv_cache_events,
+        extra_config=extra_config or {"cpu_bytes_to_use": 64 << 20},
+        engine_id="test-engine",
+        model=OffloadingModelConfig(name="test-model", dtype="float16"),
+        cache=OffloadingCacheConfig(
+            tokens_per_hash=tokens_per_block, blocks_per_chunk=blocks_per_chunk
+        ),
+        parallel=OffloadingParallelConfig(
+            rank=0,
+            world_size=1,
+            tp_size=1,
+            pp_size=1,
+            pcp_size=1,
+            dcp_size=1,
+            data_parallel_index=0,
+            data_parallel_size=1,
+            data_parallel_rank_local=0,
+            is_parallelism_agnostic=True,
+        ),
+    )
+
+
+@pytest.mark.parametrize("blocks_per_chunk", [1, 2, 4])
+def test_gpu_blocks_per_offloaded_block_tracks_blocks_per_chunk(
+    blocks_per_chunk: int,
+) -> None:
+    """The GPU-blocks-per-offloaded-block ratio must follow the config.
+
+    Deriving it from tokens_per_hash pins it to 1 for every single-group
+    model, which silently sizes the host pool short and makes a mid-chunk
+    restore read the wrong sub-slot."""
+    from vllm_metal.v1.kv_offload.spec import (
+        MetalTieringOffloadingSpec,
+        gpu_blocks_per_offloaded_block,
+    )
+
+    spec = MetalTieringOffloadingSpec(_offloading_config(blocks_per_chunk))
+    assert gpu_blocks_per_offloaded_block(spec) == blocks_per_chunk
+
+
+def test_tiering_spec_builds_manager_through_upstream(tmp_path) -> None:
+    """get_manager() runs upstream's body with the Metal classes rebound.
+
+    Constructing MetalSharedOffloadRegion by hand cannot catch a signature
+    drift against the upstream call site; only driving get_manager() can.
+
+    The isinstance check matters as much as the construction. The fs tier is
+    selected by module_path and the region by rebinding the tiering module's
+    SharedOffloadRegion. If upstream ever resolves either differently, the
+    routing silently no-ops and production quietly gets the upstream tier:
+    buffered I/O, 0o644 files, none of the macOS work. Nothing else would
+    report it."""
+    from vllm_metal.v1.kv_offload.fs_tier import MetalFileSystemTierManager
+    from vllm_metal.v1.kv_offload.spec import MetalTieringOffloadingSpec
+
+    spec = MetalTieringOffloadingSpec(
+        _offloading_config(
+            extra_config={
+                "cpu_bytes_to_use": 64 << 20,
+                "secondary_tiers": [{"type": "fs", "root_dir": str(tmp_path)}],
+            }
+        )
+    )
+    manager = spec.get_manager()
+    assert manager is not None
+    (tier,) = manager.secondary_tiers
+    assert isinstance(tier, MetalFileSystemTierManager)
+
+
+def test_host_pool_larger_than_ram_is_refused() -> None:
+    """A pool the machine cannot hold must fail at construction.
+
+    np.zeros pages in lazily, so an oversized pool starts cleanly and only
+    thrashes once blocks are written. On a fixed-RAM Mac that wedges the
+    machine instead of failing the request. Upstream guards the equivalent
+    with check_shm_free_space before ftruncate."""
+    import psutil
+    import pytest
+
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+    total = psutil.virtual_memory().total
+    with pytest.raises(ValueError, match="pageable"):
+        MetalSharedOffloadRegion(
+            engine_id="test-oversized",
+            num_blocks=1,
+            rank=0,
+            kv_bytes_per_block=total,  # the whole machine, in one block
+            cpu_page_size=total,
+        )
+
+
+def test_events_reach_the_manager_from_the_disk_tier(tmp_path) -> None:
+    """A stored block must surface as an event at the manager, not just at
+    the tier.
+
+    This is the path KV-aware routing consumes: the scheduler drains
+    OffloadingConnector.take_events(), which delegates to the manager, which
+    yields from the primary tier and every secondary tier. The tier-level
+    test proves the tier records the event; only this proves it survives the
+    hop the router actually reads from.
+
+    Pinned because a Metal-specific submit_store override once dropped the
+    bookkeeping this is built from, and nothing failed."""
+    import hashlib
+
+    from vllm.v1.kv_offload.base import ReqContext
+    from vllm.v1.kv_offload.tiering.base import TransferJob
+
+    from vllm_metal.v1.kv_offload.spec import MetalTieringOffloadingSpec
+
+    spec = MetalTieringOffloadingSpec(
+        _offloading_config(
+            extra_config={
+                "cpu_bytes_to_use": 64 << 20,
+                "secondary_tiers": [
+                    {
+                        "type": "fs",
+                        "root_dir": str(tmp_path),
+                        "enable_kv_events": True,
+                    }
+                ],
+            },
+            enable_kv_cache_events=True,
+        )
+    )
+    manager = spec.get_manager()
+    (tier,) = manager.secondary_tiers
+    assert tier.events is not None, "events not enabled on the tier"
+
+    key = hashlib.sha256(b"routed").digest() + (0).to_bytes(4, "big")
+    tier.submit_store(
+        TransferJob(
+            job_id=1,
+            keys=[key],
+            block_ids=[0],
+            req_context=ReqContext(req_id="r-route"),
+            is_promotion=False,
+        )
+    )
+    tier.drain_jobs()
+    list(tier.get_finished_jobs())
+
+    events = list(manager.take_events())
+    assert events, "no event reached the manager; a router would see nothing"
+    assert any(key in e.keys for e in events)

--- a/tests/test_kv_offload_worker.py
+++ b/tests/test_kv_offload_worker.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the Metal KV offloading worker.
+
+Round-trips blocks through the host pool and asserts byte-exact restoration,
+including bf16 (numpy-dtype-less) caches, TurboQuant packed caches, and
+offloaded blocks spanning multiple GPU blocks (block_size_factor > 1) with an
+unaligned first block.
+"""
+
+import mlx.core as mx
+import numpy as np
+import pytest
+from vllm.v1.kv_offload.base import GPULoadStoreSpec
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+from tests.kv_offload_helpers import (
+    gpu_spec,
+    make_cache,
+    make_worker,
+    randomize,
+    snapshot_blocks,
+    zero_blocks,
+)
+
+
+def _run_roundtrip(
+    cache,
+    *,
+    block_size_factor: int = 1,
+    gpu_blocks: list[int],
+    cpu_blocks: list[int],
+    block_index: int = 0,
+) -> None:
+    worker = make_worker(cache, block_size_factor=block_size_factor, num_cpu_blocks=4)
+
+    randomize(cache)
+    original = snapshot_blocks(cache, gpu_blocks)
+
+    # Store GPU -> CPU.
+    ok = worker.submit_store(
+        1, gpu_spec(gpu_blocks, block_index), CPULoadStoreSpec(cpu_blocks)
+    )
+    assert ok
+    finished = worker.get_finished()
+    assert [r.job_id for r in finished] == [1]
+    assert finished[0].success
+    assert finished[0].transfer_size > 0
+
+    # Clobber the GPU blocks, then load them back CPU -> GPU.
+    zero_blocks(cache, gpu_blocks)
+    ok = worker.submit_load(
+        2, CPULoadStoreSpec(cpu_blocks), gpu_spec(gpu_blocks, block_index)
+    )
+    assert ok
+    finished = worker.get_finished()
+    assert [r.job_id for r in finished] == [2]
+
+    restored = snapshot_blocks(cache, gpu_blocks)
+    for a, b in zip(original, restored, strict=True):
+        np.testing.assert_array_equal(a, b)
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+def test_roundtrip_dtypes(dtype: mx.Dtype) -> None:
+    cache = make_cache(dtype)
+    _run_roundtrip(cache, gpu_blocks=[5, 2, 7], cpu_blocks=[0, 1, 3])
+
+
+def test_roundtrip_turboquant() -> None:
+    cache = make_cache(
+        head_dim=64,
+        turboquant=True,
+        k_quant="q8_0",
+        v_quant="q3_0",
+    )
+    _run_roundtrip(cache, gpu_blocks=[1, 6], cpu_blocks=[2, 0])
+
+
+def test_roundtrip_block_size_factor() -> None:
+    """One CPU block spans two GPU blocks."""
+    cache = make_cache()
+    _run_roundtrip(
+        cache,
+        block_size_factor=2,
+        gpu_blocks=[3, 4, 5, 6],
+        cpu_blocks=[1, 3],
+    )
+
+
+def test_roundtrip_unaligned_first_block() -> None:
+    """Request enters its first offloaded block mid-block (skip one sub-slot)."""
+    cache = make_cache()
+    worker = make_worker(cache, block_size_factor=2, num_cpu_blocks=4)
+    randomize(cache)
+
+    # First store gpu blocks [2,3] as the two sub-slots of CPU block 1.
+    assert worker.submit_store(
+        1, gpu_spec([2, 3], block_index=0), CPULoadStoreSpec([1])
+    )
+
+    # Now store one more gpu block at logical block index 3: skip = 3 % 2 = 1,
+    # so the worker must place it in the second sub-slot of CPU block 2.
+    assert worker.submit_store(2, gpu_spec([5], block_index=3), CPULoadStoreSpec([2]))
+    assert len(worker.get_finished()) == 2
+
+    original = snapshot_blocks(cache, [5])
+    zero_blocks(cache, [5])
+    assert worker.submit_load(3, CPULoadStoreSpec([2]), gpu_spec([5], block_index=3))
+    assert len(worker.get_finished()) == 1
+    restored = snapshot_blocks(cache, [5])
+    for a, b in zip(original, restored, strict=True):
+        np.testing.assert_array_equal(a, b)
+
+
+def test_unknown_spec_types_raise() -> None:
+    """Errors must propagate: the connector-side caller asserts a successful
+    submission (job failure is unsupported upstream), so raising here surfaces
+    the root cause instead of a bare assert — swallowing it would hide it."""
+    cache = make_cache()
+    worker = make_worker(cache, block_size_factor=1, num_cpu_blocks=4)
+    with pytest.raises(ValueError, match="unexpected load spec types"):
+        worker.submit_load(1, CPULoadStoreSpec([0]), CPULoadStoreSpec([1]))
+    with pytest.raises(ValueError, match="unexpected store spec types"):
+        worker.submit_store(2, CPULoadStoreSpec([0]), CPULoadStoreSpec([1]))
+    assert worker.get_finished() == []
+
+
+def test_uncovered_per_block_array_rejected() -> None:
+    """CACHE_ATTRS completeness guard: a per-block array list the offload
+    inventory doesn't know about must fail registration, not silently drop
+    state (the 'new model family' corruption mode)."""
+    cache = make_cache()
+    cache.gdn_conv_state = [
+        mx.zeros((cache.num_blocks, 4, 8)) for _ in range(2)
+    ]  # simulate a new model family's extra per-block state
+    with pytest.raises(NotImplementedError, match="gdn_conv_state"):
+        make_worker(cache, block_size_factor=1, num_cpu_blocks=4)
+
+
+def test_out_of_range_block_ids_raise() -> None:
+    """OOB ids corrupt silently at the MLX layer (take returns garbage,
+    scatter drops writes) — the worker must fail fast instead."""
+    cache = make_cache()  # 8 GPU blocks
+    worker = make_worker(cache, block_size_factor=1, num_cpu_blocks=4)
+    with pytest.raises(ValueError, match="GPU block ids out of range"):
+        worker.submit_store(1, gpu_spec([5, 99]), CPULoadStoreSpec([0, 1]))
+    with pytest.raises(ValueError, match="CPU block ids out of range"):
+        worker.submit_store(2, gpu_spec([5, 2]), CPULoadStoreSpec([0, 7]))
+    with pytest.raises(ValueError, match="CPU block ids out of range"):
+        worker.submit_store(3, gpu_spec([5]), CPULoadStoreSpec([-1]))
+    assert worker.get_finished() == []
+
+
+def test_expected_block_bytes_overrun_raises() -> None:
+    """Carving MORE than the spec sized (row overrun) is fatal; carving less
+    is upstream's alignment padding and must be accepted (TurboQuant blocks
+    are rarely page-aligned — found live on a clean-machine e2e)."""
+    cache = make_cache()
+    with pytest.raises(ValueError, match="rows would overrun"):
+        make_worker(
+            cache,
+            block_size_factor=1,
+            num_cpu_blocks=4,
+            expected_block_bytes=100,  # far below the real carve
+        )
+
+
+def test_expected_block_bytes_padding_accepted() -> None:
+    """Upstream tiering rounds blocks up to SharedOffloadRegion's
+    BLOCK_SIZE_ALIGNMENT — mmap.PAGESIZE (16384 on Apple Silicon)."""
+    import mmap
+
+    from tests.kv_offload_helpers import gpu_block_bytes
+
+    cache = make_cache()
+    page = mmap.PAGESIZE
+    aligned = -(-gpu_block_bytes(cache) // page) * page  # upstream round_up
+    worker = make_worker(
+        cache,
+        block_size_factor=1,
+        num_cpu_blocks=4,
+        expected_block_bytes=aligned,
+    )
+    assert worker.block_size_factor == 1
+
+
+def test_expected_block_bytes_match_accepted() -> None:
+    from tests.kv_offload_helpers import gpu_block_bytes
+
+    cache = make_cache()
+    worker = make_worker(
+        cache,
+        block_size_factor=1,
+        num_cpu_blocks=4,
+        expected_block_bytes=gpu_block_bytes(cache),
+    )
+    assert worker.block_size_factor == 1
+
+
+def test_expected_block_bytes_shortfall_rejected() -> None:
+    """A carve short by more than one alignment unit is a layout
+    disagreement, not padding. Accepting it silently sizes the pool short and
+    makes every restore past the first sub-slot read the wrong bytes."""
+    import mmap
+
+    from tests.kv_offload_helpers import gpu_block_bytes
+
+    cache = make_cache()
+    # What the spec would size if it believed each CPU block held 4 GPU
+    # blocks while the worker carves for 1.
+    overstated = gpu_block_bytes(cache) * 4 + mmap.PAGESIZE
+    with pytest.raises(ValueError, match="layout disagreement"):
+        make_worker(
+            cache,
+            block_size_factor=1,
+            num_cpu_blocks=4,
+            expected_block_bytes=overstated,
+        )
+
+
+def test_unsupported_cache_dtype_rejected() -> None:
+    cache = make_cache()
+    cache.key_caches[0] = mx.zeros(cache.key_caches[0].shape, dtype=mx.int64)
+    with pytest.raises(NotImplementedError, match="unsupported cache dtype"):
+        make_worker(cache, block_size_factor=1, num_cpu_blocks=4)
+
+
+def test_too_few_cpu_blocks_raise() -> None:
+    cache = make_cache()
+    worker = make_worker(cache, block_size_factor=2, num_cpu_blocks=4)
+    with pytest.raises(ValueError, match="CPU blocks too few"):
+        worker.submit_store(1, gpu_spec([1, 2, 3]), CPULoadStoreSpec([0]))
+
+
+def test_empty_group_is_a_successful_noop() -> None:
+    cache = make_cache()
+    worker = make_worker(cache, block_size_factor=1, num_cpu_blocks=4)
+    spec = GPULoadStoreSpec([], group_sizes=[0], block_indices=[0])
+    assert worker.submit_store(1, spec, CPULoadStoreSpec([]))
+    (result,) = worker.get_finished()
+    assert result.success and result.transfer_size == 0
+
+
+def test_store_snapshots_the_host_pool_before_the_gpu_moves_on() -> None:
+    """submit_store must copy the bytes it was called with.
+
+    MLX evaluates lazily. If a gather reached the host pool unevaluated, a
+    store queued for step k would land step k+1's KV instead, and nothing
+    downstream would notice: right-sized block, successful load, silently
+    wrong KV.
+
+    Asserted against the host pool directly rather than through a store/load
+    round trip, which a matched pair of lazy reads could pass. Note the copy
+    is eager for two independent reasons (memoryview forces the gather,
+    numpy fancy-index assignment copies), so this pins the invariant rather
+    than guarding a single line.
+    """
+    cache = make_cache(mx.float16)
+    worker = make_worker(cache, block_size_factor=1, num_cpu_blocks=4)
+
+    randomize(cache)
+    gpu_blocks, cpu_blocks = [5, 2], [0, 1]
+    assert worker.submit_store(1, gpu_spec(gpu_blocks), CPULoadStoreSpec(cpu_blocks))
+    assert worker.get_finished()[0].success
+
+    pooled = [ref.cpu[cpu_blocks, 0].copy() for ref in worker._refs]
+
+    zero_blocks(cache, gpu_blocks)
+
+    for ref, before in zip(worker._refs, pooled, strict=True):
+        np.testing.assert_array_equal(ref.cpu[cpu_blocks, 0], before)
+        assert before.any(), "randomized block was already zero; test is vacuous"
+
+
+def test_store_slices_a_large_job() -> None:
+    """A store gather must not hold the whole job at once.
+
+    Job size is whatever the scheduler accumulated that step, so a long
+    prefill chunk can ask for hundreds of blocks. Holding every layer's
+    gather live until the last host copy is gigabytes of transient on a
+    machine whose KV budget is the thing under pressure.
+    """
+    cache = make_cache(mx.float16, num_blocks=64)
+    worker = make_worker(cache, block_size_factor=1, num_cpu_blocks=64)
+
+    per_block = sum(
+        int(np.prod(ref.cpu.shape[2:])) * ref.cpu.dtype.itemsize for ref in worker._refs
+    )
+    assert worker._blocks_per_slice == max(1, (256 << 20) // per_block)
+
+    # Force several slices, then assert the round trip is still exact.
+    worker._blocks_per_slice = 4
+    randomize(cache)
+    blocks = list(range(32))
+    original = snapshot_blocks(cache, blocks)
+    assert worker.submit_store(1, gpu_spec(blocks), CPULoadStoreSpec(blocks))
+    assert worker.get_finished()[0].success
+
+    zero_blocks(cache, blocks)
+    assert worker.submit_load(2, CPULoadStoreSpec(blocks), gpu_spec(blocks))
+    worker.get_finished()
+    for a, b in zip(original, snapshot_blocks(cache, blocks), strict=True):
+        np.testing.assert_array_equal(a, b)

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -17,6 +17,7 @@ from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
 from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
+from vllm_metal.v1 import worker as worker_mod  # noqa: E402
 from vllm_metal.v1.cache_policy import (  # noqa: E402
     ModelCachePolicy,
     WorkerCachePlanner,
@@ -351,6 +352,61 @@ class TestPagedAttentionPlanDiagnostics:
         worker.get_cache_block_size_bytes = MagicMock(return_value=per_block_bytes)
         return WorkerCachePlanner(worker)
 
+    def _plain_runner(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            is_hybrid=False,
+            scheduler_memory_reporting_mode=MagicMock(
+                return_value="paged_attention_capacity"
+            ),
+            profile_run=MagicMock(return_value=1_000_000_000),
+            validate_paged_attention_support=MagicMock(),
+            scheduler_config=SimpleNamespace(max_num_seqs=2),
+            cache_config=SimpleNamespace(mamba_cache_mode="none"),
+            draft_scratch_reserve_bytes=MagicMock(return_value=0),
+        )
+
+    def test_kv_offload_pool_comes_out_of_the_metal_budget(self, monkeypatch) -> None:
+        """The host pool is the same physical RAM as the wired cache, so the
+        memory fraction must bound both together. Without this the pool sits
+        on top of the budget and a large --kv-offloading-size swaps."""
+        monkeypatch.setattr(
+            WorkerCachePlanner, "_metal_limit_bytes", lambda self: 10_000_000_000
+        )
+        monkeypatch.setattr(
+            WorkerCachePlanner, "get_model_memory_usage", lambda self: 1_000_000_000
+        )
+
+        def plan_with(kv_transfer_config):
+            worker = _make_worker(self._plain_runner(), use_paged_attention=True)
+            worker.metal_config.memory_fraction = 0.5
+            worker.get_cache_block_size_bytes = MagicMock(return_value=1_000_000)
+            worker.vllm_config.kv_transfer_config = kv_transfer_config
+            return WorkerCachePlanner(worker)._paged_attention_plan(
+                overhead=1_000_000_000
+            )
+
+        without = plan_with(None)
+        pool = 2_000_000_000
+        with_pool = plan_with(
+            SimpleNamespace(
+                kv_connector="MetalOffloadingConnector",
+                kv_connector_extra_config={"cpu_bytes_to_use": pool},
+            )
+        )
+        assert with_pool.kv_budget == without.kv_budget - pool
+        assert with_pool.num_blocks == without.num_blocks - pool // 1_000_000
+        assert "kv_offload_pool=2.00GB" in with_pool.format_breakdown()
+        assert "lower --kv-offloading-size" in with_pool.format_mitigations()
+
+        # A transfer config with no connector is inert and must not budget.
+        inert = plan_with(
+            SimpleNamespace(
+                kv_connector=None,
+                kv_connector_extra_config={"cpu_bytes_to_use": pool},
+            )
+        )
+        assert inert.kv_budget == without.kv_budget
+
     def test_hybrid_oom_error_reports_lazy_gdn_state(self, monkeypatch) -> None:
         runner = SimpleNamespace(
             is_hybrid=True,
@@ -604,3 +660,66 @@ class TestHybridPlanGuard:
 
         with pytest.raises(RuntimeError, match="no resolved hybrid_runtime_plan"):
             runner.linear_cache_bytes_per_slot()
+
+
+class TestShutdownClosesConnectorStep:
+    """The connector step must end before the transfer group is torn down."""
+
+    def test_step_closes_before_kv_transfer_shutdown(self, monkeypatch) -> None:
+        order: list[str] = []
+        model_runner = SimpleNamespace(
+            finish_kv_connector_step=lambda: order.append("close"),
+        )
+        worker = _make_worker(model_runner, use_paged_attention=True)
+        worker._metal_profiler = None
+        monkeypatch.setattr(
+            worker_mod, "ensure_kv_transfer_shutdown", lambda: order.append("shutdown")
+        )
+
+        MetalWorker.shutdown(worker)
+
+        assert order == ["close", "shutdown"]
+
+    def test_shutdown_survives_a_runner_without_the_hook(self, monkeypatch) -> None:
+        """STT runners have no connector step; shutdown must not care."""
+        calls: list[str] = []
+        worker = _make_worker(SimpleNamespace(), use_paged_attention=True)
+        worker._metal_profiler = None
+        monkeypatch.setattr(
+            worker_mod, "ensure_kv_transfer_shutdown", lambda: calls.append("shutdown")
+        )
+
+        MetalWorker.shutdown(worker)
+
+        assert calls == ["shutdown"]
+
+
+class TestOffloadGuardsGateOnAConnector:
+    """validate_metal_support rejects shapes the offload path cannot serve.
+    It must run only when a connector is configured: a transfer config with
+    no connector is inert upstream, and hybrid models never asked for
+    offloading."""
+
+    def _run(self, monkeypatch, kv_transfer_config) -> list[str]:
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "vllm_metal.v1.kv_offload.spec.validate_metal_support",
+            lambda _cfg: calls.append("validate"),
+        )
+        monkeypatch.setattr(
+            worker_mod, "ensure_kv_transfer_initialized", lambda *_: None
+        )
+        monkeypatch.setattr(worker_mod, "has_kv_transfer_group", lambda: False)
+        runner = SimpleNamespace(initialize_kv_cache=lambda _cfg: calls.append("init"))
+        worker = _make_worker(runner, use_paged_attention=True)
+        worker.vllm_config.kv_transfer_config = kv_transfer_config
+        MetalWorker.initialize_from_config(worker, SimpleNamespace())
+        return calls
+
+    def test_inert_transfer_config_skips_the_guard(self, monkeypatch) -> None:
+        inert = SimpleNamespace(kv_connector=None)
+        assert self._run(monkeypatch, inert) == ["init"]
+
+    def test_connector_runs_the_guard_first(self, monkeypatch) -> None:
+        configured = SimpleNamespace(kv_connector="MetalOffloadingConnector")
+        assert self._run(monkeypatch, configured) == ["validate", "init"]

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -53,6 +53,171 @@ def _pick_mb_buffer_default(
     return None
 
 
+def _configure_kv_events(vllm_config: "VllmConfig", extra: dict) -> None:
+    """Line up the two switches that gate KV cache events.
+
+    A KV-aware router consumes the BlockStored events an offload
+    tier emits. A tier only emits them when ``enable_kv_events`` is set on
+    the tier config AND ``kv_events_config.enable_kv_cache_events`` is set
+    globally. Set one without the other and the tier logs a warning
+    mid-startup and then silently publishes nothing, which looks exactly
+    like a routing bug.
+
+    So: turn the tier switch on for the user when events are enabled
+    globally, and refuse the reverse combination at config time rather than
+    letting it degrade quietly.
+    """
+    events_config = vllm_config.kv_events_config
+    globally_on = bool(events_config and events_config.enable_kv_cache_events)
+    tiers = extra.get("secondary_tiers") or []
+    for tier in tiers:
+        if not isinstance(tier, dict):
+            continue
+        if globally_on:
+            tier.setdefault("enable_kv_events", True)
+        elif tier.get("enable_kv_events"):
+            raise NotImplementedError(
+                "Secondary KV tier has enable_kv_events set, but KV cache "
+                "events are disabled globally, so the tier would publish "
+                "nothing. Pass --kv-events-config with "
+                "'{\"enable_kv_cache_events\": true}' (plus a publisher) or "
+                "drop enable_kv_events from the tier."
+            )
+
+
+def _configure_kv_offloading(vllm_config: "VllmConfig") -> None:
+    """Translate --kv-offloading-size and validate the KV connector."""
+    config = get_config()
+    parallel_config = vllm_config.parallel_config
+    # KV offloading / KV connectors. vLLM's own translation of
+    # --kv-offloading-size N into kv_transfer_config runs AFTER this hook
+    # (_post_init_kv_transfer_config, vllm/config/vllm.py) and would
+    # force-set a connector name this platform cannot serve. So the
+    # translation is performed here instead — kv_offloading_size is
+    # cleared afterwards, which disarms the upstream translation (it
+    # returns early when the size is unset) — and the connector is routed
+    # to the Metal subclass via kv_connector_module_path. A
+    # kv_transfer_config with no connector and no offloading request is
+    # inert upstream and passes through untouched.
+    # Typed access, not getattr: vllm-metal #604 removed the defensive
+    # fallbacks here in favour of trusting vLLM's config DTOs, and a
+    # getattr with a default would silently pass a guard after an upstream
+    # rename rather than failing loudly.
+    cache_config = vllm_config.cache_config
+    kv_transfer_config = vllm_config.kv_transfer_config
+    kv_offloading_size = cache_config.kv_offloading_size
+    explicit_connector = (
+        kv_transfer_config.kv_connector if kv_transfer_config is not None else None
+    )
+    if explicit_connector not in (
+        None,
+        "OffloadingConnector",
+        "MetalOffloadingConnector",
+    ):
+        raise NotImplementedError(
+            f"KV connector '{explicit_connector}' is not supported on "
+            "Metal; only the KV offloading connector "
+            "(--kv-offloading-size N) is available."
+        )
+    if kv_offloading_size is not None or explicit_connector is not None:
+        kv_offloading_backend = cache_config.kv_offloading_backend
+        if kv_offloading_size is not None and kv_offloading_backend != "native":
+            raise NotImplementedError(
+                "Metal supports only --kv-offloading-backend native; "
+                f"'{kv_offloading_backend}' is not supported."
+            )
+        import vllm.envs as vllm_envs
+
+        if vllm_envs.VLLM_USE_SIMPLE_KV_OFFLOAD:
+            raise NotImplementedError(
+                "VLLM_USE_SIMPLE_KV_OFFLOAD is not supported on Metal; "
+                "unset it to use the native KV offloading connector."
+            )
+        if not config.use_paged_attention:
+            raise NotImplementedError(
+                "KV offloading on Metal requires paged attention "
+                "(VLLM_METAL_USE_PAGED_ATTENTION=1)."
+            )
+        if parallel_config.pipeline_parallel_size > 1:
+            raise NotImplementedError(
+                "KV offloading on Metal does not support pipeline "
+                "parallelism yet; run with pipeline_parallel_size=1."
+            )
+        if kv_transfer_config is None:
+            from vllm.config import KVTransferConfig
+
+            kv_transfer_config = KVTransferConfig()
+            vllm_config.kv_transfer_config = kv_transfer_config
+        kv_transfer_config.kv_connector = "MetalOffloadingConnector"
+        kv_transfer_config.kv_connector_module_path = (
+            "vllm_metal.v1.kv_offload.connector"
+        )
+        # Force-normalize like upstream _post_init_kv_transfer_config
+        # (vllm/config/vllm.py): offloading always runs kv_both. A
+        # passed-through kv_producer would silently disable the
+        # scheduler's defer_block_free protection (freed-block race).
+        if kv_transfer_config.kv_role not in (None, "kv_both"):
+            logger.warning(
+                "KV offloading on Metal overrides kv_role=%r to 'kv_both'.",
+                kv_transfer_config.kv_role,
+            )
+        kv_transfer_config.kv_role = "kv_both"
+        extra = kv_transfer_config.kv_connector_extra_config
+        if kv_offloading_size is not None:
+            # A non-None kv_offloading_size implies cache_config exists
+            # (it was read off cache_config above).
+            assert cache_config is not None
+            # Mirrors upstream _post_init_kv_transfer_config (GiB).
+            extra["cpu_bytes_to_use"] = int(kv_offloading_size * (1 << 30))
+            cache_config.kv_offloading_size = None
+        elif "cpu_bytes_to_use" not in extra:
+            raise NotImplementedError(
+                "KV offloading on Metal needs a host pool size: pass "
+                "--kv-offloading-size N (GiB) alongside the connector."
+            )
+        # Secondary tier types are gated here: the upstream "obj" tier
+        # needs NIXL, which has no macOS build — without this guard it
+        # crashes ungracefully deep inside engine start.
+        # MetalFileSystemTierManager is what MetalTieringOffloadingSpec
+        # rewrites "fs" to, so accept it here: this hook runs again in the
+        # engine core process, on a config the spec has already rewritten.
+        for tier in extra.get("secondary_tiers") or []:
+            tier_type = tier.get("type") if isinstance(tier, dict) else None
+            if tier_type not in ("fs", "MetalFileSystemTierManager"):
+                raise NotImplementedError(
+                    f"Secondary KV tier type '{tier_type}' is not "
+                    "supported on Metal; only 'fs' (filesystem) is "
+                    "available (the 'obj' tier requires NIXL, which has "
+                    "no macOS build)."
+                )
+        _configure_kv_events(vllm_config, extra)
+        # Remap upstream spec names to the one Metal spec, which serves both
+        # the plain host pool and secondary tiers. Unknown names fail here
+        # rather than resolving to a CUDA-bound spec deep inside engine start.
+        spec_name = extra.get("spec_name")
+        if spec_name not in (
+            None,
+            "CPUOffloadingSpec",
+            "TieringOffloadingSpec",
+            "MetalTieringOffloadingSpec",
+        ):
+            raise NotImplementedError(
+                f"Offloading spec '{spec_name}' is not supported on Metal."
+            )
+        extra["spec_name"] = "MetalTieringOffloadingSpec"
+        extra["spec_module_path"] = "vllm_metal.v1.kv_offload.spec"
+        # The host pool is anonymous RAM shared between the scheduler and the
+        # worker within one process (macOS has no tmpfs; a file-backed region
+        # would write KV churn back to SSD). That requires the single-process
+        # executor.
+        if parallel_config.distributed_executor_backend != "uni":
+            raise NotImplementedError(
+                "KV offloading on Metal requires the single-process executor "
+                "(--distributed-executor-backend uni); got "
+                f"'{parallel_config.distributed_executor_backend}'."
+            )
+
+
 class MetalPlatform(Platform):
     """Platform implementation for Apple Silicon Metal/MLX.
 
@@ -670,6 +835,8 @@ class MetalPlatform(Platform):
             # NB: the Ray job-level hook is registered only AFTER the remaining DP
             # rejections (multimodal, STT) further below, so an unsupported DP
             # config fails fast before any ray.init side effect.
+
+        _configure_kv_offloading(vllm_config)
 
         scheduler_config = vllm_config.scheduler_config
 

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -228,6 +228,9 @@ class _PagedAttentionPlan:
     hybrid_gdn_reservation: _HybridGDNReservation
     kv_budget: int
     num_blocks: int
+    # KV offloading host pool. Pageable, but the same physical RAM as the
+    # wired cache on unified memory, so it comes out of the same budget.
+    kv_offload_pool: int = 0
 
     def format_breakdown(self) -> str:
         parts = [
@@ -241,6 +244,8 @@ class _PagedAttentionPlan:
             parts.append(f"kv_budget_before_hybrid={self.base_kv_budget / 1e9:.2f}GB")
         if self.hybrid_gdn_reservation.is_hybrid:
             parts.append(self._hybrid_gdn_detail())
+        if self.kv_offload_pool:
+            parts.append(f"kv_offload_pool={self.kv_offload_pool / 1e9:.2f}GB")
         parts.append(f"kv_budget={self.kv_budget / 1e9:.2f}GB")
         return ", ".join(parts)
 
@@ -249,6 +254,8 @@ class _PagedAttentionPlan:
             "increase VLLM_METAL_MEMORY_FRACTION",
             "use a smaller or more quantized model",
         ]
+        if self.kv_offload_pool:
+            mitigations.insert(0, "lower --kv-offloading-size")
         reservation = self.hybrid_gdn_reservation
         if reservation.enabled and reservation.max_num_seqs > 1:
             seq_mitigation = (
@@ -1306,7 +1313,13 @@ class WorkerCachePlanner:
         )
         reservation = self._hybrid_gdn_reservation()
         draft_scratch_bytes = self._worker.model_runner.draft_scratch_reserve_bytes()
-        kv_budget = base_kv_budget - reservation.total_bytes - draft_scratch_bytes
+        kv_offload_pool = self._kv_offload_pool_bytes()
+        kv_budget = (
+            base_kv_budget
+            - reservation.total_bytes
+            - draft_scratch_bytes
+            - kv_offload_pool
+        )
         plan = _PagedAttentionPlan(
             block_size=block_size,
             fraction=fraction,
@@ -1319,12 +1332,31 @@ class WorkerCachePlanner:
             hybrid_gdn_reservation=reservation,
             kv_budget=kv_budget,
             num_blocks=max(0, kv_budget // per_block_bytes),
+            kv_offload_pool=kv_offload_pool,
         )
         self._validate_paged_attention_plan(
             plan,
             require_min_blocks=require_min_blocks,
         )
         return plan
+
+    def _kv_offload_pool_bytes(self) -> int:
+        """Host pool bytes of a configured KV offloading connector, else 0.
+
+        On unified memory the pool is the same physical RAM as the wired
+        cache. Leaving it outside the budget lets ``--kv-offloading-size``
+        push the resident set past what VLLM_METAL_MEMORY_FRACTION promised,
+        and the pool is pageable, so that swaps instead of failing at start.
+        The platform hook has already translated the size into
+        ``cpu_bytes_to_use`` by the time the plan runs.
+        """
+        kv_transfer_config = getattr(
+            self._worker.vllm_config, "kv_transfer_config", None
+        )
+        if kv_transfer_config is None or not kv_transfer_config.kv_connector:
+            return 0
+        extra = kv_transfer_config.kv_connector_extra_config or {}
+        return max(0, int(extra.get("cpu_bytes_to_use", 0)))
 
     def _validate_paged_attention_plan(
         self, plan: _PagedAttentionPlan, *, require_min_blocks: bool

--- a/vllm_metal/v1/decode_pipeline.py
+++ b/vllm_metal/v1/decode_pipeline.py
@@ -38,6 +38,7 @@ from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.outputs import KVConnectorOutput
 
     from vllm_metal.v1.model_runner import RequestState, _ExecutionBatch
     from vllm_metal.v1.spec_decode import PagedDecodeSegment
@@ -171,6 +172,10 @@ class PendingSampleStep:
     entries: tuple[PendingBackfillEntry, ...]
     batch: _ExecutionBatch
     scheduler_output: SchedulerOutput
+    # Collected at submit, because the connector step must close before the
+    # next step runs (see _submit_deferred_decode_sample). None when no KV
+    # connector is configured.
+    kv_connector_output: KVConnectorOutput | None
 
 
 class MetalAsyncModelRunnerOutput(AsyncModelRunnerOutput):
@@ -370,4 +375,7 @@ class DecodePipeline:
             pending.batch.set_output(entry.output_idx, [value])
 
         self._validate(pending.batch, pending.scheduler_output)
-        self._resolved = (self._pending_serial, self._build_output(pending.batch))
+        output = self._build_output(pending.batch)
+        if pending.kv_connector_output is not None:
+            output.kv_connector_output = pending.kv_connector_output
+        self._resolved = (self._pending_serial, output)

--- a/vllm_metal/v1/kv_offload/__init__.py
+++ b/vllm_metal/v1/kv_offload/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KV offloading support for the Metal backend.
+
+Implements the worker-side pieces of vLLM's OffloadingConnector for the MLX
+paged KV cache: an OffloadingSpec that sizes and manages the host pool, an
+OffloadingWorker that moves blocks between the wired MLX cache and pageable
+host memory, and a connector subclass that registers them.
+
+"""

--- a/vllm_metal/v1/kv_offload/connector.py
+++ b/vllm_metal/v1/kv_offload/connector.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OffloadingConnector subclass for the Metal backend.
+
+The stock worker half canonicalizes torch KV tensors and then copies through
+a CUDA-gated engine (``cpu/gpu_worker.py`` is ``is_cuda_alike``-only). Its
+canonical form can express split K/V, but a torch alias over an MLX array is
+still wrong here: the cache write kernels rebind ``key_caches[L]`` to a fresh
+array every layer call, so an alias taken at registration goes stale and
+carries none of the lazy-graph provenance that orders reads after pending
+writes. This subclass overrides only the registration entry point; the
+scheduler half, job bookkeeping, deferred stores, and completion reporting
+are all inherited unchanged.
+
+``MetalModelRunner`` owns the ``register_kv_caches`` call site and passes the
+live ``MetalPagedKVCache`` instead of a torch tensor dict.
+
+``MetalPlatform.check_and_update_config`` routes here by setting
+``kv_transfer_config.kv_connector = "MetalOffloadingConnector"`` +
+``kv_connector_module_path`` (it performs the ``--kv-offloading-size``
+translation itself, before vLLM's own translation would run).
+
+No mlx import at module scope: this module is also imported by the
+scheduler/engine-core process to resolve the SCHEDULER-role connector class,
+which must not initialize MLX.
+"""
+
+from __future__ import annotations
+
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
+    OffloadingConnector,
+)
+
+from vllm_metal.v1.kv_offload.spec import MetalTieringOffloadingSpec
+
+
+class MetalOffloadingConnector(OffloadingConnector):
+    def register_kv_caches(self, kv_caches) -> None:
+        from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+
+        assert self.connector_worker is not None
+        if not isinstance(kv_caches, MetalPagedKVCache):
+            raise TypeError(
+                "MetalOffloadingConnector.register_kv_caches expects the "
+                f"MetalPagedKVCache, got {type(kv_caches).__name__}"
+            )
+        spec = self.connector_worker.spec
+        if not isinstance(spec, MetalTieringOffloadingSpec):
+            raise TypeError(
+                "MetalOffloadingConnector requires MetalTieringOffloadingSpec "
+                f"(got {type(spec).__name__}); check kv_connector_extra_config"
+            )
+        # Mirrors OffloadingConnectorWorker.register_kv_caches minus the
+        # torch canonicalization: _init_worker's only job is populating
+        # self.worker from the spec.
+        self.connector_worker.worker = spec.get_metal_worker(kv_caches)

--- a/vllm_metal/v1/kv_offload/fs_tier.py
+++ b/vllm_metal/v1/kv_offload/fs_tier.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+"""macOS-tuned filesystem secondary tier for Metal KV offloading.
+
+Subclasses upstream ``FileSystemTierManager`` to use the operating system
+properly on macOS; the tier semantics (file naming, atomic writes, dedup,
+lookup) are inherited unchanged:
+
+- **F_NOCACHE** on block file descriptors. macOS has no ``O_DIRECT``, so
+  upstream's ``probe_o_direct`` reports it unavailable and falls back to
+  buffered I/O; multi-GB KV churn would then flow through the Unified Buffer
+  Cache and evict genuinely useful page cache. ``fcntl(F_NOCACHE)`` is the
+  macOS idiom for this write-once/read-rarely streaming pattern (advisory, no
+  alignment requirements).
+- **0o600 block files under a 0o700 root.** KV blocks are conversation-derived
+  data (prompt content is recoverable from them), and with ``PYTHONHASHSEED``
+  pinned the content-hash filenames let anyone who can list the directory
+  test for the presence of known prompts. Upstream creates 0o644 files.
+- **Spotlight exclusion.** Blocks are stored under a ``blocks.noindex``
+  subdirectory; the ``.noindex`` name suffix is the reliable per-directory
+  Spotlight opt-out. Backup exclusion is left to the user (``tmutil
+  addexclusion``), since it is a sticky change to their backup config.
+
+Scheduler-side only (no mlx import): ``MetalTieringOffloadingSpec`` routes the
+``fs`` tier type here through upstream's ``module_path`` hook.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import functools
+import os
+import stat
+from typing import TYPE_CHECKING
+
+from vllm.logger import init_logger
+
+# The tmp-suffix and mkdir helpers are reused so the atomic-replace protocol
+# cannot drift from upstream's.
+from vllm.v1.kv_offload.tiering.fs.io import (
+    _ensure_dirs,
+    _get_tmp_suffix,
+    _validate_offsets,
+)
+from vllm.v1.kv_offload.tiering.fs.manager import FileSystemTierManager
+
+from vllm_metal.config import get_config
+
+if TYPE_CHECKING:
+    from vllm.v1.kv_offload.tiering.base import TransferJob
+
+logger = init_logger(__name__)
+
+NOINDEX_DIRNAME = "blocks.noindex"
+
+
+# Only the F_NOCACHE constant is Darwin-specific (fcntl itself is POSIX,
+# imported unconditionally above so non-darwin mypy runs resolve the name).
+_F_NOCACHE: int | None = getattr(fcntl, "F_NOCACHE", None)
+
+
+def _set_nocache(fd: int) -> None:
+    """Advise the UBC not to retain pages for this fd (best-effort).
+
+    Must be called after open and BEFORE the first read or write. Setting it
+    afterwards is a measured no-op: page-cache growth is then identical to
+    buffered I/O (0.25 of bytes moved, against 0.02 when set first).
+    """
+    if _F_NOCACHE is None:
+        return
+    try:
+        fcntl.fcntl(fd, _F_NOCACHE, 1)
+    except OSError as exc:
+        logger.warning_once("F_NOCACHE failed: %s", exc)
+
+
+# On-disk format is upstream's byte-for-byte: block_size KV bytes, no header
+# and no footer, so a store written here is readable by an upstream fs tier and
+# vice versa.
+#
+# That means undetected corruption is possible: a torn write on power loss, bit
+# rot, or a stale writer produces a right-sized file whose contents are wrong,
+# and it will be restored into the KV cache without complaint. Upstream carries
+# the same exposure on Linux (neither side fsyncs before the atomic replace,
+# and O_DIRECT has the same torn-page behaviour as F_NOCACHE), and accepts it.
+# Metal accepts it on the same terms rather than diverging the format. If this
+# ever needs closing, close it upstream so both platforms benefit.
+
+
+def store_block(
+    dest_path: str,
+    buffer: memoryview,
+    offset: int,
+    block_size: int,
+) -> None:
+    """Upstream ``_store_block`` with F_NOCACHE and 0o600 files."""
+    _validate_offsets(buffer, [offset], block_size)
+    if os.path.exists(dest_path):
+        return
+
+    tmp_path = dest_path + _get_tmp_suffix()
+    _ensure_dirs(dest_path)
+
+    view_slice = buffer.cast("B")[offset : offset + block_size]
+    try:
+        fd = os.open(tmp_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC, 0o600)
+        try:
+            _set_nocache(fd)
+            written = os.write(fd, view_slice)
+            if written < block_size:
+                raise OSError(
+                    f"Short write: expected {block_size} bytes, wrote {written}"
+                )
+        finally:
+            os.close(fd)
+        os.replace(tmp_path, dest_path)
+    except Exception:
+        try:
+            os.remove(tmp_path)
+        except OSError as cleanup_exc:
+            logger.warning("Failed to remove temp file %s: %s", tmp_path, cleanup_exc)
+        raise
+
+
+def load_block(
+    source_path: str,
+    view: memoryview,
+    offset: int,
+    block_size: int,
+) -> None:
+    """Upstream ``_load_block`` with F_NOCACHE.
+
+    Deletion semantics match upstream exactly: a short read is provable
+    corruption and the file goes, every other error (fd exhaustion, EIO)
+    propagates untouched. F_NOCACHE is the only difference, and it exists
+    because upstream hard-codes the open flags around ``use_o_direct``
+    rather than taking an opener."""
+    _validate_offsets(view, [offset], block_size)
+    fd: int | None = None
+    view_slice = view.cast("B")[offset : offset + block_size]
+    truncated = False
+    try:
+        fd = os.open(source_path, os.O_RDONLY)
+        _set_nocache(fd)
+        bytes_read = os.readv(fd, [view_slice])
+        if bytes_read < block_size:
+            truncated = True
+            raise OSError(f"Short read: expected {block_size} bytes, read {bytes_read}")
+    except Exception:
+        if truncated:
+            try:
+                os.remove(source_path)
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Failed to remove truncated block file %s: %s",
+                    source_path,
+                    cleanup_exc,
+                )
+        raise
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
+def batch_store_block(
+    paths: list[str],
+    view: memoryview,
+    offsets: list[int],
+    block_size: int,
+) -> None:
+    """Upstream ``batch_store_block``, F_NOCACHE variant.
+
+    Upstream's fast path is a C extension whose open flags are fixed at
+    build time, so the Python loop is the only place F_NOCACHE can be set.
+    """
+    _validate_offsets(view, offsets, block_size)
+    for path, offset in zip(paths, offsets, strict=True):
+        store_block(path, view, offset, block_size)
+
+
+def batch_load_block(
+    paths: list[str],
+    view: memoryview,
+    offsets: list[int],
+    block_size: int,
+) -> None:
+    """Upstream ``batch_load_block``, F_NOCACHE variant.
+
+    On failure the OSError carries ``num_succeeded``, which upstream's
+    get_finished_jobs uses to keep the blocks that did load and mark only
+    the rest a miss. Dropping that attribute would silently turn a partial
+    failure into a full recompute.
+    """
+    _validate_offsets(view, offsets, block_size)
+    for i, (path, offset) in enumerate(zip(paths, offsets, strict=True)):
+        try:
+            load_block(path, view, offset, block_size)
+        except OSError as exc:
+            exc.num_succeeded = i  # type: ignore[attr-defined]
+            raise
+
+
+def _make_private_dir(path: str) -> None:
+    """mkdir -p; chmod 0700 only if WE created it. chmod-ing a pre-existing
+    user directory (root_dir=/tmp, a shared mount, ...) would strip other
+    users' access and e.g. /tmp's sticky bit — warn instead."""
+    if os.path.isdir(path):
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        if mode & 0o077:
+            logger.warning(
+                "KV store directory %s is group/world-accessible (%o); KV "
+                "blocks encode conversation-derived data — consider "
+                "chmod 700.",
+                path,
+                mode,
+            )
+        return
+    os.makedirs(path, exist_ok=True)
+    os.chmod(path, 0o700)
+
+
+def prepare_root_dir(root_dir: str) -> str:
+    """Harden the KV store directory and return the directory to store under.
+
+    Owner-only permissions (on directories this code creates) and a
+    ``.noindex`` nesting level so Spotlight never indexes the block churn.
+    Idempotent; safe to call on every startup against an existing store.
+    """
+    _make_private_dir(root_dir)
+    if os.path.basename(os.path.normpath(root_dir)).endswith(".noindex"):
+        return root_dir
+    nested = os.path.join(root_dir, NOINDEX_DIRNAME)
+    _make_private_dir(nested)
+    return nested
+
+
+def layout_signature() -> str:
+    """Directory component for KV layouts upstream's ``FileMapper`` cannot see.
+
+    ``FileMapper`` already hashes model name, model dtype, tokens_per_hash,
+    blocks_per_file and the KV cache groups into the store path, so those
+    layouts are disjoint on disk without help. TurboQuant is the exception:
+    it changes bytes per element while leaving every one of those fields
+    unchanged, and upstream knows nothing about it. Two runs of the same
+    model with different quant settings would otherwise share block paths
+    with incompatible byte layouts, where a load whose on-disk file is
+    larger than the reader's block silently restores wrong bytes and a short
+    read DELETES the other config's valid files.
+
+    Empty when TurboQuant is off, so the common case adds no nesting.
+    Deterministic for a fixed config, so cross-restart reuse is preserved.
+    """
+    cfg = get_config()
+    if not cfg.turboquant:
+        return ""
+    return f"tq-{cfg.k_quant}-{cfg.v_quant}"
+
+
+class MetalFileSystemTierManager(FileSystemTierManager):
+    """FileSystemTierManager with the macOS integrations described above."""
+
+    def __init__(
+        self,
+        offloading_spec,
+        primary_kv_view: memoryview,
+        tier_type: str,
+        root_dir: str,
+        **kwargs,
+    ) -> None:
+        # The factory passes the class name through as tier_type because the
+        # tier is selected by module_path. Report "fs" so metric labels and
+        # log lines match the CUDA path.
+        tier_type = "fs"
+        store_dir = prepare_root_dir(root_dir)
+        signature = layout_signature()
+        if signature:
+            store_dir = os.path.join(store_dir, signature)
+        _make_private_dir(store_dir)
+        if store_dir != root_dir:
+            logger.info("KV store blocks live under %s (Spotlight-excluded)", store_dir)
+        super().__init__(
+            offloading_spec, primary_kv_view, tier_type, store_dir, **kwargs
+        )
+        # super().__init__ just logged "O_DIRECT is not supported ... falling
+        # back to buffered I/O". True of upstream's io path, false of this
+        # one: macOS has no O_DIRECT and F_NOCACHE does the same job. Say so,
+        # or the first thing a user sees from this tier contradicts it.
+        logger.info(
+            "Metal fs tier uses fcntl(F_NOCACHE) in place of O_DIRECT; the "
+            "buffered-I/O fallback logged above does not apply to it."
+        )
+
+    # Upstream binds its batch io callbacks from its own module namespace;
+    # re-issue them with the F_NOCACHE variants. One task per job, exactly as
+    # upstream does, so job bookkeeping, partial-keep on a failed load and the
+    # pool's in-flight accounting all behave identically.
+    def submit_store(self, job_metadata: TransferJob) -> None:
+        keys = list(job_metadata.keys)
+        if self.events is not None:
+            self._store_job_keys[job_metadata.job_id] = keys
+        task = functools.partial(
+            batch_store_block,
+            [self.file_mapper.get_file_name(key) for key in keys],
+            self._primary_kv_view,
+            [int(bid) * self._block_size for bid in job_metadata.block_ids],
+            self._block_size,
+        )
+        self._pool.enqueue_store(job_metadata.job_id, 1, [task])
+
+    def submit_load(self, job_metadata: TransferJob) -> None:
+        job_id = job_metadata.job_id
+        keys = list(job_metadata.keys)
+        self._load_job_keys[job_id] = keys
+        paths = [self.file_mapper.get_file_name(key) for key in keys]
+        offsets = [int(bid) * self._block_size for bid in job_metadata.block_ids]
+
+        def load_task() -> None:
+            try:
+                batch_load_block(
+                    paths, self._primary_kv_view, offsets, self._block_size
+                )
+            except OSError as exc:
+                # Runs on a pool thread; written before task_done publishes the
+                # job, so get_finished_jobs reads it safely under the GIL.
+                self._load_progress[job_id] = getattr(exc, "num_succeeded", 0)
+                raise
+
+        self._pool.enqueue_load(job_id, 1, [load_task])

--- a/vllm_metal/v1/kv_offload/shared_region.py
+++ b/vllm_metal/v1/kv_offload/shared_region.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""macOS replacement for vLLM's SharedOffloadRegion.
+
+The upstream region (vllm/v1/kv_offload/cpu/shared_offload_region.py) backs
+the CPU offload tier with a /dev/shm mmap so the scheduler-side tiering
+manager and the worker-side handlers see the same bytes across processes.
+macOS has no tmpfs: a file-backed mmap would sit on APFS, where the pager
+writes dirty KV pages back to SSD — turning the "RAM tier" into a second
+disk tier (and leaking multi-GB files on crash).
+
+On Metal the scheduler and worker always share one process: KV offloading
+enforces the "uni" executor at config time (MetalPlatform), so the region
+can simply be anonymous RAM shared through a per-process registry keyed by
+instance id. The scheduler-role spec and the worker-role spec each construct
+a MetalSharedOffloadRegion with the same engine_id and get views over the
+same numpy buffer. Layout, ``create_next_worker_view``, ``create_kv_memoryview``,
+and cleanup bookkeeping are inherited from the upstream class unchanged.
+
+If a cross-process executor is ever supported, this class must move to real
+shared memory (e.g. POSIX shm) — a registry miss in another process would
+silently create a disjoint buffer, which is why the executor guard exists.
+"""
+
+from __future__ import annotations
+
+import mmap
+import threading
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.cpu.shared_offload_region import SharedOffloadRegion
+
+logger = init_logger(__name__)
+
+
+def _check_fits_in_ram(total_bytes: int) -> None:
+    """Refuse a host pool the machine cannot hold.
+
+    Upstream's SharedOffloadRegion calls check_shm_free_space before
+    ftruncate. There is no /dev/shm here, and np.zeros pages in lazily, so
+    an oversized pool starts cleanly and only thrashes once blocks are
+    actually written. On a fixed-RAM Mac that is a wedged machine rather
+    than a failed request, so check up front.
+
+    Compared against total RAM, not available: the pool is long-lived and
+    sizing it off whatever happens to be free at startup is not stable.
+    """
+    import psutil
+
+    total_ram = psutil.virtual_memory().total
+    # The wired KV cache and the model weights also live in this budget.
+    if total_bytes > total_ram // 2:
+        raise ValueError(
+            f"KV offloading host pool is {total_bytes / (1 << 30):.1f} GiB on "
+            f"a {total_ram / (1 << 30):.0f} GiB machine. The pool is pageable "
+            "and shares memory with the model weights and the wired KV cache, "
+            "so this would swap rather than fail cleanly. Lower "
+            "--kv-offloading-size."
+        )
+
+
+@dataclass
+class _RegionState:
+    buffer: np.ndarray  # 1-D uint8 of num_blocks * row_stride bytes
+    num_blocks: int
+    row_stride: int
+    refs: int
+
+
+_registry: dict[str, _RegionState] = {}
+_registry_lock = threading.Lock()
+
+
+class MetalSharedOffloadRegion(SharedOffloadRegion):
+    """SharedOffloadRegion over anonymous RAM, shared within one process."""
+
+    def __init__(
+        self,
+        engine_id: str,
+        num_blocks: int,
+        rank: int | None,
+        kv_bytes_per_block: int,
+        cpu_page_size: int,
+    ) -> None:
+        # Full override of the upstream constructor (it is not parameterized
+        # over its /dev/shm + madvise mechanism); every attribute consumed by
+        # the inherited methods is established here.
+        self.page_size = mmap.PAGESIZE
+        assert kv_bytes_per_block % self.page_size == 0
+
+        self.num_blocks = num_blocks
+        self._row_stride = kv_bytes_per_block
+        self.total_size_bytes = self.num_blocks * self._row_stride
+
+        self.rank = rank
+        if rank is not None:
+            self._worker_offset = rank * cpu_page_size
+            self._worker_area_end = (rank + 1) * cpu_page_size
+
+        self._engine_id = engine_id
+        _check_fits_in_ram(self.total_size_bytes)
+        with _registry_lock:
+            state = _registry.get(engine_id)
+            if state is None:
+                # np.zeros pages fault in lazily on first touch (calloc), so
+                # a large pool costs no RSS until blocks are actually stored.
+                state = _RegionState(
+                    buffer=np.zeros(self.total_size_bytes, dtype=np.uint8),
+                    num_blocks=num_blocks,
+                    row_stride=self._row_stride,
+                    refs=1,
+                )
+                _registry[engine_id] = state
+                logger.info(
+                    "Created in-process offload region %s (%.2f GB)",
+                    engine_id,
+                    self.total_size_bytes / 1e9,
+                )
+            else:
+                assert (
+                    state.num_blocks == num_blocks
+                    and state.row_stride == self._row_stride
+                ), (
+                    f"offload region {engine_id} attached with mismatched "
+                    f"geometry: {num_blocks}x{self._row_stride} vs existing "
+                    f"{state.num_blocks}x{state.row_stride}"
+                )
+                state.refs += 1
+        self._state: _RegionState | None = state
+
+        self._base = torch.frombuffer(memoryview(state.buffer), dtype=torch.int8)
+        self._views: list[torch.Tensor] = []
+        self.is_pinned = False
+        # Inherited cleanup() checks these; there is no file behind this
+        # region, so they are inert.
+        self.mmap_obj = None
+        self.fd = None
+        self.mmap_path = None
+        self._creator = False
+
+    def cleanup(self) -> None:
+        super().cleanup()
+        state = self._state
+        self._state = None
+        if state is None:
+            return
+        with _registry_lock:
+            state.refs -= 1
+            if state.refs <= 0 and _registry.get(self._engine_id) is state:
+                del _registry[self._engine_id]
+                logger.info("Released in-process offload region %s", self._engine_id)

--- a/vllm_metal/v1/kv_offload/spec.py
+++ b/vllm_metal/v1/kv_offload/spec.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OffloadingSpec for the Metal backend.
+
+``MetalTieringOffloadingSpec`` is upstream's ``TieringOffloadingSpec`` with
+the two platform-bound pieces swapped: the ``/dev/shm`` shared region and the
+CUDA copy engine. Host-pool sizing (``cpu_bytes_to_use`` / bytes per
+offloaded block) and the scheduler-side manager are inherited. Only the
+worker-side construction differs: the OffloadingWorker is built from the live
+``MetalPagedKVCache`` (per-layer MLX arrays) instead of torch
+``CanonicalKVCaches``. Upstream's canonicalization does handle split K/V (it
+carries a list of tensors per layer), but its copy engine is gated on
+``is_cuda_alike`` and the MLX cache rebinds ``key_caches[L]`` to a fresh array
+on every layer call, so a torch alias taken once at registration goes stale
+and carries no lazy-graph provenance.
+
+There is one spec, used with or without secondary tiers. On unified memory
+the host pool draws on the same RAM as the wired cache, so a separate
+CPU-only path would buy nothing the tiering path does not.
+
+Selected via ``kv_connector_extra_config["spec_name"]`` (+
+``spec_module_path``), injected by ``MetalPlatform.check_and_update_config``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, override
+
+import vllm.v1.kv_offload.tiering.spec as _tiering_spec_module
+from vllm.logger import init_logger
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
+from vllm.v1.kv_offload.base import (
+    CanonicalKVCaches,
+    OffloadingManager,
+    OffloadingMetricMetadata,
+    OffloadingWorker,
+)
+from vllm.v1.kv_offload.config import OffloadingConfig
+from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
+from vllm.v1.kv_offload.tiering.spec import TieringOffloadingSpec
+
+if TYPE_CHECKING:
+    from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+    from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+logger = init_logger(__name__)
+
+
+def validate_metal_support(kv_cache_config: KVCacheConfig) -> None:
+    groups = kv_cache_config.kv_cache_groups
+    if len(groups) != 1:
+        raise NotImplementedError(
+            "KV offloading on Metal currently supports a single KV cache "
+            f"group; got {len(groups)} (hybrid/sliding-window models are "
+            "not supported yet)"
+        )
+    if not isinstance(groups[0].kv_cache_spec, AttentionSpec):
+        # Two different configs land here as UniformTypeKVCacheSpecs rather
+        # than as multiple groups, and they need different advice:
+        #  - hybrid models (e.g. gemma-4's mixed sliding/full layer_types)
+        #  - draft-model spec decode, since #630 registers the draft KV as a
+        #    scheduler-managed cache group. Draft and target dims differ in
+        #    the usual case, so the merge into one AttentionSpec fails.
+        draft = any(name.startswith("draft_layers.") for name in groups[0].layer_names)
+        reason = (
+            "speculative decoding registers the draft model's KV as part of "
+            "this group; drop --speculative-config to use KV offloading"
+            if draft
+            else "hybrid/sliding-window models are not supported yet"
+        )
+        raise NotImplementedError(
+            "KV offloading on Metal currently supports uniform full-attention "
+            f"KV caches only; got {type(groups[0].kv_cache_spec).__name__} "
+            f"({reason})"
+        )
+
+
+def route_fs_tiers_to_metal(extra_config: dict[str, Any]) -> None:
+    """Point ``fs`` tier configs at the Metal subclass, in place.
+
+    Uses upstream's documented out-of-tree hook: ``SecondaryTierFactory.
+    get_tier_class`` imports ``type`` from ``module_path`` when one is given,
+    so no registry patching is needed. Applied on the spec rather than in the
+    platform hook, so a spec built any other way still gets the Metal tier
+    instead of silently falling back to upstream's buffered I/O and 0o644
+    block files.
+    """
+    for tier in extra_config.get("secondary_tiers") or []:
+        if isinstance(tier, dict) and tier.get("type") == "fs":
+            tier["type"] = "MetalFileSystemTierManager"
+            tier["module_path"] = "vllm_metal.v1.kv_offload.fs_tier"
+
+
+@contextmanager
+def _metal_tiering_classes() -> Iterator[None]:
+    """Swap in the Metal shared region for the duration of a call.
+
+    Upstream ``TieringOffloadingSpec.get_manager`` constructs its
+    module-global ``SharedOffloadRegion`` inline, and that one is /dev/shm
+    plus Linux ``madvise``. Rebinding it around ``super().get_manager()``
+    inherits the whole orchestration without copying it.
+
+    The ``fs`` tier does NOT need this. It is selected through upstream's
+    documented out-of-tree hook instead: ``route_fs_tiers_to_metal`` writes
+    ``module_path`` into the tier config and ``SecondaryTierFactory.
+    get_tier_class`` imports it.
+
+    Not re-entrant and not thread safe. Metal runs one engine per process
+    (the platform hook enforces the uni executor for offloading), so the
+    window cannot overlap in practice.
+    """
+    from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+    original_region = _tiering_spec_module.SharedOffloadRegion
+    _tiering_spec_module.SharedOffloadRegion = MetalSharedOffloadRegion
+    try:
+        yield
+    finally:
+        _tiering_spec_module.SharedOffloadRegion = original_region
+
+
+def gpu_blocks_per_offloaded_block(spec: CPUOffloadingSpec) -> int:
+    """GPU blocks coalesced into one offloaded block.
+
+    vLLM 0.25.1 exposed this as ``block_size_factor``, derived from
+    ``extra_config["block_size"] // gpu_block_size``. That derivation moved
+    into the offloading config builder rather than going away, and the result
+    is ``blocks_per_chunk``. Do not recompute it from ``tokens_per_hash``:
+    that is the prefix-hash granularity, which equals ``tokens_per_block`` for
+    every single-group model, so any ratio built from it is pinned to 1.
+    """
+    return int(spec.blocks_per_chunk)
+
+
+def warn_if_pool_undersized(
+    spec: CPUOffloadingSpec, kv_cache_config: KVCacheConfig
+) -> None:
+    """A host pool smaller than the GPU cache silently defeats evict-then-
+    reuse: the LRU drops blocks before the GPU cache would have re-requested
+    them, and every offload lookup misses (observed live: 32B model, 4 MiB
+    blocks, restore count stayed 0). Warn loudly at init."""
+    pool_gpu_blocks = spec.num_blocks * gpu_blocks_per_offloaded_block(spec)
+    if 0 < pool_gpu_blocks < kv_cache_config.num_blocks:
+        logger.warning(
+            "KV offloading host pool (%d GPU-block equivalents) is SMALLER "
+            "than the GPU KV cache (%d blocks). Prefixes evicted from the "
+            "GPU will usually already be evicted from the pool too, so "
+            "offload restores will rarely hit. Increase "
+            "--kv-offloading-size (or add a disk tier via secondary_tiers).",
+            pool_gpu_blocks,
+            kv_cache_config.num_blocks,
+        )
+
+
+class MetalTieringOffloadingSpec(TieringOffloadingSpec):
+    """Offloading spec for Metal: a host pool plus optional ``fs`` disk tiers.
+
+    Inherits TieringOffloadingSpec wholesale, the configuration surface
+    (``secondary_tiers`` et al.) and the scheduler-side ``get_manager``
+    orchestration, swapping only the two platform-bound pieces: the
+    ``/dev/shm`` SharedOffloadRegion (MetalSharedOffloadRegion) and the CUDA
+    worker (MetalKVOffloadWorker over the region).
+
+    Metal support validation and the pool-size warning need the
+    KVCacheConfig, which the spec no longer receives; MetalWorker runs both.
+    """
+
+    _metal_worker: MetalKVOffloadWorker | None = None
+
+    def __init__(self, config: OffloadingConfig):
+        route_fs_tiers_to_metal(config.extra_config)
+        super().__init__(config)
+        # Persistent tiers key files by PYTHONHASHSEED-dependent content
+        # hashes.
+        if self.secondary_tier_configs and os.environ.get("PYTHONHASHSEED") is None:
+            logger.warning(
+                "Secondary KV tiers are configured but PYTHONHASHSEED is "
+                "unset: block filenames are hash-seeded per process, so "
+                "blocks written now will NOT be found after a server "
+                "restart (or by other instances sharing the store). Set "
+                "PYTHONHASHSEED=0 for cross-restart reuse."
+            )
+
+    def _make_region(self, rank: int | None) -> MetalSharedOffloadRegion:
+        from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+        return MetalSharedOffloadRegion(
+            engine_id=self.config.engine_id,
+            num_blocks=self.num_blocks,
+            rank=rank,
+            kv_bytes_per_block=self.kv_bytes_per_chunk,
+            cpu_page_size=self.cpu_page_size_per_worker,
+        )
+
+    def get_worker(self, kv_caches: CanonicalKVCaches) -> OffloadingWorker:
+        raise NotImplementedError(
+            "The Metal offloading spec builds its worker from the MLX KV cache "
+            "via MetalOffloadingConnector.register_kv_caches, not from torch "
+            "CanonicalKVCaches"
+        )
+
+    def get_metal_worker(self, kv_cache: MetalPagedKVCache) -> MetalKVOffloadWorker:
+        """Worker over the live MLX cache. Called by
+        MetalOffloadingConnector.register_kv_caches."""
+        if self._metal_worker is None:
+            # Imported here so the scheduler-side spec (which only calls
+            # get_manager) never imports mlx.
+            from vllm_metal.v1.kv_offload.worker import MetalKVOffloadWorker
+
+            self._metal_worker = MetalKVOffloadWorker(
+                kv_cache,
+                block_size_factor=gpu_blocks_per_offloaded_block(self),
+                num_cpu_blocks=self.num_blocks,
+                # Scheduler and worker share one process (the platform hook
+                # enforces the "uni" executor) with a single worker rank.
+                region=self._make_region(rank=0),
+                expected_block_bytes=self.kv_bytes_per_chunk,
+            )
+        return self._metal_worker
+
+    @override
+    def get_manager(self) -> OffloadingManager:
+        """Delegate to the upstream body with the Metal classes routed in
+        (shared region and macOS-tuned ``fs`` tier; see
+        ``_metal_tiering_classes``)."""
+        with _metal_tiering_classes():
+            return super().get_manager()
+
+    @classmethod
+    @override
+    def build_metric_definitions(
+        cls, extra_config: dict[str, Any]
+    ) -> dict[str, OffloadingMetricMetadata]:
+        """Resolve secondary-tier metric definitions against the METAL tier
+        classes. The upstream body resolves each tier via
+        ``SecondaryTierFactory.get_tier_class`` at stat-logger construction —
+        outside ``get_manager``'s rebinding scope — so without this the ``fs``
+        tier's definitions would come from the upstream class and any metric
+        a Metal tier registers would KeyError at observation time."""
+        route_fs_tiers_to_metal(extra_config)
+        return super().build_metric_definitions(extra_config)

--- a/vllm_metal/v1/kv_offload/worker.py
+++ b/vllm_metal/v1/kv_offload/worker.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OffloadingWorker moving KV blocks between the MLX cache and host memory.
+
+The wired MLX KV pool is the fast tier; the host pool is plain (pageable)
+memory that macOS may reclaim under pressure. On unified memory a "transfer"
+is an on-package copy, so transfers execute synchronously inside
+``submit_store``/``submit_load`` and are reported complete on the next
+``get_finished`` poll — the OffloadingWorker contract stays async-shaped for
+a later move to ``mx.async_eval`` if profiling justifies it.
+
+Errors propagate out of ``submit_store``/``submit_load``: the upstream
+OffloadingConnectorWorker asserts a successful submission (job failure is
+unsupported upstream), so raising here surfaces the root cause directly
+instead of tripping a bare ``assert success`` with no context.
+
+Ordering rules (see kv_cache.py): the cache write
+kernels mutate Metal buffers in place but rebind ``kv_cache.<name>[layer]`` to
+fresh array objects carrying graph provenance. Stores therefore always gather
+through the *current* list entry, never a cached handle.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import mlx.core as mx
+import numpy as np
+from vllm.logger import init_logger
+from vllm.v1.kv_offload.base import (
+    GPULoadStoreSpec,
+    LoadStoreSpec,
+    OffloadingWorker,
+    TransferResult,
+)
+from vllm.v1.kv_offload.cpu.common import CPULoadStoreSpec
+
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+from vllm_metal.v1.kv_offload.shared_region import MetalSharedOffloadRegion
+
+logger = init_logger(__name__)
+
+# Measured on a 70B (80 layers, fp16): 512 blocks in one gather peaks at
+# 2.7 GB, 64 blocks at 336 MB, and throughput is the same either way
+# (23.3 vs 23.1 GB/s). This is a memory bound, not a speedup.
+_STORE_SLICE_BYTES = 256 << 20
+
+# Every MLX array list on MetalPagedKVCache that holds per-block state and
+# must therefore be offloaded together. The TurboQuant side arrays are empty
+# lists on the fp16/bf16 path.
+CACHE_ATTRS = (
+    "key_caches",
+    "value_caches",
+    "key_scale_caches",
+    "value_scale_caches",
+    "key_zero_caches",
+)
+
+# MLX dtype -> numpy dtype for the host pool. bfloat16 has no numpy dtype and
+# is round-tripped through a uint16 reinterpret view (mx.view).
+_MX_TO_NP = {
+    mx.float16: np.float16,
+    mx.float32: np.float32,
+    mx.bfloat16: np.uint16,
+    mx.int8: np.int8,
+    mx.uint8: np.uint8,
+    mx.uint16: np.uint16,
+    mx.uint32: np.uint32,
+    mx.int16: np.int16,
+    mx.int32: np.int32,
+}
+
+
+@dataclass
+class _CacheArrayRef:
+    """One MLX cache array (layer x kind) and its host-pool mirror."""
+
+    arrays: list[mx.array]  # the live list on MetalPagedKVCache
+    layer: int
+    is_bf16: bool
+    # (num_cpu_blocks, block_size_factor, block_size, heads, last_dim)
+    cpu: np.ndarray
+
+    @property
+    def gpu(self) -> mx.array:
+        # Read through the list entry: the write kernels rebind it to fresh
+        # array objects whose provenance orders reads after pending writes.
+        return self.arrays[self.layer]
+
+
+class MetalKVOffloadWorker(OffloadingWorker):
+    """Bidirectional GPU<->CPU block mover for the MLX paged KV cache.
+
+    One worker serves both directions: ``submit_store`` (GPU -> host pool)
+    and ``submit_load`` (host pool -> GPU) share the ``_transfer`` core.
+    """
+
+    def __init__(
+        self,
+        kv_cache: MetalPagedKVCache,
+        *,
+        block_size_factor: int,
+        num_cpu_blocks: int,
+        region: MetalSharedOffloadRegion,
+        expected_block_bytes: int | None = None,
+    ) -> None:
+        self.kv_cache = kv_cache
+        self.block_size_factor = block_size_factor
+        self.num_cpu_blocks = num_cpu_blocks
+        self.region: MetalSharedOffloadRegion | None = region
+        self._finished: list[TransferResult] = []
+        self._sub_slots = np.arange(block_size_factor)
+        # Cap on the transient a single store gather may hold. Job size is
+        # whatever the scheduler accumulated that step, so without this a
+        # long prefill chunk can ask for gigabytes at once.
+        self._store_slice_bytes = _STORE_SLICE_BYTES
+        self._num_gpu_blocks = int(kv_cache.num_blocks)
+
+        # Completeness guard: CACHE_ATTRS is the offload inventory. A
+        # per-block array list on the cache that is NOT in the inventory
+        # would be silently omitted from offload, and restored blocks would
+        # be rebuilt missing part of their state — the exact "new model
+        # family" silent-corruption mode. Fail fast at registration instead.
+        for name, value in vars(kv_cache).items():
+            if name in CACHE_ATTRS or not isinstance(value, list) or not value:
+                continue
+            if all(isinstance(a, mx.array) and a.ndim > 0 for a in value) and any(
+                a.shape[0] == self._num_gpu_blocks for a in value
+            ):
+                raise NotImplementedError(
+                    f"KV offloading: cache array list {name!r} on "
+                    f"{type(kv_cache).__name__} looks per-block "
+                    f"(leading dim == num_blocks) but is not in the offload "
+                    "inventory (CACHE_ATTRS); offloading this model would "
+                    "silently drop that state. Add it to CACHE_ATTRS with a "
+                    "round-trip test."
+                )
+
+        # The host pool lives in the shared region so the scheduler-side
+        # secondary tiers (disk, ...) read/write the same bytes through
+        # region.create_kv_memoryview(). Each cache array claims its slice of
+        # every block row via the region's own cursor
+        # (create_next_worker_view), keeping the row layout arithmetic in one
+        # place.
+        assert region.num_blocks == num_cpu_blocks
+
+        self._refs: list[_CacheArrayRef] = []
+        host_bytes = 0
+        for attr in CACHE_ATTRS:
+            arrays: list[mx.array] = getattr(kv_cache, attr)
+            for layer, arr in enumerate(arrays):
+                np_dtype = _MX_TO_NP.get(arr.dtype)
+                if np_dtype is None:
+                    raise NotImplementedError(
+                        f"KV offloading: unsupported cache dtype {arr.dtype} "
+                        f"({attr}[{layer}])"
+                    )
+                shape = (num_cpu_blocks, block_size_factor, *arr.shape[1:])
+                itemsize = np.dtype(np_dtype).itemsize
+                tensor_page = int(np.prod(arr.shape[1:])) * itemsize * block_size_factor
+                view = region.create_next_worker_view(tensor_page)
+                cpu = view.numpy().view(np_dtype).reshape(shape)
+                # The disk tier reads these bytes through the region's
+                # memoryview; a silent numpy copy here would corrupt it.
+                assert cpu.ctypes.data == view.data_ptr(), (
+                    "host-pool view is not zero-copy over the shared "
+                    f"region ({attr}[{layer}])"
+                )
+                self._refs.append(
+                    _CacheArrayRef(
+                        arrays=arrays,
+                        layer=layer,
+                        is_bf16=arr.dtype == mx.bfloat16,
+                        cpu=cpu,
+                    )
+                )
+                host_bytes += cpu.nbytes
+        # One gathered slice holds this many bytes per GPU block, across
+        # every layer and both K and V. Derived from the arrays actually
+        # carved, so TurboQuant's extra per-layer arrays are counted.
+        per_block = sum(
+            int(np.prod(ref.cpu.shape[2:])) * ref.cpu.dtype.itemsize
+            for ref in self._refs
+        )
+        self._blocks_per_slice = max(1, self._store_slice_bytes // max(per_block, 1))
+
+        # Two-sided carve check: the scheduler sizes the pool from vLLM's
+        # torch-side kv_cache_config (spec.kv_bytes_per_chunk);
+        # the handler carves from the live MLX arrays. The spec value may
+        # exceed the carve by alignment padding (upstream tiering rounds
+        # blocks up to BLOCK_SIZE_ALIGNMENT — the "maybe-pad" tail; fp16
+        # blocks are often exactly aligned, TurboQuant's rarely are). Padding
+        # is safe: rows are addressed by the padded stride on both sides.
+        # A carve LARGER than the spec sizing would overrun rows — fatal.
+        if expected_block_bytes is not None and num_cpu_blocks > 0:
+            actual = host_bytes // num_cpu_blocks
+            if actual > expected_block_bytes:
+                raise ValueError(
+                    f"KV offloading: handler carves {actual} bytes per "
+                    f"offloaded block from the MLX cache but the spec sized "
+                    f"the pool at {expected_block_bytes}; rows would overrun"
+                )
+            shortfall = expected_block_bytes - actual
+            # A carve SMALLER than the spec sizing is only legitimate as
+            # alignment padding, which is bounded by one alignment unit.
+            # Anything larger means the two sides disagree about the layout
+            # (a block_size_factor mismatch is the way this happens), and
+            # every restore past the first sub-slot would read the wrong
+            # bytes. Bounding it is what makes this a guard rather than a log.
+            if shortfall >= MetalSharedOffloadRegion.BLOCK_SIZE_ALIGNMENT:
+                raise ValueError(
+                    f"KV offloading: handler carves {actual} bytes per "
+                    f"offloaded block but the spec sized the pool at "
+                    f"{expected_block_bytes}, a shortfall of {shortfall} "
+                    f"bytes. That exceeds one alignment unit "
+                    f"({MetalSharedOffloadRegion.BLOCK_SIZE_ALIGNMENT}), so "
+                    f"it is a layout disagreement, not padding"
+                )
+            if shortfall > 0:
+                logger.debug(
+                    "KV offloading: %d bytes/block alignment padding "
+                    "(spec %d vs carve %d)",
+                    shortfall,
+                    expected_block_bytes,
+                    actual,
+                )
+        logger.info(
+            "KV offloading host pool: %.1f MB (%d CPU blocks x %d GPU "
+            "blocks/CPU block, %d cache arrays)",
+            host_bytes / 1e6,
+            num_cpu_blocks,
+            block_size_factor,
+            len(self._refs),
+        )
+
+    def submit_store(
+        self, job_id: int, src_spec: GPULoadStoreSpec, dst_spec: LoadStoreSpec
+    ) -> bool:
+        if not isinstance(src_spec, GPULoadStoreSpec) or not isinstance(
+            dst_spec, CPULoadStoreSpec
+        ):
+            raise ValueError(
+                f"KV offloading: unexpected store spec types "
+                f"{type(src_spec).__name__} -> {type(dst_spec).__name__}"
+            )
+        start = time.perf_counter()
+        num_bytes = self._transfer(src_spec, dst_spec, gpu_to_cpu=True)
+        self._record_finished(job_id, num_bytes, start)
+        return True
+
+    def submit_load(
+        self, job_id: int, src_spec: LoadStoreSpec, dst_spec: GPULoadStoreSpec
+    ) -> bool:
+        if not isinstance(src_spec, CPULoadStoreSpec) or not isinstance(
+            dst_spec, GPULoadStoreSpec
+        ):
+            raise ValueError(
+                f"KV offloading: unexpected load spec types "
+                f"{type(src_spec).__name__} -> {type(dst_spec).__name__}"
+            )
+        start = time.perf_counter()
+        num_bytes = self._transfer(dst_spec, src_spec, gpu_to_cpu=False)
+        self._record_finished(job_id, num_bytes, start)
+        return True
+
+    def _record_finished(self, job_id: int, num_bytes: int, start: float) -> None:
+        self._finished.append(
+            TransferResult(
+                job_id=job_id,
+                success=True,
+                transfer_size=num_bytes,
+                transfer_time=time.perf_counter() - start,
+            )
+        )
+
+    def _transfer(
+        self,
+        gpu_spec: GPULoadStoreSpec,
+        cpu_spec: CPULoadStoreSpec,
+        *,
+        gpu_to_cpu: bool,
+    ) -> int:
+        """Copy blocks between the MLX cache and the host pool.
+
+        One offloaded (CPU) block holds ``block_size_factor`` GPU-block-sized
+        sub-blocks. The first CPU block of a transfer may be entered
+        mid-block: ``block_indices[0] % block_size_factor`` sub-slots are
+        skipped, mirroring the CUDA handler
+        (vllm/v1/kv_offload/cpu/gpu_worker.py).
+        """
+        # validate_metal_support enforces a single KV cache group.
+        # Real raises, not asserts: these guard silent corruption (OOB
+        # mx.take returns garbage rows; OOB MLX scatter drops writes;
+        # negative numpy ids wrap) and must survive `python -O`. Raising
+        # fails the submission loudly (job failure is unsupported upstream).
+        if len(gpu_spec.group_sizes) != 1:
+            raise ValueError(
+                f"KV offloading: expected a single KV cache group, got "
+                f"group_sizes={gpu_spec.group_sizes!r}"
+            )
+        group_size = gpu_spec.group_sizes[0]
+        if group_size == 0:
+            return 0
+
+        gpu_ids = gpu_spec.block_ids
+        if len(gpu_ids) != group_size:
+            raise ValueError(
+                f"KV offloading: {len(gpu_ids)} GPU block ids != group size "
+                f"{group_size}"
+            )
+        if int(gpu_ids.min()) < 0 or int(gpu_ids.max()) >= self._num_gpu_blocks:
+            raise ValueError(
+                f"KV offloading: GPU block ids out of range "
+                f"[{int(gpu_ids.min())}, {int(gpu_ids.max())}] vs "
+                f"{self._num_gpu_blocks} cache blocks"
+            )
+        factor = self.block_size_factor
+        skip = gpu_spec.block_indices[0] % factor
+
+        cpu_ids = cpu_spec.block_ids
+        if int(cpu_ids.min()) < 0 or int(cpu_ids.max()) >= self.num_cpu_blocks:
+            raise ValueError(
+                f"KV offloading: CPU block ids out of range "
+                f"[{int(cpu_ids.min())}, {int(cpu_ids.max())}] vs pool of "
+                f"{self.num_cpu_blocks} blocks"
+            )
+        if len(cpu_ids) * factor < skip + group_size:
+            raise ValueError(
+                f"CPU blocks too few: {len(cpu_ids)} x {factor} < {skip} + {group_size}"
+            )
+        # Expand CPU block ids into flat (block, sub-slot) coordinates,
+        # skipping the unaligned head of the first block.
+        cpu_blocks = np.repeat(cpu_ids, factor)[skip : skip + group_size]
+        cpu_subs = np.tile(self._sub_slots, len(cpu_ids))[skip : skip + group_size]
+
+        num_bytes = 0
+        if gpu_to_cpu:
+            for lo in range(0, len(gpu_ids), self._blocks_per_slice):
+                num_bytes += self._store_slice(
+                    gpu_ids[lo : lo + self._blocks_per_slice],
+                    cpu_blocks[lo : lo + self._blocks_per_slice],
+                    cpu_subs[lo : lo + self._blocks_per_slice],
+                )
+        else:
+            mx_gpu_ids = mx.array(gpu_ids)
+            written = []
+            for ref in self._refs:
+                # Advanced indexing yields a fresh contiguous copy, so the
+                # host pool row can be safely reused right after this call.
+                host = ref.cpu[cpu_blocks, cpu_subs]
+                vals = mx.array(host)
+                if ref.is_bf16:
+                    vals = mx.view(vals, mx.bfloat16)
+                # MLX index-assigns in place, so the list entry already holds
+                # the scatter; no rebind needed.
+                arr = ref.gpu
+                arr[mx_gpu_ids] = vals
+                written.append(arr)
+                num_bytes += host.nbytes
+            mx.eval(*written)
+
+        return num_bytes
+
+    def _store_slice(self, gpu_ids, cpu_blocks, cpu_subs) -> int:
+        """Gather one slice of blocks and copy it to the host pool.
+
+        Sliced because the whole job would otherwise be live at once between
+        the gather and the last host copy. A 512-block job on a 70B is 2.7 GB
+        of transient on a machine whose KV budget is the thing under
+        pressure. Slicing costs nothing measurable: the gathers still batch
+        into one mx.eval per slice, and per-layer evaluation (upstream's CUDA
+        shape) is far worse here because every mx.eval is a command buffer
+        commit with a fixed floor.
+        """
+        mx_gpu_ids = mx.array(gpu_ids)
+        gathered = []
+        for ref in self._refs:
+            g = mx.take(ref.gpu, mx_gpu_ids, axis=0)
+            if ref.is_bf16:
+                g = mx.view(g, mx.uint16)
+            gathered.append(g)
+        mx.eval(*gathered)
+        moved = 0
+        for ref, g in zip(self._refs, gathered, strict=True):
+            host = np.frombuffer(memoryview(g), dtype=ref.cpu.dtype).reshape(g.shape)
+            ref.cpu[cpu_blocks, cpu_subs] = host
+            moved += host.nbytes
+        return moved
+
+    def get_finished(self) -> list[TransferResult]:
+        finished = self._finished
+        self._finished = []
+        return finished
+
+    def wait(self, job_ids: set[int]) -> None:
+        # Transfers complete synchronously in submit_store/submit_load;
+        # nothing is ever in flight by the time wait() can be called.
+        return
+
+    def shutdown(self) -> None:
+        self._refs.clear()
+        if self.region is not None:
+            self.region.cleanup()
+            self.region = None

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -12,6 +12,7 @@ Key contracts:
 """
 
 from collections.abc import Sequence
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypeAlias, cast
@@ -22,6 +23,11 @@ import torch
 from mlx_lm import stream_generate
 from mlx_lm.models.cache import make_prompt_cache
 from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
@@ -38,6 +44,7 @@ from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
     AsyncModelRunnerOutput,
     DraftTokenIds,
+    KVConnectorOutput,
     LogprobsLists,
     LogprobsTensors,
     ModelRunnerOutput,
@@ -45,6 +52,9 @@ from vllm.v1.outputs import (
 from vllm.v1.sample.logits_processor import LOGITSPROCS_GROUP
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
+from vllm.v1.worker.kv_connector_model_runner_mixin import (
+    KVConnectorModelRunnerMixin,
+)
 
 from vllm_metal import envs
 from vllm_metal.attention.context import (
@@ -360,6 +370,12 @@ class MetalModelRunner:
     Uses true batched decode with BatchKVCache for efficient parallel processing.
     """
 
+    # Class-level defaults so partially-constructed runners (tests build
+    # instances via __new__ + selective attributes) are safe on paths that
+    # check connector state, e.g. the non-last-PP sample early return.
+    _kv_connector_stack: ExitStack | None = None
+    _kv_connector_output: KVConnectorOutput | None = None
+
     def __init__(self, vllm_config: VllmConfig):
         """Initialize model runner.
 
@@ -426,6 +442,10 @@ class MetalModelRunner:
         # vLLM v1 async scheduling calls sample_tokens after execute_model.
         # Keep the latest execution output so sample_tokens can return it.
         self._pending_output: ModelRunnerOutput | None = None
+        # KV connector step context, held open across the execute_model /
+        # sample_tokens split (see _kv_connector_start_step).
+        self._kv_connector_stack: ExitStack | None = None
+        self._kv_connector_output: KVConnectorOutput | None = None
         self._draft_token_ids: DraftTokenIds | None = None
 
         # Paged attention state (set by worker when enabled)
@@ -842,6 +862,85 @@ class MetalModelRunner:
         This method exists to satisfy the engine's initialization protocol.
         """
         self._cache_policy.initialize_kv_cache(kv_cache_config)
+
+    def register_kv_connector_caches(self) -> None:
+        """Hand the live MLX paged KV cache to the KV connector.
+
+        Called by the worker after ``initialize_kv_cache`` when a KV connector
+        (KV offloading) is configured. The MetalOffloadingConnector accepts
+        the ``MetalPagedKVCache`` directly instead of vLLM's torch-tensor
+        registration path.
+        """
+        from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
+
+        runtime = self._paged_attention_runtime
+        kv_cache = getattr(runtime, "kv_cache", None) if runtime else None
+        if not isinstance(kv_cache, MetalPagedKVCache):
+            raise NotImplementedError(
+                "KV offloading on Metal requires the paged attention runtime "
+                "with an MLX paged KV cache; this model/backend combination "
+                f"provides {type(kv_cache).__name__ if kv_cache else 'none'}."
+            )
+        get_kv_transfer_group().register_kv_caches(kv_cache)
+
+    def _kv_connector_start_step(self, scheduler_output: SchedulerOutput) -> None:
+        """Enter the upstream connector lifecycle for this step.
+
+        Reuses KVConnectorModelRunnerMixin's context manager — which binds
+        metadata, runs this step's KV load transfers, and on exit populates a
+        KVConnectorOutput (get_finished also queues deferred store jobs) and
+        clears the metadata — held open across the async execute_model /
+        sample_tokens split via an ExitStack, so the population sequence has
+        exactly one owner (upstream).
+
+        Must run before the forward graph is built: loads scatter into the
+        cache arrays and rebind them, so attention reads see the restored
+        blocks through the arrays' provenance.
+        """
+        if self._kv_connector_stack is not None:
+            # A previous step raised between start and finish. Close it rather
+            # than raise: a context left open inverts the store-flush ordering
+            # and writes the wrong KV into the offload pool. Error, not a
+            # warning, because nothing on the normal path reaches here.
+            logger.error("Closing leaked KV connector step context.")
+            self._close_kv_connector_step()
+        stack = ExitStack()
+        stack.enter_context(set_forward_context(None, self.vllm_config))
+        # The private form on purpose. The public maybe_get_kv_connector_output
+        # only adds a has_kv_transfer_group() check, and execute_model has
+        # already made it: this runs inside that branch. Taking the wrapper
+        # would re-check it and yield None whenever the group is absent,
+        # which turns a programming error into a silent no-op.
+        self._kv_connector_output = stack.enter_context(
+            KVConnectorModelRunnerMixin._get_kv_connector_output(scheduler_output)
+        )
+        self._kv_connector_stack = stack
+
+    def _close_kv_connector_step(self) -> KVConnectorOutput | None:
+        stack = self._kv_connector_stack
+        output = self._kv_connector_output
+        self._kv_connector_stack = None
+        self._kv_connector_output = None
+        if stack is not None:
+            stack.close()  # populates `output` via the mixin's finally block
+        return output
+
+    def finish_kv_connector_step(self) -> KVConnectorOutput | None:
+        """Close this step's connector context, if one is open.
+
+        Idempotent, and the single spelling of "is a step open". Every exit
+        that ends a step goes through here, including worker shutdown."""
+        if has_kv_transfer_group() and self._kv_connector_stack is not None:
+            return self._close_kv_connector_step()
+        return None
+
+    def _attach_kv_connector_output(
+        self, output: ModelRunnerOutput
+    ) -> ModelRunnerOutput:
+        kv_connector_output = self.finish_kv_connector_step()
+        if kv_connector_output is not None:
+            output.kv_connector_output = kv_connector_output
+        return output
 
     def reset_mm_cache(self) -> None:
         """Reset profiling-time multimodal cache state when present."""
@@ -2886,6 +2985,23 @@ class MetalModelRunner:
                 "to use structured output."
             )
 
+        if has_kv_transfer_group():
+            kv_connector_metadata = scheduler_output.kv_connector_metadata
+            assert kv_connector_metadata is not None
+            get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
+            if scheduler_output.total_num_scheduled_tokens == 0:
+                # KV transfers must progress even on steps with no forward
+                # (e.g. every running request blocked on an async KV load).
+                # Pending runtime releases queued by the reconcile above must
+                # still be applied — every execute_model exit does this.
+                runtime = self._paged_attention_runtime
+                if runtime is not None:
+                    runtime.materialize_pending_state()
+                return KVConnectorModelRunnerMixin.kv_connector_no_forward(
+                    scheduler_output, self.vllm_config
+                )
+            self._kv_connector_start_step(scheduler_output)
+
         batch = _ExecutionBatch()
         self._handle_new_requests(
             batch, scheduler_output.scheduled_new_reqs, scheduler_output
@@ -2919,7 +3035,7 @@ class MetalModelRunner:
                 if runtime is not None:
                     runtime.materialize_pending_state()
                 self._validate_scheduled_outputs(batch, scheduler_output)
-                return batch.to_model_runner_output()
+                return self._attach_kv_connector_output(batch.to_model_runner_output())
             return None
 
         # Defensive invariant: the vLLM scheduler sets has_structured_output_requests
@@ -2946,11 +3062,14 @@ class MetalModelRunner:
             runtime.materialize_pending_state()
         self._validate_scheduled_outputs(batch, scheduler_output)
         if not batch.req_ids:
-            return batch.to_model_runner_output()
+            return self._attach_kv_connector_output(batch.to_model_runner_output())
         output = batch.to_model_runner_output()
         if self._is_pooling:
-            return output
-        self._pending_output = output
+            return self._attach_kv_connector_output(output)
+        # Finish the connector step now (no-op without a KV connector): the
+        # stashed output is returned verbatim by sample_tokens, which must
+        # not leave the step's bound metadata dangling.
+        self._pending_output = self._attach_kv_connector_output(output)
         return None
 
     def sample_tokens(
@@ -2972,6 +3091,11 @@ class MetalModelRunner:
             # downstream), so clear the stash and return an empty output — the
             # engine collects results from the last stage only.
             if is_non_last_stage(self.pp):
+                # KV offloading + PP is rejected at config time
+                # (MetalPlatform.check_and_update_config); if that guard is
+                # ever relaxed, this early return must also finish the
+                # connector step or non-last stages will leak bound metadata.
+                assert self._kv_connector_stack is None
                 self._execute_model_state = None
                 runtime = self._paged_attention_runtime
                 if runtime is not None:
@@ -2989,7 +3113,7 @@ class MetalModelRunner:
             if runtime is not None:
                 runtime.materialize_pending_state()
             self._validate_scheduled_outputs(batch, scheduler_output)
-            return batch.to_model_runner_output()
+            return self._attach_kv_connector_output(batch.to_model_runner_output())
 
         # Non-paged path: return output built by execute_model
         if self._pending_output is not None:
@@ -2998,7 +3122,10 @@ class MetalModelRunner:
             return output
 
         # Async scheduling: execute_model may have failed; return None so
-        # vLLM can surface the original exception.
+        # vLLM can surface the original exception. It may have failed after
+        # opening the connector step, so end the step here rather than leave
+        # it for the next one to find.
+        self.finish_kv_connector_step()
         logger.error(
             "sample_tokens called with no pending state — "
             "neither _execute_model_state nor _pending_output was set."
@@ -3069,12 +3196,21 @@ class MetalModelRunner:
         runtime = self._paged_attention_runtime
         if runtime is not None:
             runtime.materialize_pending_state()
+        # Close the connector step at submit, not at resolve. The close runs
+        # prepare_store_kv; the next step's handle_preemptions submits those
+        # jobs before re-allocating their GPU blocks. Close later and the copy
+        # runs against blocks the intervening forward overwrote, which is a
+        # silent wrong-KV write into the offload pool. Safe before the token
+        # sync: the store only queues here, and gathers through the rebound
+        # cache array under mx.eval at the next step.
+        # See tests/test_kv_offload_connector_step_order.py.
         return self._decode_pipeline.submit(
             PendingSampleStep(
                 tokens=tokens,
                 entries=tuple(entries),
                 batch=batch,
                 scheduler_output=paged_state.scheduler_output,
+                kv_connector_output=self.finish_kv_connector_step(),
             )
         )
 

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -13,6 +13,16 @@ from vllm.distributed import (
     ensure_model_parallel_initialized,
     init_distributed_environment,
 )
+from vllm.distributed.kv_transfer import (
+    ensure_kv_transfer_initialized,
+    ensure_kv_transfer_shutdown,
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorHandshakeMetadata,
+)
+from vllm.distributed.parallel_state import get_pp_group, get_tp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.tasks import SupportedTask
@@ -72,7 +82,7 @@ class MetalWorker(WorkerBase):
     # Override model_runner type from base class. Typed as MetalModelRunner
     # because its worker-facing method set is a superset of STTModelRunner's;
     # STT models are assigned an STTModelRunner at runtime (see init_device).
-    model_runner: MetalModelRunner  # type: ignore[assignment]
+    model_runner: MetalModelRunner
 
     def __init__(
         self,
@@ -250,7 +260,61 @@ class MetalWorker(WorkerBase):
         Args:
             kv_cache_config: KV cache configuration for this worker
         """
+        # Offloading specs no longer receive the KVCacheConfig, so the checks
+        # that need it run here instead, while it is still in scope. Gated on
+        # a connector being configured: these reject model shapes the offload
+        # path cannot serve, not shapes Metal cannot serve, and a transfer
+        # config with no connector is inert upstream and must stay so.
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        if kv_transfer_config is not None and kv_transfer_config.kv_connector:
+            from vllm_metal.v1.kv_offload.spec import validate_metal_support
+
+            validate_metal_support(kv_cache_config)
+
+        # Create the worker-side KV connector before KV cache initialization,
+        # mirroring vllm.v1.worker.gpu_worker.Worker.initialize_from_config.
+        # No-op unless kv_transfer_config is set (e.g. --kv-offloading-size).
+        ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
         self.model_runner.initialize_kv_cache(kv_cache_config)
+        if has_kv_transfer_group():
+            if not hasattr(self.model_runner, "register_kv_connector_caches"):
+                raise NotImplementedError(
+                    "KV offloading is not supported for STT models on Metal."
+                )
+            # The MLX paged cache already exists (allocated during
+            # determine_available_memory -> setup_paged_attention), so the
+            # connector can be handed the live cache immediately.
+            self.model_runner.register_kv_connector_caches()
+
+            # Needs both the built spec and the KVCacheConfig, so it runs
+            # here rather than in the spec constructor. Only without a disk
+            # tier: behind one, a small pool is the expected shape.
+            from vllm_metal.v1.kv_offload.spec import warn_if_pool_undersized
+
+            spec = get_kv_transfer_group().connector_worker.spec
+            if not spec.secondary_tier_configs:
+                warn_if_pool_undersized(spec, kv_cache_config)
+
+    def get_kv_connector_handshake_metadata(
+        self,
+    ) -> dict[tuple[int, int], KVConnectorHandshakeMetadata] | None:
+        """Get KV connector handshake metadata, keyed by (pp_rank, tp_rank).
+
+        Called by the engine core via ``collective_rpc`` whenever a KV
+        connector is configured. Copied from
+        ``vllm.v1.worker.gpu_worker.Worker`` (device-agnostic); the offloading
+        connector needs no handshake and yields ``None``.
+        """
+        if not has_kv_transfer_group():
+            return None
+
+        connector = get_kv_transfer_group()
+        if (metadata := connector.get_handshake_metadata()) is None:
+            return None
+
+        pp_rank = get_pp_group().rank_in_group
+        tp_rank = get_tp_group().rank_in_group
+        return {(pp_rank, tp_rank): metadata}
 
     def compile_or_warm_up_model(self) -> CompilationTimes:
         """Warm up the model for inference."""
@@ -395,6 +459,23 @@ class MetalWorker(WorkerBase):
 
     def shutdown(self) -> None:
         """Shutdown the worker and cleanup resources."""
+        # Close any open connector step before the connector goes away. If
+        # execute_model opened a step and sample_tokens never ran, the context
+        # is still open, and ensure_kv_transfer_shutdown drops the transfer
+        # group its exit path needs.
+        finish_step = getattr(self.model_runner, "finish_kv_connector_step", None)
+        if finish_step is not None:
+            try:
+                finish_step()
+            except Exception:
+                logger.exception("Closing the KV connector step failed; continuing")
+
+        try:
+            ensure_kv_transfer_shutdown()
+        except Exception:
+            # Never let connector teardown block profiler/model cleanup.
+            logger.exception("KV transfer shutdown failed; continuing")
+
         if self._metal_profiler is not None:
             self._metal_profiler.shutdown()
             self._metal_profiler = None


### PR DESCRIPTION
Adds vLLM's KV cache offloading to Apple Silicon: a host pool plus an `fs`
disk tier, driven by the same `--kv-offloading-size` and
`--kv-transfer-config` flags as CUDA. Core vLLM's `OffloadingConnector` and
`TieringOffloadingSpec` do the work; only the copy engine, the shared
region and the disk I/O are Metal-specific. On a 128 GB Mac a 32B model
restores an evicted prefix 48x faster than it recomputes it. Off by
default, and nothing changes when it is off.

Supersedes #530. On `main` at vLLM 0.28.0. Measured on 128 GB M-series
machines, macOS 15 and 26.

## The problem

On Apple Silicon the KV cache is small and does not survive a restart.
Metal memory is shared with the OS, other applications and the model
weights, and what is left for KV shrinks as the model grows. On a 128 GB
machine at memory fraction 0.45, Qwen2.5-32B-4bit has room for 124,464
tokens of KV and Llama-3.3-70B-4bit for 34,448: about one long document.
A 1.5B model holds 1.76M and never runs out.

Prefix caching only holds what fits. An evicted prefix pays a full prefill
on its next request, and a restart (development loops, redeploys,
sleep/wake) discards everything. Prefill is the slow part here: on the 70B
a 2,320-token prefix takes 42.74 s to prefill and 6.65 s to restore.

## Results

Offloading against no offloading, same model, same machine:

| Case | Model | TTFT | End-to-end | n |
|---|---|---|---|---|
| Restart, same traffic | Llama-3.3-70B | **10.50x** | 2.47x | 3 |
| Restart, same traffic | Qwen2.5-32B | **9.50x** | 2.46x | 3 |
| Evicted prefix, requested again | Llama-3.3-70B | **11.11x** | 5.19x | 3 |
| Evicted prefix, requested again | Qwen2.5-32B | **29.09x** | 7.78x | 2 |
| Restart, memory fraction 0.8 | Qwen2.5-32B | **17.06x** | 2.20x | 3 |
| Evicted prefix, memory fraction 0.8 | Qwen2.5-32B | **48.09x** | 5.56x | 3 |

Rows at 0.45 ran on a host also in interactive use. Rows at 0.8, the
documented setting, ran on a dedicated M4 Max with IQR under 1% except
3.2% on the restart offload arm. Restart ranges from 2.16x to 10.50x over
12 model configurations at 0.45 and grows with model size. Some baseline
IQRs are wide, up to 97% on the 70B restart, and the 32B evicted-prefix
row at 0.45 is two repetitions. Per-row IQR, n and the raw JSON accompany
the benchmark tool, which is a separate PR.

**Where offloading cannot help, it delays admission.** With no reuse every
secondary-tier lookup misses and the scheduler holds the request one step.
Median TTFT over 11 no-reuse controls at 0.45 is 0.91x, about 10% added,
worst 0.79x. At 0.8 the two controls read 1.00x and 0.98x on TTFT, and
1.00x and 0.98x end to end.

**The speedup is restores, not better prefix caching.** One evicted-prefix
run was repeated with server logs kept. The in-GPU prefix cache hit rate is
within 0.3 points across both arms (52.2% against 51.9%). The offload arm
served 72.4% of GPU cache misses from the external tier and prefilled
about 87k prompt tokens against the baseline's 312k, 72.1% less.

**Restored output is the same output.** An end-to-end harness, not in this
PR, asserts restored text is byte-identical to the no-offload control
across 9 models and 33 scenarios, with `external_kv_transfer > 0` and
`gpu_cache_hit_tokens == 0` so the tokens came from the tier.

## Design

Core vLLM's offloading, with the platform-bound pieces replaced.

```bash
vllm serve <model> --kv-offloading-size 32
```

That is the host pool. The disk tier is what survives a restart. It is
configured as on CUDA:

```bash
PYTHONHASHSEED=0 vllm serve <model> --kv-offloading-size 32 \
  --kv-transfer-config '{"kv_connector_extra_config":
    {"secondary_tiers": [{"type": "fs", "root_dir": "/path/to/store"}]}}'
```

`PYTHONHASHSEED` is upstream's requirement for the `fs` tier, not a Metal
one: vLLM seeds `NONE_HASH` from it, and from `os.urandom` when it is
unset, whatever `--prefix-caching-hash-algo` says. Without it a restarted
server cannot find what the previous one wrote. The plugin warns at
startup when a persistent tier is configured and the seed is unset.

One spec, `MetalTieringOffloadingSpec(TieringOffloadingSpec)`, with or
without a disk tier. On unified memory the host pool and the Metal cache
are the same RAM, so a CPU-only spec would add code without adding a tier.
The connector overrides only worker-side cache registration. Block files
are upstream's format byte for byte, so a store written here is readable
by an upstream `fs` tier and the reverse, and the tier emits the same
`BlockStored` events.

| Tier | Status |
|---|---|
| Host pool | Supported |
| `fs` (disk) | Supported |
| `p2p` | Rejected at config time. No NVLink on Apple Silicon. |
| `obj` | Rejected at config time. NIXL has no macOS build. |

### What is Metal-specific

**The worker.** Upstream's copy engine is CUDA-only (streams, pinned host
buffers, a Triton kernel). The layout is not the blocker; upstream's
canonical form can express split K/V. The blocker is that the Metal cache
rebinds `key_caches[L]` to a fresh MLX array on every layer call, so a
torch view taken once at registration goes stale. `MetalKVOffloadWorker`
moves blocks between the live MLX arrays and the host pool, reading each
layer's current list entry at store time so the read is ordered after
pending writes. A completeness guard fails registration if the cache
grows a per-block array that is not in the offload inventory, so a new
model family cannot be silently half-offloaded. TurboQuant's scale and
zero arrays are in the inventory.

**The shared region.** Upstream's is `/dev/shm` plus Linux `madvise`.
Here it is a process-private buffer in a registry keyed by engine id,
which works because scheduler and worker share one process. That is why
offloading requires the single-process executor. A pool above half of
physical RAM is refused at startup, as upstream refuses a pool `/dev/shm`
cannot hold.

**The `fs` tier.** `fcntl(F_NOCACHE)` on block file descriptors, because
macOS has no `O_DIRECT` and upstream's probe falls back to buffered I/O,
which would push multi-GB KV churn through the Unified Buffer Cache. The
flag has to be set on the descriptor before the first write, so the tier
runs the Python store and load loop rather than upstream's C batch path.
Block files are 0o600 under a 0o700 root, where upstream creates 0o644;
KV blocks are conversation-derived and with a pinned hash seed the
filenames let anyone who can list the directory test for known prompts.
Upstream could take the same change. Blocks live under `blocks.noindex`
so Spotlight ignores the churn, and TurboQuant stores get a path component
of their own, since upstream's path hashes none of the fields TurboQuant
changes.

### What the platform hook does

`check_and_update_config` translates `--kv-offloading-size` itself,
because vLLM's own translation runs after the hook and would select a
connector this platform cannot serve. It clears
`cache_config.kv_offloading_size` to disarm that translation, routes the
connector and spec to the Metal classes by module path, forces
`kv_role=kv_both` as upstream does, and rejects at config time: any other
connector, a non-`native` backend, `VLLM_USE_SIMPLE_KV_OFFLOAD`, pipeline
parallelism, a multi-process executor, and any tier type but `fs`. When
KV cache events are enabled globally it sets `enable_kv_events` on each
tier; the reverse combination is refused, because that tier would publish
nothing and a KV-aware router would route as if the instance held no
prefixes. A transfer config with no connector is inert upstream and passes
through untouched.

### What changes on the inference path

Only with a connector configured. The runner opens upstream's connector
step at the top of `execute_model`, holds it across the
`execute_model` / `sample_tokens` split, and closes it when the deferred
decode is submitted, not when it resolves. The close queues the step's
stores, and the next step's `handle_preemptions` submits them before their
GPU blocks are reallocated. Closing later would copy blocks the
intervening forward had overwritten, a silent wrong-KV write into the
pool. Steps with no forward still progress KV transfers. Every new call
site in the runner, the worker and the decode pipeline is behind
`has_kv_transfer_group()`, and the existing runner tests pass unchanged.

## Sizing

The host pool should be larger than the Metal KV cache. If it is smaller,
the pool's own LRU drops blocks before the cache would have re-requested
them, so restores mostly miss and the tier costs more than it saves. The
plugin warns at startup when that is the shape and no disk tier is
configured. At memory fraction 0.8 there is no room for a larger pool, so
the 0.8 rows use an 8 GiB pool behind the disk tier, and the disk tier
carries the restores. The same 8 GiB pool with no disk tier gives 1.00x on
the evicted prefix and 0.99x on restart, three repetitions each. At a high
memory fraction the disk tier is the only tier that adds capacity, which
is why there is no separate CPU-only path.

## Not supported

Rejected at engine start with a specific message.

- Hybrid and sliding-window models. Single uniform full-attention KV cache
  group only.
- Draft-model speculative decoding. vllm-metal#630 registers the draft KV
  in the same cache group, and draft and target dims usually differ.
- Multi-rank. The host pool is shared inside one process. The
  single-process executor is the default for pipeline_parallel_size 1.

Nothing evicts block files, as with upstream's `fs` tier. The store grows
to whatever the workload touches; a no-reuse run on the 32B wrote 84 GB.
The user page says so and names the directory to delete.

## Relationship to vllm-project/vllm#49328

#530 was closed pending that fix, which shipped in vLLM 0.28.0. The
livelock guard #530 carried is deleted; the `fs` tier populates upstream's
`_load_job_keys` and the existing livelock test passes against upstream's
guard.

## Reviewing this

Two commits, feature and docs. About 3,900 lines: 1,600 in the package,
2,200 in tests, 130 in docs. Suggested order:

1. `platform.py`, `spec.py` and `shared_region.py` together. The executor
   guard exists because of the region.
2. `model_runner.py` and `decode_pipeline.py`, the step lifecycle above.
   The only files that touch request flow.
3. `kv_offload/worker.py`. The copy engine and the read-ordering rule.
4. `fs_tier.py`.
5. Tests and docs.

```bash
pytest tests/test_kv_offload_*.py     # 76 tests, about a minute
scripts/lint.sh                       # ruff, format, mypy, shellcheck
```

Full suite 2032 passing on macOS with vLLM 0.28.0. On a clean machine
`install.sh` bootstrapped uv and Python 3.12 and the suite passed
unchanged.

The tests worth a reviewer's time:

- `test_kv_offload_connector_step_order.py` pins the store fence: the
  step's close is ordered before the next step's `handle_preemptions`.
- `test_kv_offload_cuda_parity.py` checks block placement against
  upstream's own pointer arithmetic, on the real region.
- `test_kv_offload_tiering.py` drives `get_manager()` through upstream's
  body and asserts the Metal classes come out. The `fs` tier is selected
  by upstream's `module_path` hook; the region by rebinding one module
  global around the call. If either stopped working, production would
  get buffered I/O and 0o644 files with nothing logged.
- `test_kv_offload_fs_tier.py` drives upstream's failed-load negative
  cache through this subclass, and covers the empty-job path.

## Benchmark method

Four workloads per model: no reuse and reuse-inside-cache as controls,
evicted prefix, and restart. Each runs with offloading off and on against
a freshly started server, order rotated per repetition,
`--max-concurrency 4` so TTFT measures prefill rather than queueing,
`--max-model-len 8192`.

The evicted-prefix workload runs two passes against one server. The first
overflows the cache and is untimed; the second is measured, after the
early prefixes have been evicted. vLLM's `prefix_repetition` dataset emits
every request for a prefix consecutively, so a single pass never revisits
a prefix after eviction.

The offload arm holds more KV bytes than the baseline, so there is a
control with matched capacity: the baseline gets a larger Metal cache
instead of a host pool. That cuts the offload arm's memory advantage from
+131.6% to +4.5% and the result from 29.09x to 22.19x. The rest is the
disk tier.

The benchmark tool is a separate PR. It probes the KV cache, sizes the
host pool at 1.3x it and the evicted-prefix workload at 1.4x it, and exits
non-zero if either control shows offloading ahead. The command behind the
0.8 rows:

```bash
python tools/benchmark/kv_offload_benchmark.py \
    --model mlx-community/Qwen2.5-32B-Instruct-4bit \
    --memory-fraction 0.8 --offload-size-gib 8 \
    --max-model-len 8192 --prefix-len 3072 --suffix-len 512 --repeats 3 \
    --out kv-offload-benchmark.json
```

Caveats: the 70B rows and the 12-model matrix are at 0.45 on a host also
in interactive use; load average stayed near 2.5 on both hosts, so
absolute latencies include that load while the ratios, from interleaved
and rotated runs, do not depend on it.

## Docs

`docs/kv_offloading.md` is the user page, under Features in the nav. The
read-ordering rule is documented in `kv_offload/worker.py`, where it
applies.

