### PR TITLE
[Bugfix] Keep draft KV in sync when dynamic K is zero

### DIFF
--- a/docs/speculative_decoding.md
+++ b/docs/speculative_decoding.md
@@ -75,6 +75,26 @@ VLLM_METAL_MEMORY_FRACTION=0.55 \
     --speculative-config '{"method":"draft_model","model":"Qwen/Qwen3-0.6B","num_speculative_tokens":3}'
 ```
 
+### Dynamic speculative decoding
+
+See the upstream [dynamic speculative decoding guide](https://docs.vllm.ai/en/latest/features/speculative_decoding/dynamic_speculative_decoding/)
+for configuration details. This example sets `K=3` for one scheduled request
+and `K=0` for two:
+
+```bash
+VLLM_METAL_MEMORY_FRACTION=0.55 \
+  vllm serve Qwen/Qwen3-8B \
+    --max-model-len 2048 \
+    --max-num-seqs 2 \
+    --no-async-scheduling \
+    --speculative-config '{
+      "method": "draft_model",
+      "model": "Qwen/Qwen3-0.6B",
+      "num_speculative_tokens": 3,
+      "num_speculative_tokens_per_batch_size": [[1, 1, 3], [2, 2, 0]]
+    }'
+```
+
 ## N-gram
 
 Follow the upstream [N-gram guide](https://docs.vllm.ai/en/latest/features/speculative_decoding/n_gram/)

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -280,8 +280,6 @@ class DraftModelProposer:
 
     def propose(self, ctx: ProposeContext) -> DraftTokenIds | None:
         num_speculative_tokens = ctx.num_speculative_tokens
-        if num_speculative_tokens <= 0:
-            return None
         if self._committed_group_index is None:
             raise RuntimeError(
                 "DraftModelProposer.propose() called before "
@@ -302,6 +300,12 @@ class DraftModelProposer:
         # row that ingested this step, drafting or not.
         for plan in plans:
             self._draft_seq_lens[plan.req_id] = plan.committed_len
+
+        # A scheduler step can have no speculative-token budget while still
+        # advancing committed prefill tokens. Keep the draft KV cache in sync,
+        # but do not generate any draft tokens for that step.
+        if num_speculative_tokens <= 0:
+            return None
 
         drafting_plans = [plan for plan in plans if plan.is_drafting]
         if not drafting_plans:


### PR DESCRIPTION
## Summary

- Keep the draft model KV cache synchronized when dynamic speculative
  decoding selects zero speculative tokens for a batch.
- Perform cache ingestion before returning from `propose()` when `K == 0`.
- Preserve the existing behavior of skipping draft token generation for
  zero-token batches.

## Problem

Dynamic speculative decoding may assign different speculative-token counts
based on batch size. For example:

- batch size 1: K = 3
- batch size 2: K = 0

Previously, `DraftModelProposer.propose()` returned immediately when K was
zero. This skipped not only draft generation, but also the cache-ingestion
step for committed target tokens.

When the batch later returned to K > 0, the draft model resumed from a stale
KV-cache state. This reduced speculative-token acceptance even though the
target-model output remained correct.

## Fix

Move the K=0 return until after:

- scheduler plan collection;
- committed-token ingestion into the draft model;
- draft sequence-length updates.

Draft generation is still skipped when K is zero, so the change only keeps
the draft cache synchronized.

## Reproduction

Configuration:

- target model: Qwen/Qwen3-0.6B
- draft model: Qwen/Qwen3-0.6B
- two 384-token requests
- max batched tokens: 128
- batch size 1: K = 3
- batch size 2: K = 0

Before the change:

- K=0 proposer calls: 1
- cache-ingestion plans during the K=0 call: 0
- cold acceptance: 28/57 (49.12%)
- subsequent acceptance: 36/39, due to history masking the stale-cache issue

After the change:

- K=0 proposer calls: 1
- cache-ingestion plans during the K=0 call: 2
- acceptance: 36/39 across all three runs
- generated token IDs are unchanged

## Validation

- [x] `scripts/lint.sh`
- [x] Relevant proposer/cache tests: 167 passed
- [x] Full non-slow test suite: 1986 passed, 15 skipped
- [x] Dynamic-K reproduction: K=0 produced two cache-ingestion plans
- [x] Generated token IDs remained unchanged
- [x] Full `scripts/test.sh` smoke run: 1986 passed, 15 skipped