### PR TITLE
[CI] Move model parity to nightly and /ci parity runs

### DIFF
--- a/.github/scripts/parity.py
+++ b/.github/scripts/parity.py
@@ -96,6 +96,28 @@ def start() -> dict | None:
 
 def finish(check_id: str, result: str) -> None:
     conclusion = result if result in {"success", "cancelled"} else "failure"
+    tested_sha = os.environ["PARITY_TESTED_SHA"]
+    summary = f"Tested commit: `{tested_sha}`.\n\n"
+    if os.environ["GITHUB_EVENT_NAME"] == "issue_comment":
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        number = int(event["issue"]["number"])
+        try:
+            head_sha = github_api(f"pulls/{number}")["head"]["sha"]
+            freshness = (
+                "Up to date at report time."
+                if head_sha == tested_sha
+                else "Outdated — the current PR head was not tested by this run. "
+                "Comment `/ci parity` to test the current head."
+            )
+            summary += f"Current PR head: `{head_sha}`.\n\n{freshness}\n\n"
+        except (OSError, ValueError, KeyError) as error:
+            print(f"::warning::Could not read current PR head: {error}")
+            summary += "Freshness unknown: could not read the current PR head.\n\n"
+    summary += (
+        f"[View workflow run]({workflow_url()}) for per-model "
+        "summaries of EXACT, TOP_K_MATCH, and FAIL. Download the parity "
+        "artifacts for per-batch logs and environment versions."
+    )
     github_api(
         f"check-runs/{int(check_id)}",
         method="PATCH",
@@ -104,12 +126,12 @@ def finish(check_id: str, result: str) -> None:
             "conclusion": conclusion,
             "output": {
                 "title": f"Parity matrix: {conclusion}",
-                "summary": f"[View workflow run]({workflow_url()}) for per-model "
-                "summaries of EXACT, TOP_K_MATCH, and FAIL. Download the parity "
-                "artifacts for per-batch logs and environment versions.",
+                "summary": summary,
             },
         },
     )
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as output:
+        print(f"### Parity matrix: {conclusion}\n\n{summary}", file=output)
 
 
 def main() -> None:

