### PR TITLE
perf: GQA-shared flash-decode kernel inside the paged primitive (long-context decode 2-3x)

### DIFF
--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -618,8 +618,9 @@ class _PagedRoutingOpsSpy:
         _out: mx.array,
         window_seqlen_q: int = 1,
         sinks: mx.array | None = None,
+        **_kwargs,
     ) -> None:
-        del window_seqlen_q, sinks
+        del window_seqlen_q, sinks, _kwargs
         self.calls[-1].block_tables = block_tables.tolist()
         self.calls[-1].block_size = block_size
 

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -1,13 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """GQA-shared flash-decode pass inside ``paged_attention_primitive``.
 
-Eligible long single-sequence decode (no TQ/sinks/softcap/window, head size
-in {64,96,128,256}, GQA group <= 8, context >= ``GQA_DECODE_MIN_SEQ_LEN``)
-is dispatched to ``paged_attention_gqa_decode`` and merged by the existing
-``paged_attention_v2_reduce``.  Shorter contexts, multi-sequence batches,
-and spec-decode verify windows stay on the established per-token / split-KV
-family — a different kernel family would break
-``tests/test_spec_window_parity.py`` bitwise identity.
+Eligible pure-decode batches (no TQ/sinks/softcap/window, head size in
+{64,96,128,256}, GQA group <= 8, ``window_seqlen_q <= 1``, aggregate KV
+``num_seqs * max_seq_len >= GQA_DECODE_MIN_SEQ_LEN``) dispatch to
+``paged_attention_gqa_decode`` and merge through ``paged_attention_v2_reduce``.
+Spec-decode verify windows pass ``window_seqlen_q = K+1`` and stay on the
+established family so ``tests/test_spec_window_parity.py`` stays bitwise.
 
 These tests drive the shipped primitive (not a reimplementation) against
 ``ref_paged_attn``.
@@ -61,6 +60,7 @@ def _run_primitive(
     seed: int,
     window_seqlen_q: int = 1,
     query_lens: list[int] | None = None,
+    num_decode_requests: int = -1,
 ) -> tuple[mx.array, mx.array]:
     mx.random.seed(seed)
     num_seqs = len(kv_lens)
@@ -72,11 +72,13 @@ def _run_primitive(
     n_blocks_needed = (max_kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
     tables = []
     max_blk = 0
-    for _ in range(num_seqs):
+    # Offset each sequence's pages so multi-seq batches do not alias.
+    page_stride = n_blocks_needed * 3
+    for s in range(num_seqs):
         if interleaved:
-            table = _interleaved_table(n_blocks_needed)
+            table = [b + s * page_stride for b in _interleaved_table(n_blocks_needed)]
         else:
-            table = list(range(n_blocks_needed))
+            table = list(range(s * n_blocks_needed, (s + 1) * n_blocks_needed))
         tables.append(table)
         max_blk = max(max_blk, max(table))
     num_cache_blocks = max_blk + 4
@@ -114,6 +116,7 @@ def _run_primitive(
         -1,
         out,
         window_seqlen_q=window_seqlen_q,
+        num_decode_requests=num_decode_requests,
     )
     mx.eval(out)
     ref = ref_paged_attn(
@@ -160,10 +163,7 @@ def test_gqa_decode_matches_reference(
 
 
 def test_below_crossover_stays_on_split_kv() -> None:
-    """Contexts under GQA_DECODE_MIN_SEQ_LEN must not take the new pass.
-
-    They still match the reference via the established split-KV kernel.
-    """
+    """A single sequence under GQA_DECODE_MIN_SEQ_LEN stays on split-KV."""
     ops = get_ops()
     kv_len = ops.GQA_DECODE_MIN_SEQ_LEN - 1
     assert kv_len > ops.PARTITION_SIZE
@@ -172,21 +172,35 @@ def test_below_crossover_stays_on_split_kv() -> None:
     _assert_close(out, ref, mx.float16)
 
 
-def test_multi_seq_does_not_switch_kernel_family() -> None:
-    """Two long sequences stay on split-KV (GQA-decode is single-seq only).
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_multi_seq_gqa_decode_matches_reference(dtype: mx.Dtype) -> None:
+    """True multi-seq decode (window_seqlen_q=1) takes GQA-decode.
 
-    A multi-sequence decode batch is indistinguishable from an expanded
-    spec-decode verify window; switching family would break bitwise parity.
+    Aggregate KV ``num_seqs * max_seq_len`` meets the 16k budget with two
+    8k+ sequences, which a single 8k sequence would miss.
     """
     ops = get_ops()
-    kv_lens = [ops.GQA_DECODE_MIN_SEQ_LEN, ops.GQA_DECODE_MIN_SEQ_LEN + 64]
+    half = ops.GQA_DECODE_MIN_SEQ_LEN // 2
+    kv_lens = [half, half + 64]
+    assert len(kv_lens) * max(kv_lens) >= ops.GQA_DECODE_MIN_SEQ_LEN
     assert NUM_QUERY_HEADS * len(kv_lens) < ops.min_decode_grid()
-    out, ref = _run_primitive(kv_lens, mx.float16, interleaved=True, seed=2)
-    _assert_close(out, ref, mx.float16)
+    out, ref = _run_primitive(
+        kv_lens,
+        dtype,
+        interleaved=True,
+        seed=2,
+        num_decode_requests=len(kv_lens),
+    )
+    _assert_close(out, ref, dtype)
 
 
 def test_spec_window_does_not_switch_kernel_family() -> None:
