### PR TITLE
[Bugfix] Populate prompt_logprobs_dict on both runner paths

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -25,6 +25,7 @@ from vllm_metal.v1.model_adapter import DefaultModelAdapter
 from vllm_metal.v1.pooling.backends.decoder.factory import (
     build_decoder_pooling_backend,
 )
+from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
 from vllm_metal.v1.spec_decode import SpeculativeDecodeController
 from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 
@@ -98,6 +99,7 @@ def make_stub_runner(
         "_sampler": None,
         "_native_sample_key": None,
         "_structured_output_applier": MetalStructuredOutputApplier(),
+        "_prompt_logprobs_tracker": PromptLogprobsTracker(),
         "_lora": MetalLoRARuntime(),
         "_yoco_cache_mapping": None,
         "model_args": _model_args,

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -130,7 +130,7 @@ def make_stub_runner(
     runner._cache_policy = ModelCachePolicy(runner, runner._model_adapter)
     if "_decode_pipeline" not in attrs:
         runner._decode_pipeline = DecodePipeline(
-            build_output=runner._build_output,
+            build_output=mr._ExecutionBatch.to_model_runner_output,
             validate=runner._validate_scheduled_outputs,
         )
 

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -63,6 +63,7 @@ def make_stub_runner(
         "model_config": SimpleNamespace(
             runner_type="generate",
             get_head_size=lambda: 128,
+            logprobs_mode="raw_logprobs",
             max_model_len=2048,
             is_hybrid=is_hybrid,
         ),

--- a/tests/test_prompt_logprobs.py
+++ b/tests/test_prompt_logprobs.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt logprobs accounting and tensor construction."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+import torch
+
+from vllm_metal.v1.prompt_logprobs import (
+    PromptLogprobsAccumulator,
+    PromptLogprobsWindow,
+    gather_prompt_logprobs,
+    prompt_logprobs_window,
+)
+
+
+class TestPromptLogprobsWindow:
+    def test_single_chunk_scores_every_prompt_token_but_the_first(self) -> None:
+        window = prompt_logprobs_window(start_pos=0, num_tokens=5, prompt_len=5)
+
+        assert window == PromptLogprobsWindow(0, 4, completes=True)
+        assert window.first_target == 1
+
+    def test_intermediate_chunk_scores_all_its_rows(self) -> None:
+        window = prompt_logprobs_window(start_pos=0, num_tokens=3, prompt_len=8)
+
+        assert window == PromptLogprobsWindow(0, 3, completes=False)
+
+    def test_final_chunk_drops_the_row_that_predicts_the_sampled_token(self) -> None:
+        window = prompt_logprobs_window(start_pos=3, num_tokens=5, prompt_len=8)
+
+        # rows for positions 3..7 -> targets 4..7 (four prompt tokens)
+        assert window == PromptLogprobsWindow(3, 4, completes=True)
+
+    def test_chunk_ending_one_before_the_prompt_end_is_not_yet_complete(self) -> None:
+        # Positions 0..6 forwarded for an 8-token prompt: the == case in vLLM.
+        window = prompt_logprobs_window(start_pos=0, num_tokens=7, prompt_len=8)
+
+        assert window == PromptLogprobsWindow(0, 7, completes=False)
+
+        final = prompt_logprobs_window(start_pos=7, num_tokens=1, prompt_len=8)
+        assert final == PromptLogprobsWindow(7, 0, completes=True)
+
+    def test_one_token_prompt_has_nothing_to_score(self) -> None:
+        window = prompt_logprobs_window(start_pos=0, num_tokens=1, prompt_len=1)
+
+        assert window == PromptLogprobsWindow(0, 0, completes=True)
+
+
+class TestGatherPromptLogprobs:
+    def test_column_zero_is_the_target_and_rank_is_one_based(self) -> None:
+        logits = mx.array(
+            [
+                [0.0, 1.0, 3.0, 2.0],
+                [5.0, 0.0, 0.0, 0.0],
+            ],
+            dtype=mx.float16,
+        )
+
+        tensors = gather_prompt_logprobs(logits, [1, 0], num_logprobs=2)
+
+        expected = torch.log_softmax(
+            torch.tensor(np.array(logits.astype(mx.float32))), dim=-1
+        )
+        assert tensors.logprob_token_ids.shape == (2, 3)
+        assert tensors.logprobs.shape == (2, 3)
+        assert tensors.logprob_token_ids[:, 0].tolist() == [1, 0]
+        torch.testing.assert_close(tensors.logprobs[0, 0], expected[0, 1])
+        torch.testing.assert_close(tensors.logprobs[1, 0], expected[1, 0])
+        # Top-2 alternatives in descending order.
+        assert tensors.logprob_token_ids[0, 1:].tolist() == [2, 3]
+        assert tensors.logprob_token_ids[1, 1:].tolist() == [0, 1]
+        # Token 1 in row 0 is the third highest logit; token 0 in row 1 the highest.
+        assert tensors.selected_token_ranks.tolist() == [3, 1]
+
+    def test_zero_logprobs_keeps_only_the_target_column(self) -> None:
+        logits = mx.array([[0.0, 2.0, 1.0]], dtype=mx.float32)
+
+        tensors = gather_prompt_logprobs(logits, [2], num_logprobs=0)
+
+        assert tensors.logprob_token_ids.shape == (1, 1)
+        assert tensors.logprob_token_ids.tolist() == [[2]]
+        assert tensors.selected_token_ranks.tolist() == [2]
+
+    def test_rejects_row_count_mismatch(self) -> None:
+        with pytest.raises(ValueError, match="num_targets, vocab"):
+            gather_prompt_logprobs(mx.zeros((2, 4)), [1], num_logprobs=1)
+
+
+class TestPromptLogprobsAccumulator:
+    def test_chunks_fill_disjoint_positions_of_one_tensor_set(self) -> None:
+        acc = PromptLogprobsAccumulator(prompt_len=6, num_logprobs=1)
+        first = gather_prompt_logprobs(
+            mx.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.0]]), [1, 0, 1], num_logprobs=1
+        )
+        second = gather_prompt_logprobs(mx.array([[2.0, 0.0], [0.0, 2.0]]), [0, 0], 1)
+
+        acc.fill(prompt_logprobs_window(start_pos=0, num_tokens=3, prompt_len=6), first)
+        acc.fill(
+            prompt_logprobs_window(start_pos=3, num_tokens=3, prompt_len=6), second
+        )
+
+        assert acc.tensors.logprob_token_ids.shape == (5, 2)
+        assert acc.tensors.logprob_token_ids[:, 0].tolist() == [1, 0, 1, 0, 0]
+        torch.testing.assert_close(acc.tensors.logprobs[:3], first.logprobs)
+        torch.testing.assert_close(acc.tensors.logprobs[3:], second.logprobs)
+        assert acc.tensors.selected_token_ranks.tolist() == (
+            first.selected_token_ranks.tolist() + second.selected_token_ranks.tolist()
+        )
+
+    def test_rejects_chunk_that_does_not_match_its_window(self) -> None:
+        acc = PromptLogprobsAccumulator(prompt_len=4, num_logprobs=1)
+        chunk = gather_prompt_logprobs(mx.array([[0.0, 1.0]]), [1], num_logprobs=1)
+
+        with pytest.raises(ValueError, match="window expects 2"):
+            acc.fill(
+                prompt_logprobs_window(start_pos=0, num_tokens=2, prompt_len=4), chunk
+            )
+
+    def test_rejects_window_past_the_prompt(self) -> None:
+        acc = PromptLogprobsAccumulator(prompt_len=3, num_logprobs=0)
+        chunk = gather_prompt_logprobs(mx.array([[0.0, 1.0], [1.0, 0.0]]), [1, 0], 0)
+
+        with pytest.raises(ValueError, match="exceeds"):
+            acc.fill(
+                PromptLogprobsWindow(start_pos=1, num_logits=2, completes=True), chunk
+            )
+
+
+class TestPromptLogprobsTracker:
+    def test_delivers_only_on_the_completing_chunk(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+
+        tracker = PromptLogprobsTracker()
+        prompt = [3, 1, 0, 2, 1, 0]
+        vocab = 4
+        full_rows = mx.arange(len(prompt) * vocab, dtype=mx.float32).reshape(
+            len(prompt), vocab
+        ) * mx.array([0.1])
+
+        first = tracker.observe_chunk(
+            "req-a",
+            prompt_token_ids=prompt,
+            start_pos=0,
+            num_tokens=3,
+            chunk_logits=full_rows[0:3],
+            num_logprobs=1,
+        )
+        assert first is None
+
+        final = tracker.observe_chunk(
+            "req-a",
+            prompt_token_ids=prompt,
+            start_pos=3,
+            num_tokens=3,
+            chunk_logits=full_rows[3:6],
+            num_logprobs=1,
+        )
+        assert final is not None
+        # One row per scored prompt position, column 0 is the prompt token.
+        assert final.logprob_token_ids.shape == (len(prompt) - 1, 2)
+        assert final.logprob_token_ids[:, 0].tolist() == prompt[1:]
+        # Values match a one-shot gather over the same rows.
+        expected = gather_prompt_logprobs(full_rows[:5], prompt[1:], 1)
+        torch.testing.assert_close(final.logprobs, expected.logprobs)
+        assert final.selected_token_ranks.tolist() == (
+            expected.selected_token_ranks.tolist()
+        )
+        # Delivery clears the in-progress slot.
+        assert tracker._in_progress == {}
+
+    def test_single_chunk_prompt_completes_immediately(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+
+        tracker = PromptLogprobsTracker()
+        prompt = [2, 0, 1]
+        rows = mx.array(
+            [[0.0, 1.0, 2.0], [2.0, 0.0, 1.0], [1.0, 2.0, 0.0]], dtype=mx.float32
+        )
+
+        tensors = tracker.observe_chunk(
+            "req-b",
+            prompt_token_ids=prompt,
+            start_pos=0,
+            num_tokens=3,
+            chunk_logits=rows,
+            num_logprobs=0,
+        )
+
+        assert tensors is not None
+        # The last row predicts the first sampled token and is not scored.
+        assert tensors.logprob_token_ids.shape == (2, 1)
+        assert tensors.logprob_token_ids[:, 0].tolist() == prompt[1:]
+
+    def test_one_token_prompt_delivers_empty_tensors(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+
+        tracker = PromptLogprobsTracker()
+        tensors = tracker.observe_chunk(
+            "req-c",
+            prompt_token_ids=[5],
+            start_pos=0,
+            num_tokens=1,
+            chunk_logits=mx.zeros((1, 8)),
+            num_logprobs=2,
+        )
+
+        assert tensors is not None
+        assert tensors.logprob_token_ids.shape == (0, 3)
+
+    def test_rejects_row_count_mismatch(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+
+        tracker = PromptLogprobsTracker()
+        with pytest.raises(ValueError, match=r"\(3, vocab\)"):
+            tracker.observe_chunk(
+                "req-d",
+                prompt_token_ids=[1, 2, 3, 4],
+                start_pos=0,
+                num_tokens=3,
+                chunk_logits=mx.zeros((2, 8)),
+                num_logprobs=1,
+            )
+
+    def test_discard_drops_in_progress_state(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+
+        tracker = PromptLogprobsTracker()
+        tracker.observe_chunk(
+            "req-e",
+            prompt_token_ids=[1, 2, 3, 4],
+            start_pos=0,
+            num_tokens=2,
+            chunk_logits=mx.zeros((2, 8)),
+            num_logprobs=1,
+        )
+        assert "req-e" in tracker._in_progress
+
+        tracker.discard({"req-e", "never-seen"})
+
+        assert tracker._in_progress == {}
+
+    def test_wants(self) -> None:
+        from vllm.sampling_params import SamplingParams
+
+        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+
+        assert PromptLogprobsTracker.wants(SamplingParams(prompt_logprobs=1))
+        assert not PromptLogprobsTracker.wants(SamplingParams())
+        assert not PromptLogprobsTracker.wants(None)
+
+
+class TestFullPromptLogprobs:
+    def test_matches_chunked_gather(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
+
+        prompt = [0, 2, 1, 3]
+        rows = mx.array(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [3.0, 2.0, 1.0, 0.0],
+                [1.0, 3.0, 0.0, 2.0],
+                [9.0, 9.0, 9.0, 9.0],  # predicts the sampled token; ignored
+            ],
+            dtype=mx.float32,
+        )
+
+        tensors = full_prompt_logprobs(rows, prompt, num_logprobs=2)
+
+        assert tensors.logprob_token_ids.shape == (3, 3)
+        assert tensors.logprob_token_ids[:, 0].tolist() == prompt[1:]
+        expected = gather_prompt_logprobs(rows[:3], prompt[1:], 2)
+        torch.testing.assert_close(tensors.logprobs, expected.logprobs)
+
+    def test_one_token_prompt(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
+
+        tensors = full_prompt_logprobs(mx.zeros((1, 4)), [7], num_logprobs=1)
+
+        assert tensors.logprob_token_ids.shape == (0, 2)
+
+
+class TestRunnerWiring:
+    """The two #680 symptoms, pinned at the runner seams.
+
+    ``prompt_logprobs_dict`` was hardcoded ``{}`` in ``_build_output`` and
+    nothing ever produced tensors, so ``echo+logprobs`` 500'd (the API layer
+    indexed a generated-token dict with a prompt token id) and bare
+    ``prompt_logprobs`` returned ``[None]`` silently.
+    """
+
+    def _runner(self):
+        from tests.stub_runner import make_stub_runner
+
+        return make_stub_runner(num_kv_heads=2)
+
+    def test_build_output_carries_prompt_logprobs_dict(self) -> None:
+        import vllm_metal.v1.model_runner as mr
+
+        batch = mr._ExecutionBatch()
+        batch.add_output("req-0", [1])
+        tensors = gather_prompt_logprobs(mx.zeros((1, 8)), [3], num_logprobs=1)
+        batch.prompt_logprobs_dict["req-0"] = tensors
+
+        output = mr.MetalModelRunner._build_output(batch)
+
+        assert output.prompt_logprobs_dict == {"req-0": tensors}
+
+    def test_prefill_single_populates_prompt_logprobs(self) -> None:
+        from types import SimpleNamespace
+
+        from vllm.sampling_params import SamplingParams
+
+        vocab = 32
+        prompt = [4, 7, 1, 9]
+        rows = mx.arange(len(prompt) * vocab, dtype=mx.float32).reshape(
+            1, len(prompt), vocab
+        ) * mx.array([0.01])
+
+        class _TinyModel(SimpleNamespace):
+            def make_cache(self):
+                return []
+
+            def __call__(self, input_ids, cache=None):
+                return rows
+
+        runner = self._runner()
+        runner.model = _TinyModel()
+
+        next_token, _cache, _logprobs, prompt_logprobs = runner._prefill_single(
+            prompt,
+            SamplingParams(temperature=0, prompt_logprobs=1),
+        )
+
+        assert isinstance(next_token, int)
+        assert prompt_logprobs is not None
+        assert prompt_logprobs.logprob_token_ids.shape == (len(prompt) - 1, 2)
+        assert prompt_logprobs.logprob_token_ids[:, 0].tolist() == prompt[1:]
+
+        # Without the flag the extra work is skipped entirely.
+        _, _, _, none_logprobs = runner._prefill_single(
+            prompt, SamplingParams(temperature=0)
+        )
+        assert none_logprobs is None
+
+    def test_paged_gather_delivers_on_completing_chunk(self) -> None:
+        from vllm.sampling_params import SamplingParams
+
+        import vllm_metal.v1.model_runner as mr
+
+        runner = self._runner()
+        prompt = [3, 1, 4, 1, 5, 9]
+        vocab = 16
+        params = SamplingParams(temperature=0, prompt_logprobs=1)
+
+        def _prefill(start: int, end: int, prompt_len: int | None):
+            return mr.PrefillRequest(
+                req_id="req-p",
+                token_ids=prompt[start:end],
+                sampling_params=params,
+                block_ids=[[0]],
+                generator=None,
+                prompt_len=prompt_len,
+                start_pos=start,
+                full_prompt_token_ids=prompt,
+            )
+
+        batch = mr._ExecutionBatch()
+        chunk1 = mx.zeros((1, 4, vocab))
+        runner._gather_prefill_prompt_logprobs(
+            batch, [_prefill(0, 4, None)], chunk1, [0, 4], 0
+        )
+        assert batch.prompt_logprobs_dict == {}
+
+        chunk2 = mx.zeros((1, 2, vocab))
+        runner._gather_prefill_prompt_logprobs(
+            batch, [_prefill(4, 6, len(prompt))], chunk2, [0, 2], 0
+        )
+        tensors = batch.prompt_logprobs_dict["req-p"]
+        assert tensors.logprob_token_ids.shape == (len(prompt) - 1, 2)
+        assert tensors.logprob_token_ids[:, 0].tolist() == prompt[1:]
+
+    def test_paged_gather_rejects_pruned_segment_rows(self) -> None:
+        from vllm.sampling_params import SamplingParams
+
+        import vllm_metal.v1.model_runner as mr
+
+        runner = self._runner()
+        prompt = [3, 1, 4, 1]
+        prefill = mr.PrefillRequest(
+            req_id="req-q",
+            token_ids=prompt,
+            sampling_params=SamplingParams(temperature=0, prompt_logprobs=1),
+            block_ids=[[0]],
+            generator=None,
+            prompt_len=len(prompt),
+            start_pos=0,
+            full_prompt_token_ids=prompt,
+        )
+        batch = mr._ExecutionBatch()
+
+        # A selective-logits layout would leave one row per prefill segment.
+        with pytest.raises(RuntimeError, match="selective-logits"):
+            runner._gather_prefill_prompt_logprobs(
+                batch, [prefill], mx.zeros((1, 1, 8)), [0, 1], 0
+            )
+
+    def test_paged_gather_requires_full_prompt(self) -> None:
+        from vllm.sampling_params import SamplingParams
+
+        import vllm_metal.v1.model_runner as mr
+
+        runner = self._runner()
+        prefill = mr.PrefillRequest(
+            req_id="req-r",
+            token_ids=[1, 2],
+            sampling_params=SamplingParams(temperature=0, prompt_logprobs=1),
+            block_ids=[[0]],
+            generator=None,
+            prompt_len=None,
+            start_pos=0,
+            full_prompt_token_ids=None,
+        )
+        batch = mr._ExecutionBatch()
+
+        with pytest.raises(RuntimeError, match="full prompt"):
+            runner._gather_prefill_prompt_logprobs(
+                batch, [prefill], mx.zeros((1, 2, 8)), [0, 2], 0
+            )
+
+
+@pytest.mark.slow
+def test_prompt_logprobs_end_to_end_paged():
+    """Bare ``prompt_logprobs`` returns one real entry per prompt token (#680).
+
+    Covers both reported symptoms at the engine level: the silent ``[None]``
+    (the dict below used to stay empty) and the data the OpenAI ``echo`` +
+    ``logprobs`` path indexes into (its 500 came from these tensors never
+    existing).  ``max_num_batched_tokens`` forces chunked prefill so the
+    accounting crosses chunk boundaries.
+    """
+    from vllm import LLM, SamplingParams
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+        mp.setenv("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        mp.setenv("VLLM_METAL_MEMORY_FRACTION", "0.3")
+
+        llm = LLM(
+            model="Qwen/Qwen3-0.6B",
+            max_model_len=512,
+            max_num_seqs=2,
+            max_num_batched_tokens=16,
+            enable_chunked_prefill=True,
+        )
+        prompt = (
+            "The three most important properties of a distributed cache "
+            "are consistency, availability, and partition tolerance."
+        )
+        sp = SamplingParams(temperature=0, max_tokens=4, prompt_logprobs=1, logprobs=1)
+        [output] = llm.generate([prompt], sp)
+
+        prompt_len = len(output.prompt_token_ids)
+        assert prompt_len > 16, "prompt must span multiple prefill chunks"
+        prompt_logprobs = output.prompt_logprobs
+        assert prompt_logprobs is not None
+        assert len(prompt_logprobs) == prompt_len
+        assert prompt_logprobs[0] is None
+        for position, (token_id, entry) in enumerate(
+            zip(output.prompt_token_ids[1:], prompt_logprobs[1:], strict=True), 1
+        ):
+            assert entry is not None, f"position {position} silently empty"
+            assert token_id in entry, f"prompt token missing at {position}"
+            assert entry[token_id].logprob <= 0.0

--- a/tests/test_prompt_logprobs.py
+++ b/tests/test_prompt_logprobs.py
@@ -168,7 +168,6 @@ class TestPromptLogprobsTracker:
             start_pos=0,
             num_tokens=3,
             chunk_logits=full_rows[0:3],
-            num_logprobs=1,
             logprobs_mode="raw_logprobs",
         )
         assert first is None
@@ -179,7 +178,6 @@ class TestPromptLogprobsTracker:
             start_pos=3,
             num_tokens=3,
             chunk_logits=full_rows[3:6],
-            num_logprobs=1,
             logprobs_mode="raw_logprobs",
         )
         assert final is not None
@@ -201,6 +199,7 @@ class TestPromptLogprobsTracker:
         from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
 
         tracker = PromptLogprobsTracker()
+        tracker.register("req-b", 0)
         prompt = [2, 0, 1]
         rows = mx.array(
             [[0.0, 1.0, 2.0], [2.0, 0.0, 1.0], [1.0, 2.0, 0.0]], dtype=mx.float32
@@ -212,7 +211,6 @@ class TestPromptLogprobsTracker:
             start_pos=0,
             num_tokens=3,
             chunk_logits=rows,
-            num_logprobs=0,
             logprobs_mode="raw_logprobs",
         )
 
@@ -225,13 +223,13 @@ class TestPromptLogprobsTracker:
         from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
 
         tracker = PromptLogprobsTracker()
+        tracker.register("req-c", 2)
         tensors = tracker.observe_chunk(
             "req-c",
             prompt_token_ids=[5],
             start_pos=0,
             num_tokens=1,
             chunk_logits=mx.zeros((1, 8)),
-            num_logprobs=2,
             logprobs_mode="raw_logprobs",
         )
 
@@ -242,6 +240,7 @@ class TestPromptLogprobsTracker:
         from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
 
         tracker = PromptLogprobsTracker()
+        tracker.register("req-d", 1)
         with pytest.raises(ValueError, match=r"\(3, vocab\)"):
             tracker.observe_chunk(
                 "req-d",
@@ -249,7 +248,6 @@ class TestPromptLogprobsTracker:
                 start_pos=0,
                 num_tokens=3,
                 chunk_logits=mx.zeros((2, 8)),
-                num_logprobs=1,
                 logprobs_mode="raw_logprobs",
             )
 
@@ -264,7 +262,6 @@ class TestPromptLogprobsTracker:
             start_pos=0,
             num_tokens=2,
             chunk_logits=mx.zeros((2, 8)),
-            num_logprobs=1,
             logprobs_mode="raw_logprobs",
         )
         assert "req-e" in tracker._in_progress

--- a/tests/test_prompt_logprobs.py
+++ b/tests/test_prompt_logprobs.py
@@ -84,6 +84,27 @@ class TestGatherPromptLogprobs:
         assert tensors.logprob_token_ids.tolist() == [[2]]
         assert tensors.selected_token_ranks.tolist() == [2]
 
+    def test_full_vocab_count_keeps_every_token(self) -> None:
+        logits = mx.array([[0.0, 1.0, 2.0]], dtype=mx.float32)
+
+        tensors = gather_prompt_logprobs(logits, [2], num_logprobs=3)
+
+        assert tensors.logprob_token_ids.shape == (1, 4)
+        assert tensors.logprob_token_ids[0, 0].item() == 2
+        assert sorted(tensors.logprob_token_ids[0, 1:].tolist()) == [0, 1, 2]
+
+    def test_raw_logits_mode_returns_logits_not_logprobs(self) -> None:
+        logits = mx.array([[0.0, 1.0, 2.0]], dtype=mx.float32)
+
+        tensors = gather_prompt_logprobs(
+            logits,
+            [2],
+            num_logprobs=1,
+            logprobs_mode="raw_logits",
+        )
+
+        assert tensors.logprobs[0, 0].item() == pytest.approx(2.0)
+
     def test_rejects_row_count_mismatch(self) -> None:
         with pytest.raises(ValueError, match="num_targets, vocab"):
             gather_prompt_logprobs(mx.zeros((2, 4)), [1], num_logprobs=1)
@@ -140,6 +161,7 @@ class TestPromptLogprobsTracker:
             len(prompt), vocab
         ) * mx.array([0.1])
 
+        tracker.register("req-a", 1)
         first = tracker.observe_chunk(
             "req-a",
             prompt_token_ids=prompt,
@@ -147,6 +169,7 @@ class TestPromptLogprobsTracker:
             num_tokens=3,
             chunk_logits=full_rows[0:3],
             num_logprobs=1,
+            logprobs_mode="raw_logprobs",
         )
         assert first is None
 
@@ -157,6 +180,7 @@ class TestPromptLogprobsTracker:
             num_tokens=3,
             chunk_logits=full_rows[3:6],
             num_logprobs=1,
+            logprobs_mode="raw_logprobs",
         )
         assert final is not None
         # One row per scored prompt position, column 0 is the prompt token.
@@ -168,7 +192,9 @@ class TestPromptLogprobsTracker:
         assert final.selected_token_ranks.tolist() == (
             expected.selected_token_ranks.tolist()
         )
-        # Delivery clears the in-progress slot.
+        # Delivery clears all lifecycle state so decode preemption cannot
+        # re-emit prompt logprobs for the same request.
+        assert not tracker.wants("req-a")
         assert tracker._in_progress == {}
 
     def test_single_chunk_prompt_completes_immediately(self) -> None:
@@ -187,6 +213,7 @@ class TestPromptLogprobsTracker:
             num_tokens=3,
             chunk_logits=rows,
             num_logprobs=0,
+            logprobs_mode="raw_logprobs",
         )
 
         assert tensors is not None
@@ -205,6 +232,7 @@ class TestPromptLogprobsTracker:
             num_tokens=1,
             chunk_logits=mx.zeros((1, 8)),
             num_logprobs=2,
+            logprobs_mode="raw_logprobs",
         )
 
         assert tensors is not None
