### PR TITLE
Honor configured LoRA dtype

### DIFF
--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 from vllm.lora.layers import LoRAMapping
 from vllm.sampling_params import SamplingParams
 
@@ -119,7 +120,7 @@ def test_punica_handles_fragmented_routing() -> None:
 
 def test_punica_output_dtype_matches_base_for_all_routing_paths() -> None:
     routing_cases = (
-        ((11, 22, 11, 22), False, np.float16),
+        ((11, 22, 11, 22), False, np.float32),
         ((11, 11, 11, 11), True, np.float32),
         (tuple(11 if i % 2 == 0 else 22 for i in range(80)), True, np.float32),
     )
@@ -571,6 +572,7 @@ def _lora_config_stub(
     max_lora_rank: int,
     max_cpu_loras: int | None = None,
     target_modules: list[str] | None = None,
+    lora_dtype: torch.dtype = torch.float32,
 ) -> SimpleNamespace:
     """Stand-in for ``vllm.config.lora.LoRAConfig`` — only the fields the manager reads."""
     return SimpleNamespace(
@@ -578,6 +580,7 @@ def _lora_config_stub(
         max_lora_rank=max_lora_rank,
         max_cpu_loras=max_cpu_loras,
         target_modules=target_modules,
+        lora_dtype=lora_dtype,
     )
 
 
@@ -1082,7 +1085,6 @@ def _runtime_setup_kwargs(**overrides: object) -> dict:
         "speculative_decode_enabled": False,
         "max_num_seqs": 1,
         "max_num_batched_tokens": 8,
-        "dtype": mx.float16,
         "max_position_embeddings": None,
     }
     kwargs.update(overrides)
@@ -1107,6 +1109,25 @@ def test_runtime_stt_disables_lora_without_raising() -> None:
     rt = runtime_mod.MetalLoRARuntime()
     rt.setup(**_runtime_setup_kwargs(is_stt=True))
     assert rt.enabled is False
+
+
+def test_runtime_uses_configured_lora_dtype() -> None:
+    model = _TwoLinearModel()
+    rt = runtime_mod.MetalLoRARuntime()
+
+    rt.setup(
+        **_runtime_setup_kwargs(
+            model=model,
+            lora_config=_lora_config_stub(
+                max_loras=1,
+                max_lora_rank=1,
+                lora_dtype=torch.bfloat16,
+                target_modules=["fc1"],
+            ),
+        )
+    )
+
+    assert model.fc1.lora_a_stacked.dtype == mx.bfloat16
 
 
 def test_prepare_step_raises_for_unknown_lora_id() -> None:

--- a/vllm_metal/v1/lora/layers.py
+++ b/vllm_metal/v1/lora/layers.py
@@ -164,21 +164,21 @@ class MLXLinearWithLoRA(_LoRALinearBase):
             return y
 
         # Punica expects (n_tokens, dim); collapse leading dims if needed.
