### PR TITLE
[CI] Build Metal shaders once in the test script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -147,11 +147,12 @@ main() {
   setup_dev_env
 
   if [ "$(uname)" == "Darwin" ]; then
-    # Build the native artifacts (.so + .metallib) into the package tree before
-    # install.sh's `uv pip install .`, so the wheel bundles them (maturin
-    # `include`) and CI exercises the prebuilt path users get, like release.sh.
+    # Export the deployment target in this shell for the wheel build below.
     ensure_metal_toolchain
-    build_native_artifacts
+    # install.sh builds the native artifacts before the wheel check below.
+    installs
+    # shellcheck source=/dev/null
+    source .venv-vllm-metal/bin/activate
 
     # Shift-left the release wheel guard. The pytest run below imports the source
     # tree, which shadows the installed wheel, so a maturin `include` regression
@@ -166,10 +167,6 @@ main() {
       exit 1
     fi
     verify_wheel_artifacts "${wheels[0]}"
-
-    installs
-    # shellcheck source=/dev/null
-    source .venv-vllm-metal/bin/activate
 
     section "Verifying package import"
     python -c "import vllm_metal; print('vllm_metal imported successfully')"


### PR DESCRIPTION
* Before: `scripts/test.sh` builds the Metal shaders directly, then runs `install.sh`, which builds them again. 
* After: Run installation before wheel packaging and use the native artifacts it produces. 

It reorders the existing installation and activation steps and removes the direct native build call.



| Path | Current behavior | Effect of this PR |
|---|---|---|
| CI test job | Builds shaders directly, then builds them again inside `install.sh` | **Builds once** |
| Running `scripts/test.sh` locally | Same sequence as CI | **Builds once** |
| Dev/stable release job | Builds shaders once before packaging its wheel | Unchanged |
| User installing a release wheel | Downloads prebuilt artifacts; installation does not compile these shaders | Unchanged |
| Developer running `./install.sh` | Builds shaders once per invocation, even if unchanged | Unchanged |
| `VLLM_METAL_BUILD_FROM_SOURCE=1` | Uses a separate MLX compilation path inside the running process | Unchanged |

Here, shader compilation means building the bundled `.metallib` libraries. CI and release jobs still build their own artifacts on separate runners.

In sampled CI logs, the redundant second build occupied [18.0 seconds](https://github.com/vllm-project/vllm-metal/actions/runs/33929716377/job/101205676384) to [28.5 seconds](https://github.com/vllm-project/vllm-metal/actions/runs/33877625045/job/101038282062). 


