### PR TITLE
Fix VLLM_USE_MODELSCOPE=1 silently falling back to HuggingFace for weight download

### DIFF
--- a/vllm_metal/utils.py
+++ b/vllm_metal/utils.py
@@ -30,7 +30,11 @@ def get_model_download_path(model_repo_name: str) -> str:
     if Path(model_repo_name).exists():
         return model_repo_name
 
-    if os.environ.get("VLLM_USE_MODELSCOPE", "False").lower() == "true":
+    # Reuse vLLM core's own env parsing (accepts "1"/"true") so the plugin
+    # and core cannot drift apart on which spellings enable ModelScope.
+    from vllm.envs import VLLM_USE_MODELSCOPE
+
+    if VLLM_USE_MODELSCOPE:
         try:
             from modelscope.hub.snapshot_download import snapshot_download
 

--- a/vllm_metal/utils.py
+++ b/vllm_metal/utils.py
@@ -2,7 +2,6 @@
 """Metal utility functions for vLLM Metal plugin."""
 
 import logging
-import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #682

## Problem

`get_model_download_path()` enabled the ModelScope path only when the env var was exactly `"true"`:

```python
if os.environ.get("VLLM_USE_MODELSCOPE", "False").lower() == "true":
```

vLLM core accepts both `"1"` and `"true"` (`vllm/envs.py`), so `VLLM_USE_MODELSCOPE=1` produced a half-working setup: configs/tokenizer downloaded via ModelScope, then weights silently crawled from HuggingFace (rate-limited or unreachable in some regions), with no hint in the logs that the env var had been ignored.

## Fix

Reuse vLLM core's parsed flag instead of re-parsing the string, so the plugin and core cannot drift apart:

```python
from vllm.envs import VLLM_USE_MODELSCOPE

if VLLM_USE_MODELSCOPE:
```

(`from vllm.envs import ...` is already the established pattern elsewhere in the plugin, e.g. `vllm_metal/__init__.py`.)

## Verification

- `VLLM_USE_MODELSCOPE=1 vllm serve mlx-community/Qwen3.8-27B-4bit` now logs `Downloading model ... from ModelScope...` and weights come from modelscope.cn (previously fell through to HF).
- `VLLM_USE_MODELSCOPE=true` unchanged.
- `import vllm_metal.utils` OK.

Tested on vllm-metal 0.28.0 source checkout + vLLM core 0.28.0 macOS arm64 wheel.