@@ -222,12 +250,14 @@ class TestPromptLogprobsTracker:
                 num_tokens=3,
                 chunk_logits=mx.zeros((2, 8)),
                 num_logprobs=1,
+                logprobs_mode="raw_logprobs",
             )
 
     def test_discard_drops_in_progress_state(self) -> None:
         from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
 
         tracker = PromptLogprobsTracker()
+        tracker.register("req-e", 1)
         tracker.observe_chunk(
             "req-e",
             prompt_token_ids=[1, 2, 3, 4],
@@ -235,21 +265,25 @@ class TestPromptLogprobsTracker:
             num_tokens=2,
             chunk_logits=mx.zeros((2, 8)),
             num_logprobs=1,
+            logprobs_mode="raw_logprobs",
         )
         assert "req-e" in tracker._in_progress
+        assert tracker.wants("req-e")
 
         tracker.discard({"req-e", "never-seen"})
 
+        assert not tracker.wants("req-e")
         assert tracker._in_progress == {}
 
     def test_wants(self) -> None:
-        from vllm.sampling_params import SamplingParams
-
         from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
 
-        assert PromptLogprobsTracker.wants(SamplingParams(prompt_logprobs=1))
-        assert not PromptLogprobsTracker.wants(SamplingParams())
-        assert not PromptLogprobsTracker.wants(None)
+        tracker = PromptLogprobsTracker()
+
+        tracker.register("req", 1)
+
+        assert tracker.wants("req")
+        assert not tracker.wants("other")
 
 
 class TestFullPromptLogprobs:
