### PR TITLE
[Bugfix] Fix StableLM paged attention scale

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -94,6 +94,7 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Llama 3 | ✅ | GQA (paged) | ✅ | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` |
 | Mistral-7B | ✅ | GQA (paged) | ✅ | `mlx-community/Mistral-7B-Instruct-v0.3-4bit` |
 | Mistral-Small-24B | 🔵 | GQA (paged) | ✅ | `mlx-community/Mistral-Small-24B-Instruct-2501-4bit` |
+| StableLM 2 | 🔵 | MHA + partial RoPE (paged) | ✅ | `mlx-community/stablelm-2-zephyr-1_6b-4bit` |
 | GPT-OSS | 🔵 | Sink attention (paged) | ✅ | `openai/gpt-oss-20b` |
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | — |
 | MiniCPM3-4B | ✅ | MLA (paged latent cache) | ✅ | `mlx-community/MiniCPM3-4B-4bit` |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -94,7 +94,7 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Llama 3 | ✅ | GQA (paged) | ✅ | `mlx-community/Meta-Llama-3.1-8B-Instruct-4bit` |
 | Mistral-7B | ✅ | GQA (paged) | ✅ | `mlx-community/Mistral-7B-Instruct-v0.3-4bit` |
 | Mistral-Small-24B | 🔵 | GQA (paged) | ✅ | `mlx-community/Mistral-Small-24B-Instruct-2501-4bit` |
-| StableLM 2 | 🔵 | MHA + partial RoPE (paged) | ✅ | `mlx-community/stablelm-2-zephyr-1_6b-4bit` |
+| StableLM 2 | ✅ | MHA + partial RoPE (paged) | ✅ | `mlx-community/stablelm-2-zephyr-1_6b-4bit` |
 | GPT-OSS | 🔵 | Sink attention (paged) | ✅ | `openai/gpt-oss-20b` |
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | — |
 | MiniCPM3-4B | ✅ | MLA (paged latent cache) | ✅ | `mlx-community/MiniCPM3-4B-4bit` |
@@ -109,4 +109,4 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Granite 3.3 | 🔵 | GQA (paged) | ✅ | `mlx-community/granite-3.3-8b-instruct-4bit` |
 | EXAONE 4.0 | 🔵 | GQA (paged) | ✅ | `mlx-community/exaone-4.0-1.2b-4bit` |
 | Laguna | ✅  | GQA (paged) | ✅ | `poolside/Laguna-XS-2.1-NVFP4-mlx` |
-| Hunyuan (dense) | 🔵 | GQA + QK norm (paged) | ✅ | `mlx-community/Hunyuan-1.8B-Instruct-4bit` |
+| Hunyuan (dense) | ✅ | GQA + QK norm (paged) | ✅ | `mlx-community/Hunyuan-1.8B-Instruct-4bit` |

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for Gemma4-specific branches in sdpa.
+"""Unit tests for paged SDPA attention contracts.
 
 Covers:
 - ``pad_qkv_to_cache_head_dim`` / ``truncate_padded_output`` pure helpers.
 - ``prepare_sdpa_qkv`` branches (K-eq-V fallback, v_norm, YOCO shared_kv).
-- ``sdpa_forward`` propagation of per-layer ``num_kv_heads`` to the kernel.
+- ``sdpa_forward`` propagation of per-layer metadata to the kernel.
 
 The ``prepare_sdpa_qkv`` tests use minimal fake attention modules rather
 than real mlx_lm Attention modules so they stay fast and deterministic.
@@ -21,6 +21,7 @@ import mlx.nn as nn
 import pytest
 
 import vllm_metal.attention.impls.sdpa as sdpa_mod
+from vllm_metal.attention.attention_contracts import attention_contract_for
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.caches.mha_layout import (
     MHAKVCacheLayout,
@@ -756,12 +757,12 @@ class TestSDPAForward:
         assert sliding_call.block_tables == [[8, 9], [10, 0]]
         assert sliding_call.block_size == 16
 
-    def test_kernel_receives_per_layer_kv_heads(self) -> None:
-        """Heterogeneous layers must pass their concrete KV-head count.
+    def test_kernel_uses_layer_heads_and_registered_default_scale(self) -> None:
+        """Kernel metadata comes from the layer, not padded cache allocation.
 
-        Regression guard for Gemma4-style mixed KV layouts: ``sdpa_forward``
-        resolves the layer's actual cache shape from ``kv_heads_per_layer``
-        and must pass that same count to ``paged_attention_primitive``.
+        StableLM exposes no scale attribute. Mixed layouts may allocate a wider
+        cache, but its registered default must use the projected query width.
+        Unregistered scale-less modules must continue to fail before dispatch.
         """
         actual_kv_heads = 1
         cache = MetalPagedKVCache(
@@ -772,14 +773,25 @@ class TestSDPAForward:
             block_size=8,
             dtype=mx.float16,
             kv_heads_per_layer=[_N_KV_HEADS, actual_kv_heads],
-            head_dim_per_layer=[_HEAD_DIM, _HEAD_DIM],
+            head_dim_per_layer=[_HEAD_DIM, _CACHE_HEAD_DIM],
         )
 
-        inner = SimpleNamespace(
-            n_heads=_N_HEADS,
-            n_kv_heads=actual_kv_heads,
-            scale=_HEAD_DIM**-0.5,
-            o_proj=lambda out: out,
+        from mlx_lm.models.stablelm import Attention, ModelArgs
+
+        inner = Attention(
+            ModelArgs(
+                model_type="stablelm",
+                vocab_size=32,
+                hidden_size=_HIDDEN,
+                num_attention_heads=_N_HEADS,
+                num_hidden_layers=1,
+                num_key_value_heads=actual_kv_heads,
+                intermediate_size=16,
+                rope_theta=10_000.0,
+                use_qkv_bias=False,
+                partial_rotary_factor=0.25,
+                layer_norm_eps=1e-5,
+            )
         )
         ctx = _make_ctx(_SEQ_LEN)
         x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN))
@@ -789,7 +801,7 @@ class TestSDPAForward:
         values = mx.ones((_BATCH, actual_kv_heads, _SEQ_LEN, _HEAD_DIM))
         kv_for_sharing = (keys, values)
 
-        captured: dict[str, int] = {}
+        captured: dict[str, int | float] = {}
 
         class _FakeOps:
             def reshape_and_cache(
@@ -808,10 +820,12 @@ class TestSDPAForward:
                 _key_cache,
                 _value_cache,
                 num_kv_heads,
+                scale,
                 *_args,
                 **_kwargs,
             ) -> None:
                 captured["num_kv_heads"] = num_kv_heads
+                captured["scale"] = scale
 
         with (
             patch.object(
@@ -826,9 +840,25 @@ class TestSDPAForward:
                 return_value=mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM)),
             ),
         ):
-            sdpa_forward(inner, x, ctx, cache, layer_idx=1)
+            unregistered = SimpleNamespace(
+                n_heads=_N_HEADS,
+                n_kv_heads=actual_kv_heads,
+                o_proj=lambda out: out,
+            )
+            with pytest.raises(AttributeError, match="neither 'scale' nor 'sm_scale'"):
+                sdpa_forward(unregistered, x, ctx, cache, layer_idx=1)
+
+            sdpa_forward(
+                inner,
+                x,
+                ctx,
+                cache,
+                layer_idx=1,
+                attention_contract=attention_contract_for(inner),
+            )
 
         assert captured["num_kv_heads"] == actual_kv_heads
+        assert captured["scale"] == pytest.approx(_HEAD_DIM**-0.5)
 
     def test_gpt_oss_scale_and_sinks_reach_kernel(self) -> None:
         """GPT-OSS exposes ``sm_scale`` and per-head attention sinks."""

--- a/vllm_metal/attention/attention_contracts.py
+++ b/vllm_metal/attention/attention_contracts.py
@@ -17,6 +17,7 @@ class AttentionContract:
     """Architecture-specific behavior consumed by the paged SDPA path."""
 
     qk_norm_placement: QKNormPlacement = QKNormPlacement.BEFORE_ROPE
+    derive_scale_from_query: bool = False
 
 
 DEFAULT_ATTENTION_CONTRACT = AttentionContract()
@@ -24,6 +25,7 @@ _ATTENTION_CONTRACTS: dict[str, AttentionContract] = {
     "mlx_lm.models.hunyuan_v1_dense": AttentionContract(
         qk_norm_placement=QKNormPlacement.AFTER_ROPE
     ),
+    "mlx_lm.models.stablelm": AttentionContract(derive_scale_from_query=True),
 }
 
 

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -30,6 +30,7 @@ All operations use MLX arrays end-to-end — no PyTorch MPS bridge.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 import mlx.core as mx
@@ -546,7 +547,7 @@ def sdpa_forward(
     # Softmax scale — GPT-OSS names it sm_scale rather than scale.
     attn_scale = getattr(inner, "scale", None)
     if attn_scale is None:
-        attn_scale = inner.sm_scale
+        attn_scale = getattr(inner, "sm_scale", None)
 
     # Attention logit softcapping (Gemma 2: ``attn_logit_softcapping``).
     # mlx_lm applies ``tanh(qk / cap) * cap`` to the pre-softmax scores; the
@@ -575,6 +576,15 @@ def sdpa_forward(
         position_embeddings=position_embeddings,
         attention_contract=attention_contract,
     )
+    if attn_scale is None:
+        if not attention_contract.derive_scale_from_query:
+            raise AttributeError(
+                f"{type(inner).__module__}.{type(inner).__name__} exposes "
+                "neither 'scale' nor 'sm_scale'"
+            )
+        # StableLM computes the standard scale inline and exposes no scale
+        # attribute. Use the projected query width before any cache padding.
+        attn_scale = math.sqrt(1 / queries.shape[-1])
 
     # --- Metal kernel dispatch ---
     n_heads = queries.shape[1]

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -361,7 +361,7 @@ def prepare_sdpa_qkv(
             values = keys
         else:
             keys, values = shared_kv
-        q_norm = _named_norm(inner, "q_norm", "query_layernorm")
+        q_norm = _named_norm(inner, "q_norm", "query_layernorm", "q_layernorm")
         if norm_placement is QKNormPlacement.BEFORE_ROPE:
             queries, keys = _apply_qk_norms(queries, keys, q_norm)
         queries = queries.transpose(0, 2, 1, 3)
@@ -387,8 +387,8 @@ def prepare_sdpa_qkv(
                 values = keys
 
         # Per-head RMSNorm (Qwen3, Qwen3.5, Gemma4, Phi3/Phi4 when present).
-        q_norm = _named_norm(inner, "q_norm", "query_layernorm")
-        k_norm = _named_norm(inner, "k_norm", "key_layernorm")
+        q_norm = _named_norm(inner, "q_norm", "query_layernorm", "q_layernorm")
+        k_norm = _named_norm(inner, "k_norm", "key_layernorm", "k_layernorm")
         if norm_placement is QKNormPlacement.BEFORE_ROPE:
             queries, keys = _apply_qk_norms(queries, keys, q_norm, k_norm)
         if hasattr(inner, "v_norm"):


### PR DESCRIPTION
## Summary

- The pinned MLX-LM StableLM attention class is routed through paged SDPA but computes its standard softmax scale inline and exposes neither `scale` nor `sm_scale`; current main therefore raises `AttributeError` on the first request.
- Register query-derived scale as an explicit StableLM attention contract, while preserving every architecture-provided `scale` or `sm_scale` and keeping unknown scale-less modules fail-loud.
- Exercise the production contract lookup and kernel boundary with the real pinned StableLM attention class, and document the tested checkpoint as experimental.

Addresses the confirmed live StableLM defect in #656.

## Scope

The tested checkpoint has `qk_layernorm=false`, and its MLX-LM RoPE object already encodes the 16-of-64 partial rotary width. This change intentionally does not alter Q/K normalization or RoPE behavior.

## Reproduction

On unchanged main at `4d7228a`, with the worktree explicitly first on `PYTHONPATH`, `mlx-community/stablelm-2-zephyr-1_6b-4bit` (`3fb50cde`) loaded and patched all 24 attention layers, then its first paged request failed at `inner.sm_scale` because the real attention module has no such attribute.

## Validation

Exact commit `4e43d0b` in a clean detached worktree on an Apple M4, 32 GB, macOS 15.6, with vLLM 0.28.0, MLX 0.32.0, the pinned MLX-LM revision `254d153` (package 0.31.3), and Transformers 5.12.1:

- Pinned/current MLX-LM source audit: StableLM is the only pinned structurally routed SDPA class without an explicit scale. Current MLX-LM also has new scale-less non-SDPA projection lookalikes; the default contract remains fail-loud rather than silently applying an SDPA scale to them.
- Real checkpoint through source-built native paged kernels: 24/24 layers patched; prefill and decode completed. The five established prompts matched the independently rerun MLX path for all 50 generated token IDs. An additional sixth probe matched 7/10 tokens before selecting a different continuation, so this PR claims the crash fix and scale contract rather than universal bit-identical decoding.
- `pytest -q -m "not slow" tests/test_attention_sdpa.py tests/test_hunyuan_qk_norm.py tests/test_attention_dispatch.py`: 39 passed, 1 deselected.
- `TORCHDYNAMO_DISABLE=1 pytest -q -m "not slow" tests/`: 1974 passed, 15 skipped, 52 deselected. Without that environment override, four sampling tests hit an Inductor linker failure caused by spaces in the reused venv path; the same four failures reproduce on unchanged main.
- `shellcheck`, `ruff check`, `ruff format --check`, and `mypy`: passed.
- Native extension and all four Metal libraries built from source; the release wheel artifact check passed with both extensions targeting macOS 15.0.

No performance claim is made.