### PR TITLE
[CI] Run lint only on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [macos-15, ubuntu-24.04-arm, ubuntu-24.04]
+        os: [macos-15]
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
CI currently runs the same lint script on macOS, Ubuntu ARM, and Ubuntu x86. This PR removes the two Ubuntu matrix entries and retain the `lint (macos-15)` one. 

test on ubuntu is not very meaningful to vllm-metal. 