@@ -267,7 +301,12 @@ class TestFullPromptLogprobs:
             dtype=mx.float32,
         )
 
-        tensors = full_prompt_logprobs(rows, prompt, num_logprobs=2)
+        tensors = full_prompt_logprobs(
+            rows,
+            prompt,
+            num_logprobs=2,
+            logprobs_mode="raw_logprobs",
+        )
 
         assert tensors.logprob_token_ids.shape == (3, 3)
         assert tensors.logprob_token_ids[:, 0].tolist() == prompt[1:]
@@ -277,9 +316,36 @@ class TestFullPromptLogprobs:
     def test_one_token_prompt(self) -> None:
         from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
 
-        tensors = full_prompt_logprobs(mx.zeros((1, 4)), [7], num_logprobs=1)
+        tensors = full_prompt_logprobs(
+            mx.zeros((1, 4)),
+            [7],
+            num_logprobs=1,
+            logprobs_mode="raw_logprobs",
+        )
 
         assert tensors.logprob_token_ids.shape == (0, 2)
+
+    def test_minus_one_resolves_to_full_vocab(self) -> None:
+        from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
+
+        rows = mx.array(
+            [
+                [0.0, 1.0, 2.0],
+                [2.0, 0.0, 1.0],
+                [9.0, 9.0, 9.0],
+            ],
+            dtype=mx.float32,
+        )
+
+        tensors = full_prompt_logprobs(
+            rows,
+            [0, 1, 2],
+            num_logprobs=-1,
+            logprobs_mode="raw_logprobs",
+        )
+
+        assert tensors.logprob_token_ids.shape == (2, 4)
+        assert sorted(tensors.logprob_token_ids[0, 1:].tolist()) == [0, 1, 2]
 
 
 class TestRunnerWiring:
@@ -354,6 +420,7 @@ class TestRunnerWiring:
         prompt = [3, 1, 4, 1, 5, 9]
         vocab = 16
         params = SamplingParams(temperature=0, prompt_logprobs=1)
+        runner._prompt_logprobs_tracker.register("req-p", 1)
 
         def _prefill(start: int, end: int, prompt_len: int | None):
             return mr.PrefillRequest(
@@ -382,6 +449,16 @@ class TestRunnerWiring:
         assert tensors.logprob_token_ids.shape == (len(prompt) - 1, 2)
         assert tensors.logprob_token_ids[:, 0].tolist() == prompt[1:]
 
+        replay = mr._ExecutionBatch()
+        runner._gather_prefill_prompt_logprobs(
+            replay,
+            [_prefill(0, len(prompt), len(prompt))],
+            mx.zeros((1, len(prompt), vocab)),
+            [0, len(prompt)],
+            0,
+        )
+        assert replay.prompt_logprobs_dict == {}
+
     def test_paged_gather_rejects_pruned_segment_rows(self) -> None:
         from vllm.sampling_params import SamplingParams
 
@@ -400,6 +477,7 @@ class TestRunnerWiring:
             full_prompt_token_ids=prompt,
         )
         batch = mr._ExecutionBatch()
+        runner._prompt_logprobs_tracker.register("req-q", 1)
 
         # A selective-logits layout would leave one row per prefill segment.
         with pytest.raises(RuntimeError, match="selective-logits"):
@@ -424,6 +502,7 @@ class TestRunnerWiring:
             full_prompt_token_ids=None,
         )
         batch = mr._ExecutionBatch()
+        runner._prompt_logprobs_tracker.register("req-r", 1)
 
         with pytest.raises(RuntimeError, match="full prompt"):
             runner._gather_prefill_prompt_logprobs(

--- a/tests/test_prompt_logprobs.py
+++ b/tests/test_prompt_logprobs.py
@@ -84,15 +84,6 @@ class TestGatherPromptLogprobs:
         assert tensors.logprob_token_ids.tolist() == [[2]]
         assert tensors.selected_token_ranks.tolist() == [2]
 
-    def test_full_vocab_count_keeps_every_token(self) -> None:
-        logits = mx.array([[0.0, 1.0, 2.0]], dtype=mx.float32)
-
-        tensors = gather_prompt_logprobs(logits, [2], num_logprobs=3)
-
-        assert tensors.logprob_token_ids.shape == (1, 4)
-        assert tensors.logprob_token_ids[0, 0].item() == 2
-        assert sorted(tensors.logprob_token_ids[0, 1:].tolist()) == [0, 1, 2]
-
     def test_raw_logits_mode_returns_logits_not_logprobs(self) -> None:
         logits = mx.array([[0.0, 1.0, 2.0]], dtype=mx.float32)
 

--- a/tests/test_prompt_logprobs.py
+++ b/tests/test_prompt_logprobs.py
@@ -10,7 +10,9 @@ import torch
 
 from vllm_metal.v1.prompt_logprobs import (
     PromptLogprobsAccumulator,
+    PromptLogprobsTracker,
     PromptLogprobsWindow,
+    full_prompt_logprobs,
     gather_prompt_logprobs,
     prompt_logprobs_window,
 )
@@ -96,10 +98,6 @@ class TestGatherPromptLogprobs:
 
         assert tensors.logprobs[0, 0].item() == pytest.approx(2.0)
 
-    def test_rejects_row_count_mismatch(self) -> None:
-        with pytest.raises(ValueError, match="num_targets, vocab"):
-            gather_prompt_logprobs(mx.zeros((2, 4)), [1], num_logprobs=1)
-
 
 class TestPromptLogprobsAccumulator:
     def test_chunks_fill_disjoint_positions_of_one_tensor_set(self) -> None:
@@ -122,29 +120,9 @@ class TestPromptLogprobsAccumulator:
             first.selected_token_ranks.tolist() + second.selected_token_ranks.tolist()
         )
 
