### PR TITLE
[Bugfix] Unpin transformers and serve MLX-quant Qwen3.5/3.6 natively

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,16 +46,14 @@ dependencies = [
     # import tvm-ffi; this bounds the resolver only.
     # TODO: remove once xgrammar bounds its own apache-tvm-ffi range.
     "apache-tvm-ffi>=0.1.9,<0.1.13; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    # mlx-vlm 0.6.2 includes PaddleOCR-VL multi-image M-RoPE fixes.
-    "mlx-vlm>=0.6.2,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # mlx-vlm 0.6.8 drives MLX-quantized Qwen3.5/3.6 wrappers with correct
+    # mRoPE state; 0.6.4 leaves it unset and garbles their output (#685).
+    # Capped below 0.6.16, which drops `target_verify` from
+    # Qwen3_5MLP.__call__ and trips the CompiledMLPBlocks wrapper guard.
+    "mlx-vlm>=0.6.8,<0.6.16; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
     # Keep aligned with vLLM 0.28.0's Transformers lower bound.
-    # Temporary cap: transformers 5.13.0 (released 2026-07-03) breaks MLX Metal
-    # availability inside the vLLM process on GitHub's macOS runner VMs, so
-    # platform resolution falls back to CPU. Verified A/B on the same runner:
-    # 5.13.0 -> CpuPlatform, 5.12.1 -> MetalPlatform.
-    # TODO: remove once the interaction is understood/fixed upstream.
-    "transformers>=5.5.3,<5.13",
+    "transformers>=5.5.3",
     "accelerate>=0.26.0",
     "safetensors>=0.4.0",
     # Imported directly (model download/cache paths); keep aligned with vLLM

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -65,9 +65,11 @@ class TestShouldForceTextBackbone:
             ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
         ],
     )
