### PR TITLE
Gate the qwen3_5/3_6 auto-mode text-backbone override on the installed mlx-vlm

### DIFF
--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -7,6 +7,7 @@ import mlx.core as mx
 import pytest
 
 import vllm_metal.envs as envs
+import vllm_metal.v1.model_adapter
 from vllm_metal.config import reset_config
 from vllm_metal.multimodal.paddleocr_vl import PaddleOCRVLMultimodalAdapter
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
@@ -106,8 +107,16 @@ class TestShouldForceTextBackbone:
         assert result is False
 
     def test_mlx_quant_qwen35_wrapper_uses_auto_override_with_vision_config(
-        self,
+        self, monkeypatch
     ) -> None:
+        # mlx-vlm <= 0.6.7 garbles these wrappers with unset mRoPE state;
+        # pin the probe to the known-bad side so this test does not depend
+        # on which mlx-vlm the test environment happens to install.
+        monkeypatch.setattr(
+            vllm_metal.v1.model_adapter,
+            "_mlx_vlm_garbles_qwen35_mrope",
+            lambda: True,
+        )
         hf_config = SimpleNamespace(
             model_type="qwen3_5",
             architectures=["Qwen3_5ForConditionalGeneration"],
@@ -118,6 +127,28 @@ class TestShouldForceTextBackbone:
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is True
+
+    def test_mlx_quant_qwen35_wrapper_keeps_multimodal_on_fixed_mlxvlm(
+        self, monkeypatch
+    ) -> None:
+        # mlx-vlm 0.6.8 serves MLX-quantized Qwen3.5/3.6 wrappers correctly
+        # on the multimodal path (A/B verified in #685), so the auto-mode
+        # override must not fire there.
+        monkeypatch.setattr(
+            vllm_metal.v1.model_adapter,
+            "_mlx_vlm_garbles_qwen35_mrope",
+            lambda: False,
+        )
+        hf_config = SimpleNamespace(
+            model_type="qwen3_5",
+            architectures=["Qwen3_5ForConditionalGeneration"],
+            quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+            vision_config=SimpleNamespace(spatial_merge_size=2),
+            text_config=SimpleNamespace(model_type="qwen3_5_text"),
+        )
+        adapter = DefaultModelAdapter()
+        result = adapter.should_force_text_backbone(hf_config)
+        assert result is False
 
     def test_multimodal_native_mode_disables_mlx_quant_override(
         self, monkeypatch

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -19,6 +19,25 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+def _mlx_vlm_garbles_qwen35_mrope() -> bool:
+    """Whether the installed mlx-vlm garbles Qwen3.5/3.6 MLX checkpoints.
+
+    A/B verified in #685: 0.6.4 emits unset-mRoPE token soup, 0.6.8 serves
+    correctly. Returns True (keep the text-backbone override) when mlx-vlm
+    is older than the fixed revision or cannot be imported at all, which
+    keeps the failure mode conservative.
+    """
+    try:
+        from mlx_vlm import __version__ as mlx_vlm_version
+    except Exception:
+        return True
+    try:
+        major, minor, patch = (int(part) for part in mlx_vlm_version.split(".")[:3])
+    except ValueError:
+        return True
+    return (major, minor, patch) < (0, 6, 8)
+
+
 @dataclass(frozen=True, slots=True)
 class TargetModelForwardOutput:
     """Target-model forward output needed by sampling and speculative decode."""
@@ -278,10 +297,18 @@ class DefaultModelAdapter(ModelAdapter):
             return True
 
         # MLX affine Qwen3.5/Qwen3.6 text wrappers may still carry a
-        # vision_config, but mlx_vlm drives those text-only checkpoints with
-        # unset mRoPE state and produces garbled output.  Real Qwen3-VL uses
-        # Qwen3VLForConditionalGeneration, which is not in the text-wrapper
-        # architecture set above and therefore keeps the native path.
+        # vision_config. mlx_vlm <= 0.6.7 drives those text-only checkpoints
+        # with unset mRoPE state and produces garbled output, but 0.6.8 (the
+        # revision these checkpoints were converted with, still inside the
+        # plugin's >=0.6.2,<0.7 pin) serves them correctly on the multimodal
+        # path — verified A/B on Qwen3.5-4B and Qwen3.8-27B (#685). Gate the
+        # override on the installed mlx-vlm so 0.6.8+ keeps native vision
+        # while known-bad versions stay on the text backbone. Real Qwen3-VL
+        # uses Qwen3VLForConditionalGeneration, which is not in the
+        # text-wrapper architecture set above and therefore keeps the
+        # native path.
+        if not _mlx_vlm_garbles_qwen35_mrope():
+            return False
         return self._has_mlx_quantized_weights(hf_config)
 
     def _has_fp8_quantization_config(self, hf_config: Any) -> bool:


### PR DESCRIPTION
## Summary

Implements the version-scoped override proposed in #685.

The MLX-affine arm of `_matches_auto_text_backbone_override` currently forces every MLX-quantized Qwen3.5/3.6 conditional-generation wrapper onto the text backbone, because the pinned mlx-vlm (0.6.4) drives them with unset mRoPE state and garbles output. #685 established — and I independently A/B-verified at a second checkpoint size (comment on the issue) — that mlx-vlm **0.6.8**, the revision these checkpoints were converted with and still inside the plugin's `>=0.6.2,<0.7` pin, serves them correctly on the multimodal path:

- mlx-vlm 0.6.4 + `multimodal-native` + Qwen3.5-4B-MLX-4bit: unconditional multi-language token soup.
- mlx-vlm **0.6.8** + same model, same image, nothing else changed: accurate structured description (shapes, colors, positions, the number 42, and the overlap/occlusion).

This PR adds a tiny probe (`_mlx_vlm_garbles_qwen35_mrope`, version tuple < (0, 6, 8)) and gates only that arm on it, so `auto` mode keeps native vision once a fixed mlx-vlm is installed while known-bad versions keep today's safe behavior. The probe fails closed (returns True → keep override) when mlx-vlm cannot be imported or its version is unparseable. FP8 handling, the Gemma4 branch, and `multimodal-native` bypass behavior are all unchanged.

Note the transformers `<5.13` cap still gates actually *installing* 0.6.8 in one environment with vllm-metal (0.6.8 wants transformers>=5.14); that cap decision stays with the maintainers — this change only makes the override honest about which mlx-vlm is actually loaded, which also matters for anyone testing 0.6.8 in an isolated venv today (as #685's author did).

## Issue

Implements the RFC half of #685.

## Validation

- `pytest tests/test_model_adapter.py`: **77 passed** (existing override test now pins the probe to the known-bad side so it stays environment-independent; new test covers the fixed-version side asserting the override does not fire).
- `ruff check` + `ruff format --check` clean; `mypy` output identical to unchanged main (4 pre-existing gguf-enum notes in this local env, zero new).
- The runtime A/B evidence is in the #685 comment (4B) and the original issue (27B, M5 Pro).

## Type of Change

- [x] Bug fix / behavioral refinement

## Area

- [x] Multimodal model adaptation