### PR TITLE
[Bugfix] Route Phi-1/1.5 through paged attention (dense output projection + derived scale)

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -95,6 +95,7 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Mistral-7B | ✅ | GQA (paged) | ✅ | `mlx-community/Mistral-7B-Instruct-v0.3-4bit` |
 | Mistral-Small-24B | 🔵 | GQA (paged) | ✅ | `mlx-community/Mistral-Small-24B-Instruct-2501-4bit` |
 | StableLM 2 | ✅ | MHA + partial RoPE (paged) | ✅ | `mlx-community/stablelm-2-zephyr-1_6b-4bit` |
+| Phi 1.5 / Phi 2 | ✅ | MHA/MQA + partial RoPE (paged) | ✅ | `mlx-community/phi-2-4bit` |
 | GPT-OSS | 🔵 | Sink attention (paged) | ✅ | `openai/gpt-oss-20b` |
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | — |
 | MiniCPM3-4B | ✅ | MLA (paged latent cache) | ✅ | `mlx-community/MiniCPM3-4B-4bit` |

--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -95,7 +95,7 @@ Llama-3.2-1B-Instruct, and Mistral-7B-Instruct-v0.3 Q8_0
 | Mistral-7B | ✅ | GQA (paged) | ✅ | `mlx-community/Mistral-7B-Instruct-v0.3-4bit` |
 | Mistral-Small-24B | 🔵 | GQA (paged) | ✅ | `mlx-community/Mistral-Small-24B-Instruct-2501-4bit` |
 | StableLM 2 | ✅ | MHA + partial RoPE (paged) | ✅ | `mlx-community/stablelm-2-zephyr-1_6b-4bit` |
-| Phi 1.5 / Phi 2 | ✅ | MHA/MQA + partial RoPE (paged) | ✅ | `mlx-community/phi-2-4bit` |
+| Phi 1.5 / Phi 2 | ✅ | MHA + partial RoPE (paged) | ✅ | `mlx-community/phi-2-hf-4bit-mlx` |
 | GPT-OSS | 🔵 | Sink attention (paged) | ✅ | `openai/gpt-oss-20b` |
 | GLM-4.5 | 🟡 | MLA (paged latent cache, MLX SDPA — no Metal kernel) | 🟡 | — |
 | MiniCPM3-4B | ✅ | MLA (paged latent cache) | ✅ | `mlx-community/MiniCPM3-4B-4bit` |

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -1174,3 +1174,89 @@ class TestApplyGProjGate:
 
         assert result.shape == out.shape
         assert mx.allclose(result, expected, atol=1e-6).item()
+
+
+class TestPhiAttention:
+    """Phi-1/1.5 (``mlx_lm.models.phi``) reaches the paged kernel.
+
+    The real class spells its output projection ``dense`` (not ``o_proj``)
+    and computes the standard softmax scale inline, so it needs both the
+    dispatch alias and the query-derived-scale contract to serve on the
+    paged path.
+    """
+
+    def test_phi_dispatch_and_derived_scale_reach_kernel(self) -> None:
+        """is_sdpa accepts ``dense`` and the kernel sees head_dim**-0.5."""
+        from mlx_lm.models.phi import ModelArgs, PhiAttention
+
+        n_heads, n_kv_heads, head_dim = 4, 2, 16
+        hidden = n_heads * head_dim
+        inner = PhiAttention(
+            ModelArgs(
+                model_type="phi",
+                vocab_size=32,
+                hidden_size=hidden,
+                num_attention_heads=n_heads,
+                num_hidden_layers=1,
+                num_key_value_heads=n_kv_heads,
+                partial_rotary_factor=0.5,
+                intermediate_size=16,
+            )
+        )
+
+        assert sdpa_mod.is_sdpa(inner)
+
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        ctx = _make_ctx(_SEQ_LEN)
+        x = mx.ones((_BATCH, _SEQ_LEN, hidden))
+
+        queries = mx.ones((_BATCH, n_heads, _SEQ_LEN, head_dim))
+        keys = mx.ones((_BATCH, n_kv_heads, _SEQ_LEN, head_dim))
+        values = mx.ones((_BATCH, n_kv_heads, _SEQ_LEN, head_dim))
+        kv_for_sharing = (keys, values)
+
+        captured: dict[str, float] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self, _key, _value, key_cache, value_cache, _slot_mapping
+            ):
+                return key_cache, value_cache
+
+            def paged_attention_primitive(
+                self, _query, _key_cache, _value_cache, _num_kv_heads, scale, *_a, **_k
+            ):
+                captured["scale"] = scale
+
+        with (
+            patch.object(
+                sdpa_mod,
+                "prepare_sdpa_qkv",
+                return_value=(queries, keys, values, None, kv_for_sharing),
+            ),
+            patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+            patch.object(
+                sdpa_mod,
+                "truncate_padded_output",
+                return_value=mx.zeros((_BATCH, _SEQ_LEN, hidden)),
+            ),
+        ):
+            out = sdpa_forward(
+                inner,
+                x,
+                ctx,
+                cache,
+                layer_idx=0,
+                attention_contract=attention_contract_for(inner),
+            )
+
+        assert captured["scale"] == pytest.approx(head_dim**-0.5)
+        # The output ran through PhiAttention.dense, not a missing o_proj.
+        assert out is not None

