### PR TITLE
perf: scoped GQA paged decode for single-request long contexts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,7 @@
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_USE_PAGED_ATTENTION` | `1` | Enable experimental paged KV cache |
 | `VLLM_METAL_DISABLE_NAX` | `0` | Emergency override for automatic M5 NAX prefill attention. Set to `1` to force the non-NAX fallback. |
+| `VLLM_METAL_DISABLE_GQA_DECODE` | `0` | Force-close the GQA flash-decode dispatch gate ([#715](https://github.com/vllm-project/vllm-metal/pull/715) / [#713](https://github.com/vllm-project/vllm-metal/issues/713)). Set to `1` so long-context single-request decode stays on the established per-token / split-KV kernels — the server-topology A/B hatch (mirrors `VLLM_METAL_DISABLE_NAX`). Off by default. The GQA kernel only auto-routes a single decode request with KV ≥ 16384; multi-request batches never take it. |
 | `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` uses the compatibility allowlist; `multimodal-native` disables overrides |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |

--- a/docs/gqa-decode.md
+++ b/docs/gqa-decode.md
@@ -1,0 +1,94 @@
+# GQA decode routing
+
+The paged attention primitive can use `paged_attention_gqa_decode` for a
+limited set of single-request, long-context decode calls. Automatic routing
+is intentionally narrower than the shapes supported by the shader.
+
+## Automatic eligibility
+
+The following geometry and KV-length bounds are inclusive:
+
+| Query heads | KV heads | Head dimension | Minimum KV tokens | Maximum KV tokens |
+|---:|---:|---:|---:|---:|
+| 32 | 8 | 128 | 32,768 | 131,072 |
+| 24 | 4 | 256 | 32,768 | 131,072 |
+| 16 | 2 | 128 | 65,536 | 131,072 |
+
+Every row additionally requires:
+
+- One pure-decode request, with `num_decode_requests` equal to 1 or omitted.
+- A verification window of at most 1.
+- Matching FP16 or BF16 query, key-cache, and value-cache types.
+- Kernel block size 16. This is the block size passed to the primitive after
+  any hybrid-cache view conversion.
+- No TurboQuant, attention sinks, logit soft-capping, or sliding-window
+  attention.
+- Enough partition threadgroups for the conservative occupancy guard:
+  `ceil(KV tokens / 512) * KV heads >= 3 * detected GPU cores`.
+  An unknown GPU core count falls back.
+
+Calls outside these bounds use the established attention family. That
+includes multi-request batches, even if each request individually matches a
+row, and lengths above the maximum. The 16/2/128 geometry deliberately starts
+at 64K; small measured gains at 32K were not used to widen automatic routing.
+
+The gate checks geometry rather than model names and does not contain a
+device-name allowlist. Its bounds and occupancy guard are empirical choices,
+not a claim that GQA wins for every device or competing GPU workload.
+
+## Disable switch
+
+Set `VLLM_METAL_DISABLE_GQA_DECODE=1` before starting the server to keep
+eligible requests on the established path. This switch provides an A/B and
+operational fallback; it cannot enable an otherwise ineligible call.
+
+There is no startup calibration or disk-cached performance threshold for
+this gate. `VLLM_METAL_GQA_AUTOTUNE` and the former mutable gate-parameter
+APIs are no longer used.
+
+## Validation
+
+`tests/test_gqa_paged_decode.py` evaluates the primitive and checks
+`last_paged_dispatch()` alongside the numerical reference. Positive cases
+must actually report `gqa_decode`; boundary, multi-request, verification,
+feature, and disabled cases must report the appropriate established family.
+`tests/test_attention_sdpa.py` checks that the environment switch reaches
+the primitive, and `tests/test_native_sdpa_decode.py` provides a separate
+numerical comparison.
+
+`last_paged_dispatch()` records the last family selected in the process. It
+is suitable for serial tests and isolated worker checks; it is not
+per-request telemetry for concurrent serving. Evaluate the operation before
+reading it, because MLX builds graphs lazily.
+
+For performance validation, rebuild native artifacts from the tested
+revision and use the real `vllm serve` process topology. Record the model,
+runtime versions, hardware, warmup, KV lengths, repetitions, and background
+GPU activity; compare enabled and disabled arms with actual worker-side
+dispatch checks. Separate primitive timing from HTTP decode throughput,
+and keep noisy measurements visible. The
+[macOS benchmarking discussion](https://github.com/vllm-project/vllm-metal/issues/713)
+explains why in-process engine measurements and short probes are not
+interchangeable with serving results.
+
+## Why the broader gate was removed
+
+An earlier design combined a partition-occupancy floor with a scalar
+potential-KV-reread proxy and fitted a threshold at startup. Additional
+geometry, submission-mode, and load tests did not justify extending that
+single threshold to all shader-supported cases. The proxy is not measured
+DRAM traffic: each simdgroup still issues its own K/V loads, and the actual
+traffic depends on cache residency. Grouping related heads can improve
+locality without an explicit cross-simdgroup KV broadcast.
+
+A separate experiment added paired timing, confirmation runs, numerical
+checks, telemetry, and invocation-bound permits with expiry, revocation,
+and native validation before encoding. It rejected known invalidation but
+did not establish performance for later requests after resource conditions
+changed. Tests in which requests always fell back did not validate positive
+GQA performance. That experimental machinery is not part of this routing
+implementation.
+
+These limitations motivate the explicit scope above; they do not establish
+that a more general optimization is impossible. Expanding automatic routing
+requires its own dispatch, numerical, and real-serving benchmark evidence.

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -701,6 +701,53 @@ class TestSDPAForward:
         assert captured["num_kv_heads"] == 2
         assert captured["scale"] == 0.5
 
+    def test_gqa_disable_env_reaches_primitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``sdpa_forward`` must pass ``VLLM_METAL_DISABLE_GQA_DECODE`` through."""
+        captured: dict[str, bool | None] = {}
+
+        class _FakeOps:
+            def reshape_and_cache(
+                self,
+                _keys,
+                _values,
+                key_cache,
+                value_cache,
+                _slot_mapping,
+            ) -> tuple[mx.array, mx.array]:
+                return key_cache, value_cache
+
+            def paged_attention_primitive(self, *_args, **kwargs) -> None:
+                captured["gqa_disabled"] = kwargs.get("gqa_disabled")
+
+        inner = _make_inner()
+        inner.o_proj = lambda out: out
+        cache = MetalPagedKVCache(
+            num_layers=1,
+            num_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            num_blocks=1,
+            block_size=8,
+            dtype=mx.float16,
+        )
+        x = mx.ones((_BATCH, _SEQ_LEN, _HIDDEN), dtype=mx.float16)
+        zeros = mx.zeros((_BATCH, _SEQ_LEN, _N_HEADS * _HEAD_DIM), dtype=mx.float16)
+
+        def _run() -> None:
+            with (
+                patch.object(sdpa_mod, "get_ops", return_value=_FakeOps()),
+                patch.object(sdpa_mod, "truncate_padded_output", return_value=zeros),
+            ):
+                sdpa_forward(inner, x, _make_ctx(_SEQ_LEN), cache, layer_idx=0)
+
+        _run()
+        assert captured.get("gqa_disabled") is False
+
+        monkeypatch.setenv("VLLM_METAL_DISABLE_GQA_DECODE", "1")
+        _run()
+        assert captured.get("gqa_disabled") is True
+
     def test_mixed_batch_routes_slots_and_page_tables_by_layer_group(self) -> None:
         """Full and sliding layers consume their scheduler-group metadata."""
         layout = MHAKVCacheLayout(

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -619,8 +619,9 @@ class _PagedRoutingOpsSpy:
         _out: mx.array,
         window_seqlen_q: int = 1,
         sinks: mx.array | None = None,
+        **_kwargs,
     ) -> None:
-        del window_seqlen_q, sinks
+        del window_seqlen_q, sinks, _kwargs
         self.calls[-1].block_tables = block_tables.tolist()
         self.calls[-1].block_size = block_size
 

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -1,15 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """GQA-shared flash-decode pass inside ``paged_attention_primitive``.
 
-Eligible pure-decode batches (no TQ/sinks/softcap/window, head size in
-{64,96,128,256}, GQA group <= 8, ``window_seqlen_q <= 1``, aggregate KV
-``num_seqs * max_seq_len >= GQA_DECODE_MIN_SEQ_LEN``) dispatch to
-``paged_attention_gqa_decode`` and merge through ``paged_attention_v2_reduce``.
-Spec-decode verify windows pass ``window_seqlen_q = K+1`` and stay on the
-established family so ``tests/test_spec_window_parity.py`` stays bitwise.
+Eligible single-request, long-context decode (no TQ/sinks/softcap/window,
+head size in {64,96,128,256}, GQA group <= 8, ``window_seqlen_q <= 1``,
+``num_seqs == 1`` with the scheduler confirming one real decode request,
+KV ``max_seq_len >= GQA_DECODE_MIN_SEQ_LEN``) dispatches to
+``paged_attention_gqa_decode`` and merges through ``paged_attention_v2_reduce``.
+Multi-request batches, spec-decode verify windows, and everything under the
+crossover stay on the established per-token / split-KV family.
+``VLLM_METAL_DISABLE_GQA_DECODE`` (mirror kwarg ``gqa_disabled``) forces
+eligible batches back to the established kernels.
 
-These tests drive the shipped primitive (not a reimplementation) against
-``ref_paged_attn``.
+The routing tests assert the dispatch family via ``ops.last_paged_dispatch()``
+(the gate lives below the Python boundary, so the family name is the only
+faithful record of which kernel ran); parity is checked against
+``ref_paged_attn`` on every path.
 """
 
 from __future__ import annotations
@@ -52,6 +57,11 @@ def _assert_close(out: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
     )
 
 
+def _dispatch_family() -> str:
+    """Kernel family chosen by the most recent primitive eval."""
+    return get_ops().last_paged_dispatch()
+
+
 def _run_primitive(
     kv_lens: list[int],
     dtype: mx.Dtype,
@@ -61,11 +71,15 @@ def _run_primitive(
     window_seqlen_q: int = 1,
     query_lens: list[int] | None = None,
     num_decode_requests: int = -1,
+    gqa_disabled: bool = False,
+    num_query_heads: int = NUM_QUERY_HEADS,
+    num_kv_heads: int = NUM_KV_HEADS,
+    head_size: int = HEAD_SIZE,
 ) -> tuple[mx.array, mx.array]:
     mx.random.seed(seed)
     num_seqs = len(kv_lens)
     max_kv_len = max(kv_lens)
-    scale = HEAD_SIZE**-0.5
+    scale = head_size**-0.5
     if query_lens is None:
         query_lens = [1] * num_seqs
     total_q = sum(query_lens)
@@ -83,12 +97,12 @@ def _run_primitive(
         max_blk = max(max_blk, max(table))
     num_cache_blocks = max_blk + 4
     key_cache = mx.random.normal(
-        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+        (num_cache_blocks, BLOCK_SIZE, num_kv_heads, head_size)
     ).astype(dtype)
     value_cache = mx.random.normal(
-        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+        (num_cache_blocks, BLOCK_SIZE, num_kv_heads, head_size)
     ).astype(dtype)
-    query = mx.random.normal((total_q, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    query = mx.random.normal((total_q, num_query_heads, head_size)).astype(dtype)
     padded = max(len(t) for t in tables)
     block_tables = mx.array(
         [t + [0] * (padded - len(t)) for t in tables], dtype=mx.int32
@@ -105,7 +119,7 @@ def _run_primitive(
         query,
         key_cache,
         value_cache,
-        NUM_KV_HEADS,
+        num_kv_heads,
         scale,
         0.0,
         block_tables,
@@ -117,6 +131,7 @@ def _run_primitive(
         out,
         window_seqlen_q=window_seqlen_q,
         num_decode_requests=num_decode_requests,
+        gqa_disabled=gqa_disabled,
     )
     mx.eval(out)
     ref = ref_paged_attn(
@@ -158,8 +173,44 @@ def test_gqa_decode_matches_reference(
     assert ops.has_gqa_decode_kernel()
     assert kv_len >= ops.GQA_DECODE_MIN_SEQ_LEN
     assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    # num_decode_requests omitted (-1): the conservative default still
+    # routes a single long-context sequence to the GQA kernel.
     out, ref = _run_primitive([kv_len], dtype, interleaved=interleaved, seed=0)
+    assert _dispatch_family() == "gqa_decode"
     _assert_close(out, ref, dtype)
+
+
+def test_explicit_one_decode_request_takes_gqa() -> None:
+    """Production passes num_decode_requests=1 for a lone decode row."""
+    ops = get_ops()
+    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN
+    out, ref = _run_primitive(
+        [kv_len],
+        mx.bfloat16,
+        interleaved=True,
+        seed=4,
+        num_decode_requests=1,
+    )
+    assert _dispatch_family() == "gqa_decode"
+    _assert_close(out, ref, mx.bfloat16)
+
+
+def test_qwen38_gqa_shape_takes_kernel() -> None:
+    """The measured 27B shape (24q/4kv/hs256) at the 16k crossover."""
+    ops = get_ops()
+    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN
+    out, ref = _run_primitive(
+        [kv_len],
+        mx.bfloat16,
+        interleaved=True,
+        seed=5,
+        num_decode_requests=1,
+        num_query_heads=24,
+        num_kv_heads=4,
+        head_size=256,
+    )
+    assert _dispatch_family() == "gqa_decode"
+    _assert_close(out, ref, mx.bfloat16)
 
 
 def test_below_crossover_stays_on_split_kv() -> None:
@@ -169,15 +220,22 @@ def test_below_crossover_stays_on_split_kv() -> None:
     assert kv_len > ops.PARTITION_SIZE
     assert NUM_QUERY_HEADS < ops.min_decode_grid()
     out, ref = _run_primitive([kv_len], mx.float16, interleaved=True, seed=1)
+    assert _dispatch_family() == "per_token_ps512"
     _assert_close(out, ref, mx.float16)
 
 
 @pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
-def test_multi_seq_gqa_decode_matches_reference(dtype: mx.Dtype) -> None:
-    """True multi-seq decode (window_seqlen_q=1) takes GQA-decode.
+@pytest.mark.parametrize("num_decode_requests", [2, -1])
+def test_multi_request_batch_stays_on_established_kernels(
+    dtype: mx.Dtype, num_decode_requests: int
+) -> None:
+    """Multi-request decode never takes the GQA kernel (review on #715).
 
-    Aggregate KV ``num_seqs * max_seq_len`` meets the 16k budget with two
-    8k+ sequences, which a single 8k sequence would miss.
+    The batch's aggregate KV meets the 16k budget with two 8k+ sequences,
+    which the earlier draft routed to GQA-decode; the gate is now scoped to
+    ``num_seqs == 1``.  Both the explicit scheduler count and the omitted
+    default must stay on the established split-KV family, with unchanged
+    numerics.
     """
     ops = get_ops()
     half = ops.GQA_DECODE_MIN_SEQ_LEN // 2
@@ -189,9 +247,29 @@ def test_multi_seq_gqa_decode_matches_reference(dtype: mx.Dtype) -> None:
         dtype,
         interleaved=True,
         seed=2,
-        num_decode_requests=len(kv_lens),
+        num_decode_requests=num_decode_requests,
     )
+    assert _dispatch_family() == "per_token_ps512"
     _assert_close(out, ref, dtype)
+
+
+def test_two_individually_eligible_requests_stay_off_gqa() -> None:
+    """Two 16k decode rows: each would take GQA alone; the batch must not.
+
+    This is the production-serving shape the first-cut gate refuses
+    (review on #715). Kernel microbench of 4x64k GQA is follow-up work.
+    """
+    ops = get_ops()
+    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN
+    out, ref = _run_primitive(
+        [kv_len, kv_len],
+        mx.float16,
+        interleaved=True,
+        seed=6,
+        num_decode_requests=2,
+    )
+    assert _dispatch_family() == "per_token_ps512"
+    _assert_close(out, ref, mx.float16)
 
 
 def test_spec_window_does_not_switch_kernel_family() -> None:
@@ -213,4 +291,40 @@ def test_spec_window_does_not_switch_kernel_family() -> None:
         window_seqlen_q=window,
         query_lens=[window],
     )
+    assert _dispatch_family().startswith("window_")
     _assert_close(out, ref, mx.float16)
+
+
+def test_gqa_disable_flag_forces_established_kernels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gqa_disabled=True keeps eligible batches off the GQA kernel.
+
+    This mirrors VLLM_METAL_DISABLE_GQA_DECODE (issue #713 benchmarking
+    escape hatch): results must be unchanged on the fallback family.
+    """
+    from vllm_metal import envs
+
+    ops = get_ops()
+    assert envs.VLLM_METAL_DISABLE_GQA_DECODE is False  # default off
+    kv_len = 2 * ops.GQA_DECODE_MIN_SEQ_LEN
+    out_on, ref = _run_primitive([kv_len], mx.bfloat16, interleaved=True, seed=7)
+    assert _dispatch_family() == "gqa_decode"
+    out_off, _ = _run_primitive(
+        [kv_len], mx.bfloat16, interleaved=True, seed=7, gqa_disabled=True
+    )
+    assert _dispatch_family() == "per_token_ps512"
+    _assert_close(out_on, ref, mx.bfloat16)
+    _assert_close(out_off, ref, mx.bfloat16)  # numerics identical either way
+
+    monkeypatch.setenv("VLLM_METAL_DISABLE_GQA_DECODE", "1")
+    assert envs.VLLM_METAL_DISABLE_GQA_DECODE is True
+    out_env, _ = _run_primitive(
+        [kv_len],
+        mx.bfloat16,
+        interleaved=True,
+        seed=7,
+        gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
+    )
+    assert _dispatch_family() == "per_token_ps512"
+    _assert_close(out_env, ref, mx.bfloat16)

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -1,20 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""GQA-shared flash-decode pass inside ``paged_attention_primitive``.
+"""Scoped GQA decode routing, verified after the native primitive executes.
 
-Eligible single-request, long-context decode (no TQ/sinks/softcap/window,
-head size in {64,96,128,256}, GQA group <= 8, ``window_seqlen_q <= 1``,
-``num_seqs == 1`` with the scheduler confirming one real decode request,
-KV ``max_seq_len >= GQA_DECODE_MIN_SEQ_LEN``) dispatches to
-``paged_attention_gqa_decode`` and merges through ``paged_attention_v2_reduce``.
-Multi-request batches, spec-decode verify windows, and everything under the
-crossover stay on the established per-token / split-KV family.
-``VLLM_METAL_DISABLE_GQA_DECODE`` (mirror kwarg ``gqa_disabled``) forces
-eligible batches back to the established kernels.
-
-The routing tests assert the dispatch family via ``ops.last_paged_dispatch()``
-(the gate lives below the Python boundary, so the family name is the only
-faithful record of which kernel ran); parity is checked against
-``ref_paged_attn`` on every path.
+The default optimization covers three measured attention geometries, one
+request, ordinary FP16/BF16 caches, 16-token kernel pages, and bounded long
+contexts. Numerical support for another shape does not authorize its default
+use. These tests inspect the actual dispatcher and compare both selected and
+fallback paths against attention references; timing is deliberately excluded.
 """
 
 from __future__ import annotations
@@ -26,7 +17,7 @@ import pytest
 from tools.attention_bench_utils import ref_paged_attn
 from vllm_metal.metal import get_ops
 
-NUM_QUERY_HEADS = 16
+NUM_QUERY_HEADS = 32
 NUM_KV_HEADS = 8
 HEAD_SIZE = 128
 BLOCK_SIZE = 16
@@ -34,6 +25,7 @@ BLOCK_SIZE = 16
 _TOLERANCES = {
     mx.bfloat16: (3e-2, 2e-2),
     mx.float16: (1.5e-2, 2e-2),
+    mx.float32: (2e-4, 2e-4),
 }
 
 
@@ -55,11 +47,159 @@ def _assert_close(out: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
         atol=atol,
         rtol=rtol,
     )
+    # Long-context outputs are small: absolute tolerances alone could accept
+    # an incorrectly zero-filled result, so also bound the relative L2 error.
+    out_np = np.array(out.astype(mx.float32))
+    ref_np = np.array(ref.astype(mx.float32))
+    relative_l2 = np.linalg.norm(out_np - ref_np) / max(np.linalg.norm(ref_np), 1e-10)
+    assert (
+        relative_l2
+        < {
+            mx.bfloat16: 2e-2,
+            mx.float16: 6e-3,
+            mx.float32: 1e-3,
+        }[dtype]
+    )
+
+
+def _require_grid(kv_len: int, kv_heads: int) -> None:
+    """Positive route tests need the measured grid guard on this GPU."""
+    cores = get_ops().detected_gpu_core_count()
+    if cores <= 0:
+        pytest.skip("GPU core count unavailable: GQA conservatively disabled")
+    if ((kv_len + 511) // 512) * kv_heads < 3 * cores:
+        pytest.skip("This boundary is below the GQA grid guard on this GPU")
+
+
+def _eligible_context(kv_heads: int = NUM_KV_HEADS, minimum: int = 32768) -> int:
+    cores = get_ops().detected_gpu_core_count()
+    if cores <= 0:
+        pytest.skip("GPU core count unavailable: GQA conservatively disabled")
+    # Round to whole partitions; this helper only sizes positive-test inputs.
+    # Expected shape/length decisions are explicit in the boundary tests.
+    partitions = (3 * cores + kv_heads - 1) // kv_heads
+    n = max(minimum, partitions * 512)
+    if n > 131072:
+        pytest.skip("No context inside the scoped range meets this GPU's grid guard")
+    return n
 
 
 def _dispatch_family() -> str:
-    """Kernel family chosen by the most recent primitive eval."""
     return get_ops().last_paged_dispatch()
+
+
+def _assert_fallback() -> None:
+    # Existing occupancy routing chooses ps0 or ps512 depending on the GPU.
+    assert _dispatch_family() in {"per_token_ps0", "per_token_ps512"}
+
+
+def _grouped_paged_reference(
+    *,
+    query: mx.array,
+    key_cache: mx.array,
+    value_cache: mx.array,
+    query_lens: list[int],
+    kv_lens: list[int],
+    block_tables: np.ndarray,
+    scale: float,
+    sliding_window: int | None = None,
+    soft_cap: float = 0.0,
+) -> mx.array:
+    """FP32 attention without repeating K/V for each grouped query head.
+
+    Fold the query-token and GQA-group axes into a matrix row axis. Each KV
+    head then owns one ordinary QK/PV matrix product, so the 128K reference
+    retains only the unique gathered K/V instead of allocating a copy for
+    every query head. This is a high-level full-softmax oracle, independent
+    of the paged kernel's partitioning and online softmax implementation.
+    """
+    # GPU matrix-matrix and matrix-vector paths can use different effective
+    # precision even for float32 arrays. Keep the oracle's arithmetic on CPU
+    # so grouping changes neither its precision nor its error allowance.
+    with mx.stream(mx.cpu):
+        _, block_size, kv_heads, head_size = key_cache.shape
+        query_heads = query.shape[1]
+        group = query_heads // kv_heads
+        outputs = []
+        offset = 0
+        for index, (query_len, kv_len) in enumerate(
+            zip(query_lens, kv_lens, strict=True)
+        ):
+            pages = mx.array(
+                block_tables[index, : (kv_len + block_size - 1) // block_size]
+            )
+            keys = (
+                key_cache[pages]
+                .reshape(-1, kv_heads, head_size)[:kv_len]
+                .astype(mx.float32)
+                .transpose(1, 0, 2)
+            )
+            values = (
+                value_cache[pages]
+                .reshape(-1, kv_heads, head_size)[:kv_len]
+                .astype(mx.float32)
+                .transpose(1, 0, 2)
+            )
+            queries = (
+                query[offset : offset + query_len]
+                .astype(mx.float32)
+                .reshape(query_len, kv_heads, group, head_size)
+                .transpose(1, 0, 2, 3)
+                .reshape(kv_heads, query_len * group, head_size)
+            )
+            scores = mx.einsum("krd,knd->krn", queries * scale, keys)
+            scores = scores.reshape(kv_heads, query_len, group, kv_len)
+            if soft_cap > 0:
+                scores = soft_cap * mx.tanh(scores / soft_cap)
+            query_positions = (kv_len - query_len + mx.arange(query_len))[:, None]
+            key_positions = mx.arange(kv_len)[None, :]
+            allowed = key_positions <= query_positions
+            if sliding_window is not None:
+                allowed = allowed & (key_positions > query_positions - sliding_window)
+            scores = mx.where(allowed[None, :, None, :], scores, float("-inf"))
+            probabilities = mx.softmax(scores, axis=-1).reshape(
+                kv_heads, query_len * group, kv_len
+            )
+            result = mx.einsum("krn,knd->krd", probabilities, values)
+            outputs.append(
+                result.reshape(kv_heads, query_len, group, head_size)
+                .transpose(1, 0, 2, 3)
+                .reshape(query_len, query_heads, head_size)
+            )
+            offset += query_len
+        return mx.concatenate(outputs, axis=0)
+
+
+@pytest.mark.parametrize("query_heads", [3, 12])
+@pytest.mark.parametrize(
+    "sliding_window,soft_cap", [(None, 0.0), (7, 0.0), (None, 2.0), (7, 2.0)]
+)
+def test_grouped_reference_matches_expanded_reference(
+    query_heads, sliding_window, soft_cap
+):
+    """Cross-check grouping, causal rows, page gathering and feature masks."""
+    mx.random.seed(39)
+    query = mx.random.normal((4, query_heads, 16))
+    keys = mx.random.normal((12, 8, 3, 16))
+    values = mx.random.normal((12, 8, 3, 16))
+    kwargs = {
+        "query": query,
+        "key_cache": keys,
+        "value_cache": values,
+        "query_lens": [1, 3],
+        "kv_lens": [19, 23],
+        "block_tables": np.array([[7, 2, 9], [1, 8, 4]], dtype=np.int32),
+        "scale": 16**-0.5,
+        "sliding_window": sliding_window,
+        "soft_cap": soft_cap,
+    }
+    grouped = _grouped_paged_reference(**kwargs)
+    with mx.stream(mx.cpu):
+        expanded = ref_paged_attn(**kwargs)
+    mx.eval(grouped, expanded)
+    np.testing.assert_allclose(
+        np.array(grouped), np.array(expanded), atol=2e-6, rtol=2e-5
+    )
 
 
 def _run_primitive(
@@ -75,6 +215,11 @@ def _run_primitive(
     num_query_heads: int = NUM_QUERY_HEADS,
     num_kv_heads: int = NUM_KV_HEADS,
     head_size: int = HEAD_SIZE,
+    block_size: int = BLOCK_SIZE,
+    softcap: float = 0.0,
+    sliding_window: int = -1,
+    sink_value: float | None = None,
+    turboquant: bool = False,
 ) -> tuple[mx.array, mx.array]:
     mx.random.seed(seed)
     num_seqs = len(kv_lens)
@@ -82,37 +227,66 @@ def _run_primitive(
     scale = head_size**-0.5
     if query_lens is None:
         query_lens = [1] * num_seqs
-    total_q = sum(query_lens)
-    n_blocks_needed = (max_kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    n_blocks_needed = (max_kv_len + block_size - 1) // block_size
     tables = []
     max_blk = 0
-    # Offset each sequence's pages so multi-seq batches do not alias.
-    page_stride = n_blocks_needed * 3
     for s in range(num_seqs):
         if interleaved:
-            table = [b + s * page_stride for b in _interleaved_table(n_blocks_needed)]
+            table = [
+                b + s * (n_blocks_needed * 3 + 4)
+                for b in _interleaved_table(n_blocks_needed)
+            ]
         else:
             table = list(range(s * n_blocks_needed, (s + 1) * n_blocks_needed))
         tables.append(table)
         max_blk = max(max_blk, max(table))
-    num_cache_blocks = max_blk + 4
-    key_cache = mx.random.normal(
-        (num_cache_blocks, BLOCK_SIZE, num_kv_heads, head_size)
-    ).astype(dtype)
-    value_cache = mx.random.normal(
-        (num_cache_blocks, BLOCK_SIZE, num_kv_heads, head_size)
-    ).astype(dtype)
-    query = mx.random.normal((total_q, num_query_heads, head_size)).astype(dtype)
-    padded = max(len(t) for t in tables)
-    block_tables = mx.array(
-        [t + [0] * (padded - len(t)) for t in tables], dtype=mx.int32
+    cache_shape = (max_blk + 4, block_size, num_kv_heads, head_size)
+    key_cache = mx.random.normal(cache_shape).astype(dtype)
+    value_cache = mx.random.normal(cache_shape).astype(dtype)
+    query = mx.random.normal((sum(query_lens), num_query_heads, head_size)).astype(
+        dtype
     )
+    block_tables = mx.array(tables, dtype=mx.int32)
     kv_lens_arr = mx.array(kv_lens, dtype=mx.int32)
     cu = [0]
     for qlen in query_lens:
         cu.append(cu[-1] + qlen)
     cu_seqlens_q = mx.array(cu, dtype=mx.int32)
+    sinks = (
+        None
+        if sink_value is None
+        else mx.full((num_query_heads,), sink_value, dtype=mx.float32)
+    )
     mx.eval(key_cache, value_cache, query, block_tables, kv_lens_arr, cu_seqlens_q)
+
+    key_ref, value_ref = key_cache, value_cache
+    quant_kwargs = {}
+    if turboquant:
+        from vllm_metal.attention.caches.turboquant import (
+            get_v_centroids,
+            turbo_quant_decode,
+            turbo_quant_encode,
+        )
+
+        (key_cache, k_scale, k_zero), (value_cache, v_scale) = turbo_quant_encode(
+            key_cache, value_cache, "q8_0"
+        )
+        key_ref, value_ref = turbo_quant_decode(
+            (key_cache, k_scale, k_zero),
+            (value_cache, v_scale),
+            output_dtype=dtype,
+            key_quant_type="q8_0",
+        )
+        quant_kwargs = {
+            "key_scale_cache": k_scale,
+            "value_scale_cache": v_scale,
+            "key_zero_cache": k_zero,
+            "v_centroids": get_v_centroids(3),
+            "use_turboquant": True,
+            "quant_type": "q8_0",
+            "v_bits": 3,
+        }
+        mx.eval(key_cache, value_cache, k_scale, k_zero, v_scale, key_ref, value_ref)
 
     out = mx.array(0)
     get_ops().paged_attention_primitive(
@@ -121,28 +295,44 @@ def _run_primitive(
         value_cache,
         num_kv_heads,
         scale,
-        0.0,
+        softcap,
         block_tables,
         kv_lens_arr,
         cu_seqlens_q,
-        BLOCK_SIZE,
+        block_size,
         max_kv_len,
-        -1,
+        sliding_window,
         out,
         window_seqlen_q=window_seqlen_q,
         num_decode_requests=num_decode_requests,
         gqa_disabled=gqa_disabled,
+        sinks=sinks,
+        **quant_kwargs,
     )
     mx.eval(out)
-    ref = ref_paged_attn(
-        query=query,
-        key_cache=key_cache,
-        value_cache=value_cache,
-        query_lens=query_lens,
-        kv_lens=kv_lens,
-        block_tables=np.array(block_tables),
-        scale=scale,
-    )
+    if sinks is None:
+        ref = _grouped_paged_reference(
+            query=query,
+            key_cache=key_ref,
+            value_cache=value_ref,
+            query_lens=query_lens,
+            kv_lens=kv_lens,
+            block_tables=np.array(block_tables),
+            scale=scale,
+            sliding_window=None if sliding_window < 0 else sliding_window,
+            soft_cap=softcap,
+        )
+    else:
+        assert query_lens == [1] and softcap == 0 and sliding_window < 0
+        flat_k = key_cache[block_tables[0]].reshape(-1, num_kv_heads, head_size)
+        flat_v = value_cache[block_tables[0]].reshape(-1, num_kv_heads, head_size)
+        ref = mx.fast.scaled_dot_product_attention(
+            query.transpose(1, 0, 2)[None],
+            flat_k[:max_kv_len].transpose(1, 0, 2)[None],
+            flat_v[:max_kv_len].transpose(1, 0, 2)[None],
+            scale=scale,
+            sinks=sinks.astype(dtype),
+        ).reshape(out.shape)
     mx.eval(ref)
     return out, ref
 
@@ -153,178 +343,290 @@ def test_gqa_decode_kernel_is_in_default_library() -> None:
         "default shader library is missing paged_attention_gqa_decode; "
         "rebuild with `python -m vllm_metal.metal.build`"
     )
-    assert ops.GQA_DECODE_MIN_SEQ_LEN == 16384
+    assert ops.GQA_DECODE_MIN_SEQ_LEN == 32768
+    assert ops.GQA_DECODE_MAX_SEQ_LEN == 131072
+
+
+def test_unknown_core_count_keeps_measured_shape_on_baseline() -> None:
+    if get_ops().detected_gpu_core_count() > 0:
+        pytest.skip("This platform exposes GPU core count")
+    out, ref = _run_primitive(
+        [32768],
+        mx.bfloat16,
+        interleaved=False,
+        seed=37,
+        num_decode_requests=1,
+    )
+    _assert_fallback()
+    _assert_close(out, ref, mx.bfloat16)
 
 
 @pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
-@pytest.mark.parametrize(
-    "kv_len,interleaved",
-    [
-        (16384, True),  # crossover: first length that must take GQA-decode
-        (16384 + 17, True),  # partial last block
-        (20000, True),  # hybrid-style interleaved table
-        (16384, False),  # contiguous table still valid through the primitive
-    ],
-)
-def test_gqa_decode_matches_reference(
-    kv_len: int, interleaved: bool, dtype: mx.Dtype
-) -> None:
-    ops = get_ops()
-    assert ops.has_gqa_decode_kernel()
-    assert kv_len >= ops.GQA_DECODE_MIN_SEQ_LEN
-    assert NUM_QUERY_HEADS < ops.min_decode_grid()
-    # num_decode_requests omitted (-1): the conservative default still
-    # routes a single long-context sequence to the GQA kernel.
-    out, ref = _run_primitive([kv_len], dtype, interleaved=interleaved, seed=0)
+@pytest.mark.parametrize("offset,interleaved", [(0, False), (17, True)])
+def test_gqa_decode_matches_reference(dtype, offset, interleaved) -> None:
+    n = _eligible_context() + offset
+    if n > 131072:
+        pytest.skip("Partial-tail case exceeds this device's eligible range")
+    out, ref = _run_primitive([n], dtype, interleaved=interleaved, seed=0)
     assert _dispatch_family() == "gqa_decode"
     _assert_close(out, ref, dtype)
 
 
-def test_explicit_one_decode_request_takes_gqa() -> None:
-    """Production passes num_decode_requests=1 for a lone decode row."""
-    ops = get_ops()
-    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN
+@pytest.mark.parametrize("num_decode_requests", [-1, 1])
+def test_one_decode_request_takes_gqa(num_decode_requests) -> None:
     out, ref = _run_primitive(
-        [kv_len],
+        [_eligible_context()],
         mx.bfloat16,
         interleaved=True,
         seed=4,
-        num_decode_requests=1,
+        num_decode_requests=num_decode_requests,
     )
     assert _dispatch_family() == "gqa_decode"
     _assert_close(out, ref, mx.bfloat16)
 
 
-def test_qwen38_gqa_shape_takes_kernel() -> None:
-    """The measured 27B shape (24q/4kv/hs256) at the 16k crossover."""
-    ops = get_ops()
-    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN
+@pytest.mark.parametrize(
+    "q,kv,head,minimum", [(32, 8, 128, 32768), (24, 4, 256, 32768), (16, 2, 128, 65536)]
+)
+@pytest.mark.parametrize("offset", [-1, 0, 1])
+def test_each_geometry_lower_boundary_dispatch(q, kv, head, minimum, offset):
+    n = minimum + offset
+    if offset >= 0:
+        _require_grid(n, kv)
     out, ref = _run_primitive(
-        [kv_len],
+        [n],
         mx.bfloat16,
         interleaved=True,
-        seed=5,
-        num_decode_requests=1,
-        num_query_heads=24,
-        num_kv_heads=4,
-        head_size=256,
+        seed=715,
+        num_query_heads=q,
+        num_kv_heads=kv,
+        head_size=head,
     )
-    assert _dispatch_family() == "gqa_decode"
+    if offset >= 0:
+        assert _dispatch_family() == "gqa_decode"
+    else:
+        _assert_fallback()
     _assert_close(out, ref, mx.bfloat16)
 
 
-def test_below_crossover_stays_on_split_kv() -> None:
-    """A single sequence under GQA_DECODE_MIN_SEQ_LEN stays on split-KV."""
-    ops = get_ops()
-    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN - 1
-    assert kv_len > ops.PARTITION_SIZE
-    assert NUM_QUERY_HEADS < ops.min_decode_grid()
-    out, ref = _run_primitive([kv_len], mx.float16, interleaved=True, seed=1)
-    assert _dispatch_family() == "per_token_ps512"
+@pytest.mark.parametrize("q,kv,head", [(32, 8, 128), (24, 4, 256), (16, 2, 128)])
+@pytest.mark.parametrize("n", [131072, 131073])
+def test_each_geometry_upper_boundary_dispatch(q, kv, head, n):
+    if n == 131072:
+        _require_grid(n, kv)
+    out, ref = _run_primitive(
+        [n],
+        mx.float16,
+        interleaved=False,
+        seed=716,
+        num_query_heads=q,
+        num_kv_heads=kv,
+        head_size=head,
+    )
+    if n == 131072:
+        assert _dispatch_family() == "gqa_decode"
+    else:
+        _assert_fallback()
     _assert_close(out, ref, mx.float16)
 
 
-@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
-@pytest.mark.parametrize("num_decode_requests", [2, -1])
-def test_multi_request_batch_stays_on_established_kernels(
-    dtype: mx.Dtype, num_decode_requests: int
-) -> None:
-    """Multi-request decode never takes the GQA kernel (review on #715).
-
-    The batch's aggregate KV meets the 16k budget with two 8k+ sequences,
-    which the earlier draft routed to GQA-decode; the gate is now scoped to
-    ``num_seqs == 1``.  Both the explicit scheduler count and the omitted
-    default must stay on the established split-KV family, with unchanged
-    numerics.
-    """
-    ops = get_ops()
-    half = ops.GQA_DECODE_MIN_SEQ_LEN // 2
-    kv_lens = [half, half + 64]
-    assert len(kv_lens) * max(kv_lens) >= ops.GQA_DECODE_MIN_SEQ_LEN
-    assert NUM_QUERY_HEADS * len(kv_lens) < ops.min_decode_grid()
+@pytest.mark.parametrize(
+    "q,kv,head,n",
+    [
+        (16, 2, 128, 16384),  # Reproduced MiniCPM5 regression.
+        (16, 2, 128, 32768),  # Small measured gain deliberately omitted.
+        (32, 8, 128, 16384),
+        (24, 4, 256, 16384),
+        (32, 4, 64, 32768),  # Both narrow-head regressions stay excluded.
+        (64, 8, 64, 32768),
+        (32, 4, 64, 65536),  # Same old byte proxy/grid as the preceding row.
+        (16, 2, 96, 65536),
+        (16, 4, 256, 65536),  # Supported shader, unmeasured default geometry.
+        (16, 8, 128, 65536),
+        (16, 16, 128, 65536),  # MHA.
+    ],
+)
+def test_unselected_shapes_really_use_fallback(q, kv, head, n):
     out, ref = _run_primitive(
-        kv_lens,
-        dtype,
+        [n],
+        mx.bfloat16,
+        interleaved=True,
+        seed=717,
+        num_query_heads=q,
+        num_kv_heads=kv,
+        head_size=head,
+    )
+    _assert_fallback()
+    _assert_close(out, ref, mx.bfloat16)
+
+
+@pytest.mark.parametrize("block_size", [8, 32])
+def test_unmeasured_kernel_page_sizes_use_fallback(block_size):
+    out, ref = _run_primitive(
+        [_eligible_context()],
+        mx.float16,
+        interleaved=True,
+        seed=718,
+        block_size=block_size,
+    )
+    _assert_fallback()
+    _assert_close(out, ref, mx.float16)
+
+
+@pytest.mark.parametrize("num_decode_requests", [-1, 2])
+def test_two_individually_eligible_requests_stay_off_gqa(num_decode_requests):
+    n = _eligible_context()
+    out, ref = _run_primitive(
+        [n, n + 1],
+        mx.float16,
         interleaved=True,
         seed=2,
         num_decode_requests=num_decode_requests,
     )
-    assert _dispatch_family() == "per_token_ps512"
-    _assert_close(out, ref, dtype)
+    _assert_fallback()
+    _assert_close(out, ref, mx.float16)
 
 
-def test_two_individually_eligible_requests_stay_off_gqa() -> None:
-    """Two 16k decode rows: each would take GQA alone; the batch must not.
-
-    This is the production-serving shape the first-cut gate refuses
-    (review on #715). Kernel microbench of 4x64k GQA is follow-up work.
-    """
-    ops = get_ops()
-    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN
+@pytest.mark.parametrize("num_decode_requests", [-2, 0, 2])
+def test_scheduler_must_confirm_one_decode_or_omit_count(num_decode_requests):
     out, ref = _run_primitive(
-        [kv_len, kv_len],
+        [_eligible_context()],
         mx.float16,
         interleaved=True,
-        seed=6,
-        num_decode_requests=2,
+        seed=3,
+        num_decode_requests=num_decode_requests,
     )
-    assert _dispatch_family() == "per_token_ps512"
+    _assert_fallback()
+    _assert_close(out, ref, mx.float16)
+
+
+@pytest.mark.parametrize("query_lens", [[3], [1, 2]])
+def test_prefill_and_mixed_batches_stay_off_gqa(query_lens):
+    n = _eligible_context()
+    out, ref = _run_primitive(
+        [n] * len(query_lens),
+        mx.float16,
+        interleaved=True,
+        seed=8,
+        query_lens=query_lens,
+        num_decode_requests=1 if len(query_lens) == 2 else 0,
+    )
+    assert _dispatch_family() in {"nax_prefill", "tiled_prefill"}
     _assert_close(out, ref, mx.float16)
 
 
 def test_spec_window_does_not_switch_kernel_family() -> None:
-    """A K+1 verify window on a long context stays on the window/split path.
-
-    Production expanded verify windows pass window_seqlen_q=K+1 even when
-    packed as length-1 segments; this keeps them off GQA-decode so they
-    stay bitwise with the windowed dispatch.
-    """
-    ops = get_ops()
-    ctx = ops.GQA_DECODE_MIN_SEQ_LEN
-    window = 4
-    kv_len = ctx + window
     out, ref = _run_primitive(
-        [kv_len],
+        [_eligible_context() + 4],
         mx.float16,
         interleaved=True,
-        seed=3,
-        window_seqlen_q=window,
-        query_lens=[window],
+        seed=9,
+        window_seqlen_q=4,
+        query_lens=[4],
     )
     assert _dispatch_family().startswith("window_")
     _assert_close(out, ref, mx.float16)
 
 
-def test_gqa_disable_flag_forces_established_kernels(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """gqa_disabled=True keeps eligible batches off the GQA kernel.
+@pytest.mark.parametrize(
+    "feature", [{"softcap": 2.0}, {"sliding_window": 4096}, {"sink_value": 12.0}]
+)
+def test_special_attention_features_use_fallback(feature):
+    out, ref = _run_primitive(
+        [_eligible_context()],
+        mx.float16,
+        interleaved=True,
+        seed=10,
+        **feature,
+    )
+    _assert_fallback()
+    _assert_close(out, ref, mx.float16)
 
-    This mirrors VLLM_METAL_DISABLE_GQA_DECODE (issue #713 benchmarking
-    escape hatch): results must be unchanged on the fallback family.
-    """
+
+def test_turboquant_uses_fallback_with_dequantized_reference() -> None:
+    out, ref = _run_primitive(
+        [_eligible_context(kv_heads=2, minimum=65536)],
+        mx.float16,
+        interleaved=False,
+        seed=12,
+        num_query_heads=16,
+        num_kv_heads=2,
+        turboquant=True,
+    )
+    _assert_fallback()
+    _assert_close(out, ref, mx.float16)
+
+
+def test_matching_float32_uses_fallback() -> None:
+    out, ref = _run_primitive(
+        [_eligible_context()], mx.float32, interleaved=True, seed=11
+    )
+    _assert_fallback()
+    _assert_close(out, ref, mx.float32)
+
+
+def test_gqa_disable_flag_forces_established_kernels(monkeypatch) -> None:
     from vllm_metal import envs
 
-    ops = get_ops()
-    assert envs.VLLM_METAL_DISABLE_GQA_DECODE is False  # default off
-    kv_len = 2 * ops.GQA_DECODE_MIN_SEQ_LEN
-    out_on, ref = _run_primitive([kv_len], mx.bfloat16, interleaved=True, seed=7)
+    monkeypatch.delenv("VLLM_METAL_DISABLE_GQA_DECODE", raising=False)
+    assert envs.VLLM_METAL_DISABLE_GQA_DECODE is False
+    n = _eligible_context()
+    out_on, ref = _run_primitive([n], mx.bfloat16, interleaved=True, seed=7)
     assert _dispatch_family() == "gqa_decode"
     out_off, _ = _run_primitive(
-        [kv_len], mx.bfloat16, interleaved=True, seed=7, gqa_disabled=True
+        [n], mx.bfloat16, interleaved=True, seed=7, gqa_disabled=True
     )
-    assert _dispatch_family() == "per_token_ps512"
+    _assert_fallback()
     _assert_close(out_on, ref, mx.bfloat16)
-    _assert_close(out_off, ref, mx.bfloat16)  # numerics identical either way
+    _assert_close(out_off, ref, mx.bfloat16)
 
     monkeypatch.setenv("VLLM_METAL_DISABLE_GQA_DECODE", "1")
     assert envs.VLLM_METAL_DISABLE_GQA_DECODE is True
     out_env, _ = _run_primitive(
-        [kv_len],
+        [n],
         mx.bfloat16,
         interleaved=True,
         seed=7,
         gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
     )
-    assert _dispatch_family() == "per_token_ps512"
+    _assert_fallback()
     _assert_close(out_env, ref, mx.bfloat16)
+
+
+@pytest.mark.parametrize(
+    "q,kv,head,n,cores,expected",
+    [
+        (32, 8, 128, 32767, 40, False),
+        (32, 8, 128, 32768, 40, True),
+        (24, 4, 256, 32767, 40, False),
+        (24, 4, 256, 32768, 40, True),
+        (16, 2, 128, 16384, 20, False),
+        (16, 2, 128, 32768, 40, False),
+        (16, 2, 128, 65535, 40, False),
+        (16, 2, 128, 65536, 40, True),
+        (16, 2, 128, 65536, 80, True),
+        (16, 2, 128, 65536, 86, False),  # Grid256 < 258.
+        (16, 2, 128, 65537, 86, True),  # Partial partition raises grid to258.
+        (24, 4, 256, 32768, 86, False),
+        (24, 4, 256, 32769, 86, True),
+        (32, 8, 128, 131072, 40, True),
+        (24, 4, 256, 131072, 40, True),
+        (16, 2, 128, 131072, 40, True),
+        (32, 8, 128, 131073, 40, False),
+        (24, 4, 256, 131073, 40, False),
+        (16, 2, 128, 131073, 40, False),
+        (32, 8, 128, 65536, 0, False),
+        (32, 8, 128, 65536, -1, False),
+        (32, 4, 64, 65536, 40, False),
+        (64, 8, 64, 32768, 40, False),
+        (16, 2, 96, 65536, 40, False),
+        (16, 4, 256, 65536, 40, False),
+        (16, 8, 128, 65536, 40, False),
+        (16, 16, 128, 65536, 40, False),
+        (8, 1, 128, 65536, 40, False),
+        (18, 4, 128, 65536, 40, False),
+        (16, 0, 128, 65536, 40, False),
+    ],
+)
+def test_shape_and_device_performance_gate(q, kv, head, n, cores, expected):
+    assert get_ops().gqa_decode_shape_eligible(q, kv, head, n, cores) == expected

--- a/tests/test_gqa_paged_decode.py
+++ b/tests/test_gqa_paged_decode.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GQA-shared flash-decode pass inside ``paged_attention_primitive``.
+
+Eligible pure-decode batches (no TQ/sinks/softcap/window, head size in
+{64,96,128,256}, GQA group <= 8, ``window_seqlen_q <= 1``, aggregate KV
+``num_seqs * max_seq_len >= GQA_DECODE_MIN_SEQ_LEN``) dispatch to
+``paged_attention_gqa_decode`` and merge through ``paged_attention_v2_reduce``.
+Spec-decode verify windows pass ``window_seqlen_q = K+1`` and stay on the
+established family so ``tests/test_spec_window_parity.py`` stays bitwise.
+
+These tests drive the shipped primitive (not a reimplementation) against
+``ref_paged_attn``.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from tools.attention_bench_utils import ref_paged_attn
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+}
+
+
+def _interleaved_table(n_blocks: int) -> list[int]:
+    """Run-of-2, skip-1 pattern produced by hybrid GDN block interleave."""
+    table: list[int] = []
+    b = 3
+    while len(table) < n_blocks:
+        table += [b, b + 1]
+        b += 3
+    return table[:n_blocks]
+
+
+def _assert_close(out: mx.array, ref: mx.array, dtype: mx.Dtype) -> None:
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )
+
+
+def _run_primitive(
+    kv_lens: list[int],
+    dtype: mx.Dtype,
+    *,
+    interleaved: bool,
+    seed: int,
+    window_seqlen_q: int = 1,
+    query_lens: list[int] | None = None,
+    num_decode_requests: int = -1,
+) -> tuple[mx.array, mx.array]:
+    mx.random.seed(seed)
+    num_seqs = len(kv_lens)
+    max_kv_len = max(kv_lens)
+    scale = HEAD_SIZE**-0.5
+    if query_lens is None:
+        query_lens = [1] * num_seqs
+    total_q = sum(query_lens)
+    n_blocks_needed = (max_kv_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+    tables = []
+    max_blk = 0
+    # Offset each sequence's pages so multi-seq batches do not alias.
+    page_stride = n_blocks_needed * 3
+    for s in range(num_seqs):
+        if interleaved:
+            table = [b + s * page_stride for b in _interleaved_table(n_blocks_needed)]
+        else:
+            table = list(range(s * n_blocks_needed, (s + 1) * n_blocks_needed))
+        tables.append(table)
+        max_blk = max(max_blk, max(table))
+    num_cache_blocks = max_blk + 4
+    key_cache = mx.random.normal(
+        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    value_cache = mx.random.normal(
+        (num_cache_blocks, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)
+    ).astype(dtype)
+    query = mx.random.normal((total_q, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    padded = max(len(t) for t in tables)
+    block_tables = mx.array(
+        [t + [0] * (padded - len(t)) for t in tables], dtype=mx.int32
+    )
+    kv_lens_arr = mx.array(kv_lens, dtype=mx.int32)
+    cu = [0]
+    for qlen in query_lens:
+        cu.append(cu[-1] + qlen)
+    cu_seqlens_q = mx.array(cu, dtype=mx.int32)
+    mx.eval(key_cache, value_cache, query, block_tables, kv_lens_arr, cu_seqlens_q)
+
+    out = mx.array(0)
+    get_ops().paged_attention_primitive(
+        query,
+        key_cache,
+        value_cache,
+        NUM_KV_HEADS,
+        scale,
+        0.0,
+        block_tables,
+        kv_lens_arr,
+        cu_seqlens_q,
+        BLOCK_SIZE,
+        max_kv_len,
+        -1,
+        out,
+        window_seqlen_q=window_seqlen_q,
+        num_decode_requests=num_decode_requests,
+    )
+    mx.eval(out)
+    ref = ref_paged_attn(
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=np.array(block_tables),
+        scale=scale,
+    )
+    mx.eval(ref)
+    return out, ref
+
+
+def test_gqa_decode_kernel_is_in_default_library() -> None:
+    ops = get_ops()
+    assert ops.has_gqa_decode_kernel(), (
+        "default shader library is missing paged_attention_gqa_decode; "
+        "rebuild with `python -m vllm_metal.metal.build`"
+    )
+    assert ops.GQA_DECODE_MIN_SEQ_LEN == 16384
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize(
+    "kv_len,interleaved",
+    [
+        (16384, True),  # crossover: first length that must take GQA-decode
+        (16384 + 17, True),  # partial last block
+        (20000, True),  # hybrid-style interleaved table
+        (16384, False),  # contiguous table still valid through the primitive
+    ],
+)
+def test_gqa_decode_matches_reference(
+    kv_len: int, interleaved: bool, dtype: mx.Dtype
+) -> None:
+    ops = get_ops()
+    assert ops.has_gqa_decode_kernel()
+    assert kv_len >= ops.GQA_DECODE_MIN_SEQ_LEN
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    out, ref = _run_primitive([kv_len], dtype, interleaved=interleaved, seed=0)
+    _assert_close(out, ref, dtype)
+
+
+def test_below_crossover_stays_on_split_kv() -> None:
+    """A single sequence under GQA_DECODE_MIN_SEQ_LEN stays on split-KV."""
+    ops = get_ops()
+    kv_len = ops.GQA_DECODE_MIN_SEQ_LEN - 1
+    assert kv_len > ops.PARTITION_SIZE
+    assert NUM_QUERY_HEADS < ops.min_decode_grid()
+    out, ref = _run_primitive([kv_len], mx.float16, interleaved=True, seed=1)
+    _assert_close(out, ref, mx.float16)
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_multi_seq_gqa_decode_matches_reference(dtype: mx.Dtype) -> None:
+    """True multi-seq decode (window_seqlen_q=1) takes GQA-decode.
+
+    Aggregate KV ``num_seqs * max_seq_len`` meets the 16k budget with two
+    8k+ sequences, which a single 8k sequence would miss.
+    """
+    ops = get_ops()
+    half = ops.GQA_DECODE_MIN_SEQ_LEN // 2
+    kv_lens = [half, half + 64]
+    assert len(kv_lens) * max(kv_lens) >= ops.GQA_DECODE_MIN_SEQ_LEN
+    assert NUM_QUERY_HEADS * len(kv_lens) < ops.min_decode_grid()
+    out, ref = _run_primitive(
+        kv_lens,
+        dtype,
+        interleaved=True,
+        seed=2,
+        num_decode_requests=len(kv_lens),
+    )
+    _assert_close(out, ref, dtype)
+
+
+def test_spec_window_does_not_switch_kernel_family() -> None:
+    """A K+1 verify window on a long context stays on the window/split path.
+
+    Production expanded verify windows pass window_seqlen_q=K+1 even when
+    packed as length-1 segments; this keeps them off GQA-decode so they
+    stay bitwise with the windowed dispatch.
+    """
+    ops = get_ops()
+    ctx = ops.GQA_DECODE_MIN_SEQ_LEN
+    window = 4
+    kv_len = ctx + window
+    out, ref = _run_primitive(
+        [kv_len],
+        mx.float16,
+        interleaved=True,
+        seed=3,
+        window_seqlen_q=window,
+        query_lens=[window],
+    )
+    _assert_close(out, ref, mx.float16)

--- a/tests/test_native_sdpa_decode.py
+++ b/tests/test_native_sdpa_decode.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native SDPA is a test-only numeric/performance ceiling.
+
+Production decode always goes through ``paged_attention_primitive`` (the
+GQA-shared flash-decode pass at long context).  These tests keep MLX native
+SDPA around as a reference: contiguous paged GQA output must match it, and
+the shipped attention module must not dispatch to it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+import vllm_metal.attention.impls.sdpa as sdpa_mod
+from tools.attention_bench_utils import native_sdpa_contiguous_decode
+from vllm_metal.metal import get_ops
+
+NUM_QUERY_HEADS = 16
+NUM_KV_HEADS = 8
+HEAD_SIZE = 128
+BLOCK_SIZE = 16
+
+_TOLERANCES = {
+    mx.bfloat16: (3e-2, 2e-2),
+    mx.float16: (1.5e-2, 2e-2),
+}
+
+
+def test_production_decode_does_not_call_native_sdpa() -> None:
+    src = inspect.getsource(sdpa_mod.sdpa_forward)
+    assert "_native_sdpa_decode_fast_path" not in src
+    assert "scaled_dot_product_attention" not in src
+    assert not hasattr(sdpa_mod, "_native_sdpa_decode_fast_path")
+    assert not hasattr(sdpa_mod, "_gqa_decode_kernels")
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_paged_gqa_matches_native_sdpa_reference(dtype: mx.Dtype) -> None:
+    """Contiguous long decode: shipped primitive vs MLX native SDPA."""
+    ops = get_ops()
+    seq = ops.GQA_DECODE_MIN_SEQ_LEN
+    assert ops.has_gqa_decode_kernel()
+    mx.random.seed(11)
+    n_blocks = seq // BLOCK_SIZE
+    first = 2
+    num_cache = first + n_blocks + 2
+    kc = mx.random.normal((num_cache, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)).astype(
+        dtype
+    )
+    vc = mx.random.normal((num_cache, BLOCK_SIZE, NUM_KV_HEADS, HEAD_SIZE)).astype(
+        dtype
+    )
+    q = mx.random.normal((1, NUM_QUERY_HEADS, HEAD_SIZE)).astype(dtype)
+    scale = HEAD_SIZE**-0.5
+    table = list(range(first, first + n_blocks))
+    bt = mx.array([table], dtype=mx.int32)
+    sl = mx.array([seq], dtype=mx.int32)
+    cu = mx.array([0, 1], dtype=mx.int32)
+    mx.eval(kc, vc, q, bt, sl, cu)
+
+    out = mx.array(0)
+    ops.paged_attention_primitive(
+        q, kc, vc, NUM_KV_HEADS, scale, 0.0, bt, sl, cu, BLOCK_SIZE, seq, -1, out
+    )
+    mx.eval(out)
+    ref = native_sdpa_contiguous_decode(q, kc, vc, first, seq, scale)
+    mx.eval(ref)
+    atol, rtol = _TOLERANCES[dtype]
+    np.testing.assert_allclose(
+        np.array(out.astype(mx.float32)),
+        np.array(ref.astype(mx.float32)),
+        atol=atol,
+        rtol=rtol,
+    )

--- a/tests/test_native_sdpa_decode.py
+++ b/tests/test_native_sdpa_decode.py
@@ -19,7 +19,7 @@ import vllm_metal.attention.impls.sdpa as sdpa_mod
 from tools.attention_bench_utils import native_sdpa_contiguous_decode
 from vllm_metal.metal import get_ops
 
-NUM_QUERY_HEADS = 16
+NUM_QUERY_HEADS = 32
 NUM_KV_HEADS = 8
 HEAD_SIZE = 128
 BLOCK_SIZE = 16
@@ -42,7 +42,13 @@ def test_production_decode_does_not_call_native_sdpa() -> None:
 def test_paged_gqa_matches_native_sdpa_reference(dtype: mx.Dtype) -> None:
     """Contiguous long decode: shipped primitive vs MLX native SDPA."""
     ops = get_ops()
-    seq = ops.GQA_DECODE_MIN_SEQ_LEN
+    cores = ops.detected_gpu_core_count()
+    if cores <= 0:
+        pytest.skip("GPU core count unavailable: GQA conservatively disabled")
+    n_grid = ((3 * cores + NUM_KV_HEADS - 1) // NUM_KV_HEADS) * 512
+    seq = max(32768, n_grid)
+    if seq > 131072:
+        pytest.skip("No context inside the scoped range meets the GPU grid guard")
     assert ops.has_gqa_decode_kernel()
     mx.random.seed(11)
     n_blocks = seq // BLOCK_SIZE
@@ -67,6 +73,7 @@ def test_paged_gqa_matches_native_sdpa_reference(dtype: mx.Dtype) -> None:
         q, kc, vc, NUM_KV_HEADS, scale, 0.0, bt, sl, cu, BLOCK_SIZE, seq, -1, out
     )
     mx.eval(out)
+    assert ops.last_paged_dispatch() == "gqa_decode"
     ref = native_sdpa_contiguous_decode(q, kc, vc, first, seq, scale)
     mx.eval(ref)
     atol, rtol = _TOLERANCES[dtype]

--- a/tools/attention_bench_utils.py
+++ b/tools/attention_bench_utils.py
@@ -7,6 +7,36 @@ import mlx.core as mx
 import numpy as np
 
 
+def native_sdpa_contiguous_decode(
+    query: mx.array,
+    key_cache: mx.array,
+    value_cache: mx.array,
+    first_block: int,
+    seq: int,
+    scale: float,
+) -> mx.array:
+    """Test-only reference: MLX native SDPA over a contiguous paged run.
+
+    ``query`` is ``(1, n_heads, head_dim)``.  The sequence occupies
+    ``key_cache`` rows ``[first_block * block_size, first_block * block_size + seq)``.
+    Production decode does **not** call this; it is the performance/numeric
+    ceiling used to check the paged GQA-decode kernel.
+    """
+    n_heads = int(query.shape[1])
+    dim = int(query.shape[2])
+    n_kv_heads = int(key_cache.shape[2])
+    block = int(key_cache.shape[1])
+    group = n_heads // n_kv_heads
+    flat_k = key_cache.reshape(-1, n_kv_heads, dim)
+    flat_v = value_cache.reshape(-1, n_kv_heads, dim)
+    row0 = first_block * block
+    k_view = flat_k[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+    v_view = flat_v[row0 : row0 + seq].transpose(1, 0, 2)[:, None]
+    q_sdpa = query.reshape(n_kv_heads, group, 1, dim)
+    out = mx.fast.scaled_dot_product_attention(q_sdpa, k_view, v_view, scale=scale)
+    return out.reshape(1, n_heads, dim)
+
+
 def ref_paged_attn(
     query: mx.array,
     key_cache: mx.array,

--- a/vllm_metal/attention/context.py
+++ b/vllm_metal/attention/context.py
@@ -95,9 +95,7 @@ class PagedAttentionContext:
     # never go stale; every layer of a group reuses the first layer's
     # conversion instead of re-serializing the Python lists above (see
     # ``impls.sdpa._kernel_metadata``).
-    kernel_metadata_cache: dict[tuple[int | None, int], Any] = field(
-        default_factory=dict
-    )
+    kernel_metadata_cache: dict[tuple, Any] = field(default_factory=dict)
 
 
 def set_context(ctx: PagedAttentionContext) -> None:

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 import mlx.core as mx
 import mlx.nn as nn
 
+from vllm_metal import envs
 from vllm_metal.attention.attention_contracts import (
     DEFAULT_ATTENTION_CONTRACT,
     AttentionContract,
@@ -805,6 +806,7 @@ def sdpa_forward(
             v_bits=kv_cache.v_bits,
             window_seqlen_q=ctx.verify_window_q,
             num_decode_requests=ctx.num_decode_requests,
+            gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
         )
     else:
         ops.paged_attention_primitive(
@@ -824,6 +826,7 @@ def sdpa_forward(
             window_seqlen_q=ctx.verify_window_q,
             sinks=sinks,
             num_decode_requests=ctx.num_decode_requests,
+            gqa_disabled=envs.VLLM_METAL_DISABLE_GQA_DECODE,
         )
 
     # Reshape + strip padding back to actual head_dim before o_proj.

--- a/vllm_metal/attention/impls/sdpa.py
+++ b/vllm_metal/attention/impls/sdpa.py
@@ -804,6 +804,7 @@ def sdpa_forward(
             quant_type=kv_cache.k_quant,
             v_bits=kv_cache.v_bits,
             window_seqlen_q=ctx.verify_window_q,
+            num_decode_requests=ctx.num_decode_requests,
         )
     else:
         ops.paged_attention_primitive(
@@ -822,6 +823,7 @@ def sdpa_forward(
             out,
             window_seqlen_q=ctx.verify_window_q,
             sinks=sinks,
+            num_decode_requests=ctx.num_decode_requests,
         )
 
     # Reshape + strip padding back to actual head_dim before o_proj.

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     VLLM_METAL_NATIVE_SAMPLING: bool = False
     VLLM_METAL_MLA_KERNEL: bool = False
     VLLM_METAL_DISABLE_NAX: bool = False
+    VLLM_METAL_DISABLE_GQA_DECODE: bool = False
     VLLM_METAL_SPEC_VERIFY_WINDOW: bool = False
     VLLM_METAL_SPEC_INGEST_CHUNK: int = 1024
     VLLM_METAL_BUILD_FROM_SOURCE: bool = False
@@ -95,6 +96,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_METAL_MLA_KERNEL": lambda: os.getenv("VLLM_METAL_MLA_KERNEL", "0") == "1",
     # Emergency override for automatic M5 NAX prefill attention.
     "VLLM_METAL_DISABLE_NAX": lambda: os.getenv("VLLM_METAL_DISABLE_NAX", "0") == "1",
+    # Emergency override for the GQA-shared flash-decode dispatch gate
+    # (issue #713): force long-context decode back to the established
+    # per-token / split-KV kernels. Mainly a benchmarking/A-B escape
+    # hatch so controlled comparisons can run under the server topology.
+    "VLLM_METAL_DISABLE_GQA_DECODE": lambda: (
+        os.getenv("VLLM_METAL_DISABLE_GQA_DECODE", "0") == "1"
+    ),
     # Spec-decode verification window mode (issue #465). Off by default —
     # verify windows keep the expanded per-token layout (main behavior)
     # unless this opt-in is set. Set to "1" to merge K+1 verify windows

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -2143,6 +2143,123 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
   }
 }
 
+// ---------------------------------------------------------------------------
+// GQA-shared flash-decode pass for pure-decode batches.
+//
+// One threadgroup per (PARTITION_SIZE-token partition, kv head, sequence);
+// each simdgroup owns one query head of the GQA group, so the whole group
+// shares every K/V row load — the per-token kernel above instead re-reads
+// the same KV rows once per query head from separate threadgroups — and the
+// online softmax stays entirely in registers (no threadgroup-memory score
+// staging, no barriers).  At long contexts this lifts single-sequence decode
+// KV-scan bandwidth from ~40GB/s to ~190GB/s on M5 Pro.
+//
+// Partials are written in the exact contract paged_attention_v2_reduce
+// consumes: log2-space running (max, exp-sum) stats plus the
+// epsilon-normalised partial at tmp_out[token, head, partition, :], so the
+// existing reduce pass merges them unchanged.  Engaged only for pure-decode
+// batches without TurboQuant/FP8/sinks/softcap/sliding-window (dispatch gate
+// in paged_ops.cpp); everything else keeps the established paths.
+template <typename T, int HEAD_SIZE, int BLOCK_SIZE, int PARTITION_SIZE>
+[[kernel]] void paged_attention_gqa_decode(
+    device float *exp_sums [[buffer(0)]], device float *max_logits [[buffer(1)]],
+    device T *tmp_out [[buffer(2)]], device const T *q [[buffer(3)]],
+    device const T *k_cache [[buffer(4)]], device const T *v_cache [[buffer(5)]],
+    const constant int &num_kv_heads [[buffer(8)]],
+    const constant float &scale [[buffer(9)]],
+    device const uint32_t *block_tables [[buffer(11)]],
+    device const uint32_t *context_lens [[buffer(12)]],
+    const constant int &max_num_blocks_per_seq [[buffer(13)]],
+    const constant int &q_stride [[buffer(15)]],
+    const constant int &kv_block_stride [[buffer(16)]],
+    const constant int &kv_head_stride [[buffer(17)]],
+    uint3 tg_pos [[threadgroup_position_in_grid]],
+    uint3 tg_per_grid [[threadgroups_per_grid]],
+    uint3 tptg [[threads_per_threadgroup]],
+    uint sg [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]]) {
+  static_assert(HEAD_SIZE % 32 == 0, "one lane-strided slice per lane");
+  constexpr int SLICE = HEAD_SIZE / 32;  // elements per lane
+  const int partition_idx = tg_pos.x;
+  const int kv_head_idx = tg_pos.y;
+  const int seq_idx = tg_pos.z;
+  const int context_len = static_cast<int>(context_lens[seq_idx]);
+  const int t0 = partition_idx * PARTITION_SIZE;
+  if (t0 >= context_len) {
+    // The reduce reads only ceil(context_len / PARTITION_SIZE) partitions,
+    // so stats for later partitions are never consumed (same early-out as
+    // the partitioned per-token kernel).
+    return;
+  }
+  const int t_end = min(t0 + PARTITION_SIZE, context_len);
+
+  const int group = tptg.x / 32;  // query heads per kv head (GQA group)
+  const int head_idx = kv_head_idx * group + static_cast<int>(sg);
+  const int num_heads = num_kv_heads * group;
+  const int max_num_partitions = tg_per_grid.x;
+  const int64_t kv_token_stride =
+      static_cast<int64_t>(num_kv_heads) * kv_head_stride;
+
+  // Lane-strided query slice, loaded once.
+  device const T *q_ptr =
+      q + seq_idx * q_stride + head_idx * HEAD_SIZE + lane * SLICE;
+  float qv[SLICE];
+#pragma unroll
+  for (int i = 0; i < SLICE; i++) {
+    qv[i] = float(q_ptr[i]);
+  }
+
+  device const uint32_t *bt =
+      block_tables + seq_idx * max_num_blocks_per_seq;
+
+  // Online softmax in log2 space (v2_reduce contract): folding log2(e) into
+  // the scale turns every exp into a 1-instruction exp2 on Apple GPUs.
+  float m = -FLT_MAX;
+  float l = 0.f;
+  float acc[SLICE] = {0.f};
+  const float log2e_scale = scale * M_LOG2E_F;
+  for (int t = t0; t < t_end; t++) {
+    const int64_t row = static_cast<int64_t>(bt[t / BLOCK_SIZE]) *
+            kv_block_stride +
+        (t % BLOCK_SIZE) * kv_token_stride + kv_head_idx * kv_head_stride +
+        lane * SLICE;
+    device const T *krow = k_cache + row;
+    float dot = 0.f;
+#pragma unroll
+    for (int i = 0; i < SLICE; i++) {
+      dot += qv[i] * float(krow[i]);
+    }
+    const float s = simd_sum(dot) * log2e_scale;
+    const float m_new = max(m, s);
+    // exp2(-FLT_MAX - s) == 0 under -fno-fast-math, so the first-iteration
+    // rescale needs no guard (same identity the masked-score path uses).
+    const float alpha = exp2(m - m_new);
+    const float p = exp2(s - m_new);
+    l = l * alpha + p;
+    device const T *vrow = v_cache + row;
+#pragma unroll
+    for (int i = 0; i < SLICE; i++) {
+      acc[i] = acc[i] * alpha + p * float(vrow[i]);
+    }
+    m = m_new;
+  }
+
+  const int64_t pidx =
+      (static_cast<int64_t>(seq_idx) * num_heads + head_idx) *
+          max_num_partitions +
+      partition_idx;
+  if (lane == 0) {
+    max_logits[pidx] = m;
+    exp_sums[pidx] = l;
+  }
+  device T *out_ptr = tmp_out + pidx * HEAD_SIZE + lane * SLICE;
+  const float inv_l = 1.f / (l + 1e-6f);
+#pragma unroll
+  for (int i = 0; i < SLICE; i++) {
+    out_ptr[i] = T(acc[i] * inv_l);
+  }
+}
+
 // Tiled paged attention kernel (paged_attention_tiled) is in
 // pagedattention_tiled.metal.
 
@@ -2337,3 +2454,46 @@ instantiate_paged_attention_v1(half, char, uchar, 32);
 instantiate_paged_attention_v2(float, char, uchar, 32);
 instantiate_paged_attention_v2(bfloat16_t, char, uchar, 32);
 instantiate_paged_attention_v2(half, char, uchar, 32);
+
+// GQA-shared flash-decode pass (pure decode, non-TQ): half/bfloat16 caches,
+// head sizes divisible by 32 up to 256, kernel block sizes 8/16/32.  Other
+// configs keep the per-token kernel via the dispatch gate in paged_ops.cpp.
+#define instantiate_gqa_decode_inner(type, head_size, block_size,            \
+                                     partition_size)                         \
+  template [[host_name("paged_attention_gqa_decode_" #type "_hs" #head_size  \
+                       "_bs" #block_size "_ps" #partition_size)]]            \
+  [[kernel]] void paged_attention_gqa_decode<type, head_size, block_size,    \
+                                             partition_size>(                \
+      device float *exp_sums [[buffer(0)]],                                  \
+      device float *max_logits [[buffer(1)]], device type *tmp_out           \
+      [[buffer(2)]],                                                         \
+      device const type *q [[buffer(3)]],                                    \
+      device const type *k_cache [[buffer(4)]],                              \
+      device const type *v_cache [[buffer(5)]],                              \
+      const constant int &num_kv_heads [[buffer(8)]],                        \
+      const constant float &scale [[buffer(9)]],                             \
+      device const uint32_t *block_tables [[buffer(11)]],                    \
+      device const uint32_t *context_lens [[buffer(12)]],                    \
+      const constant int &max_num_blocks_per_seq [[buffer(13)]],             \
+      const constant int &q_stride [[buffer(15)]],                           \
+      const constant int &kv_block_stride [[buffer(16)]],                    \
+      const constant int &kv_head_stride [[buffer(17)]],                     \
+      uint3 tg_pos [[threadgroup_position_in_grid]],                         \
+      uint3 tg_per_grid [[threadgroups_per_grid]],                           \
+      uint3 tptg [[threads_per_threadgroup]],                                \
+      uint sg [[simdgroup_index_in_threadgroup]],                            \
+      uint lane [[thread_index_in_simdgroup]]);
+
+#define instantiate_gqa_decode_hs(type, block_size, partition_size)          \
+  instantiate_gqa_decode_inner(type, 64, block_size, partition_size);        \
+  instantiate_gqa_decode_inner(type, 96, block_size, partition_size);        \
+  instantiate_gqa_decode_inner(type, 128, block_size, partition_size);       \
+  instantiate_gqa_decode_inner(type, 256, block_size, partition_size);
+
+#define instantiate_gqa_decode_bs(type, partition_size)                      \
+  instantiate_gqa_decode_hs(type, 8, partition_size);                        \
+  instantiate_gqa_decode_hs(type, 16, partition_size);                       \
+  instantiate_gqa_decode_hs(type, 32, partition_size);
+
+instantiate_gqa_decode_bs(bfloat16_t, VLLM_METAL_PARTITION_SIZE);
+instantiate_gqa_decode_bs(half, VLLM_METAL_PARTITION_SIZE);

--- a/vllm_metal/metal/kernels_v2/pagedattention.metal
+++ b/vllm_metal/metal/kernels_v2/pagedattention.metal
@@ -2147,12 +2147,12 @@ template <typename T, int HEAD_SIZE, int NUM_THREADS, int NUM_SIMD_LANES,
 // GQA-shared flash-decode pass for pure-decode batches.
 //
 // One threadgroup per (PARTITION_SIZE-token partition, kv head, sequence);
-// each simdgroup owns one query head of the GQA group, so the whole group
-// shares every K/V row load — the per-token kernel above instead re-reads
-// the same KV rows once per query head from separate threadgroups — and the
-// online softmax stays entirely in registers (no threadgroup-memory score
-// staging, no barriers).  At long contexts this lifts single-sequence decode
-// KV-scan bandwidth from ~40GB/s to ~190GB/s on M5 Pro.
+// each simdgroup owns one query head of the GQA group. Co-locating these
+// heads can improve KV cache locality, but each simdgroup still issues its
+// own K/V loads (there is no explicit cross-simdgroup broadcast). The online
+// softmax stays in registers, with no score staging or barriers. The serial
+// token loop trades intra-head parallelism for this locality, so dispatch
+// must account for the shape and device rather than context length alone.
 //
 // Partials are written in the exact contract paged_attention_v2_reduce
 // consumes: log2-space running (max, exp-sum) stats plus the

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -36,6 +36,11 @@ using namespace mlx::core;
 
 static std::string v2_paged_attention_source_;
 constexpr int kPartitionSize = VLLM_METAL_PARTITION_SIZE;
+// Below this context length the GQA-shared decode pass loses to the
+// established per-token / split-KV kernel (measured on M5 Pro).  Kept as
+// a named constant so the dispatch gate and the Python test surface cannot
+// drift.
+constexpr int kGqaDecodeMinSeqLen = 16384;
 
 // Window mode for spec-decode verification (per-token kernel): query rows
 // per threadgroup (2 = the measured register/occupancy sweet spot on Apple
@@ -433,6 +438,63 @@ static void dispatch_paged_attention_tiled(
       MTL::Size::Make(cfg.NUM_THREADS, 1, 1));
 }
 
+// ---------------------------------------------------------------------------
+// Shared pass-2 for the split-KV decode paths: merge per-partition partials
+// into `out` (log-sum-exp combine).  Partials must follow the ps512 contract:
+// log2-space (max, exp-sum) stats plus epsilon-normalised partial outputs in
+// tmp_out[token, head, partition, :].
+static void dispatch_paged_attention_v2_reduce(
+    metal::Device& d, metal::CommandEncoder& enc, array& out,
+    const array& exp_sums, const array& max_logits, const array& tmp_out,
+    const array& seq_lens, const array& cu_seqlens_q, int num_seqs,
+    int total_q_tokens, int num_heads, int head_size, int max_num_partitions,
+    const std::string& dt, bool use_sinks, const array* sinks,
+    bool use_tq_fc) {
+  std::string rname =
+      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
+      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
+  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
+  // other function constants are inert for it.  TurboQuant batches take this
+  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
+  // and sinks are folded here rather than in the partitioned kernel so the
+  // sink logit is counted once globally.  The cache key MUST encode every
+  // constant the pipeline is specialized on — otherwise the first compile
+  // wins and a later caller with different constants silently reuses the
+  // wrong pipeline.
+  std::string rhash = rname + "_v2reduce"
+      + "_tq" + (use_tq_fc ? "1" : "0")
+      + "_sk" + (use_sinks ? "1" : "0");
+  auto* lib = d.get_library("paged_attention_v2_kern");
+  auto* rkernel = d.get_kernel(
+      rname, lib, rhash,
+      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
+       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
+  enc.set_compute_pipeline_state(rkernel);
+  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
+  // (odd partition counts would yield 8 mod 16 and trip the API-validation
+  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
+  // is never touched.
+  size_t reduce_shmem =
+      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
+  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
+  enc.set_output_array(out, 0);
+  enc.set_input_array(exp_sums, 1);
+  enc.set_input_array(max_logits, 2);
+  enc.set_input_array(tmp_out, 3);
+  enc.set_input_array(seq_lens, 4);
+  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
+  enc.set_bytes(max_num_partitions_i, 5);
+  if (use_sinks) {
+    enc.set_input_array(*sinks, 6);
+  }
+  enc.set_input_array(cu_seqlens_q, 7);
+  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
+  enc.set_bytes(num_seqs_i, 8);
+  enc.dispatch_threadgroups(
+      MTL::Size::Make(num_heads, total_q_tokens, 1),
+      MTL::Size::Make(256, 1, 1));
+}
+
 static void dispatch_paged_attention_v2_online(
     array& out, const array& query,
     const array& key_cache, const array& value_cache,
@@ -440,7 +502,7 @@ static void dispatch_paged_attention_v2_online(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    int window_seqlen_q, Stream s,
+    int window_seqlen_q, int num_decode_requests, Stream s,
     // TurboQuant (optional, all nullptr when disabled):
     const array* key_scale_cache = nullptr,
     const array* value_scale_cache = nullptr,
@@ -596,6 +658,19 @@ static void dispatch_paged_attention_v2_online(
 
   auto& enc = metal::get_command_encoder(s);
 
+  // Split-KV scratch factory shared by the split paths below: partial output
+  // + softmax (max, exp-sum) stats.  Tiny (~64 KB tmp_out @ conc=1/8K).
+  // add_temporary keeps them alive until the command buffer completes; MLX
+  // auto-inserts a barrier between the two dispatches via input/output
+  // dependency tracking (set_output here -> set_input in the reduce),
+  // mirroring MLX's own sdpa_vector_2pass.
+  auto make_temp = [&](Shape shape, Dtype dtype) {
+    array a(std::move(shape), dtype, nullptr, {});
+    a.set_data(allocator::malloc(a.nbytes()));
+    enc.add_temporary(a);
+    return a;
+  };
+
   // TurboQuant scale/zero/centroid buffers (slots 22-27); shared by both paths.
   auto bind_turboquant = [&]() {
     if (!use_turboquant) return;
@@ -616,6 +691,99 @@ static void dispatch_paged_attention_v2_online(
     enc.set_input_array(*sinks, 18);
   };
 
+  // ----- GQA-shared flash-decode pass -------------------------------------
+  // Pure-decode batches without TurboQuant/FP8/sinks/softcap/sliding-window
+  // take a dedicated split-KV kernel whose threadgroups share every KV row
+  // load across the whole GQA group (the per-token kernel re-reads each row
+  // once per query head from separate threadgroups) and keep the online
+  // softmax in registers — no threadgroup-memory score staging, no barriers.
+  // This lifts long-context decode from ~40GB/s to ~190GB/s effective
+  // KV-scan bandwidth on M5 Pro.  Partials follow the ps512 contract and
+  // merge through the standard v2 reduce.  Instantiated for head sizes
+  // {64,96,128,256}, GQA groups <= 8 (one simdgroup per q head), and
+  // same-dtype half/bfloat16 Q/K/V; anything else falls through to the
+  // per-token kernel below.
+  //
+  // Spec-decode expanded windows pack as many length-1 segments (same
+  // shape as multi-seq decode) with window_seqlen_q == 1.  Production
+  // passes num_decode_requests = scheduler request count, which is 1 for
+  // a single expanded window and N for N real decode requests.  Callers
+  // that omit it (num_decode_requests < 0) keep the conservative
+  // single-seq gate so tests/test_spec_window_parity.py stays bitwise.
+  // Windowed verify windows have has_prefill and never reach this pass.
+  //
+  // Occupancy: a single short sequence underfills the GPU (measured
+  // crossover ~16k tokens on M5 Pro).  Multi-seq scales the same KV
+  // budget across the batch, so 4 seqs at 4k is treated like 1 seq at 16k.
+  const int gqa_group = num_kv_heads > 0 ? num_heads / num_kv_heads : 0;
+  const bool gqa_real_decode_batch =
+      (num_decode_requests < 0) ? (num_seqs == 1)
+                                : (num_decode_requests == num_seqs);
+  const bool gqa_decode =
+      pure_decode && window_seqlen_q <= 1 && gqa_real_decode_batch
+      && dtype_ok && query.dtype() == value_cache.dtype()
+      && !use_turboquant && softcap <= 0.f && sinks == nullptr
+      && sliding_window < 0 && num_kv_heads > 0
+      && num_heads % num_kv_heads == 0 && gqa_group >= 1 && gqa_group <= 8
+      && (head_size == 64 || head_size == 96 || head_size == 128 ||
+          head_size == 256)
+      && max_num_partitions >= 2
+      && (int64_t)num_seqs * (int64_t)max_seq_len >= kGqaDecodeMinSeqLen;
+  if (gqa_decode) {
+    std::string gname =
+        "paged_attention_gqa_decode_" + dt + "_hs" + std::to_string(head_size) +
+        "_bs" + std::to_string(block_size) + "_ps" +
+        std::to_string(kPartitionSize);
+    // Instantiated in pagedattention.metal and shipped in the v2 metallib.
+    // A missing specialization is a build/packaging bug: fail loudly
+    // rather than silently drop eligible long decode back to the slower
+    // per-token kernel.
+    auto* gkernel = d.get_kernel(gname, lib, gname, {});
+
+    array g_tmp_out = make_temp(
+        Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
+        query.dtype());
+    array g_exp_sums =
+        make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+    array g_max_logits =
+        make_temp(Shape{total_q_tokens, num_heads, max_num_partitions}, float32);
+
+    // Binds mirror paged_attention_gqa_decode's signature exactly (the
+    // kernel declares only these slots; no shared-mem carve).
+    enc.set_compute_pipeline_state(gkernel);
+    enc.set_output_array(g_exp_sums, 0);
+    enc.set_output_array(g_max_logits, 1);
+    enc.set_output_array(g_tmp_out, 2);
+    enc.set_input_array(query, 3);
+    enc.set_input_array(key_cache, 4);
+    enc.set_input_array(value_cache, 5);
+    int32_t g_nkv = static_cast<int32_t>(num_kv_heads);
+    enc.set_bytes(g_nkv, 8);
+    enc.set_bytes(scale, 9);
+    enc.set_input_array(block_tables, 11);
+    enc.set_input_array(seq_lens, 12);
+    int32_t g_max_blocks = static_cast<int32_t>(block_tables.shape(1));
+    enc.set_bytes(g_max_blocks, 13);
+    int32_t g_q_stride = static_cast<int32_t>(num_heads * head_size);
+    int32_t g_kv_block_stride = static_cast<int32_t>(key_cache.strides()[0]);
+    int32_t g_kv_head_stride = static_cast<int32_t>(key_cache.strides()[2]);
+    enc.set_bytes(g_q_stride, 15);
+    enc.set_bytes(g_kv_block_stride, 16);
+    enc.set_bytes(g_kv_head_stride, 17);
+    // One threadgroup per (partition, kv head, sequence); each simdgroup
+    // owns one query head of the GQA group.
+    enc.dispatch_threadgroups(
+        MTL::Size::Make(max_num_partitions, num_kv_heads, num_seqs),
+        MTL::Size::Make(32 * gqa_group, 1, 1));
+
+    dispatch_paged_attention_v2_reduce(
+        d, enc, out, g_exp_sums, g_max_logits, g_tmp_out, seq_lens,
+        cu_seqlens_q, num_seqs, total_q_tokens, num_heads, head_size,
+        max_num_partitions, dt, /*use_sinks=*/false, nullptr,
+        /*use_tq_fc=*/false);
+    return;
+  }
+
   if (!partition) {
     // Single-pass path (grid.z = 1): the original decode/per-token kernel.
     enc.set_compute_pipeline_state(kernel);
@@ -633,17 +801,6 @@ static void dispatch_paged_attention_v2_online(
   }
 
   // ----- Split-KV path: paged_attention(_ps512) -> paged_attention_v2_reduce.
-  // Per-partition scratch: partial output + softmax (max, exp-sum) stats.
-  // Tiny (~64 KB tmp_out @ conc=1/8K).  add_temporary keeps them alive until
-  // the command buffer completes; MLX auto-inserts a barrier between the two
-  // dispatches via input/output dependency tracking (set_output here ->
-  // set_input below), mirroring MLX's own sdpa_vector_2pass.
-  auto make_temp = [&](Shape shape, Dtype dtype) {
-    array a(std::move(shape), dtype, nullptr, {});
-    a.set_data(allocator::malloc(a.nbytes()));
-    enc.add_temporary(a);
-    return a;
-  };
   array tmp_out = make_temp(
       Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
       query.dtype());
@@ -671,48 +828,10 @@ static void dispatch_paged_attention_v2_online(
       MTL::Size::Make(NUM_THREADS, 1, 1));
 
   // Pass 2: reduce per-partition partials -> out (log-sum-exp combine).
-  std::string rname =
-      "paged_attention_v2_reduce_" + dt + "_hs" + std::to_string(head_size) +
-      "_nt256_nsl32_ps" + std::to_string(kPartitionSize);
-  // The reduce kernel reads only use_sinks (40) and use_turboquant (50); the
-  // other function constants are inert for it.  TurboQuant batches take this
-  // path (use_tq_fc varies: the TQ reduce applies the deferred inverse FWHT),
-  // and sinks are folded here rather than in the partitioned kernel so the
-  // sink logit is counted once globally.  The cache key MUST encode every
-  // constant the pipeline is specialized on — otherwise the first compile
-  // wins and a later caller with different constants silently reuses the
-  // wrong pipeline.
-  std::string rhash = rname + "_v2reduce"
-      + "_tq" + (use_tq_fc ? "1" : "0")
-      + "_sk" + (use_sinks ? "1" : "0");
-  auto* rkernel = d.get_kernel(
-      rname, lib, rhash,
-      {{&use_sinks, MTL::DataType::DataTypeBool, NS::UInteger(40)},
-       {&use_tq_fc, MTL::DataType::DataTypeBool, NS::UInteger(50)}});
-  enc.set_compute_pipeline_state(rkernel);
-  // Metal requires setThreadgroupMemoryLength to be a multiple of 16 bytes
-  // (odd partition counts would yield 8 mod 16 and trip the API-validation
-  // layer).  The kernel reads exactly 2*num_partitions floats; the padding
-  // is never touched.
-  size_t reduce_shmem =
-      static_cast<size_t>(2 * max_num_partitions) * sizeof(float);
-  enc.set_threadgroup_memory_length((reduce_shmem + 15) & ~size_t(15), 0);
-  enc.set_output_array(out, 0);
-  enc.set_input_array(exp_sums, 1);
-  enc.set_input_array(max_logits, 2);
-  enc.set_input_array(tmp_out, 3);
-  enc.set_input_array(seq_lens, 4);
-  int32_t max_num_partitions_i = static_cast<int32_t>(max_num_partitions);
-  enc.set_bytes(max_num_partitions_i, 5);
-  if (use_sinks) {
-    enc.set_input_array(*sinks, 6);
-  }
-  enc.set_input_array(cu_seqlens_q, 7);
-  int32_t num_seqs_i = static_cast<int32_t>(num_seqs);
-  enc.set_bytes(num_seqs_i, 8);
-  enc.dispatch_threadgroups(
-      MTL::Size::Make(num_heads, total_q_tokens, 1),
-      MTL::Size::Make(NUM_THREADS, 1, 1));
+  dispatch_paged_attention_v2_reduce(
+      d, enc, out, exp_sums, max_logits, tmp_out, seq_lens, cu_seqlens_q,
+      num_seqs, total_q_tokens, num_heads, head_size, max_num_partitions, dt,
+      use_sinks, sinks, use_tq_fc);
 }
 
 // ---------------------------------------------------------------------------
@@ -729,13 +848,15 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
       Stream stream, int num_kv_heads, float scale, float softcap,
       int block_size, int max_seq_len, int sliding_window,
       bool use_turboquant = false, int k_bits = 8, int v_bits = 3,
-      int window_seqlen_q = 1, bool use_sinks = false)
+      int window_seqlen_q = 1, bool use_sinks = false,
+      int num_decode_requests = -1)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
         sliding_window_(sliding_window),
         use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits),
-        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks) {}
+        window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks),
+        num_decode_requests_(num_decode_requests) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -761,6 +882,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         num_kv_heads_, scale_, softcap_,
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_, window_seqlen_q_,
+        num_decode_requests_,
         stream(),
         ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_, sk);
   }
@@ -778,7 +900,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->k_bits_ == k_bits_
         && rhs->v_bits_ == v_bits_
         && rhs->window_seqlen_q_ == window_seqlen_q_
-        && rhs->use_sinks_ == use_sinks_;
+        && rhs->use_sinks_ == use_sinks_
+        && rhs->num_decode_requests_ == num_decode_requests_;
   }
 
  private:
@@ -793,6 +916,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int v_bits_;
   int window_seqlen_q_;
   bool use_sinks_;
+  int num_decode_requests_;
 };
 
 static array paged_attention_primitive_fn(
@@ -808,7 +932,7 @@ static array paged_attention_primitive_fn(
     const array* key_zero_cache = nullptr,
     const array* v_centroids = nullptr,
     int v_bits = 3, int window_seqlen_q = 1,
-    const array* sinks = nullptr) {
+    const array* sinks = nullptr, int num_decode_requests = -1) {
   if (sinks != nullptr) {
     // Upstream MLX refuses the same combination
     // (mlx_lm/models/base.py: "Quantized SDPA does not support attention
@@ -902,7 +1026,8 @@ static array paged_attention_primitive_fn(
       default_stream(Device::gpu),
       num_kv_heads, scale, softcap,
       block_size, max_seq_len, sliding_window,
-      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr);
+      use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr,
+      num_decode_requests);
   if (use_turboquant) {
     return array(
         query.shape(), query.dtype(), std::move(prim),
@@ -1617,9 +1742,26 @@ void gdn_linear_attention_impl(
 
 NB_MODULE(_paged_ops, m) {
   m.attr("PARTITION_SIZE") = nb::int_(kPartitionSize);
+  m.attr("GQA_DECODE_MIN_SEQ_LEN") = nb::int_(kGqaDecodeMinSeqLen);
   m.def("min_decode_grid", &min_decode_grid,
         "Decode-grid threshold (threadgroups) below which split-KV decode "
         "engages on this machine.");
+  m.def(
+      "has_gqa_decode_kernel",
+      []() {
+        try {
+          auto& d = metal::device(Device::gpu);
+          auto* lib = d.get_library("paged_attention_v2_kern");
+          auto* k = d.get_kernel(
+              "paged_attention_gqa_decode_half_hs128_bs16_ps512", lib,
+              "paged_attention_gqa_decode_half_hs128_bs16_ps512", {});
+          return k != nullptr;
+        } catch (const std::exception&) {
+          return false;
+        }
+      },
+      "True when the loaded v2 shader library contains the GQA-shared "
+      "flash-decode pass (the default prebuilt metallib on this branch).");
 
   m.def("init_v2_library", &init_v2_library,
         nb::arg("v2_src"),
@@ -1803,7 +1945,8 @@ NB_MODULE(_paged_ops, m) {
            const std::string& quant_type,
            int v_bits,
            int window_seqlen_q,
-           nb::object sinks_h) {
+           nb::object sinks_h,
+           int num_decode_requests) {
           const array* sk = sinks_h.is_none()
               ? nullptr : nb::inst_ptr<array>(sinks_h);
           const array* ks = use_turboquant
@@ -1824,7 +1967,7 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(cu_seqlens_q_h),
               block_size, max_seq_len, sliding_window,
               use_turboquant, quant_type, ks, vs, kz, vc, v_bits,
-              window_seqlen_q, sk);
+              window_seqlen_q, sk, num_decode_requests);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -1844,6 +1987,7 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("v_bits") = 3,
         nb::arg("window_seqlen_q") = 1,
         nb::arg("sinks") = nb::none(),
+        nb::arg("num_decode_requests") = -1,
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.  window_seqlen_q must equal the "
         "longest cu_seqlens_q segment (validated when > 1); small "

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -37,11 +37,10 @@ using namespace mlx::core;
 
 static std::string v2_paged_attention_source_;
 constexpr int kPartitionSize = VLLM_METAL_PARTITION_SIZE;
-// Below this context length the GQA-shared decode pass loses to the
-// established per-token / split-KV kernel (measured on M5 Pro).  Kept as
-// a named constant so the dispatch gate and the Python test surface cannot
-// drift.
-constexpr int kGqaDecodeMinSeqLen = 16384;
+// Default routing is limited to the documented, measured long-context range.
+// Numerical shader support is broader than this empirical performance policy.
+constexpr int kGqaDecodeMinSeqLen = 32768;
+constexpr int kGqaDecodeMaxSeqLen = 131072;
 
 // Last dispatch family chosen by dispatch_paged_attention_v2_online
 // ("gqa_decode" / "per_token_ps0" / "per_token_ps512" / "window_ps0" /
@@ -88,9 +87,9 @@ constexpr int kWindowMaxHeadSize = VLLM_METAL_PA_WINDOW_MAX_HEAD;
 
 // GPU core count via IORegistry.  Metal/MLX expose no core-count API, but the
 // split-KV gate needs to scale per machine — a small laptop GPU and a large
-// desktop one saturate at very different grid sizes.  Read once; falls back to
-// a modest default if the query ever fails (future macOS / service tree).
-static int gpu_core_count() {
+// desktop one saturate at very different grid sizes. Read once; zero means
+// unknown so the new GQA performance gate can fail closed.
+static int detected_gpu_core_count() {
   static const int v = []() {
     int cores = 0;
     io_iterator_t it;
@@ -112,9 +111,42 @@ static int gpu_core_count() {
       }
       IOObjectRelease(it);
     }
-    return cores > 0 ? cores : 14;
+    return cores;
   }();
   return v;
+}
+
+// Preserve the established split-KV fallback when detection is unavailable.
+static int gpu_core_count() {
+  const int cores = detected_gpu_core_count();
+  return cores > 0 ? cores : 14;
+}
+
+// Conservative default scope, based on the measured single-request cases in
+// docs/gqa-decode.md. This is an empirical policy, not a universal cost model:
+// do not infer eligibility for unmeasured geometries from a byte-traffic proxy.
+// The MiniCPM-style 32K gain was small, so its default starts at 64K. All
+// defaults stop at 128K; larger contexts require their own serving evidence.
+static bool gqa_decode_shape_eligible(int num_heads, int num_kv_heads,
+                                     int head_size, int max_seq_len,
+                                     int gpu_cores) {
+  if (gpu_cores <= 0 || max_seq_len < kGqaDecodeMinSeqLen ||
+      max_seq_len > kGqaDecodeMaxSeqLen)
+    return false;
+  const bool measured_32k =
+      (num_heads == 32 && num_kv_heads == 8 && head_size == 128) ||
+      (num_heads == 24 && num_kv_heads == 4 && head_size == 256);
+  const bool measured_64k =
+      num_heads == 16 && num_kv_heads == 2 && head_size == 128 &&
+      max_seq_len >= 65536;
+  if (!measured_32k && !measured_64k) return false;
+
+  // Retain the conservative occupancy floor to avoid routing an underfilled
+  // GQA grid on a larger GPU. Core count is detected, not a device-name table.
+  // This guard does not promise that shared-GPU load cannot change the gain.
+  const int64_t partitions =
+      (static_cast<int64_t>(max_seq_len) + kPartitionSize - 1) / kPartitionSize;
+  return partitions * num_kv_heads >= 3LL * gpu_cores;
 }
 
 // Engage the split while the base decode grid (num_q_heads * num_seqs) stays
@@ -708,17 +740,11 @@ static void dispatch_paged_attention_v2_online(
   };
 
   // ----- GQA-shared flash-decode pass -------------------------------------
-  // Pure-decode batches without TurboQuant/FP8/sinks/softcap/sliding-window
-  // take a dedicated split-KV kernel whose threadgroups share every KV row
-  // load across the whole GQA group (the per-token kernel re-reads each row
-  // once per query head from separate threadgroups) and keep the online
-  // softmax in registers — no threadgroup-memory score staging, no barriers.
-  // This lifts long-context decode from ~40GB/s to ~190GB/s effective
-  // KV-scan bandwidth on M5 Pro.  Partials follow the ps512 contract and
-  // merge through the standard v2 reduce.  Instantiated for head sizes
-  // {64,96,128,256}, GQA groups <= 8 (one simdgroup per q head), and
-  // same-dtype half/bfloat16 Q/K/V; anything else falls through to the
-  // per-token kernel below.
+  // Pure decode without TurboQuant/FP8/sinks/softcap/sliding-window.
+  // One threadgroup per (partition, KV head, sequence), with one SIMD
+  // group per query head. Co-locating query heads can improve KV cache
+  // locality; each SIMD group still issues its own loads. Online softmax
+  // stays in registers. Partials use the ps512 contract and standard reduce.
   //
   // Scoped to the single-request, long-context case that was measured and
   // parity-tested (review on #715): num_seqs == 1 and the scheduler
@@ -731,23 +757,26 @@ static void dispatch_paged_attention_v2_online(
   // established kernels (A/B escape hatch for the benchmarking pitfalls
   // documented in issue #713).
   //
-  // Occupancy: a single short sequence underfills the GPU (measured
-  // crossover ~16k tokens on M5 Pro).  num_seqs is 1 here, so this is
-  // just max_seq_len >= kGqaDecodeMinSeqLen.
+  // Default eligibility is narrower than the compiled shader domain. Keep
+  // the measured head geometries, length range and block16 serving layout;
+  // all other shapes use the established family. There is no startup timing
+  // or mutable process-wide threshold in this path.
   const int gqa_group = num_kv_heads > 0 ? num_heads / num_kv_heads : 0;
   const bool gqa_single_request =
-      num_seqs == 1 && (num_decode_requests < 0 || num_decode_requests == 1);
+      num_seqs == 1 && (num_decode_requests == -1 || num_decode_requests == 1);
   const bool gqa_decode =
       !gqa_disabled
       && pure_decode && window_seqlen_q <= 1 && gqa_single_request
+      && (query.dtype() == float16 || query.dtype() == bfloat16)
       && dtype_ok && query.dtype() == value_cache.dtype()
       && !use_turboquant && softcap <= 0.f && sinks == nullptr
-      && sliding_window < 0 && num_kv_heads > 0
+      && sliding_window < 0 && block_size == 16 && num_kv_heads > 0
       && num_heads % num_kv_heads == 0 && gqa_group >= 1 && gqa_group <= 8
       && (head_size == 64 || head_size == 96 || head_size == 128 ||
           head_size == 256)
       && max_num_partitions >= 2
-      && max_seq_len >= kGqaDecodeMinSeqLen;
+      && gqa_decode_shape_eligible(num_heads, num_kv_heads, head_size,
+                                  max_seq_len, detected_gpu_core_count());
   if (gqa_decode) {
     record_paged_dispatch("gqa_decode");
     std::string gname =
@@ -1771,6 +1800,14 @@ void gdn_linear_attention_impl(
 NB_MODULE(_paged_ops, m) {
   m.attr("PARTITION_SIZE") = nb::int_(kPartitionSize);
   m.attr("GQA_DECODE_MIN_SEQ_LEN") = nb::int_(kGqaDecodeMinSeqLen);
+  m.attr("GQA_DECODE_MAX_SEQ_LEN") = nb::int_(kGqaDecodeMaxSeqLen);
+  m.def("detected_gpu_core_count", &detected_gpu_core_count,
+        "Detected GPU core count, or zero when detection is unavailable.");
+  m.def("gqa_decode_shape_eligible", &gqa_decode_shape_eligible,
+        nb::arg("num_heads"), nb::arg("num_kv_heads"), nb::arg("head_size"),
+        nb::arg("max_seq_len"), nb::arg("gpu_cores"),
+        "Measured default scope with a conservative grid guard; "
+        "functional dispatch checks also apply.");
   m.def("min_decode_grid", &min_decode_grid,
         "Decode-grid threshold (threadgroups) below which split-KV decode "
         "engages on this machine.");

--- a/vllm_metal/metal/paged_ops.cpp
+++ b/vllm_metal/metal/paged_ops.cpp
@@ -9,6 +9,7 @@
 // RTTI matching which fails due to hidden symbol visibility in libmlx.
 
 #include <algorithm>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -41,6 +42,18 @@ constexpr int kPartitionSize = VLLM_METAL_PARTITION_SIZE;
 // a named constant so the dispatch gate and the Python test surface cannot
 // drift.
 constexpr int kGqaDecodeMinSeqLen = 16384;
+
+// Last dispatch family chosen by dispatch_paged_attention_v2_online
+// ("gqa_decode" / "per_token_ps0" / "per_token_ps512" / "window_ps0" /
+// "window_ps512" / "nax_prefill" / "tiled_prefill").  Diagnostic surface
+// for the routing tests: the gate lives below the Python boundary, so the
+// family name is the only faithful record of which kernel ran.
+static std::mutex g_last_dispatch_mu;
+static std::string g_last_dispatch;
+inline void record_paged_dispatch(const std::string& name) {
+  std::lock_guard<std::mutex> lk(g_last_dispatch_mu);
+  g_last_dispatch = name;
+}
 
 // Window mode for spec-decode verification (per-token kernel): query rows
 // per threadgroup (2 = the measured register/occupancy sweet spot on Apple
@@ -502,7 +515,8 @@ static void dispatch_paged_attention_v2_online(
     const array& block_tables, const array& seq_lens,
     const array& cu_seqlens_q,
     int block_size, int max_seq_len, int sliding_window,
-    int window_seqlen_q, int num_decode_requests, Stream s,
+    int window_seqlen_q, int num_decode_requests, bool gqa_disabled,
+    Stream s,
     // TurboQuant (optional, all nullptr when disabled):
     const array* key_scale_cache = nullptr,
     const array* value_scale_cache = nullptr,
@@ -542,6 +556,7 @@ static void dispatch_paged_attention_v2_online(
   // softmax state before final normalization.
   if (has_prefill && !window_batch && !use_turboquant && dtype_ok) {
     if (nax_eligible(query.dtype(), head_size, block_size)) {
+      record_paged_dispatch("nax_prefill");
       dispatch_paged_attention_nax(
           out, query, key_cache, value_cache,
           num_kv_heads, scale, softcap,
@@ -550,6 +565,7 @@ static void dispatch_paged_attention_v2_online(
       return;
     }
     if (auto cfg = select_tile_config(head_size)) {
+      record_paged_dispatch("tiled_prefill");
       dispatch_paged_attention_tiled(
           out, query, key_cache, value_cache,
           num_kv_heads, scale, softcap,
@@ -704,23 +720,26 @@ static void dispatch_paged_attention_v2_online(
   // same-dtype half/bfloat16 Q/K/V; anything else falls through to the
   // per-token kernel below.
   //
-  // Spec-decode expanded windows pack as many length-1 segments (same
-  // shape as multi-seq decode) with window_seqlen_q == 1.  Production
-  // passes num_decode_requests = scheduler request count, which is 1 for
-  // a single expanded window and N for N real decode requests.  Callers
-  // that omit it (num_decode_requests < 0) keep the conservative
-  // single-seq gate so tests/test_spec_window_parity.py stays bitwise.
-  // Windowed verify windows have has_prefill and never reach this pass.
+  // Scoped to the single-request, long-context case that was measured and
+  // parity-tested (review on #715): num_seqs == 1 and the scheduler
+  // confirms a real decode request (num_decode_requests == 1; callers that
+  // omit it default to -1, which keeps the conservative single-seq gate so
+  // tests/test_spec_window_parity.py stays bitwise).  Multi-request decode
+  // batches stay on the established per-token/split-KV family until the
+  // batched GQA kernel carries its own measurements and tests.
+  // VLLM_METAL_DISABLE_GQA_DECODE forces eligible batches back to the
+  // established kernels (A/B escape hatch for the benchmarking pitfalls
+  // documented in issue #713).
   //
   // Occupancy: a single short sequence underfills the GPU (measured
-  // crossover ~16k tokens on M5 Pro).  Multi-seq scales the same KV
-  // budget across the batch, so 4 seqs at 4k is treated like 1 seq at 16k.
+  // crossover ~16k tokens on M5 Pro).  num_seqs is 1 here, so this is
+  // just max_seq_len >= kGqaDecodeMinSeqLen.
   const int gqa_group = num_kv_heads > 0 ? num_heads / num_kv_heads : 0;
-  const bool gqa_real_decode_batch =
-      (num_decode_requests < 0) ? (num_seqs == 1)
-                                : (num_decode_requests == num_seqs);
+  const bool gqa_single_request =
+      num_seqs == 1 && (num_decode_requests < 0 || num_decode_requests == 1);
   const bool gqa_decode =
-      pure_decode && window_seqlen_q <= 1 && gqa_real_decode_batch
+      !gqa_disabled
+      && pure_decode && window_seqlen_q <= 1 && gqa_single_request
       && dtype_ok && query.dtype() == value_cache.dtype()
       && !use_turboquant && softcap <= 0.f && sinks == nullptr
       && sliding_window < 0 && num_kv_heads > 0
@@ -728,8 +747,9 @@ static void dispatch_paged_attention_v2_online(
       && (head_size == 64 || head_size == 96 || head_size == 128 ||
           head_size == 256)
       && max_num_partitions >= 2
-      && (int64_t)num_seqs * (int64_t)max_seq_len >= kGqaDecodeMinSeqLen;
+      && max_seq_len >= kGqaDecodeMinSeqLen;
   if (gqa_decode) {
+    record_paged_dispatch("gqa_decode");
     std::string gname =
         "paged_attention_gqa_decode_" + dt + "_hs" + std::to_string(head_size) +
         "_bs" + std::to_string(block_size) + "_ps" +
@@ -786,6 +806,8 @@ static void dispatch_paged_attention_v2_online(
 
   if (!partition) {
     // Single-pass path (grid.z = 1): the original decode/per-token kernel.
+    record_paged_dispatch(
+        window_batch ? "window_ps0" : "per_token_ps0");
     enc.set_compute_pipeline_state(kernel);
     enc.set_threadgroup_memory_length(shmem, 0);
     bind_paged_attn_buffers(enc, out, query, key_cache, value_cache,
@@ -801,6 +823,8 @@ static void dispatch_paged_attention_v2_online(
   }
 
   // ----- Split-KV path: paged_attention(_ps512) -> paged_attention_v2_reduce.
+  record_paged_dispatch(
+      window_batch ? "window_ps512" : "per_token_ps512");
   array tmp_out = make_temp(
       Shape{total_q_tokens, num_heads, max_num_partitions, head_size},
       query.dtype());
@@ -849,14 +873,15 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
       int block_size, int max_seq_len, int sliding_window,
       bool use_turboquant = false, int k_bits = 8, int v_bits = 3,
       int window_seqlen_q = 1, bool use_sinks = false,
-      int num_decode_requests = -1)
+      int num_decode_requests = -1, bool gqa_disabled = false)
       : UnaryPrimitive(stream),
         num_kv_heads_(num_kv_heads), scale_(scale), softcap_(softcap),
         block_size_(block_size), max_seq_len_(max_seq_len),
         sliding_window_(sliding_window),
         use_turboquant_(use_turboquant), k_bits_(k_bits), v_bits_(v_bits),
         window_seqlen_q_(window_seqlen_q), use_sinks_(use_sinks),
-        num_decode_requests_(num_decode_requests) {}
+        num_decode_requests_(num_decode_requests),
+        gqa_disabled_(gqa_disabled) {}
 
   void eval_cpu(const std::vector<array>&, array&) override {
     throw std::runtime_error(
@@ -882,7 +907,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         num_kv_heads_, scale_, softcap_,
         inputs[3], inputs[4], inputs[5],  // block_tables, seq_lens, cu_seqlens_q
         block_size_, max_seq_len_, sliding_window_, window_seqlen_q_,
-        num_decode_requests_,
+        num_decode_requests_, gqa_disabled_,
         stream(),
         ks, vs, kz, vc, use_turboquant_, k_bits_, v_bits_, sk);
   }
@@ -901,7 +926,8 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
         && rhs->v_bits_ == v_bits_
         && rhs->window_seqlen_q_ == window_seqlen_q_
         && rhs->use_sinks_ == use_sinks_
-        && rhs->num_decode_requests_ == num_decode_requests_;
+        && rhs->num_decode_requests_ == num_decode_requests_
+        && rhs->gqa_disabled_ == gqa_disabled_;
   }
 
  private:
@@ -917,6 +943,7 @@ class PagedAttentionPrimitive : public UnaryPrimitive {
   int window_seqlen_q_;
   bool use_sinks_;
   int num_decode_requests_;
+  bool gqa_disabled_;
 };
 
 static array paged_attention_primitive_fn(
@@ -932,7 +959,8 @@ static array paged_attention_primitive_fn(
     const array* key_zero_cache = nullptr,
     const array* v_centroids = nullptr,
     int v_bits = 3, int window_seqlen_q = 1,
-    const array* sinks = nullptr, int num_decode_requests = -1) {
+    const array* sinks = nullptr, int num_decode_requests = -1,
+    bool gqa_disabled = false) {
   if (sinks != nullptr) {
     // Upstream MLX refuses the same combination
     // (mlx_lm/models/base.py: "Quantized SDPA does not support attention
@@ -1027,7 +1055,7 @@ static array paged_attention_primitive_fn(
       num_kv_heads, scale, softcap,
       block_size, max_seq_len, sliding_window,
       use_turboquant, k_bits, v_bits, window_seqlen_q, sinks != nullptr,
-      num_decode_requests);
+      num_decode_requests, gqa_disabled);
   if (use_turboquant) {
     return array(
         query.shape(), query.dtype(), std::move(prim),
@@ -1946,7 +1974,8 @@ NB_MODULE(_paged_ops, m) {
            int v_bits,
            int window_seqlen_q,
            nb::object sinks_h,
-           int num_decode_requests) {
+           int num_decode_requests,
+           bool gqa_disabled) {
           const array* sk = sinks_h.is_none()
               ? nullptr : nb::inst_ptr<array>(sinks_h);
           const array* ks = use_turboquant
@@ -1967,7 +1996,7 @@ NB_MODULE(_paged_ops, m) {
               *nb::inst_ptr<array>(cu_seqlens_q_h),
               block_size, max_seq_len, sliding_window,
               use_turboquant, quant_type, ks, vs, kz, vc, v_bits,
-              window_seqlen_q, sk, num_decode_requests);
+              window_seqlen_q, sk, num_decode_requests, gqa_disabled);
           nb::inst_ptr<array>(out_h)->overwrite_descriptor(result);
         },
         nb::arg("query"),
@@ -1988,6 +2017,7 @@ NB_MODULE(_paged_ops, m) {
         nb::arg("window_seqlen_q") = 1,
         nb::arg("sinks") = nb::none(),
         nb::arg("num_decode_requests") = -1,
+        nb::arg("gqa_disabled") = false,
         "Paged attention primitive (read-only). Cache writes are handled "
         "by MLX-native scatter upstream.  window_seqlen_q must equal the "
         "longest cu_seqlens_q segment (validated when > 1); small "
@@ -1995,7 +2025,21 @@ NB_MODULE(_paged_ops, m) {
         "the per-token kernel's window mode.  sinks is an optional float32 "
         "array of one learned logit per query head (GPT-OSS style attention "
         "sinks); it joins the softmax denominator without contributing a "
-        "value row, and is rejected together with TurboQuant.");
+        "value row, and is rejected together with TurboQuant.  "
+        "gqa_disabled mirrors VLLM_METAL_DISABLE_GQA_DECODE and keeps "
+        "eligible batches off the GQA-shared decode kernel.");
+
+  m.def(
+      "last_paged_dispatch",
+      []() {
+        std::lock_guard<std::mutex> lk(g_last_dispatch_mu);
+        return g_last_dispatch;
+      },
+      "Dispatch family chosen by the most recent paged_attention_primitive "
+      "eval (\"gqa_decode\", \"per_token_ps0\", \"per_token_ps512\", "
+      "\"window_ps0\", \"window_ps512\", \"nax_prefill\", "
+      "\"tiled_prefill\").  Diagnostic surface for routing tests; empty "
+      "before the first eval.");
 
   m.def("gdn_linear_attention", &gdn_linear_attention_impl,
         nb::arg("q"), nb::arg("k"), nb::arg("v"),


### PR DESCRIPTION
This PR adds a GQA decode kernel inside the paged attention primitive, with automatic routing restricted to the measured single-request, long-context cases requested in review. `VLLM_METAL_DISABLE_GQA_DECODE=1` keeps eligible calls on the established path, and tests inspect the actual C++ dispatch.

## Scope

Automatic routing requires one pure-decode request, matching FP16/BF16 Q/K/V, kernel block size 16, and one of these geometries and inclusive KV-length ranges:

| Query heads | KV heads | Head dimension | KV tokens |
|---:|---:|---:|---:|
| 32 | 8 | 128 | 32,768–131,072 |
| 24 | 4 | 256 | 32,768–131,072 |
| 16 | 2 | 128 | 65,536–131,072 |

All rows also require `ceil(KV tokens / 512) × KV heads >= 3 × detected GPU cores`; unknown core counts fall back. This occupancy guard and the table are empirical scope limits, not a guarantee for every GPU or competing workload. There is no model-name or device-name allowlist. The 16/2/128 geometry deliberately remains on the established path at 32K.

Multi-request batches, speculative verification windows, lengths outside the table, TurboQuant, sinks, soft-capping, and sliding-window attention retain the established family. `num_decode_requests` must be 1 or omitted, and the verification window must be at most 1. The disable switch cannot broaden eligibility.

The kernel groups query heads using the same KV head in a threadgroup and feeds 512-token partials into the existing reduction. Each simdgroup still issues its own K/V loads; grouping can improve locality, without an explicit cross-simdgroup broadcast or a fixed DRAM-byte saving. Startup calibration, cached thresholds, and mutable gate parameters have been removed. No runtime permission framework is added.

## Validation

Local revision: `efa0e31cda60fb2bb018d5a2588af3617e29ac63`; native artifacts rebuilt and worker-side stale-artifact checks clear. GitHub lint, test, and DCO checks pass for this head ([CI run](https://github.com/vllm-project/vllm-metal/actions/runs/34749135355)).

- Targeted routing, numerical, SDPA, and verification tests: **224 passed, 1 skipped**.
- Non-slow repository suite: **1,986 passed, 19 skipped, 39 deselected**. The local runner redirects only the Whisper tokenizer fixture to ModelScope-sourced files and blocks Hugging Face HTTP; this fixture-source redirection is outside the repository and does not alter assertions. These are local results, not remote CI results.
- Routing tests evaluate the primitive before checking `last_paged_dispatch()`, covering GQA selection, length bounds, geometry/block exclusions, multi-request fallback, and the disable flag. Numerical checks include reference attention, native SDPA, and relative-error bounds for small long-context outputs.

Serving environment: M5 Max (40 GPU cores, 48 GiB), macOS 26.6.2, Python 3.12.9, vLLM 0.28.0+cpu, MLX 0.32.0, mlx-lm 0.31.3, Transformers 5.12.1. Separate `vllm serve` arms, one request, cached prefixes, prefill chunk 2,048, at least 30 seconds warmup per length, 3 × 128 generated tokens; the table reports median decode tok/s, computed as `(completion_tokens - 1) / (last_token_time - first_token_time)` with returned token IDs and usage verified. Compiled MLP and native sampling are off. `max_model_len` / memory fraction: Qwen3-4B 40,960 / 0.4; Qwen3.8-27B-4bit 33,024 / 0.85; MiniCPM5-2B 131,072 / 0.4.

| Model | Prompt tokens | Default route | Default tok/s | Disabled tok/s | Ratio |
|---|---:|---|---:|---:|---:|
| Qwen3-4B | 32,768 | `gqa_decode` | 40.32 | 29.89 | 1.35× |
| Qwen3.8-27B-4bit | 32,768 | `gqa_decode` | 24.38 | 21.14 | 1.15× |
| MiniCPM5-2B | 16,384, reverse-order control | `per_token_ps512` | 74.82 | 75.00 | 1.00× |
| MiniCPM5-2B | 32,768 | `per_token_ps512` | 51.40 | 51.85 | 0.99× |
| MiniCPM5-2B | 65,536 | `gqa_decode` | 43.59 | 29.27 | 1.49× |
| MiniCPM5-2B | 120,000 | `gqa_decode` | 29.67 | 14.03 | 2.11× |

Worker checks after every measured request confirm the listed route; every disabled arm uses `per_token_ps512`. Positive GQA cells have within-arm CV ≤ 1.1%. Existing background tasks were retained. Recorded thermal states included nominal and fair, with no new swapouts during measured phases. GPU-utilization readings include the benchmark itself and do not establish identical resource conditions between arms.

The initial default-first MiniCPM5 16K run was 65.57 vs 73.64 tok/s (0.89×), despite both arms selecting the baseline. The difference did not reproduce with reversed arm order (74.82 vs 75.00, 0.998×); both results are retained. The first discrepancy is not attributable to GQA kernel execution.

MiniCPM5's 64K and 120K free-running generations first diverge at output token 36. Follow-up fixed-history checks at three positions per length use two-token requests: the first token comes from prefill, and the second from an actual decode forward. All six pairs have identical decode histories and choose the same second token; Top-10 overlap is 9–10/10. Full-vocabulary BF16 logits are not identical (relative L2 0.97–2.75%, maximum absolute difference 0.4375). Re-prefilling the preceding history changes its KV computation; these sampled checks do not reproduce the original accumulated decode trajectory or establish full-generation equivalence. Qwen3-4B, Qwen3.8-27B-4bit, and the shorter MiniCPM5 runs had matching output tokens.

Separate single-evaluation primitive probes cover each geometry's lower and upper bounds in FP16/BF16: 12 cells, six alternating AB/BA pairs each, all observed pairs favor GQA, with cell median ratios 1.51–3.84×. Five cells exceed 3% CV (maximum 3.72%); these are noisier measurements, not 12 uniformly stable results. Primitive ratios are not HTTP throughput ratios.

Earlier M5 Pro figures in this discussion refer to `b66217c`, not this revision.

## Broader routing investigated

We tested an occupancy floor plus a scalar potential-KV-reread proxy, fitted at startup. Additional geometries, submission modes, and competing GPU work did not justify extrapolating one fitted threshold to every supported shape. Actual DRAM traffic depends on cache residency, and a deterministic selection rule does not make its performance independent of runtime load.

Further experiments used alternating paired timings, independent confirmation, numerical/dispatch checks, telemetry, and compute/bandwidth competition. An invocation-bound permit prototype added expiry, one-time use, revocation, and native validation before encoding. It handled known invalidation but did not establish performance for subsequent requests after resource conditions changed; always-fallback runs did not validate a positive optimization. That machinery remains outside this PR.

These findings support returning to explicit measured scope, not a conclusion that general optimization is impossible. Wider routing should come with its own numerical, dispatch, and real-serving evidence. See [routing documentation](https://github.com/suntp/vllm-metal/blob/perf/gqa-decode-paged/docs/gqa-decode.md) and the [macOS benchmarking discussion](https://github.com/vllm-project/vllm-metal/issues/713).