-        shape = y.shape
-        x2, y2 = (
-            (x.reshape(-1, x.shape[-1]), y.reshape(-1, y.shape[-1]))
-            if x.ndim > 2
-            else (x, y)
-        )
-        out = self.punica_wrapper.add_lora_linear(
-            y2,
-            x2,
+        output_shape = y.shape
+        if x.ndim > 2:
+            x = x.reshape(-1, x.shape[-1])
+            y = y.reshape(-1, y.shape[-1])
+        if x.dtype != self.lora_a_stacked.dtype:
+            x = x.astype(self.lora_a_stacked.dtype)
+        output = self.punica_wrapper.add_lora_linear(
+            y,
+            x,
             self.lora_a_stacked,
             self.lora_b_stacked,
             scale=1.0,
             lora_ranks=self._lora_ranks,
         )
-        return out if out is y else out.reshape(shape)
+        return output if output.shape == output_shape else output.reshape(output_shape)
 
 
 class MLXQuantizedLinearWithLoRA(_LoRALinearBase):
@@ -215,19 +215,18 @@ class MLXQuantizedLinearWithLoRA(_LoRALinearBase):
         if self.punica_wrapper is None or self.punica_wrapper.no_lora:
             return y
 
-        # Run the LoRA delta in the adapter dtype regardless of the quantized
-        # base output dtype, then cast back so downstream layers are unaffected.
-        lora_dtype = self.lora_a_stacked.dtype
-        shape = y.shape
-        x_flat = x.reshape(-1, x.shape[-1]) if x.ndim > 2 else x
-        y_flat = y.reshape(-1, y.shape[-1]) if y.ndim > 2 else y
-        out = self.punica_wrapper.add_lora_linear(
-            y_flat.astype(lora_dtype),
-            x_flat.astype(lora_dtype),
+        output_shape = y.shape
+        if x.ndim > 2:
+            x = x.reshape(-1, x.shape[-1])
+            y = y.reshape(-1, y.shape[-1])
+        if x.dtype != self.lora_a_stacked.dtype:
+            x = x.astype(self.lora_a_stacked.dtype)
+        output = self.punica_wrapper.add_lora_linear(
+            y,
+            x,
             self.lora_a_stacked,
             self.lora_b_stacked,
             scale=1.0,
             lora_ranks=self._lora_ranks,
         )
-        out = out.astype(y.dtype)
-        return out if out.shape == shape else out.reshape(shape)
+        return output if output.shape == output_shape else output.reshape(output_shape)

--- a/vllm_metal/v1/lora/punica_wrapper.py
+++ b/vllm_metal/v1/lora/punica_wrapper.py
@@ -107,11 +107,12 @@ class PunicaWrapperMLX:
         if self._expanded_slot_indices is not None:
             lora_a = mx.take(lora_a_stacked, self._expanded_slot_indices, axis=0)
             lora_b = mx.take(lora_b_stacked, self._expanded_slot_indices, axis=0)
-            return (
-                y
-                + mx.matmul(lora_b, mx.matmul(lora_a, x[:, :, None])).squeeze(-1)
-                * scale
-            )
+            delta = mx.matmul(lora_b, mx.matmul(lora_a, x[:, :, None])).squeeze(-1)
+            if scale != 1.0:
+                delta = delta * scale
+            if delta.dtype != y.dtype:
+                delta = delta.astype(y.dtype)
+            return y + delta
 
         max_rank = int(lora_a_stacked.shape[1])
         ranks = lora_ranks if lora_ranks is not None else [max_rank] * self.max_loras

--- a/vllm_metal/v1/lora/runtime.py
+++ b/vllm_metal/v1/lora/runtime.py
@@ -7,8 +7,9 @@ import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-import mlx.core as mx
 from vllm.lora.layers import LoRAMapping
+
+from vllm_metal.pytorch_backend.tensor_bridge import TORCH_TO_MLX_DTYPE
 
 from .worker_manager import MetalWorkerLoRAManager
 
@@ -64,7 +65,6 @@ class MetalLoRARuntime:
         speculative_decode_enabled: bool,
         max_num_seqs: int,
         max_num_batched_tokens: int,
-        dtype: mx.Dtype,
         max_position_embeddings: int | None,
     ) -> None:
         if lora_config is None:
@@ -95,7 +95,7 @@ class MetalLoRARuntime:
             lora_config=lora_config,
             max_num_seqs=max_num_seqs,
             max_num_batched_tokens=max_num_batched_tokens,
-            dtype=dtype,
+            dtype=TORCH_TO_MLX_DTYPE[lora_config.lora_dtype],
             max_position_embeddings=max_position_embeddings,
         )
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -629,13 +629,12 @@ class MetalModelRunner:
             max_position_embeddings = getattr(cfg, "max_position_embeddings", None)
         self._lora.setup(
             model=self._forward_model,
-            lora_config=getattr(self.vllm_config, "lora_config", None),
+            lora_config=self.vllm_config.lora_config,
             is_stt=False,
             paged_attention_enabled=self.metal_config.use_paged_attention,
             speculative_decode_enabled=self.vllm_config.speculative_config is not None,
             max_num_seqs=self.scheduler_config.max_num_seqs,
             max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
-            dtype=self.kv_cache_dtype or mx.float16,
             max_position_embeddings=max_position_embeddings,
         )
         # Probed here because it runs a cacheless one-token forward, which is


### PR DESCRIPTION
This PR is:

- To honor vLLM’s resolved `LoRAConfig.lora_dtype` when creating Metal LoRA adapter buffers
- To run LoRA and QLoRA adapter inputs/deltas in the configured adapter dtype
- To preserve the base layer output dtype when adding the LoRA delta

Previously, Metal LoRA used `kv_cache_dtype or mx.float16` for adapter buffers, so `--lora-dtype` could be silently ignored.
This keeps dtype ownership inside `MetalLoRARuntime` and keeps `model_runner.py` as orchestration only.