### PR TITLE
[CI] Reject HTTP errors in smoke health checks

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -30,7 +30,7 @@ run_smoke_test() {
   # 2. Wait for the server to be ready
   echo "Waiting for vLLM to start..."
   local health_url="http://localhost:8000/health"
-  if ! curl --retry 30 --retry-delay 10 --retry-all-errors -s "$health_url" > /dev/null; then
+  if ! curl --retry 30 --retry-delay 10 --retry-all-errors -fs "$health_url" > /dev/null; then
     echo "vLLM failed to start."
     kill $vllm_pid
     exit 1


### PR DESCRIPTION
The smoke readiness check accepts HTTP 503 after curl exhausts its retries. [vLLM returns 503 when the engine is dead](https://github.com/vllm-project/vllm/blob/v0.28.0/vllm/entrypoints/serve/instrumentator/health.py). Add `--fail` so HTTP errors reach the existing startup-failure branch before a completion is submitted. The retry count and delay stay unchanged.

Validation on Apple M4 / macOS 15.6, curl 8.7.1, exact commit `77c29c2`:

- Real HTTP fixture, original 30-retry/10-second settings: unchanged main exits 0 after 31 HTTP 503 responses; this commit exits 22.
- Full smoke-function fault injection (shortened retry timing): persistent 503/404 exits 1 without a completion request and cleans up its server; healthy and 503-to-200 recovery cases pass.
- `python -m pytest -q -m 'not slow' tests/`: 1,985 passed, 15 skipped, 52 deselected. Unchanged main passes the same suite.
- Ruff, formatting, mypy, ShellCheck, native extension/Metal builds, and release-wheel artifact checks pass.
- Both repository serving goldens pass, run sequentially with `VLLM_METAL_MEMORY_FRACTION=0.1` and no block override. Slow tests and M5-only NAX execution were not exercised.