--- a/vllm_metal/attention/attention_contracts.py
+++ b/vllm_metal/attention/attention_contracts.py
@@ -26,6 +26,9 @@ _ATTENTION_CONTRACTS: dict[str, AttentionContract] = {
         qk_norm_placement=QKNormPlacement.AFTER_ROPE
     ),
     "mlx_lm.models.stablelm": AttentionContract(derive_scale_from_query=True),
+    # Phi computes the standard scale inline in its forward and exposes no
+    # scale attribute, exactly like StableLM.
+    "mlx_lm.models.phi": AttentionContract(derive_scale_from_query=True),
 }
 
 

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -90,7 +90,8 @@ def is_sdpa(module: nn.Module) -> bool:
 
     Accepts two contracts:
 
-    - Split-projection SDPA: ``q_proj`` / ``k_proj`` / ``o_proj``, plus
+    - Split-projection SDPA: ``q_proj`` / ``k_proj`` / output projection
+      (``o_proj``, or ``dense`` as in ``mlx_lm.models.phi``), plus
       EITHER ``v_proj`` OR the explicit ``use_k_eq_v = True`` opt-in.
       The latter admits Gemma4 26B / 31B full-attention layers which
       share the K projection for values and never define ``v_proj``
@@ -110,7 +111,7 @@ def is_sdpa(module: nn.Module) -> bool:
     return (
         hasattr(module, "q_proj")
         and hasattr(module, "k_proj")
-        and hasattr(module, "o_proj")
+        and _output_projection(module) is not None
         and (hasattr(module, "v_proj") or getattr(module, "use_k_eq_v", False))
     )
 
@@ -233,6 +234,21 @@ def _named_norm(module: nn.Module, *names: str) -> nn.Module | None:
         norm = getattr(module, name, None)
         if norm is not None:
             return norm
+    return None
+
+
+def _output_projection(module: nn.Module) -> nn.Module | None:
+    """Return the attention-output projection on *module*.
+
+    Nearly every mlx_lm SDPA architecture calls it ``o_proj``; Phi-1/1.5
+    (``mlx_lm.models.phi``) spell theirs ``dense``.  Probing by name keeps
+    ``is_sdpa`` and the forward path aligned on the same alias set instead
+    of the forward breaking on architectures that already pass dispatch.
+    """
+    for name in ("o_proj", "dense"):
+        proj = getattr(module, name, None)
+        if proj is not None:
+            return proj
     return None
 
 
@@ -813,7 +829,7 @@ def sdpa_forward(
     if gate is not None:
         out = out * mx.sigmoid(gate)
     out = apply_g_proj_gate(inner, out, x, n_heads, actual_head_dim)
-    return inner.o_proj(out), kv_for_sharing
+    return _output_projection(inner)(out), kv_for_sharing
 
 
 def apply_g_proj_gate(


### PR DESCRIPTION
## Summary

`mlx_lm.models.phi` (phi-1 / phi-1.5 / phi-2 checkpoints) currently cannot serve on the paged path, for two independent reasons:

1. **Output projection name**: `PhiAttention` spells its output projection `dense`, not `o_proj`, so `is_sdpa`'s split-projection contract rejects it (and the forward path would crash on `inner.o_proj` even if dispatched).
2. **Scale attribute**: like StableLM before #687, Phi computes the standard softmax scale inline in its forward (`scale = math.sqrt(1 / queries.shape[-1])`) and exposes neither `scale` nor `sm_scale`, so `sdpa_forward` raises `AttributeError` before dispatch.

Fixes:

- `_output_projection(module)` probes `o_proj` then `dense`; both `is_sdpa`'s split-projection branch and the `sdpa_forward` output call go through it, keeping dispatch and forward aligned on the same alias set.
- Registers `"mlx_lm.models.phi"` with `derive_scale_from_query=True` — the exact pattern #687 established for StableLM. The derived formula matches `PhiAttention`'s own forward verbatim. Unregistered scale-less modules keep failing loudly before dispatch (unchanged).
- Adds `docs/supported_models.md` row for Phi.

## Issue

Follow-up to the scale discussion in #656 (whose author measured mlx-lm having exactly two inline-scale SDPA families — StableLM, now fixed by #687, and Phi, addressed here).

## Validation

- New regression test drives the **real pinned** `mlx_lm.models.phi.PhiAttention` through `sdpa_forward` with a fake ops layer: asserts `is_sdpa(inner)` is True and the kernel receives `head_dim ** -0.5`.
- `pytest tests/test_attention_sdpa.py`: **30/30 passed** (including the StableLM and GPT-OSS scale regressions unchanged); `tests/test_hunyuan_qk_norm.py` passed.
- `ruff check` + `ruff format --check` clean; `mypy` clean for the touched modules.
- Note: `PhiAttention`'s partial RoPE (`partial_rotary_factor`) is encoded in its own `nn.RoPE` dimensions, which `prepare_sdpa_qkv` already applies as-is — same conclusion #687 reached for StableLM's RoPE.

## Type of Change

- [x] Bug fix

## Area

- [x] Paged attention SDPA dispatch