### PR TITLE
[Bugfix] Load BF16 LoRA adapters natively in MLX

### DIFF
--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 from vllm.lora.layers import LoRAMapping
 from vllm.sampling_params import SamplingParams
 
@@ -255,8 +256,8 @@ def test_linear_wrapper_call_with_active_lora_changes_output() -> None:
 # PEFT loader (round-trip through a tmp safetensors file)
 
 
-def _write_peft_adapter(tmp_path: Path) -> Path:
-    from safetensors.numpy import save_file
+def _write_peft_adapter(tmp_path: Path, *, dtype: torch.dtype = torch.float32) -> Path:
+    from safetensors.torch import save_file
 
     config = {
         "peft_type": "LORA",
@@ -267,8 +268,8 @@ def _write_peft_adapter(tmp_path: Path) -> Path:
         "use_rslora": False,
     }
     (tmp_path / "adapter_config.json").write_text(json.dumps(config))
-    a = np.arange(6, dtype=np.float32).reshape(2, 3)
-    b = np.arange(8, dtype=np.float32).reshape(4, 2)
+    a = torch.arange(6, dtype=dtype).reshape(2, 3)
+    b = torch.arange(8, dtype=dtype).reshape(4, 2)
     save_file(
         {
             "base_model.model.layers.0.self_attn.q_proj.lora_A.weight": a,
@@ -279,12 +280,19 @@ def _write_peft_adapter(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_peft_loader_normalizes_module_name_and_keeps_orientation(
-    tmp_path: Path,
+@pytest.mark.parametrize(
+    "torch_dtype,mlx_dtype",
+    [
+        (torch.float32, mx.float32),
+        (torch.float16, mx.float16),
+        (torch.bfloat16, mx.bfloat16),
+    ],
+    ids=["float32", "float16", "bfloat16"],
+)
+def test_peft_loader_normalizes_module_name_and_preserves_weights(
+    tmp_path: Path, torch_dtype: torch.dtype, mlx_dtype: mx.Dtype
 ) -> None:
-    pytest.importorskip("safetensors.numpy")
-
-    adapter_dir = _write_peft_adapter(tmp_path)
+    adapter_dir = _write_peft_adapter(tmp_path, dtype=torch_dtype)
     loaded = peft_loader_mod.load_peft_adapter(adapter_dir, lora_id=1)
 
     assert loaded.lora_id == 1
@@ -292,9 +300,38 @@ def test_peft_loader_normalizes_module_name_and_keeps_orientation(
     assert "layers.0.self_attn.q_proj" in loaded.weights
 
     weights = loaded.weights["layers.0.self_attn.q_proj"]
-    assert weights.lora_a.shape == (2, 3)
-    assert weights.lora_b.shape == (4, 2)
+    assert weights.lora_a.dtype == mlx_dtype
+    assert weights.lora_b.dtype == mlx_dtype
+    np.testing.assert_array_equal(
+        np.array(weights.lora_a.astype(mx.float32)), np.arange(6).reshape(2, 3)
+    )
+    np.testing.assert_array_equal(
+        np.array(weights.lora_b.astype(mx.float32)), np.arange(8).reshape(4, 2)
+    )
     assert weights.scaling == pytest.approx(4.0)
+
+
+def test_peft_loader_materializes_weights_before_return(tmp_path: Path) -> None:
+    from safetensors.torch import save
+
+    adapter_dir = _write_peft_adapter(tmp_path)
+    loaded = peft_loader_mod.load_peft_adapter(adapter_dir, lora_id=1)
+    replacement = save(
+        {
+            "base_model.model.layers.0.self_attn.q_proj.lora_A.weight": torch.zeros(
+                2, 3
+            ),
+            "base_model.model.layers.0.self_attn.q_proj.lora_B.weight": torch.zeros(
+                4, 2
+            ),
+        }
+    )
+    # Overwrite the same file: save_file atomically replaces it on some versions.
+    (adapter_dir / "adapter_model.safetensors").write_bytes(replacement)
+
+    weights = loaded.weights["layers.0.self_attn.q_proj"]
+    np.testing.assert_array_equal(np.array(weights.lora_a), np.arange(6).reshape(2, 3))
+    np.testing.assert_array_equal(np.array(weights.lora_b), np.arange(8).reshape(4, 2))
 
 
 @pytest.mark.parametrize(

--- a/vllm_metal/v1/lora/peft_loader.py
+++ b/vllm_metal/v1/lora/peft_loader.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import mlx.core as mx
-from safetensors import safe_open
 from vllm.lora.peft_helper import PEFTHelper
 from vllm.lora.utils import parse_fine_tuned_lora_name
 
@@ -57,8 +56,10 @@ def load_peft_adapter(
     helper = PEFTHelper.from_local_dir(str(adapter_path), max_position_embeddings)
     if lora_config is not None:
         helper.validate_legal(lora_config)
-    with safe_open(str(safetensors_path), framework="np") as f:
-        raw = {k: mx.array(f.get_tensor(k)) for k in f.keys()}
+    raw = mx.load(str(safetensors_path))
+    # Preserve eager loading: later in-place adapter updates must not change
+    # tensors already returned to the adapter manager.
+    mx.eval(raw)
 
     pairs: dict[str, dict[str, mx.array]] = {}
     for name, tensor in raw.items():


### PR DESCRIPTION
## Summary

BF16 PEFT adapters fail before registration with `TypeError: data type 'bfloat16' not understood` because the loader reads their tensors through NumPy. Load Safetensors directly with MLX, and materialize the arrays before returning so later in-place file updates cannot change already-loaded weights.

Extend the existing loader round-trip to check FP32, FP16, and BF16 dtypes and values. Add one regression for the eager-loading contract. PEFT config validation, name normalization, scaling, and adapter-slot handling retain their existing behavior.

## Validation

Exact head `42e029a`, clean worktree, Apple M4 / macOS 15.6; MLX 0.32.0, pinned MLX-LM `254d153`, vLLM 0.28.0, Safetensors 0.8.0:

- Real reproducer: [`chradden/TinyLlama-1.1B-Chat-v1.0-bf16-lora-adapter`](https://huggingface.co/chradden/TinyLlama-1.1B-Chat-v1.0-bf16-lora-adapter/tree/5a1393cc5ec42919d9cf52c89d674e68532c1437), revision `5a1393c`. `load_peft_adapter(snapshot, lora_id=1, lora_config=LoRAConfig(max_lora_rank=8))` passes PEFT validation then crashes on unchanged main `327d7cb`. This head loads all 88 BF16 tensors across 44 modules; all 1,126,400 parameter bit patterns match the PyTorch Safetensors reader.
- The focused BF16 regression fails on main; FP32, FP16, and eager ownership pass. The ownership regression fails if `mx.eval(raw)` is removed.
- `python -m pytest -q -m 'not slow' tests/test_lora.py tests/test_qlora.py`: 86 passed.
- `python -m pytest -q -m 'not slow' tests/`: 1,977 passed, 15 skipped, 52 deselected.
- Repository Qwen3-0.6B and Qwen3.5-0.8B serving golden checks pass with `--num-gpu-blocks-override 256`.
- Ruff lint/format, mypy, ShellCheck, native extension and all four Metal libraries, and release-wheel artifact/deployment-target checks pass.

Additional local probes covered signed/fractional values, rank-one adapters, mixed BF16/FP16 matrices, plain and quantized projection parity, malformed/partial files, removal, and file-handle cleanup. The published-adapter check validates loading and exact weights, not full-model generation; serving goldens exercise the existing Qwen models.