-    def test_rejects_chunk_that_does_not_match_its_window(self) -> None:
-        acc = PromptLogprobsAccumulator(prompt_len=4, num_logprobs=1)
-        chunk = gather_prompt_logprobs(mx.array([[0.0, 1.0]]), [1], num_logprobs=1)
-
-        with pytest.raises(ValueError, match="window expects 2"):
-            acc.fill(
-                prompt_logprobs_window(start_pos=0, num_tokens=2, prompt_len=4), chunk
-            )
-
-    def test_rejects_window_past_the_prompt(self) -> None:
-        acc = PromptLogprobsAccumulator(prompt_len=3, num_logprobs=0)
-        chunk = gather_prompt_logprobs(mx.array([[0.0, 1.0], [1.0, 0.0]]), [1, 0], 0)
-
-        with pytest.raises(ValueError, match="exceeds"):
-            acc.fill(
-                PromptLogprobsWindow(start_pos=1, num_logits=2, completes=True), chunk
-            )
-
 
 class TestPromptLogprobsTracker:
     def test_delivers_only_on_the_completing_chunk(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
-
         tracker = PromptLogprobsTracker()
         prompt = [3, 1, 0, 2, 1, 0]
         vocab = 4
@@ -184,11 +162,9 @@ class TestPromptLogprobsTracker:
         # Delivery clears all lifecycle state so decode preemption cannot
         # re-emit prompt logprobs for the same request.
         assert not tracker.wants("req-a")
-        assert tracker._in_progress == {}
+        assert not tracker.wants_any(["req-a"])
 
     def test_single_chunk_prompt_completes_immediately(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
-
         tracker = PromptLogprobsTracker()
         tracker.register("req-b", 0)
         prompt = [2, 0, 1]
@@ -211,8 +187,6 @@ class TestPromptLogprobsTracker:
         assert tensors.logprob_token_ids[:, 0].tolist() == prompt[1:]
 
     def test_one_token_prompt_delivers_empty_tensors(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
-
         tracker = PromptLogprobsTracker()
         tracker.register("req-c", 2)
         tensors = tracker.observe_chunk(
@@ -227,24 +201,7 @@ class TestPromptLogprobsTracker:
         assert tensors is not None
         assert tensors.logprob_token_ids.shape == (0, 3)
 
-    def test_rejects_row_count_mismatch(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
-
-        tracker = PromptLogprobsTracker()
-        tracker.register("req-d", 1)
-        with pytest.raises(ValueError, match=r"\(3, vocab\)"):
-            tracker.observe_chunk(
-                "req-d",
-                prompt_token_ids=[1, 2, 3, 4],
-                start_pos=0,
-                num_tokens=3,
-                chunk_logits=mx.zeros((2, 8)),
-                logprobs_mode="raw_logprobs",
-            )
-
     def test_discard_drops_in_progress_state(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
-
         tracker = PromptLogprobsTracker()
         tracker.register("req-e", 1)
         tracker.observe_chunk(
@@ -255,29 +212,28 @@ class TestPromptLogprobsTracker:
             chunk_logits=mx.zeros((2, 8)),
             logprobs_mode="raw_logprobs",
         )
-        assert "req-e" in tracker._in_progress
         assert tracker.wants("req-e")
 
         tracker.discard({"req-e", "never-seen"})
 
         assert not tracker.wants("req-e")
-        assert tracker._in_progress == {}
 
-    def test_wants(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import PromptLogprobsTracker
+        tracker.register("req-e", 0)
+        tensors = tracker.observe_chunk(
+            "req-e",
+            prompt_token_ids=[1, 2],
+            start_pos=0,
+            num_tokens=2,
+            chunk_logits=mx.zeros((2, 8)),
+            logprobs_mode="raw_logprobs",
+        )
 
-        tracker = PromptLogprobsTracker()
-
-        tracker.register("req", 1)
-
-        assert tracker.wants("req")
-        assert not tracker.wants("other")
+        assert tensors is not None
+        assert tensors.logprob_token_ids.shape == (1, 1)
 
 
 class TestFullPromptLogprobs:
     def test_matches_chunked_gather(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
-
         prompt = [0, 2, 1, 3]
         rows = mx.array(
             [
@@ -302,8 +258,6 @@ class TestFullPromptLogprobs:
         torch.testing.assert_close(tensors.logprobs, expected.logprobs)
 
     def test_one_token_prompt(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
-
         tensors = full_prompt_logprobs(
             mx.zeros((1, 4)),
             [7],
@@ -314,8 +268,6 @@ class TestFullPromptLogprobs:
         assert tensors.logprob_token_ids.shape == (0, 2)
 
     def test_minus_one_resolves_to_full_vocab(self) -> None:
-        from vllm_metal.v1.prompt_logprobs import full_prompt_logprobs
-
         rows = mx.array(
             [
                 [0.0, 1.0, 2.0],
@@ -339,7 +291,7 @@ class TestFullPromptLogprobs:
 class TestRunnerWiring:
     """The two #680 symptoms, pinned at the runner seams.
 
-    ``prompt_logprobs_dict`` was hardcoded ``{}`` in ``_build_output`` and
+    ``prompt_logprobs_dict`` was hardcoded ``{}`` in the output builder and
     nothing ever produced tensors, so ``echo+logprobs`` 500'd (the API layer
     indexed a generated-token dict with a prompt token id) and bare
     ``prompt_logprobs`` returned ``[None]`` silently.
@@ -350,7 +302,7 @@ class TestRunnerWiring:
 
         return make_stub_runner(num_kv_heads=2)
 
-    def test_build_output_carries_prompt_logprobs_dict(self) -> None:
+    def test_batch_output_carries_prompt_logprobs_dict(self) -> None:
         import vllm_metal.v1.model_runner as mr
 
         batch = mr._ExecutionBatch()
@@ -358,7 +310,7 @@ class TestRunnerWiring:
         tensors = gather_prompt_logprobs(mx.zeros((1, 8)), [3], num_logprobs=1)
         batch.prompt_logprobs_dict["req-0"] = tensors
 
-        output = mr.MetalModelRunner._build_output(batch)
+        output = batch.to_model_runner_output()
 
         assert output.prompt_logprobs_dict == {"req-0": tensors}
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -852,7 +852,7 @@ class TestV1SamplingBatch:
             ),
         )
 
-        output = MetalModelRunner._build_output(batch)
+        output = batch.to_model_runner_output()
 
         assert output.logprobs is not None
         assert output.logprobs.logprob_token_ids.shape == (2, 3)

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2071,18 +2071,19 @@ class TestV1MetalModelRunnerGDNLifecycle:
             mx.full((1, 1, 4, 32), 9, dtype=mx.float32),
         )
 
-        expected_output = object()
+        batch = mr._ExecutionBatch()
+        batch.add_output("done", [1])
         monkeypatch.setattr(
             runner,
             "_sample_paged_batch",
-            lambda grammar_output: (mr._ExecutionBatch(), object()),
+            lambda grammar_output: (batch, object()),
         )
         monkeypatch.setattr(runner, "_validate_scheduled_outputs", lambda *args: None)
-        monkeypatch.setattr(runner, "_build_output", lambda batch: expected_output)
 
         output = runner.sample_tokens(None)
 
-        assert output is expected_output
+        assert isinstance(output, ModelRunnerOutput)
+        assert output.req_ids == ["done"]
         assert not cache.has_pending_conv_state(0)
         assert not cache.has_pending_recurrent_state(0)
         mx.eval(cache.conv_states[0], cache.recurrent_states[0])

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2629,9 +2629,10 @@ class TestPipelineGateSpecDecodeDerivation:
         )
 
     def test_prompt_logprobs_request_disables_pipeline(self) -> None:
-        # Arrange — a decode-phase request asking for prompt logprobs must
-        # keep the synchronous sample path (logprobs need eager logits).
+        # Arrange — an active prompt-logprobs request must keep the synchronous
+        # sample path until the prompt scores are delivered.
         runner = self._runner(drafter=None)
+        runner._prompt_logprobs_tracker.register("r0", 5)
         runner._request_states = {
             "r0": mr.RequestState(
                 token_ids=[1, 7],

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1100,6 +1100,7 @@ class MetalModelRunner:
                 logits[0],
                 token_ids,
                 sampling_params.prompt_logprobs,
+                logprobs_mode=self.model_config.logprobs_mode,
             )
 
         # Extract last token logits
@@ -1466,7 +1467,7 @@ class MetalModelRunner:
                 # projection-free intermediate forward (no logits at all) and
                 # the selective layout (last prefill row only).
                 needs_prompt_logprob_rows = any(
-                    PromptLogprobsTracker.wants(pr.sampling_params)
+                    self._prompt_logprobs_tracker.wants(pr.req_id)
                     for pr in prefill_reqs
                 )
                 if (
@@ -1614,7 +1615,7 @@ class MetalModelRunner:
                 and SamplingBatch.params_allow_native_random(decode_params)
             ),
             has_prompt_logprobs=any(
-                sp.prompt_logprobs is not None for sp in decode_params
+                self._prompt_logprobs_tracker.wants(req_id) for req_id in decode_req_ids
             ),
         )
         return self._decode_pipeline.evaluate_gate(capabilities, step, sampling)
@@ -1939,10 +1940,9 @@ class MetalModelRunner:
         (``ModelRunnerOutput.prompt_logprobs_dict``).
         """
         for i, prefill in enumerate(prefill_reqs):
-            if not PromptLogprobsTracker.wants(prefill.sampling_params):
+            if not self._prompt_logprobs_tracker.wants(prefill.req_id):
                 continue
-            num_logprobs = prefill.sampling_params.prompt_logprobs
-            assert num_logprobs is not None
+            num_logprobs = self._prompt_logprobs_tracker.num_logprobs(prefill.req_id)
             if logits is None:
                 raise RuntimeError(
                     "Prompt logprobs requested but the forward produced no "
@@ -1970,6 +1970,7 @@ class MetalModelRunner:
                 num_tokens=len(prefill.token_ids),
                 chunk_logits=logits[0, seg_start:seg_end, :],
                 num_logprobs=num_logprobs,
+                logprobs_mode=self.model_config.logprobs_mode,
             )
             if tensors is not None:
                 batch.prompt_logprobs_dict[prefill.req_id] = tensors
@@ -2392,6 +2393,10 @@ class MetalModelRunner:
             generator = _create_request_generator(sampling_params)
 
             if self._paged_attention_runtime is not None:
+                if sampling_params.prompt_logprobs is not None:
+                    self._prompt_logprobs_tracker.register(
+                        req_id, sampling_params.prompt_logprobs
+                    )
                 sched_block_ids = self._copy_paged_block_ids(new_req.block_ids)
                 if self._paged_state_group_indices:
                     self._state_block_ids_by_req[req_id] = self._copy_state_block_ids(
@@ -2625,7 +2630,7 @@ class MetalModelRunner:
             needs_full_prompt = (
                 prefill.start_pos > 0
                 or self._is_mm_request(prefill.req_id)
-                or PromptLogprobsTracker.wants(prefill.sampling_params)
+                or self._prompt_logprobs_tracker.wants(prefill.req_id)
             )
             if needs_full_prompt:
                 state = self._request_states.get(prefill.req_id)

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1942,7 +1942,6 @@ class MetalModelRunner:
         for i, prefill in enumerate(prefill_reqs):
             if not self._prompt_logprobs_tracker.wants(prefill.req_id):
                 continue
-            num_logprobs = self._prompt_logprobs_tracker.num_logprobs(prefill.req_id)
             if logits is None:
                 raise RuntimeError(
                     "Prompt logprobs requested but the forward produced no "
@@ -1969,7 +1968,6 @@ class MetalModelRunner:
                 start_pos=prefill.start_pos,
                 num_tokens=len(prefill.token_ids),
                 chunk_logits=logits[0, seg_start:seg_end, :],
-                num_logprobs=num_logprobs,
                 logprobs_mode=self.model_config.logprobs_mode,
             )
             if tensors is not None:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -39,6 +39,7 @@ from vllm.v1.outputs import (
     AsyncModelRunnerOutput,
     DraftTokenIds,
     LogprobsLists,
+    LogprobsTensors,
     ModelRunnerOutput,
 )
 from vllm.v1.sample.logits_processor import LOGITSPROCS_GROUP
@@ -105,6 +106,10 @@ from vllm_metal.v1.pooling.contract import (
     ExecutablePoolingBackend,
 )
 from vllm_metal.v1.pooling.validation import validate_pooling_request
+from vllm_metal.v1.prompt_logprobs import (
+    PromptLogprobsTracker,
+    full_prompt_logprobs,
+)
 from vllm_metal.v1.proposer import (
     Gemma4MTPProposer,
     MetalProposer,
@@ -233,6 +238,9 @@ class _ExecutionBatch:
     paged_prefill_entries: list[_PendingPrefillEntry] = field(default_factory=list)
     paged_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
     valid_decode_reqs: list[tuple[str, RequestState]] = field(default_factory=list)
+    # Completed prompt-logprobs tensors, delivered on the step that finishes
+    # each requesting prompt (the vLLM v1 ``prompt_logprobs_dict`` contract).
+    prompt_logprobs_dict: dict[str, LogprobsTensors] = field(default_factory=dict)
 
     def add_output(
         self,
@@ -454,6 +462,10 @@ class MetalModelRunner:
 
         # Structured-output bitmask applier for the paged path.
         self._structured_output_applier = MetalStructuredOutputApplier()
+
+        # Per-request prompt-logprobs accumulation across prefill chunks
+        # (populated only for requests whose SamplingParams ask for it).
+        self._prompt_logprobs_tracker = PromptLogprobsTracker()
 
         # One-step-ahead decode pipelining (owner: decode_pipeline.py).
         # Gate-eligible pure-decode greedy steps defer the sampling sync one
@@ -1062,7 +1074,7 @@ class MetalModelRunner:
         token_ids: list[int],
         sampling_params: SamplingParams,
         generator: torch.Generator | None = None,
-    ) -> tuple[int, list[KVCache], LogprobsLists | None]:
+    ) -> tuple[int, list[KVCache], LogprobsLists | None, LogprobsTensors | None]:
         """Process a single prefill request.
 
         Args:
@@ -1070,7 +1082,7 @@ class MetalModelRunner:
             sampling_params: Sampling parameters for this request
 
         Returns:
-            Tuple of (next_token, cache)
+            Tuple of (next_token, cache, sample logprobs, prompt logprobs)
         """
         cache: list[KVCache] = make_prompt_cache(self._forward_model)
 
@@ -1078,6 +1090,17 @@ class MetalModelRunner:
         model_output = self._forward_model(input_ids, cache=cache)
 
         logits = self._extract_logits(model_output)
+
+        # The non-paged path forwards the whole prompt in one chunk, so the
+        # packed rows cover every prompt position and one gather fulfills the
+        # engine's prompt-logprobs contract.
+        prompt_logprobs: LogprobsTensors | None = None
+        if sampling_params.prompt_logprobs is not None:
+            prompt_logprobs = full_prompt_logprobs(
+                logits[0],
+                token_ids,
+                sampling_params.prompt_logprobs,
+            )
 
         # Extract last token logits
         last_logits = logits[:, -1, :]
@@ -1095,7 +1118,7 @@ class MetalModelRunner:
         [next_token] = result.token_ids
         mx.eval(*[c.state for c in cache])
 
-        return next_token, cache, result.logprobs
+        return next_token, cache, result.logprobs, prompt_logprobs
 
     def _batched_decode(
         self, decode_reqs: list[tuple[str, RequestState]]
@@ -1438,17 +1461,30 @@ class MetalModelRunner:
                     and all(pr.prompt_len is None for pr in prefill_reqs)
                     and self._drafter is None
                 )
-                if intermediate_only and self._intermediate_forward_supported:
+                # Prompt-logprobs requests need a logits row for every prompt
+                # position, so their steps skip both head-pruning paths: the
+                # projection-free intermediate forward (no logits at all) and
+                # the selective layout (last prefill row only).
+                needs_prompt_logprob_rows = any(
+                    PromptLogprobsTracker.wants(pr.sampling_params)
+                    for pr in prefill_reqs
+                )
+                if (
+                    intermediate_only
+                    and self._intermediate_forward_supported
+                    and not needs_prompt_logprob_rows
+                ):
                     intermediate_hidden = self._model_adapter.intermediate_forward(
                         self._forward_model, input_ids, cache=offset_caches
                     ).hidden_states
                     logits = None
                     target_hidden_states = None
                 else:
-                    logits_layout = self._paged_logits_layout(
-                        cu_seqlens,
-                        num_decode_segments=len(decode_segments),
-                    )
+                    if not needs_prompt_logprob_rows:
+                        logits_layout = self._paged_logits_layout(
+                            cu_seqlens,
+                            num_decode_segments=len(decode_segments),
+                        )
                     target_output = self._target_forward(
                         input_ids,
                         cache=offset_caches,
@@ -1661,6 +1697,13 @@ class MetalModelRunner:
                     "Intermediate-only step has rows that must sample — "
                     "routing desynced."
                 )
+            self._gather_prefill_prompt_logprobs(
+                batch,
+                prefill_reqs,
+                logits,
+                logits_cu_seqlens,
+                num_decode_segments,
+            )
             for pr in prefill_reqs:
                 self._paged_request_seq_lens[pr.req_id] = pr.start_pos + len(
                     pr.token_ids
@@ -1793,6 +1836,15 @@ class MetalModelRunner:
         for pr in prefill_reqs:
             self._paged_request_seq_lens[pr.req_id] = pr.start_pos + len(pr.token_ids)
 
+        # ---- prompt logprobs for requests that asked for them ----
+        self._gather_prefill_prompt_logprobs(
+            batch,
+            prefill_reqs,
+            logits,
+            logits_cu_seqlens,
+            num_decode_segments,
+        )
+
         # ---- postprocess: write results back into batch ----
         for i, entry in enumerate(batch.paged_prefill_entries):
             next_token = prefill_result.token_ids[i]
@@ -1870,6 +1922,57 @@ class MetalModelRunner:
         )
 
         return batch, scheduler_output
+
+    def _gather_prefill_prompt_logprobs(
+        self,
+        batch: _ExecutionBatch,
+        prefill_reqs: list[PrefillRequest],
+        logits: mx.array | None,
+        logits_cu_seqlens: list[int],
+        num_decode_segments: int,
+    ) -> None:
+        """Score this step's prefill chunks for prompt-logprobs requests.
+
+        Feeds each requesting chunk's logits rows to the tracker; a request's
+        completed tensors land in ``batch.prompt_logprobs_dict`` on the chunk
+        that finishes its prompt, which is the step the engine expects them
+        (``ModelRunnerOutput.prompt_logprobs_dict``).
+        """
+        for i, prefill in enumerate(prefill_reqs):
+            if not PromptLogprobsTracker.wants(prefill.sampling_params):
+                continue
+            num_logprobs = prefill.sampling_params.prompt_logprobs
+            assert num_logprobs is not None
+            if logits is None:
+                raise RuntimeError(
+                    "Prompt logprobs requested but the forward produced no "
+                    "logits — the intermediate-forward gate desynced."
+                )
+            full_prompt = prefill.full_prompt_token_ids
+            if full_prompt is None:
+                raise RuntimeError(
+                    f"Prompt logprobs requested for {prefill.req_id!r} but "
+                    "the prefill pack carries no full prompt — "
+                    "_build_prefill_pack gating desynced."
+                )
+            seg_start = logits_cu_seqlens[num_decode_segments + i]
+            seg_end = logits_cu_seqlens[num_decode_segments + i + 1]
+            if seg_end - seg_start != len(prefill.token_ids):
+                raise RuntimeError(
+                    "Prompt logprobs requested but the head projected only "
+                    f"{seg_end - seg_start} of {len(prefill.token_ids)} chunk "
+                    "rows — the selective-logits gate desynced."
+                )
+            tensors = self._prompt_logprobs_tracker.observe_chunk(
+                prefill.req_id,
+                prompt_token_ids=full_prompt,
+                start_pos=prefill.start_pos,
+                num_tokens=len(prefill.token_ids),
+                chunk_logits=logits[0, seg_start:seg_end, :],
+                num_logprobs=num_logprobs,
+            )
+            if tensors is not None:
+                batch.prompt_logprobs_dict[prefill.req_id] = tensors
 
     def _register_new_request_mm_features(
         self, req_id: str, new_req: NewRequestData
@@ -2338,12 +2441,14 @@ class MetalModelRunner:
                     )
                 continue
 
-            next_token, cache, logprobs = self._prefill_single(
+            next_token, cache, logprobs, prompt_logprobs = self._prefill_single(
                 token_ids,
                 sampling_params,
                 generator=generator,
             )
             batch.add_output(req_id, [next_token], logprobs)
+            if prompt_logprobs is not None:
+                batch.prompt_logprobs_dict[req_id] = prompt_logprobs
             self._request_states[req_id] = RequestState(
                 token_ids=list(token_ids) + [next_token],
                 prompt_len=len(token_ids),
@@ -2505,17 +2610,22 @@ class MetalModelRunner:
         Multimodal requests need it at every chunk including the first —
         ``adapter.get_mrope_input_positions`` must see the whole prompt
         to compute correct M-RoPE positions for image placeholders, then
-        a later commit slices the chunk-relevant range.  Both conditions
-        share the same two-source resolution (RequestState first, new_req
-        fallback) and the same contract-bug raises.
+        a later commit slices the chunk-relevant range.  Prompt-logprobs
+        requests need it at every chunk too: each chunk's last row scores
+        the first token of the *next* chunk, so the targets always reach
+        one past this chunk's own tokens.  All conditions share the same
+        two-source resolution (RequestState first, new_req fallback) and
+        the same contract-bug raises.
         """
         prefill_pack: list[PrefillRequest] = []
         for entry in batch.paged_prefill_entries:
             prefill = entry.prefill
             full_prompt = None
 
-            needs_full_prompt = prefill.start_pos > 0 or self._is_mm_request(
-                prefill.req_id
+            needs_full_prompt = (
+                prefill.start_pos > 0
+                or self._is_mm_request(prefill.req_id)
+                or PromptLogprobsTracker.wants(prefill.sampling_params)
             )
             if needs_full_prompt:
                 state = self._request_states.get(prefill.req_id)
@@ -2566,7 +2676,7 @@ class MetalModelRunner:
             req_id_to_index=batch.req_id_to_index,
             sampled_token_ids=batch.sampled_tokens,
             logprobs=batch.merged_logprobs(),
-            prompt_logprobs_dict={},
+            prompt_logprobs_dict=dict(batch.prompt_logprobs_dict),
             pooler_output=batch.pooler_outputs,
         )
 
@@ -2679,6 +2789,11 @@ class MetalModelRunner:
             # Block freeing is handled by the scheduler's kv_cache_manager.
             self._paged_request_seq_lens.pop(req_id, None)
             self._state_block_ids_by_req.pop(req_id, None)
+
+        # In-progress prompt-logprobs state survives preemption (a resumed
+        # request re-runs its prompt chunks over the same positions) and is
+        # dropped only when the engine finishes the request.
+        self._prompt_logprobs_tracker.discard(evicted_req_ids)
 
         invalidated = set(evicted_req_ids)
         if preempted_req_ids:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -278,6 +278,17 @@ class _ExecutionBatch:
         """Return whether this step has any paged execution work."""
         return bool(self.paged_prefill_entries or self.paged_decode_reqs)
 
+    def to_model_runner_output(self) -> ModelRunnerOutput:
+        """Build ``ModelRunnerOutput`` from this completed batch."""
+        return ModelRunnerOutput(
+            req_ids=self.req_ids,
+            req_id_to_index=self.req_id_to_index,
+            sampled_token_ids=self.sampled_tokens,
+            logprobs=self.merged_logprobs(),
+            prompt_logprobs_dict=dict(self.prompt_logprobs_dict),
+            pooler_output=self.pooler_outputs,
+        )
+
     def decoder_pooling_batch(
         self,
         cu_seqlens: list[int],
@@ -471,7 +482,7 @@ class MetalModelRunner:
         # Gate-eligible pure-decode greedy steps defer the sampling sync one
         # step so the next step's graph build overlaps the in-flight forward.
         self._decode_pipeline = DecodePipeline(
-            build_output=self._build_output,
+            build_output=_ExecutionBatch.to_model_runner_output,
             validate=self._validate_scheduled_outputs,
         )
 
@@ -1466,9 +1477,8 @@ class MetalModelRunner:
                 # position, so their steps skip both head-pruning paths: the
                 # projection-free intermediate forward (no logits at all) and
                 # the selective layout (last prefill row only).
-                needs_prompt_logprob_rows = any(
-                    self._prompt_logprobs_tracker.wants(pr.req_id)
-                    for pr in prefill_reqs
+                needs_prompt_logprob_rows = self._prompt_logprobs_tracker.wants_any(
+                    pr.req_id for pr in prefill_reqs
                 )
                 if (
                     intermediate_only
@@ -1614,9 +1624,7 @@ class MetalModelRunner:
                 and not states_missing
                 and SamplingBatch.params_allow_native_random(decode_params)
             ),
-            has_prompt_logprobs=any(
-                self._prompt_logprobs_tracker.wants(req_id) for req_id in decode_req_ids
-            ),
+            has_prompt_logprobs=self._prompt_logprobs_tracker.wants_any(decode_req_ids),
         )
         return self._decode_pipeline.evaluate_gate(capabilities, step, sampling)
 
@@ -2671,18 +2679,6 @@ class MetalModelRunner:
 
         return prefill_pack
 
-    @staticmethod
-    def _build_output(batch: _ExecutionBatch) -> ModelRunnerOutput:
-        """Build ``ModelRunnerOutput`` from a completed batch."""
-        return ModelRunnerOutput(
-            req_ids=batch.req_ids,
-            req_id_to_index=batch.req_id_to_index,
-            sampled_token_ids=batch.sampled_tokens,
-            logprobs=batch.merged_logprobs(),
-            prompt_logprobs_dict=dict(batch.prompt_logprobs_dict),
-            pooler_output=batch.pooler_outputs,
-        )
-
     def _run_encoder_pooling_batch(
         self,
         scheduler_output: SchedulerOutput,
@@ -2696,7 +2692,7 @@ class MetalModelRunner:
         ):
             batch.add_output(output.req_id, [], None, output.pooler_output)
         self._validate_scheduled_outputs(batch, scheduler_output)
-        return self._build_output(batch)
+        return batch.to_model_runner_output()
 
     def _run_non_paged_decode_batch(self, batch: _ExecutionBatch) -> None:
         """Run non-paged decode work."""
@@ -2928,7 +2924,7 @@ class MetalModelRunner:
                 if runtime is not None:
                     runtime.materialize_pending_state()
                 self._validate_scheduled_outputs(batch, scheduler_output)
-                return self._build_output(batch)
+                return batch.to_model_runner_output()
             return None
 
         # Defensive invariant: the vLLM scheduler sets has_structured_output_requests
@@ -2955,8 +2951,8 @@ class MetalModelRunner:
             runtime.materialize_pending_state()
         self._validate_scheduled_outputs(batch, scheduler_output)
         if not batch.req_ids:
-            return self._build_output(batch)
-        output = self._build_output(batch)
+            return batch.to_model_runner_output()
+        output = batch.to_model_runner_output()
         if self._is_pooling:
             return output
         self._pending_output = output
@@ -2998,7 +2994,7 @@ class MetalModelRunner:
             if runtime is not None:
                 runtime.materialize_pending_state()
             self._validate_scheduled_outputs(batch, scheduler_output)
-            return self._build_output(batch)
+            return batch.to_model_runner_output()
 
         # Non-paged path: return output built by execute_model
         if self._pending_output is not None:

--- a/vllm_metal/v1/prompt_logprobs.py
+++ b/vllm_metal/v1/prompt_logprobs.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt logprobs for the Metal runner.
+
+vLLM's ``SamplingParams.prompt_logprobs`` (and the OpenAI ``echo`` +
+``logprobs`` combination the server maps onto it) asks for the log
+probability the model assigns to each prompt token given its prefix, plus the
+top-k alternatives at that position.  The engine expects one
+``LogprobsTensors`` per request covering positions ``1 .. prompt_len - 1``,
+delivered on the step that finishes the prompt (``prompt_logprobs_dict`` in
+``ModelRunnerOutput``); chunked prefill fills it slice by slice.  This module
+holds the accounting and the tensor construction so the paged and non-paged
+runner paths share one contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import torch
+from vllm.v1.outputs import LogprobsTensors
+from vllm.v1.sample.sampler import Sampler
+
+from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+
+
+@dataclass(frozen=True, slots=True)
+class PromptLogprobsWindow:
+    """Which rows of one prefill chunk produce prompt logprobs.
+
+    The chunk forwards prompt positions ``[start_pos, start_pos + num_tokens)``.
+    The row at position ``p`` predicts prompt token ``p + 1``, so the first
+    ``num_logits`` rows of the chunk score prompt tokens
+    ``[start_pos + 1, start_pos + 1 + num_logits)``; the row that predicts the
+    first sampled token is not a prompt logprob.  ``completes`` is True when
+    this chunk reaches the end of the prompt, which is when the accumulated
+    tensors are handed to the engine.
+    """
+
+    start_pos: int
+    num_logits: int
+    completes: bool
+
+    @property
+    def first_target(self) -> int:
+        return self.start_pos + 1
+
+
+def prompt_logprobs_window(
+    *, start_pos: int, num_tokens: int, prompt_len: int
+) -> PromptLogprobsWindow:
+    """Mirror of vLLM's ``_get_prompt_logprobs_dict`` chunk accounting."""
+    num_remaining = prompt_len - (start_pos + 1)
+    if num_tokens <= num_remaining:
+        # A chunk with more prompt tokens to come; every row scores a prompt
+        # token.  The == case has nothing left to score afterwards but the
+        # engine still expects delivery on the completing step.
+        return PromptLogprobsWindow(start_pos, num_tokens, completes=False)
+    return PromptLogprobsWindow(start_pos, max(num_remaining, 0), completes=True)
+
+
+class PromptLogprobsAccumulator:
+    """Per-request ``LogprobsTensors`` filled one prefill chunk at a time."""
+
+    def __init__(self, *, prompt_len: int, num_logprobs: int) -> None:
+        if prompt_len < 1:
+            raise ValueError("prompt_len must be at least 1")
+        self.prompt_len = prompt_len
+        self.num_logprobs = num_logprobs
+        self.tensors = LogprobsTensors.empty_cpu(prompt_len - 1, num_logprobs + 1)
+
+    def fill(self, window: PromptLogprobsWindow, chunk: LogprobsTensors) -> None:
+        """Copy one chunk's rows into positions ``window.start_pos ...``."""
+        start = window.start_pos
+        end = start + window.num_logits
+        if chunk.logprob_token_ids.shape[0] != window.num_logits:
+            raise ValueError(
+                "prompt logprobs chunk has "
+                f"{chunk.logprob_token_ids.shape[0]} rows, window expects "
+                f"{window.num_logits}"
+            )
+        if end > self.prompt_len - 1:
+            raise ValueError(
+                f"prompt logprobs window [{start}, {end}) exceeds the "
+                f"{self.prompt_len - 1} scored prompt positions"
+            )
+        self.tensors.logprob_token_ids[start:end].copy_(chunk.logprob_token_ids)
+        self.tensors.logprobs[start:end].copy_(chunk.logprobs)
+        self.tensors.selected_token_ranks[start:end].copy_(chunk.selected_token_ranks)
+
+
+class PromptLogprobsTracker:
+    """In-progress prompt-logprobs accumulators keyed by request id.
+
+    One instance lives on the runner.  Every prefill chunk of a request whose
+    ``SamplingParams.prompt_logprobs`` is set is observed exactly once, with
+    the logits rows the model produced for that chunk; the tracker scores the
+    rows that target prompt tokens and returns the request's completed
+    ``LogprobsTensors`` on the chunk that finishes the prompt (``None``
+    before that).  State survives preemption on purpose — a resumed request
+    re-runs its prompt chunks and overwrites the same positions — and is
+    dropped via :meth:`discard` when the engine finishes the request.
+    """
+
+    def __init__(self) -> None:
+        self._in_progress: dict[str, PromptLogprobsAccumulator] = {}
+
+    @staticmethod
+    def wants(sampling_params: object) -> bool:
+        """Whether *sampling_params* asks for prompt logprobs."""
+        return getattr(sampling_params, "prompt_logprobs", None) is not None
+
+    def observe_chunk(
+        self,
+        req_id: str,
+        *,
+        prompt_token_ids: list[int],
+        start_pos: int,
+        num_tokens: int,
+        chunk_logits: mx.array,
+        num_logprobs: int,
+    ) -> LogprobsTensors | None:
+        """Score one prefill chunk's logits rows against the prompt.
+
+        ``chunk_logits`` holds one row per forwarded chunk position
+        (``num_tokens`` rows); only the leading ``window.num_logits`` rows
+        target prompt tokens and are scored.  Returns the completed tensors
+        when this chunk reaches the end of the prompt.
+        """
+        if chunk_logits.ndim != 2 or chunk_logits.shape[0] != num_tokens:
+            raise ValueError(
+                f"chunk_logits must be ({num_tokens}, vocab); got shape "
+                f"{tuple(chunk_logits.shape)}"
+            )
+        prompt_len = len(prompt_token_ids)
+        window = prompt_logprobs_window(
+            start_pos=start_pos, num_tokens=num_tokens, prompt_len=prompt_len
+        )
+        accumulator = self._in_progress.get(req_id)
+        if accumulator is None:
+            accumulator = PromptLogprobsAccumulator(
+                prompt_len=prompt_len, num_logprobs=num_logprobs
+            )
+            self._in_progress[req_id] = accumulator
+        if window.num_logits > 0:
+            targets = prompt_token_ids[
+                window.first_target : window.first_target + window.num_logits
+            ]
+            chunk = gather_prompt_logprobs(
+                chunk_logits[: window.num_logits],
+                targets,
+                accumulator.num_logprobs,
+            )
+            accumulator.fill(window, chunk)
+        if not window.completes:
+            return None
+        del self._in_progress[req_id]
+        return accumulator.tensors
+
+    def discard(self, req_ids: set[str] | list[str]) -> None:
+        """Drop in-progress state for finished or aborted requests."""
+        for req_id in req_ids:
+            self._in_progress.pop(req_id, None)
+
+
+def full_prompt_logprobs(
+    logits_rows: mx.array,
+    prompt_token_ids: list[int],
+    num_logprobs: int,
+) -> LogprobsTensors:
+    """One-shot prompt logprobs when the whole prompt ran in one forward.
+
+    ``logits_rows`` holds one row per prompt position (the non-paged path
+    forwards the full prompt in a single chunk); rows past the scored
+    positions — the last row predicts the first sampled token — are ignored.
+    """
+    prompt_len = len(prompt_token_ids)
+    window = prompt_logprobs_window(
+        start_pos=0, num_tokens=prompt_len, prompt_len=prompt_len
+    )
+    accumulator = PromptLogprobsAccumulator(
+        prompt_len=prompt_len, num_logprobs=num_logprobs
+    )
+    if window.num_logits > 0:
+        targets = prompt_token_ids[1 : 1 + window.num_logits]
+        chunk = gather_prompt_logprobs(
+            logits_rows[: window.num_logits], targets, num_logprobs
+        )
+        accumulator.fill(window, chunk)
+    return accumulator.tensors
+
+
+def gather_prompt_logprobs(
+    logits_rows: mx.array,
+    target_token_ids: list[int],
+    num_logprobs: int,
+) -> LogprobsTensors:
+    """Score ``target_token_ids`` against ``logits_rows`` (one row per target).
+
+    Uses vLLM's own ``Sampler.compute_logprobs`` / ``gather_logprobs`` so the
+    returned tensors carry the same layout as the sampled-token logprobs:
+    column 0 is the target token, the rest are the top-``num_logprobs``
+    alternatives, and ``selected_token_ranks`` holds the target's 1-based rank.
+    """
+    if logits_rows.ndim != 2 or logits_rows.shape[0] != len(target_token_ids):
+        raise ValueError(
+            "logits_rows must be (num_targets, vocab); got shape "
+            f"{tuple(logits_rows.shape)} for {len(target_token_ids)} targets"
+        )
+    mx.eval(logits_rows)
+    logits = mlx_to_torch(logits_rows.astype(mx.float32), device="cpu")
+    logprobs = Sampler.compute_logprobs(logits)
+    targets = torch.tensor(target_token_ids, dtype=torch.int64)
+    return Sampler.gather_logprobs(logprobs, num_logprobs, targets)

--- a/vllm_metal/v1/prompt_logprobs.py
+++ b/vllm_metal/v1/prompt_logprobs.py
@@ -1,19 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Prompt logprobs for the Metal runner.
-
-vLLM's ``SamplingParams.prompt_logprobs`` (and the OpenAI ``echo`` +
-``logprobs`` combination the server maps onto it) asks for the log
-probability the model assigns to each prompt token given its prefix, plus the
-top-k alternatives at that position.  The engine expects one
-``LogprobsTensors`` per request covering positions ``1 .. prompt_len - 1``,
-delivered on the step that finishes the prompt (``prompt_logprobs_dict`` in
-``ModelRunnerOutput``); chunked prefill fills it slice by slice.  This module
-holds the accounting and the tensor construction so the paged and non-paged
-runner paths share one contract.
-"""
+"""Prompt logprobs accounting and tensor construction for the Metal runner."""
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 import mlx.core as mx
@@ -75,17 +65,6 @@ class PromptLogprobsAccumulator:
         """Copy one chunk's rows into positions ``window.start_pos ...``."""
         start = window.start_pos
         end = start + window.num_logits
-        if chunk.logprob_token_ids.shape[0] != window.num_logits:
-            raise ValueError(
-                "prompt logprobs chunk has "
-                f"{chunk.logprob_token_ids.shape[0]} rows, window expects "
-                f"{window.num_logits}"
-            )
-        if end > self.prompt_len - 1:
-            raise ValueError(
-                f"prompt logprobs window [{start}, {end}) exceeds the "
-                f"{self.prompt_len - 1} scored prompt positions"
-            )
         self.tensors.logprob_token_ids[start:end].copy_(chunk.logprob_token_ids)
         self.tensors.logprobs[start:end].copy_(chunk.logprobs)
         self.tensors.selected_token_ranks[start:end].copy_(chunk.selected_token_ranks)
@@ -112,6 +91,10 @@ class PromptLogprobsTracker:
         """Whether *req_id* still needs prompt logprobs."""
         return req_id in self._active
 
+    def wants_any(self, req_ids: Iterable[str]) -> bool:
+        """Whether any request still needs prompt logprobs."""
+        return any(req_id in self._active for req_id in req_ids)
+
     def observe_chunk(
         self,
         req_id: str,
@@ -128,11 +111,6 @@ class PromptLogprobsTracker:
         target prompt tokens and are scored.  Returns the completed tensors
         when this chunk reaches the end of the prompt.
         """
-        if chunk_logits.ndim != 2 or chunk_logits.shape[0] != num_tokens:
-            raise ValueError(
-                f"chunk_logits must be ({num_tokens}, vocab); got shape "
-                f"{tuple(chunk_logits.shape)}"
-            )
         prompt_len = len(prompt_token_ids)
         window = prompt_logprobs_window(
             start_pos=start_pos, num_tokens=num_tokens, prompt_len=prompt_len

--- a/vllm_metal/v1/prompt_logprobs.py
+++ b/vllm_metal/v1/prompt_logprobs.py
@@ -49,7 +49,7 @@ class PromptLogprobsWindow:
 
 
 def prompt_logprobs_window(
-    *, start_pos: int, num_tokens: int, prompt_len: int
+    start_pos: int, num_tokens: int, prompt_len: int
 ) -> PromptLogprobsWindow:
     """Mirror of vLLM's ``_get_prompt_logprobs_dict`` chunk accounting."""
     num_remaining = prompt_len - (start_pos + 1)
@@ -115,7 +115,6 @@ class PromptLogprobsTracker:
     def observe_chunk(
         self,
         req_id: str,
-        *,
         prompt_token_ids: list[int],
         start_pos: int,
         num_tokens: int,
@@ -175,7 +174,6 @@ def full_prompt_logprobs(
     logits_rows: mx.array,
     prompt_token_ids: list[int],
     num_logprobs: int,
-    *,
     logprobs_mode: str,
 ) -> LogprobsTensors:
     """One-shot prompt logprobs when the whole prompt ran in one forward.
@@ -212,7 +210,6 @@ def gather_prompt_logprobs(
     logits_rows: mx.array,
     target_token_ids: list[int],
     num_logprobs: int,
-    *,
     logprobs_mode: str = "raw_logprobs",
 ) -> LogprobsTensors:
     """Score ``target_token_ids`` against ``logits_rows`` (one row per target).

--- a/vllm_metal/v1/prompt_logprobs.py
+++ b/vllm_metal/v1/prompt_logprobs.py
@@ -23,6 +23,8 @@ from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
 
+_LOGITS_LOGPROBS_MODES = ("raw_logits", "processed_logits")
+
 
 @dataclass(frozen=True, slots=True)
 class PromptLogprobsWindow:
@@ -90,25 +92,29 @@ class PromptLogprobsAccumulator:
 
 
 class PromptLogprobsTracker:
-    """In-progress prompt-logprobs accumulators keyed by request id.
+    """Active prompt-logprobs requests keyed by request id.
 
-    One instance lives on the runner.  Every prefill chunk of a request whose
-    ``SamplingParams.prompt_logprobs`` is set is observed exactly once, with
-    the logits rows the model produced for that chunk; the tracker scores the
-    rows that target prompt tokens and returns the request's completed
-    ``LogprobsTensors`` on the chunk that finishes the prompt (``None``
-    before that).  State survives preemption on purpose — a resumed request
-    re-runs its prompt chunks and overwrites the same positions — and is
-    dropped via :meth:`discard` when the engine finishes the request.
+    ``SamplingParams.prompt_logprobs`` stays on the request for its full
+    lifetime, but vLLM expects prompt logprobs exactly once.  The runner
+    registers each new request here, clears it after delivery, and keeps
+    in-progress chunks across prompt-stage preemption.
     """
 
     def __init__(self) -> None:
+        self._active: dict[str, int] = {}
         self._in_progress: dict[str, PromptLogprobsAccumulator] = {}
 
-    @staticmethod
-    def wants(sampling_params: object) -> bool:
-        """Whether *sampling_params* asks for prompt logprobs."""
-        return getattr(sampling_params, "prompt_logprobs", None) is not None
+    def register(self, req_id: str, num_logprobs: int) -> None:
+        """Track one request until its prompt logprobs are delivered."""
+        self._active[req_id] = num_logprobs
+
+    def wants(self, req_id: str) -> bool:
+        """Whether *req_id* still needs prompt logprobs."""
+        return req_id in self._active
+
+    def num_logprobs(self, req_id: str) -> int:
+        """Return the request's configured prompt-logprobs count."""
+        return self._active[req_id]
 
     def observe_chunk(
         self,
@@ -119,6 +125,7 @@ class PromptLogprobsTracker:
         num_tokens: int,
         chunk_logits: mx.array,
         num_logprobs: int,
+        logprobs_mode: str,
     ) -> LogprobsTensors | None:
         """Score one prefill chunk's logits rows against the prompt.
 
@@ -139,7 +146,10 @@ class PromptLogprobsTracker:
         accumulator = self._in_progress.get(req_id)
         if accumulator is None:
             accumulator = PromptLogprobsAccumulator(
-                prompt_len=prompt_len, num_logprobs=num_logprobs
+                prompt_len=prompt_len,
+                num_logprobs=_resolve_num_logprobs(
+                    num_logprobs, int(chunk_logits.shape[-1])
+                ),
             )
             self._in_progress[req_id] = accumulator
         if window.num_logits > 0:
@@ -150,16 +160,19 @@ class PromptLogprobsTracker:
                 chunk_logits[: window.num_logits],
                 targets,
                 accumulator.num_logprobs,
+                logprobs_mode=logprobs_mode,
             )
             accumulator.fill(window, chunk)
         if not window.completes:
             return None
         del self._in_progress[req_id]
+        self._active.pop(req_id, None)
         return accumulator.tensors
 
     def discard(self, req_ids: set[str] | list[str]) -> None:
-        """Drop in-progress state for finished or aborted requests."""
+        """Drop prompt-logprobs state for finished or aborted requests."""
         for req_id in req_ids:
+            self._active.pop(req_id, None)
             self._in_progress.pop(req_id, None)
 
 
@@ -167,6 +180,8 @@ def full_prompt_logprobs(
     logits_rows: mx.array,
     prompt_token_ids: list[int],
     num_logprobs: int,
+    *,
+    logprobs_mode: str,
 ) -> LogprobsTensors:
     """One-shot prompt logprobs when the whole prompt ran in one forward.
 
@@ -178,22 +193,32 @@ def full_prompt_logprobs(
     window = prompt_logprobs_window(
         start_pos=0, num_tokens=prompt_len, prompt_len=prompt_len
     )
+    num_logprobs = _resolve_num_logprobs(num_logprobs, int(logits_rows.shape[-1]))
     accumulator = PromptLogprobsAccumulator(
         prompt_len=prompt_len, num_logprobs=num_logprobs
     )
     if window.num_logits > 0:
         targets = prompt_token_ids[1 : 1 + window.num_logits]
         chunk = gather_prompt_logprobs(
-            logits_rows[: window.num_logits], targets, num_logprobs
+            logits_rows[: window.num_logits],
+            targets,
+            num_logprobs,
+            logprobs_mode=logprobs_mode,
         )
         accumulator.fill(window, chunk)
     return accumulator.tensors
+
+
+def _resolve_num_logprobs(num_logprobs: int, vocab_size: int) -> int:
+    return vocab_size if num_logprobs == -1 else num_logprobs
 
 
 def gather_prompt_logprobs(
     logits_rows: mx.array,
     target_token_ids: list[int],
     num_logprobs: int,
+    *,
+    logprobs_mode: str = "raw_logprobs",
 ) -> LogprobsTensors:
     """Score ``target_token_ids`` against ``logits_rows`` (one row per target).
 
@@ -209,6 +234,10 @@ def gather_prompt_logprobs(
         )
     mx.eval(logits_rows)
     logits = mlx_to_torch(logits_rows.astype(mx.float32), device="cpu")
-    logprobs = Sampler.compute_logprobs(logits)
+    scores = (
+        logits
+        if logprobs_mode in _LOGITS_LOGPROBS_MODES
+        else Sampler.compute_logprobs(logits)
+    )
     targets = torch.tensor(target_token_ids, dtype=torch.int64)
-    return Sampler.gather_logprobs(logprobs, num_logprobs, targets)
+    return Sampler.gather_logprobs(scores, num_logprobs, targets)

--- a/vllm_metal/v1/prompt_logprobs.py
+++ b/vllm_metal/v1/prompt_logprobs.py
@@ -112,10 +112,6 @@ class PromptLogprobsTracker:
         """Whether *req_id* still needs prompt logprobs."""
         return req_id in self._active
 
-    def num_logprobs(self, req_id: str) -> int:
-        """Return the request's configured prompt-logprobs count."""
-        return self._active[req_id]
-
     def observe_chunk(
         self,
         req_id: str,
@@ -124,7 +120,6 @@ class PromptLogprobsTracker:
         start_pos: int,
         num_tokens: int,
         chunk_logits: mx.array,
-        num_logprobs: int,
         logprobs_mode: str,
     ) -> LogprobsTensors | None:
         """Score one prefill chunk's logits rows against the prompt.
@@ -148,7 +143,7 @@ class PromptLogprobsTracker:
             accumulator = PromptLogprobsAccumulator(
                 prompt_len=prompt_len,
                 num_logprobs=_resolve_num_logprobs(
-                    num_logprobs, int(chunk_logits.shape[-1])
+                    self._active[req_id], int(chunk_logits.shape[-1])
                 ),
             )
             self._in_progress[req_id] = accumulator


### PR DESCRIPTION
## Summary

Fixes #680.

The Metal runners hardcoded `prompt_logprobs_dict={}` in every `ModelRunnerOutput`, so the two OpenAI-API surfaces that need prompt logprobs both misbehaved on any model: `echo=true` + `logprobs=N` returned HTTP 500 (vLLM's completion layer indexes a generated-token top-logprobs dict with a prompt token id and hits `KeyError`), and bare `prompt_logprobs=N` silently returned `[None]` instead of one entry per prompt token. This fulfills the vLLM v1 contract instead: one `LogprobsTensors` per requesting prompt covering positions `1..prompt_len-1`, delivered on the step that finishes the prompt, sliced per chunk under chunked prefill.

## Changes

- `vllm_metal/v1/prompt_logprobs.py` (new): the accounting and tensor construction shared by both runner paths.
  - `prompt_logprobs_window` mirrors upstream `_get_prompt_logprobs_dict` chunk accounting: an intermediate chunk scores all its rows, the `==` boundary chunk defers delivery to the next step, and the completing chunk drops the tail row that predicts the first sampled token.
  - `PromptLogprobsAccumulator` fills one CPU `LogprobsTensors` chunk by chunk; `gather_prompt_logprobs` goes through vLLM's own `Sampler.compute_logprobs` / `gather_logprobs`, so column 0 is the target token, alternatives are the top-k, and ranks are 1-based — the same layout as sampled-token logprobs.
  - `PromptLogprobsTracker` owns in-progress state per request: kept across preemption (a resumed request re-runs its chunks over the same positions), dropped when the engine finishes the request.
- Paged path (`vllm_metal/v1/model_runner.py`): steps containing a requesting prefill skip both head-pruning fast paths — the projection-free intermediate forward (which produces no logits at all) and the selective-logits layout (which keeps only each prefill segment's last row) — so every prompt position has a logits row. `_sample_paged_batch` feeds each requesting chunk's rows to the tracker on both the intermediate-only and the sampling branch, and the completed tensors land in the step's output. The prefill pack now carries the full prompt for requesting chunks: each chunk's last row scores the first token of the *next* chunk, so targets always reach one past the chunk's own tokens.
- Non-paged path: `_prefill_single` forwards the whole prompt in one chunk and gathers one-shot (`full_prompt_logprobs`).
- `_build_output` passes the batch's completed tensors through instead of `{}`. Desyncs raise: a requesting chunk whose segment rows were pruned, or whose pack lacks the full prompt, is a `RuntimeError`, not silent bad data.

STT keeps `{}`: transcription requests have no prompt-logprobs surface.

## Tests

`tests/test_prompt_logprobs.py`:

- Window accounting against upstream's chunk cases (intermediate, `==` boundary, completing, one-token prompt).
- Gather layout (column 0 target, descending alternatives, 1-based ranks) and accumulator slicing across chunks.
- Tracker: delivery only on the completing chunk, values identical to a one-shot gather over the same rows, empty tensors for a one-token prompt, discard, row-count mismatch.
- Runner wiring regressions for both symptoms: `_build_output` carries the dict (was hardcoded `{}`), `_prefill_single` populates tensors for the non-paged path, `_gather_prefill_prompt_logprobs` delivers on the completing chunk and raises on pruned segments / missing full prompt.
- Slow E2E (`test_prompt_logprobs_end_to_end_paged`): `Qwen/Qwen3-0.6B` with `max_num_batched_tokens=16` forcing chunked prefill; asserts one real entry per prompt token with the prompt token present in each (the exact data the `echo`+`logprobs` path indexes, and the silent-`[None]` repro inverted).

## Validation

Apple M1 Pro, 16 GiB, macOS 27.0, Python 3.12.14, vllm 0.28.0+cpu, mlx 0.32.0, mlx_lm 0.31.3, source install with `VLLM_METAL_BUILD_FROM_SOURCE=1`.

```
$ pytest tests/ -q -m "not slow"
1973 passed, 15 skipped, 53 deselected in 36.66s
$ pytest tests/test_prompt_logprobs.py -q
25 passed in 15.59s  # includes the slow chunked-prefill E2E
$ ruff check . && ruff format --check . && mypy vllm_metal
Success: no issues found in 127 source files
```

Manual check of the issue's repro shape via the offline engine (same code path the server drives): `prompt_logprobs=1` now returns `len(prompt_token_ids)` entries, `[0] is None`, every other position carries the prompt token's logprob.
