### PR TITLE
perf: VLLM_METAL_DISABLE_GQA_DECODE escape hatch + macOS benchmarking guide

### DIFF
--- a/docs/benchmarking-macos.md
+++ b/docs/benchmarking-macos.md
@@ -2,7 +2,7 @@
 
 Three measurement hazards documented in [#713] can silently distort
 performance numbers on Apple Silicon. All three were hit while
-validating the decode work in #693 on an M5 Pro; each cost hours of
+validating the decode work in [#715](https://github.com/vllm-project/vllm-metal/pull/715) (successor of #693) on an M5 Pro; each cost hours of
 misattribution before being isolated.
 
 ## 1. Absolute numbers: use the server topology

--- a/docs/benchmarking-macos.md
+++ b/docs/benchmarking-macos.md
@@ -1,0 +1,57 @@
+# Benchmarking vllm-metal on macOS
+
+Three measurement hazards documented in [#713] can silently distort
+performance numbers on Apple Silicon. All three were hit while
+validating the decode work in #693 on an M5 Pro; each cost hours of
+misattribution before being isolated.
+
+## 1. Absolute numbers: use the server topology
+
+In-process engines (`VLLM_ENABLE_V1_MULTIPROCESSING=0`, i.e. the `LLM(...)`
+offline API) run the engine core as a thread sharing one interpreter/GIL
+with the driver's output processing. At long-context decode this
+understates absolute throughput by **1.5-2.1x** versus `vllm serve`, and
+it **compresses ratios** (a true 2.22x comparison read as 1.56x), because
+the penalty grows with the speed of the path measured.
+
+Rules:
+
+- Absolute performance claims: server topology only.
+- In-process is for debugging and, at most, same-harness A/B with an
+  explicit label that both legs share the penalty.
+- To A/B a dispatch gate under the server topology, force the gate with
+  an env instead of monkeypatching in-process, e.g.
+  `VLLM_METAL_DISABLE_GQA_DECODE=1` (mirrors `VLLM_METAL_DISABLE_NAX`).
+
+## 2. Check GPU co-tenancy before every measurement window
+
+WindowServer and app renderers (browsers, Electron-style clients) can
+hold the GPU at 50%+ device utilization while every vLLM process is
+idle. A workload then time-shares the GPU with the compositor: measured
+impact was **-16% for real decode** and up to 5x for short probes. It
+mimics a machine regression and it is neither (thermal logs stay clean).
+
+```bash
+ioreg -r -c AGXAccelerator -d "1" | grep -oE '"Device Utilization %"=[0-9]+'
+```
+
+- `<= 12%` sustained: quiet window, absolute numbers meaningful.
+- Higher: co-tenant active. Label results as "realistic desktop load"
+  or wait; do not treat as a regression.
+
+Record this utilization alongside every benchmark you publish.
+
+## 3. Short-burst GEMM probes are not machine-state diagnostics
+
+A fresh-process matmul "canary" reads the **parked-clock rate** (~25
+TFLOPS on an M5 Pro where the sustained rate is ~120) until some heavier
+workload has run; short bursts neither trigger nor benefit from the
+clock ramp. A 2048^3 probe additionally caps at ~19-30 TFLOPS
+regardless of state - the shape never reaches the fast GEMM path.
+
+- Measure machine capability with the real workload, or with a
+  **sustained (>= 30 s) probe**.
+- Never use short-probe TFLOPS as a fast/slow verdict; the utilization
+  gate in section 2 is the reliable co-tenancy signal.
+
+[#713]: https://github.com/vllm-project/vllm-metal/issues/713

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_DISABLE_NAX` | `0` | Emergency override for automatic M5 NAX prefill attention. Set to `1` to force the non-NAX fallback. |
+| `VLLM_METAL_DISABLE_GQA_DECODE` | `0` | Force-close the GQA flash-decode dispatch gate ([#713](https://github.com/vllm-project/vllm-metal/issues/713) / [#714](https://github.com/vllm-project/vllm-metal/pull/714)). Set to `1` so long-context decode stays on the established per-token / split-KV kernels — the server-topology A/B hatch (mirrors `VLLM_METAL_DISABLE_NAX`). Off by default. |
 | `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` uses the compatibility allowlist; `multimodal-native` disables overrides |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -701,6 +701,53 @@ class TestSDPAForward:
         assert captured["num_kv_heads"] == 2
         assert captured["scale"] == 0.5
 
+    def test_gqa_disable_env_reaches_primitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``sdpa_forward`` must pass ``VLLM_METAL_DISABLE_GQA_DECODE`` through."""
+        captured: dict[str, bool | None] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self,
+                _keys,
+                _values,
+                key_cache,
+                value_cache,
+                _slot_mapping,
+            ) -> tuple[mx.array, mx.array]:
+                return key_cache, value_cache
+
+            def paged_attention_primitive(self, *_args, **kwargs) -> None:
+                captured["gqa_disabled"] = kwargs.get("gqa_disabled")
+
+        inner = _make_inner()
+        inner.o_proj = lambda out: out
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN), dtype=mx.float16)
+        zeros = mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM), dtype=mx.float16)
+
+        def _run() -> None:
+            with (
+                patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+                patch.object(sdpa_mod, "truncate_padded_output", return_value=zeros),
+            ):
+                sdpa_forward(inner, x, _make_ctx(_SEQ_LEN), cache, layer_idx=0)
+
+        _run()
+        assert captured.get("gqa_disabled") is False
+
+        monkeypatch.setenv("VLLM_METAL_DISABLE_GQA_DECODE", "1")
+        _run()
+        assert captured.get("gqa_disabled") is True
+
     def test_mixed_batch_routes_slots_and_page_tables_by_layer_group(self) -> None:
         """Full and sliding layers consume their scheduler-group metadata."""
         layout = MHAKVCacheLayout(

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -619,8 +619,9 @@ class _PagedRoutingOpsSpy:
         _out: mx.array,
         window_seqlen_q: int = 1,
         sinks: mx.array | None = None,
+        **_kwargs,
     ) -> None:
-        del window_seqlen_q, sinks
+        del window_seqlen_q, sinks, _kwargs
         self.calls[-1].block_tables = block_tables.tolist()
         self.calls[-1].block_size = block_size
 

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -61,6 +61,7 @@ def _run_primitive(
     window_seqlen_q: int = 1,
     query_lens: list[int] | None = None,
     num_decode_requests: int = -1,
+    gqa_disabled: bool = False,
 ) -> tuple[mx.array, mx.array]:
     mx.random.seed(seed)
     num_seqs = len(kv_lens)
@@ -117,6 +118,7 @@ def _run_primitive(
         out,
         window_seqlen_q=window_seqlen_q,
         num_decode_requests=num_decode_requests,
+        gqa_disabled=gqa_disabled,
     )
     mx.eval(out)
     ref = ref_paged_attn(
@@ -214,3 +216,22 @@ def test_spec_window_does_not_switch_kernel_family() -> None:
         query_lens=[window],
     )
     _assert_close(out, ref, mx.float16)
+
+
+def test_gqa_disable_env_forces_established_kernels(monkeypatch) -> None:
+    """VLLM_METAL_DISABLE_GQA_DECODE=1 keeps eligible batches off the GQA
+    kernel without changing results (issue #713 benchmarking escape hatch)."""
+    from vllm_metal import envs
+
+    ops = get_ops()
+    assert envs.VLLM_METAL_DISABLE_GQA_DECODE is False  # default off
+    kv_len = 2 * ops.GQA_DECODE_MIN_SEQ_LEN
+    out_on, ref = _run_primitive([kv_len], mx.bfloat16, interleaved=True, seed=7)
+    out_off, _ = _run_primitive(
+        [kv_len], mx.bfloat16, interleaved=True, seed=7, gqa_disabled=True
+    )
+    _assert_close(out_on, ref, mx.bfloat16)
+    _assert_close(out_off, ref, mx.bfloat16)  # numerics identical either way
+
+    monkeypatch.setenv("VLLM_METAL_DISABLE_GQA_DECODE", "1")
+    assert envs.VLLM_METAL_DISABLE_GQA_DECODE is True

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GQA-shared flash-decode pass inside ``paged_attention_primitive``.
+
+Eligible pure-decode batches (no TQ/sinks/softcap/window, head size in
+{64,96,128,256}, GQA group <= 8, ``window_seqlen_q <= 1``, aggregate KV
+``num_seqs * max_seq_len >= GQA_DECODE_MIN_SEQ_LEN``) dispatch to
+``paged_attention_gqa_decode`` and merge through ``paged_attention_v2_reduce``.
+Spec-decode verify windows pass ``window_seqlen_q = K+1`` and stay on the
+established family so ``tests/test_spec_window_parity.py`` stays bitwise.
+
+These tests drive the shipped primitive (not a reimplementation) against
+``ref_paged_attn``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from tools.attention_bench_utils import ref_paged_attn
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+}
+
+
+def _interleaved_table(n_blocks: int) -> list[int]:
+    """Run-of-2, skip-1 pattern produced by hybrid GDN block interleave."""
+    table: list[int] = []
+    b = 3
+    while len(table) < n_blocks:
+        table += [b, b + 1]
+        b += 3
+    return table[:n_blocks]
+
+
+def _assert_close(out: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def _run_primitive(
+    kv_lens: list[int],
+    dtype: mx.Dtype,
+    *,
+    interleaved: bool,
+    seed: int,
+    window_seqlen_q: int = 1,
+    query_lens: list[int] | None = None,
+    num_decode_requests: int = -1,
+) -> tuple[mx.array, mx.array]:
+    mx.random.seed(seed)
+    num_seqs = len(kv_lens)
+    max_kv_len = max(kv_lens)
+    scale = HEAD_SIZE**-0.5
+    if query_lens is None:
+        query_lens = [1] * num_seqs
+    total_q = sum(query_lens)
+    n_blocks_needed = (max_kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    tables = []
+    max_blk = 0
+    # Offset each sequence's pages so multi-seq batches do not alias.
+    page_stride = n_blocks_needed * 3
+    for s in range(num_seqs):
+        if interleaved:
+            table = [b + s * page_stride for b in _interleaved_table(n_blocks_needed)]
+        else:
+            table = list(range(s * n_blocks_needed, (s + 1) * n_blocks_needed))
+        tables.append(table)
+        max_blk = max(max_blk, max(table))
+    num_cache_blocks = max_blk + 4
+    key_cache = mx.random.normal(
+        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    value_cache = mx.random.normal(
+        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    query = mx.random.normal((total_q, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    padded = max(len(t) for t in tables)
+    block_tables = mx.array(
+        [t + [0] * (padded - len(t)) for t in tables], dtype=mx.int32
+    )
+    kv_lens_arr = mx.array(kv_lens, dtype=mx.int32)
+    cu = [0]
+    for qlen in query_lens:
+        cu.append(cu[-1] + qlen)
+    cu_seqlens_q = mx.array(cu, dtype=mx.int32)
+    mx.eval(key_cache, value_cache, query, block_tables, kv_lens_arr, cu_seqlens_q)
+
+    out = mx.array(0)
+    get_ops().paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        NUM_KV_HEADS,
+        scale,
+        0.0,
+        block_tables,
+        kv_lens_arr,
+        cu_seqlens_q,
+        BLOCK_SIZE,
+        max_kv_len,
+        -1,
+        out,
+        window_seqlen_q=window_seqlen_q,
+        num_decode_requests=num_decode_requests,
+    )
+    mx.eval(out)
+    ref = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=np.array(block_tables),
+        scale=scale,
+    )
+    mx.eval(ref)
+    return out, ref
+
+
+def test_gqa_decode_kernel_is_in_default_library() -> None:
+    ops = get_ops()
+    assert ops.has_gqa_decode_kernel(), (
+        "default shader library is missing paged_attention_gqa_decode; "
+        "rebuild with `python -m vllm_metal.metal.build`"
+    )
+    assert ops.GQA_DECODE_MIN_SEQ_LEN == 16384
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize(
+    "kv_len,interleaved",
+    [
+        (16384, True),  # crossover: first length that must take GQA-decode
+        (16384 + 17, True),  # partial last block
+        (20000, True),  # hybrid-style interleaved table
+        (16384, False),  # contiguous table still valid through the primitive
+    ],
+)
+def test_gqa_decode_matches_reference(
+    kv_len: int, interleaved: bool, dtype: mx.Dtype
+) -> None:
+    ops = get_ops()
+    assert ops.has_gqa_decode_kernel()
+    assert kv_len >= ops.GQA_DECODE_MIN_SEQ_LEN
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    out, ref = _run_primitive([kv_len], dtype, interleaved=interleaved, seed=0)
+    _assert_close(out, ref, dtype)
+
+
+def test_below_crossover_stays_on_split_kv() -> None:
+    """A single sequence under GQA_DECODE_MIN_SEQ_LEN stays on split-KV."""
+    ops = get_ops()
+    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN - 1
+    assert kv_len > ops.PARTITION_SIZE
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    out, ref = _run_primitive([kv_len], mx.float16, interleaved=True, seed=1)
+    _assert_close(out, ref, mx.float16)
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_multi_seq_gqa_decode_matches_reference(dtype: mx.Dtype) -> None:
+    """True multi-seq decode (window_seqlen_q=1) takes GQA-decode.
+
+    Aggregate KV ``num_seqs * max_seq_len`` meets the 16k budget with two
+    8k+ sequences, which a single 8k sequence would miss.
+    """
+    ops = get_ops()
+    half = ops.GQA_DECODE_MIN_SEQ_LEN // 2
+    kv_lens = [half, half + 64]
+    assert len(kv_lens) * max(kv_lens) >= ops.GQA_DECODE_MIN_SEQ_LEN
+    assert NUM_QUERY_HEADS * len(kv_lens) < ops.min_decode_grid()
+    out, ref = _run_primitive(
+        kv_lens,
+        dtype,
+        interleaved=True,
+        seed=2,
+        num_decode_requests=len(kv_lens),
+    )
+    _assert_close(out, ref, dtype)
+
+
+def test_spec_window_does_not_switch_kernel_family() -> None:
+    """A K+1 verify window on a long context stays on the window/split path.
+
+    Production expanded verify windows pass window_seqlen_q=K+1 even when
+    packed as length-1 segments; this keeps them off GQA-decode so they
+    stay bitwise with the windowed dispatch.
+    """
+    ops = get_ops()
+    ctx = ops.GQA_DECODE_MIN_SEQ_LEN
+    window = 4
+    kv_len = ctx + window
+    out, ref = _run_primitive(
+        [kv_len],
+        mx.float16,
+        interleaved=True,
+        seed=3,
+        window_seqlen_q=window,
+        query_lens=[window],
+    )
+    _assert_close(out, ref, mx.float16)

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -235,3 +235,11 @@ def test_gqa_disable_env_forces_established_kernels(monkeypatch) -> None:
 
     monkeypatch.setenv("VLLM_METAL_DISABLE_GQA_DECODE", "1")
     assert envs.VLLM_METAL_DISABLE_GQA_DECODE is True
+    out_env, _ = _run_primitive(
+        [kv_len],
+        mx.bfloat16,
+        interleaved=True,
+        seed=7,
+        gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
+    )
+    _assert_close(out_env, ref, mx.bfloat16)

--- a/tests/test_native_sdpa_decode.py
+++ b/tests/test_native_sdpa_decode.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native SDPA is a test-only numeric/performance ceiling.
+
+Production decode always goes through ``paged_attention_primitive`` (the
+GQA-shared flash-decode pass at long context).  These tests keep MLX native
+SDPA around as a reference: contiguous paged GQA output must match it, and
+the shipped attention module must not dispatch to it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+import vllm_metal.attention.impls.sdpa as sdpa_mod
+from tools.attention_bench_utils import native_sdpa_contiguous_decode
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+}
+
+
+def test_production_decode_does_not_call_native_sdpa() -> None:
+    src = inspect.getsource(sdpa_mod.sdpa_forward)
+    assert "_native_sdpa_decode_fast_path" not in src
+    assert "scaled_dot_product_attention" not in src
+    assert not hasattr(sdpa_mod, "_native_sdpa_decode_fast_path")
+    assert not hasattr(sdpa_mod, "_gqa_decode_kernels")
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_paged_gqa_matches_native_sdpa_reference(dtype: mx.Dtype) -> None:
+    """Contiguous long decode: shipped primitive vs MLX native SDPA."""
+    ops = get_ops()
+    seq = ops.GQA_DECODE_MIN_SEQ_LEN
+    assert ops.has_gqa_decode_kernel()
+    mx.random.seed(11)
+    n_blocks = seq // BLOCK_SIZE
+    first = 2
+    num_cache = first + n_blocks + 2
+    kc = mx.random.normal((num_cache, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)).astype(
+        dtype
+    )
+    vc = mx.random.normal((num_cache, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)).astype(
+        dtype
+    )
+    q = mx.random.normal((1, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    scale = HEAD_SIZE**-0.5
+    table = list(range(first, first + n_blocks))
+    bt = mx.array([table], dtype=mx.int32)
+    sl = mx.array([seq], dtype=mx.int32)
+    cu = mx.array([0, 1], dtype=mx.int32)
+    mx.eval(kc, vc, q, bt, sl, cu)
+
+    out = mx.array(0)
+    ops.paged_attention_primitive(
+        q, kc, vc, NUM_KV_HEADS, scale, 0.0, bt, sl, cu, BLOCK_SIZE, seq, -1, out
+    )
+    mx.eval(out)
+    ref = native_sdpa_contiguous_decode(q, kc, vc, first, seq, scale)
+    mx.eval(ref)
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )

--- a/tools/attention_bench_utils.py
+++ b/tools/attention_bench_utils.py
@@ -7,6 +7,36 @@ import mlx.core as mx
 import numpy as np
 
 
+def native_sdpa_contiguous_decode(
+    query: mx.array,
+    key_cache: mx.array,
+    value_cache: mx.array,
+    first_block: int,
+    seq: int,
+    scale: float,
+) -> mx.array:
+    """Test-only reference: MLX native SDPA over a contiguous paged run.
+
+    ``query`` is ``(1, n_heads, head_dim)``.  The sequence occupies
+    ``key_cache`` rows ``[first_block * block_size, first_block * block_size + seq)``.
+    Production decode does **not** call this; it is the performance/numeric
+    ceiling used to check the paged GQA-decode kernel.
+    """
+    n_heads = int(query.shape[1])
+    dim = int(query.shape[2])
+    n_kv_heads = int(key_cache.shape[2])
+    block = int(key_cache.shape[1])
+    group = n_heads // n_kv_heads
+    flat_k = key_cache.reshape(-1, n_kv_heads, dim)
+    flat_v = value_cache.reshape(-1, n_kv_heads, dim)
+    row0 = first_block * block
+    k_view = flat_k[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+    v_view = flat_v[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+    q_sdpa = query.reshape(n_kv_heads, group, 1, dim)
+    out = mx.fast.scaled_dot_product_attention(q_sdpa, k_view, v_view, scale=scale)
+    return out.reshape(1, n_heads, dim)
+
+
 def ref_paged_attn(
     query: mx.array,
     key_cache: mx.array,

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -95,9 +95,7 @@ class PagedAttentionContext:
     # never go stale; every layer of a group reuses the first layer's
     # conversion instead of re-serializing the Python lists above (see
     # ``impls.sdpa._kernel_metadata``).
-    kernel_metadata_cache: dict[tuple[int | None, int], Any] = field(
-        default_factory=dict
-    )
+    kernel_metadata_cache: dict[tuple, Any] = field(default_factory=dict)
 
 
 def set_context(ctx: PagedAttentionContext) -> None:

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 import mlx.core as mx
 import mlx.nn as nn
 
+from vllm_metal import envs
 from vllm_metal.attention.attention_contracts import (
     DEFAULT_ATTENTION_CONTRACT,
     AttentionContract,
@@ -805,6 +806,7 @@ def sdpa_forward(
             v_bits=kv_cache.v_bits,
             window_seqlen_q=ctx.verify_window_q,
             num_decode_requests=ctx.num_decode_requests,
+            gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
         )
     else:
         ops.paged_attention_primitive(
@@ -824,6 +826,7 @@ def sdpa_forward(
             window_seqlen_q=ctx.verify_window_q,
             sinks=sinks,
             num_decode_requests=ctx.num_decode_requests,
+            gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
         )
 
     # Reshape + strip padding back to actual head_dim before o_proj.

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -804,6 +804,7 @@ def sdpa_forward(
             quant_type=kv_cache.k_quant,
             v_bits=kv_cache.v_bits,
             window_seqlen_q=ctx.verify_window_q,
+            num_decode_requests=ctx.num_decode_requests,
         )
     else:
         ops.paged_attention_primitive(
@@ -822,6 +823,7 @@ def sdpa_forward(
             out,
             window_seqlen_q=ctx.verify_window_q,
             sinks=sinks,
+            num_decode_requests=ctx.num_decode_requests,
         )
 
     # Reshape + strip padding back to actual head_dim before o_proj.

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     VLLM_METAL_NATIVE_SAMPLING: bool = False
     VLLM_METAL_MLA_KERNEL: bool = False
     VLLM_METAL_DISABLE_NAX: bool = False
+    VLLM_METAL_DISABLE_GQA_DECODE: bool = False
     VLLM_METAL_SPEC_VERIFY_WINDOW: bool = False
     VLLM_METAL_SPEC_INGEST_CHUNK: int = 1024
     VLLM_METAL_BUILD_FROM_SOURCE: bool = False
@@ -95,6 +96,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
     # Emergency override for automatic M5 NAX prefill attention.
     "VLLM_METAL_DISABLE_NAX": lambda: os.getenv("VLLM_METAL_DISABLE_NAX", "0") == "1",
+    # Emergency override for the GQA-shared flash-decode dispatch gate
+    # (issue #713): force long-context decode back to the established
+    # per-token / split-KV kernels. Mainly a benchmarking/A-B escape
+    # hatch so controlled comparisons can run under the server topology.
+    "VLLM_METAL_DISABLE_GQA_DECODE": lambda: (
+        os.getenv("VLLM_METAL_DISABLE_GQA_DECODE", "0") == "1"
+    ),
     # Spec-decode verification window mode (issue #465). Off by default —
     # verify windows keep the expanded per-token layout (main behavior)
     # unless this opt-in is set. Set to "1" to merge K+1 verify windows

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -2143,6 +2143,123 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   }
 }
 
+// ---------------------------------------------------------------------------
+// GQA-shared flash-decode pass for pure-decode batches.
+//
+// One threadgroup per (PARTITION_SIZE-token partition, kv head, sequence);
+// each simdgroup owns one query head of the GQA group, so the whole group
+// shares every K/V row load — the per-token kernel above instead re-reads
+// the same KV rows once per query head from separate threadgroups — and the
+// online softmax stays entirely in registers (no threadgroup-memory score
+// staging, no barriers).  At long contexts this lifts single-sequence decode
+// KV-scan bandwidth from ~40GB/s to ~190GB/s on M5 Pro.
+//
+// Partials are written in the exact contract paged_attention_v2_reduce
+// consumes: log2-space running (max, exp-sum) stats plus the
+// epsilon-normalised partial at tmp_out[token, head, partition, :], so the
+// existing reduce pass merges them unchanged.  Engaged only for pure-decode
+// batches without TurboQuant/FP8/sinks/softcap/sliding-window (dispatch gate
+// in paged_ops.cpp); everything else keeps the established paths.
+template <typename T, int HEAD_SIZE, int BLOCK_SIZE, int PARTITION_SIZE>
+[[kernel]] void paged_attention_gqa_decode(
+    device float *exp_sums [[buffer(0)]], device float *max_logits [[buffer(1)]],
+    device T *tmp_out [[buffer(2)]], device const T *q [[buffer(3)]],
+    device const T *k_cache [[buffer(4)]], device const T *v_cache [[buffer(5)]],
+    const constant int &num_kv_heads [[buffer(8)]],
+    const constant float &scale [[buffer(9)]],
+    device const uint32_t *block_tables [[buffer(11)]],
+    device const uint32_t *context_lens [[buffer(12)]],
+    const constant int &max_num_blocks_per_seq [[buffer(13)]],
+    const constant int &q_stride [[buffer(15)]],
+    const constant int &kv_block_stride [[buffer(16)]],
+    const constant int &kv_head_stride [[buffer(17)]],
+    uint3 tg_pos [[threadgroup_position_in_grid]],
+    uint3 tg_per_grid [[threadgroups_per_grid]],
+    uint3 tptg [[threads_per_threadgroup]],
+    uint sg [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]) {
+  static_assert(HEAD_SIZE % 32 == 0, "one lane-strided slice per lane");
+  constexpr int SLICE = HEAD_SIZE / 32;  // elements per lane
+  const int partition_idx = tg_pos.x;
+  const int kv_head_idx = tg_pos.y;
+  const int seq_idx = tg_pos.z;
+  const int context_len = static_cast<int>(context_lens[seq_idx]);
+  const int t0 = partition_idx * PARTITION_SIZE;
+  if (t0 >= context_len) {
+    // The reduce reads only ceil(context_len / PARTITION_SIZE) partitions,
+    // so stats for later partitions are never consumed (same early-out as
+    // the partitioned per-token kernel).
+    return;
+  }
+  const int t_end = min(t0 + PARTITION_SIZE, context_len);
+
+  const int group = tptg.x / 32;  // query heads per kv head (GQA group)
+  const int head_idx = kv_head_idx * group + static_cast<int>(sg);
+  const int num_heads = num_kv_heads * group;
+  const int max_num_partitions = tg_per_grid.x;
+  const int64_t kv_token_stride =
+      static_cast<int64_t>(num_kv_heads) * kv_head_stride;
+
+  // Lane-strided query slice, loaded once.
+  device const T *q_ptr =
+      q + seq_idx * q_stride + head_idx * HEAD_SIZE + lane * SLICE;
+  float qv[SLICE];
+#pragma unroll
+  for (int i = 0; i < SLICE; i++) {
+    qv[i] = float(q_ptr[i]);
+  }
+
+  device const uint32_t *bt =
+      block_tables + seq_idx * max_num_blocks_per_seq;
+
+  // Online softmax in log2 space (v2_reduce contract): folding log2(e) into
+  // the scale turns every exp into a 1-instruction exp2 on Apple GPUs.
+  float m = -FLT_MAX;
+  float l = 0.f;
+  float acc[SLICE] = {0.f};
+  const float log2e_scale = scale * M_LOG2E_F;
+  for (int t = t0; t < t_end; t++) {
+    const int64_t row = static_cast<int64_t>(bt[t / BLOCK_SIZE]) *
+            kv_block_stride +
+        (t % BLOCK_SIZE) * kv_token_stride + kv_head_idx * kv_head_stride +
+        lane * SLICE;
+    device const T *krow = k_cache + row;
+    float dot = 0.f;
+#pragma unroll
+    for (int i = 0; i < SLICE; i++) {
+      dot += qv[i] * float(krow[i]);
+    }
+    const float s = simd_sum(dot) * log2e_scale;
+    const float m_new = max(m, s);
+    // exp2(-FLT_MAX - s) == 0 under -fno-fast-math, so the first-iteration
+    // rescale needs no guard (same identity the masked-score path uses).
+    const float alpha = exp2(m - m_new);
+    const float p = exp2(s - m_new);
+    l = l * alpha + p;
+    device const T *vrow = v_cache + row;
+#pragma unroll
+    for (int i = 0; i < SLICE; i++) {
+      acc[i] = acc[i] * alpha + p * float(vrow[i]);
+    }
+    m = m_new;
+  }
+
+  const int64_t pidx =
+      (static_cast<int64_t>(seq_idx) * num_heads + head_idx) *
+          max_num_partitions +
+      partition_idx;
+  if (lane == 0) {
+    max_logits[pidx] = m;
+    exp_sums[pidx] = l;
+  }
+  device T *out_ptr = tmp_out + pidx * HEAD_SIZE + lane * SLICE;
+  const float inv_l = 1.f / (l + 1e-6f);
+#pragma unroll
+  for (int i = 0; i < SLICE; i++) {
+    out_ptr[i] = T(acc[i] * inv_l);
+  }
+}
+
 // Tiled paged attention kernel (paged_attention_tiled) is in
 // pagedattention_tiled.metal.
 
@@ -2337,3 +2454,46 @@ instantiate_paged_attention_v1(half, char, uchar, 32);
 instantiate_paged_attention_v2(float, char, uchar, 32);
 instantiate_paged_attention_v2(bfloat16_t, char, uchar, 32);
 instantiate_paged_attention_v2(half, char, uchar, 32);
+
+// GQA-shared flash-decode pass (pure decode, non-TQ): half/bfloat16 caches,
+// head sizes divisible by 32 up to 256, kernel block sizes 8/16/32.  Other
+// configs keep the per-token kernel via the dispatch gate in paged_ops.cpp.
+#define instantiate_gqa_decode_inner(type, head_size, block_size,            \
+                                     partition_size)                         \
+  template [[host_name("paged_attention_gqa_decode_" #type "_hs" #head_size  \
+                       "_bs" #block_size "_ps" #partition_size)]]            \
+  [[kernel]] void paged_attention_gqa_decode<type, head_size, block_size,    \
+                                             partition_size>(                \
+      device float *exp_sums [[buffer(0)]],                                  \
+      device float *max_logits [[buffer(1)]], device type *tmp_out           \
+      [[buffer(2)]],                                                         \
+      device const type *q [[buffer(3)]],                                    \
+      device const type *k_cache [[buffer(4)]],                              \
+      device const type *v_cache [[buffer(5)]],                              \
+      const constant int &num_kv_heads [[buffer(8)]],                        \
+      const constant float &scale [[buffer(9)]],                             \
+      device const uint32_t *block_tables [[buffer(11)]],                    \
+      device const uint32_t *context_lens [[buffer(12)]],                    \
+      const constant int &max_num_blocks_per_seq [[buffer(13)]],             \
+      const constant int &q_stride [[buffer(15)]],                           \
+      const constant int &kv_block_stride [[buffer(16)]],                    \
+      const constant int &kv_head_stride [[buffer(17)]],                     \
+      uint3 tg_pos [[threadgroup_position_in_grid]],                         \
+      uint3 tg_per_grid [[threadgroups_per_grid]],                           \
+      uint3 tptg [[threads_per_threadgroup]],                                \
+      uint sg [[simdgroup_index_in_threadgroup]],                            \
+      uint lane [[thread_index_in_simdgroup]]);
+
+#define instantiate_gqa_decode_hs(type, block_size, partition_size)          \
+  instantiate_gqa_decode_inner(type, 64, block_size, partition_size);        \
+  instantiate_gqa_decode_inner(type, 96, block_size, partition_size);        \
+  instantiate_gqa_decode_inner(type, 128, block_size, partition_size);       \
+  instantiate_gqa_decode_inner(type, 256, block_size, partition_size);
+
+#define instantiate_gqa_decode_bs(type, partition_size)                      \
+  instantiate_gqa_decode_hs(type, 8, partition_size);                        \
+  instantiate_gqa_decode_hs(type, 16, partition_size);                       \
+  instantiate_gqa_decode_hs(type, 32, partition_size);
+
+instantiate_gqa_decode_bs(bfloat16_t, VLLM_METAL_PARTITION_SIZE);
+instantiate_gqa_decode_bs(half, VLLM_METAL_PARTITION_SIZE);

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -36,6 +36,11 @@ using namespace mlx::core;
 
 static std::string v2_paged_attention_source_;
 constexpr int kPartitionSize = VLLM_METAL_PARTITION_SIZE;
+// Below this context length the GQA-shared decode pass loses to the
+// established per-token / split-KV kernel (measured on M5 Pro).  Kept as
+// a named constant so the dispatch gate and the Python test surface cannot
+// drift.
+constexpr int kGqaDecodeMinSeqLen = 16384;
 
 // Window mode for spec-decode verification (per-token kernel): query rows
 // per threadgroup (2 = the measured register/occupancy sweet spot on Apple
@@ -433,6 +438,63 @@ static void dispatch_paged_attention_tiled(
       MTL::Size::Make(cfg.NUM_THREADS, 1, 1));
 }
 
+// ---------------------------------------------------------------------------
+// Shared pass-2 for the split-KV decode paths: merge per-partition partials
+// into `out` (log-sum-exp combine).  Partials must follow the ps512 contract:
+// log2-space (max, exp-sum) stats plus epsilon-normalised partial outputs in
+// tmp_out[token, head, partition, :].
+static void dispatch_paged_attention_v2_reduce(
+    metal::Device& d, metal::CommandEncoder& enc, array& out,
+    const array& exp_sums, const array& max_logits, const array& tmp_out,
+    const array& seq_lens, const array& cu_seqlens_q, int num_seqs,
+    int total_q_tokens, int num_heads, int head_size, int max_num_partitions,
+    const std::string& dt, bool use_sinks, const array* sinks,
+    bool use_tq_fc) {
+  std::string rname =
+      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
+      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
+  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
+  // other function constants are inert for it.  TurboQuant batches take this
+  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
+  // and sinks are folded here rather than in the partitioned kernel so the
+  // sink logit is counted once globally.  The cache key MUST encode every
+  // constant the pipeline is specialized on — otherwise the first compile
+  // wins and a later caller with different constants silently reuses the
+  // wrong pipeline.
+  std::string rhash = rname + "_v2reduce"
+      + "_tq" + (use_tq_fc ? "1" : "0")
+      + "_sk" + (use_sinks ? "1" : "0");
+  auto* lib = d.get_library("paged_attention_v2_kern");
+  auto* rkernel = d.get_kernel(
+      rname, lib, rhash,
+      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
+  enc.set_compute_pipeline_state(rkernel);
+  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
+  // (odd partition counts would yield 8 mod 16 and trip the API-validation
+  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
+  // is never touched.
+  size_t reduce_shmem =
+      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
+  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(seq_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+  if (use_sinks) {
+    enc.set_input_array(*sinks, 6);
+  }
+  enc.set_input_array(cu_seqlens_q, 7);
+  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
+  enc.set_bytes(num_seqs_i, 8);
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, 1),
+      MTL::Size::Make(256, 1, 1));
+}
+
 static void dispatch_paged_attention_v2_online(
     array& out, const array& query,
     const array& key_cache, const array& value_cache,
@@ -440,7 +502,7 @@ static void dispatch_paged_attention_v2_online(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    int window_seqlen_q, Stream s,
+    int window_seqlen_q, int num_decode_requests, Stream s,
     // TurboQuant (optional, all nullptr when disabled):
     const array* key_scale_cache = nullptr,
     const array* value_scale_cache = nullptr,
@@ -596,6 +658,19 @@ static void dispatch_paged_attention_v2_online(
 
   auto& enc = metal::get_command_encoder(s);
 
+  // Split-KV scratch factory shared by the split paths below: partial output
+  // + softmax (max, exp-sum) stats.  Tiny (~64 KB tmp_out @ conc=1/8K).
+  // add_temporary keeps them alive until the command buffer completes; MLX
+  // auto-inserts a barrier between the two dispatches via input/output
+  // dependency tracking (set_output here -> set_input in the reduce),
+  // mirroring MLX's own sdpa_vector_2pass.
+  auto make_temp = [&](Shape shape, Dtype dtype) {
+    array a(std::move(shape), dtype, nullptr, {});
+    a.set_data(allocator::malloc(a.nbytes()));
+    enc.add_temporary(a);
+    return a;
+  };
+
   // TurboQuant scale/zero/centroid buffers (slots 22-27); shared by both paths.
   auto bind_turboquant = [&]() {
     if (!use_turboquant) return;
@@ -616,6 +691,99 @@ static void dispatch_paged_attention_v2_online(
     enc.set_input_array(*sinks, 18);
   };
 
+  // ----- GQA-shared flash-decode pass -------------------------------------
+  // Pure-decode batches without TurboQuant/FP8/sinks/softcap/sliding-window
+  // take a dedicated split-KV kernel whose threadgroups share every KV row
+  // load across the whole GQA group (the per-token kernel re-reads each row
+  // once per query head from separate threadgroups) and keep the online
+  // softmax in registers — no threadgroup-memory score staging, no barriers.
+  // This lifts long-context decode from ~40GB/s to ~190GB/s effective
+  // KV-scan bandwidth on M5 Pro.  Partials follow the ps512 contract and
+  // merge through the standard v2 reduce.  Instantiated for head sizes
+  // {64,96,128,256}, GQA groups <= 8 (one simdgroup per q head), and
+  // same-dtype half/bfloat16 Q/K/V; anything else falls through to the
+  // per-token kernel below.
+  //
+  // Spec-decode expanded windows pack as many length-1 segments (same
+  // shape as multi-seq decode) with window_seqlen_q == 1.  Production
+  // passes num_decode_requests = scheduler request count, which is 1 for
+  // a single expanded window and N for N real decode requests.  Callers
+  // that omit it (num_decode_requests < 0) keep the conservative
+  // single-seq gate so tests/test_spec_window_parity.py stays bitwise.
+  // Windowed verify windows have has_prefill and never reach this pass.
+  //
+  // Occupancy: a single short sequence underfills the GPU (measured
+  // crossover ~16k tokens on M5 Pro).  Multi-seq scales the same KV
+  // budget across the batch, so 4 seqs at 4k is treated like 1 seq at 16k.
+  const int gqa_group = num_kv_heads > 0 ? num_heads / num_kv_heads : 0;
+  const bool gqa_real_decode_batch =
+      (num_decode_requests < 0) ? (num_seqs == 1)
+                                : (num_decode_requests == num_seqs);
+  const bool gqa_decode =
+      pure_decode && window_seqlen_q <= 1 && gqa_real_decode_batch
+      && dtype_ok && query.dtype() == value_cache.dtype()
+      && !use_turboquant && softcap <= 0.f && sinks == nullptr
+      && sliding_window < 0 && num_kv_heads > 0
+      && num_heads % num_kv_heads == 0 && gqa_group >= 1 && gqa_group <= 8
+      && (head_size == 64 || head_size == 96 || head_size == 128 ||
+          head_size == 256)
+      && max_num_partitions >= 2
+      && (int64_t)num_seqs * (int64_t)max_seq_len >= kGqaDecodeMinSeqLen;
+  if (gqa_decode) {
+    std::string gname =
+        "paged_attention_gqa_decode_" + dt + "_hs" + std::to_string(head_size) +
+        "_bs" + std::to_string(block_size) + "_ps" +
+        std::to_string(kPartitionSize);
+    // Instantiated in pagedattention.metal and shipped in the v2 metallib.
+    // A missing specialization is a build/packaging bug: fail loudly
+    // rather than silently drop eligible long decode back to the slower
+    // per-token kernel.
+    auto* gkernel = d.get_kernel(gname, lib, gname, {});
+
+    array g_tmp_out = make_temp(
+        Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
+        query.dtype());
+    array g_exp_sums =
+        make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+    array g_max_logits =
+        make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+
+    // Binds mirror paged_attention_gqa_decode's signature exactly (the
+    // kernel declares only these slots; no shared-mem carve).
+    enc.set_compute_pipeline_state(gkernel);
+    enc.set_output_array(g_exp_sums, 0);
+    enc.set_output_array(g_max_logits, 1);
+    enc.set_output_array(g_tmp_out, 2);
+    enc.set_input_array(query, 3);
+    enc.set_input_array(key_cache, 4);
+    enc.set_input_array(value_cache, 5);
+    int32_t g_nkv = static_cast<int32_t>(num_kv_heads);
+    enc.set_bytes(g_nkv, 8);
+    enc.set_bytes(scale, 9);
+    enc.set_input_array(block_tables, 11);
+    enc.set_input_array(seq_lens, 12);
+    int32_t g_max_blocks = static_cast<int32_t>(block_tables.shape(1));
+    enc.set_bytes(g_max_blocks, 13);
+    int32_t g_q_stride = static_cast<int32_t>(num_heads * head_size);
+    int32_t g_kv_block_stride = static_cast<int32_t>(key_cache.strides()[0]);
+    int32_t g_kv_head_stride = static_cast<int32_t>(key_cache.strides()[2]);
+    enc.set_bytes(g_q_stride, 15);
+    enc.set_bytes(g_kv_block_stride, 16);
+    enc.set_bytes(g_kv_head_stride, 17);
+    // One threadgroup per (partition, kv head, sequence); each simdgroup
+    // owns one query head of the GQA group.
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(max_num_partitions, num_kv_heads, num_seqs),
+        MTL::Size::Make(32 * gqa_group, 1, 1));
+
+    dispatch_paged_attention_v2_reduce(
+        d, enc, out, g_exp_sums, g_max_logits, g_tmp_out, seq_lens,
+        cu_seqlens_q, num_seqs, total_q_tokens, num_heads, head_size,
+        max_num_partitions, dt, /*use_sinks=*/false, nullptr,
+        /*use_tq_fc=*/false);
+    return;
+  }
+
   if (!partition) {
     // Single-pass path (grid.z = 1): the original decode/per-token kernel.
     enc.set_compute_pipeline_state(kernel);
@@ -633,17 +801,6 @@ static void dispatch_paged_attention_v2_online(
   }
 
   // ----- Split-KV path: paged_attention(_ps512) -> paged_attention_v2_reduce.
-  // Per-partition scratch: partial output + softmax (max, exp-sum) stats.
-  // Tiny (~64 KB tmp_out @ conc=1/8K).  add_temporary keeps them alive until
-  // the command buffer completes; MLX auto-inserts a barrier between the two
-  // dispatches via input/output dependency tracking (set_output here ->
-  // set_input below), mirroring MLX's own sdpa_vector_2pass.
-  auto make_temp = [&](Shape shape, Dtype dtype) {
-    array a(std::move(shape), dtype, nullptr, {});
-    a.set_data(allocator::malloc(a.nbytes()));
-    enc.add_temporary(a);
-    return a;
-  };
   array tmp_out = make_temp(
       Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
       query.dtype());
@@ -671,48 +828,10 @@ static void dispatch_paged_attention_v2_online(
       MTL::Size::Make(NUM_THREADS, 1, 1));
 
   // Pass 2: reduce per-partition partials -> out (log-sum-exp combine).
-  std::string rname =
-      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
-      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
-  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
-  // other function constants are inert for it.  TurboQuant batches take this
-  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
-  // and sinks are folded here rather than in the partitioned kernel so the
-  // sink logit is counted once globally.  The cache key MUST encode every
-  // constant the pipeline is specialized on — otherwise the first compile
-  // wins and a later caller with different constants silently reuses the
-  // wrong pipeline.
-  std::string rhash = rname + "_v2reduce"
-      + "_tq" + (use_tq_fc ? "1" : "0")
-      + "_sk" + (use_sinks ? "1" : "0");
-  auto* rkernel = d.get_kernel(
-      rname, lib, rhash,
-      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
-       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
-  enc.set_compute_pipeline_state(rkernel);
-  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
-  // (odd partition counts would yield 8 mod 16 and trip the API-validation
-  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
-  // is never touched.
-  size_t reduce_shmem =
-      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
-  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
-  enc.set_output_array(out, 0);
-  enc.set_input_array(exp_sums, 1);
-  enc.set_input_array(max_logits, 2);
-  enc.set_input_array(tmp_out, 3);
-  enc.set_input_array(seq_lens, 4);
-  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
-  enc.set_bytes(max_num_partitions_i, 5);
-  if (use_sinks) {
-    enc.set_input_array(*sinks, 6);
-  }
-  enc.set_input_array(cu_seqlens_q, 7);
-  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
-  enc.set_bytes(num_seqs_i, 8);
-  enc.dispatch_threadgroups(
-      MTL::Size::Make(num_heads, total_q_tokens, 1),
-      MTL::Size::Make(NUM_THREADS, 1, 1));
+  dispatch_paged_attention_v2_reduce(
+      d, enc, out, exp_sums, max_logits, tmp_out, seq_lens, cu_seqlens_q,
+      num_seqs, total_q_tokens, num_heads, head_size, max_num_partitions, dt,
+      use_sinks, sinks, use_tq_fc);
 }
 
 // ---------------------------------------------------------------------------
@@ -729,13 +848,15 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
       Stream stream, int num_kv_heads, float scale, float softcap,
       int block_size, int max_seq_len, int sliding_window,
       bool use_turboquant = false, int k_bits = 8, int v_bits = 3,
-      int window_seqlen_q = 1, bool use_sinks = false)
+      int window_seqlen_q = 1, bool use_sinks = false,
+      int num_decode_requests = -1)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
         sliding_window_(sliding_window),
         use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits),
-        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks) {}
+        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks),
+        num_decode_requests_(num_decode_requests) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -761,6 +882,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         num_kv_heads_, scale_, softcap_,
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_, window_seqlen_q_,
+        num_decode_requests_,
         stream(),
         ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_, sk);
   }
@@ -778,7 +900,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->k_bits_ == k_bits_
         && rhs->v_bits_ == v_bits_
         && rhs->window_seqlen_q_ == window_seqlen_q_
-        && rhs->use_sinks_ == use_sinks_;
+        && rhs->use_sinks_ == use_sinks_
+        && rhs->num_decode_requests_ == num_decode_requests_;
   }
 
  private:
@@ -793,6 +916,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int v_bits_;
   int window_seqlen_q_;
   bool use_sinks_;
+  int num_decode_requests_;
 };
 
 static array paged_attention_primitive_fn(
@@ -808,7 +932,7 @@ static array paged_attention_primitive_fn(
     const array* key_zero_cache = nullptr,
     const array* v_centroids = nullptr,
     int v_bits = 3, int window_seqlen_q = 1,
-    const array* sinks = nullptr) {
+    const array* sinks = nullptr, int num_decode_requests = -1) {
   if (sinks != nullptr) {
     // Upstream MLX refuses the same combination
     // (mlx_lm/models/base.py: "Quantized SDPA does not support attention
@@ -902,7 +1026,8 @@ static array paged_attention_primitive_fn(
       default_stream(Device::gpu),
       num_kv_heads, scale, softcap,
       block_size, max_seq_len, sliding_window,
-      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr);
+      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr,
+      num_decode_requests);
   if (use_turboquant) {
     return array(
         query.shape(), query.dtype(), std::move(prim),
@@ -1617,9 +1742,26 @@ void gdn_linear_attention_impl(
 
 NB_MODULE(_paged_ops, m) {
   m.attr("PARTITION_SIZE") = nb::int_(kPartitionSize);
+  m.attr("GQA_DECODE_MIN_SEQ_LEN") = nb::int_(kGqaDecodeMinSeqLen);
   m.def("min_decode_grid", &min_decode_grid,
         "Decode-grid threshold (threadgroups) below which split-KV decode "
         "engages on this machine.");
+  m.def(
+      "has_gqa_decode_kernel",
+      []() {
+        try {
+          auto& d = metal::device(Device::gpu);
+          auto* lib = d.get_library("paged_attention_v2_kern");
+          auto* k = d.get_kernel(
+              "paged_attention_gqa_decode_half_hs128_bs16_ps512", lib,
+              "paged_attention_gqa_decode_half_hs128_bs16_ps512", {});
+          return k != nullptr;
+        } catch (const std::exception&) {
+          return false;
+        }
+      },
+      "True when the loaded v2 shader library contains the GQA-shared "
+      "flash-decode pass (the default prebuilt metallib on this branch).");
 
   m.def("init_v2_library", &init_v2_library,
         nb::arg("v2_src"),
@@ -1803,7 +1945,8 @@ NB_MODULE(_paged_ops, m) {
            const std::string& quant_type,
            int v_bits,
            int window_seqlen_q,
-           nb::object sinks_h) {
+           nb::object sinks_h,
+           int num_decode_requests) {
           const array* sk = sinks_h.is_none()
               ? nullptr : nb::inst_ptr<array>(sinks_h);
           const array* ks = use_turboquant
@@ -1824,7 +1967,7 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(cu_seqlens_q_h),
               block_size, max_seq_len, sliding_window,
               use_turboquant, quant_type, ks, vs, kz, vc, v_bits,
-              window_seqlen_q, sk);
+              window_seqlen_q, sk, num_decode_requests);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -1844,6 +1987,7 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("v_bits") = 3,
         nb::arg("window_seqlen_q") = 1,
         nb::arg("sinks") = nb::none(),
+        nb::arg("num_decode_requests") = -1,
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.  window_seqlen_q must equal the "
         "longest cu_seqlens_q segment (validated when > 1); small "

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -502,7 +502,8 @@ static void dispatch_paged_attention_v2_online(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    int window_seqlen_q, int num_decode_requests, Stream s,
+    int window_seqlen_q, int num_decode_requests, bool gqa_disabled,
+    Stream s,
     // TurboQuant (optional, all nullptr when disabled):
     const array* key_scale_cache = nullptr,
     const array* value_scale_cache = nullptr,
@@ -720,7 +721,8 @@ static void dispatch_paged_attention_v2_online(
       (num_decode_requests < 0) ? (num_seqs == 1)
                                 : (num_decode_requests == num_seqs);
   const bool gqa_decode =
-      pure_decode && window_seqlen_q <= 1 && gqa_real_decode_batch
+      !gqa_disabled
+      && pure_decode && window_seqlen_q <= 1 && gqa_real_decode_batch
       && dtype_ok && query.dtype() == value_cache.dtype()
       && !use_turboquant && softcap <= 0.f && sinks == nullptr
       && sliding_window < 0 && num_kv_heads > 0
@@ -849,14 +851,15 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
       int block_size, int max_seq_len, int sliding_window,
       bool use_turboquant = false, int k_bits = 8, int v_bits = 3,
       int window_seqlen_q = 1, bool use_sinks = false,
-      int num_decode_requests = -1)
+      int num_decode_requests = -1, bool gqa_disabled = false)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
         sliding_window_(sliding_window),
         use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits),
         window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks),
-        num_decode_requests_(num_decode_requests) {}
+        num_decode_requests_(num_decode_requests),
+        gqa_disabled_(gqa_disabled) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -882,7 +885,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         num_kv_heads_, scale_, softcap_,
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_, window_seqlen_q_,
-        num_decode_requests_,
+        num_decode_requests_, gqa_disabled_,
         stream(),
         ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_, sk);
   }
@@ -901,7 +904,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->v_bits_ == v_bits_
         && rhs->window_seqlen_q_ == window_seqlen_q_
         && rhs->use_sinks_ == use_sinks_
-        && rhs->num_decode_requests_ == num_decode_requests_;
+        && rhs->num_decode_requests_ == num_decode_requests_
+        && rhs->gqa_disabled_ == gqa_disabled_;
   }
 
  private:
@@ -917,6 +921,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int window_seqlen_q_;
   bool use_sinks_;
   int num_decode_requests_;
+  bool gqa_disabled_;
 };
 
 static array paged_attention_primitive_fn(
@@ -932,7 +937,8 @@ static array paged_attention_primitive_fn(
     const array* key_zero_cache = nullptr,
     const array* v_centroids = nullptr,
     int v_bits = 3, int window_seqlen_q = 1,
-    const array* sinks = nullptr, int num_decode_requests = -1) {
+    const array* sinks = nullptr, int num_decode_requests = -1,
+    bool gqa_disabled = false) {
   if (sinks != nullptr) {
     // Upstream MLX refuses the same combination
     // (mlx_lm/models/base.py: "Quantized SDPA does not support attention
@@ -1027,7 +1033,7 @@ static array paged_attention_primitive_fn(
       num_kv_heads, scale, softcap,
       block_size, max_seq_len, sliding_window,
       use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr,
-      num_decode_requests);
+      num_decode_requests, gqa_disabled);
   if (use_turboquant) {
     return array(
         query.shape(), query.dtype(), std::move(prim),
@@ -1946,7 +1952,8 @@ NB_MODULE(_paged_ops, m) {
            int v_bits,
            int window_seqlen_q,
            nb::object sinks_h,
-           int num_decode_requests) {
+           int num_decode_requests,
+           bool gqa_disabled) {
           const array* sk = sinks_h.is_none()
               ? nullptr : nb::inst_ptr<array>(sinks_h);
           const array* ks = use_turboquant
@@ -1967,7 +1974,7 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(cu_seqlens_q_h),
               block_size, max_seq_len, sliding_window,
               use_turboquant, quant_type, ks, vs, kz, vc, v_bits,
-              window_seqlen_q, sk, num_decode_requests);
+              window_seqlen_q, sk, num_decode_requests, gqa_disabled);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -1988,6 +1995,7 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("window_seqlen_q") = 1,
         nb::arg("sinks") = nb::none(),
         nb::arg("num_decode_requests") = -1,
+        nb::arg("gqa_disabled") = false,
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.  window_seqlen_q must equal the "
         "longest cu_seqlens_q segment (validated when > 1); small "


### PR DESCRIPTION
> **Stacked on an older #715 commit.** The disable flag, `sdpa_forward` plumbing, `docs/configuration.md` row, and routing tests now live **in #715 itself** (`b66217c`, per review). Please do **not** merge this before #715.
>
> After #715 merges, this PR should be rebased onto main as **docs-only**: the remaining unique file is `docs/benchmarking-macos.md` (#713). If that doc is folded into #715 instead, this PR can close.

## What remains here

**`docs/benchmarking-macos.md`** — three measurement hazards from #713 with detection recipes:

- server topology for absolute claims (in-process `LLM()` understates decode 1.5–2.1× and compresses ratios)
- AGX `Device Utilization %` gate for desktop GPU co-tenancy (measured −16% on real decode)
- why short-burst GEMM probes are not a fast/slow oracle

## What moved to #715

`VLLM_METAL_DISABLE_GQA_DECODE`, both `paged_attention_primitive` call sites, primitive equality, the dispatch kill switch, and the tests that assert the env reaches the primitive. Reviewing those diffs on this PR will duplicate (and, until rebase, **conflict with**) #715.

Addresses the documentation half of #713.
