### PR TITLE
Route hybrid models through a state-family table

### DIFF
--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Contract tests for the hybrid runtime plan and its GDN family owner."""
+"""Contract tests for the hybrid runtime plan, its GDN family owner and the
+state-family factory."""
 
 from __future__ import annotations
 
@@ -13,6 +14,7 @@ from vllm.v1.kv_cache_interface import MambaSpec
 from tests.stub_runner import make_gdn_hybrid_plan
 from vllm_metal.attention.impls.linear import GDNPagedAttentionWrapper
 from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
+from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
 from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
 from vllm_metal.attention.runtime.hybrid_plan import (
@@ -151,6 +153,30 @@ class TestGdnPlanRejection:
         with pytest.raises(ValueError) as excinfo:
             build_gdn_hybrid_plan(args, num_layers)
         assert str(excinfo.value) == expected
+
+
+class TestStateFamilyFactory:
+    def test_routes_gdn_args_to_the_gdn_family(self) -> None:
+        plan = build_hybrid_runtime_plan(GDN_ARGS, 8)
+
+        assert plan.family.label == "gdn"
+        assert plan.layers.attention_indices == (3, 7)
+
+    def test_rejects_args_without_a_state_family(self) -> None:
+        args = {"model_type": "nemotron_h", "num_hidden_layers": 52}
+        expected = (
+            "Metal hybrid runtime has no state family for model_type='nemotron_h'."
+        )
+
+        with pytest.raises(NotImplementedError) as excinfo:
+            build_hybrid_runtime_plan(args, 52)
+        assert str(excinfo.value) == expected
+
+    def test_malformed_interval_is_a_gdn_error_not_a_miss(self) -> None:
+        args = {**GDN_ARGS, "full_attention_interval": "4"}
+
+        with pytest.raises(ValueError, match="must be positive integers"):
+            build_hybrid_runtime_plan(args, 8)
 
 
 class TestStateCacheSpec:

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -32,13 +32,15 @@ from vllm_metal.v1.structured_output import MetalStructuredOutputApplier
 def make_stub_runner(
     *,
     model_args: dict[str, Any] | None = None,
+    is_hybrid: bool = False,
     **attrs: Any,
 ) -> mr.MetalModelRunner:
     """Create a ``MetalModelRunner`` stub without running ``__init__``.
 
     Sets sensible defaults for all internal attributes.  ``_vocab_size``
     is derived from ``model_args["vocab_size"]`` automatically — never