--- a/.github/scripts/parity.py
+++ b/.github/scripts/parity.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Authorize parity runs and report checks; never execute PR code here."""
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+REPOSITORY = "vllm-project/vllm-metal"
+
+
+def workflow_url() -> str:
+    return (
+        f"{os.environ['GITHUB_SERVER_URL']}/{REPOSITORY}"
+        f"/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    )
+
+
+def github_api(path: str, *, method: str = "GET", data: dict | None = None) -> dict:
+    request = urllib.request.Request(
+        f"{os.environ['GITHUB_API_URL']}/repos/{REPOSITORY}/{path}",
+        data=json.dumps(data).encode() if data is not None else None,
+        headers={
+            "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def resolve_target() -> dict | None:
+    if os.environ["GITHUB_REPOSITORY"] != REPOSITORY:
+        return None
+    event_name = os.environ["GITHUB_EVENT_NAME"]
+    if event_name == "schedule":
+        return {
+            "repository": REPOSITORY,
+            "sha": os.environ["GITHUB_SHA"],
+            "key": "nightly",
+        }
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    if (
+        event_name != "issue_comment"
+        or event.get("issue", {}).get("pull_request") is None
+        or event.get("comment", {}).get("body") != "/ci parity"
+    ):
+        return None
+    username = urllib.parse.quote(event["comment"]["user"]["login"], safe="")
+    try:
+        permission = github_api(f"collaborators/{username}/permission")["permission"]
+    except urllib.error.HTTPError as error:
+        if error.code in (403, 404):
+            return None
+        raise
+    if permission not in {"admin", "maintain", "write"}:
+        return None
+    number = int(event["issue"]["number"])
+    pr = github_api(f"pulls/{number}")
+    if pr["state"] != "open" or not pr["head"]["repo"]:
+        return None
+    return {
+        "repository": pr["head"]["repo"]["full_name"],
+        "sha": pr["head"]["sha"],
+        "key": f"pr-{number}",
+    }
+
+
+def start() -> dict | None:
+    target = resolve_target()
+    if target is None:
+        return None
+    check = github_api(
+        "check-runs",
+        method="POST",
+        data={
+            "name": "Parity",
+            "head_sha": target["sha"],
+            "status": "in_progress",
+            "details_url": workflow_url(),
+            "output": {
+                "title": "Parity matrix requested",
+                "summary": f"Testing {target['repository']}@{target['sha']}. "
+                f"[View workflow run]({workflow_url()}) for results and logs.",
+            },
+        },
+    )
+    return {**target, "check_id": str(check["id"])}
+
+
+def finish(check_id: str, result: str) -> None:
+    conclusion = result if result in {"success", "cancelled"} else "failure"
+    github_api(
+        f"check-runs/{int(check_id)}",
+        method="PATCH",
+        data={
+            "status": "completed",
+            "conclusion": conclusion,
+            "output": {
+                "title": f"Parity matrix: {conclusion}",
+                "summary": f"[View workflow run]({workflow_url()}) for per-model "
+                "summaries of EXACT, TOP_K_MATCH, and FAIL. Download the parity "
+                "artifacts for per-batch logs and environment versions.",
+            },
+        },
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("resolve", "report"))
+    args = parser.parse_args()
+    if args.action == "report":
+        finish(os.environ["PARITY_CHECK_ID"], os.environ["PARITY_RESULT"])
+        return
+    target = start()
+    with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        print(f"run={str(target is not None).lower()}", file=output)
+        for key, value in (target or {}).items():
+            print(f"{key}={value}", file=output)
+    if target is None:
+        print("::notice::Parity was not authorized or the PR is no longer open.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_parity.py
+++ b/.github/scripts/test_parity.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+import json
+from unittest.mock import Mock
+
+import parity
+import pytest
+
+
+@pytest.fixture
+def event(monkeypatch, tmp_path):
+    payload = {
+        "issue": {"number": 42, "pull_request": {}},
+        "comment": {
+            "body": "/ci parity",
+            "user": {"login": "reviewer"},
+            "author_association": "MEMBER",
+        },
+    }
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(payload))
+    for key, value in {
+        "GITHUB_REPOSITORY": parity.REPOSITORY,
+        "GITHUB_EVENT_NAME": "issue_comment",
+        "GITHUB_EVENT_PATH": str(event_path),
+        "GITHUB_SHA": "main-sha",
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_RUN_ID": "123",
+    }.items():
+        monkeypatch.setenv(key, value)
+    return payload, event_path
+
+
+def test_only_authorized_exact_commands_can_launch_pr_code(event, monkeypatch):
+    api = Mock(return_value={"permission": "read"})
+    monkeypatch.setattr(parity, "github_api", api)
+    assert parity.start() is None
+    api.assert_called_once_with("collaborators/reviewer/permission")
+
+    api.reset_mock()
+    payload, event_path = event
+    payload["comment"]["body"] = "/ci parity extra"
+    event_path.write_text(json.dumps(payload))
+    assert parity.start() is None
+    api.assert_not_called()
+
+
+def test_captured_fork_sha_and_original_check_are_used(event, monkeypatch):
+    pr = {
+        "state": "open",
+        "head": {"sha": "pr-sha", "repo": {"full_name": "contributor/fork"}},
+    }
+    api = Mock(side_effect=[{"permission": "maintain"}, pr, {"id": 99}, {}])
+    monkeypatch.setattr(parity, "github_api", api)
+    target = parity.start()
+    assert target["repository"] == "contributor/fork"
+    assert target["sha"] == "pr-sha"
+    assert api.call_args.kwargs["data"]["head_sha"] == "pr-sha"
+
+    pr["head"]["sha"] = "newer-pr-sha"
+    parity.finish(target["check_id"], "failure")
+    assert api.call_args.args == ("check-runs/99",)
+    assert api.call_args.kwargs["data"]["conclusion"] == "failure"
+
+
+def test_nightly_uses_event_sha_and_does_not_run_in_forks(event, monkeypatch):
+    api = Mock()
+    monkeypatch.setattr(parity, "github_api", api)
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+    assert parity.resolve_target() == {
+        "repository": parity.REPOSITORY,
+        "sha": "main-sha",
+        "key": "nightly",
+    }
+    monkeypatch.setenv("GITHUB_REPOSITORY", "contributor/fork")
+    assert parity.start() is None
+    api.assert_not_called()

--- a/.github/scripts/test_parity.py
+++ b/.github/scripts/test_parity.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
+import urllib.error
 from unittest.mock import Mock
 
 import parity
@@ -25,6 +26,8 @@ def event(monkeypatch, tmp_path):
         "GITHUB_SHA": "main-sha",
         "GITHUB_SERVER_URL": "https://github.com",
         "GITHUB_RUN_ID": "123",
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "summary.md"),
+        "PARITY_TESTED_SHA": "pr-sha",
     }.items():
         monkeypatch.setenv(key, value)
 
@@ -41,7 +44,7 @@ def test_captured_fork_sha_and_original_check_are_used(event, monkeypatch):
         "state": "open",
         "head": {"sha": "pr-sha", "repo": {"full_name": "contributor/fork"}},
     }
-    api = Mock(side_effect=[{"permission": "maintain"}, pr, {"id": 99}, {}])
+    api = Mock(side_effect=[{"permission": "maintain"}, pr, {"id": 99}, pr, {}])
     monkeypatch.setattr(parity, "github_api", api)
     target = parity.start()
     assert target["repository"] == "contributor/fork"
@@ -52,6 +55,46 @@ def test_captured_fork_sha_and_original_check_are_used(event, monkeypatch):
     parity.finish(target["check_id"], "failure")
     assert api.call_args.args == ("check-runs/99",)
     assert api.call_args.kwargs["data"]["conclusion"] == "failure"
+
+
+@pytest.mark.parametrize(
+    ("head", "expected"),
+    [
+        ({"head": {"sha": "a" * 40}}, "Up to date at report time."),
+        ({"head": {"sha": "b" * 40}}, "Outdated"),
+        (urllib.error.URLError("unavailable"), "Freshness unknown"),
+    ],
+)
+def test_report_preserves_result_and_shows_freshness(
+    event, monkeypatch, tmp_path, head, expected
+):
+    monkeypatch.setenv("PARITY_TESTED_SHA", "a" * 40)
+    api = Mock(side_effect=[head, {}])
+    monkeypatch.setattr(parity, "github_api", api)
+    parity.finish("99", "success")
+    assert api.call_args_list[0].args == ("pulls/42",)
+    assert api.call_args.args == ("check-runs/99",)
+    data = api.call_args.kwargs["data"]
+    assert data["conclusion"] == "success"
+    summary = data["output"]["summary"]
+    assert f"Tested commit: `{'a' * 40}`" in summary
+    assert expected in summary
+    if isinstance(head, dict):
+        assert f"Current PR head: `{head['head']['sha']}`" in summary
+    assert summary in (tmp_path / "summary.md").read_text()
+
+
+def test_nightly_report_does_not_fetch_pr_head(event, monkeypatch):
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+    monkeypatch.setenv("PARITY_TESTED_SHA", "main-sha")
+    api = Mock()
+    monkeypatch.setattr(parity, "github_api", api)
+    parity.finish("99", "success")
+    assert api.call_count == 1
+    assert api.call_args.args == ("check-runs/99",)
+    assert (
+        "Tested commit: `main-sha`" in api.call_args.kwargs["data"]["output"]["summary"]
+    )
 
 
 def test_nightly_uses_event_sha_and_does_not_run_in_forks(event, monkeypatch):

--- a/.github/scripts/test_parity.py
+++ b/.github/scripts/test_parity.py
@@ -27,21 +27,13 @@ def event(monkeypatch, tmp_path):
         "GITHUB_RUN_ID": "123",
     }.items():
         monkeypatch.setenv(key, value)
-    return payload, event_path
 
 
-def test_only_authorized_exact_commands_can_launch_pr_code(event, monkeypatch):
+def test_read_only_user_cannot_launch_pr_code(event, monkeypatch):
     api = Mock(return_value={"permission": "read"})
     monkeypatch.setattr(parity, "github_api", api)
     assert parity.start() is None
     api.assert_called_once_with("collaborators/reviewer/permission")
-
-    api.reset_mock()
-    payload, event_path = event
-    payload["comment"]["body"] = "/ci parity extra"
-    event_path.write_text(json.dumps(payload))
-    assert parity.start() is None
-    api.assert_not_called()
 
 
 def test_captured_fork_sha_and_original_check_are_used(event, monkeypatch):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Cache HuggingFace models
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/huggingface/hub
-        key: hf-${{ runner.os }}-${{ hashFiles('scripts/test.sh') }}
-
     - name: Test
       run: |
         scripts/test.sh

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -113,25 +113,18 @@ jobs:
         with:
           path: ~/.cache/huggingface/hub
           key: ${{ steps.models.outputs.cache-primary-key }}
-      - name: Compare all batch sizes
+      - name: Compare parity through HTTP serving
         run: |
           source .venv-vllm-metal/bin/activate
-          printf '### %s\n\nCommit: %s\n\n| Batch | EXACT | TOP_K_MATCH | FAIL | Exit |\n|---|---:|---:|---:|---:|\n' "$MODEL_ID" "$TESTED_SHA" >> "$GITHUB_STEP_SUMMARY"
-          failed=0
-          for batch in 1 2; do
-            log="$RUNNER_TEMP/parity/batch-${batch}.log"
-            if python tools/check_parity.py --model "$MODEL_PATH" --top-k 5 --max-tokens 20 --batch-size "$batch" 2>&1 | tee "$log"; then
-              code=0
-            else
-              code=$?
-              failed=1
-            fi
-            exact=$(awk '/^EXACT / {n++} END {print n+0}' "$log")
-            topk=$(awk '/^TOP_K_MATCH / {n++} END {print n+0}' "$log")
-            mismatches=$(awk '/^FAIL / {n++} END {print n+0}' "$log")
-            printf '| %s | %s | %s | %s | %s |\n' "$batch" "$exact" "$topk" "$mismatches" "$code" >> "$GITHUB_STEP_SUMMARY"
-          done
-          exit "$failed"
+          python tools/check_parity.py --model "$MODEL_PATH" --top-k 5 --max-tokens 20 \
+            --batch-size 1 2 --output-dir "$RUNNER_TEMP/parity"
+      - name: Summarize parity
+        if: always()
+        run: |
+          printf '### %s\n\nCommit: %s\n\n' "$MODEL_ID" "$TESTED_SHA" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$RUNNER_TEMP/parity/summary.md" ]; then
+            cat "$RUNNER_TEMP/parity/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -61,7 +61,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
       MACOSX_DEPLOYMENT_TARGET: '15.0'
-      # Leave headroom for the CPU runtime on hosted Mac runners.
+      # Use 0.65 on small GHA runners; 0.8 makes parity tests extremely slow.
       VLLM_METAL_MEMORY_FRACTION: '0.65'
       GLOO_SOCKET_IFNAME: lo0
       MODEL_ID: ${{ matrix.model.id }}

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,159 @@
+name: Parity
+
+on:
+  schedule:
+    - cron: '17 7 * * *' # Daily at 07:17 UTC.
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  resolve:
+    if: >-
+      github.repository == 'vllm-project/vllm-metal' &&
+      (github.event_name == 'schedule' ||
+       (github.event.issue.pull_request && github.event.comment.body == '/ci parity'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    outputs:
+      run: ${{ steps.target.outputs.run }}
+      sha: ${{ steps.target.outputs.sha }}
+      repository: ${{ steps.target.outputs.repository }}
+      key: ${{ steps.target.outputs.key }}
+      check_id: ${{ steps.target.outputs.check_id }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }} # Trusted default-branch code, not the PR checkout.
+          persist-credentials: false
+      - name: Resolve parity target
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/parity.py resolve
+
+  parity:
+    needs: resolve
+    if: needs.resolve.outputs.run == 'true'
+    name: Parity (${{ matrix.os }}, ${{ matrix.model.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    concurrency:
+      group: parity-${{ needs.resolve.outputs.key }}-${{ matrix.os }}-${{ matrix.model.name }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, macos-26]
+        model:
+          - name: qwen3-0.6b
+            id: Qwen/Qwen3-0.6B
+            revision: c1899de289a04d12100db370d81485cdf75e47ca
+          - name: qwen35-0.8b
+            id: Qwen/Qwen3.5-0.8B
+            revision: 2fc06364715b967f1860aea9cf38778875588b17
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+      MACOSX_DEPLOYMENT_TARGET: '15.0'
+      # Leave headroom for the CPU runtime on hosted Mac runners.
+      VLLM_METAL_MEMORY_FRACTION: '0.65'
+      GLOO_SOCKET_IFNAME: lo0
+      MODEL_ID: ${{ matrix.model.id }}
+      MODEL_REVISION: ${{ matrix.model.revision }}
+      TESTED_SHA: ${{ needs.resolve.outputs.sha }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.resolve.outputs.repository }}
+          ref: ${{ needs.resolve.outputs.sha }}
+          submodules: recursive
+          persist-credentials: false
+      - uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
+        id: models
+        with:
+          path: ~/.cache/huggingface/hub
+          key: parity-hf-${{ runner.os }}-${{ matrix.model.name }}-${{ matrix.model.revision }}
+      - name: Install the tested checkout
+        run: |
+          test "$(git rev-parse HEAD)" = "$TESTED_SHA"
+          mkdir -p "$RUNNER_TEMP/parity"
+          printf 'commit=%s\nmodel=%s\nrevision=%s\n' "$TESTED_SHA" "$MODEL_ID" "$MODEL_REVISION" > "$RUNNER_TEMP/parity/environment.txt"
+          ./install.sh
+      - name: Prepare checkpoint
+        run: |
+          source .venv-vllm-metal/bin/activate
+          python - <<'PY'
+          import importlib.metadata as metadata
+          import os
+          import platform
+          import sys
+          from huggingface_hub import snapshot_download
+          from vllm.platforms import current_platform
+          assert type(current_platform).__name__ == "MetalPlatform", current_platform
+          with open(os.environ["RUNNER_TEMP"] + "/parity/environment.txt", "a") as f:
+              print(platform.platform(), file=f)
+              print(sys.version, file=f)
+              for package in ("vllm-metal", "vllm", "mlx", "mlx-lm"):
+                  print(package, metadata.version(package), file=f)
+          model = snapshot_download(os.environ["MODEL_ID"], revision=os.environ["MODEL_REVISION"])
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              print(f"MODEL_PATH={model}", file=f)
+          PY
+      - uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5
+        if: success() && github.event_name == 'schedule' && steps.models.outputs.cache-hit != 'true'
+        with:
+          path: ~/.cache/huggingface/hub
+          key: ${{ steps.models.outputs.cache-primary-key }}
+      - name: Compare all batch sizes
+        run: |
+          source .venv-vllm-metal/bin/activate
+          printf '### %s\n\nCommit: %s\n\n| Batch | EXACT | TOP_K_MATCH | FAIL | Exit |\n|---|---:|---:|---:|---:|\n' "$MODEL_ID" "$TESTED_SHA" >> "$GITHUB_STEP_SUMMARY"
+          failed=0
+          for batch in 1 2; do
+            log="$RUNNER_TEMP/parity/batch-${batch}.log"
+            if python tools/check_parity.py --model "$MODEL_PATH" --top-k 5 --max-tokens 20 --batch-size "$batch" 2>&1 | tee "$log"; then
+              code=0
+            else
+              code=$?
+              failed=1
+            fi
+            exact=$(awk '/^EXACT / {n++} END {print n+0}' "$log")
+            topk=$(awk '/^TOP_K_MATCH / {n++} END {print n+0}' "$log")
+            mismatches=$(awk '/^FAIL / {n++} END {print n+0}' "$log")
+            printf '| %s | %s | %s | %s | %s |\n' "$batch" "$exact" "$topk" "$mismatches" "$code" >> "$GITHUB_STEP_SUMMARY"
+          done
+          exit "$failed"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: parity-${{ matrix.os }}-${{ matrix.model.name }}-${{ needs.resolve.outputs.sha }}
+          path: ${{ runner.temp }}/parity
+          retention-days: 14
+
+  report:
+    needs: [resolve, parity]
+    if: always() && needs.resolve.outputs.check_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Report parity result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARITY_CHECK_ID: ${{ needs.resolve.outputs.check_id }}
+          PARITY_RESULT: ${{ needs.parity.result }}
+        run: python3 .github/scripts/parity.py report

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -145,6 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
       checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -156,4 +157,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PARITY_CHECK_ID: ${{ needs.resolve.outputs.check_id }}
           PARITY_RESULT: ${{ needs.parity.result }}
+          PARITY_TESTED_SHA: ${{ needs.resolve.outputs.sha }}
         run: python3 .github/scripts/parity.py report

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -58,7 +58,7 @@ scripts/lint.sh
 
 ## Run CI locally
 
-Mirrors the `test` job in CI — serving smoke tests plus the non-slow pytest suite:
+Mirrors the `test` job in CI: wheel validation, Metal platform checks, and the non-slow pytest suite. Model parity runs separately in the [daily and requested workflow](tools.md#scheduled-and-requested-ci):
 
 ```bash
 scripts/test.sh

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -16,3 +16,9 @@ Both backends use the same checkpoint and input token IDs in separate processes.
 - `FAIL`: a mismatch fails the comparison, or generation is incomplete.
 
 Exit status is 0 when all prompts pass, otherwise nonzero. No saved golden token IDs or regeneration step is needed.
+
+## Scheduled and requested CI
+
+Parity runs daily at 07:17 UTC on `main`. Users with repository write access can also comment `/ci parity` on an open PR once the workflow is on the default branch.
+
+Both triggers test Qwen3-0.6B and Qwen3.5-0.8B on macOS 15 and 26 with Xcode 26.3: 40 shared prompts, 20 output tokens, top-K 5, and batch sizes 1/2. The `Parity` check links to job summaries and logs retained for 14 days. Regular PR CI runs fast tests without starting model servers.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,10 +6,12 @@ With the project environment active, compare paged serving against a fresh refer
 
 ```bash
 python tools/check_parity.py --model Qwen/Qwen3-0.6B
-python tools/check_parity.py --model /path/to/checkpoint --top-k 5 --batch-size 4
+python tools/check_parity.py --model /path/to/checkpoint --top-k 5 --batch-size 1 2 --output-dir parity-results
 ```
 
-Both backends use the same checkpoint and input token IDs in separate processes. The default is the 40 prompts in `tools/parity_prompts.py`, greedy decoding, and 10 output tokens, ignoring EOS. Use `--prompt` for custom text, `--max-tokens` for output length, and `--help` for all options. Inputs are plain text without a chat template.
+The tool generates the native MLX reference once and exits that process before starting one `vllm serve` instance. It checks `/health`, compares individual prompts and pairs of prompts through `/v1/completions`, then stops the server. The server's sequence limit is the largest requested batch size, and prefix caching is disabled. Each pair is submitted in one HTTP request. These are request batch sizes, not assertions about the actual GPU batch size. Both backends use the same checkpoint and input token IDs.
+
+The default is the 40 prompts in `tools/parity_prompts.py`, greedy decoding, and 10 output tokens, ignoring EOS. Use `--prompt` for custom text, `--max-tokens` for output length, and `--help` for all options. Inputs are plain text without a chat template. Logs, the native reference, and a summary are saved to `--output-dir`, or a new temporary directory printed at startup. The tool selects an available localhost port automatically.
 
 - `EXACT`: every output token matches.
 - `TOP_K_MATCH`: the first divergence passes mutual top-K membership; later tokens are not compared. Enabled with `--top-k K`.
@@ -21,4 +23,6 @@ Exit status is 0 when all prompts pass, otherwise nonzero. No saved golden token
 
 Parity runs daily at 07:17 UTC on `main`. Users with repository write access can also comment `/ci parity` on an open PR once the workflow is on the default branch.
 
-Both triggers test Qwen3-0.6B and Qwen3.5-0.8B on macOS 15 and 26 with Xcode 26.3: 40 shared prompts, 20 output tokens, top-K 5, and batch sizes 1/2. The `Parity` check links to job summaries and logs retained for 14 days. Regular PR CI runs fast tests without starting model servers.
+Both triggers invoke this same tool for Qwen3-0.6B and Qwen3.5-0.8B on macOS 15 and 26 with Xcode 26.3: 40 shared prompts, 20 output tokens, top-K 5, and HTTP request batch sizes 1/2. CI supplies the checkpoint and environment and collects the tool's results.
+
+The `Parity` check links to job summaries and artifacts containing the native reference, server log, and per-batch results, retained for 14 days. Regular PR CI runs fast tests without starting model servers.

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,140 +1,5 @@
 #!/bin/bash
 
-# Run a paged-attention smoke test: serve a model, check golden output.
-#
-# Usage: run_smoke_test <model> <revision> <prompt> <expected> [extra_serve_args...]
-run_smoke_test() {
-  local model="$1"
-  local revision="$2"
-  local prompt="$3"
-  local expected="$4"
-  local alt_expected=""
-  shift 4
-  # Optional alt golden: next arg that doesn't start with '--' is alt_expected.
-  if [ $# -gt 0 ] && [[ "$1" != --* ]]; then
-    alt_expected="$1"
-    shift
-  fi
-  local extra_args=("$@")
-
-  section "Smoke test: $model"
-
-  # 1. Start vLLM with paged attention
-  GLOO_SOCKET_IFNAME=lo0 \
-    VLLM_METAL_USE_PAGED_ATTENTION=1 \
-    VLLM_METAL_MEMORY_FRACTION=0.8 \
-    vllm serve "$model" --revision "$revision" --max-model-len 512 --max-num-batched-tokens 64 ${extra_args[@]+"${extra_args[@]}"} &
-
-  local vllm_pid=$!
-
-  # 2. Wait for the server to be ready
-  echo "Waiting for vLLM to start..."
-  local health_url="http://localhost:8000/health"
-  if ! curl --retry 30 --retry-delay 10 --retry-all-errors -fs "$health_url" > /dev/null; then
-    echo "vLLM failed to start."
-    kill $vllm_pid
-    exit 1
-  fi
-
-  echo "Model loaded successfully!"
-
-  # 3. Test completions endpoint with golden comparison
-  echo "Testing completions with golden output..."
-  local response
-  response=$(curl -s -X POST "http://localhost:8000/v1/completions" \
-    -H "Content-Type: application/json" \
-    -d "{
-      \"model\": \"$model\",
-      \"prompt\": \"$prompt\",
-      \"temperature\": 0,
-      \"max_tokens\": 10
-    }")
-
-  if ! echo "$response" | grep -q '"choices"'; then
-    echo "Completions test failed. Response:"
-    echo "$response"
-    kill $vllm_pid
-    exit 1
-  fi
-
-  local actual
-  actual=$(echo "$response" | python3 -c "import sys,json; print(json.loads(sys.stdin.read(), strict=False)['choices'][0]['text'])")
-
-  if [ "$actual" != "$expected" ]; then
-    # Check alt_expected (optional 5th positional arg) for kernels with
-    # different numerical paths (e.g. tiled MMA vs scalar attention).
-    if [ -n "${alt_expected:-}" ] && [ "$actual" == "$alt_expected" ]; then
-      echo "Smoke test passed! Output matches alternate golden."
-    else
-      echo "Golden comparison FAILED"
-      echo "  expected: '$expected'"
-      echo "  actual:   '$actual'"
-      kill $vllm_pid
-      exit 1
-    fi
-  else
-    echo "Smoke test passed! Output matches golden."
-  fi
-
-  # Graceful shutdown with SIGKILL fallback
-  local shutdown_timeout=10
-  local port_timeout=15
-
-  kill $vllm_pid 2>/dev/null
-  for ((shutdown_wait=0; shutdown_wait<shutdown_timeout; shutdown_wait++)); do
-    if ! kill -0 $vllm_pid 2>/dev/null; then break; fi
-    sleep 1
-  done
-  if kill -0 $vllm_pid 2>/dev/null; then
-    echo "Warning: vLLM did not terminate after ${shutdown_timeout}s, sending SIGKILL"
-    kill -9 $vllm_pid 2>/dev/null
-  fi
-  wait $vllm_pid 2>/dev/null || true
-
-  # Wait for port to be released before next test
-  local port_wait=0
-  while lsof -i :8000 -sTCP:LISTEN >/dev/null 2>&1; do
-    sleep 1
-    port_wait=$((port_wait + 1))
-    if [ $port_wait -ge $port_timeout ]; then
-      echo "Warning: port 8000 still in use after ${port_timeout}s"
-      break
-    fi
-  done
-}
-
-smoke_tests() {
-  # Qwen3-0.6B: standard GQA paged attention path
-  # Primary golden: scalar kernel (matches MLX inline-cache ground truth).
-  # Alt golden: tiled MMA kernel (half×half QK accumulation order diverges
-  # at token 6 — "Italy" vs "France", both valid completions).
-  run_smoke_test \
-    "Qwen/Qwen3-0.6B" \
-    "c1899de289a04d12100db370d81485cdf75e47ca" \
-    "The capital of France is" \
-    " Paris. The capital of France is also the capital" \
-    " Paris. The capital of Italy is Rome. The"
-
-  # Qwen3.5-0.8B: hybrid SDPA + GDN linear attention paged path
-  # max-num-seqs=1: limits GDN linear state allocation (~10MB/slot × N slots)
-  # which is critical on CI runners with only ~5GB Metal memory.
-  run_smoke_test \
-    "Qwen/Qwen3.5-0.8B" \
-    "2fc06364715b967f1860aea9cf38778875588b17" \
-    "The capital of France is" \
-    " Paris.
-The capital of France is Paris." \
-    --max-num-seqs 1
-}
-
-installs() {
-  section "Installing vllm"
-
-  if [ "$(uname)" == "Darwin" ]; then
-    ./install.sh
-  fi
-}
-
 main() {
   set -eu -o pipefail
 
@@ -150,7 +15,7 @@ main() {
     # Export the deployment target in this shell for the wheel build below.
     ensure_metal_toolchain
     # install.sh builds the native artifacts before the wheel check below.
-    installs
+    ./install.sh
     # shellcheck source=/dev/null
     source .venv-vllm-metal/bin/activate
 
@@ -171,19 +36,14 @@ main() {
     section "Verifying package import"
     python -c "import vllm_metal; print('vllm_metal imported successfully')"
 
-    # Preflight: assert vLLM resolves the Metal platform before spending
-    # minutes on smokes. When this fails, MLX cannot see Metal inside the
-    # full vLLM process and every smoke dies confusingly on vLLM's CPU
-    # fallback; an unpinned dependency regression can cause this (see
-    # transformers 5.13.0, #471).
+    # Catch platform-resolution regressions without loading a model (#471).
     section "Checking Metal platform resolution"
     python -c "import sys; from vllm.platforms import current_platform; name = type(current_platform).__name__; print('Resolved platform:', name); sys.exit(0 if name == 'MetalPlatform' else 1)"
 
-    smoke_tests
     section "Running tests"
     # Exclude perf/long-running tests by default; run them explicitly via:
     #   pytest -m slow tests/ -v --tb=short
-    pytest -m "not slow" tests/ -v --tb=short
+    pytest -m "not slow" tests/ .github/scripts/test_parity.py -v --tb=short
   fi
 }
 

--- a/tests/test_parity_tool.py
+++ b/tests/test_parity_tool.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from tools.check_parity import compare_results
+import io
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from tools.check_parity import check_parity, compare_results, http_generate, http_result
 
 
 class TestParityTool:
@@ -43,3 +50,121 @@ class TestParityTool:
         ref = self._result([1], [[1, 6]])
         got = self._result([6], [[6, 1]])
         assert not compare_results([ref], [got], max_tokens=2, top_k=2)
+
+    def test_http_logprobs_exclude_sampled_token_outside_top_k(self):
+        choice = {
+            "token_ids": [6],
+            "text": "six",
+            "logprobs": {
+                "top_logprobs": [{"token_id:6": -3, "token_id:1": -1, "token_id:5": -2}]
+            },
+        }
+        got = http_result(choice, top_k=2)
+        assert {entry["id"] for entry in got["top_logprobs"][0]} == {1, 5}
+
+    @pytest.mark.parametrize(
+        ("batch_size", "expected_prompts"),
+        [(1, [[10], [20], [30]]), (2, [[[10], [20]], [30]])],
+    )
+    def test_http_prompt_batches_keep_reference_order(
+        self, monkeypatch, batch_size, expected_prompts
+    ):
+        sent = []
+
+        def respond(request, timeout):
+            assert request.full_url == "http://localhost:8000/v1/completions"
+            payload = json.loads(request.data)
+            assert payload["ignore_eos"] and payload["return_token_ids"]
+            assert payload["return_tokens_as_token_ids"]
+            assert payload["temperature"] == 0
+            sent.append(payload["prompt"])
+            prompts = payload["prompt"]
+            if isinstance(prompts[0], int):
+                prompts = [prompts]
+            choices = [
+                {
+                    "index": i,
+                    "prompt_token_ids": ids,
+                    "token_ids": [ids[0] + 1],
+                    "text": str(ids[0] + 1),
+                    "logprobs": {"top_logprobs": [{f"token_id:{ids[0] + 1}": -1}]},
+                }
+                for i, ids in enumerate(prompts)
+            ]
+            return io.BytesIO(json.dumps({"choices": choices[::-1]}).encode())
+
+        monkeypatch.setattr("urllib.request.urlopen", respond)
+        results = http_generate(
+            "http://localhost:8000/v1/",
+            "model",
+            [{"input_ids": [10]}, {"input_ids": [20]}, {"input_ids": [30]}],
+            max_tokens=1,
+            top_k=1,
+            batch_size=batch_size,
+        )
+        assert sent == expected_prompts
+        assert [result["tokens"] for result in results] == [[11], [21], [31]]
+
+    @pytest.mark.parametrize("indices", [[0], [0, 0]])
+    def test_http_rejects_missing_or_duplicate_choices(self, monkeypatch, indices):
+        choices = [
+            {"index": i, "prompt_token_ids": [1], "token_ids": [2], "text": "two"}
+            for i in indices
+        ]
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda *args, **kwargs: io.BytesIO(
+                json.dumps({"choices": choices}).encode()
+            ),
+        )
+        with pytest.raises(ValueError):
+            http_generate(
+                "http://localhost/v1",
+                "model",
+                [{"input_ids": [1]}] * 2,
+                1,
+                batch_size=2,
+            )
+
+    def test_http_rejects_changed_input_ids(self, monkeypatch):
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda *args, **kwargs: io.BytesIO(
+                b'{"choices": [{"index": 0, "prompt_token_ids": [99]}]}'
+            ),
+        )
+        with pytest.raises(ValueError, match="input token IDs"):
+            http_generate("http://localhost/v1", "model", [{"input_ids": [1]}], 1)
+
+    def test_canonical_flow_reuses_reference_and_server(self, monkeypatch, tmp_path):
+        events = []
+        row = {**self._result([2], []), "input_ids": [1]}
+
+        def generate_reference(command, **kwargs):
+            path = Path(command[command.index("--generate-reference") + 1])
+            assert json.loads(path.read_text()) == ["test prompt"]
+            path.write_text(json.dumps([row]))
+            events.append("reference exited")
+
+        @contextmanager
+        def server(model, max_model_len, max_num_seqs, log_path, env):
+            assert max_num_seqs == 2
+            events.append("server started")
+            yield "http://localhost/v1"
+            events.append("server stopped")
+
+        def generate(base_url, model, reference, max_tokens, top_k, batch_size):
+            events.append(f"batch size {batch_size}")
+            return reference
+
+        monkeypatch.setattr("subprocess.run", generate_reference)
+        monkeypatch.setattr("tools.check_parity.serving", server)
+        monkeypatch.setattr("tools.check_parity.http_generate", generate)
+        assert check_parity(str(tmp_path), ["test prompt"], 1, output_dir=tmp_path)
+        assert events == [
+            "reference exited",
+            "server started",
+            "batch size 1",
+            "batch size 2",
+            "server stopped",
+        ]

--- a/tools/check_parity.py
+++ b/tools/check_parity.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Compare greedy paged serving with the environment's native mlx-lm.
 
-Each backend runs in a fresh process with the same checkpoint and input IDs.
+Generate one native reference, then reuse one HTTP server for individual
+and batched prompt requests. Both backends use the same checkpoint and input IDs.
 See docs/tools.md or --help for usage.
 """
 
