### PR TITLE
[Bugfix] Allow repeated Metal frame captures

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -53,17 +53,17 @@ llm.start_profile(profile_prefix="my_run")  # → start_capture
 out = llm.generate(["Hello"], SamplingParams(max_tokens=8))
 llm.stop_profile()  # → stop_capture
 
-# Trace lands at /tmp/metal-trace/my_run_dp0_pp0_tp0.gputrace
+# The log reports the full path under /tmp/metal-trace/my_run_*.gputrace.
 ```
 
-The trace filename is `<prefix>_dp<X>_pp<Y>_tp<Z>.gputrace` (data-, pipeline-, tensor-parallel ranks). On a single Apple Silicon device this resolves to `<prefix>_dp0_pp0_tp0.gputrace`.
+The trace filename includes the optional prefix, vLLM's worker-rank suffix, and a unique capture ID: `<prefix>_<worker-ranks>_<capture-id>.gputrace`. Each start/stop cycle writes a separate bundle, including when a worker is restarted with the same prefix and output directory. The full path is logged when capture starts.
 
 ## Opening and Reading the Trace
 
 The `.gputrace` is an Apple bundle (a folder, not a single file). To inspect:
 
 ```bash
-open /tmp/metal-trace/my_run_dp0_pp0_tp0.gputrace
+open /tmp/metal-trace/my_run_*.gputrace
 ```
 
 This launches Xcode and loads the **GPU Frame Debugger**. Useful views (in the left sidebar):

--- a/tests/test_metal_profiler.py
+++ b/tests/test_metal_profiler.py
@@ -62,13 +62,23 @@ def test_raises_when_trace_dir_missing(
         MetalProfilerWrapper(cfg, trace_name="run")
 
 
-def test_start_passes_trace_path_to_mlx(
+@pytest.mark.parametrize("new_wrapper", [False, True])
+def test_captures_use_distinct_trace_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    new_wrapper: bool,
 ) -> None:
     monkeypatch.setenv("MTL_CAPTURE_ENABLED", "1")
-    mock_start = MagicMock()
-    monkeypatch.setattr("mlx.core.metal.start_capture", mock_start)
+    captures: list[Path] = []
+
+    def start_capture(path: str) -> None:
+        trace_path = Path(path)
+        # Like Metal, refuse to overwrite an earlier capture.
+        trace_path.mkdir()
+        captures.append(trace_path)
+
+    monkeypatch.setattr("mlx.core.metal.start_capture", start_capture)
+    monkeypatch.setattr("mlx.core.metal.stop_capture", MagicMock())
 
     cfg = ProfilerConfig(
         profiler="torch",
@@ -76,9 +86,20 @@ def test_start_passes_trace_path_to_mlx(
     )
     wrapper = MetalProfilerWrapper(cfg, trace_name="run42")
     wrapper.start()
+    assert wrapper.is_running
+    wrapper.stop()
 
-    expected = str(Path(cfg.torch_profiler_dir) / "run42.gputrace")
-    mock_start.assert_called_once_with(expected)
+    if new_wrapper:
+        wrapper = MetalProfilerWrapper(cfg, trace_name="run42")
+    wrapper.start()
+    assert wrapper.is_running
+    wrapper.stop()
+
+    assert len(captures) == 2
+    for path in captures:
+        assert path.parent == Path(cfg.torch_profiler_dir)
+        assert path.name.startswith("run42_")
+        assert path.suffix == ".gputrace"
 
 
 def test_stop_calls_mlx_stop_capture(

--- a/vllm_metal/profiler/wrapper.py
+++ b/vllm_metal/profiler/wrapper.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import override
+from uuid import uuid4
 
 import mlx.core as mx
 from vllm.config import ProfilerConfig
@@ -37,7 +38,7 @@ logger = init_logger(__name__)
 class MetalProfilerWrapper(WorkerProfiler):
     """Metal frame-capture flavor of vLLM's WorkerProfiler.
 
-    Trace output: ``<profiler_config.torch_profiler_dir>/<trace_name>.gputrace``
+    Trace output: ``<torch_profiler_dir>/<trace_name>_<capture_id>.gputrace``
     """
 
     def __init__(self, profiler_config: ProfilerConfig, trace_name: str) -> None:
@@ -71,17 +72,17 @@ class MetalProfilerWrapper(WorkerProfiler):
             )
 
         Path(trace_dir).mkdir(parents=True, exist_ok=True)
-        self._trace_path = str(Path(trace_dir) / f"{trace_name}.gputrace")
-
-        logger.info_once(
-            "Metal frame capture enabled. Trace will be saved to %s",
-            self._trace_path,
-            scope="local",
-        )
+        self._trace_prefix = Path(trace_dir) / f"{trace_name}_"
 
     @override
     def _start(self) -> None:
-        mx.metal.start_capture(self._trace_path)
+        # Metal refuses to capture to an existing bundle, including one left
+        # by an earlier start/stop cycle or a previous worker instance.
+        trace_path = f"{self._trace_prefix}{uuid4().hex}.gputrace"
+        mx.metal.start_capture(trace_path)
+        logger.info(
+            "Metal frame capture started. Trace will be saved to %s", trace_path
+        )
 
     @override
     def _stop(self) -> None:


### PR DESCRIPTION
A second Metal frame capture reuses the first `.gputrace` path, so Metal rejects the existing bundle and the profiler stays inactive. Generate a fresh capture ID on each start and log the resulting path. The directory, prefix, worker-rank suffix, and earlier bundles are preserved; the filename examples are updated.

Reproduction on main `a7e82c5` (MLX 0.32.0):

```python
# Run with MTL_CAPTURE_ENABLED=1 set before Python starts.
import tempfile
import mlx.core as mx
from vllm.config import ProfilerConfig
from vllm_metal.profiler import MetalProfilerWrapper

p = MetalProfilerWrapper(
    ProfilerConfig(profiler="torch", torch_profiler_dir=tempfile.mkdtemp()), "run"
)
for _ in range(2):
    p.start()
    print(p.is_running)  # main: True, False; patch: True, True
    mx.eval(mx.arange(32) + 1)
    mx.synchronize()
    p.stop()
```

Validation on clean commit `a3df3da`, Apple M4 / macOS 15.6, Python 3.12, MLX 0.32.0 and vLLM 0.28.0:

- Both regression cases fail on main and pass here: another capture on the same wrapper, and a new wrapper using the same name/directory.
- Real `MetalWorker.profile` calls produced four separate bundles, including after a fresh Python process reused the directory. Native capture validation used small MLX array operations; Xcode replay was not tested.
- Profiler tests: **8 passed**. Complete non-slow suite: **1,987 passed, 15 skipped, 52 deselected** (main: 1,986 passed, same skips).
- Ruff, formatting, mypy, ShellCheck, native extension/all four shader libraries, and wheel artifact/target checks pass. Both repository serving goldens pass with `VLLM_METAL_MEMORY_FRACTION=0.1`.