-    set it separately.  Pass keyword arguments to override any attribute.
+    set it separately.  ``is_hybrid`` lands on the default ``model_config``.
+    Pass keyword arguments to override any attribute.
     """
     runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
 
@@ -58,7 +60,10 @@ def make_stub_runner(
             mamba_cache_mode="none",
         ),
         "model_config": SimpleNamespace(
-            runner_type="generate", get_head_size=lambda: 128, max_model_len=2048
+            runner_type="generate",
+            get_head_size=lambda: 128,
+            max_model_len=2048,
+            is_hybrid=is_hybrid,
         ),
         "model": object(),
         "tokenizer": None,

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -10,7 +10,7 @@ from typing import Any
 import mlx.core as mx
 
 import vllm_metal.v1.model_runner as mr
-from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
+from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
 from vllm_metal.attention.runtime.hybrid_plan import (
     ATTENTION_LAYER,
     STATE_LAYER,
@@ -218,9 +218,9 @@ def make_gemma4_mixed_mha_runner(
     )
 
 
-# Production family policy, resolved through the public builder from the
+# Production family policy, resolved through the family table from the
 # smallest valid hybrid layout so tests cannot drift from what production installs.
-_GDN_FAMILY_SPEC = build_gdn_hybrid_plan(
+_GDN_FAMILY_SPEC = build_hybrid_runtime_plan(
     {
         "full_attention_interval": 2,
         "linear_num_key_heads": 1,

--- a/tests/test_kv_cache_spec_capacity.py
+++ b/tests/test_kv_cache_spec_capacity.py
@@ -33,7 +33,7 @@ def _policy(
     head_dim=256,
     sliding_window_per_layer=None,
 ):
-    # ``is_mla``/``is_hybrid`` are derived from the model config, not settable.
+    # ``is_mla`` derives from model args; ``is_hybrid`` comes from the model config.
     model_args = {"kv_lora_rank": head_dim} if is_mla else {}
     runner = make_stub_runner(
         model_args=model_args,
@@ -97,11 +97,11 @@ def test_hybrid_mamba_spec_reserves_one_state_block_per_request() -> None:
     attention_block_size = 544
     max_model_len = 2048
     runner = make_stub_runner(
-        model_args={"full_attention_interval": 2},
         model_config=SimpleNamespace(
             runner_type="generate",
             get_head_size=lambda: 128,
             max_model_len=max_model_len,
+            is_hybrid=True,
         ),
         num_layers=2,
         hybrid_runtime_plan=make_gdn_hybrid_plan(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -774,6 +774,39 @@ class TestModelLifecycle:
         assert runner.model_args["model_type"] == "gemma4"
         assert runner.model_args["vocab_size"] == _TEXT_MODEL_ARGS["vocab_size"]
 
+    def test_load_reads_omitted_text_keys_off_the_built_language_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A re-saved Qwen3.5 config omits full_attention_interval; mlx-lm
+        resolves it to 4 on the built text model, and routing must see that."""
+        text_config = dict(_TEXT_MODEL_ARGS) | {
+            "linear_num_key_heads": 2,
+            "linear_num_value_heads": 4,
+            "linear_key_head_dim": 32,
+            "linear_value_head_dim": 16,
+            "linear_conv_kernel_dim": 3,
+        }
+        args = SimpleNamespace(model_type="qwen3_5", text_config=text_config)
+        fake_model = SimpleNamespace(
+            args=args,
+            language_model=SimpleNamespace(
+                args=SimpleNamespace(**text_config, full_attention_interval=4)
+            ),
+        )
+        _stub_generation_model(monkeypatch, config=None, model=fake_model)
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(is_hybrid=True)
+        )
+
+        lifecycle.load()
+
+        assert runner.model_args["full_attention_interval"] == 4
+        assert runner.hybrid_runtime_plan.family.label == "gdn"
+        assert runner.hybrid_runtime_plan.layers.num_attention == (
+            _TEXT_MODEL_ARGS["num_hidden_layers"] // 4
+        )
+
     def test_load_stt_model_loads_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake_model = SimpleNamespace(
             create_runtime_adapter=lambda model_name: (object(), model_name)

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -55,9 +55,32 @@ def _runner_model_config(**overrides: object) -> object:
         "revision": None,
         "tokenizer": None,
         "tokenizer_revision": None,
+        "is_hybrid": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+_GDN_HYBRID_ARGS = {
+    "num_hidden_layers": 8,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 4,
+    "hidden_size": 1024,
+    "full_attention_interval": 4,
+    "linear_num_key_heads": 2,
+    "linear_num_value_heads": 4,
+    "linear_key_head_dim": 32,
+    "linear_value_head_dim": 16,
+    "linear_conv_kernel_dim": 3,
+}
+
+_NEMOTRON_H_ARGS = {
+    "model_type": "nemotron_h",
+    "num_hidden_layers": 52,
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "hidden_size": 4096,
+}
 
 
 def _text_config(**overrides: object) -> SimpleNamespace:
@@ -1090,10 +1113,33 @@ class TestModelLifecycle:
 
 
 class TestResolveModelDims:
-    def _resolve(self, args: dict[str, object]) -> object:
-        lifecycle, runner = _make_lifecycle(model_args=args)
+    def _resolve(self, args: dict[str, object], *, is_hybrid: bool = False) -> object:
+        lifecycle, runner = _make_lifecycle(
+            model_args=args, model_config=_runner_model_config(is_hybrid=is_hybrid)
+        )
         lifecycle.resolve_model_dims()
         return runner
+
+    def test_hybrid_model_installs_its_family_plan(self) -> None:
+        runner = self._resolve(_GDN_HYBRID_ARGS, is_hybrid=True)
+
+        assert runner.hybrid_runtime_plan.family.label == "gdn"
+        assert runner.hybrid_runtime_plan.layers.attention_indices == (3, 7)
+
+    def test_routing_follows_the_typed_field_not_the_args(self) -> None:
+        runner = self._resolve(_GDN_HYBRID_ARGS, is_hybrid=False)
+
+        assert runner.hybrid_runtime_plan is None
+
+    def test_hybrid_model_without_a_family_rejects_before_any_plan(self) -> None:
+        lifecycle, runner = _make_lifecycle(
+            model_args=_NEMOTRON_H_ARGS,
+            model_config=_runner_model_config(is_hybrid=True),
+        )
+
+        with pytest.raises(NotImplementedError, match="model_type='nemotron_h'"):
+            lifecycle.resolve_model_dims()
+        assert runner.hybrid_runtime_plan is None
 
     def test_standard_mha(self) -> None:
         runner = self._resolve(

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -219,10 +219,10 @@ class TestCachePolicyPerLayerBytes:
         head_dim: int,
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
-        model_args: dict | None = None,
+        is_hybrid: bool = False,
     ) -> object:
         return make_stub_runner(
-            model_args=model_args,
+            is_hybrid=is_hybrid,
             num_layers=num_layers,
             num_kv_cache_layers=num_layers,
             num_kv_heads=num_kv_heads,
@@ -288,7 +288,7 @@ class TestCachePolicyPerLayerBytes:
             head_dim=256,
             kv_heads_per_layer=[4, 4, 4, 4],
             head_dim_per_layer=[256, 256, 256, 256],
-            model_args={"full_attention_interval": 2},
+            is_hybrid=True,
         )
 
         with pytest.raises(

--- a/tests/test_spec_decode_metadata.py
+++ b/tests/test_spec_decode_metadata.py
@@ -209,7 +209,7 @@ class TestSpecDecodePolicy:
             )
 
     def test_hybrid_scheduled_tokens_are_rejected(self) -> None:
-        with pytest.raises(NotImplementedError, match="hybrid GDN"):
+        with pytest.raises(NotImplementedError, match="hybrid models"):
             SpeculativeDecodeController().validate_supported(
                 _scheduler_output(scheduled_spec_decode_tokens={"r0": [1]}),
                 [("r0", _request_state())],

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -44,7 +44,7 @@ TQ_PAGE = turboquant_page_size_bytes(
 
 def _hybrid_runner():
     return make_stub_runner(
-        model_args={"full_attention_interval": 4},
+        is_hybrid=True,
         num_layers=NUM_LAYERS,
         hybrid_runtime_plan=make_gdn_hybrid_plan(
             NUM_LAYERS,
@@ -104,7 +104,7 @@ class TestHybridTurboQuantCachePolicy:
 
         for sdpa_layers in ([3, 7], [0, 4]):
             runner = make_stub_runner(
-                model_args={"full_attention_interval": 4},
+                is_hybrid=True,
                 num_layers=NUM_LAYERS,
                 hybrid_runtime_plan=make_gdn_hybrid_plan(
                     NUM_LAYERS,

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -655,7 +655,7 @@ class TestV1MetalModelRunnerSpecDecodeVerification:
         backend = HybridRuntimeStub(state_cache)
         runner = make_stub_runner(
             tokenizer=object(),
-            model_args={"full_attention_interval": 2},
+            is_hybrid=True,
             _paged_attention_runtime=backend,
         )
         runner.num_layers = 0
@@ -2375,14 +2375,14 @@ class TestMergeVerifyWindows:
 
     def test_false_for_hybrid_even_when_opted_in(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_SPEC_VERIFY_WINDOW", "1")
-        runner = make_stub_runner(model_args={"full_attention_interval": 4})
+        runner = make_stub_runner(is_hybrid=True)
         assert runner.merge_verify_windows is False
 
     def test_false_past_window_head_bound_even_when_opted_in(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_SPEC_VERIFY_WINDOW", "1")
         runner = make_stub_runner(
             model_config=SimpleNamespace(
-                runner_type="generate", get_head_size=lambda: 512
+                runner_type="generate", get_head_size=lambda: 512, is_hybrid=False
             )
         )
         assert runner.merge_verify_windows is False

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -213,6 +213,7 @@ def _pooling_model_config(**overrides):
         "tokenizer": "stub-pooling-model",
         "tokenizer_revision": None,
         "get_head_size": lambda: 128,
+        "is_hybrid": False,
     }
     values.update(overrides)
     return SimpleNamespace(**values)

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -141,7 +141,7 @@ class TestOneSequenceKvBytes:
 
     def test_hybrid_adds_linear_state(self) -> None:
         model_runner = make_stub_runner(
-            model_args={"full_attention_interval": 2},
+            is_hybrid=True,
             num_kv_heads=4,
             head_dim=256,
             kv_cache_dtype=mx.float16,
@@ -178,7 +178,7 @@ class TestOneSequenceKvBytes:
         # sequence falls short by the padding on every linear layer.
         padded_page = 4096
         model_runner = make_stub_runner(
-            model_args={"full_attention_interval": 2},
+            is_hybrid=True,
             num_kv_heads=4,
             head_dim=256,
             kv_cache_dtype=mx.float16,
@@ -208,7 +208,7 @@ class TestOneSequenceKvBytes:
 
     def test_linear_cache_bytes_uses_float32_recurrent(self) -> None:
         runner = mr.MetalModelRunner.__new__(mr.MetalModelRunner)
-        runner.model_args = {"full_attention_interval": 2}
+        runner.model_config = SimpleNamespace(is_hybrid=True)
         runner._model_adapter = DefaultModelAdapter()
         runner._cache_policy = ModelCachePolicy(runner, runner._model_adapter)
         runner.kv_cache_dtype = mx.float16
@@ -535,7 +535,7 @@ class TestAlignStateSizing:
     def _make_align_runner() -> mr.MetalModelRunner:
         """Qwen-shaped 24-layer GDN plan: 18 state layers striped over 6 SDPA."""
         return make_stub_runner(
-            model_args={"full_attention_interval": 4},
+            is_hybrid=True,
             kv_cache_dtype=mx.float16,
             hybrid_runtime_plan=build_gdn_hybrid_plan(
                 {
@@ -568,8 +568,8 @@ class TestAlignStateSizing:
 
 class TestHybridPlanGuard:
     def test_hybrid_sizing_without_plan_rejects(self) -> None:
-        # is_hybrid derives from model_args; the stub leaves the plan at None.
-        runner = make_stub_runner(model_args={"full_attention_interval": 2})
+        # The typed config says hybrid; the stub leaves the plan at None.
+        runner = make_stub_runner(is_hybrid=True)
 
         with pytest.raises(RuntimeError, match="no resolved hybrid_runtime_plan"):
             runner.linear_cache_bytes_per_slot()

--- a/vllm_metal/attention/runtime/factory.py
+++ b/vllm_metal/attention/runtime/factory.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Factory for hybrid state-family runtime plans."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from vllm_metal.attention.runtime.families.gdn import (
+    build_gdn_hybrid_plan,
+    supports_gdn_hybrid,
+)
+from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
+
+
+@dataclass(frozen=True, slots=True)
+class StateFamilyPlanBuilder:
+    supports: Callable[[Mapping[str, Any]], bool]
+    build: Callable[[Mapping[str, Any], int], HybridRuntimePlan]
+
+
+_STATE_FAMILY_PLAN_BUILDERS = (
+    # ``ModelConfig.is_hybrid`` only says a model mixes attention and state
+    # layers; the family that owns its topology and geometry is resolved here.
+    StateFamilyPlanBuilder(
+        supports=supports_gdn_hybrid,
+        build=build_gdn_hybrid_plan,
+    ),
+)
+
+
+def build_hybrid_runtime_plan(
+    model_args: Mapping[str, Any], num_layers: int
+) -> HybridRuntimePlan:
+    for builder in _STATE_FAMILY_PLAN_BUILDERS:
+        if builder.supports(model_args):
+            return builder.build(model_args, num_layers)
+
+    raise NotImplementedError(
+        f"Metal hybrid runtime has no state family for "
+        f"model_type={model_args.get('model_type')!r}."
+    )

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -108,6 +108,11 @@ _GDN_FAMILY = StateFamilySpec(
 )
 
 
+def supports_gdn_hybrid(model_args: Mapping[str, Any]) -> bool:
+    """Whether these model args describe a GDN linear-attention hybrid."""
+    return "full_attention_interval" in model_args
+
+
 def build_gdn_hybrid_plan(
     model_args: Mapping[str, Any], num_layers: int
 ) -> HybridRuntimePlan:

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -517,7 +517,7 @@ class MetalPlatform(Platform):
                 cache_config.mamba_ssm_cache_dtype = "float32"
             elif cache_config.mamba_ssm_cache_dtype != "float32":
                 raise NotImplementedError(
-                    "Hybrid GDN models on Metal require "
+                    "Hybrid models on Metal require "
                     "--mamba-ssm-cache-dtype float32 because recurrent state is "
                     "stored in fp32."
                 )
@@ -525,7 +525,7 @@ class MetalPlatform(Platform):
                 # Before the downgrades below, which overwrite the mode: an
                 # explicit --mamba-cache-mode all must fail fast on every path.
                 raise NotImplementedError(
-                    "mamba_cache_mode='all' is not supported for hybrid GDN "
+                    "mamba_cache_mode='all' is not supported for hybrid "
                     "models on Metal (nor upstream, which falls back to "
                     "'align' for models without SupportsMambaPrefixCaching). "
                     "Use align mode: --enable-prefix-caching resolves to it."
@@ -841,7 +841,7 @@ class MetalPlatform(Platform):
 
     @staticmethod
     def _disable_hybrid_prefix_caching(vllm_config: "VllmConfig", reason: str) -> None:
-        """Downgrade default-on prefix caching for a hybrid GDN model.
+        """Downgrade default-on prefix caching for a hybrid model.
 
         vLLM 0.28.0 enables prefix caching by default for hybrid models
         (vllm#50991) and resolves ``mamba_cache_mode``/``mamba_block_size``
@@ -858,13 +858,13 @@ class MetalPlatform(Platform):
             # user's two explicit choices conflict; fail with the Metal
             # constraint before upstream's misleading error fires.
             raise NotImplementedError(
-                "Prefix caching for hybrid GDN models on Metal cannot serve "
+                "Prefix caching for hybrid models on Metal cannot serve "
                 f"this configuration ({reason}), and --mamba-block-size "
                 "requires prefix caching. Drop --mamba-block-size or the "
                 "conflicting option."
             )
         logger.warning(
-            "Disabling prefix caching for this hybrid GDN model: %s. "
+            "Disabling prefix caching for this hybrid model: %s. "
             "(vLLM enables prefix caching by default for hybrid models; "
             "pass --no-enable-prefix-caching to make this explicit.)",
             reason,
@@ -878,7 +878,7 @@ class MetalPlatform(Platform):
 
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
-        """Metal supports hybrid KV cache for models like Qwen3.5 (SDPA + GDN)."""
+        """Metal supports the hybrid KV cache manager for hybrid models."""
         return True
 
     @classmethod
@@ -981,7 +981,7 @@ class MetalPlatform(Platform):
         # the kernel sees more, smaller blocks.
         if model_config.is_hybrid and metal_config.use_paged_attention:
             logger.warning(
-                "Hybrid model (e.g., Qwen3.5) with paged attention enabled. "
+                "Hybrid model with paged attention enabled. "
                 "Using block-size translation (PR #235) to convert vLLM's large "
                 "block_size to a Metal kernel-compatible size.\n"
                 "  Mechanism: Each vLLM block is split into multiple kernel blocks.\n"

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -14,7 +14,7 @@ from mlx_vlm import load as mlx_vlm_load
 from vllm.logger import init_logger
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
-from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
+from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
 from vllm_metal.compat import apply_compat_patches
 from vllm_metal.compiled_mlp import CompiledMLPBlocks
 from vllm_metal.gguf.source import GGUFLoadSource
@@ -494,7 +494,7 @@ class ModelLifecycle:
     def _install_hybrid_state_plan(self, args: dict[str, Any]) -> None:
         """Resolve the state family that owns this model's hybrid layers."""
         if self._runner.is_hybrid:
-            self._runner.hybrid_runtime_plan = build_gdn_hybrid_plan(
+            self._runner.hybrid_runtime_plan = build_hybrid_runtime_plan(
                 args, self._runner.num_layers
             )
 

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -543,6 +543,13 @@ class ModelLifecycle:
 
         merged_values = dict(model_values)
         text_values = self._config_to_mapping(text_config)
+        # mlx-lm builds the text sub-model from this raw dict and resolves the
+        # omitted keys on its args, so read those off the built module.
+        language_model = getattr(model, "language_model", None)
+        resolved_text_args = getattr(language_model, "args", None)
+        if resolved_text_args is not None:
+            for key, value in self._config_to_mapping(resolved_text_args).items():
+                text_values.setdefault(key, value)
         for key, value in text_values.items():
             merged_values.setdefault(key, value)
         return merged_values

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -700,7 +700,7 @@ class MetalModelRunner:
             raise NotImplementedError(
                 "Pipeline parallelism on Metal is validated only for uniform-"
                 "attention generation on the paged path (e.g. Qwen3 with "
-                "VLLM_METAL_USE_PAGED_ATTENTION=1); YOCO / hybrid (GDN) / MLA / "
+                "VLLM_METAL_USE_PAGED_ATTENTION=1); YOCO / hybrid / MLA / "
                 "pooling / VLM (multimodal) / non-paged configs are not "
                 "supported under PP yet."
             )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -487,13 +487,8 @@ class MetalModelRunner:
 
     @property
     def is_hybrid(self) -> bool:
-        """Whether the model mixes SDPA and linear attention layers.
-
-        Hybrid models (Qwen3.5) have ``full_attention_interval`` in their
-        config: every N-th layer uses SDPA, the rest use GDN linear attention.
-        """
-        fai = self.model_args.get("full_attention_interval", 0)
-        return isinstance(fai, int) and fai > 0
+        """Whether the model mixes attention layers with recurrent state layers."""
+        return self.model_config.is_hybrid
 
     @property
     def merge_verify_windows(self) -> bool:

--- a/vllm_metal/v1/spec_decode.py
+++ b/vllm_metal/v1/spec_decode.py
@@ -153,7 +153,7 @@ class SpeculativeDecodeController:
         if (active_spec_tokens or has_invalid_spec_tokens) and is_hybrid:
             raise NotImplementedError(
                 "Speculative decode verification is not supported for hybrid "
-                "GDN models on Metal yet."
+                "models on Metal yet."
             )
 
         decode_req_ids = {req_id for req_id, _ in decode_reqs}


### PR DESCRIPTION
PR 2 of the Nemotron-H stack in #644, on top of #668. The platform already reads vLLM's typed `ModelConfig.is_hybrid`, but the runner still sniffs `full_attention_interval` out of the mlx args, so a Nemotron-H checkpoint is hybrid to the engine and dense to the worker. On main that is 0/52 layers patched, 38 GB of KV budgeted for six attention layers, and a 500 on the first request.

The runner now reads the typed field too, and "which family" comes from a table in `attention/runtime/factory.py` copied from the encoder pooling loaders in #608. It has one row, GDN, and every supported model goes through it, so it is load-bearing today: the typed field is also true for LFM2 and Jamba and the table is what keeps them out of the GDN parser. Lifecycle imports no family anymore. No stateless role yet; per your note on #668 it waits for the Mamba-2 row in PR 3. If you would rather the table land with that row, I can fold this into PR 3.

The first commit is a runtime fix this needed: transformers' Qwen3.5 text config drops `full_attention_interval` when it derives `layer_types`, and mlx-lm resolves it on the built text model, so `_extract_model_args` now reads omitted keys off `language_model.args`. Same bug class as #449, with the omitted-key test.