@@ -11,9 +12,14 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
+import socket
 import subprocess
 import sys
 import tempfile
+import time
+import urllib.request
+from contextlib import contextmanager, redirect_stdout, suppress
 from itertools import zip_longest
 from pathlib import Path
 
@@ -73,60 +79,65 @@ def mlx_generate(
     return results
 
 
-def metal_generate(
-    model_path: str,
-    reference: list[dict],
-    max_tokens: int,
-    top_k: int | None = None,
-    batch_size: int = 1,
-) -> list[dict]:
-    os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
-    os.environ["VLLM_METAL_USE_PAGED_ATTENTION"] = "1"
-    os.environ.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.3")
-    from vllm import LLM, SamplingParams
-
-    llm = LLM(
-        model=model_path,
-        max_model_len=max(len(row["input_ids"]) for row in reference) + max_tokens,
-        max_num_seqs=batch_size,
-        enable_prefix_caching=False,
-        disable_log_stats=True,
-        max_logprobs=top_k or 20,
-    )
-    outputs = llm.generate(
-        [{"prompt_token_ids": row["input_ids"]} for row in reference],
-        SamplingParams(
-            temperature=0, max_tokens=max_tokens, ignore_eos=True, logprobs=top_k
-        ),
-        use_tqdm=False,
-    )
-    results = []
-    for out in outputs:
-        completion = out.outputs[0]
-        top_logprobs = []
-        if top_k is not None:
-            assert completion.logprobs is not None
-            for step in completion.logprobs:
-                assert step is not None
-                top_logprobs.append(
-                    [
-                        {
-                            "id": token,
-                            "text": value.decoded_token,
-                            "logprob": value.logprob,
-                            "rank": value.rank,
-                        }
-                        for token, value in step.items()
-                    ]
-                )
-        results.append(
-            {
-                "tokens": list(completion.token_ids),
-                "text": completion.text,
-                "top_logprobs": top_logprobs,
-            }
+@contextmanager
+def serving(
+    model: str, max_model_len: int, max_num_seqs: int, log_path: Path, env: dict
+):
+    """Start one local server and clean up its process group on every exit."""
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+    base_url = f"http://127.0.0.1:{port}"
+    with log_path.open("w") as log:
+        server = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "vllm.entrypoints.cli.main",
+                "serve",
+                model,
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--max-model-len",
+                str(max_model_len),
+                "--max-num-seqs",
+                str(max_num_seqs),
+                "--no-enable-prefix-caching",
+                "--generation-config",
+                "vllm",
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env=env,
         )
-    return results
+        try:
+            deadline = time.monotonic() + 300
+            while time.monotonic() < deadline:
+                if server.poll() is not None:
+                    raise RuntimeError(f"Server exited during startup; see {log_path}")
+                try:
+                    with urllib.request.urlopen(
+                        f"{base_url}/health", timeout=2
+                    ) as response:
+                        if response.status == 200:
+                            break
+                except OSError:
+                    pass
+                time.sleep(1)
+            else:
+                raise TimeoutError(f"Server did not become healthy; see {log_path}")
+            yield f"{base_url}/v1"
+        finally:
+            with suppress(ProcessLookupError):
+                os.killpg(server.pid, signal.SIGTERM)
+            with suppress(subprocess.TimeoutExpired):
+                server.wait(timeout=10)
+            with suppress(ProcessLookupError):
+                os.killpg(server.pid, signal.SIGKILL)
+            server.wait()
 
 
 def check_parity(
@@ -134,39 +145,34 @@ def check_parity(
     prompts: list[str],
     max_tokens: int,
     top_k: int | None = None,
-    batch_size: int = 1,
+    batch_sizes: tuple[int, ...] = (1, 2),
+    output_dir: Path | None = None,
 ) -> bool:
-    """Run both backends and report the first differing token for each prompt."""
-    if not prompts:
-        raise ValueError("At least one prompt is required.")
+    """Generate one reference, then compare every request batch size on one server."""
+    if not prompts or not batch_sizes or min(batch_sizes) < 1:
+        raise ValueError("Prompts and positive request batch sizes are required.")
+    output_dir = output_dir or Path(tempfile.mkdtemp(prefix="metal-parity-"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Artifacts: {output_dir.resolve()}", flush=True)
+    summary = output_dir / "summary.md"
+    summary.write_text(
+        "| Prompts/request | EXACT | TOP_K_MATCH | FAIL | Exit |\n|---|---:|---:|---:|---:|\n"
+    )
     if not Path(model).is_dir():
         from huggingface_hub import snapshot_download
 
         model = snapshot_download(model)
     model = str(Path(model).resolve())
-    reference = run_backend("mlx", model, prompts, max_tokens, top_k)
-    outputs = run_backend("metal", model, reference, max_tokens, top_k, batch_size)
-    return compare_results(reference, outputs, max_tokens=max_tokens, top_k=top_k)
-
-
-def run_backend(
-    backend: str,
-    model: str,
-    inputs: list,
-    max_tokens: int,
-    top_k: int | None = None,
-    batch_size: int = 1,
-) -> list[dict]:
-    """Run one backend in a fresh process, releasing its model before returning."""
-    with tempfile.TemporaryDirectory(prefix="metal-parity-") as directory:
-        data = Path(directory) / "tokens.json"
-        data.write_text(json.dumps(inputs))
-        env = os.environ.copy()
-        env["PYTHONPATH"] = os.pathsep.join(
-            filter(
-                None, [str(Path(__file__).resolve().parents[1]), env.get("PYTHONPATH")]
-            )
-        )
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, [str(Path(__file__).resolve().parents[1]), env.get("PYTHONPATH")])
+    )
+    env.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.3")
+    env.setdefault("GLOO_SOCKET_IFNAME", "lo0")
+    reference_path = output_dir / "reference.json"
+    reference_path.write_text(json.dumps(prompts))
+    print("Generating native MLX reference...", flush=True)
+    with (output_dir / "reference.log").open("w") as log:
         subprocess.run(
             [
                 sys.executable,
@@ -175,18 +181,122 @@ def run_backend(
                 model,
                 "--max-tokens",
                 str(max_tokens),
-                "--batch-size",
-                str(batch_size),
-                "--backend",
-                backend,
-                "--data",
-                str(data),
+                "--generate-reference",
+                str(reference_path),
             ]
             + (["--top-k", str(top_k)] if top_k is not None else []),
             check=True,
             env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
         )
-        return json.loads(data.read_text())
+    reference = json.loads(reference_path.read_text())
+    max_model_len = max(len(row["input_ids"]) for row in reference) + max_tokens
+    passed = True
+    print("Starting vLLM server...", flush=True)
+    with serving(
+        model, max_model_len, max(batch_sizes), output_dir / "serve.log", env
+    ) as base_url:
+        for size in batch_sizes:
+            print(f"Prompts/request: {size}", flush=True)
+            outputs = http_generate(base_url, model, reference, max_tokens, top_k, size)
+            log_path = output_dir / f"batch-{size}.log"
+            with log_path.open("w") as log, redirect_stdout(log):
+                matched = compare_results(
+                    reference, outputs, max_tokens=max_tokens, top_k=top_k
+                )
+            report = log_path.read_text()
+            print(report, end="")
+            counts = [
+                sum(line.startswith(status + " ") for line in report.splitlines())
+                for status in ("EXACT", "TOP_K_MATCH", "FAIL")
+            ]
+            with summary.open("a") as output:
+                print(
+                    f"| {size} | {counts[0]} | {counts[1]} | {counts[2]} | {int(not matched)} |",
+                    file=output,
+                )
+            passed &= matched
+    return passed
+
+
+def http_generate(
+    base_url: str,
+    model: str,
+    reference: list[dict],
+    max_tokens: int,
+    top_k: int | None = None,
+    batch_size: int = 1,
+) -> list[dict]:
+    """Submit prompt batches sequentially to one server, preserving input order."""
+    if not reference or batch_size < 1:
+        raise ValueError(
+            "Reference prompts and a positive request batch size are required."
+        )
+    results = []
+    for start in range(0, len(reference), batch_size):
+        batch = reference[start : start + batch_size]
+        input_ids = [row["input_ids"] for row in batch]
+        request = urllib.request.Request(
+            f"{base_url.rstrip('/')}/completions",
+            data=json.dumps(
+                {
+                    "model": model,
+                    "prompt": input_ids[0] if len(batch) == 1 else input_ids,
+                    "temperature": 0,
+                    "max_tokens": max_tokens,
+                    "ignore_eos": True,
+                    "logprobs": top_k,
+                    "return_token_ids": True,
+                    "return_tokens_as_token_ids": True,
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(request, timeout=120) as response:
+            choices = sorted(
+                json.load(response)["choices"], key=lambda choice: choice["index"]
+            )
+        for index, (row, choice) in enumerate(zip(batch, choices, strict=True)):
+            if (
+                choice["index"] != index
+                or choice["prompt_token_ids"] != row["input_ids"]
+            ):
+                raise ValueError("Server changed prompt indices or input token IDs.")
+            results.append(http_result(choice, top_k))
+    return results
+
+
+def http_result(choice: dict, top_k: int | None) -> dict:
+    """Convert completion logprobs to the comparator's token-ID format."""
+    tokens = choice["token_ids"]
+    top_logprobs = []
+    if top_k is not None:
+        for sampled, step in zip(
+            tokens, choice["logprobs"]["top_logprobs"], strict=True
+        ):
+            candidates = {
+                int(token.removeprefix("token_id:")): score
+                for token, score in step.items()
+            }
+            # The API returns the sampled token plus top-K. An extra entry
+            # means the sampled token is outside top-K.
+            if len(candidates) > top_k:
+                candidates.pop(sampled)
+            top_logprobs.append(
+                [
+                    {
+                        "id": token,
+                        "text": f"token_id:{token}",
+                        "logprob": score,
+                        "rank": rank,
+                    }
+                    for rank, (token, score) in enumerate(
+                        sorted(candidates.items(), key=lambda item: -item[1]), start=1
+                    )
+                ]
+            )
+    return {"tokens": tokens, "text": choice["text"], "top_logprobs": top_logprobs}
 
 
 def compare_results(
@@ -263,43 +373,45 @@ def main() -> None:
     )
     parser.add_argument("--max-tokens", type=int, default=10)
     parser.add_argument(
-        "--batch-size",
-        type=int,
-        default=1,
-        help="Maximum concurrent Metal requests (default: 1); MLX runs sequentially",
-    )
-    parser.add_argument(
         "--top-k",
         type=int,
         help="Accept mutual top-k membership at the first divergence",
     )
-    parser.add_argument("--backend", choices=("mlx", "metal"), help=argparse.SUPPRESS)
-    parser.add_argument("--data", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        nargs="+",
+        default=[1, 2],
+        help="Prompts per HTTP request (default: 1 2)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Artifact directory (default: a new temporary directory)",
+    )
+    parser.add_argument("--generate-reference", type=Path, help=argparse.SUPPRESS)
     args = parser.parse_args()
     if args.max_tokens < 1:
         parser.error("--max-tokens must be positive")
     if args.top_k is not None and args.top_k < 1:
         parser.error("--top-k must be positive")
-    if args.batch_size < 1:
-        parser.error("--batch-size must be positive")
-    if args.backend:
-        data = json.loads(args.data.read_text())
-        if args.backend == "mlx":
-            outputs = mlx_generate(args.model, data, args.max_tokens, args.top_k)
-        else:
-            outputs = metal_generate(
-                args.model, data, args.max_tokens, args.top_k, args.batch_size
-            )
-        args.data.write_text(json.dumps(outputs))
-    else:
-        passed = check_parity(
-            args.model,
-            args.prompt or PROMPTS,
-            args.max_tokens,
-            args.top_k,
-            args.batch_size,
-        )
-        raise SystemExit(0 if passed else 1)
+    if min(args.batch_size) < 1:
+        parser.error("--batch-size values must be positive")
+    if args.generate_reference:
+        prompts = json.loads(args.generate_reference.read_text())
+        reference = mlx_generate(args.model, prompts, args.max_tokens, args.top_k)
+        args.generate_reference.write_text(json.dumps(reference))
+        return
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(1))
+    passed = check_parity(
+        args.model,
+        args.prompt or PROMPTS,
+        args.max_tokens,
+        args.top_k,
+        tuple(args.batch_size),
+        args.output_dir,
+    )
+    raise SystemExit(0 if passed else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Our current CI is running slow e2e smoke test on every commit / PR. 

This PR aims to 
* make per commit / PR CI **faster**, by removing the slow e2e test.
* move the slow e2e tests to nightly CI, and it can be manually triggered by `/ci parity` with write access. In the future we can improve the test coverage, it's ok to be **slower** (e.g., add speculative decoding. It should have been catch a recent correctness regression). 


## Summary

Adds a daily run at 07:17 UTC on `main` and `/ci parity` for PRs, restricted to users with repository write access. 

Each run tests the captured commit against native `mlx-lm`: Qwen3-0.6B and Qwen3.5-0.8B, macOS 15/26, 40 shared prompts, 20 output tokens, top-K 5, and HTTP request batch sizes 1/2.

CI and local use invoke the same `tools/check_parity.py` command. For each model/OS, it generates one native MLX reference, exits that process, starts one `vllm serve` instance, checks `/health`, compares prompts through `/v1/completions` first individually, then in pairs within one request, and shuts the server down. The offline Metal execution path is removed.

The `Parity` check reports the tested SHA and whether it matches the current PR head at report time. It links to per-model summaries and artifacts containing the native reference, server log, per-batch results, and environment versions, retained for 14 days. Regular PR CI retains wheel validation, Metal platform checks, and non-slow tests.

Depends on #705. The comment and scheduled triggers activate once the workflow is on the default branch.

## Validation

- The canonical CLI passed all 160 local comparisons across both models, 40 prompts, 20 output tokens, and HTTP request batch sizes 1/2: 124 EXACT, 36 TOP_K_MATCH, 0 FAIL. Each model used one server for 40 single-prompt and 20 paired requests, followed by verified process cleanup. Local validation used `VLLM_METAL_MEMORY_FRACTION=0.10`; CI retains `0.65`.
- All 18 focused comparison, request-batching, orchestration, and reporting tests passed, including response ordering, partial final batches, and missing/duplicate choices. Ruff and workflow validation passed.
- The full hosted matrix has not been completed for this version.

## Read the result

click `Actions` tab in github, scroll down and find the run. 

<img width="1900" height="812" alt="image" src="https://github.com/user-attachments/assets/c540546f-08d6-495e-a089-d7a22eb1ad4a" />


## Lesson learnt

1. VLLM_METAL_MEMORY_FRACTION
- **No**: `VLLM_METAL_MEMORY_FRACTION=0.80`: hit the 45-minute timeout
- **Yes**: `0.65`: the same job passed in 9m33s Keep this setting for the small GHA runners.

2. Different Metal compilation behavior
- Metal Shading Language 3.2 on macOS 15 
- Metal Shading Language 4.0 on macOS 26
- So this CI keep both

## Acknowledgement

Learnt a lot from this post: https://vllm.ai/blog/2026-07-16-keeping-vllm-production-quality