-    """A K+1 verify window on a long context stays on the window/split path."""
+    """A K+1 verify window on a long context stays on the window/split path.
+
+    Production expanded verify windows pass window_seqlen_q=K+1 even when
+    packed as length-1 segments; this keeps them off GQA-decode so they
+    stay bitwise with the windowed dispatch.
+    """
     ops = get_ops()
     ctx = ops.GQA_DECODE_MIN_SEQ_LEN
     window = 4

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GQA-shared flash-decode pass inside ``paged_attention_primitive``.
+
+Eligible long single-sequence decode (no TQ/sinks/softcap/window, head size
+in {64,96,128,256}, GQA group <= 8, context >= ``GQA_DECODE_MIN_SEQ_LEN``)
+is dispatched to ``paged_attention_gqa_decode`` and merged by the existing
+``paged_attention_v2_reduce``.  Shorter contexts, multi-sequence batches,
+and spec-decode verify windows stay on the established per-token / split-KV
+family — a different kernel family would break
+``tests/test_spec_window_parity.py`` bitwise identity.
+
+These tests drive the shipped primitive (not a reimplementation) against
+``ref_paged_attn``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from tools.attention_bench_utils import ref_paged_attn
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+}
+
+
+def _interleaved_table(n_blocks: int) -> list[int]:
+    """Run-of-2, skip-1 pattern produced by hybrid GDN block interleave."""
+    table: list[int] = []
+    b = 3
+    while len(table) < n_blocks:
+        table += [b, b + 1]
+        b += 3
+    return table[:n_blocks]
+
+
+def _assert_close(out: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def _run_primitive(
+    kv_lens: list[int],
+    dtype: mx.Dtype,
+    *,
+    interleaved: bool,
+    seed: int,
+    window_seqlen_q: int = 1,
+    query_lens: list[int] | None = None,
+) -> tuple[mx.array, mx.array]:
+    mx.random.seed(seed)
+    num_seqs = len(kv_lens)
+    max_kv_len = max(kv_lens)
+    scale = HEAD_SIZE**-0.5
+    if query_lens is None:
+        query_lens = [1] * num_seqs
+    total_q = sum(query_lens)
+    n_blocks_needed = (max_kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    tables = []
+    max_blk = 0
+    for _ in range(num_seqs):
+        if interleaved:
+            table = _interleaved_table(n_blocks_needed)
+        else:
+            table = list(range(n_blocks_needed))
+        tables.append(table)
+        max_blk = max(max_blk, max(table))
+    num_cache_blocks = max_blk + 4
+    key_cache = mx.random.normal(
+        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    value_cache = mx.random.normal(
+        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    query = mx.random.normal((total_q, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    padded = max(len(t) for t in tables)
+    block_tables = mx.array(
+        [t + [0] * (padded - len(t)) for t in tables], dtype=mx.int32
+    )
+    kv_lens_arr = mx.array(kv_lens, dtype=mx.int32)
+    cu = [0]
+    for qlen in query_lens:
+        cu.append(cu[-1] + qlen)
+    cu_seqlens_q = mx.array(cu, dtype=mx.int32)
+    mx.eval(key_cache, value_cache, query, block_tables, kv_lens_arr, cu_seqlens_q)
+
+    out = mx.array(0)
+    get_ops().paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        NUM_KV_HEADS,
+        scale,
+        0.0,
+        block_tables,
+        kv_lens_arr,
+        cu_seqlens_q,
+        BLOCK_SIZE,
+        max_kv_len,
+        -1,
+        out,
+        window_seqlen_q=window_seqlen_q,
+    )
+    mx.eval(out)
+    ref = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=np.array(block_tables),
+        scale=scale,
+    )
+    mx.eval(ref)
+    return out, ref
+
+
+def test_gqa_decode_kernel_is_in_default_library() -> None:
+    ops = get_ops()
+    assert ops.has_gqa_decode_kernel(), (
+        "default shader library is missing paged_attention_gqa_decode; "
+        "rebuild with `python -m vllm_metal.metal.build`"
+    )
+    assert ops.GQA_DECODE_MIN_SEQ_LEN == 16384
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize(
+    "kv_len,interleaved",
+    [
+        (16384, True),  # crossover: first length that must take GQA-decode
+        (16384 + 17, True),  # partial last block
+        (20000, True),  # hybrid-style interleaved table
+        (16384, False),  # contiguous table still valid through the primitive
+    ],
+)
+def test_gqa_decode_matches_reference(
+    kv_len: int, interleaved: bool, dtype: mx.Dtype
+) -> None:
+    ops = get_ops()
+    assert ops.has_gqa_decode_kernel()
+    assert kv_len >= ops.GQA_DECODE_MIN_SEQ_LEN
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    out, ref = _run_primitive([kv_len], dtype, interleaved=interleaved, seed=0)
+    _assert_close(out, ref, dtype)
+
+
+def test_below_crossover_stays_on_split_kv() -> None:
+    """Contexts under GQA_DECODE_MIN_SEQ_LEN must not take the new pass.
+
+    They still match the reference via the established split-KV kernel.
+    """
+    ops = get_ops()
+    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN - 1
+    assert kv_len > ops.PARTITION_SIZE
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    out, ref = _run_primitive([kv_len], mx.float16, interleaved=True, seed=1)
+    _assert_close(out, ref, mx.float16)
+
+
+def test_multi_seq_does_not_switch_kernel_family() -> None:
+    """Two long sequences stay on split-KV (GQA-decode is single-seq only).
+
+    A multi-sequence decode batch is indistinguishable from an expanded
+    spec-decode verify window; switching family would break bitwise parity.
+    """
+    ops = get_ops()
+    kv_lens = [ops.GQA_DECODE_MIN_SEQ_LEN, ops.GQA_DECODE_MIN_SEQ_LEN + 64]
+    assert NUM_QUERY_HEADS * len(kv_lens) < ops.min_decode_grid()
+    out, ref = _run_primitive(kv_lens, mx.float16, interleaved=True, seed=2)
+    _assert_close(out, ref, mx.float16)
+
+
+def test_spec_window_does_not_switch_kernel_family() -> None:
+    """A K+1 verify window on a long context stays on the window/split path."""
+    ops = get_ops()
+    ctx = ops.GQA_DECODE_MIN_SEQ_LEN
+    window = 4
+    kv_len = ctx + window
+    out, ref = _run_primitive(
+        [kv_len],
+        mx.float16,
+        interleaved=True,
+        seed=3,
+        window_seqlen_q=window,
+        query_lens=[window],
+    )
+    _assert_close(out, ref, mx.float16)

--- a/tests/test_native_sdpa_decode.py
+++ b/tests/test_native_sdpa_decode.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness gates for the single-sequence decode fast path.
+
+``_native_sdpa_decode_fast_path`` routes decode attention either to MLX's
+native SDPA over zero-copy strided views (contiguous block runs) or to a
+block-table-driven flash-decode kernel (non-contiguous runs, e.g. hybrid
+GDN interleave). Both paths are compared against a float32 einsum reference
+here — the flash-decode launch config is in threads, not threadgroups, a
+mistake these tests catch immediately (it computes only tile 0 / kv head 0).
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from vllm_metal.attention.impls.sdpa import (
+    _GQA_TILE,
+    _native_sdpa_decode_fast_path,
+)
+
+
+def _ref_sdpa(q: mx.array, k: mx.array, v: mx.array, scale: float) -> mx.array:
+    """float32 reference: q (Hq, D), k/v (seq, Hkv, D) -> (Hq, D)."""
+    n_heads, dim = q.shape
+    n_kv_heads = k.shape[1]
+    group = n_heads // n_kv_heads
+    qf = q.astype(mx.float32).reshape(n_kv_heads, group, dim)
+    kf = k.astype(mx.float32).transpose(1, 0, 2)
+    vf = v.astype(mx.float32).transpose(1, 0, 2)
+    s = mx.einsum("kgd,ksd->kgs", qf, kf) * scale
+    return mx.einsum("kgs,ksd->kgd", mx.softmax(s, axis=-1), vf).reshape(n_heads, dim)
+
+
+def _make_ctx(seq: int):
+    return SimpleNamespace(context_lens=[seq], kernel_metadata_cache={})
+
+
+def _interleaved_table(n_blocks: int) -> list[int]:
+    """Run-of-2, skip-1 pattern produced by hybrid GDN block interleave."""
+    table: list[int] = []
+    b = 3
+    while len(table) < n_blocks:
+        table += [b, b + 1]
+        b += 3
+    return table[:n_blocks]
+
+
+def _run_fast_path(
+    n_kv_heads: int,
+    group: int,
+    dim: int,
+    block: int,
+    seq: int,
+    dtype,
+    contig: bool,
+    seed: int = 0,
+):
+    mx.random.seed(seed)
+    n_blocks = (seq + block - 1) // block
+    n_cache_blocks = n_blocks * 2 + 16
+    kc = mx.random.normal((n_cache_blocks, block, n_kv_heads, dim)).astype(dtype)
+    vc = mx.random.normal((n_cache_blocks, block, n_kv_heads, dim)).astype(dtype)
+    if contig:
+        table = list(range(7, 7 + n_blocks))
+    else:
+        table = _interleaved_table(n_blocks)
+    q = mx.random.normal((1, n_kv_heads * group, dim)).astype(dtype)
+    scale = 1.0 / math.sqrt(dim)
+    ctx = _make_ctx(seq)
+    out = _native_sdpa_decode_fast_path(
+        q,
+        kc,
+        vc,
+        ctx,
+        None,
+        [table],
+        block,
+        n_kv_heads,
+        scale,
+        0.0,
+        None,
+        None,
+        None,
+    )
+    assert out is not None, "fast path did not fire"
+    rows = [table[t // block] * block + t % block for t in range(seq)]
+    kg = kc.reshape(-1, n_kv_heads, dim)[mx.array(rows)]
+    vg = vc.reshape(-1, n_kv_heads, dim)[mx.array(rows)]
+    ref = _ref_sdpa(q[0], kg, vg, scale)
+    diff = mx.max(mx.abs(out.reshape(-1, dim).astype(mx.float32) - ref)).item()
+    return diff, ctx
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "n_kv_heads,group,dim,block,seq",
+    [
+        (8, 4, 128, 16, 1),  # single token
+        (8, 4, 128, 16, 4096),
+        (8, 4, 128, 16, 4097),  # seq % block != 0
+        (4, 8, 128, 32, 5000),
+        (1, 8, 64, 16, 3333),  # MQA, head_dim 64
+        (2, 2, 256, 8, 2000),  # head_dim 256
+        (8, 4, 96, 16, 1000),  # head_dim 96
+        (8, 4, 128, 16, _GQA_TILE - 1),
+        (8, 4, 128, 16, _GQA_TILE),  # exactly one tile
+        (8, 4, 128, 16, _GQA_TILE + 1),
+        (8, 1, 128, 16, 2000),  # no GQA grouping
+        (8, 4, 128, 544, 30000),  # hybrid align block size
+    ],
+)
+def test_kernel_path_matches_reference(n_kv_heads, group, dim, block, seq, dtype):
+    diff, _ = _run_fast_path(n_kv_heads, group, dim, block, seq, dtype, contig=False)
+    assert diff < 0.01, f"max abs diff {diff}"
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("seq", [1, 100, 4096, 30000])
+def test_contiguous_path_matches_reference(seq, dtype):
+    diff, _ = _run_fast_path(8, 4, 128, 16, seq, dtype, contig=True)
+    assert diff < 0.01, f"max abs diff {diff}"
+
+
+def test_plan_memoized_per_forward_step():
+    """Second layer on the same ctx must reuse the plan, not rescan."""
+    _, ctx = _run_fast_path(8, 4, 128, 16, 4096, mx.bfloat16, contig=False)
+    assert len(ctx.kernel_metadata_cache) == 1
+    # Repeat with a different table object under the same ctx: the memoized
+    # plan (not the new list) drives the dispatch.
+    mx.random.seed(1)
+    n_kv_heads, group, dim, block, seq = 8, 4, 128, 16, 4096
+    n_blocks = (seq + block - 1) // block
+    kc = mx.random.normal((n_blocks * 2 + 16, block, n_kv_heads, dim)).astype(
+        mx.bfloat16
+    )
+    q = mx.random.normal((1, n_kv_heads * group, dim)).astype(mx.bfloat16)
+    out = _native_sdpa_decode_fast_path(
+        q,
+        kc,
+        kc,
+        ctx,
+        None,
+        [list(range(5, 5 + n_blocks))],  # contiguous, but memoized plan wins
+        block,
+        n_kv_heads,
+        1.0 / math.sqrt(dim),
+        0.0,
+        None,
+        None,
+        None,
+    )
+    assert out is not None
+    assert len(ctx.kernel_metadata_cache) == 1
+
+
+def _gating_kwargs():
+    return {
+        "q_3d": mx.zeros((1, 32, 128), dtype=mx.bfloat16),
+        "k_cache": mx.zeros((64, 16, 8, 128), dtype=mx.bfloat16),
+        "v_cache": mx.zeros((64, 16, 8, 128), dtype=mx.bfloat16),
+        "ctx": _make_ctx(60),
+        "group_index": None,
+        "raw_block_tables": [[3, 4, 6, 7]],
+        "cache_block_size": 16,
+        "cache_kv_heads": 8,
+        "attn_scale": 0.088,
+        "attn_softcap": 0.0,
+        "layer_sliding_window": None,
+        "sinks": None,
+        "verify_window_q": None,
+    }
+
+
+def _fast_path_named(**kw):
+    return _native_sdpa_decode_fast_path(
+        kw["q_3d"],
+        kw["k_cache"],
+        kw["v_cache"],
+        kw["ctx"],
+        kw["group_index"],
+        kw["raw_block_tables"],
+        kw["cache_block_size"],
+        kw["cache_kv_heads"],
+        kw["attn_scale"],
+        kw["attn_softcap"],
+        kw["layer_sliding_window"],
+        kw["sinks"],
+        kw["verify_window_q"],
+    )
+
+
+def test_gating_fallbacks():
+    kw = _gating_kwargs()
+    assert _fast_path_named(**kw) is not None  # baseline fires
+
+    bad = dict(kw, attn_softcap=50.0)
+    assert _fast_path_named(**bad) is None, "softcap must fall back"
+
+    bad = dict(kw, sinks=mx.zeros((32,), dtype=mx.float32))
+    assert _fast_path_named(**bad) is None, "sinks must fall back"
+
+    bad = dict(kw, layer_sliding_window=1024)
+    assert _fast_path_named(**bad) is None, "sliding window must fall back"
+
+    bad = dict(kw, verify_window_q=4)
+    assert _fast_path_named(**bad) is None, "verify window must fall back"
+
+    bad = dict(kw, q_3d=mx.zeros((2, 32, 128), dtype=mx.bfloat16))
+    assert _fast_path_named(**bad) is None, "multi-token must fall back"
+
+    bad = dict(kw, ctx=SimpleNamespace(context_lens=[30, 30], kernel_metadata_cache={}))
+    assert _fast_path_named(**bad) is None, "multi-seq must fall back"
+
+    bad = dict(kw, q_3d=mx.zeros((1, 32, 128), dtype=mx.float32))
+    assert _fast_path_named(**bad) is None, "fp32 must fall back"
+
+    bad = dict(kw, q_3d=mx.zeros((1, 32, 80), dtype=mx.bfloat16))
+    assert _fast_path_named(**bad) is None, "unsupported head_dim must fall back"
+
+    bad = dict(kw, raw_block_tables=[[3, 4]], ctx=_make_ctx(60))  # needs 4 blocks
+    assert _fast_path_named(**bad) is None, "short table must fall back"
+
+
+def test_env_disable(monkeypatch):
+    monkeypatch.setenv("VLLM_METAL_NATIVE_SDPA_DECODE", "0")
+    assert _fast_path_named(**_gating_kwargs()) is None

--- a/tests/test_native_sdpa_decode.py
+++ b/tests/test_native_sdpa_decode.py
@@ -1,219 +1,78 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Correctness gates for the contiguous native-SDPA decode fast path.
+"""Native SDPA is a test-only numeric/performance ceiling.
 
-``_native_sdpa_decode_fast_path`` routes *contiguous* single-sequence decode
-to MLX native SDPA over zero-copy strided views. Non-contiguous runs return
-``None`` so ``sdpa_forward`` falls through to ``paged_attention_primitive``
-(GQA-shared flash-decode at long context, split-KV otherwise) — those
-shapes are covered by ``tests/test_gqa_paged_decode.py``.
+Production decode always goes through ``paged_attention_primitive`` (the
+GQA-shared flash-decode pass at long context).  These tests keep MLX native
+SDPA around as a reference: contiguous paged GQA output must match it, and
+the shipped attention module must not dispatch to it.
 """
 
 from __future__ import annotations
 
 import inspect
-import math
-from types import SimpleNamespace
 
 import mlx.core as mx
+import numpy as np
 import pytest
 
 import vllm_metal.attention.impls.sdpa as sdpa_mod
-from vllm_metal.attention.impls.sdpa import _native_sdpa_decode_fast_path
+from tools.attention_bench_utils import native_sdpa_contiguous_decode
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+}
 
 
-def _ref_sdpa(q: mx.array, k: mx.array, v: mx.array, scale: float) -> mx.array:
-    """float32 reference: q (Hq, D), k/v (seq, Hkv, D) -> (Hq, D)."""
-    n_heads, dim = q.shape
-    n_kv_heads = k.shape[1]
-    group = n_heads // n_kv_heads
-    qf = q.astype(mx.float32).reshape(n_kv_heads, group, dim)
-    kf = k.astype(mx.float32).transpose(1, 0, 2)
-    vf = v.astype(mx.float32).transpose(1, 0, 2)
-    s = mx.einsum("kgd,ksd->kgs", qf, kf) * scale
-    return mx.einsum("kgs,ksd->kgd", mx.softmax(s, axis=-1), vf).reshape(n_heads, dim)
-
-
-def _make_ctx(seq: int):
-    return SimpleNamespace(context_lens=[seq], kernel_metadata_cache={})
-
-
-def _run_fast_path(
-    n_kv_heads: int,
-    group: int,
-    dim: int,
-    block: int,
-    seq: int,
-    dtype,
-    contig: bool,
-    seed: int = 0,
-):
-    mx.random.seed(seed)
-    n_blocks = (seq + block - 1) // block
-    n_cache_blocks = n_blocks * 2 + 16
-    kc = mx.random.normal((n_cache_blocks, block, n_kv_heads, dim)).astype(dtype)
-    vc = mx.random.normal((n_cache_blocks, block, n_kv_heads, dim)).astype(dtype)
-    if contig:
-        table = list(range(7, 7 + n_blocks))
-    else:
-        table = (
-            [3, 4, 6, 7][:n_blocks]
-            if n_blocks <= 4
-            else ([3, 4] + list(range(6, 6 + n_blocks - 2)))
-        )
-    q = mx.random.normal((1, n_kv_heads * group, dim)).astype(dtype)
-    scale = 1.0 / math.sqrt(dim)
-    ctx = _make_ctx(seq)
-    out = _native_sdpa_decode_fast_path(
-        q,
-        kc,
-        vc,
-        ctx,
-        None,
-        [table],
-        block,
-        n_kv_heads,
-        scale,
-        0.0,
-        None,
-        None,
-        None,
-    )
-    return out, q, kc, vc, table, scale, ctx
-
-
-@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
-@pytest.mark.parametrize("seq", [1, 100, 4096, 4097, 16384])
-def test_contiguous_path_matches_reference(seq, dtype):
-    out, q, kc, vc, table, scale, _ = _run_fast_path(
-        8, 4, 128, 16, seq, dtype, contig=True
-    )
-    assert out is not None, "contiguous native-SDPA path did not fire"
-    block = 16
-    rows = [table[t // block] * block + t % block for t in range(seq)]
-    kg = kc.reshape(-1, 8, 128)[mx.array(rows)]
-    vg = vc.reshape(-1, 8, 128)[mx.array(rows)]
-    ref = _ref_sdpa(q[0], kg, vg, scale)
-    diff = mx.max(mx.abs(out.reshape(-1, 128).astype(mx.float32) - ref)).item()
-    assert diff < 0.01, f"max abs diff {diff}"
-
-
-def test_non_contiguous_defers_to_paged_kernel():
-    out, *_ = _run_fast_path(8, 4, 128, 16, 4096, mx.bfloat16, contig=False)
-    assert out is None
-
-
-def test_plan_memoized_per_forward_step():
-    """Second layer on the same ctx must reuse the plan, not rescan."""
-    _, _, _, _, _, _, ctx = _run_fast_path(
-        8, 4, 128, 16, 4096, mx.bfloat16, contig=True
-    )
-    assert len(ctx.kernel_metadata_cache) == 1
-    mx.random.seed(1)
-    n_kv_heads, group, dim, block, seq = 8, 4, 128, 16, 4096
-    n_blocks = (seq + block - 1) // block
-    kc = mx.random.normal((n_blocks * 2 + 16, block, n_kv_heads, dim)).astype(
-        mx.bfloat16
-    )
-    q = mx.random.normal((1, n_kv_heads * group, dim)).astype(mx.bfloat16)
-    out = _native_sdpa_decode_fast_path(
-        q,
-        kc,
-        kc,
-        ctx,
-        None,
-        [list(range(20, 20 + n_blocks))],  # different table; memoized plan wins
-        block,
-        n_kv_heads,
-        1.0 / math.sqrt(dim),
-        0.0,
-        None,
-        None,
-        None,
-    )
-    assert out is not None
-    assert len(ctx.kernel_metadata_cache) == 1
-
-
-def _gating_kwargs(*, contig: bool = False):
-    table = [3, 4, 5, 6] if contig else [3, 4, 6, 7]
-    return {
-        "q_3d": mx.zeros((1, 32, 128), dtype=mx.bfloat16),
-        "k_cache": mx.zeros((64, 16, 8, 128), dtype=mx.bfloat16),
-        "v_cache": mx.zeros((64, 16, 8, 128), dtype=mx.bfloat16),
-        "ctx": _make_ctx(60),
-        "group_index": None,
-        "raw_block_tables": [table],
-        "cache_block_size": 16,
-        "cache_kv_heads": 8,
-        "attn_scale": 0.088,
-        "attn_softcap": 0.0,
-        "layer_sliding_window": None,
-        "sinks": None,
-        "verify_window_q": None,
-    }
-
-
-def _fast_path_named(**kw):
-    return _native_sdpa_decode_fast_path(
-        kw["q_3d"],
-        kw["k_cache"],
-        kw["v_cache"],
-        kw["ctx"],
-        kw["group_index"],
-        kw["raw_block_tables"],
-        kw["cache_block_size"],
-        kw["cache_kv_heads"],
-        kw["attn_scale"],
-        kw["attn_softcap"],
-        kw["layer_sliding_window"],
-        kw["sinks"],
-        kw["verify_window_q"],
-    )
-
-
-def test_gating_fallbacks():
-    kw = _gating_kwargs(contig=True)
-    assert _fast_path_named(**kw) is not None  # contiguous fires native SDPA
-
-    assert _fast_path_named(**_gating_kwargs(contig=False)) is None
-
-    bad = dict(kw, attn_softcap=50.0)
-    assert _fast_path_named(**bad) is None, "softcap must fall back"
-
-    bad = dict(kw, sinks=mx.zeros((32,), dtype=mx.float32))
-    assert _fast_path_named(**bad) is None, "sinks must fall back"
-
-    bad = dict(kw, layer_sliding_window=1024)
-    assert _fast_path_named(**bad) is None, "sliding window must fall back"
-
-    bad = dict(kw, verify_window_q=4)
-    assert _fast_path_named(**bad) is None, "verify window must fall back"
-
-    bad = dict(kw, q_3d=mx.zeros((2, 32, 128), dtype=mx.bfloat16))
-    assert _fast_path_named(**bad) is None, "multi-token must fall back"
-
-    bad = dict(kw, ctx=SimpleNamespace(context_lens=[30, 30], kernel_metadata_cache={}))
-    assert _fast_path_named(**bad) is None, "multi-seq must fall back"
-
-    bad = dict(kw, q_3d=mx.zeros((1, 32, 128), dtype=mx.float32))
-    assert _fast_path_named(**bad) is None, "fp32 must fall back"
-
-    bad = dict(kw, q_3d=mx.zeros((1, 32, 80), dtype=mx.bfloat16))
-    assert _fast_path_named(**bad) is None, "unsupported head_dim must fall back"
-
-    bad = dict(kw, raw_block_tables=[[3, 4]], ctx=_make_ctx(60))  # needs 4 blocks
-    assert _fast_path_named(**bad) is None, "short table must fall back"
-
-
-def test_env_disable(monkeypatch):
-    monkeypatch.setenv("VLLM_METAL_NATIVE_SDPA_DECODE", "0")
-    assert _fast_path_named(**_gating_kwargs(contig=True)) is None
-
-
-def test_no_python_jit_gqa_kernels():
-    """Shipped decode must not construct mx.fast.metal_kernel GQA pass1/merge."""
+def test_production_decode_does_not_call_native_sdpa() -> None:
+    src = inspect.getsource(sdpa_mod.sdpa_forward)
+    assert "_native_sdpa_decode_fast_path" not in src
+    assert "scaled_dot_product_attention" not in src
+    assert not hasattr(sdpa_mod, "_native_sdpa_decode_fast_path")
     assert not hasattr(sdpa_mod, "_gqa_decode_kernels")
-    assert not hasattr(sdpa_mod, "_GQA_DECODE_PASS1_TEMPLATE")
-    src = inspect.getsource(sdpa_mod._native_sdpa_decode_fast_path)
-    assert "metal_kernel" not in src
-    assert "_gqa_decode_kernels" not in src
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_paged_gqa_matches_native_sdpa_reference(dtype: mx.Dtype) -> None:
+    """Contiguous long decode: shipped primitive vs MLX native SDPA."""
+    ops = get_ops()
+    seq = ops.GQA_DECODE_MIN_SEQ_LEN
+    assert ops.has_gqa_decode_kernel()
+    mx.random.seed(11)
+    n_blocks = seq // BLOCK_SIZE
+    first = 2
+    num_cache = first + n_blocks + 2
+    kc = mx.random.normal((num_cache, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)).astype(
+        dtype
+    )
+    vc = mx.random.normal((num_cache, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)).astype(
+        dtype
+    )
+    q = mx.random.normal((1, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    scale = HEAD_SIZE**-0.5
+    table = list(range(first, first + n_blocks))
+    bt = mx.array([table], dtype=mx.int32)
+    sl = mx.array([seq], dtype=mx.int32)
+    cu = mx.array([0, 1], dtype=mx.int32)
+    mx.eval(kc, vc, q, bt, sl, cu)
+
+    out = mx.array(0)
+    ops.paged_attention_primitive(
+        q, kc, vc, NUM_KV_HEADS, scale, 0.0, bt, sl, cu, BLOCK_SIZE, seq, -1, out
+    )
+    mx.eval(out)
+    ref = native_sdpa_contiguous_decode(q, kc, vc, first, seq, scale)
+    mx.eval(ref)
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )

--- a/tests/test_native_sdpa_decode.py
+++ b/tests/test_native_sdpa_decode.py
@@ -1,26 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Correctness gates for the single-sequence decode fast path.
+"""Correctness gates for the contiguous native-SDPA decode fast path.
 
-``_native_sdpa_decode_fast_path`` routes decode attention either to MLX's
-native SDPA over zero-copy strided views (contiguous block runs) or to a
-block-table-driven flash-decode kernel (non-contiguous runs, e.g. hybrid
-GDN interleave). Both paths are compared against a float32 einsum reference
-here — the flash-decode launch config is in threads, not threadgroups, a
-mistake these tests catch immediately (it computes only tile 0 / kv head 0).
+``_native_sdpa_decode_fast_path`` routes *contiguous* single-sequence decode
+to MLX native SDPA over zero-copy strided views. Non-contiguous runs return
+``None`` so ``sdpa_forward`` falls through to ``paged_attention_primitive``
+(GQA-shared flash-decode at long context, split-KV otherwise) — those
+shapes are covered by ``tests/test_gqa_paged_decode.py``.
 """
 
 from __future__ import annotations
 
+import inspect
 import math
 from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
 
-from vllm_metal.attention.impls.sdpa import (
-    _GQA_TILE,
-    _native_sdpa_decode_fast_path,
-)
+import vllm_metal.attention.impls.sdpa as sdpa_mod
+from vllm_metal.attention.impls.sdpa import _native_sdpa_decode_fast_path
 
 
 def _ref_sdpa(q: mx.array, k: mx.array, v: mx.array, scale: float) -> mx.array:
@@ -37,16 +35,6 @@ def _ref_sdpa(q: mx.array, k: mx.array, v: mx.array, scale: float) -> mx.array:
 
 def _make_ctx(seq: int):
     return SimpleNamespace(context_lens=[seq], kernel_metadata_cache={})
-
-
-def _interleaved_table(n_blocks: int) -> list[int]:
-    """Run-of-2, skip-1 pattern produced by hybrid GDN block interleave."""
-    table: list[int] = []
-    b = 3
-    while len(table) < n_blocks:
-        table += [b, b + 1]
-        b += 3
-    return table[:n_blocks]
 
 
 def _run_fast_path(
@@ -67,7 +55,11 @@ def _run_fast_path(
     if contig:
         table = list(range(7, 7 + n_blocks))
     else:
-        table = _interleaved_table(n_blocks)
+        table = (
+            [3, 4, 6, 7][:n_blocks]
+            if n_blocks <= 4
+            else ([3, 4] + list(range(6, 6 + n_blocks - 2)))
+        )
     q = mx.random.normal((1, n_kv_heads * group, dim)).astype(dtype)
     scale = 1.0 / math.sqrt(dim)
     ctx = _make_ctx(seq)
@@ -86,51 +78,36 @@ def _run_fast_path(
         None,
         None,
     )
-    assert out is not None, "fast path did not fire"
-    rows = [table[t // block] * block + t % block for t in range(seq)]
-    kg = kc.reshape(-1, n_kv_heads, dim)[mx.array(rows)]
-    vg = vc.reshape(-1, n_kv_heads, dim)[mx.array(rows)]
-    ref = _ref_sdpa(q[0], kg, vg, scale)
-    diff = mx.max(mx.abs(out.reshape(-1, dim).astype(mx.float32) - ref)).item()
-    return diff, ctx
+    return out, q, kc, vc, table, scale, ctx
 
 
 @pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
-@pytest.mark.parametrize(
-    "n_kv_heads,group,dim,block,seq",
-    [
-        (8, 4, 128, 16, 1),  # single token
-        (8, 4, 128, 16, 4096),
-        (8, 4, 128, 16, 4097),  # seq % block != 0
-        (4, 8, 128, 32, 5000),
-        (1, 8, 64, 16, 3333),  # MQA, head_dim 64
-        (2, 2, 256, 8, 2000),  # head_dim 256
-        (8, 4, 96, 16, 1000),  # head_dim 96
-        (8, 4, 128, 16, _GQA_TILE - 1),
-        (8, 4, 128, 16, _GQA_TILE),  # exactly one tile
-        (8, 4, 128, 16, _GQA_TILE + 1),
-        (8, 1, 128, 16, 2000),  # no GQA grouping
-        (8, 4, 128, 544, 30000),  # hybrid align block size
-    ],
-)
-def test_kernel_path_matches_reference(n_kv_heads, group, dim, block, seq, dtype):
-    diff, _ = _run_fast_path(n_kv_heads, group, dim, block, seq, dtype, contig=False)
-    assert diff < 0.01, f"max abs diff {diff}"
-
-
-@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
-@pytest.mark.parametrize("seq", [1, 100, 4096, 30000])
+@pytest.mark.parametrize("seq", [1, 100, 4096, 4097, 16384])
 def test_contiguous_path_matches_reference(seq, dtype):
-    diff, _ = _run_fast_path(8, 4, 128, 16, seq, dtype, contig=True)
+    out, q, kc, vc, table, scale, _ = _run_fast_path(
+        8, 4, 128, 16, seq, dtype, contig=True
+    )
+    assert out is not None, "contiguous native-SDPA path did not fire"
+    block = 16
+    rows = [table[t // block] * block + t % block for t in range(seq)]
+    kg = kc.reshape(-1, 8, 128)[mx.array(rows)]
+    vg = vc.reshape(-1, 8, 128)[mx.array(rows)]
+    ref = _ref_sdpa(q[0], kg, vg, scale)
+    diff = mx.max(mx.abs(out.reshape(-1, 128).astype(mx.float32) - ref)).item()
     assert diff < 0.01, f"max abs diff {diff}"
+
+
+def test_non_contiguous_defers_to_paged_kernel():
+    out, *_ = _run_fast_path(8, 4, 128, 16, 4096, mx.bfloat16, contig=False)
+    assert out is None
 
 
 def test_plan_memoized_per_forward_step():
     """Second layer on the same ctx must reuse the plan, not rescan."""
-    _, ctx = _run_fast_path(8, 4, 128, 16, 4096, mx.bfloat16, contig=False)
+    _, _, _, _, _, _, ctx = _run_fast_path(
+        8, 4, 128, 16, 4096, mx.bfloat16, contig=True
+    )
     assert len(ctx.kernel_metadata_cache) == 1
-    # Repeat with a different table object under the same ctx: the memoized
-    # plan (not the new list) drives the dispatch.
     mx.random.seed(1)
     n_kv_heads, group, dim, block, seq = 8, 4, 128, 16, 4096
     n_blocks = (seq + block - 1) // block
@@ -144,7 +121,7 @@ def test_plan_memoized_per_forward_step():
         kc,
         ctx,
         None,
-        [list(range(5, 5 + n_blocks))],  # contiguous, but memoized plan wins
+        [list(range(20, 20 + n_blocks))],  # different table; memoized plan wins
         block,
         n_kv_heads,
         1.0 / math.sqrt(dim),
@@ -157,14 +134,15 @@ def test_plan_memoized_per_forward_step():
     assert len(ctx.kernel_metadata_cache) == 1
 
 
-def _gating_kwargs():
+def _gating_kwargs(*, contig: bool = False):
+    table = [3, 4, 5, 6] if contig else [3, 4, 6, 7]
     return {
         "q_3d": mx.zeros((1, 32, 128), dtype=mx.bfloat16),
         "k_cache": mx.zeros((64, 16, 8, 128), dtype=mx.bfloat16),
         "v_cache": mx.zeros((64, 16, 8, 128), dtype=mx.bfloat16),
         "ctx": _make_ctx(60),
         "group_index": None,
-        "raw_block_tables": [[3, 4, 6, 7]],
+        "raw_block_tables": [table],
         "cache_block_size": 16,
         "cache_kv_heads": 8,
         "attn_scale": 0.088,
@@ -194,8 +172,10 @@ def _fast_path_named(**kw):
 
 
 def test_gating_fallbacks():
-    kw = _gating_kwargs()
-    assert _fast_path_named(**kw) is not None  # baseline fires
+    kw = _gating_kwargs(contig=True)
+    assert _fast_path_named(**kw) is not None  # contiguous fires native SDPA
+
+    assert _fast_path_named(**_gating_kwargs(contig=False)) is None
 
     bad = dict(kw, attn_softcap=50.0)
     assert _fast_path_named(**bad) is None, "softcap must fall back"
@@ -227,4 +207,13 @@ def test_gating_fallbacks():
 
 def test_env_disable(monkeypatch):
     monkeypatch.setenv("VLLM_METAL_NATIVE_SDPA_DECODE", "0")
-    assert _fast_path_named(**_gating_kwargs()) is None
+    assert _fast_path_named(**_gating_kwargs(contig=True)) is None
+
+
+def test_no_python_jit_gqa_kernels():
+    """Shipped decode must not construct mx.fast.metal_kernel GQA pass1/merge."""
+    assert not hasattr(sdpa_mod, "_gqa_decode_kernels")
+    assert not hasattr(sdpa_mod, "_GQA_DECODE_PASS1_TEMPLATE")
+    src = inspect.getsource(sdpa_mod._native_sdpa_decode_fast_path)
+    assert "metal_kernel" not in src
+    assert "_gqa_decode_kernels" not in src

--- a/tools/attention_bench_utils.py
+++ b/tools/attention_bench_utils.py
@@ -7,6 +7,36 @@ import mlx.core as mx
 import numpy as np
 
 
+def native_sdpa_contiguous_decode(
+    query: mx.array,
+    key_cache: mx.array,
+    value_cache: mx.array,
+    first_block: int,
+    seq: int,
+    scale: float,
+) -> mx.array:
+    """Test-only reference: MLX native SDPA over a contiguous paged run.
+
+    ``query`` is ``(1, n_heads, head_dim)``.  The sequence occupies
+    ``key_cache`` rows ``[first_block * block_size, first_block * block_size + seq)``.
+    Production decode does **not** call this; it is the performance/numeric
+    ceiling used to check the paged GQA-decode kernel.
+    """
+    n_heads = int(query.shape[1])
+    dim = int(query.shape[2])
+    n_kv_heads = int(key_cache.shape[2])
+    block = int(key_cache.shape[1])
+    group = n_heads // n_kv_heads
+    flat_k = key_cache.reshape(-1, n_kv_heads, dim)
+    flat_v = value_cache.reshape(-1, n_kv_heads, dim)
+    row0 = first_block * block
+    k_view = flat_k[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+    v_view = flat_v[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+    q_sdpa = query.reshape(n_kv_heads, group, 1, dim)
+    out = mx.fast.scaled_dot_product_attention(q_sdpa, k_view, v_view, scale=scale)
+    return out.reshape(1, n_heads, dim)
+
+
 def ref_paged_attn(
     query: mx.array,
     key_cache: mx.array,

--- a/tools/e2e_qwen38.py
+++ b/tools/e2e_qwen38.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3.8-27B-4bit e2e decode A/B: paged GQA vs old per-token/split-KV.
+
+Same process, same weights. ``num_decode_requests=0`` misses the GQA gate
+and is the old kernel; the production path is GQA when the 16k occupancy
+gate fires. Prefill is unchanged by this PR; we still record TTFT.
+
+Usage (from repo root, venv active):
+
+    VLLM_ENABLE_V1_MULTIPROCESSING=0 VLLM_METAL_COMPILED_MLP=1 \\
+      VLLM_METAL_NATIVE_SAMPLING=1 python tools/e2e_qwen38.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from dataclasses import asdict, dataclass
+
+import mlx.core as mx
+
+MODEL = os.environ.get(
+    "GQA_E2E_MODEL",
+    "/Users/suntp/.cache/modelscope/models/mlx-community--Qwen3.8-27B-4bit/snapshots/master",
+)
+OUT_DIR = os.getcwd()  # logs/results land where you invoke it
+TAG = os.environ.get("GQA_E2E_TAG", "e2e")
+LOG = (
+    os.path.join(OUT_DIR, f"e2e-qwen38-{TAG}.log")
+    if TAG != "e2e"
+    else os.path.join(OUT_DIR, "e2e-qwen38.log")
+)
+JSON_OUT = (
+    os.path.join(OUT_DIR, f"e2e-qwen38-{TAG}.json")
+    if TAG != "e2e"
+    else os.path.join(OUT_DIR, "e2e-qwen38.json")
+)
+FAST_MIN_TFLOPS = float(os.environ.get("GQA_E2E_MIN_TFLOPS", "100"))
+FAST_WAIT_S = int(os.environ.get("GQA_E2E_FAST_WAIT_S", "1200"))
+REQUIRE_FAST = os.environ.get("GQA_E2E_REQUIRE_FAST", "0") == "1"
+
+GEN_TOKENS = 32
+MAX_MODEL_LEN = 110_000
+MAX_NUM_SEQS = 4
+
+# (ctx, concurrency). Gate fires when conc * ctx >= 16384 (pure decode).
+CASES: list[tuple[int, int]] = [
+    (4096, 1),
+    (8192, 1),
+    (16384, 1),
+    (32768, 1),
+    (65536, 1),
+    (102400, 1),
+    (8192, 2),
+    (16384, 2),
+    (32768, 2),
+    (4096, 4),
+    (8192, 4),
+    (16384, 4),
+]
+
+
+def log(msg: str) -> None:
+    line = msg if msg.endswith("\n") else msg + "\n"
+    sys.stdout.write(line)
+    sys.stdout.flush()
+    with open(LOG, "a", encoding="utf-8") as f:
+        f.write(line)
+
+
+def probe_tflops() -> float:
+    a = mx.random.normal((2048, 2048)).astype(mx.bfloat16)
+    b = mx.random.normal((2048, 2048)).astype(mx.bfloat16)
+    for _ in range(5):
+        mx.eval(a @ b)
+    ts = []
+    for _ in range(8):
+        t0 = time.perf_counter()
+        mx.eval(a @ b)
+        ts.append(time.perf_counter() - t0)
+    best = min(ts)
+    return (2 * (2048**3)) / best / 1e12
+
+
+def wait_for_fast(min_tflops: float, timeout_s: int) -> float:
+    """Idle between probes so the GPU can thermally recover.
+
+    Sustained GEMM keeps clocks down; a short burst every 20s is enough
+    to notice when the chip comes back.
+    """
+    deadline = time.time() + timeout_s
+    best = 0.0
+    while True:
+        tps = probe_tflops()
+        best = max(best, tps)
+        state = "fast" if tps >= min_tflops else "slow"
+        log(f"probe_tflops={tps:.1f} best={best:.1f} state={state}")
+        if tps >= min_tflops:
+            return tps
+        if time.time() >= deadline:
+            return tps
+        time.sleep(20.0)
+
+
+def install_gqa_switch() -> callable:
+    """Return a setter(disable: bool). Old path = num_decode_requests=0."""
+    import vllm_metal.attention.impls.sdpa as sdpa_mod
+
+    state = {"disable": False}
+    real_get_ops = sdpa_mod.get_ops
+
+    class _Ops:
+        def __init__(self, inner):
+            object.__setattr__(self, "_inner", inner)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def paged_attention_primitive(self, *args, **kwargs):
+            if state["disable"]:
+                kwargs["num_decode_requests"] = 0
+            return self._inner.paged_attention_primitive(*args, **kwargs)
+
+    cache: dict = {}
+
+    def _get_ops():
+        inner = real_get_ops()
+        proxy = cache.get(id(inner))
+        if proxy is None:
+            proxy = _Ops(inner)
+            cache[id(inner)] = proxy
+        return proxy
+
+    sdpa_mod.get_ops = _get_ops  # type: ignore[method-assign]
+    return lambda disable: state.update(disable=disable)
+
+
+@dataclass
+class Row:
+    ctx: int
+    conc: int
+    mode: str
+    gate_expect: str
+    prompt_tokens: int
+    gen_tokens: int
+    ttft_s: float
+    decode_s: float
+    decode_tok_s: float
+    e2e_s: float
+    prefill_tok_s: float
+
+
+def _metrics_times(req) -> tuple[float, float, float]:
+    """Return (ttft, decode_s, e2e_s) from vLLM request metrics + wall fallback."""
+    m = getattr(req, "metrics", None)
+    if m is None:
+        return float("nan"), float("nan"), float("nan")
+    arrival = getattr(m, "arrival_time", None)
+    first = getattr(m, "first_token_time", None)
+    last = getattr(m, "finished_time", None) or getattr(m, "last_token_time", None)
+    if not arrival or not first or not last:
+        return float("nan"), float("nan"), float("nan")
+    return first - arrival, last - first, last - arrival
+
+
+def _make_prompts(tokenizer, ctx: int, conc: int):
+    """Exact-length token prompts (no decode/encode round-trip shrink)."""
+    from vllm.inputs import TokensPrompt
+
+    filler = tokenizer.encode(
+        "The history of mathematics is a long story of counting, measuring, and reasoning. ",
+        add_special_tokens=False,
+    )
+    if not filler:
+        raise RuntimeError("tokenizer produced empty filler")
+    prompts = []
+    for i in range(conc):
+        salt = tokenizer.encode(f" #{i}", add_special_tokens=False) or [filler[0]]
+        n_body = max(1, ctx - len(salt))
+        body: list[int] = []
+        while len(body) < n_body:
+            body.extend(filler)
+        ids = body[:n_body] + salt
+        ids = ids[:ctx]
+        if len(ids) < ctx:
+            ids.extend([filler[0]] * (ctx - len(ids)))
+        prompts.append(TokensPrompt(prompt_token_ids=ids))
+    return prompts
+
+
+def _generate(llm, prompts, max_tokens: int):
+    from vllm import SamplingParams
+
+    sp = SamplingParams(temperature=0.0, max_tokens=max_tokens, ignore_eos=True)
+    t0 = time.perf_counter()
+    outs = llm.generate(prompts, sp, use_tqdm=False)
+    wall = time.perf_counter() - t0
+    n_gen = [len(o.outputs[0].token_ids) for o in outs]
+    n_prompt = [len(o.prompt_token_ids or []) for o in outs]
+    ttfts, decs = [], []
+    for o in outs:
+        ttft, dec, _ = _metrics_times(o)
+        ttfts.append(ttft)
+        decs.append(dec)
+    ttft = max(ttfts) if ttfts and ttfts[0] == ttfts[0] else float("nan")
+    decode_s = max(decs) if decs and decs[0] == decs[0] else float("nan")
+    return outs, wall, n_prompt, n_gen, ttft, decode_s
+
+
+def run_pair(llm, tokenizer, setter, ctx: int, conc: int) -> list[Row]:
+    """Prefill once (fills prefix cache), then decode-only old vs GQA.
+
+    Prefix caching is content-keyed on the prompt, so the two decode legs
+    both skip prefill and are comparable. The first generate of 1 token is
+    the prefill measurement.
+    """
+    prompts = _make_prompts(tokenizer, ctx, conc)
+    agg = ctx * conc
+    gate = "ON" if agg >= 16384 else "off"
+
+    setter(False)
+    _, prefill_wall, n_prompt, _, ttft_prefill, _ = _generate(llm, prompts, 1)
+    prompt_tokens = sum(n_prompt) if n_prompt and n_prompt[0] else ctx * conc
+    prefill_s = ttft_prefill if ttft_prefill == ttft_prefill else prefill_wall
+    prefill_tok_s = prompt_tokens / prefill_s if prefill_s > 0 else float("nan")
+    log(
+        f"{ctx:7d} {conc:4d} prefill {gate:>4} "
+        f"{prefill_s:8.3f}s  {prefill_tok_s:8.1f} tok/s  (prompt_tokens={prompt_tokens})"
+    )
+
+    rows = []
+    for mode in ("old", "gqa"):
+        setter(mode == "old")
+        _, wall, _, n_gen, ttft, decode_s = _generate(llm, prompts, GEN_TOKENS)
+        total_gen = sum(n_gen)
+        # Prefer engine decode span; if metrics are missing, the prefix-cache
+        # hit makes the whole wall ≈ decode, which is what we want.
+        if decode_s != decode_s or decode_s <= 0:
+            decode_s = wall
+        decode_tok_s = total_gen / decode_s if decode_s > 0 else float("nan")
+        row = Row(
+            ctx=ctx,
+            conc=conc,
+            mode=mode,
+            gate_expect=gate,
+            prompt_tokens=prompt_tokens,
+            gen_tokens=total_gen,
+            ttft_s=ttft if ttft == ttft else prefill_s,
+            decode_s=decode_s,
+            decode_tok_s=decode_tok_s,
+            e2e_s=wall,
+            prefill_tok_s=prefill_tok_s,
+        )
+        rows.append(row)
+        log(
+            f"{row.ctx:7d} {row.conc:4d} {row.mode:<4} {row.gate_expect:>4} "
+            f"{row.ttft_s:8.3f} {row.decode_s:8.3f} {row.decode_tok_s:9.2f} "
+            f"{row.prefill_tok_s:13.1f} {row.e2e_s:8.2f}"
+        )
+    return rows
+
+
+def main() -> int:
+    os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    os.environ.setdefault("VLLM_METAL_COMPILED_MLP", "1")
+    os.environ.setdefault("VLLM_METAL_NATIVE_SAMPLING", "1")
+
+    if os.path.exists(LOG):
+        os.remove(LOG)
+
+    from vllm_metal.metal import get_ops
+
+    ops = get_ops()
+    log(f"model={MODEL}")
+    log(f"tag={TAG} log={LOG}")
+    log(f"has_gqa={ops.has_gqa_decode_kernel()} min_seq={ops.GQA_DECODE_MIN_SEQ_LEN}")
+    log(
+        f"compiled_mlp={os.environ.get('VLLM_METAL_COMPILED_MLP')} native_sampling={os.environ.get('VLLM_METAL_NATIVE_SAMPLING')}"
+    )
+    log(
+        f"gen_tokens={GEN_TOKENS} max_model_len={MAX_MODEL_LEN} max_num_seqs={MAX_NUM_SEQS}"
+    )
+    log(
+        f"require_fast={REQUIRE_FAST} min_tflops={FAST_MIN_TFLOPS} wait_s={FAST_WAIT_S}"
+    )
+    tflops = (
+        wait_for_fast(FAST_MIN_TFLOPS, FAST_WAIT_S) if REQUIRE_FAST else probe_tflops()
+    )
+    log(
+        f"probe_tflops={tflops:.1f} state={'fast' if tflops >= FAST_MIN_TFLOPS else 'slow'}"
+    )
+    if REQUIRE_FAST and tflops < FAST_MIN_TFLOPS:
+        log(
+            f"FAST_UNREACHABLE after {FAST_WAIT_S}s (best {tflops:.1f} < {FAST_MIN_TFLOPS})"
+        )
+        log("DONE")
+        return 2
+
+    setter = install_gqa_switch()
+
+    from transformers import AutoTokenizer
+    from vllm import LLM
+
+    log("loading LLM…")
+    t_load = time.perf_counter()
+    llm = LLM(
+        model=MODEL,
+        max_model_len=MAX_MODEL_LEN,
+        max_num_seqs=MAX_NUM_SEQS,
+        trust_remote_code=True,
+        disable_log_stats=False,
+        enable_prefix_caching=True,
+    )
+    log(f"loaded in {time.perf_counter() - t_load:.1f}s")
+    tflops_loaded = probe_tflops()
+    log(
+        f"probe_tflops_loaded={tflops_loaded:.1f} state={'fast' if tflops_loaded >= FAST_MIN_TFLOPS else 'slow'}"
+    )
+    tokenizer = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)
+
+    rows: list[Row] = []
+    log(
+        f"{'ctx':>7} {'conc':>4} {'mode':<4} {'gate':>4} "
+        f"{'ttft_s':>8} {'dec_s':>8} {'dec_tok/s':>9} {'prefill_tok/s':>13} {'e2e_s':>8}"
+    )
+    for ctx, conc in CASES:
+        try:
+            rows.extend(run_pair(llm, tokenizer, setter, ctx, conc))
+        except Exception as exc:  # noqa: BLE001
+            log(f"{ctx:7d} {conc:4d} FAIL {type(exc).__name__}: {exc}")
+
+    # Speedup table
+    log("\n=== decode tok/s speedup (gqa / old) ===")
+    by = {(r.ctx, r.conc, r.mode): r for r in rows}
+    for ctx, conc in CASES:
+        old = by.get((ctx, conc, "old"))
+        gqa = by.get((ctx, conc, "gqa"))
+        if not old or not gqa:
+            continue
+        sp = gqa.decode_tok_s / old.decode_tok_s if old.decode_tok_s else float("nan")
+        log(
+            f"ctx={ctx:<6} conc={conc}  old={old.decode_tok_s:7.2f} tok/s  "
+            f"gqa={gqa.decode_tok_s:7.2f} tok/s  speedup={sp:5.2f}x  gate={gqa.gate_expect}"
+        )
+
+    tflops_end = probe_tflops()
+    log(f"probe_tflops_end={tflops_end:.1f}")
+    payload = {
+        "tflops": tflops,
+        "tflops_loaded": tflops_loaded,
+        "tflops_end": tflops_end,
+        "model": MODEL,
+        "tag": TAG,
+        "rows": [asdict(r) for r in rows],
+    }
+    with open(JSON_OUT, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    log(f"wrote {JSON_OUT}")
+    log("DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -91,13 +91,12 @@ class PagedAttentionContext:
     # legacy single-group path.
     kv_groups: tuple[PagedKVGroupContext, ...] | None = None
     # Kernel-format metadata memo, keyed by (KV group index, cache block
-    # size).  The context lives for exactly one forward pass, so entries
-    # never go stale; every layer of a group reuses the first layer's
-    # conversion instead of re-serializing the Python lists above (see
-    # ``impls.sdpa._kernel_metadata``).
-    kernel_metadata_cache: dict[tuple[int | None, int], Any] = field(
-        default_factory=dict
-    )
+    # size) — or ("native_decode", group, block size) for the decode
+    # fast-path dispatch plan.  The context lives for exactly one forward
+    # pass, so entries never go stale; every layer of a group reuses the
+    # first layer's conversion instead of re-serializing the Python lists
+    # above (see ``impls.sdpa._kernel_metadata``).
+    kernel_metadata_cache: dict[tuple, Any] = field(default_factory=dict)
 
 
 def set_context(ctx: PagedAttentionContext) -> None:

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -91,11 +91,10 @@ class PagedAttentionContext:
     # legacy single-group path.
     kv_groups: tuple[PagedKVGroupContext, ...] | None = None
     # Kernel-format metadata memo, keyed by (KV group index, cache block
-    # size) — or ("native_decode", group, block size) for the decode
-    # fast-path dispatch plan.  The context lives for exactly one forward
-    # pass, so entries never go stale; every layer of a group reuses the
-    # first layer's conversion instead of re-serializing the Python lists
-    # above (see ``impls.sdpa._kernel_metadata``).
+    # size).  The context lives for exactly one forward pass, so entries
+    # never go stale; every layer of a group reuses the first layer's
+    # conversion instead of re-serializing the Python lists above (see
+    # ``impls.sdpa._kernel_metadata``).
     kernel_metadata_cache: dict[tuple, Any] = field(default_factory=dict)
 
 

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -780,23 +780,43 @@ def sdpa_forward(
             window_seqlen_q=ctx.verify_window_q,
         )
     else:
-        ops.paged_attention_primitive(
-            q_3d,
-            kernel_k_cache,
-            kernel_v_cache,
-            cache_kv_heads,
-            attn_scale,
-            attn_softcap,
-            block_tables,
-            seq_lens,
-            cu_seqlens_q,
-            kernel_block_size,
-            max_seq_len,
-            layer_sliding_window,
-            out,
-            window_seqlen_q=ctx.verify_window_q,
-            sinks=sinks,
-        )
+        try:
+            fast_out = _native_sdpa_decode_fast_path(
+                q_3d,
+                kernel_k_cache,
+                kernel_v_cache,
+                raw_block_tables,
+                ctx.context_lens,
+                cache_block_size,
+                cache_kv_heads,
+                attn_scale,
+                attn_softcap,
+                layer_sliding_window,
+                sinks,
+                getattr(ctx, "verify_window_q", None),
+            )
+        except Exception:  # noqa: BLE001 - fall back to the paged kernel
+            fast_out = None
+        if fast_out is not None:
+            out = fast_out
+        else:
+            ops.paged_attention_primitive(
+                q_3d,
+                kernel_k_cache,
+                kernel_v_cache,
+                cache_kv_heads,
+                attn_scale,
+                attn_softcap,
+                block_tables,
+                seq_lens,
+                cu_seqlens_q,
+                kernel_block_size,
+                max_seq_len,
+                layer_sliding_window,
+                out,
+                window_seqlen_q=ctx.verify_window_q,
+                sinks=sinks,
+            )
 
     # Reshape + strip padding back to actual head_dim before o_proj.
     out = truncate_padded_output(out, B, L, n_heads, cache_head_dim, actual_head_dim)
@@ -804,6 +824,275 @@ def sdpa_forward(
         out = out * mx.sigmoid(gate)
     out = apply_g_proj_gate(inner, out, x, n_heads, actual_head_dim)
     return inner.o_proj(out), kv_for_sharing
+
+
+# ---------------------------------------------------------------------------
+# Custom GQA decode kernel (flash-decode style) for non-contiguous block runs
+# ---------------------------------------------------------------------------
+
+_GQA_DECODE_HEADER = "#include <metal_simdgroup>\nusing namespace metal;\n"
+
+_GQA_DECODE_PASS1_TEMPLATE = """
+    uint lane = thread_index_in_simdgroup;
+    uint group = simdgroup_index_in_threadgroup;
+
+    int tile = int(threadgroup_position_in_grid.x);
+    int kv = int(threadgroup_position_in_grid.y);
+    int t0 = tile * TILE;
+    if (t0 >= seq) { return; }
+    int t_end = min(t0 + TILE, seq);
+
+    const device bfloat16_t* qg = q + ((kv * GROUP + group) * D);
+
+    float qv[SLICE];
+    for (int i = 0; i < SLICE; i++) qv[i] = float(qg[lane * SLICE + i]);
+
+    float m = -1e30f;
+    float l = 0.0f;
+    float acc[SLICE] = {0.0f};
+
+    for (int t = t0; t < t_end; t++) {
+        int blk = int(block_table[t / BLOCK]);
+        int off = t % BLOCK;
+        const device bfloat16_t* krow = k_cache + ((blk * BLOCK + off) * KVH + kv) * D;
+
+        float dot = 0.0f;
+        const device bfloat16_t* kl = krow + lane * SLICE;
+        for (int i = 0; i < SLICE; i++)
+            dot += qv[i] * float(kl[i]);
+
+        float s = simd_sum(dot) * SCALE;
+        float m_new = max(m, s);
+        float alpha = (m > -1e29f) ? exp(m - m_new) : 0.0f;
+        float p = exp(s - m_new);
+        l = l * alpha + p;
+        const device bfloat16_t* vl = v_cache + ((blk * BLOCK + off) * KVH + kv) * D + lane * SLICE;
+        for (int i = 0; i < SLICE; i++)
+            acc[i] = acc[i] * alpha + p * float(vl[i]);
+        m = m_new;
+    }
+
+    int idx = (tile * KVH + kv) * GROUP + group;
+    partial_m[idx] = m;
+    partial_l[idx] = l;
+    device float* outp = partial_acc + (size_t)idx * D + lane * SLICE;
+    for (int i = 0; i < SLICE; i++) outp[i] = acc[i];
+"""
+
+_GQA_DECODE_MERGE_TEMPLATE = """
+    uint lane = thread_index_in_simdgroup;
+    int hg = int(threadgroup_position_in_grid.x);
+    int kv = hg / GROUP;
+    int group = hg % GROUP;
+    int nt = (seq + TILE - 1) / TILE;
+
+    float m = -1e30f;
+    for (int t = 0; t < nt; t++)
+        m = max(m, partial_m[(t * KVH + kv) * GROUP + group]);
+
+    float l = 0.0f;
+    float acc[SLICE] = {0.0f};
+    for (int t = 0; t < nt; t++) {
+        int idx = (t * KVH + kv) * GROUP + group;
+        float pm = partial_m[idx];
+        if (pm <= -1e29f) continue;
+        float w = exp(pm - m);
+        l += partial_l[idx] * w;
+        const device float* a = partial_acc + (size_t)idx * D + lane * SLICE;
+        for (int i = 0; i < SLICE; i++) acc[i] += a[i] * w;
+    }
+    float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
+    device bfloat16_t* o = out + (size_t)hg * D + lane * SLICE;
+    for (int i = 0; i < SLICE; i++) o[i] = bfloat16_t(acc[i] * inv);
+"""
+
+_GQA_TILE = 128
+_gqa_kernel_cache: dict = {}
+
+
+def _gqa_decode_kernels(kv_heads: int, group: int, dim: int, block: int, scale: float):
+    import mlx.core as mx
+
+    key = (kv_heads, group, dim, block, scale)
+    kernels = _gqa_kernel_cache.get(key)
+    if kernels is not None:
+        return kernels
+    if dim % 32:
+        raise ValueError("head dim must be divisible by 32")
+    defines = (
+        f"#define D {dim}\n#define SLICE {dim // 32}\n#define KVH {kv_heads}\n"
+        f"#define GROUP {group}\n#define BLOCK {block}\n#define TILE {_GQA_TILE}\n"
+        f"#define SCALE {scale!r}f\n"
+    )
+    header = _GQA_DECODE_HEADER + defines
+    pass1 = mx.fast.metal_kernel(
+        name=f"vllm_metal_gqa_decode_p1_k{kv_heads}g{group}d{dim}b{block}",
+        input_names=["q", "k_cache", "v_cache", "block_table", "seq"],
+        output_names=["partial_m", "partial_l", "partial_acc"],
+        header=header,
+        source=_GQA_DECODE_PASS1_TEMPLATE,
+    )
+    merge = mx.fast.metal_kernel(
+        name=f"vllm_metal_gqa_decode_mg_k{kv_heads}g{group}d{dim}",
+        input_names=["partial_m", "partial_l", "partial_acc", "seq"],
+        output_names=["out"],
+        header=header,
+        source=_GQA_DECODE_MERGE_TEMPLATE,
+    )
+    kernels = (pass1, merge)
+    _gqa_kernel_cache[key] = kernels
+    return kernels
+
+
+_NATIVE_FP_STATS = {"hit": 0, "miss": {}}
+_SDPA_LDIST = {}
+
+
+def _native_fp_miss(reason: str) -> None:
+    _NATIVE_FP_STATS["miss"][reason] = _NATIVE_FP_STATS["miss"].get(reason, 0) + 1
+
+
+_table_arr_cache: dict = {}
+
+
+def _table_array_cache(raw_block_tables, cache_block_size):
+    """mx.array for the first sequence's block table, cached per forward step.
+
+    The same host list object is shared by every layer of one forward, so
+    keying on ``id`` lets the H2D upload happen once per step instead of once
+    per layer per token. The list object dies with the request's scheduler
+    state, so ids cannot be confused across steps in practice; the first
+    element is stored for a cheap sanity check.
+    """
+    import mlx.core as mx
+
+    tbl = raw_block_tables[0]
+    key = id(tbl)
+    hit = _table_arr_cache.get(key)
+    if hit is not None and hit[0] == tbl[0] and hit[2] == len(tbl):
+        return hit[1]
+    arr = mx.array(tbl, dtype=mx.int32)
+    _table_arr_cache[key] = (tbl[0], arr, len(tbl))
+    if len(_table_arr_cache) > 64:
+        _table_arr_cache.clear()
+    return arr
+
+
+def _native_sdpa_decode_fast_path(
+    q_3d,
+    k_cache,
+    v_cache,
+    raw_block_tables,
+    context_lens,
+    cache_block_size,
+    cache_kv_heads,
+    attn_scale,
+    attn_softcap,
+    layer_sliding_window,
+    sinks,
+    verify_window_q,
+):
+    """Zero-copy MLX-native SDPA path for single-sequence decode steps.
+
+    When one sequence's vLLM blocks are physically contiguous in the paged
+    cache (the common single-request decode case), its KV is a dense slice of
+    the flattened cache, so ``mx.fast.scaled_dot_product_attention`` can read
+    it through strided views with no gather/copy. The native kernel's KV-scan
+    bandwidth (~200 GB/s on M5 Pro) is several times the paged Metal
+    kernel's at long contexts, which dominates single-stream decode.
+
+    ``raw_block_tables`` / ``context_lens`` are host-side Python lists, so
+    the contiguity check costs no GPU synchronisation.
+
+    Returns the attention output ``(L, heads, cache_head_dim)`` or ``None``
+    when the fast path does not apply (falls back to the paged kernel).
+    """
+    import mlx.core as mx
+
+    from vllm_metal import envs
+
+    if not envs.VLLM_METAL_NATIVE_SDPA_DECODE:
+        return None
+    if (
+        q_3d.shape[0] != 1  # decode single token
+        or len(context_lens) != 1  # single sequence in the batch
+        or attn_softcap  # softcap unsupported on the native path
+        or sinks is not None
+        # No-window layers use the sentinel -1 (see kv_cache.py); only a real
+        # positive window disqualifies the native path.
+        or (layer_sliding_window or 0) > 0  # windows unsupported
+        # verify_window_q defaults to 1 (one query token per step); values > 1
+        # mean an expanded spec-decode verify window, unsupported here.
+        or (verify_window_q or 1) > 1
+        or q_3d.dtype not in (mx.float16, mx.bfloat16)
+        or q_3d.shape[2] not in (64, 96, 128, 256)  # native kernel widths
+    ):
+        _native_fp_miss("conditions")
+        return None
+
+    seq = int(context_lens[0])
+    table = raw_block_tables[0]
+    n_blocks_needed = (seq + cache_block_size - 1) // cache_block_size
+    if n_blocks_needed > len(table):
+        _native_fp_miss("table_short")
+        return None
+    run = table[:n_blocks_needed]
+    first = run[0]
+
+    heads = q_3d.shape[1]
+    if heads % cache_kv_heads:
+        return None
+    group = heads // cache_kv_heads
+    dim = q_3d.shape[2]
+
+    if run == list(range(first, first + n_blocks_needed)):
+        # Contiguous run: zero-copy strided views straight into native SDPA.
+        flat_k = k_cache.reshape(-1, cache_kv_heads, k_cache.shape[-1])
+        flat_v = v_cache.reshape(-1, cache_kv_heads, v_cache.shape[-1])
+        row0 = first * cache_block_size
+        k_view = flat_k[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+        v_view = flat_v[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+        q_sdpa = q_3d.reshape(cache_kv_heads, group, 1, dim)
+        out = mx.fast.scaled_dot_product_attention(
+            q_sdpa, k_view, v_view, scale=attn_scale
+        )
+        _NATIVE_FP_STATS["hit_contig"] = _NATIVE_FP_STATS.get("hit_contig", 0) + 1
+        return out.reshape(1, heads, dim)
+
+    # Non-contiguous run (hybrid GDN interleave): custom flash-decode kernel
+    # over the block table.
+    try:
+        block_arr = _table_array_cache(raw_block_tables, cache_block_size)
+        pass1, merge = _gqa_decode_kernels(
+            cache_kv_heads, group, dim, cache_block_size, float(attn_scale)
+        )
+        nt = (seq + _GQA_TILE - 1) // _GQA_TILE
+        q = q_3d.reshape(cache_kv_heads * group, dim)
+        pm, pl, pacc = pass1(
+            inputs=[q, k_cache, v_cache, block_arr, seq],
+            output_shapes=[
+                (nt, cache_kv_heads, group),
+                (nt, cache_kv_heads, group),
+                (nt, cache_kv_heads, group, dim),
+            ],
+            output_dtypes=[mx.float32, mx.float32, mx.float32],
+            grid=(nt, cache_kv_heads, 1),
+            threadgroup=(32, group, 1),
+            stream=mx.gpu,
+        )
+        out = merge(
+            inputs=[pm, pl, pacc, seq],
+            output_shapes=[(cache_kv_heads * group, dim)],
+            output_dtypes=[mx.bfloat16 if q.dtype == mx.bfloat16 else mx.float16],
+            grid=(cache_kv_heads * group, 1, 1),
+            threadgroup=(32, 1, 1),
+            stream=mx.gpu,
+        )[0]
+        _NATIVE_FP_STATS["hit_kernel"] = _NATIVE_FP_STATS.get("hit_kernel", 0) + 1
+        return out.reshape(1, heads, dim)
+    except Exception:
+        _native_fp_miss("kernel_error")
+        return None
 
 
 def apply_g_proj_gate(

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -785,8 +785,9 @@ def sdpa_forward(
                 q_3d,
                 kernel_k_cache,
                 kernel_v_cache,
+                ctx,
+                None if ctx.kv_groups is None else group_index,
                 raw_block_tables,
-                ctx.context_lens,
                 cache_block_size,
                 cache_kv_heads,
                 attn_scale,
@@ -842,7 +843,7 @@ _GQA_DECODE_PASS1_TEMPLATE = """
     if (t0 >= seq) { return; }
     int t_end = min(t0 + TILE, seq);
 
-    const device bfloat16_t* qg = q + ((kv * GROUP + group) * D);
+    const device STOR_T* qg = q + ((kv * GROUP + group) * D);
 
     float qv[SLICE];
     for (int i = 0; i < SLICE; i++) qv[i] = float(qg[lane * SLICE + i]);
@@ -854,10 +855,10 @@ _GQA_DECODE_PASS1_TEMPLATE = """
     for (int t = t0; t < t_end; t++) {
         int blk = int(block_table[t / BLOCK]);
         int off = t % BLOCK;
-        const device bfloat16_t* krow = k_cache + ((blk * BLOCK + off) * KVH + kv) * D;
+        const device STOR_T* krow = k_cache + ((blk * BLOCK + off) * KVH + kv) * D;
 
         float dot = 0.0f;
-        const device bfloat16_t* kl = krow + lane * SLICE;
+        const device STOR_T* kl = krow + lane * SLICE;
         for (int i = 0; i < SLICE; i++)
             dot += qv[i] * float(kl[i]);
 
@@ -866,7 +867,7 @@ _GQA_DECODE_PASS1_TEMPLATE = """
         float alpha = (m > -1e29f) ? exp(m - m_new) : 0.0f;
         float p = exp(s - m_new);
         l = l * alpha + p;
-        const device bfloat16_t* vl = v_cache + ((blk * BLOCK + off) * KVH + kv) * D + lane * SLICE;
+        const device STOR_T* vl = v_cache + ((blk * BLOCK + off) * KVH + kv) * D + lane * SLICE;
         for (int i = 0; i < SLICE; i++)
             acc[i] = acc[i] * alpha + p * float(vl[i]);
         m = m_new;
@@ -902,38 +903,44 @@ _GQA_DECODE_MERGE_TEMPLATE = """
         for (int i = 0; i < SLICE; i++) acc[i] += a[i] * w;
     }
     float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
-    device bfloat16_t* o = out + (size_t)hg * D + lane * SLICE;
-    for (int i = 0; i < SLICE; i++) o[i] = bfloat16_t(acc[i] * inv);
+    device STOR_T* o = out + (size_t)hg * D + lane * SLICE;
+    for (int i = 0; i < SLICE; i++) o[i] = STOR_T(acc[i] * inv);
 """
 
 _GQA_TILE = 128
 _gqa_kernel_cache: dict = {}
 
 
-def _gqa_decode_kernels(kv_heads: int, group: int, dim: int, block: int, scale: float):
-    import mlx.core as mx
-
-    key = (kv_heads, group, dim, block, scale)
+def _gqa_decode_kernels(
+    kv_heads: int, group: int, dim: int, block: int, scale: float, dtype
+):
+    key = (kv_heads, group, dim, block, scale, dtype)
     kernels = _gqa_kernel_cache.get(key)
     if kernels is not None:
         return kernels
     if dim % 32:
         raise ValueError("head dim must be divisible by 32")
+    if dtype == mx.bfloat16:
+        stor_t, tag = "bfloat16_t", "bf16"
+    elif dtype == mx.float16:
+        stor_t, tag = "float16_t", "fp16"
+    else:
+        raise ValueError(f"unsupported storage dtype {dtype}")
     defines = (
         f"#define D {dim}\n#define SLICE {dim // 32}\n#define KVH {kv_heads}\n"
         f"#define GROUP {group}\n#define BLOCK {block}\n#define TILE {_GQA_TILE}\n"
-        f"#define SCALE {scale!r}f\n"
+        f"#define SCALE {scale!r}f\n#define STOR_T {stor_t}\n"
     )
     header = _GQA_DECODE_HEADER + defines
     pass1 = mx.fast.metal_kernel(
-        name=f"vllm_metal_gqa_decode_p1_k{kv_heads}g{group}d{dim}b{block}",
+        name=f"vllm_metal_gqa_decode_p1_k{kv_heads}g{group}d{dim}b{block}_{tag}",
         input_names=["q", "k_cache", "v_cache", "block_table", "seq"],
         output_names=["partial_m", "partial_l", "partial_acc"],
         header=header,
         source=_GQA_DECODE_PASS1_TEMPLATE,
     )
     merge = mx.fast.metal_kernel(
-        name=f"vllm_metal_gqa_decode_mg_k{kv_heads}g{group}d{dim}",
+        name=f"vllm_metal_gqa_decode_mg_k{kv_heads}g{group}d{dim}_{tag}",
         input_names=["partial_m", "partial_l", "partial_acc", "seq"],
         output_names=["out"],
         header=header,
@@ -945,45 +952,62 @@ def _gqa_decode_kernels(kv_heads: int, group: int, dim: int, block: int, scale: 
 
 
 _NATIVE_FP_STATS = {"hit": 0, "miss": {}}
-_SDPA_LDIST = {}
 
 
 def _native_fp_miss(reason: str) -> None:
     _NATIVE_FP_STATS["miss"][reason] = _NATIVE_FP_STATS["miss"].get(reason, 0) + 1
 
 
-_table_arr_cache: dict = {}
+@dataclass(frozen=True, eq=False)
+class _NativeDecodePlan:
+    """Per-forward dispatch decision for the native decode fast path.
 
-
-def _table_array_cache(raw_block_tables, cache_block_size):
-    """mx.array for the first sequence's block table, cached per forward step.
-
-    The same host list object is shared by every layer of one forward, so
-    keying on ``id`` lets the H2D upload happen once per step instead of once
-    per layer per token. The list object dies with the request's scheduler
-    state, so ids cannot be confused across steps in practice; the first
-    element is stored for a cheap sanity check.
+    The block table and context length only change between forward steps, so
+    the contiguity scan and the block-table H2D upload run once per step (on
+    the first attention layer) and are memoized on the paged context — the
+    per-layer hot path is a dict lookup instead of an O(blocks) list compare
+    plus an upload per layer. ``eq=False``: identity comparison only (the
+    default ``__eq__`` would compare mx arrays, which raises on ``bool()``).
     """
-    import mlx.core as mx
 
-    tbl = raw_block_tables[0]
-    key = id(tbl)
-    hit = _table_arr_cache.get(key)
-    if hit is not None and hit[0] == tbl[0] and hit[2] == len(tbl):
-        return hit[1]
-    arr = mx.array(tbl, dtype=mx.int32)
-    _table_arr_cache[key] = (tbl[0], arr, len(tbl))
-    if len(_table_arr_cache) > 64:
-        _table_arr_cache.clear()
-    return arr
+    seq: int  # context length of the single sequence (includes current token)
+    n_blocks: int  # blocks covered by the sequence's run
+    contig_first: int  # first physical block when the run is contiguous, else -1
+    table_arr: mx.array | None  # raw block-table upload when non-contiguous
+
+
+def _native_decode_plan(
+    ctx: PagedAttentionContext,
+    group_index: int | None,
+    raw_block_tables: list[list[int]],
+    cache_block_size: int,
+) -> _NativeDecodePlan:
+    key = ("native_decode", group_index, cache_block_size)
+    plan = ctx.kernel_metadata_cache.get(key)
+    if plan is None:
+        seq = ctx.context_lens[0]
+        table = raw_block_tables[0]
+        n_blocks = (seq + cache_block_size - 1) // cache_block_size
+        contig_first = -1
+        table_arr = None
+        if n_blocks <= len(table):
+            first = table[0]
+            if table[:n_blocks] == list(range(first, first + n_blocks)):
+                contig_first = first
+            else:
+                table_arr = mx.array(table, dtype=mx.int32)
+        plan = _NativeDecodePlan(seq, n_blocks, contig_first, table_arr)
+        ctx.kernel_metadata_cache[key] = plan
+    return plan
 
 
 def _native_sdpa_decode_fast_path(
     q_3d,
     k_cache,
     v_cache,
+    ctx: PagedAttentionContext,
+    group_index: int | None,
     raw_block_tables,
-    context_lens,
     cache_block_size,
     cache_kv_heads,
     attn_scale,
@@ -1001,21 +1025,25 @@ def _native_sdpa_decode_fast_path(
     bandwidth (~200 GB/s on M5 Pro) is several times the paged Metal
     kernel's at long contexts, which dominates single-stream decode.
 
-    ``raw_block_tables`` / ``context_lens`` are host-side Python lists, so
-    the contiguity check costs no GPU synchronisation.
+    Non-contiguous runs (hybrid GDN interleave, prefix-cache restores) go
+    through a block-table-driven flash-decode kernel built with
+    ``mx.fast.metal_kernel`` (~190 GB/s), and everything else falls back to
+    the paged kernel.
+
+    The contiguity scan is memoized per forward step on the paged context
+    (see :func:`_native_decode_plan`), so the hot path adds no GPU
+    synchronisation and no per-layer Python rescans.
 
     Returns the attention output ``(L, heads, cache_head_dim)`` or ``None``
     when the fast path does not apply (falls back to the paged kernel).
     """
-    import mlx.core as mx
-
     from vllm_metal import envs
 
     if not envs.VLLM_METAL_NATIVE_SDPA_DECODE:
         return None
     if (
         q_3d.shape[0] != 1  # decode single token
-        or len(context_lens) != 1  # single sequence in the batch
+        or len(ctx.context_lens) != 1  # single sequence in the batch
         or attn_softcap  # softcap unsupported on the native path
         or sinks is not None
         # No-window layers use the sentinel -1 (see kv_cache.py); only a real
@@ -1030,26 +1058,21 @@ def _native_sdpa_decode_fast_path(
         _native_fp_miss("conditions")
         return None
 
-    seq = int(context_lens[0])
-    table = raw_block_tables[0]
-    n_blocks_needed = (seq + cache_block_size - 1) // cache_block_size
-    if n_blocks_needed > len(table):
-        _native_fp_miss("table_short")
-        return None
-    run = table[:n_blocks_needed]
-    first = run[0]
-
     heads = q_3d.shape[1]
     if heads % cache_kv_heads:
+        _native_fp_miss("gqa")
         return None
     group = heads // cache_kv_heads
     dim = q_3d.shape[2]
 
-    if run == list(range(first, first + n_blocks_needed)):
+    plan = _native_decode_plan(ctx, group_index, raw_block_tables, cache_block_size)
+    seq = plan.seq
+
+    if plan.contig_first >= 0:
         # Contiguous run: zero-copy strided views straight into native SDPA.
         flat_k = k_cache.reshape(-1, cache_kv_heads, k_cache.shape[-1])
         flat_v = v_cache.reshape(-1, cache_kv_heads, v_cache.shape[-1])
-        row0 = first * cache_block_size
+        row0 = plan.contig_first * cache_block_size
         k_view = flat_k[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
         v_view = flat_v[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
         q_sdpa = q_3d.reshape(cache_kv_heads, group, 1, dim)
@@ -1061,30 +1084,34 @@ def _native_sdpa_decode_fast_path(
 
     # Non-contiguous run (hybrid GDN interleave): custom flash-decode kernel
     # over the block table.
+    if plan.table_arr is None:
+        _native_fp_miss("table_short")
+        return None
     try:
-        block_arr = _table_array_cache(raw_block_tables, cache_block_size)
         pass1, merge = _gqa_decode_kernels(
-            cache_kv_heads, group, dim, cache_block_size, float(attn_scale)
+            cache_kv_heads, group, dim, cache_block_size, float(attn_scale), q_3d.dtype
         )
         nt = (seq + _GQA_TILE - 1) // _GQA_TILE
         q = q_3d.reshape(cache_kv_heads * group, dim)
         pm, pl, pacc = pass1(
-            inputs=[q, k_cache, v_cache, block_arr, seq],
+            inputs=[q, k_cache, v_cache, plan.table_arr, seq],
             output_shapes=[
                 (nt, cache_kv_heads, group),
                 (nt, cache_kv_heads, group),
                 (nt, cache_kv_heads, group, dim),
             ],
             output_dtypes=[mx.float32, mx.float32, mx.float32],
-            grid=(nt, cache_kv_heads, 1),
+            # grid is in threads (mx.fast.metal_kernel convention): one
+            # threadgroup per (tile, kv_head), each with `group` simdgroups.
+            grid=(nt * 32, cache_kv_heads * group, 1),
             threadgroup=(32, group, 1),
             stream=mx.gpu,
         )
         out = merge(
             inputs=[pm, pl, pacc, seq],
             output_shapes=[(cache_kv_heads * group, dim)],
-            output_dtypes=[mx.bfloat16 if q.dtype == mx.bfloat16 else mx.float16],
-            grid=(cache_kv_heads * group, 1, 1),
+            output_dtypes=[q_3d.dtype],
+            grid=(cache_kv_heads * group * 32, 1, 1),
             threadgroup=(32, 1, 1),
             stream=mx.gpu,
         )[0]

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -828,128 +828,8 @@ def sdpa_forward(
 
 
 # ---------------------------------------------------------------------------
-# Custom GQA decode kernel (flash-decode style) for non-contiguous block runs
+# Native-SDPA decode fast path (contiguous single-sequence runs only)
 # ---------------------------------------------------------------------------
-
-_GQA_DECODE_HEADER = "#include <metal_simdgroup>\nusing namespace metal;\n"
-
-_GQA_DECODE_PASS1_TEMPLATE = """
-    uint lane = thread_index_in_simdgroup;
-    uint group = simdgroup_index_in_threadgroup;
-
-    int tile = int(threadgroup_position_in_grid.x);
-    int kv = int(threadgroup_position_in_grid.y);
-    int t0 = tile * TILE;
-    if (t0 >= seq) { return; }
-    int t_end = min(t0 + TILE, seq);
-
-    const device STOR_T* qg = q + ((kv * GROUP + group) * D);
-
-    float qv[SLICE];
-    for (int i = 0; i < SLICE; i++) qv[i] = float(qg[lane * SLICE + i]);
-
-    float m = -1e30f;
-    float l = 0.0f;
-    float acc[SLICE] = {0.0f};
-
-    for (int t = t0; t < t_end; t++) {
-        int blk = int(block_table[t / BLOCK]);
-        int off = t % BLOCK;
-        const device STOR_T* krow = k_cache + ((blk * BLOCK + off) * KVH + kv) * D;
-
-        float dot = 0.0f;
-        const device STOR_T* kl = krow + lane * SLICE;
-        for (int i = 0; i < SLICE; i++)
-            dot += qv[i] * float(kl[i]);
-
-        float s = simd_sum(dot) * SCALE;
-        float m_new = max(m, s);
-        float alpha = (m > -1e29f) ? exp(m - m_new) : 0.0f;
-        float p = exp(s - m_new);
-        l = l * alpha + p;
-        const device STOR_T* vl = v_cache + ((blk * BLOCK + off) * KVH + kv) * D + lane * SLICE;
-        for (int i = 0; i < SLICE; i++)
-            acc[i] = acc[i] * alpha + p * float(vl[i]);
-        m = m_new;
-    }
-
-    int idx = (tile * KVH + kv) * GROUP + group;
-    partial_m[idx] = m;
-    partial_l[idx] = l;
-    device float* outp = partial_acc + (size_t)idx * D + lane * SLICE;
-    for (int i = 0; i < SLICE; i++) outp[i] = acc[i];
-"""
-
-_GQA_DECODE_MERGE_TEMPLATE = """
-    uint lane = thread_index_in_simdgroup;
-    int hg = int(threadgroup_position_in_grid.x);
-    int kv = hg / GROUP;
-    int group = hg % GROUP;
-    int nt = (seq + TILE - 1) / TILE;
-
-    float m = -1e30f;
-    for (int t = 0; t < nt; t++)
-        m = max(m, partial_m[(t * KVH + kv) * GROUP + group]);
-
-    float l = 0.0f;
-    float acc[SLICE] = {0.0f};
-    for (int t = 0; t < nt; t++) {
-        int idx = (t * KVH + kv) * GROUP + group;
-        float pm = partial_m[idx];
-        if (pm <= -1e29f) continue;
-        float w = exp(pm - m);
-        l += partial_l[idx] * w;
-        const device float* a = partial_acc + (size_t)idx * D + lane * SLICE;
-        for (int i = 0; i < SLICE; i++) acc[i] += a[i] * w;
-    }
-    float inv = (l > 0.0f) ? 1.0f / l : 0.0f;
-    device STOR_T* o = out + (size_t)hg * D + lane * SLICE;
-    for (int i = 0; i < SLICE; i++) o[i] = STOR_T(acc[i] * inv);
-"""
-
-_GQA_TILE = 128
-_gqa_kernel_cache: dict = {}
-
-
-def _gqa_decode_kernels(
-    kv_heads: int, group: int, dim: int, block: int, scale: float, dtype
-):
-    key = (kv_heads, group, dim, block, scale, dtype)
-    kernels = _gqa_kernel_cache.get(key)
-    if kernels is not None:
-        return kernels
-    if dim % 32:
-        raise ValueError("head dim must be divisible by 32")
-    if dtype == mx.bfloat16:
-        stor_t, tag = "bfloat16_t", "bf16"
-    elif dtype == mx.float16:
-        stor_t, tag = "float16_t", "fp16"
-    else:
-        raise ValueError(f"unsupported storage dtype {dtype}")
-    defines = (
-        f"#define D {dim}\n#define SLICE {dim // 32}\n#define KVH {kv_heads}\n"
-        f"#define GROUP {group}\n#define BLOCK {block}\n#define TILE {_GQA_TILE}\n"
-        f"#define SCALE {scale!r}f\n#define STOR_T {stor_t}\n"
-    )
-    header = _GQA_DECODE_HEADER + defines
-    pass1 = mx.fast.metal_kernel(
-        name=f"vllm_metal_gqa_decode_p1_k{kv_heads}g{group}d{dim}b{block}_{tag}",
-        input_names=["q", "k_cache", "v_cache", "block_table", "seq"],
-        output_names=["partial_m", "partial_l", "partial_acc"],
-        header=header,
-        source=_GQA_DECODE_PASS1_TEMPLATE,
-    )
-    merge = mx.fast.metal_kernel(
-        name=f"vllm_metal_gqa_decode_mg_k{kv_heads}g{group}d{dim}_{tag}",
-        input_names=["partial_m", "partial_l", "partial_acc", "seq"],
-        output_names=["out"],
-        header=header,
-        source=_GQA_DECODE_MERGE_TEMPLATE,
-    )
-    kernels = (pass1, merge)
-    _gqa_kernel_cache[key] = kernels
-    return kernels
-
 
 _NATIVE_FP_STATS = {"hit": 0, "miss": {}}
 
@@ -963,17 +843,16 @@ class _NativeDecodePlan:
     """Per-forward dispatch decision for the native decode fast path.
 
     The block table and context length only change between forward steps, so
-    the contiguity scan and the block-table H2D upload run once per step (on
-    the first attention layer) and are memoized on the paged context — the
-    per-layer hot path is a dict lookup instead of an O(blocks) list compare
-    plus an upload per layer. ``eq=False``: identity comparison only (the
-    default ``__eq__`` would compare mx arrays, which raises on ``bool()``).
+    the contiguity scan runs once per step (on the first attention layer)
+    and is memoized on the paged context — the per-layer hot path is a dict
+    lookup instead of an O(blocks) list compare. ``eq=False``: identity
+    comparison only (the default ``__eq__`` would compare mx arrays, which
+    raises on ``bool()``).
     """
 
     seq: int  # context length of the single sequence (includes current token)
     n_blocks: int  # blocks covered by the sequence's run
     contig_first: int  # first physical block when the run is contiguous, else -1
-    table_arr: mx.array | None  # raw block-table upload when non-contiguous
 
 
 def _native_decode_plan(
@@ -989,14 +868,11 @@ def _native_decode_plan(
         table = raw_block_tables[0]
         n_blocks = (seq + cache_block_size - 1) // cache_block_size
         contig_first = -1
-        table_arr = None
         if n_blocks <= len(table):
             first = table[0]
             if table[:n_blocks] == list(range(first, first + n_blocks)):
                 contig_first = first
-            else:
-                table_arr = mx.array(table, dtype=mx.int32)
-        plan = _NativeDecodePlan(seq, n_blocks, contig_first, table_arr)
+        plan = _NativeDecodePlan(seq, n_blocks, contig_first)
         ctx.kernel_metadata_cache[key] = plan
     return plan
 
@@ -1025,10 +901,12 @@ def _native_sdpa_decode_fast_path(
     bandwidth (~200 GB/s on M5 Pro) is several times the paged Metal
     kernel's at long contexts, which dominates single-stream decode.
 
-    Non-contiguous runs (hybrid GDN interleave, prefix-cache restores) go
-    through a block-table-driven flash-decode kernel built with
-    ``mx.fast.metal_kernel`` (~190 GB/s), and everything else falls back to
-    the paged kernel.
+    Non-contiguous runs (hybrid GDN interleave, prefix-cache restores) and
+    every ineligible shape return ``None`` so ``sdpa_forward`` falls through
+    to ``paged_attention_primitive``.  Eligible long single-sequence decode
+    is handled there by the precompiled GQA-shared flash-decode pass; shorter
+    contexts and multi-sequence / windowed batches keep the established
+    per-token and split-KV kernels.
 
     The contiguity scan is memoized per forward step on the paged context
     (see :func:`_native_decode_plan`), so the hot path adds no GPU
@@ -1082,44 +960,15 @@ def _native_sdpa_decode_fast_path(
         _NATIVE_FP_STATS["hit_contig"] = _NATIVE_FP_STATS.get("hit_contig", 0) + 1
         return out.reshape(1, heads, dim)
 
-    # Non-contiguous run (hybrid GDN interleave): custom flash-decode kernel
-    # over the block table.
-    if plan.table_arr is None:
+    # Non-contiguous (or a short table): the precompiled paged kernel owns
+    # this shape.  Eligible long single-seq decode takes the GQA-shared
+    # flash-decode pass inside the primitive; everything else stays on the
+    # established per-token / split-KV path.
+    if plan.n_blocks > len(raw_block_tables[0]):
         _native_fp_miss("table_short")
-        return None
-    try:
-        pass1, merge = _gqa_decode_kernels(
-            cache_kv_heads, group, dim, cache_block_size, float(attn_scale), q_3d.dtype
-        )
-        nt = (seq + _GQA_TILE - 1) // _GQA_TILE
-        q = q_3d.reshape(cache_kv_heads * group, dim)
-        pm, pl, pacc = pass1(
-            inputs=[q, k_cache, v_cache, plan.table_arr, seq],
-            output_shapes=[
-                (nt, cache_kv_heads, group),
-                (nt, cache_kv_heads, group),
-                (nt, cache_kv_heads, group, dim),
-            ],
-            output_dtypes=[mx.float32, mx.float32, mx.float32],
-            # grid is in threads (mx.fast.metal_kernel convention): one
-            # threadgroup per (tile, kv_head), each with `group` simdgroups.
-            grid=(nt * 32, cache_kv_heads * group, 1),
-            threadgroup=(32, group, 1),
-            stream=mx.gpu,
-        )
-        out = merge(
-            inputs=[pm, pl, pacc, seq],
-            output_shapes=[(cache_kv_heads * group, dim)],
-            output_dtypes=[q_3d.dtype],
-            grid=(cache_kv_heads * group * 32, 1, 1),
-            threadgroup=(32, 1, 1),
-            stream=mx.gpu,
-        )[0]
-        _NATIVE_FP_STATS["hit_kernel"] = _NATIVE_FP_STATS.get("hit_kernel", 0) + 1
-        return out.reshape(1, heads, dim)
-    except Exception:
-        _native_fp_miss("kernel_error")
-        return None
+    else:
+        _native_fp_miss("non_contig")
+    return None
 
 
 def apply_g_proj_gate(

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -778,46 +778,27 @@ def sdpa_forward(
             quant_type=kv_cache.k_quant,
             v_bits=kv_cache.v_bits,
             window_seqlen_q=ctx.verify_window_q,
+            num_decode_requests=ctx.num_decode_requests,
         )
     else:
-        try:
-            fast_out = _native_sdpa_decode_fast_path(
-                q_3d,
-                kernel_k_cache,
-                kernel_v_cache,
-                ctx,
-                None if ctx.kv_groups is None else group_index,
-                raw_block_tables,
-                cache_block_size,
-                cache_kv_heads,
-                attn_scale,
-                attn_softcap,
-                layer_sliding_window,
-                sinks,
-                getattr(ctx, "verify_window_q", None),
-            )
-        except Exception:  # noqa: BLE001 - fall back to the paged kernel
-            fast_out = None
-        if fast_out is not None:
-            out = fast_out
-        else:
-            ops.paged_attention_primitive(
-                q_3d,
-                kernel_k_cache,
-                kernel_v_cache,
-                cache_kv_heads,
-                attn_scale,
-                attn_softcap,
-                block_tables,
-                seq_lens,
-                cu_seqlens_q,
-                kernel_block_size,
-                max_seq_len,
-                layer_sliding_window,
-                out,
-                window_seqlen_q=ctx.verify_window_q,
-                sinks=sinks,
-            )
+        ops.paged_attention_primitive(
+            q_3d,
+            kernel_k_cache,
+            kernel_v_cache,
+            cache_kv_heads,
+            attn_scale,
+            attn_softcap,
+            block_tables,
+            seq_lens,
+            cu_seqlens_q,
+            kernel_block_size,
+            max_seq_len,
+            layer_sliding_window,
+            out,
+            window_seqlen_q=ctx.verify_window_q,
+            sinks=sinks,
+            num_decode_requests=ctx.num_decode_requests,
+        )
 
     # Reshape + strip padding back to actual head_dim before o_proj.
     out = truncate_padded_output(out, B, L, n_heads, cache_head_dim, actual_head_dim)
@@ -825,150 +806,6 @@ def sdpa_forward(
         out = out * mx.sigmoid(gate)
     out = apply_g_proj_gate(inner, out, x, n_heads, actual_head_dim)
     return inner.o_proj(out), kv_for_sharing
-
-
-# ---------------------------------------------------------------------------
-# Native-SDPA decode fast path (contiguous single-sequence runs only)
-# ---------------------------------------------------------------------------
-
-_NATIVE_FP_STATS = {"hit": 0, "miss": {}}
-
-
-def _native_fp_miss(reason: str) -> None:
-    _NATIVE_FP_STATS["miss"][reason] = _NATIVE_FP_STATS["miss"].get(reason, 0) + 1
-
-
-@dataclass(frozen=True, eq=False)
-class _NativeDecodePlan:
-    """Per-forward dispatch decision for the native decode fast path.
-
-    The block table and context length only change between forward steps, so
-    the contiguity scan runs once per step (on the first attention layer)
-    and is memoized on the paged context — the per-layer hot path is a dict
-    lookup instead of an O(blocks) list compare. ``eq=False``: identity
-    comparison only (the default ``__eq__`` would compare mx arrays, which
-    raises on ``bool()``).
-    """
-
-    seq: int  # context length of the single sequence (includes current token)
-    n_blocks: int  # blocks covered by the sequence's run
-    contig_first: int  # first physical block when the run is contiguous, else -1
-
-
-def _native_decode_plan(
-    ctx: PagedAttentionContext,
-    group_index: int | None,
-    raw_block_tables: list[list[int]],
-    cache_block_size: int,
-) -> _NativeDecodePlan:
-    key = ("native_decode", group_index, cache_block_size)
-    plan = ctx.kernel_metadata_cache.get(key)
-    if plan is None:
-        seq = ctx.context_lens[0]
-        table = raw_block_tables[0]
-        n_blocks = (seq + cache_block_size - 1) // cache_block_size
-        contig_first = -1
-        if n_blocks <= len(table):
-            first = table[0]
-            if table[:n_blocks] == list(range(first, first + n_blocks)):
-                contig_first = first
-        plan = _NativeDecodePlan(seq, n_blocks, contig_first)
-        ctx.kernel_metadata_cache[key] = plan
-    return plan
-
-
-def _native_sdpa_decode_fast_path(
-    q_3d,
-    k_cache,
-    v_cache,
-    ctx: PagedAttentionContext,
-    group_index: int | None,
-    raw_block_tables,
-    cache_block_size,
-    cache_kv_heads,
-    attn_scale,
-    attn_softcap,
-    layer_sliding_window,
-    sinks,
-    verify_window_q,
-):
-    """Zero-copy MLX-native SDPA path for single-sequence decode steps.
-
-    When one sequence's vLLM blocks are physically contiguous in the paged
-    cache (the common single-request decode case), its KV is a dense slice of
-    the flattened cache, so ``mx.fast.scaled_dot_product_attention`` can read
-    it through strided views with no gather/copy. The native kernel's KV-scan
-    bandwidth (~200 GB/s on M5 Pro) is several times the paged Metal
-    kernel's at long contexts, which dominates single-stream decode.
-
-    Non-contiguous runs (hybrid GDN interleave, prefix-cache restores) and
-    every ineligible shape return ``None`` so ``sdpa_forward`` falls through
-    to ``paged_attention_primitive``.  Eligible long single-sequence decode
-    is handled there by the precompiled GQA-shared flash-decode pass; shorter
-    contexts and multi-sequence / windowed batches keep the established
-    per-token and split-KV kernels.
-
-    The contiguity scan is memoized per forward step on the paged context
-    (see :func:`_native_decode_plan`), so the hot path adds no GPU
-    synchronisation and no per-layer Python rescans.
-
-    Returns the attention output ``(L, heads, cache_head_dim)`` or ``None``
-    when the fast path does not apply (falls back to the paged kernel).
-    """
-    from vllm_metal import envs
-
-    if not envs.VLLM_METAL_NATIVE_SDPA_DECODE:
-        return None
-    if (
-        q_3d.shape[0] != 1  # decode single token
-        or len(ctx.context_lens) != 1  # single sequence in the batch
-        or attn_softcap  # softcap unsupported on the native path
-        or sinks is not None
-        # No-window layers use the sentinel -1 (see kv_cache.py); only a real
-        # positive window disqualifies the native path.
-        or (layer_sliding_window or 0) > 0  # windows unsupported
-        # verify_window_q defaults to 1 (one query token per step); values > 1
-        # mean an expanded spec-decode verify window, unsupported here.
-        or (verify_window_q or 1) > 1
-        or q_3d.dtype not in (mx.float16, mx.bfloat16)
-        or q_3d.shape[2] not in (64, 96, 128, 256)  # native kernel widths
-    ):
-        _native_fp_miss("conditions")
-        return None
-
-    heads = q_3d.shape[1]
-    if heads % cache_kv_heads:
-        _native_fp_miss("gqa")
-        return None
-    group = heads // cache_kv_heads
-    dim = q_3d.shape[2]
-
-    plan = _native_decode_plan(ctx, group_index, raw_block_tables, cache_block_size)
-    seq = plan.seq
-
-    if plan.contig_first >= 0:
-        # Contiguous run: zero-copy strided views straight into native SDPA.
-        flat_k = k_cache.reshape(-1, cache_kv_heads, k_cache.shape[-1])
-        flat_v = v_cache.reshape(-1, cache_kv_heads, v_cache.shape[-1])
-        row0 = plan.contig_first * cache_block_size
-        k_view = flat_k[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
-        v_view = flat_v[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
-        q_sdpa = q_3d.reshape(cache_kv_heads, group, 1, dim)
-        out = mx.fast.scaled_dot_product_attention(
-            q_sdpa, k_view, v_view, scale=attn_scale
-        )
-        _NATIVE_FP_STATS["hit_contig"] = _NATIVE_FP_STATS.get("hit_contig", 0) + 1
-        return out.reshape(1, heads, dim)
-
-    # Non-contiguous (or a short table): the precompiled paged kernel owns
-    # this shape.  Eligible long single-seq decode takes the GQA-shared
-    # flash-decode pass inside the primitive; everything else stays on the
-    # established per-token / split-KV path.
-    if plan.n_blocks > len(raw_block_tables[0]):
-        _native_fp_miss("table_short")
-    else:
-        _native_fp_miss("non_contig")
-    return None
 
 
 def apply_g_proj_gate(

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -95,6 +95,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
     # Emergency override for automatic M5 NAX prefill attention.
     "VLLM_METAL_DISABLE_NAX": lambda: os.getenv("VLLM_METAL_DISABLE_NAX", "0") == "1",
+    # Route single-sequence decode attention through MLX's native SDPA
+    # (zero-copy strided view over the paged cache) instead of the paged
+    # Metal kernel. The native kernel reaches ~200GB/s effective KV scan
+    # bandwidth vs ~40GB/s for the paged kernel at long contexts, and is
+    # only taken when the sequence's blocks are physically contiguous
+    # (the common single-request case). Set to "0" to force the paged
+    # kernel everywhere.
+    "VLLM_METAL_NATIVE_SDPA_DECODE": lambda: (
+        os.getenv("VLLM_METAL_NATIVE_SDPA_DECODE", "1") == "1"
+    ),
     # Spec-decode verification window mode (issue #465). Off by default —
     # verify windows keep the expanded per-token layout (main behavior)
     # unless this opt-in is set. Set to "1" to merge K+1 verify windows

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -95,13 +95,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
     # Emergency override for automatic M5 NAX prefill attention.
     "VLLM_METAL_DISABLE_NAX": lambda: os.getenv("VLLM_METAL_DISABLE_NAX", "0") == "1",
-    # Route single-sequence decode attention through MLX's native SDPA
-    # (zero-copy strided view over the paged cache) instead of the paged
-    # Metal kernel. The native kernel reaches ~200GB/s effective KV scan
-    # bandwidth vs ~40GB/s for the paged kernel at long contexts, and is
-    # only taken when the sequence's blocks are physically contiguous
-    # (the common single-request case). Set to "0" to force the paged
-    # kernel everywhere.
+    # Route single-sequence decode attention through faster paths instead of
+    # the paged Metal kernel: contiguous block runs go to MLX's native SDPA
+    # via zero-copy strided views (~200GB/s effective KV-scan bandwidth vs
+    # ~40GB/s for the paged kernel at long contexts), non-contiguous runs
+    # (hybrid GDN interleave) go through a block-table-driven flash-decode
+    # kernel (~190GB/s). Set to "0" to force the paged kernel everywhere.
     "VLLM_METAL_NATIVE_SDPA_DECODE": lambda: (
         os.getenv("VLLM_METAL_NATIVE_SDPA_DECODE", "1") == "1"
     ),

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     VLLM_METAL_NATIVE_SAMPLING: bool = False
     VLLM_METAL_MLA_KERNEL: bool = False
     VLLM_METAL_DISABLE_NAX: bool = False
+    VLLM_METAL_NATIVE_SDPA_DECODE: bool = True
     VLLM_METAL_SPEC_VERIFY_WINDOW: bool = False
     VLLM_METAL_SPEC_INGEST_CHUNK: int = 1024
     VLLM_METAL_BUILD_FROM_SOURCE: bool = False
@@ -95,12 +96,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
     # Emergency override for automatic M5 NAX prefill attention.
     "VLLM_METAL_DISABLE_NAX": lambda: os.getenv("VLLM_METAL_DISABLE_NAX", "0") == "1",
-    # Route single-sequence decode attention through faster paths instead of
-    # the paged Metal kernel: contiguous block runs go to MLX's native SDPA
-    # via zero-copy strided views (~200GB/s effective KV-scan bandwidth vs
-    # ~40GB/s for the paged kernel at long contexts), non-contiguous runs
-    # (hybrid GDN interleave) go through a block-table-driven flash-decode
-    # kernel (~190GB/s). Set to "0" to force the paged kernel everywhere.
+    # Route contiguous single-sequence decode through MLX native SDPA
+    # (zero-copy strided views over the paged cache, ~200GB/s KV-scan).
+    # Non-contiguous runs fall through to paged_attention_primitive, which
+    # takes the GQA-shared flash-decode pass at long single-seq contexts.
+    # Set to "0" to force the paged kernel even for contiguous runs.
     "VLLM_METAL_NATIVE_SDPA_DECODE": lambda: (
         os.getenv("VLLM_METAL_NATIVE_SDPA_DECODE", "1") == "1"
     ),

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     VLLM_METAL_NATIVE_SAMPLING: bool = False
     VLLM_METAL_MLA_KERNEL: bool = False
     VLLM_METAL_DISABLE_NAX: bool = False
-    VLLM_METAL_NATIVE_SDPA_DECODE: bool = True
     VLLM_METAL_SPEC_VERIFY_WINDOW: bool = False
     VLLM_METAL_SPEC_INGEST_CHUNK: int = 1024
     VLLM_METAL_BUILD_FROM_SOURCE: bool = False
@@ -96,14 +95,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
     # Emergency override for automatic M5 NAX prefill attention.
     "VLLM_METAL_DISABLE_NAX": lambda: os.getenv("VLLM_METAL_DISABLE_NAX", "0") == "1",
-    # Route contiguous single-sequence decode through MLX native SDPA
-    # (zero-copy strided views over the paged cache, ~200GB/s KV-scan).
-    # Non-contiguous runs fall through to paged_attention_primitive, which
-    # takes the GQA-shared flash-decode pass at long single-seq contexts.
-    # Set to "0" to force the paged kernel even for contiguous runs.
-    "VLLM_METAL_NATIVE_SDPA_DECODE": lambda: (
-        os.getenv("VLLM_METAL_NATIVE_SDPA_DECODE", "1") == "1"
-    ),
     # Spec-decode verification window mode (issue #465). Off by default —
     # verify windows keep the expanded per-token layout (main behavior)
     # unless this opt-in is set. Set to "1" to merge K+1 verify windows

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -2143,6 +2143,123 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   }
 }
 
+// ---------------------------------------------------------------------------
+// GQA-shared flash-decode pass for pure-decode batches.
+//
+// One threadgroup per (PARTITION_SIZE-token partition, kv head, sequence);
+// each simdgroup owns one query head of the GQA group, so the whole group
+// shares every K/V row load — the per-token kernel above instead re-reads
+// the same KV rows once per query head from separate threadgroups — and the
+// online softmax stays entirely in registers (no threadgroup-memory score
+// staging, no barriers).  At long contexts this lifts single-sequence decode
+// KV-scan bandwidth from ~40GB/s to ~190GB/s on M5 Pro.
+//
+// Partials are written in the exact contract paged_attention_v2_reduce
+// consumes: log2-space running (max, exp-sum) stats plus the
+// epsilon-normalised partial at tmp_out[token, head, partition, :], so the
+// existing reduce pass merges them unchanged.  Engaged only for pure-decode
+// batches without TurboQuant/FP8/sinks/softcap/sliding-window (dispatch gate
+// in paged_ops.cpp); everything else keeps the established paths.
+template <typename T, int HEAD_SIZE, int BLOCK_SIZE, int PARTITION_SIZE>
+[[kernel]] void paged_attention_gqa_decode(
+    device float *exp_sums [[buffer(0)]], device float *max_logits [[buffer(1)]],
+    device T *tmp_out [[buffer(2)]], device const T *q [[buffer(3)]],
+    device const T *k_cache [[buffer(4)]], device const T *v_cache [[buffer(5)]],
+    const constant int &num_kv_heads [[buffer(8)]],
+    const constant float &scale [[buffer(9)]],
+    device const uint32_t *block_tables [[buffer(11)]],
+    device const uint32_t *context_lens [[buffer(12)]],
+    const constant int &max_num_blocks_per_seq [[buffer(13)]],
+    const constant int &q_stride [[buffer(15)]],
+    const constant int &kv_block_stride [[buffer(16)]],
+    const constant int &kv_head_stride [[buffer(17)]],
+    uint3 tg_pos [[threadgroup_position_in_grid]],
+    uint3 tg_per_grid [[threadgroups_per_grid]],
+    uint3 tptg [[threads_per_threadgroup]],
+    uint sg [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]) {
+  static_assert(HEAD_SIZE % 32 == 0, "one lane-strided slice per lane");
+  constexpr int SLICE = HEAD_SIZE / 32;  // elements per lane
+  const int partition_idx = tg_pos.x;
+  const int kv_head_idx = tg_pos.y;
+  const int seq_idx = tg_pos.z;
+  const int context_len = static_cast<int>(context_lens[seq_idx]);
+  const int t0 = partition_idx * PARTITION_SIZE;
+  if (t0 >= context_len) {
+    // The reduce reads only ceil(context_len / PARTITION_SIZE) partitions,
+    // so stats for later partitions are never consumed (same early-out as
+    // the partitioned per-token kernel).
+    return;
+  }
+  const int t_end = min(t0 + PARTITION_SIZE, context_len);
+
+  const int group = tptg.x / 32;  // query heads per kv head (GQA group)
+  const int head_idx = kv_head_idx * group + static_cast<int>(sg);
+  const int num_heads = num_kv_heads * group;
+  const int max_num_partitions = tg_per_grid.x;
+  const int64_t kv_token_stride =
+      static_cast<int64_t>(num_kv_heads) * kv_head_stride;
+
+  // Lane-strided query slice, loaded once.
+  device const T *q_ptr =
+      q + seq_idx * q_stride + head_idx * HEAD_SIZE + lane * SLICE;
+  float qv[SLICE];
+#pragma unroll
+  for (int i = 0; i < SLICE; i++) {
+    qv[i] = float(q_ptr[i]);
+  }
+
+  device const uint32_t *bt =
+      block_tables + seq_idx * max_num_blocks_per_seq;
+
+  // Online softmax in log2 space (v2_reduce contract): folding log2(e) into
+  // the scale turns every exp into a 1-instruction exp2 on Apple GPUs.
+  float m = -FLT_MAX;
+  float l = 0.f;
+  float acc[SLICE] = {0.f};
+  const float log2e_scale = scale * M_LOG2E_F;
+  for (int t = t0; t < t_end; t++) {
+    const int64_t row = static_cast<int64_t>(bt[t / BLOCK_SIZE]) *
+            kv_block_stride +
+        (t % BLOCK_SIZE) * kv_token_stride + kv_head_idx * kv_head_stride +
+        lane * SLICE;
+    device const T *krow = k_cache + row;
+    float dot = 0.f;
+#pragma unroll
+    for (int i = 0; i < SLICE; i++) {
+      dot += qv[i] * float(krow[i]);
+    }
+    const float s = simd_sum(dot) * log2e_scale;
+    const float m_new = max(m, s);
+    // exp2(-FLT_MAX - s) == 0 under -fno-fast-math, so the first-iteration
+    // rescale needs no guard (same identity the masked-score path uses).
+    const float alpha = exp2(m - m_new);
+    const float p = exp2(s - m_new);
+    l = l * alpha + p;
+    device const T *vrow = v_cache + row;
+#pragma unroll
+    for (int i = 0; i < SLICE; i++) {
+      acc[i] = acc[i] * alpha + p * float(vrow[i]);
+    }
+    m = m_new;
+  }
+
+  const int64_t pidx =
+      (static_cast<int64_t>(seq_idx) * num_heads + head_idx) *
+          max_num_partitions +
+      partition_idx;
+  if (lane == 0) {
+    max_logits[pidx] = m;
+    exp_sums[pidx] = l;
+  }
+  device T *out_ptr = tmp_out + pidx * HEAD_SIZE + lane * SLICE;
+  const float inv_l = 1.f / (l + 1e-6f);
+#pragma unroll
+  for (int i = 0; i < SLICE; i++) {
+    out_ptr[i] = T(acc[i] * inv_l);
+  }
+}
+
 // Tiled paged attention kernel (paged_attention_tiled) is in
 // pagedattention_tiled.metal.
 
@@ -2337,3 +2454,46 @@ instantiate_paged_attention_v1(half, char, uchar, 32);
 instantiate_paged_attention_v2(float, char, uchar, 32);
 instantiate_paged_attention_v2(bfloat16_t, char, uchar, 32);
 instantiate_paged_attention_v2(half, char, uchar, 32);
+
+// GQA-shared flash-decode pass (pure decode, non-TQ): half/bfloat16 caches,
+// head sizes divisible by 32 up to 256, kernel block sizes 8/16/32.  Other
+// configs keep the per-token kernel via the dispatch gate in paged_ops.cpp.
+#define instantiate_gqa_decode_inner(type, head_size, block_size,            \
+                                     partition_size)                         \
+  template [[host_name("paged_attention_gqa_decode_" #type "_hs" #head_size  \
+                       "_bs" #block_size "_ps" #partition_size)]]            \
+  [[kernel]] void paged_attention_gqa_decode<type, head_size, block_size,    \
+                                             partition_size>(                \
+      device float *exp_sums [[buffer(0)]],                                  \
+      device float *max_logits [[buffer(1)]], device type *tmp_out           \
+      [[buffer(2)]],                                                         \
+      device const type *q [[buffer(3)]],                                    \
+      device const type *k_cache [[buffer(4)]],                              \
+      device const type *v_cache [[buffer(5)]],                              \
+      const constant int &num_kv_heads [[buffer(8)]],                        \
+      const constant float &scale [[buffer(9)]],                             \
+      device const uint32_t *block_tables [[buffer(11)]],                    \
+      device const uint32_t *context_lens [[buffer(12)]],                    \
+      const constant int &max_num_blocks_per_seq [[buffer(13)]],             \
+      const constant int &q_stride [[buffer(15)]],                           \
+      const constant int &kv_block_stride [[buffer(16)]],                    \
+      const constant int &kv_head_stride [[buffer(17)]],                     \
+      uint3 tg_pos [[threadgroup_position_in_grid]],                         \
+      uint3 tg_per_grid [[threadgroups_per_grid]],                           \
+      uint3 tptg [[threads_per_threadgroup]],                                \
+      uint sg [[simdgroup_index_in_threadgroup]],                            \
+      uint lane [[thread_index_in_simdgroup]]);
+
+#define instantiate_gqa_decode_hs(type, block_size, partition_size)          \
+  instantiate_gqa_decode_inner(type, 64, block_size, partition_size);        \
+  instantiate_gqa_decode_inner(type, 96, block_size, partition_size);        \
+  instantiate_gqa_decode_inner(type, 128, block_size, partition_size);       \
+  instantiate_gqa_decode_inner(type, 256, block_size, partition_size);
+
+#define instantiate_gqa_decode_bs(type, partition_size)                      \
+  instantiate_gqa_decode_hs(type, 8, partition_size);                        \
+  instantiate_gqa_decode_hs(type, 16, partition_size);                       \
+  instantiate_gqa_decode_hs(type, 32, partition_size);
+
+instantiate_gqa_decode_bs(bfloat16_t, VLLM_METAL_PARTITION_SIZE);
+instantiate_gqa_decode_bs(half, VLLM_METAL_PARTITION_SIZE);

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -433,6 +433,63 @@ static void dispatch_paged_attention_tiled(
       MTL::Size::Make(cfg.NUM_THREADS, 1, 1));
 }
 
+// ---------------------------------------------------------------------------
+// Shared pass-2 for the split-KV decode paths: merge per-partition partials
+// into `out` (log-sum-exp combine).  Partials must follow the ps512 contract:
+// log2-space (max, exp-sum) stats plus epsilon-normalised partial outputs in
+// tmp_out[token, head, partition, :].
+static void dispatch_paged_attention_v2_reduce(
+    metal::Device& d, metal::CommandEncoder& enc, array& out,
+    const array& exp_sums, const array& max_logits, const array& tmp_out,
+    const array& seq_lens, const array& cu_seqlens_q, int num_seqs,
+    int total_q_tokens, int num_heads, int head_size, int max_num_partitions,
+    const std::string& dt, bool use_sinks, const array* sinks,
+    bool use_tq_fc) {
+  std::string rname =
+      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
+      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
+  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
+  // other function constants are inert for it.  TurboQuant batches take this
+  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
+  // and sinks are folded here rather than in the partitioned kernel so the
+  // sink logit is counted once globally.  The cache key MUST encode every
+  // constant the pipeline is specialized on — otherwise the first compile
+  // wins and a later caller with different constants silently reuses the
+  // wrong pipeline.
+  std::string rhash = rname + "_v2reduce"
+      + "_tq" + (use_tq_fc ? "1" : "0")
+      + "_sk" + (use_sinks ? "1" : "0");
+  auto* lib = d.get_library("paged_attention_v2_kern");
+  auto* rkernel = d.get_kernel(
+      rname, lib, rhash,
+      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
+  enc.set_compute_pipeline_state(rkernel);
+  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
+  // (odd partition counts would yield 8 mod 16 and trip the API-validation
+  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
+  // is never touched.
+  size_t reduce_shmem =
+      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
+  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(seq_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+  if (use_sinks) {
+    enc.set_input_array(*sinks, 6);
+  }
+  enc.set_input_array(cu_seqlens_q, 7);
+  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
+  enc.set_bytes(num_seqs_i, 8);
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, 1),
+      MTL::Size::Make(256, 1, 1));
+}
+
 static void dispatch_paged_attention_v2_online(
     array& out, const array& query,
     const array& key_cache, const array& value_cache,
@@ -596,6 +653,19 @@ static void dispatch_paged_attention_v2_online(
 
   auto& enc = metal::get_command_encoder(s);
 
+  // Split-KV scratch factory shared by the split paths below: partial output
+  // + softmax (max, exp-sum) stats.  Tiny (~64 KB tmp_out @ conc=1/8K).
+  // add_temporary keeps them alive until the command buffer completes; MLX
+  // auto-inserts a barrier between the two dispatches via input/output
+  // dependency tracking (set_output here -> set_input in the reduce),
+  // mirroring MLX's own sdpa_vector_2pass.
+  auto make_temp = [&](Shape shape, Dtype dtype) {
+    array a(std::move(shape), dtype, nullptr, {});
+    a.set_data(allocator::malloc(a.nbytes()));
+    enc.add_temporary(a);
+    return a;
+  };
+
   // TurboQuant scale/zero/centroid buffers (slots 22-27); shared by both paths.
   auto bind_turboquant = [&]() {
     if (!use_turboquant) return;
@@ -616,6 +686,96 @@ static void dispatch_paged_attention_v2_online(
     enc.set_input_array(*sinks, 18);
   };
 
+  // ----- GQA-shared flash-decode pass -------------------------------------
+  // Pure-decode batches without TurboQuant/FP8/sinks/softcap/sliding-window
+  // take a dedicated split-KV kernel whose threadgroups share every KV row
+  // load across the whole GQA group (the per-token kernel re-reads each row
+  // once per query head from separate threadgroups) and keep the online
+  // softmax in registers — no threadgroup-memory score staging, no barriers.
+  // This lifts long-context single-sequence decode from ~40GB/s to ~190GB/s
+  // effective KV-scan bandwidth on M5 Pro.  Partials follow the ps512
+  // contract and merge through the standard v2 reduce.  Instantiated for
+  // head sizes {64,96,128,256}, GQA groups <= 8 (one simdgroup per q head),
+  // and same-dtype half/bfloat16 Q/K/V; anything else falls through to the
+  // per-token kernel below.  Engages only once the KV volume makes the split
+  // pay (below ~16K context the serial per-partition loop is latency-bound
+  // against the wider base grid — measured on M5 Pro).  Restricted to
+  // single-sequence batches: a multi-sequence decode batch is
+  // indistinguishable from an expanded spec-decode verify window, and those
+  // must stay bitwise identical to the windowed dispatch
+  // (tests/test_spec_window_parity.py), which a different kernel family
+  // breaks.
+  const int gqa_group = num_kv_heads > 0 ? num_heads / num_kv_heads : 0;
+  const bool gqa_decode =
+      pure_decode && num_seqs == 1
+      && dtype_ok && query.dtype() == value_cache.dtype()
+      && !use_turboquant && softcap <= 0.f && sinks == nullptr
+      && sliding_window < 0 && num_kv_heads > 0
+      && num_heads % num_kv_heads == 0 && gqa_group >= 1 && gqa_group <= 8
+      && (head_size == 64 || head_size == 96 || head_size == 128 ||
+          head_size == 256)
+      && max_num_partitions >= 2 && max_seq_len >= 16384;
+  if (gqa_decode) {
+    std::string gname =
+        "paged_attention_gqa_decode_" + dt + "_hs" + std::to_string(head_size) +
+        "_bs" + std::to_string(block_size) + "_ps" +
+        std::to_string(kPartitionSize);
+    // The kernel only exists in freshly built shader libraries; a stale
+    // prebuilt .metallib (or an older wheel's) does not carry it — fall
+    // through to the per-token kernel instead of failing the dispatch.
+    MTL::ComputePipelineState* gkernel = nullptr;
+    try {
+      gkernel = d.get_kernel(gname, lib, gname, {});
+    } catch (const std::exception&) {
+    }
+    if (gkernel != nullptr) {
+
+    array g_tmp_out = make_temp(
+        Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
+        query.dtype());
+    array g_exp_sums =
+        make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+    array g_max_logits =
+        make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+
+    // Binds mirror paged_attention_gqa_decode's signature exactly (the
+    // kernel declares only these slots; no shared-mem carve).
+    enc.set_compute_pipeline_state(gkernel);
+    enc.set_output_array(g_exp_sums, 0);
+    enc.set_output_array(g_max_logits, 1);
+    enc.set_output_array(g_tmp_out, 2);
+    enc.set_input_array(query, 3);
+    enc.set_input_array(key_cache, 4);
+    enc.set_input_array(value_cache, 5);
+    int32_t g_nkv = static_cast<int32_t>(num_kv_heads);
+    enc.set_bytes(g_nkv, 8);
+    enc.set_bytes(scale, 9);
+    enc.set_input_array(block_tables, 11);
+    enc.set_input_array(seq_lens, 12);
+    int32_t g_max_blocks = static_cast<int32_t>(block_tables.shape(1));
+    enc.set_bytes(g_max_blocks, 13);
+    int32_t g_q_stride = static_cast<int32_t>(num_heads * head_size);
+    int32_t g_kv_block_stride = static_cast<int32_t>(key_cache.strides()[0]);
+    int32_t g_kv_head_stride = static_cast<int32_t>(key_cache.strides()[2]);
+    enc.set_bytes(g_q_stride, 15);
+    enc.set_bytes(g_kv_block_stride, 16);
+    enc.set_bytes(g_kv_head_stride, 17);
+    // One threadgroup per (partition, kv head, sequence); each simdgroup
+    // owns one query head of the GQA group.
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(max_num_partitions, num_kv_heads, num_seqs),
+        MTL::Size::Make(32 * gqa_group, 1, 1));
+
+    dispatch_paged_attention_v2_reduce(
+        d, enc, out, g_exp_sums, g_max_logits, g_tmp_out, seq_lens,
+        cu_seqlens_q, num_seqs, total_q_tokens, num_heads, head_size,
+        max_num_partitions, dt, /*use_sinks=*/false, nullptr,
+        /*use_tq_fc=*/false);
+    return;
+    }
+    // Kernel unavailable in the loaded shader library: fall through.
+  }
+
   if (!partition) {
     // Single-pass path (grid.z = 1): the original decode/per-token kernel.
     enc.set_compute_pipeline_state(kernel);
@@ -633,17 +793,6 @@ static void dispatch_paged_attention_v2_online(
   }
 
   // ----- Split-KV path: paged_attention(_ps512) -> paged_attention_v2_reduce.
-  // Per-partition scratch: partial output + softmax (max, exp-sum) stats.
-  // Tiny (~64 KB tmp_out @ conc=1/8K).  add_temporary keeps them alive until
-  // the command buffer completes; MLX auto-inserts a barrier between the two
-  // dispatches via input/output dependency tracking (set_output here ->
-  // set_input below), mirroring MLX's own sdpa_vector_2pass.
-  auto make_temp = [&](Shape shape, Dtype dtype) {
-    array a(std::move(shape), dtype, nullptr, {});
-    a.set_data(allocator::malloc(a.nbytes()));
-    enc.add_temporary(a);
-    return a;
-  };
   array tmp_out = make_temp(
       Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
       query.dtype());
@@ -671,48 +820,10 @@ static void dispatch_paged_attention_v2_online(
       MTL::Size::Make(NUM_THREADS, 1, 1));
 
   // Pass 2: reduce per-partition partials -> out (log-sum-exp combine).
-  std::string rname =
-      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
-      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
-  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
-  // other function constants are inert for it.  TurboQuant batches take this
-  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
-  // and sinks are folded here rather than in the partitioned kernel so the
-  // sink logit is counted once globally.  The cache key MUST encode every
-  // constant the pipeline is specialized on — otherwise the first compile
-  // wins and a later caller with different constants silently reuses the
-  // wrong pipeline.
-  std::string rhash = rname + "_v2reduce"
-      + "_tq" + (use_tq_fc ? "1" : "0")
-      + "_sk" + (use_sinks ? "1" : "0");
-  auto* rkernel = d.get_kernel(
-      rname, lib, rhash,
-      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
-       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
-  enc.set_compute_pipeline_state(rkernel);
-  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
-  // (odd partition counts would yield 8 mod 16 and trip the API-validation
-  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
-  // is never touched.
-  size_t reduce_shmem =
-      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
-  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
-  enc.set_output_array(out, 0);
-  enc.set_input_array(exp_sums, 1);
-  enc.set_input_array(max_logits, 2);
-  enc.set_input_array(tmp_out, 3);
-  enc.set_input_array(seq_lens, 4);
-  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
-  enc.set_bytes(max_num_partitions_i, 5);
-  if (use_sinks) {
-    enc.set_input_array(*sinks, 6);
-  }
-  enc.set_input_array(cu_seqlens_q, 7);
-  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
-  enc.set_bytes(num_seqs_i, 8);
-  enc.dispatch_threadgroups(
-      MTL::Size::Make(num_heads, total_q_tokens, 1),
-      MTL::Size::Make(NUM_THREADS, 1, 1));
+  dispatch_paged_attention_v2_reduce(
+      d, enc, out, exp_sums, max_logits, tmp_out, seq_lens, cu_seqlens_q,
+      num_seqs, total_q_tokens, num_heads, head_size, max_num_partitions, dt,
+      use_sinks, sinks, use_tq_fc);
 }
 
 // ---------------------------------------------------------------------------

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -502,7 +502,7 @@ static void dispatch_paged_attention_v2_online(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    int window_seqlen_q, Stream s,
+    int window_seqlen_q, int num_decode_requests, Stream s,
     // TurboQuant (optional, all nullptr when disabled):
     const array* key_scale_cache = nullptr,
     const array* value_scale_cache = nullptr,
@@ -697,29 +697,38 @@ static void dispatch_paged_attention_v2_online(
   // load across the whole GQA group (the per-token kernel re-reads each row
   // once per query head from separate threadgroups) and keep the online
   // softmax in registers — no threadgroup-memory score staging, no barriers.
-  // This lifts long-context single-sequence decode from ~40GB/s to ~190GB/s
-  // effective KV-scan bandwidth on M5 Pro.  Partials follow the ps512
-  // contract and merge through the standard v2 reduce.  Instantiated for
-  // head sizes {64,96,128,256}, GQA groups <= 8 (one simdgroup per q head),
-  // and same-dtype half/bfloat16 Q/K/V; anything else falls through to the
-  // per-token kernel below.  Engages only once the KV volume makes the split
-  // pay (below ~16K context the serial per-partition loop is latency-bound
-  // against the wider base grid — measured on M5 Pro).  Restricted to
-  // single-sequence batches: a multi-sequence decode batch is
-  // indistinguishable from an expanded spec-decode verify window, and those
-  // must stay bitwise identical to the windowed dispatch
-  // (tests/test_spec_window_parity.py), which a different kernel family
-  // breaks.
+  // This lifts long-context decode from ~40GB/s to ~190GB/s effective
+  // KV-scan bandwidth on M5 Pro.  Partials follow the ps512 contract and
+  // merge through the standard v2 reduce.  Instantiated for head sizes
+  // {64,96,128,256}, GQA groups <= 8 (one simdgroup per q head), and
+  // same-dtype half/bfloat16 Q/K/V; anything else falls through to the
+  // per-token kernel below.
+  //
+  // Spec-decode expanded windows pack as many length-1 segments (same
+  // shape as multi-seq decode) with window_seqlen_q == 1.  Production
+  // passes num_decode_requests = scheduler request count, which is 1 for
+  // a single expanded window and N for N real decode requests.  Callers
+  // that omit it (num_decode_requests < 0) keep the conservative
+  // single-seq gate so tests/test_spec_window_parity.py stays bitwise.
+  // Windowed verify windows have has_prefill and never reach this pass.
+  //
+  // Occupancy: a single short sequence underfills the GPU (measured
+  // crossover ~16k tokens on M5 Pro).  Multi-seq scales the same KV
+  // budget across the batch, so 4 seqs at 4k is treated like 1 seq at 16k.
   const int gqa_group = num_kv_heads > 0 ? num_heads / num_kv_heads : 0;
+  const bool gqa_real_decode_batch =
+      (num_decode_requests < 0) ? (num_seqs == 1)
+                                : (num_decode_requests == num_seqs);
   const bool gqa_decode =
-      pure_decode && num_seqs == 1
+      pure_decode && window_seqlen_q <= 1 && gqa_real_decode_batch
       && dtype_ok && query.dtype() == value_cache.dtype()
       && !use_turboquant && softcap <= 0.f && sinks == nullptr
       && sliding_window < 0 && num_kv_heads > 0
       && num_heads % num_kv_heads == 0 && gqa_group >= 1 && gqa_group <= 8
       && (head_size == 64 || head_size == 96 || head_size == 128 ||
           head_size == 256)
-      && max_num_partitions >= 2 && max_seq_len >= kGqaDecodeMinSeqLen;
+      && max_num_partitions >= 2
+      && (int64_t)num_seqs * (int64_t)max_seq_len >= kGqaDecodeMinSeqLen;
   if (gqa_decode) {
     std::string gname =
         "paged_attention_gqa_decode_" + dt + "_hs" + std::to_string(head_size) +
@@ -839,13 +848,15 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
       Stream stream, int num_kv_heads, float scale, float softcap,
       int block_size, int max_seq_len, int sliding_window,
       bool use_turboquant = false, int k_bits = 8, int v_bits = 3,
-      int window_seqlen_q = 1, bool use_sinks = false)
+      int window_seqlen_q = 1, bool use_sinks = false,
+      int num_decode_requests = -1)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
         sliding_window_(sliding_window),
         use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits),
-        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks) {}
+        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks),
+        num_decode_requests_(num_decode_requests) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -871,6 +882,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         num_kv_heads_, scale_, softcap_,
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_, window_seqlen_q_,
+        num_decode_requests_,
         stream(),
         ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_, sk);
   }
@@ -888,7 +900,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->k_bits_ == k_bits_
         && rhs->v_bits_ == v_bits_
         && rhs->window_seqlen_q_ == window_seqlen_q_
-        && rhs->use_sinks_ == use_sinks_;
+        && rhs->use_sinks_ == use_sinks_
+        && rhs->num_decode_requests_ == num_decode_requests_;
   }
 
  private:
@@ -903,6 +916,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int v_bits_;
   int window_seqlen_q_;
   bool use_sinks_;
+  int num_decode_requests_;
 };
 
 static array paged_attention_primitive_fn(
@@ -918,7 +932,7 @@ static array paged_attention_primitive_fn(
     const array* key_zero_cache = nullptr,
     const array* v_centroids = nullptr,
     int v_bits = 3, int window_seqlen_q = 1,
-    const array* sinks = nullptr) {
+    const array* sinks = nullptr, int num_decode_requests = -1) {
   if (sinks != nullptr) {
     // Upstream MLX refuses the same combination
     // (mlx_lm/models/base.py: "Quantized SDPA does not support attention
@@ -1012,7 +1026,8 @@ static array paged_attention_primitive_fn(
       default_stream(Device::gpu),
       num_kv_heads, scale, softcap,
       block_size, max_seq_len, sliding_window,
-      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr);
+      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr,
+      num_decode_requests);
   if (use_turboquant) {
     return array(
         query.shape(), query.dtype(), std::move(prim),
@@ -1930,7 +1945,8 @@ NB_MODULE(_paged_ops, m) {
            const std::string& quant_type,
            int v_bits,
            int window_seqlen_q,
-           nb::object sinks_h) {
+           nb::object sinks_h,
+           int num_decode_requests) {
           const array* sk = sinks_h.is_none()
               ? nullptr : nb::inst_ptr<array>(sinks_h);
           const array* ks = use_turboquant
@@ -1951,7 +1967,7 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(cu_seqlens_q_h),
               block_size, max_seq_len, sliding_window,
               use_turboquant, quant_type, ks, vs, kz, vc, v_bits,
-              window_seqlen_q, sk);
+              window_seqlen_q, sk, num_decode_requests);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -1971,6 +1987,7 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("v_bits") = 3,
         nb::arg("window_seqlen_q") = 1,
         nb::arg("sinks") = nb::none(),
+        nb::arg("num_decode_requests") = -1,
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.  window_seqlen_q must equal the "
         "longest cu_seqlens_q segment (validated when > 1); small "

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -36,6 +36,11 @@ using namespace mlx::core;
 
 static std::string v2_paged_attention_source_;
 constexpr int kPartitionSize = VLLM_METAL_PARTITION_SIZE;
+// Below this context length the GQA-shared decode pass loses to the
+// established per-token / split-KV kernel (measured on M5 Pro).  Kept as
+// a named constant so the dispatch gate and the Python test surface cannot
+// drift.
+constexpr int kGqaDecodeMinSeqLen = 16384;
 
 // Window mode for spec-decode verification (per-token kernel): query rows
 // per threadgroup (2 = the measured register/occupancy sweet spot on Apple
@@ -714,21 +719,17 @@ static void dispatch_paged_attention_v2_online(
       && num_heads % num_kv_heads == 0 && gqa_group >= 1 && gqa_group <= 8
       && (head_size == 64 || head_size == 96 || head_size == 128 ||
           head_size == 256)
-      && max_num_partitions >= 2 && max_seq_len >= 16384;
+      && max_num_partitions >= 2 && max_seq_len >= kGqaDecodeMinSeqLen;
   if (gqa_decode) {
     std::string gname =
         "paged_attention_gqa_decode_" + dt + "_hs" + std::to_string(head_size) +
         "_bs" + std::to_string(block_size) + "_ps" +
         std::to_string(kPartitionSize);
-    // The kernel only exists in freshly built shader libraries; a stale
-    // prebuilt .metallib (or an older wheel's) does not carry it — fall
-    // through to the per-token kernel instead of failing the dispatch.
-    MTL::ComputePipelineState* gkernel = nullptr;
-    try {
-      gkernel = d.get_kernel(gname, lib, gname, {});
-    } catch (const std::exception&) {
-    }
-    if (gkernel != nullptr) {
+    // Instantiated in pagedattention.metal and shipped in the v2 metallib.
+    // A missing specialization is a build/packaging bug: fail loudly
+    // rather than silently drop eligible long decode back to the slower
+    // per-token kernel.
+    auto* gkernel = d.get_kernel(gname, lib, gname, {});
 
     array g_tmp_out = make_temp(
         Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
@@ -772,8 +773,6 @@ static void dispatch_paged_attention_v2_online(
         max_num_partitions, dt, /*use_sinks=*/false, nullptr,
         /*use_tq_fc=*/false);
     return;
-    }
-    // Kernel unavailable in the loaded shader library: fall through.
   }
 
   if (!partition) {
@@ -1728,9 +1727,26 @@ void gdn_linear_attention_impl(
 
 NB_MODULE(_paged_ops, m) {
   m.attr("PARTITION_SIZE") = nb::int_(kPartitionSize);
+  m.attr("GQA_DECODE_MIN_SEQ_LEN") = nb::int_(kGqaDecodeMinSeqLen);
   m.def("min_decode_grid", &min_decode_grid,
         "Decode-grid threshold (threadgroups) below which split-KV decode "
         "engages on this machine.");
+  m.def(
+      "has_gqa_decode_kernel",
+      []() {
+        try {
+          auto& d = metal::device(Device::gpu);
+          auto* lib = d.get_library("paged_attention_v2_kern");
+          auto* k = d.get_kernel(
+              "paged_attention_gqa_decode_half_hs128_bs16_ps512", lib,
+              "paged_attention_gqa_decode_half_hs128_bs16_ps512", {});
+          return k != nullptr;
+        } catch (const std::exception&) {
+          return false;
+        }
+      },
+      "True when the loaded v2 shader library contains the GQA-shared "
+      "flash-decode pass (the default prebuilt metallib on this branch).");
 
   m.def("init_v2_library", &init_v2_library,
         nb::arg("v2_src"),


### PR DESCRIPTION
## What

Reworked per the review direction above: the GQA flash-decode kernel now lives **inside the paged primitive** — `paged_attention_gqa_decode` dispatched from `paged_attention_primitive` in `paged_ops.cpp`, merged through the unchanged `v2_reduce`. No additional decode path, no Python-side routing; native SDPA is dropped from production and remains only as a test-only numeric ceiling (`sdpa.py` net −275 lines, `VLLM_METAL_NATIVE_SDPA_DECODE` env removed).

**Kernel design** — one threadgroup per (512-token partition, kv head, sequence); each simdgroup owns one query head of the GQA group, so every K/V row load is shared across the group (the per-token kernel re-reads each row once per query head from separate threadgroups); online softmax stays entirely in registers (log2 domain, `exp2`); partials follow the existing ps512 contract so the standard reduce consumes them unchanged. Instantiated for head sizes {64, 96, 128, 256} × block sizes {8, 16, 32} × half/bf16 in the v2 metallib; a missing specialization fails loudly.

**Conservative gate**: pure-decode batches, `window_seqlen_q <= 1`, true decode batch (`num_decode_requests == num_seqs`; callers that omit it keep the legacy single-seq gate), same-dtype fp16/bf16, no TurboQuant/sinks/softcap/sliding-window, GQA group ∈ [1, 8], aggregate KV ≥ 16384 (measured occupancy crossover on M5 Pro — below it the established split-KV kernel wins). Spec-decode verify windows are excluded so `test_spec_window_parity.py` stays bitwise.

## Numbers

**Kernel-level A/B** (same process, same tensors, gate on/off; Qwen3.8-like 24q/4kv/hs256 bf16):

| context | conc | per-token kernel | GQA kernel | speedup |
|---:|---:|---:|---:|---:|
| 16k | 1 | 63 GB/s | 133 GB/s | 2.1× |
| 64k | 1 | 44 GB/s | 176 GB/s | 4.0× |
| 64k | 2 | 44 GB/s | 174 GB/s | 4.0× |
| 256k agg | 4 | 46 GB/s | 226 GB/s | 4.9× |

Below the gate the dispatch falls back to the established kernels (GQA is 0.68× at 4k×1 — that is what the threshold is for). Small-GQA models (16q/8kv/hs128) see 1.0–1.8×.

**End-to-end, server topology, 100k context, single stream** (3 runs each, variance < 0.5%; methodology and measurement hazards documented in #713):

| configuration | decode tok/s |
|---|---:|
| pre-PR baseline (this PR's branch, gate forced off) | 4.25 |
| previous draft's fast path (native SDPA + python kernel) | 9.19 |
| **this PR (GQA merged into the paged primitive)** | **9.44** (quiet desktop: 11.2) |

**200k**: 8.70 tok/s sustained (250 GB/s effective), ~3× the pre-PR baseline. Honest disclosure: the previous draft's native-SDPA contiguous branch reached 12.1 in ideal conditions at 200k (~350 GB/s on the KV scan); the single-path GQA kernel currently scans at ~200–226 GB/s, so the longest contexts give up ~14–28% vs that draft's peak while gaining the unified path, multi-sequence support and simpler dispatch. Kernel headroom toward 300+ GB/s is identified as follow-up work.

The paged kernel's long-context collapse that motivates this was independently corroborated on M3 Max and M4 Max in this thread (10–33 GB/s across three chip generations while both alternative paths reach 45–79 GB/s on the same tensors).

## Tests

- Attention/decode suites **246/246** including the 13 new `test_gqa_paged_decode.py` cases (16k boundary, half-block tails, interleaved + contiguous tables, fp16/bf16, multi-seq) and **103/103** `test_spec_window_parity` (bitwise).
- Full tree: 1988 pass; the 21 failures + 6 errors are environment-only (Hub-unreachable, unrelated GGUF oracle, subprocess e2e).
- `ruff check` / `ruff format` clean.
- The same-process e2e A/B harness used for the validation is in-tree: `tools/e2e_qwen38.py`.

## Related

- #695 — the backing analysis (single-sequence decode bandwidth collapse and the dispatch diagnosis).
- #713 — measurement methodology used for the e2e numbers above (in-process vs server topology, desktop GPU co-tenancy, probe pitfalls).