-    def test_mlx_quant_conditional_generation_uses_auto_override(
+    def test_mlx_quant_conditional_generation_keeps_native_path(
         self, model_type: str, architecture: str, bits: int
     ) -> None:
+        # mlx-vlm >=0.6.8 drives these wrappers with correct mRoPE state, so
+        # the auto-mode override no longer routes them to the text backbone.
         hf_config = SimpleNamespace(
             model_type=model_type,
             architectures=[architecture],
@@ -75,7 +77,7 @@ class TestShouldForceTextBackbone:
         )
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
-        assert result is True
+        assert result is False
 
     @pytest.mark.parametrize(
         ("model_type", "architecture", "vision_config"),
@@ -105,7 +107,7 @@ class TestShouldForceTextBackbone:
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
 
-    def test_mlx_quant_qwen35_wrapper_uses_auto_override_with_vision_config(
+    def test_mlx_quant_qwen35_wrapper_keeps_native_path_with_vision_config(
         self,
     ) -> None:
         hf_config = SimpleNamespace(
@@ -117,7 +119,7 @@ class TestShouldForceTextBackbone:
         )
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
-        assert result is True
+        assert result is False
 
     def test_multimodal_native_mode_disables_mlx_quant_override(
         self, monkeypatch
@@ -559,11 +561,14 @@ class TestNormalizeModelConfig:
             ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
         ],
     )
-    def test_clears_multimodal_config_for_mlx_quant_wrapper_in_auto_mode(
+    def test_preserves_multimodal_config_for_mlx_quant_wrapper_in_auto_mode(
         self, model_type: str, architecture: str
     ) -> None:
+        # These wrappers serve correctly on the multimodal path with the
+        # pinned mlx-vlm floor, so auto mode must leave their config alone.
+        sentinel = SimpleNamespace(language_model_only=False)
         model_config = SimpleNamespace(
-            multimodal_config=SimpleNamespace(language_model_only=False),
+            multimodal_config=sentinel,
             hf_config=SimpleNamespace(
                 model_type=model_type,
                 architectures=[architecture],
@@ -573,7 +578,7 @@ class TestNormalizeModelConfig:
 
         DefaultModelAdapter().normalize_model_config(model_config)
 
-        assert model_config.multimodal_config is None
+        assert model_config.multimodal_config is sentinel
 
     def test_preserves_multimodal_config_for_other_models(self) -> None:
         sentinel = SimpleNamespace(language_model_only=False)

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -59,10 +59,8 @@ class TestShouldForceTextBackbone:
     @pytest.mark.parametrize(
         ("model_type", "architecture"),
         [
-            # Dense and MoE MLX 4-bit wrappers from issues #580 and #571.
+            # Only the dense Qwen3.5 wrapper has a native multimodal adapter.
             ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
-            ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
-            ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
         ],
     )
     def test_mlx_quant_conditional_generation_keeps_native_path(
@@ -78,6 +76,28 @@ class TestShouldForceTextBackbone:
         adapter = DefaultModelAdapter()
         result = adapter.should_force_text_backbone(hf_config)
         assert result is False
+
+    @pytest.mark.parametrize(
+        ("model_type", "architecture"),
+        [
+            ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
+            ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
+            ("qwen3_6_moe", "Qwen3_6MoeForConditionalGeneration"),
+        ],
+    )
+    def test_mlx_quant_wrapper_without_adapter_keeps_text_backbone(
+        self, model_type: str, architecture: str
+    ) -> None:
+        # `build_multimodal_adapter` has no adapter for these, and an image
+        # request against a missing adapter raises in the runner.
+        hf_config = SimpleNamespace(
+            model_type=model_type,
+            architectures=[architecture],
+            quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+        )
+        adapter = DefaultModelAdapter()
+        assert adapter.should_force_text_backbone(hf_config) is True
+        assert adapter.build_multimodal_adapter(object(), hf_config) is None
 
     @pytest.mark.parametrize(
         ("model_type", "architecture", "vision_config"),
@@ -557,8 +577,6 @@ class TestNormalizeModelConfig:
         ("model_type", "architecture"),
         [
             ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
-            ("qwen3_5_moe", "Qwen3_5MoeForConditionalGeneration"),
-            ("qwen3_6", "Qwen3_6ForConditionalGeneration"),
         ],
     )
     def test_preserves_multimodal_config_for_mlx_quant_wrapper_in_auto_mode(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -372,11 +372,25 @@ class TestModelLifecycle:
 
         assert runner._is_vlm is False
 
-    def test_load_uses_adapter_override_for_qwen35_mlx_quant_dense_wrapper(
+    def test_load_keeps_qwen35_mlx_quant_dense_wrapper_as_vlm(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        _stub_generation_model(monkeypatch, config=_text_config())
+        # The auto-mode override used to route MLX-quantized wrappers to the
+        # text backbone; the pinned mlx-vlm floor serves them natively, so auto
+        # mode now keeps the multimodal path.
+        vision_tower = object()
+        language_model = _Qwen35LanguageModelStub()
+        fake_model = _qwen35_vlm_model(
+            vision_tower=vision_tower,
+            language_model=language_model,
+        )
+        _stub_generation_model(
+            monkeypatch,
+            config=fake_model.config,
+            is_vlm=True,
+            model=fake_model,
+        )
         lifecycle, runner = _make_lifecycle(
             model_config=_runner_model_config(
                 hf_config=SimpleNamespace(
@@ -392,8 +406,8 @@ class TestModelLifecycle:
 
         lifecycle.load()
 
-        assert runner._is_vlm is False
-        assert runner._multimodal_adapter is None
+        assert runner._is_vlm is True
+        assert isinstance(runner._multimodal_adapter, Qwen3VLMultimodalAdapter)
 
     def test_load_multimodal_native_mode_keeps_qwen35_fp8_as_vlm(
         self,

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -251,13 +251,12 @@ class DefaultModelAdapter(ModelAdapter):
         override once mlx_vlm Gemma4 parity is fixed upstream.
 
         Qwen3.5/Qwen3.6 conditional-generation wrappers: these configs are
-        marked multimodal even when served text-only, and both quantized
-        families diverge under mlx_vlm.load() — FP8 fails on
-        `*_weight_scale_inv` tensors, while MLX affine checkpoints load but,
-        unless the config exposes a real VL shape, run the bare language model
-        with unset mrope state and generate garbled output.  Both route through
-        the mlx_lm text loader instead; MLX-quant wrappers with a native VL
-        config keep the multimodal path.
+        marked multimodal even when served text-only, and the FP8 family fails
+        under mlx_vlm.load() on `*_weight_scale_inv` tensors, so it routes
+        through the mlx_lm text loader instead.  MLX affine checkpoints used to
+        need the same treatment because mlx_vlm left their mRoPE state unset;
+        the pinned mlx-vlm floor (>=0.6.8) drives them correctly, so they keep
+        the native multimodal path.
         """
         if hf_config is None:
             return False
@@ -277,25 +276,13 @@ class DefaultModelAdapter(ModelAdapter):
         if self._has_fp8_quantization_config(hf_config):
             return True
 
-        # MLX affine Qwen3.5/Qwen3.6 text wrappers may still carry a
-        # vision_config, but mlx_vlm drives those text-only checkpoints with
-        # unset mRoPE state and produces garbled output.  Real Qwen3-VL uses
-        # Qwen3VLForConditionalGeneration, which is not in the text-wrapper
-        # architecture set above and therefore keeps the native path.
-        return self._has_mlx_quantized_weights(hf_config)
+        return False
 
     def _has_fp8_quantization_config(self, hf_config: Any) -> bool:
         quantization_config_from_hf = getattr(hf_config, "quantization_config", None)
         if isinstance(quantization_config_from_hf, dict):
             return quantization_config_from_hf.get("quant_method") == "fp8"
         return getattr(quantization_config_from_hf, "quant_method", None) == "fp8"
-
-    def _has_mlx_quantized_weights(self, hf_config: Any) -> bool:
-        mlx_quantization_from_hf = getattr(hf_config, "quantization", None)
-        return (
-            isinstance(mlx_quantization_from_hf, dict)
-            and "bits" in mlx_quantization_from_hf
-        )
 
     def should_force_text_backbone(self, hf_config: Any) -> bool:
         """Whether the current serve mode should use the text-only path.

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -276,7 +276,28 @@ class DefaultModelAdapter(ModelAdapter):
         if self._has_fp8_quantization_config(hf_config):
             return True
 
-        return False
+        # MLX affine wrappers only keep the native path when
+        # `build_multimodal_adapter` actually has an adapter for them. The MoE
+        # and Qwen3.6 wrappers do not, and an image request against a missing
+        # adapter raises in the runner, so they stay on the text backbone.
+        return self._has_mlx_quantized_weights(
+            hf_config
+        ) and not self._is_qwen3_vl_family(hf_config)
+
+    def _is_qwen3_vl_family(self, hf_config: Any) -> bool:
+        """Whether ``build_multimodal_adapter`` has a native adapter for this."""
+        model_type = getattr(hf_config, "model_type", "")
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        return model_type in _QWEN3_VL_MODEL_TYPES or any(
+            arch in _QWEN3_VL_ARCHITECTURES for arch in architectures
+        )
+
+    def _has_mlx_quantized_weights(self, hf_config: Any) -> bool:
+        mlx_quantization_from_hf = getattr(hf_config, "quantization", None)
+        return (
+            isinstance(mlx_quantization_from_hf, dict)
+            and "bits" in mlx_quantization_from_hf
+        )
 
     def _has_fp8_quantization_config(self, hf_config: Any) -> bool:
         quantization_config_from_hf = getattr(hf_config, "quantization_config", None)
@@ -600,9 +621,7 @@ validate_paged_attention_support` only when ``kv_heads_per_layer`` has
 
         model_type = getattr(hf_config, "model_type", "")
         architectures = getattr(hf_config, "architectures", ()) or ()
-        if model_type in _QWEN3_VL_MODEL_TYPES or any(
-            arch in _QWEN3_VL_ARCHITECTURES for arch in architectures
-        ):
+        if self._is_qwen3_vl_family(hf_config):
             from vllm_metal.multimodal.qwen3_vl import Qwen3VLMultimodalAdapter
 
             return cast(


### PR DESCRIPTION
The `transformers<5.13` cap came from #471, added when 5.13.0 was A/B'd on the CI runner as the reason MLX Metal stopped resolving inside the vLLM process, and it has sat behind a TODO ever since. It is now also what blocks mlx-vlm 0.6.8, the release that fixes the unset-mRoPE garbling on MLX-quantized Qwen3.5/3.6 wrappers reported in #685, so auto mode still routes those checkpoints to the text backbone and they serve without vision.

Four transformers minors later the premise no longer holds, so this drops the cap rather than working around it. The mlx-vlm floor moves to 0.6.8, capped below 0.6.16 which drops `target_verify` from `Qwen3_5MLP.__call__` and trips the `CompiledMLPBlocks` guard. With a fixed mlx-vlm pinned, the MLX-affine arm of the auto-mode override is dead weight, so the second commit deletes it together with `_has_mlx_quantized_weights`. The Gemma4 and FP8 arms stay; they are separate unfixed problems.

This makes #711 unnecessary and is mutually exclusive with it.