### PR TITLE
Reuse vLLM hybrid state dtypes

### DIFF
--- a/tests/attention/test_hybrid_runtime_plan.py
+++ b/tests/attention/test_hybrid_runtime_plan.py
@@ -39,6 +39,8 @@ from vllm_metal.attention.runtime.hybrid_plan import (
     HybridRuntimePlan,
 )
 
+STATE_DTYPES = (torch.float16, torch.float32)
+
 NEMOTRON_H_ARGS = {
     "model_type": "nemotron_h",
     "hybrid_override_pattern": ["M", "E", "M", "*", "-", "M"],
@@ -97,7 +99,7 @@ class _FakeModel(nn.Module):
         ]
 
 
-def _make_tiny_plan() -> HybridRuntimePlan:
+def _make_tiny_plan(state_dtypes=STATE_DTYPES) -> HybridRuntimePlan:
     """Four layers, attention at 1 and 3, geometry sized for the fakes."""
     return make_gdn_hybrid_plan(
         4,
@@ -107,13 +109,16 @@ def _make_tiny_plan() -> HybridRuntimePlan:
         num_v_heads=1,
         value_head_dim=4,
         key_head_dim=32,
+        state_dtypes=state_dtypes,
     )
 
 
 def _make_nemotron_runtime() -> HybridPagedAttentionRuntime:
     """Four real Nemotron-H blocks (M-*M) on an fp32 pool sized for the tiny args."""
     return HybridPagedAttentionRuntime(
-        hybrid_plan=make_nemotron_hybrid_plan("M-*M"),
+        hybrid_plan=make_nemotron_hybrid_plan(
+            "M-*M", state_dtypes=(torch.float32, torch.float32)
+        ),
         max_num_seqs=2,
         num_kv_heads=2,
         head_dim=8,
@@ -122,9 +127,9 @@ def _make_nemotron_runtime() -> HybridPagedAttentionRuntime:
     )
 
 
-def _make_runtime() -> HybridPagedAttentionRuntime:
+def _make_runtime(state_dtypes=STATE_DTYPES) -> HybridPagedAttentionRuntime:
     return HybridPagedAttentionRuntime(
-        hybrid_plan=_make_tiny_plan(),
+        hybrid_plan=_make_tiny_plan(state_dtypes),
         max_num_seqs=2,
         num_kv_heads=1,
         head_dim=4,
@@ -135,7 +140,7 @@ def _make_runtime() -> HybridPagedAttentionRuntime:
 
 class TestGdnPlanDecision:
     def test_topology_follows_the_interval_rule(self) -> None:
-        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8, STATE_DTYPES)
 
         assert plan.layers.attention_indices == (3, 7)
         assert plan.layers.state_indices == (0, 1, 2, 4, 5, 6)
@@ -153,7 +158,7 @@ class TestGdnPlanDecision:
         )
 
     def test_geometry_packs_qk_and_v_into_the_conv_stream(self) -> None:
-        plan = build_gdn_hybrid_plan(GDN_ARGS, 8)
+        plan = build_gdn_hybrid_plan(GDN_ARGS, 8, STATE_DTYPES)
 
         # conv_dim = 2*32*2 + 4*16 = 192, hand-written.
         assert plan.geometry.conv_kernel_dim == 3
@@ -172,7 +177,7 @@ class TestGdnPlanRejection:
         expected = f"GDN hybrid model args are missing required {missing!r}."
 
         with pytest.raises(ValueError) as excinfo:
-            build_gdn_hybrid_plan(args, 8)
+            build_gdn_hybrid_plan(args, 8, STATE_DTYPES)
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize(
@@ -191,7 +196,7 @@ class TestGdnPlanRejection:
         )
 
         with pytest.raises(ValueError) as excinfo:
-            build_gdn_hybrid_plan(args, num_layers)
+            build_gdn_hybrid_plan(args, num_layers, STATE_DTYPES)
         assert str(excinfo.value) == expected
 
 
@@ -201,7 +206,9 @@ class TestStateFamilyFactory:
         ["qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text", "qwen3_next"],
     )
     def test_routes_gdn_model_types_to_the_gdn_family(self, model_type: str) -> None:
-        plan = build_hybrid_runtime_plan({**GDN_ARGS, "model_type": model_type}, 8)
+        plan = build_hybrid_runtime_plan(
+            {**GDN_ARGS, "model_type": model_type}, 8, STATE_DTYPES
+        )
 
         assert plan.family.label == "gdn"
         assert plan.layers.attention_indices == (3, 7)
@@ -213,11 +220,11 @@ class TestStateFamilyFactory:
         )
 
         with pytest.raises(NotImplementedError) as excinfo:
-            build_hybrid_runtime_plan(args, 8)
+            build_hybrid_runtime_plan(args, 8, STATE_DTYPES)
         assert str(excinfo.value) == expected
 
     def test_routes_nemotron_args_to_the_nemotron_family(self) -> None:
-        plan = build_hybrid_runtime_plan(NEMOTRON_H_ARGS, 6)
+        plan = build_hybrid_runtime_plan(NEMOTRON_H_ARGS, 6, STATE_DTYPES)
 
         assert plan.family.label == "nemotron_h"
         assert plan.layers.layer_roles == (
@@ -233,13 +240,13 @@ class TestStateFamilyFactory:
         args = {**GDN_ARGS, "full_attention_interval": "4"}
 
         with pytest.raises(ValueError, match="must be positive integers"):
-            build_hybrid_runtime_plan(args, 8)
+            build_hybrid_runtime_plan(args, 8, STATE_DTYPES)
 
 
 class TestNemotronHPlanDecision:
     def test_string_pattern_reads_as_characters(self) -> None:
         plan = build_nemotron_h_hybrid_plan(
-            {**NEMOTRON_H_ARGS, "hybrid_override_pattern": "M*E"}, 3
+            {**NEMOTRON_H_ARGS, "hybrid_override_pattern": "M*E"}, 3, STATE_DTYPES
         )
 
         assert plan.layers.layer_roles == (
@@ -249,7 +256,9 @@ class TestNemotronHPlanDecision:
         )
 
     def test_spec_is_mamba2_typed_with_fp32_state(self) -> None:
-        plan = build_nemotron_h_hybrid_plan(NEMOTRON_H_ARGS, 6)
+        plan = build_nemotron_h_hybrid_plan(
+            NEMOTRON_H_ARGS, 6, (torch.bfloat16, torch.float32)
+        )
         expected = MambaSpec(
             shapes=((3, 160), (4, 8, 32)),
             dtypes=(torch.bfloat16, torch.float32),
@@ -260,7 +269,6 @@ class TestNemotronHPlanDecision:
         )
 
         spec = plan.state_cache_spec(
-            conv_dtype=torch.bfloat16,
             mamba_block_size=2048,
             page_size_padded=None,
             mamba_cache_mode="none",
@@ -269,7 +277,7 @@ class TestNemotronHPlanDecision:
         assert spec == expected
 
     def test_geometry_matches_the_built_mixer(self) -> None:
-        plan = build_nemotron_h_hybrid_plan(NEMOTRON_H_TINY_ARGS, 2)
+        plan = build_nemotron_h_hybrid_plan(NEMOTRON_H_TINY_ARGS, 2, STATE_DTYPES)
         mixer = NemotronHMamba2Mixer(ModelArgs(**NEMOTRON_H_TINY_ARGS))
 
         geometry = plan.geometry
@@ -281,7 +289,9 @@ class TestNemotronHPlanDecision:
         assert geometry.key_head_dim == mixer.ssm_state_size
 
     def test_spec_shapes_match_vllm_mamba2_calculator(self) -> None:
-        plan = build_nemotron_h_hybrid_plan(NEMOTRON_H_ARGS, 6)
+        plan = build_nemotron_h_hybrid_plan(
+            NEMOTRON_H_ARGS, 6, (torch.bfloat16, torch.float32)
+        )
         expected = MambaStateShapeCalculator.mamba2_state_shape(
             tp_world_size=1,
             intermediate_size=32,
@@ -293,7 +303,6 @@ class TestNemotronHPlanDecision:
         )
 
         spec = plan.state_cache_spec(
-            conv_dtype=torch.bfloat16,
             mamba_block_size=2048,
             page_size_padded=None,
             mamba_cache_mode="none",
@@ -309,7 +318,7 @@ class TestNemotronHPlanRejection:
         expected = f"Nemotron-H hybrid model args are missing required {missing!r}."
 
         with pytest.raises(ValueError) as excinfo:
-            build_nemotron_h_hybrid_plan(args, 6)
+            build_nemotron_h_hybrid_plan(args, 6, STATE_DTYPES)
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize(("value", "shown"), [(0, "0"), ("32", "'32'")])
@@ -321,7 +330,7 @@ class TestNemotronHPlanRejection:
         )
 
         with pytest.raises(ValueError) as excinfo:
-            build_nemotron_h_hybrid_plan(args, 6)
+            build_nemotron_h_hybrid_plan(args, 6, STATE_DTYPES)
         assert str(excinfo.value) == expected
 
     def test_unknown_block_token_rejects(self) -> None:
@@ -329,7 +338,7 @@ class TestNemotronHPlanRejection:
         expected = "Nemotron-H hybrid_override_pattern must use M, *, - or E; got 'Z'."
 
         with pytest.raises(ValueError) as excinfo:
-            build_nemotron_h_hybrid_plan(args, 3)
+            build_nemotron_h_hybrid_plan(args, 3, STATE_DTYPES)
         assert str(excinfo.value) == expected
 
     @pytest.mark.parametrize(
@@ -343,7 +352,7 @@ class TestNemotronHPlanRejection:
         )
 
         with pytest.raises(ValueError) as excinfo:
-            build_nemotron_h_hybrid_plan(args, len(pattern))
+            build_nemotron_h_hybrid_plan(args, len(pattern), STATE_DTYPES)
         assert str(excinfo.value) == expected
 
 
@@ -368,7 +377,6 @@ class TestStateCacheSpec:
         )
 
         spec = plan.state_cache_spec(
-            conv_dtype=torch.float16,
             mamba_block_size=2048,
             page_size_padded=None,
             mamba_cache_mode="align",
@@ -397,11 +405,15 @@ class TestRuntimeUsesThePlan:
         assert str(excinfo.value) == expected
 
     def test_state_cache_is_sized_from_the_plan_geometry(self) -> None:
-        runtime = _make_runtime()
+        runtime = _make_runtime((torch.float32, torch.bfloat16))
 
         runtime.initialize(num_blocks=2)
 
         state_cache = runtime.state_cache
+        state_cache.ensure_capacity(1)
+        state_cache.ensure_capacity(2)
+        assert state_cache.conv_states[0].dtype == mx.float32
+        assert state_cache.recurrent_states[0].dtype == mx.bfloat16
         assert state_cache.num_layers == 2
         assert state_cache.conv_kernel_dim == 2
         assert state_cache.conv_dim == 4
@@ -487,17 +499,21 @@ class TestHybridPatchModel:
         assert wrapper_before._mamba2_state_cache is runtime_b.state_cache
         assert wrapper_before._mamba2_cache_idx == 1
 
-    def test_state_pool_dtype_mismatch_rejects_at_patch_time(self) -> None:
+    def test_nemotron_state_pool_dtype_mismatch_rejects_at_patch_time(self) -> None:
         runtime = HybridPagedAttentionRuntime(
-            hybrid_plan=_make_tiny_plan(),
+            hybrid_plan=make_nemotron_hybrid_plan(
+                "M-*M", state_dtypes=(torch.bfloat16, torch.float32)
+            ),
             max_num_seqs=2,
-            num_kv_heads=1,
-            head_dim=4,
+            num_kv_heads=2,
+            head_dim=8,
             block_size=4,
             dtype=mx.bfloat16,
         )
         runtime.initialize(num_blocks=2)
-        model = _FakeModel("sasa")
+        model = Model(
+            ModelArgs(**{**NEMOTRON_H_TINY_ARGS, "hybrid_override_pattern": "M-*M"})
+        )
         expected = (
             "state pool dtype mlx.core.bfloat16 does not match the layer 0 mixer "
             "dtype mlx.core.float32; pass --dtype matching the checkpoint so "

--- a/tests/attention/test_shortconv_wrapper.py
+++ b/tests/attention/test_shortconv_wrapper.py
@@ -67,6 +67,7 @@ def _make_module() -> ShortConv:
 
 def _make_wrapper(
     module: ShortConv,
+    state_dtype: mx.Dtype = mx.float32,
 ) -> tuple[ShortConvPagedWrapper, ShortConvStateCache]:
     state_cache = ShortConvStateCache(
         num_layers=1,
@@ -74,7 +75,7 @@ def _make_wrapper(
         conv_kernel_dim=L_CACHE,
         conv_dim=HIDDEN,
         initial_seqs=MAX_SEQS,
-        dtype=mx.float32,
+        dtype=state_dtype,
     )
     wrapper = ShortConvPagedWrapper(
         module, layer_idx=0, cache_idx=0, state_cache=state_cache
@@ -130,18 +131,22 @@ def _run_wrapper_step(
 
 def _assert_close(actual: mx.array, expected: mx.array) -> None:
     np.testing.assert_allclose(
-        np.array(actual, copy=False),
-        np.array(expected, copy=False),
+        np.array(actual.astype(mx.float32), copy=False),
+        np.array(expected.astype(mx.float32), copy=False),
         atol=ATOL,
         rtol=RTOL,
     )
 
 
 class TestShortConvPagedWrapper:
+    @pytest.mark.parametrize("input_dtype", [mx.float32, mx.bfloat16])
+    @pytest.mark.parametrize("state_dtype", [mx.float32, mx.bfloat16, mx.float16])
     @pytest.mark.parametrize(
         "grouped", [False, True], ids=["request-slots", "block-slots"]
     )
-    def test_packed_multi_request_matches_sequential_reference(self, grouped) -> None:
+    def test_packed_multi_request_matches_sequential_reference(
+        self, grouped, input_dtype, state_dtype
+    ) -> None:
         """Three requests packed per step vs mlx_lm cache-by-cache reference.
 
         Runs a prefill step and two decode steps; both the per-step outputs
@@ -149,14 +154,14 @@ class TestShortConvPagedWrapper:
         """
         mx.random.seed(0)
         module = _make_module()
-        wrapper, state_cache = _make_wrapper(module)
+        module.set_dtype(input_dtype)
+        wrapper, state_cache = _make_wrapper(module, state_dtype)
 
         slot_ids = [2, 0, 5]
         # Per request: prefill chunk then two single-token decode chunks.
         request_chunks = [
-            [mx.random.normal((1, t, HIDDEN)) for t in (5, 1, 1)],
-            [mx.random.normal((1, t, HIDDEN)) for t in (3, 1, 1)],
-            [mx.random.normal((1, t, HIDDEN)) for t in (7, 1, 1)],
+            [mx.random.normal((1, t, HIDDEN)).astype(input_dtype) for t in lengths]
+            for lengths in ((5, 1, 1), (3, 1, 1), (7, 1, 1))
         ]
 
         # Reference: each request sequentially with mlx_lm's own cache.
@@ -164,9 +169,12 @@ class TestShortConvPagedWrapper:
         ref_caches: list[ArraysCache] = []
         for chunks in request_chunks:
             cache = ArraysCache(size=1)
-            ref_outputs.append(
-                [module(chunk, mask=None, cache=cache) for chunk in chunks]
-            )
+            cache[0] = mx.zeros((1, L_CACHE - 1, HIDDEN), dtype=state_dtype)
+            outputs = []
+            for chunk in chunks:
+                outputs.append(module(chunk, mask=None, cache=cache))
+                cache[0] = cache[0].astype(state_dtype)
+            ref_outputs.append(outputs)
             ref_caches.append(cache)
 
         # Wrapper: the three requests packed together, one step at a time.
@@ -177,6 +185,7 @@ class TestShortConvPagedWrapper:
                 _assert_close(outputs[req], ref_outputs[req][step])
 
         # Final per-request conv state must match the mlx_lm cache tail.
+        assert state_cache.conv_states[0].dtype == state_dtype
         for req, slot in enumerate(slot_ids):
             _assert_close(
                 state_cache.conv_states[0][slot : slot + 1],

--- a/tests/attention/test_shortconv_wrapper.py
+++ b/tests/attention/test_shortconv_wrapper.py
@@ -182,7 +182,8 @@ class TestShortConvPagedWrapper:
             chunks = [request_chunks[req][step] for req in range(3)]
             outputs = _run_wrapper_step(wrapper, chunks, slot_ids, grouped)
             for req in range(3):
-                _assert_close(outputs[req], ref_outputs[req][step])
+                assert outputs[req].dtype == input_dtype
+                _assert_close(outputs[req], ref_outputs[req][step].astype(input_dtype))
 
         # Final per-request conv state must match the mlx_lm cache tail.
         assert state_cache.conv_states[0].dtype == state_dtype

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import mlx.core as mx
+import torch
 
 import vllm_metal.v1.model_runner as mr
 from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
@@ -58,6 +59,8 @@ def make_stub_runner(
             mamba_page_size_padded=None,
             mamba_block_size=2048,
             mamba_cache_mode="none",
+            mamba_cache_dtype="auto",
+            mamba_ssm_cache_dtype="float32",
         ),
         "model_config": SimpleNamespace(
             runner_type="generate",
@@ -107,6 +110,9 @@ def make_stub_runner(
         setattr(runner, k, v)
     for k, v in attrs.items():
         setattr(runner, k, v)
+    if "vllm_config" not in attrs:
+        runner.vllm_config.model_config = runner.model_config
+        runner.vllm_config.cache_config = runner.cache_config
     if "_paged_block_size" in attrs and "_paged_group_block_sizes" not in attrs:
         runner._paged_scheduler_group_indices = (0,)
         runner._paged_group_block_sizes = (attrs["_paged_block_size"],)
@@ -261,6 +267,7 @@ _GDN_FAMILY_SPEC = build_hybrid_runtime_plan(
         "linear_conv_kernel_dim": 1,
     },
     2,
+    (torch.float16, torch.float32),
 ).family
 
 
@@ -273,6 +280,7 @@ def make_gdn_hybrid_plan(
     num_v_heads: int,
     value_head_dim: int,
     key_head_dim: int,
+    state_dtypes: tuple[torch.dtype, ...] = (torch.float16, torch.float32),
 ) -> HybridRuntimePlan:
     """Build a GDN hybrid plan with explicit topology and geometry."""
     attention = frozenset(attention_indices)
@@ -282,6 +290,7 @@ def make_gdn_hybrid_plan(
     return HybridRuntimePlan(
         layers=HybridLayerPlan(layer_roles=layer_roles),
         family=_GDN_FAMILY_SPEC,
+        state_dtypes=state_dtypes,
         geometry=RecurrentStateGeometry(
             conv_kernel_dim=conv_kernel_dim,
             conv_dim=conv_dim,
@@ -292,8 +301,14 @@ def make_gdn_hybrid_plan(
     )
 
 
-def make_nemotron_hybrid_plan(pattern: str) -> HybridRuntimePlan:
+def make_nemotron_hybrid_plan(
+    pattern: str,
+    *,
+    state_dtypes: tuple[torch.dtype, ...] = (torch.float16, torch.float32),
+) -> HybridRuntimePlan:
     """Build a Nemotron-H plan for ``pattern`` through the family table."""
     return build_hybrid_runtime_plan(
-        {**NEMOTRON_H_TINY_ARGS, "hybrid_override_pattern": pattern}, len(pattern)
+        {**NEMOTRON_H_TINY_ARGS, "hybrid_override_pattern": pattern},
+        len(pattern),
+        state_dtypes,
     )

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -18,6 +18,7 @@ from vllm_metal.attention.impls.gdn_lazy import (
     GDNRecurrentDecodeRequest,
     GDNRecurrentPrefillRequest,
 )
+from vllm_metal.attention.impls.linear import GDNPagedAttentionWrapper, _GDNForwardState
 from vllm_metal.metal import get_ops
 
 
@@ -276,6 +277,8 @@ def _make_state_cache(
     num_v_heads: int = 1,
     value_head_dim: int = 4,
     key_head_dim: int = 32,
+    dtype: mx.Dtype = mx.float32,
+    recurrent_dtype: mx.Dtype = mx.float32,
 ) -> GDNPagedStateCache:
     return GDNPagedStateCache(
         num_layers=num_layers,
@@ -285,7 +288,8 @@ def _make_state_cache(
         num_v_heads=num_v_heads,
         value_head_dim=value_head_dim,
         key_head_dim=key_head_dim,
-        dtype=mx.float32,
+        dtype=dtype,
+        recurrent_dtype=recurrent_dtype,
     )
 
 
@@ -432,20 +436,28 @@ class TestLazyConvDecode:
         expected_state[slot_ids] = 9
         np.testing.assert_array_equal(np.array(cache.conv_states[0]), expected_state)
 
-    def test_mixed_dtype_state_update_matches_eager_conv(self) -> None:
+    @pytest.mark.parametrize(
+        "input_dtype,state_dtype",
+        [(mx.float32, mx.bfloat16), (mx.bfloat16, mx.float32)],
+    )
+    def test_mixed_dtype_state_update_matches_eager_conv(
+        self, input_dtype, state_dtype
+    ) -> None:
         # Arrange
         _require_metal()
         mx.random.seed(1)
         conv_dim = 4
         kernel_size = 3
-        cache = _make_state_cache(conv_kernel_dim=kernel_size, conv_dim=conv_dim)
-        initial_state = mx.random.normal(cache.conv_states[0].shape).astype(mx.bfloat16)
+        cache = _make_state_cache(
+            conv_kernel_dim=kernel_size, conv_dim=conv_dim, dtype=state_dtype
+        )
+        initial_state = mx.random.normal(cache.conv_states[0].shape).astype(state_dtype)
         cache.conv_states[0] = mx.array(initial_state)
         weight = mx.random.normal((conv_dim, kernel_size)).astype(mx.float32)
         inner = SimpleNamespace(
             conv_kernel_size=kernel_size, conv1d=_DepthwiseConv1D(weight)
         )
-        mixed_qkv = mx.random.normal((1, 2, conv_dim)).astype(mx.float32)
+        mixed_qkv = mx.random.normal((1, 2, conv_dim)).astype(input_dtype)
         slot_ids = [1, 0]
 
         expected_state = mx.array(initial_state)
@@ -460,7 +472,7 @@ class TestLazyConvDecode:
             )
             expected_state[slot : slot + 1] = conv_input[
                 :, -(kernel_size - 1) :
-            ].astype(mx.bfloat16)
+            ].astype(state_dtype)
             expected_outputs.append(nn.silu(inner.conv1d(conv_input))[:, -1:])
         expected = mx.concatenate(expected_outputs, axis=1)
 
@@ -473,7 +485,7 @@ class TestLazyConvDecode:
         assert actual is not None
         mx.eval(actual, expected, cache.conv_states[0], expected_state)
         assert actual.dtype == mx.float32
-        assert cache.conv_states[0].dtype == mx.bfloat16
+        assert cache.conv_states[0].dtype == state_dtype
         np.testing.assert_allclose(np.array(actual), np.array(expected), atol=5e-3)
         np.testing.assert_allclose(
             np.array(cache.conv_states[0].astype(mx.float32)),
@@ -537,7 +549,7 @@ class TestLazyConvPrefill:
             conv_kernel_size=kernel_size, conv1d=_DepthwiseConv1D(weight)
         )
         slot_ids = [3, 1]
-        mixed_qkv = mx.random.normal((1, total_tokens, conv_dim)).astype(mx.float32)
+        mixed_qkv = mx.random.normal((1, total_tokens, conv_dim)).astype(mx.bfloat16)
 
         expected_state = mx.array(initial_state)
         expected_outputs = []
@@ -956,7 +968,9 @@ class TestLazyRecurrentDecode:
         assert result is not None
         assert fake_kernel.threadgroup == (32, 8, 1)
 
-    def test_matches_cpp_recurrent_path(self) -> None:
+    @pytest.mark.parametrize("input_dtype", [mx.float32, mx.bfloat16, mx.float16])
+    @pytest.mark.parametrize("state_dtype", [mx.float32, mx.bfloat16, mx.float16])
+    def test_matches_cpp_recurrent_path(self, input_dtype, state_dtype) -> None:
         # Arrange
         _require_metal()
         mx.random.seed(0)
@@ -966,19 +980,23 @@ class TestLazyRecurrentDecode:
         d_k = 32
         d_v = 4
         slot_ids = [1, 0]
-        cache_lazy = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
-        cache_cpp = _make_state_cache(value_head_dim=d_v, key_head_dim=d_k)
+        cache_lazy = _make_state_cache(
+            value_head_dim=d_v, key_head_dim=d_k, recurrent_dtype=state_dtype
+        )
+        cache_cpp = _make_state_cache(
+            value_head_dim=d_v, key_head_dim=d_k, recurrent_dtype=state_dtype
+        )
         initial_state = mx.random.normal(cache_lazy.recurrent_states[0].shape).astype(
-            mx.float32
+            state_dtype
         )
         cache_lazy.recurrent_states[0] = mx.array(initial_state)
         cache_cpp.recurrent_states[0] = mx.array(initial_state)
 
-        q = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
-        k = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(mx.float32)
-        v = mx.random.normal((1, total_tokens, n_hv, d_v)).astype(mx.float32)
-        g = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
-        beta = mx.random.normal((1, total_tokens, n_hv)).astype(mx.float32)
+        q = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(input_dtype)
+        k = mx.random.normal((1, total_tokens, n_hk, d_k)).astype(input_dtype)
+        v = mx.random.normal((1, total_tokens, n_hv, d_v)).astype(input_dtype)
+        g = mx.random.normal((1, total_tokens, n_hv)).astype(input_dtype)
+        beta = mx.random.normal((1, total_tokens, n_hv)).astype(input_dtype)
         request = _recurrent_request(
             q=q,
             k=k,
@@ -987,6 +1005,7 @@ class TestLazyRecurrentDecode:
             beta=beta,
             cache=cache_lazy,
             slot_ids=slot_ids,
+            output_dtype=input_dtype,
         )
 
         # Act
@@ -999,35 +1018,24 @@ class TestLazyRecurrentDecode:
         cache_lazy.apply_pending_recurrent_state(0)
         mx.eval(lazy_out, cache_lazy.recurrent_states[0])
 
-        q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k))
-        k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k))
-        v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v))
-        g_flat = mx.contiguous(g.reshape(total_tokens, n_hv))
-        beta_flat = mx.contiguous(beta.reshape(total_tokens, n_hv))
-        cpp_out = mx.zeros((total_tokens, n_hv, d_v), dtype=mx.float32)
-        mx.eval(
-            q_flat,
-            k_flat,
-            v_flat,
-            g_flat,
-            beta_flat,
-            cache_cpp.recurrent_states[0],
-            cpp_out,
+        _get_native_ops_or_skip()
+        fallback = GDNPagedAttentionWrapper(
+            _TinyGDNInner(), layer_idx=0, cache_idx=0, state_cache=cache_cpp
         )
-        _get_native_ops_or_skip().gdn_linear_attention(
-            q_flat,
-            k_flat,
-            v_flat,
-            g_flat,
-            beta_flat,
-            cache_cpp.recurrent_states[0],
-            mx.array([0, 1, 2], dtype=mx.int32),
-            mx.array(slot_ids, dtype=mx.int32),
-            cpp_out,
-            n_hk,
-            n_hv,
-            d_k,
-            d_v,
+        cpp_out = fallback._run_recurrent_fallback(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            _GDNForwardState(
+                x=mx.zeros((1, total_tokens, 68), dtype=input_dtype),
+                cu_seqlens=[0, 1, 2],
+                num_requests=2,
+                total_tokens=total_tokens,
+                slot_ids=slot_ids,
+                num_decode_requests=2,
+            ),
         )
         mx.synchronize()
         mx.eval(
@@ -1036,14 +1044,16 @@ class TestLazyRecurrentDecode:
             cache_lazy.recurrent_states[0],
             cache_cpp.recurrent_states[0],
         )
-        np.testing.assert_allclose(np.array(lazy_out), np.array(cpp_out), atol=1e-4)
-        # The lazy typed prefill path intentionally runs the recurrence at the
-        # requested output dtype to avoid extra graph casts.  The fallback C++
-        # oracle above runs in fp32, so the state can differ slightly more than
-        # the rounded y output while still remaining numerically close.
         np.testing.assert_allclose(
-            np.array(cache_lazy.recurrent_states[0]),
-            np.array(cache_cpp.recurrent_states[0]),
+            np.array(lazy_out.astype(mx.float32)),
+            np.array(cpp_out.astype(mx.float32)),
+            atol=1e-4,
+        )
+        assert cache_lazy.recurrent_states[0].dtype == state_dtype
+        assert cache_cpp.recurrent_states[0].dtype == state_dtype
+        np.testing.assert_allclose(
+            np.array(cache_lazy.recurrent_states[0].astype(mx.float32)),
+            np.array(cache_cpp.recurrent_states[0].astype(mx.float32)),
             atol=1e-3,
         )
 

--- a/tests/test_gdn_lazy_kernels.py
+++ b/tests/test_gdn_lazy_kernels.py
@@ -1022,7 +1022,7 @@ class TestLazyRecurrentDecode:
         fallback = GDNPagedAttentionWrapper(
             _TinyGDNInner(), layer_idx=0, cache_idx=0, state_cache=cache_cpp
         )
-        cpp_out = fallback._run_recurrent_fallback(
+        fallback_args = (
             q,
             k,
             v,
@@ -1037,6 +1037,11 @@ class TestLazyRecurrentDecode:
                 num_decode_requests=2,
             ),
         )
+        if mx.result_type(input_dtype, state_dtype) != state_dtype:
+            with pytest.raises(RuntimeError, match="--mamba-ssm-cache-dtype float32"):
+                fallback._run_recurrent_fallback(*fallback_args)
+            return
+        cpp_out = fallback._run_recurrent_fallback(*fallback_args)
         mx.synchronize()
         mx.eval(
             lazy_out,

--- a/tests/test_kv_cache_spec_capacity.py
+++ b/tests/test_kv_cache_spec_capacity.py
@@ -150,7 +150,7 @@ def test_hybrid_one_sequence_estimate_charges_vllm_group_padding() -> None:
         ),
     )
     attention_layer_bytes = 2 * cdiv(2048, 544) * 544 * 2 * 1 * 128
-    state_layer_bytes = plan.state_bytes_per_layer(2)
+    state_layer_bytes = plan.state_bytes_per_layer()
     expected = 2 * attention_layer_bytes + 6 * state_layer_bytes
 
     estimate = runner._cache_policy.estimate_one_sequence_kv_bytes(

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -58,6 +58,8 @@ def _runner_model_config(**overrides: object) -> object:
         "tokenizer": None,
         "tokenizer_revision": None,
         "is_hybrid": False,
+        "architecture": "Qwen3NextForCausalLM",
+        "model_impl": "vllm",
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -1181,10 +1183,19 @@ class TestResolveModelDims:
         return runner
 
     def test_hybrid_model_installs_its_family_plan(self) -> None:
-        runner = self._resolve(_GDN_HYBRID_ARGS, is_hybrid=True)
+        lifecycle, runner = _make_lifecycle(
+            model_args=_GDN_HYBRID_ARGS,
+            model_config=_runner_model_config(is_hybrid=True, dtype=torch.bfloat16),
+        )
+        runner.cache_config.mamba_ssm_cache_dtype = "auto"
+        lifecycle.resolve_model_dims()
 
         assert runner.hybrid_runtime_plan.family.label == "gdn"
         assert runner.hybrid_runtime_plan.layers.attention_indices == (3, 7)
+        assert runner.hybrid_runtime_plan.state_dtypes == (
+            torch.bfloat16,
+            torch.bfloat16,
+        )
 
     def test_routing_follows_the_typed_field_not_the_args(self) -> None:
         runner = self._resolve(_GDN_HYBRID_ARGS, is_hybrid=False)

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1200,7 +1200,7 @@ class TestResolveModelDims:
         )
 
     def test_hybrid_state_dtypes_come_from_the_configured_registry(self) -> None:
-        state_dtypes = (torch.float32, torch.float16)
+        state_dtypes = (torch.float32, torch.float32)
         model_cls = SimpleNamespace(
             get_mamba_state_dtype_from_config=lambda _: state_dtypes
         )
@@ -1215,6 +1215,36 @@ class TestResolveModelDims:
         lifecycle.resolve_model_dims()
 
         assert runner.hybrid_runtime_plan.state_dtypes == state_dtypes
+
+    @pytest.mark.parametrize(
+        ("model_dtype", "conv_dtype", "ssm_dtype", "supported"),
+        [
+            (torch.bfloat16, "auto", "auto", True),
+            (torch.bfloat16, "auto", "float32", True),
+            (torch.float16, "auto", "auto", True),
+            (torch.float32, "auto", "auto", True),
+            (torch.bfloat16, "auto", "float16", False),
+            (torch.bfloat16, "float32", "bfloat16", False),
+            (torch.float32, "float16", "float16", False),
+        ],
+    )
+    def test_gdn_dtype_support_is_checked_at_initialization(
+        self, model_dtype, conv_dtype, ssm_dtype, supported
+    ) -> None:
+        lifecycle, runner = _make_lifecycle(
+            model_args=_GDN_HYBRID_ARGS,
+            model_config=_runner_model_config(is_hybrid=True, dtype=model_dtype),
+        )
+        runner.cache_config.mamba_cache_dtype = conv_dtype
+        runner.cache_config.mamba_ssm_cache_dtype = ssm_dtype
+
+        if supported:
+            lifecycle.resolve_model_dims()
+            assert runner.hybrid_runtime_plan is not None
+        else:
+            with pytest.raises(ValueError, match="--mamba-ssm-cache-dtype float32"):
+                lifecycle.resolve_model_dims()
+            assert runner.hybrid_runtime_plan is None
 
     def test_routing_follows_the_typed_field_not_the_args(self) -> None:
         runner = self._resolve(_GDN_HYBRID_ARGS, is_hybrid=False)

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 from mlx_lm.models.nemotron_h import Model as NemotronHModel
 from mlx_lm.models.nemotron_h import ModelArgs as NemotronHModelArgs
+from vllm.model_executor.models import ModelRegistry
 
 import vllm_metal.envs as envs
 from tests.stub_runner import NEMOTRON_H_TINY_ARGS, make_stub_runner
@@ -60,6 +61,7 @@ def _runner_model_config(**overrides: object) -> object:
         "is_hybrid": False,
         "architecture": "Qwen3NextForCausalLM",
         "model_impl": "vllm",
+        "registry": ModelRegistry,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -1196,6 +1198,23 @@ class TestResolveModelDims:
             torch.bfloat16,
             torch.bfloat16,
         )
+
+    def test_hybrid_state_dtypes_come_from_the_configured_registry(self) -> None:
+        state_dtypes = (torch.float32, torch.float16)
+        model_cls = SimpleNamespace(
+            get_mamba_state_dtype_from_config=lambda _: state_dtypes
+        )
+        registry = SimpleNamespace(
+            resolve_model_cls=lambda *_args, **_kwargs: (model_cls, "override")
+        )
+        lifecycle, runner = _make_lifecycle(
+            model_args=_GDN_HYBRID_ARGS,
+            model_config=_runner_model_config(is_hybrid=True, registry=registry),
+        )
+
+        lifecycle.resolve_model_dims()
+
+        assert runner.hybrid_runtime_plan.state_dtypes == state_dtypes
 
     def test_routing_follows_the_typed_field_not_the_args(self) -> None:
         runner = self._resolve(_GDN_HYBRID_ARGS, is_hybrid=False)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1387,25 +1387,18 @@ class TestMetalPlatform:
         assert cache_config.enable_prefix_caching is True
         assert cache_config.mamba_cache_mode == "align"
 
-    @pytest.mark.parametrize(
-        ("dtype", "reject"),
-        [("auto", False), ("float16", True), ("bfloat16", True)],
-    )
-    def test_check_and_update_config_hybrid_gdn_state_dtype(
-        self, dtype: str, reject: bool, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.parametrize("dtype", ["auto", "float16", "bfloat16", "float32"])
+    def test_check_and_update_config_preserves_upstream_state_dtype(
+        self, dtype: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         cache_config = CacheConfig(
             enable_prefix_caching=False, mamba_ssm_cache_dtype=dtype
         )
         vllm_config = self._hybrid_vllm_config(cache_config)
 
-        if reject:
-            with pytest.raises(NotImplementedError, match="require.*float32"):
-                MetalPlatform.check_and_update_config(vllm_config)
-        else:
-            self._patch_stt_resolution(monkeypatch, is_stt=False)
-            MetalPlatform.check_and_update_config(vllm_config)
-            assert cache_config.mamba_ssm_cache_dtype == "float32"
+        self._patch_stt_resolution(monkeypatch, is_stt=False)
+        MetalPlatform.check_and_update_config(vllm_config)
+        assert cache_config.mamba_ssm_cache_dtype == dtype
 
     def test_check_and_update_config_increases_max_num_scheduled_tokens_below_max_model_len(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_shortconv_hybrid_spec.py
+++ b/tests/test_shortconv_hybrid_spec.py
@@ -86,17 +86,28 @@ def _ordinary_paged_cache(monkeypatch):
     )
 
 
-def _runner(model, *, mode="align"):
+def _runner(model, *, mode="align", cache_dtype="auto"):
     runner = make_stub_runner(
         model=model,
         model_args=asdict(model.args),
         is_hybrid=True,
         kv_cache_dtype=mx.bfloat16,
+        model_config=SimpleNamespace(
+            is_hybrid=True,
+            model_impl="vllm",
+            architecture=(
+                "Lfm2ForCausalLM"
+                if model.args.model_type == "lfm2"
+                else "Lfm2MoeForCausalLM"
+            ),
+            dtype=torch.bfloat16,
+        ),
         cache_config=SimpleNamespace(
             block_size=BLOCK_SIZE,
             mamba_block_size=BLOCK_SIZE if mode == "align" else 128,
             mamba_page_size_padded=None,
             mamba_cache_mode=mode,
+            mamba_cache_dtype=cache_dtype,
             num_gpu_blocks_override=None,
         ),
         scheduler_config=SimpleNamespace(
@@ -144,7 +155,7 @@ def test_scheduler_spec_bills_only_the_convolution_tail(lfm_model, mode):
 
 def test_upstream_scheduler_groups_adopt_conv_names_and_shared_state_pools(lfm_model):
     """Round-trip real vLLM grouping, including its shared_by physical layout."""
-    runner = _runner(lfm_model)
+    runner = _runner(lfm_model, cache_dtype="float32")
     runtime = _runtime(runner)
     engine_config = SimpleNamespace(
         cache_config=runner.cache_config,
@@ -179,6 +190,7 @@ def test_upstream_scheduler_groups_adopt_conv_names_and_shared_state_pools(lfm_m
     cache = runtime.state_cache
     assert cache.allocated_seqs == 0
     cache.ensure_capacity(NUM_BLOCKS)
+    assert cache.conv_states[0].dtype == mx.float32
     assert cache.num_state_pools == 2
     for tensor in scheduler_cache.kv_cache_tensors:
         indices = [
@@ -193,7 +205,7 @@ def test_upstream_scheduler_groups_adopt_conv_names_and_shared_state_pools(lfm_m
         )
     assert (
         sum(array.nbytes for array in cache.updated_state_arrays())
-        == NUM_BLOCKS * 2 * 256
+        == NUM_BLOCKS * 2 * 512
     )
-    assert runner._cache_policy.hybrid_align_state_bytes_per_block() == 2 * 256
-    assert runner._cache_policy.hybrid_align_growth_bytes_per_block() == 256
+    assert runner._cache_policy.hybrid_align_state_bytes_per_block() == 2 * 512
+    assert runner._cache_policy.hybrid_align_growth_bytes_per_block() == 512

--- a/tests/test_shortconv_hybrid_spec.py
+++ b/tests/test_shortconv_hybrid_spec.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import mlx.core as mx
 import pytest
 import torch
+from vllm.model_executor.models import ModelRegistry
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.core.kv_cache_utils import (
     get_kv_cache_config_from_groups,
@@ -95,6 +96,7 @@ def _runner(model, *, mode="align", cache_dtype="auto"):
         model_config=SimpleNamespace(
             is_hybrid=True,
             model_impl="vllm",
+            registry=ModelRegistry,
             architecture=(
                 "Lfm2ForCausalLM"
                 if model.args.model_type == "lfm2"

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest
+import torch
 
 pytest.importorskip("vllm", reason="vllm not installed")
 
@@ -547,6 +548,7 @@ class TestAlignStateSizing:
                     "linear_conv_kernel_dim": 2,
                 },
                 24,
+                (torch.float16, torch.float32),
             ),
         )
 

--- a/vllm_metal/attention/caches/gdn_cache.py
+++ b/vllm_metal/attention/caches/gdn_cache.py
@@ -69,6 +69,7 @@ class GDNPagedStateCache:
         key_head_dim: int,
         initial_seqs: int | None = None,
         dtype: mx.Dtype = mx.float16,
+        recurrent_dtype: mx.Dtype = mx.float32,
     ) -> None:
         if dtype not in (mx.float16, mx.bfloat16, mx.float32):
             raise ValueError(f"Unsupported dtype for GDN state cache: {dtype}")
@@ -91,14 +92,14 @@ class GDNPagedStateCache:
         self.value_head_dim = value_head_dim
         self.key_head_dim = key_head_dim
         self.dtype = dtype
+        self.recurrent_dtype = recurrent_dtype
 
         self.conv_states: list[mx.array] = [
             mx.zeros(self._conv_shape(initial_seqs), dtype=dtype)
             for _ in range(num_layers)
         ]
-        # Recurrent state uses float32 to avoid overflow in kernel accumulation.
         self.recurrent_states: list[mx.array] = [
-            mx.zeros(self._recurrent_shape(initial_seqs), dtype=mx.float32)
+            mx.zeros(self._recurrent_shape(initial_seqs), dtype=recurrent_dtype)
             for _ in range(num_layers)
         ]
         self.pending_conv_states: list[mx.array | None] = [
@@ -177,7 +178,9 @@ class GDNPagedStateCache:
                 conv[:old_allocated] = old_conv
 
             old_recurrent = self.recurrent_states[layer_idx]
-            recurrent = mx.zeros(self._recurrent_shape(num_seqs), dtype=mx.float32)
+            recurrent = mx.zeros(
+                self._recurrent_shape(num_seqs), dtype=self.recurrent_dtype
+            )
             if old_allocated:
                 recurrent[:old_allocated] = old_recurrent
 

--- a/vllm_metal/attention/impls/gdn_lazy.py
+++ b/vllm_metal/attention/impls/gdn_lazy.py
@@ -22,12 +22,6 @@ _RECURRENT_MAX_KEY_HEAD_DIM = 256
 _RECURRENT_PREFILL_THREADGROUP_DV = 4
 
 
-def _astype_if_needed(array: mx.array, dtype: mx.Dtype) -> mx.array:
-    if array.dtype == dtype:
-        return array
-    return array.astype(dtype)
-
-
 @dataclass(frozen=True)
 class GDNRecurrentRequest:
     """Common inputs for one lazy GDN recurrent kernel attempt."""
@@ -252,6 +246,7 @@ class GDNLazyKernels:
         state_view = state_cache.conv_state_for_decode(cache_idx, slot_ids)
         conv_state_in = state_view.state
         weight = inner.conv1d.weight
+        output_dtype = mx.result_type(mixed_qkv, conv_state_in, weight)
 
         mixed_qkv_2d = mixed_qkv.reshape(num_requests, conv_dim)
         slot_ids_arr = state_view.cache_slot_ids
@@ -269,7 +264,7 @@ class GDNLazyKernels:
             num_requests,
         ]
         template = [
-            ("T", mixed_qkv.dtype),
+            ("T", output_dtype),
             ("StT", conv_state_in.dtype),
             ("CONV_DIM", conv_dim),
             ("KERNEL_SIZE", kernel_size),
@@ -280,7 +275,7 @@ class GDNLazyKernels:
             grid=(grid_size, 1, 1),
             threadgroup=(tg_size, 1, 1),
             output_shapes=[(num_requests, conv_dim), state_updates_shape],
-            output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
+            output_dtypes=[output_dtype, conv_state_in.dtype],
         )
         state_cache.write_conv_rows(cache_idx, conv_state_updates, slot_ids_arr)
         if state_view.uses_compact_state:
@@ -317,6 +312,7 @@ class GDNLazyKernels:
         if state_cache.has_pending_conv_state(cache_idx):
             state_cache.apply_pending_conv_state(cache_idx)
         conv_state_in = state_cache.conv_states[cache_idx]
+        output_dtype = mx.result_type(mixed_qkv, conv_state_in, inner.conv1d.weight)
         mixed_qkv_2d = mixed_qkv.reshape(total_tokens, conv_dim)
         slot_ids_arr = mx.array(slot_ids, dtype=mx.int32)
         cu_seqlens_arr = mx.array(cu_seqlens, dtype=mx.int32)
@@ -335,7 +331,7 @@ class GDNLazyKernels:
                 total_tokens,
             ],
             template=[
-                ("T", mixed_qkv.dtype),
+                ("T", output_dtype),
                 ("StT", conv_state_in.dtype),
                 ("CONV_DIM", conv_dim),
                 ("KERNEL_SIZE", kernel_size),
@@ -343,7 +339,7 @@ class GDNLazyKernels:
             grid=(grid_size, 1, 1),
             threadgroup=(tg_size, 1, 1),
             output_shapes=[(total_tokens, conv_dim), state_updates_shape],
-            output_dtypes=[mixed_qkv.dtype, conv_state_in.dtype],
+            output_dtypes=[output_dtype, conv_state_in.dtype],
         )
         state_cache.set_pending_conv_state(cache_idx, slot_ids, conv_state_updates)
         return conv_out.reshape(1, total_tokens, conv_dim)
@@ -393,7 +389,7 @@ class GDNLazyKernels:
         ]
         template = [
             ("T", request.output_dtype),
-            ("StT", mx.float32),
+            ("StT", state_in.dtype),
             ("Dk", d_k),
             ("Dv", d_v),
             ("Hk", n_hk),
@@ -405,7 +401,7 @@ class GDNLazyKernels:
             grid=(_RECURRENT_SIMDGROUP_WIDTH, d_v, num_requests * n_hv),
             threadgroup=(_RECURRENT_SIMDGROUP_WIDTH, request.threadgroup_dv, 1),
             output_shapes=[(total_tokens, n_hv, d_v), (num_requests, n_hv, d_v, d_k)],
-            output_dtypes=[request.output_dtype, mx.float32],
+            output_dtypes=[request.output_dtype, state_in.dtype],
         )
         # Park the compact update instead of scattering it into the stable
         # pool.  A steady-state decode chain then reads and writes only
@@ -465,11 +461,11 @@ class GDNLazyKernels:
         state_dtype = state_in.dtype
 
         kernel_inputs = [
-            _astype_if_needed(request.q.reshape(total_tokens, n_hk, d_k), kernel_dtype),
-            _astype_if_needed(request.k.reshape(total_tokens, n_hk, d_k), kernel_dtype),
-            _astype_if_needed(request.v.reshape(total_tokens, n_hv, d_v), kernel_dtype),
-            _astype_if_needed(request.g.reshape(total_tokens, n_hv), kernel_dtype),
-            _astype_if_needed(request.beta.reshape(total_tokens, n_hv), kernel_dtype),
+            request.q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype),
+            request.k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype),
+            request.v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype),
+            request.g.reshape(total_tokens, n_hv).astype(kernel_dtype),
+            request.beta.reshape(total_tokens, n_hv).astype(kernel_dtype),
             state_in,
             cu_seqlens_arr,
             slot_ids_arr,
@@ -503,5 +499,5 @@ class GDNLazyKernels:
             request.state_cache.write_recurrent_rows(
                 request.cache_idx, state_updates, slot_ids_arr
             )
-        y_out = _astype_if_needed(y_out, request.output_dtype)
+        y_out = y_out.astype(request.output_dtype)
         return y_out

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -417,6 +417,13 @@ class GDNPagedAttentionWrapper(nn.Module):
         # Promote only as needed to preserve input, state, and output precision.
         recurrent_pool = self._gdn_state_cache.recurrent_states[self._gdn_cache_idx]
         kernel_dtype = mx.result_type(q, k, v, g, beta, recurrent_pool, state.x)
+        if recurrent_pool.dtype != kernel_dtype:
+            raise RuntimeError(
+                f"GDN fallback does not support {recurrent_pool.dtype} recurrent "
+                f"state with {kernel_dtype} kernel buffers. Set "
+                f"--mamba-ssm-cache-dtype {str(kernel_dtype).removeprefix('mlx.core.')} "
+                "to enable in-place state updates."
+            )
         q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
         k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
         v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype))
@@ -425,16 +432,9 @@ class GDNPagedAttentionWrapper(nn.Module):
 
         cu_seqlens_arr = mx.array(state.cu_seqlens, dtype=mx.int32)
         # Stable request → slot mapping from model_runner's allocator.
-        slot_ids = mx.array(state.slot_ids, dtype=mx.int32)
-        slot_mapping = slot_ids
+        slot_mapping = mx.array(state.slot_ids, dtype=mx.int32)
 
         y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
-        cast_state = recurrent_pool.dtype != kernel_dtype
-        if cast_state:
-            recurrent_pool = mx.contiguous(
-                recurrent_pool[slot_mapping].astype(kernel_dtype)
-            )
-            slot_mapping = mx.arange(state.num_requests, dtype=mx.int32)
 
         mx.eval(
             q_flat,
@@ -465,12 +465,6 @@ class GDNPagedAttentionWrapper(nn.Module):
             d_v,
         )
         mx.eval(y_flat, recurrent_pool)
-        if cast_state:
-            self._gdn_state_cache.write_recurrent_rows(
-                self._gdn_cache_idx,
-                recurrent_pool,
-                slot_ids,
-            )
         return y_flat.astype(state.x.dtype)
 
     def _project_output(

--- a/vllm_metal/attention/impls/linear.py
+++ b/vllm_metal/attention/impls/linear.py
@@ -118,7 +118,6 @@ class GDNPagedAttentionWrapper(nn.Module):
         state_cache: GDNPagedStateCache,
     ) -> None:
         super().__init__()
-        state_cache.require_mixer_dtype(inner.conv1d.weight.dtype, layer_idx=layer_idx)
         object.__setattr__(self, "_inner", inner)
         object.__setattr__(self, "_gdn_layer_idx", layer_idx)
         object.__setattr__(self, "_gdn_cache_idx", cache_idx)
@@ -258,7 +257,9 @@ class GDNPagedAttentionWrapper(nn.Module):
 
         if defer_conv_state:
             state_cache.set_pending_conv_state(
-                cache_idx, slot_ids, mx.concatenate(conv_updates, axis=0)
+                cache_idx,
+                slot_ids,
+                mx.concatenate(conv_updates, axis=0).astype(state_cache.dtype),
             )
 
         return mx.concatenate(conv_outputs, axis=1)
@@ -412,9 +413,10 @@ class GDNPagedAttentionWrapper(nn.Module):
         d_v = inner.head_v_dim
 
         # Flatten for kernel: remove batch dim.
-        # Use float32 for kernel dispatch to avoid float16 overflow in
-        # recurrent state accumulation.  Output is cast back after.
-        kernel_dtype = mx.float32
+        # The native kernel uses one buffer dtype and accumulates in float32.
+        # Promote only as needed to preserve input, state, and output precision.
+        recurrent_pool = self._gdn_state_cache.recurrent_states[self._gdn_cache_idx]
+        kernel_dtype = mx.result_type(q, k, v, g, beta, recurrent_pool, state.x)
         q_flat = mx.contiguous(q.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
         k_flat = mx.contiguous(k.reshape(total_tokens, n_hk, d_k).astype(kernel_dtype))
         v_flat = mx.contiguous(v.reshape(total_tokens, n_hv, d_v).astype(kernel_dtype))
@@ -423,10 +425,16 @@ class GDNPagedAttentionWrapper(nn.Module):
 
         cu_seqlens_arr = mx.array(state.cu_seqlens, dtype=mx.int32)
         # Stable request → slot mapping from model_runner's allocator.
-        slot_mapping = mx.array(state.slot_ids, dtype=mx.int32)
+        slot_ids = mx.array(state.slot_ids, dtype=mx.int32)
+        slot_mapping = slot_ids
 
         y_flat = mx.zeros((total_tokens, n_hv, d_v), dtype=kernel_dtype)
-        recurrent_pool = self._gdn_state_cache.recurrent_states[self._gdn_cache_idx]
+        cast_state = recurrent_pool.dtype != kernel_dtype
+        if cast_state:
+            recurrent_pool = mx.contiguous(
+                recurrent_pool[slot_mapping].astype(kernel_dtype)
+            )
+            slot_mapping = mx.arange(state.num_requests, dtype=mx.int32)
 
         mx.eval(
             q_flat,
@@ -457,6 +465,12 @@ class GDNPagedAttentionWrapper(nn.Module):
             d_v,
         )
         mx.eval(y_flat, recurrent_pool)
+        if cast_state:
+            self._gdn_state_cache.write_recurrent_rows(
+                self._gdn_cache_idx,
+                recurrent_pool,
+                slot_ids,
+            )
         return y_flat.astype(state.x.dtype)
 
     def _project_output(

--- a/vllm_metal/attention/impls/shortconv.py
+++ b/vllm_metal/attention/impls/shortconv.py
@@ -98,4 +98,4 @@ class ShortConvPagedWrapper(nn.Module):
         # All tokens in this forward are committed. Speculative verification
         # remains rejected because it would require rolling this state back.
         state_cache.write_conv_rows(cache_idx, updates, ids)
-        return inner.out_proj(c_gate * conv_out)
+        return inner.out_proj(c_gate * conv_out).astype(x.dtype)

--- a/vllm_metal/attention/runtime/factory.py
+++ b/vllm_metal/attention/runtime/factory.py
@@ -7,6 +7,8 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+import torch
+
 from vllm_metal.attention.runtime.families.gdn import (
     GDN_FAMILY,
     GDN_MODEL_TYPES,
@@ -29,7 +31,9 @@ from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan, StateFam
 class StateFamilyPlanBuilder:
     model_types: frozenset[str]
     family: StateFamilySpec
-    build: Callable[[Mapping[str, Any], int], HybridRuntimePlan]
+    build: Callable[
+        [Mapping[str, Any], int, tuple[torch.dtype, ...]], HybridRuntimePlan
+    ]
 
 
 _STATE_FAMILY_PLAN_BUILDERS = (
@@ -68,7 +72,9 @@ def state_family_for_model_type(model_type: str) -> StateFamilySpec:
 
 
 def build_hybrid_runtime_plan(
-    model_args: Mapping[str, Any], num_layers: int
+    model_args: Mapping[str, Any],
+    num_layers: int,
+    state_dtypes: tuple[torch.dtype, ...],
 ) -> HybridRuntimePlan:
     builder = _builder_for_model_type(model_args["model_type"])
-    return builder.build(model_args, num_layers)
+    return builder.build(model_args, num_layers, state_dtypes)

--- a/vllm_metal/attention/runtime/families/gdn.py
+++ b/vllm_metal/attention/runtime/families/gdn.py
@@ -105,7 +105,7 @@ def create_gdn_state_cache(
     num_layers: int,
     max_seqs: int,
     initial_seqs: int,
-    dtype: mx.Dtype,
+    dtypes: tuple[mx.Dtype, ...],
 ) -> GDNPagedStateCache:
     if not isinstance(geometry, RecurrentStateGeometry):
         raise TypeError("GDN state cache requires recurrent state geometry")
@@ -118,7 +118,8 @@ def create_gdn_state_cache(
         value_head_dim=geometry.value_head_dim,
         key_head_dim=geometry.key_head_dim,
         initial_seqs=initial_seqs,
-        dtype=dtype,
+        dtype=dtypes[0],
+        recurrent_dtype=dtypes[1],
     )
 
 
@@ -133,8 +134,6 @@ GDN_FAMILY = StateFamilySpec(
     wrapper_cls=GDNPagedAttentionWrapper,
     is_state_module=is_linear_attention,
     mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
-    # Match the fp32 recurrent pool used for kernel accumulation.
-    state_dtypes=(None, torch.float32),
     # Scheduler-side mamba caching strategies the GDN state path implements.
     supported_cache_modes=("none", "align"),
     supports_decode_pipeline=True,
@@ -144,7 +143,9 @@ GDN_FAMILY = StateFamilySpec(
 
 
 def build_gdn_hybrid_plan(
-    model_args: Mapping[str, Any], num_layers: int
+    model_args: Mapping[str, Any],
+    num_layers: int,
+    state_dtypes: tuple[torch.dtype, ...],
 ) -> HybridRuntimePlan:
     """Resolve GDN layer topology and recurrent geometry from model args."""
     gdn_config = GDNHybridConfig.from_model_args(model_args)
@@ -152,4 +153,5 @@ def build_gdn_hybrid_plan(
         layers=HybridLayerPlan(layer_roles=gdn_config.layer_roles(num_layers)),
         family=GDN_FAMILY,
         geometry=gdn_config.state_geometry(),
+        state_dtypes=state_dtypes,
     )

--- a/vllm_metal/attention/runtime/families/nemotron_h.py
+++ b/vllm_metal/attention/runtime/families/nemotron_h.py
@@ -116,8 +116,6 @@ NEMOTRON_H_FAMILY = StateFamilySpec(
     wrapper_cls=Mamba2PagedStateWrapper,
     is_state_module=is_mamba2_mixer,
     mamba_type=MambaAttentionBackendEnum.MAMBA2,
-    # Conv tail follows the runtime dtype; match the fp32 SSM state of ssm_update.
-    state_dtypes=(None, torch.float32),
     # One private slot per resident request; state is not block-keyed.
     supported_cache_modes=("none",),
     # Full-step path only; not validated on the decode pipeline.
@@ -129,7 +127,9 @@ NEMOTRON_H_FAMILY = StateFamilySpec(
 
 
 def build_nemotron_h_hybrid_plan(
-    model_args: Mapping[str, Any], num_layers: int
+    model_args: Mapping[str, Any],
+    num_layers: int,
+    state_dtypes: tuple[torch.dtype, ...],
 ) -> HybridRuntimePlan:
     """Resolve Nemotron-H block roles and Mamba-2 geometry from model args."""
     nemotron_config = NemotronHHybridConfig.from_model_args(model_args)
@@ -137,4 +137,5 @@ def build_nemotron_h_hybrid_plan(
         layers=HybridLayerPlan(layer_roles=nemotron_config.layer_roles()),
         family=NEMOTRON_H_FAMILY,
         geometry=nemotron_config.state_geometry(),
+        state_dtypes=state_dtypes,
     )

--- a/vllm_metal/attention/runtime/families/shortconv.py
+++ b/vllm_metal/attention/runtime/families/shortconv.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import mlx.core as mx
+import torch
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 
 from vllm_metal.attention.caches.shortconv_cache import ShortConvStateCache
@@ -28,7 +29,7 @@ def _create_shortconv_state_cache(
     num_layers: int,
     max_seqs: int,
     initial_seqs: int,
-    dtype: mx.Dtype,
+    dtypes: tuple[mx.Dtype, ...],
 ) -> ShortConvStateCache:
     if not isinstance(geometry, ConvStateGeometry):
         raise TypeError("ShortConv state cache requires convolution-only geometry")
@@ -38,7 +39,7 @@ def _create_shortconv_state_cache(
         conv_kernel_dim=geometry.conv_kernel_dim,
         conv_dim=geometry.conv_dim,
         initial_seqs=initial_seqs,
-        dtype=dtype,
+        dtype=dtypes[0],
     )
 
 
@@ -49,7 +50,6 @@ SHORTCONV_FAMILY = StateFamilySpec(
     wrapper_cls=ShortConvPagedWrapper,
     is_state_module=is_shortconv,
     mamba_type=MambaAttentionBackendEnum.SHORT_CONV,
-    state_dtypes=(None,),
     supported_cache_modes=("none", "align"),
     # Served with the decode pipeline since it landed on main.
     supports_decode_pipeline=True,
@@ -59,7 +59,9 @@ SHORTCONV_FAMILY = StateFamilySpec(
 
 
 def build_shortconv_hybrid_plan(
-    model_args: Mapping[str, Any], num_layers: int
+    model_args: Mapping[str, Any],
+    num_layers: int,
+    state_dtypes: tuple[torch.dtype, ...],
 ) -> HybridRuntimePlan:
     """Resolve explicit attention/conv layer roles and the pre-conv tail shape."""
     layer_types = model_args.get("layer_types")
@@ -106,4 +108,5 @@ def build_shortconv_hybrid_plan(
         ),
         family=SHORTCONV_FAMILY,
         geometry=ConvStateGeometry(conv_kernel_dim=kernel, conv_dim=width),
+        state_dtypes=state_dtypes,
     )

--- a/vllm_metal/attention/runtime/hybrid.py
+++ b/vllm_metal/attention/runtime/hybrid.py
@@ -25,6 +25,7 @@ from vllm_metal.attention.patching import DEFAULT_ATTN_ATTR_NAMES, walk_and_wrap
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
 from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
 from vllm_metal.attention.state import AlignStateManager, RequestStateManager
+from vllm_metal.pytorch_backend.tensor_bridge import TORCH_TO_MLX_DTYPE
 
 logger = init_logger(__name__)
 
@@ -108,7 +109,9 @@ class HybridPagedAttentionRuntime(PagedAttentionRuntimeBase):
             num_layers=self._hybrid_plan.layers.num_state,
             max_seqs=state_slots,
             initial_seqs=0,
-            dtype=self._dtype,
+            dtypes=tuple(
+                TORCH_TO_MLX_DTYPE[dtype] for dtype in self._hybrid_plan.state_dtypes
+            ),
         )
         self._state_manager = (
             AlignStateManager(self._state_cache, self._block_size)

--- a/vllm_metal/attention/runtime/hybrid_plan.py
+++ b/vllm_metal/attention/runtime/hybrid_plan.py
@@ -142,21 +142,18 @@ class StateCacheFactory(Protocol):
         num_layers: int,
         max_seqs: int,
         initial_seqs: int,
-        dtype: mx.Dtype,
+        dtypes: tuple[mx.Dtype, ...],
     ) -> PagedStateCache: ...
 
 
 @dataclass(frozen=True, slots=True)
 class StateFamilySpec:
-    """Per-family policy: how state layers are detected, wrapped and typed."""
+    """Per-family implementation: how state layers are detected and wrapped."""
 
     label: str
     wrapper_cls: type[PagedStateWrapper]
     is_state_module: Callable[[Any], bool]
     mamba_type: MambaAttentionBackendEnum
-    # None follows the runtime's convolution dtype; fixed dtypes describe
-    # accumulation state such as GDN's fp32 recurrent matrix.
-    state_dtypes: tuple[torch.dtype | None, ...]
     supported_cache_modes: tuple[str, ...]
     supports_decode_pipeline: bool
     layer_name: str
@@ -170,20 +167,28 @@ class HybridRuntimePlan:
     layers: HybridLayerPlan
     family: StateFamilySpec
     geometry: StateGeometry
+    state_dtypes: tuple[torch.dtype, ...]
 
-    def state_bytes_per_layer(self, conv_dtype_size: int) -> int:
+    def __post_init__(self) -> None:
+        if len(self.state_dtypes) != len(self.geometry.state_shapes):
+            raise ValueError(
+                f"{self.family.label} state geometry has "
+                f"{len(self.geometry.state_shapes)} tensors, but upstream resolved "
+                f"{len(self.state_dtypes)} state dtypes"
+            )
+
+    def state_bytes_per_layer(self) -> int:
         """Bytes one request holds in one recurrent state layer."""
         return sum(
-            prod(shape) * (conv_dtype_size if dtype is None else dtype.itemsize)
+            prod(shape) * dtype.itemsize
             for shape, dtype in zip(
-                self.geometry.state_shapes, self.family.state_dtypes, strict=True
+                self.geometry.state_shapes, self.state_dtypes, strict=True
             )
         )
 
     def state_cache_spec(
         self,
         *,
-        conv_dtype: torch.dtype,
         mamba_block_size: int,
         page_size_padded: int | None,
         mamba_cache_mode: str,
@@ -191,10 +196,7 @@ class HybridRuntimePlan:
         """Build the scheduler-visible state spec for one state layer."""
         return MambaSpec(
             shapes=self.geometry.state_shapes,
-            dtypes=tuple(
-                conv_dtype if dtype is None else dtype
-                for dtype in self.family.state_dtypes
-            ),
+            dtypes=self.state_dtypes,
             block_size=mamba_block_size,
             page_size_padded=page_size_padded,
             mamba_type=self.family.mamba_type,

--- a/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_decode.metal
@@ -1,4 +1,4 @@
-// Template params: T (output/input dtype), StT (state dtype), CONV_DIM, KERNEL_SIZE
+// Template params: T (output dtype), StT (state dtype), CONV_DIM, KERNEL_SIZE
 // Inputs: input, conv_state_in, weights, slot_mapping, num_requests
 // Outputs: output, conv_state_out
 // Grid: (num_requests * CONV_DIM, 1, 1) — one thread per (request, channel)

--- a/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_prefill.metal
+++ b/vllm_metal/metal/kernels_v2/gdn_conv1d_silu_prefill.metal
@@ -1,4 +1,4 @@
-// Template params: T (output/input dtype), StT (state dtype), CONV_DIM, KERNEL_SIZE
+// Template params: T (output dtype), StT (state dtype), CONV_DIM, KERNEL_SIZE
 // Inputs: input, conv_state_in, weights, cu_seqlens, slot_mapping, num_requests, total_tokens
 // Outputs: output, conv_state_out
 // Grid: ((total_tokens + num_requests * (KERNEL_SIZE - 1)) * CONV_DIM, 1, 1)

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -513,31 +513,6 @@ class MetalPlatform(Platform):
 
         if model_config is not None and model_config.is_hybrid:
             cache_config = vllm_config.cache_config
-            is_shortconv = getattr(model_config.hf_config, "model_type", None) in (
-                "lfm2",
-                "lfm2_moe",
-            )
-            if (
-                is_shortconv
-                and cache_config.mamba_cache_dtype != "auto"
-                and cache_config.mamba_cache_dtype
-                != str(model_config.dtype).removeprefix("torch.")
-            ):
-                raise NotImplementedError(
-                    "ShortConv state on Metal uses the model dtype; "
-                    "--mamba-cache-dtype must be auto or match --dtype."
-                )
-            # ShortConv has only a model-dtype convolution tail. The fp32
-            # requirement belongs to families with recurrent SSM state.
-            if not is_shortconv:
-                if cache_config.mamba_ssm_cache_dtype == "auto":
-                    cache_config.mamba_ssm_cache_dtype = "float32"
-                elif cache_config.mamba_ssm_cache_dtype != "float32":
-                    raise NotImplementedError(
-                        "Hybrid models on Metal require "
-                        "--mamba-ssm-cache-dtype float32 because recurrent state is "
-                        "stored in fp32."
-                    )
             if cache_config.mamba_cache_mode == "all":
                 # Before the downgrades below, which overwrite the mode: an
                 # explicit --mamba-cache-mode all must fail fast on every path.

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -392,7 +392,7 @@ class ModelCachePolicy:
 
         if self._runner.is_hybrid:
             hybrid_plan = self._hybrid_plan()
-            state_spec = self._state_layer_spec(hybrid_plan, torch_dtype)
+            state_spec = self._state_layer_spec(hybrid_plan)
             for layer_idx in range(num_spec_layers):
                 if hybrid_plan.layers.is_state_layer(layer_idx):
                     specs[f"layers.{layer_idx}.{hybrid_plan.family.layer_name}"] = (
@@ -409,16 +409,13 @@ class ModelCachePolicy:
         )
         return specs
 
-    def _state_layer_spec(
-        self, hybrid_plan: HybridRuntimePlan, torch_dtype: torch.dtype
-    ) -> MambaSpec:
+    def _state_layer_spec(self, hybrid_plan: HybridRuntimePlan) -> MambaSpec:
         """Build the scheduler-visible spec shared by every state layer."""
         cache_config = self._runner.cache_config
         mamba_block_size = cache_config.mamba_block_size
         # Upstream resolves this during config setup and asserts it here.
         assert mamba_block_size is not None
         return hybrid_plan.state_cache_spec(
-            conv_dtype=torch_dtype,
             mamba_block_size=mamba_block_size,
             page_size_padded=cache_config.mamba_page_size_padded,
             mamba_cache_mode=cache_config.mamba_cache_mode,
@@ -896,25 +893,18 @@ class ModelCachePolicy:
         if not self._runner.is_hybrid:
             raise RuntimeError("linear_cache_bytes_per_slot() requires a hybrid model")
         hybrid_plan = self._hybrid_plan()
-        return hybrid_plan.layers.num_state * hybrid_plan.state_bytes_per_layer(
-            self._require_kv_cache_dtype().size
-        )
+        return hybrid_plan.layers.num_state * hybrid_plan.state_bytes_per_layer()
 
     def hybrid_align_state_bytes_per_block(self) -> int:
         """Per-pool-block linear-state bytes under align-mode prefix caching."""
         hybrid_plan = self._hybrid_plan()
         layer_plan = hybrid_plan.layers
         pools = _align_state_pool_count(layer_plan.num_state, layer_plan.num_attention)
-        return (
-            hybrid_plan.state_bytes_per_layer(self._require_kv_cache_dtype().size)
-            * pools
-        )
+        return hybrid_plan.state_bytes_per_layer() * pools
 
     def hybrid_align_growth_bytes_per_block(self) -> int:
         """One old physical state pool retained during align-cache growth."""
-        return self._hybrid_plan().state_bytes_per_layer(
-            self._require_kv_cache_dtype().size
-        )
+        return self._hybrid_plan().state_bytes_per_layer()
 
     def build_paged_attention_runtime(
         self, *, block_size: int
@@ -1018,9 +1008,7 @@ class ModelCachePolicy:
         padded = self._runner.cache_config.mamba_page_size_padded
         if padded is not None:
             return padded
-        return self._hybrid_plan().state_bytes_per_layer(
-            self._require_kv_cache_dtype().size
-        )
+        return self._hybrid_plan().state_bytes_per_layer()
 
     def _build_hybrid_backend(self, block_size: int) -> HybridPagedAttentionRuntime:
         config = get_config()

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -12,7 +12,6 @@ import torch
 from mlx_lm import load as mlx_lm_load
 from mlx_vlm import load as mlx_vlm_load
 from vllm.logger import init_logger
-from vllm.model_executor.models import ModelRegistry
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
@@ -496,7 +495,7 @@ class ModelLifecycle:
         """Resolve the state family that owns this model's hybrid layers."""
         if self._runner.is_hybrid:
             model_config = self._runner.model_config
-            model_cls, _ = ModelRegistry.resolve_model_cls(
+            model_cls, _ = model_config.registry.resolve_model_cls(
                 model_config.architecture, model_config=model_config
             )
             self._runner.hybrid_runtime_plan = build_hybrid_runtime_plan(

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -12,6 +12,7 @@ import torch
 from mlx_lm import load as mlx_lm_load
 from mlx_vlm import load as mlx_vlm_load
 from vllm.logger import init_logger
+from vllm.model_executor.models import ModelRegistry
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
@@ -494,8 +495,14 @@ class ModelLifecycle:
     def _install_hybrid_state_plan(self, args: dict[str, Any]) -> None:
         """Resolve the state family that owns this model's hybrid layers."""
         if self._runner.is_hybrid:
+            model_config = self._runner.model_config
+            model_cls, _ = ModelRegistry.resolve_model_cls(
+                model_config.architecture, model_config=model_config
+            )
             self._runner.hybrid_runtime_plan = build_hybrid_runtime_plan(
-                args, self._runner.num_layers
+                args,
+                self._runner.num_layers,
+                model_cls.get_mamba_state_dtype_from_config(self._runner.vllm_config),
             )
 
     def _install_runtime_extensions(

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -498,11 +498,19 @@ class ModelLifecycle:
             model_cls, _ = model_config.registry.resolve_model_cls(
                 model_config.architecture, model_config=model_config
             )
-            self._runner.hybrid_runtime_plan = build_hybrid_runtime_plan(
+            plan = build_hybrid_runtime_plan(
                 args,
                 self._runner.num_layers,
                 model_cls.get_mamba_state_dtype_from_config(self._runner.vllm_config),
             )
+            if plan.family.label == "gdn":
+                conv, ssm = plan.state_dtypes
+                if ssm != torch.float32 and not (model_config.dtype == conv == ssm):
+                    raise ValueError(
+                        "GDN requires matching model/cache dtypes or "
+                        "--mamba-ssm-cache-dtype float32."
+                    )
+            self._runner.hybrid_runtime_plan = plan
 
     def _install_runtime_extensions(
         self,


### PR DESCRIPTION
Follow-up to #598. Reuse vLLM's resolved hybrid state dtypes for cache sizing and allocation (inspired by #699), replacing local model-specific rules. GDN fallback rejects dtype combinations it cannot update in place.

