### PR TITLE
[Bugfix] preserve model revisions across Metal loading paths

### DIFF
--- a/tests/quant/test_awq_e2e_dense_matrix.py
+++ b/tests/quant/test_awq_e2e_dense_matrix.py
@@ -70,6 +70,7 @@ _DENSE_AWQ_MATRIX = [
 def _runner_model_config(repo: str, *, dtype):
     return SimpleNamespace(
         model=repo,
+        revision=None,
         hf_config=None,
         is_multimodal_model=False,
         trust_remote_code=False,

--- a/tests/quant/test_awq_e2e_qwen25_15b.py
+++ b/tests/quant/test_awq_e2e_qwen25_15b.py
@@ -42,6 +42,7 @@ _AWQ_REPO = "Qwen/Qwen2.5-1.5B-Instruct-AWQ"
 def _runner_model_config(*, dtype):
     return SimpleNamespace(
         model=_AWQ_REPO,
+        revision=None,
         hf_config=None,
         is_multimodal_model=False,
         trust_remote_code=False,

--- a/tests/quant/test_awq_loader.py
+++ b/tests/quant/test_awq_loader.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import Mock
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -46,6 +47,24 @@ def _write_config(tmp_path: Path, config: dict) -> Path:
 
 class TestConfigDetection:
     """``AWQQuantLoader.for_model``: detection, accept, decline, reject."""
+
+    @pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
+    def test_revision_reaches_config_and_weight_loaders(
+        self, monkeypatch, tmp_path, revision
+    ):
+        config_dir = _write_config(tmp_path, {"quantization_config": _AWQ_INNER})
+        download = Mock(return_value=str(config_dir / "config.json"))
+        load = Mock(return_value=(nn.Module(), None))
+        monkeypatch.setattr("vllm_metal.quant.awq_loader.hf_hub_download", download)
+        monkeypatch.setattr("vllm_metal.quant.awq_loader.mlx_lm_load", load)
+
+        loader = AWQQuantLoader.for_model("org/model", revision=revision)
+        assert loader is not None
+        loader.load("org/model", target_dtype=mx.float16, revision=revision)
+
+        download.assert_called_once_with("org/model", "config.json", revision=revision)
+        load.assert_called_once()
+        assert load.call_args.kwargs["revision"] == revision
 
     def test_returns_none_for_non_awq(self, tmp_path):
         """Non-AWQ checkpoints get None back, no exception."""

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -12,11 +12,15 @@ real scheduler.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import mlx.core as mx
 import pytest
 from vllm.sampling_params import SamplingParams
 
 from vllm_metal.attention.context import OffsetCache, get_context
+from vllm_metal.v1 import draft_model_proposer
 from vllm_metal.v1.draft_model_proposer import DraftModelProposer
 from vllm_metal.v1.model_runner import PrefillRequest, RequestState
 from vllm_metal.v1.proposer import ProposeContext
@@ -28,6 +32,23 @@ COMMITTED_NUM_BLOCKS = 2
 SCRATCH_RESERVE_BLOCKS = 2
 VOCAB_SIZE = 64
 PROMPT_LEN = 20
+
+
+@pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
+def test_draft_load_preserves_revision(monkeypatch, revision):
+    dims, model = object(), object()
+    config = SimpleNamespace(
+        draft_model_config=SimpleNamespace(model="org/draft", revision=revision)
+    )
+    monkeypatch.setattr(draft_model_proposer, "resolve_draft_dims", lambda *_: dims)
+    resolve_path = Mock(return_value="org/draft")
+    load = Mock(return_value=(model, None))
+    monkeypatch.setattr(draft_model_proposer, "get_model_download_path", resolve_path)
+    monkeypatch.setattr(draft_model_proposer, "mlx_lm_load", load)
+
+    assert draft_model_proposer._load_draft_model(config, None) == (model, dims)
+    resolve_path.assert_called_once_with("org/draft", revision=revision)
+    load.assert_called_once_with("org/draft", revision=revision)
 
 
 class _StubDraftModel:

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -9,6 +9,7 @@ import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -169,6 +170,46 @@ def _make_lifecycle(
 
 
 class TestModelLifecycle:
+    @pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
+    @pytest.mark.parametrize("backend", ["text", "vlm", "awq"])
+    def test_generation_load_preserves_revision(
+        self, monkeypatch: pytest.MonkeyPatch, revision: str | None, backend: str
+    ) -> None:
+        model, tokenizer = object(), object()
+        loader = Mock(return_value=(model, tokenizer))
+        awq_loader = SimpleNamespace(load=loader) if backend == "awq" else None
+        detect_awq = Mock(return_value=awq_loader)
+        monkeypatch.setattr(model_lifecycle.AWQQuantLoader, "for_model", detect_awq)
+        monkeypatch.setattr(model_lifecycle, "mlx_lm_load", loader)
+        monkeypatch.setattr(model_lifecycle, "mlx_vlm_load", loader)
+        resolve_path = Mock(return_value="org/model")
+        monkeypatch.setattr(model_lifecycle, "get_model_download_path", resolve_path)
+        lifecycle, runner = _make_lifecycle(
+            model_config=_runner_model_config(
+                model="org/model",
+                revision=revision,
+                is_multimodal_model=backend == "vlm",
+            )
+        )
+        request = GenerationLoadRequest.from_runner(
+            runner, SimpleNamespace(should_force_text_backbone=lambda _: False)
+        )
+
+        result = lifecycle._load_generation_model(
+            request.model_name,
+            request.is_vlm,
+            model_config=request.model_config,
+            target_dtype=request.target_dtype,
+        )
+
+        assert result == (model, tokenizer)
+        resolve_path.assert_called_once_with("org/model", revision=revision)
+        loader.assert_called_once()
+        assert loader.call_args.args == ("org/model",)
+        assert loader.call_args.kwargs["revision"] == revision
+        if backend != "vlm":
+            detect_awq.assert_called_once_with("org/model", revision=revision)
+
     def test_private_mlx_lm_compatible_model_path_adapts_indexed_custom_shards(
         self, tmp_path: Path
     ) -> None:
@@ -313,7 +354,7 @@ class TestModelLifecycle:
         captured: dict[str, object] = {}
 
         def _fake_load(
-            path: str, *, tokenizer_config: object, lazy: bool
+            path: str, *, tokenizer_config: object, lazy: bool, revision: str | None
         ) -> tuple[object, object]:
             captured["lazy"] = lazy
             return object(), object()
@@ -490,7 +531,7 @@ class TestModelLifecycle:
 
         class _StubAWQLoader:
             @classmethod
-            def for_model(cls, _model_name: str) -> None:
+            def for_model(cls, _model_name: str, *, revision: str | None) -> None:
                 return None
 
         def _load_text(
@@ -498,6 +539,7 @@ class TestModelLifecycle:
             *,
             tokenizer_config: object,
             lazy: bool,
+            revision: str | None,
         ) -> tuple[object, object]:
             return text_model, text_tokenizer
 
@@ -524,7 +566,9 @@ class TestModelLifecycle:
         vlm_tokenizer = object()
         vlm_lazy: list[bool] = []
 
-        def _load_vlm(_model_name: str, *, lazy: bool) -> tuple[object, object]:
+        def _load_vlm(
+            _model_name: str, *, lazy: bool, revision: str | None
+        ) -> tuple[object, object]:
             vlm_lazy.append(lazy)
             return vlm_model, vlm_tokenizer
 
@@ -877,7 +921,9 @@ class TestModelLifecycle:
 
         class _StubAWQLoader:
             @classmethod
-            def for_model(cls, _model_name: str) -> _StubAWQLoader | None:
+            def for_model(
+                cls, _model_name: str, *, revision: str | None
+            ) -> _StubAWQLoader | None:
                 return cls() if is_awq else None
 
             def load(
@@ -886,6 +932,7 @@ class TestModelLifecycle:
                 *,
                 target_dtype: object,
                 tokenizer_config: dict[str, object] | None,
+                revision: str | None,
             ) -> tuple[object, object]:
                 awq_load_calls.append(
                     {
@@ -1040,7 +1087,7 @@ class TestModelLifecycle:
 
         class _StubAWQLoader:
             @classmethod
-            def for_model(cls, _model_name: str) -> None:
+            def for_model(cls, _model_name: str, *, revision: str | None) -> None:
                 return None
 
         monkeypatch.setitem(sys.modules, "gguf", None)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -61,6 +61,7 @@ class TestMetalPlatform:
     ) -> VllmConfig:
         """Build the upstream DTOs without re-entering the platform hook."""
         model_fields = vars(model_config) if model_config is not None else {}
+        model_fields.setdefault("revision", None)
         max_model_len = int(model_fields.get("max_model_len", 2048))
         cache = (
             cache_config
@@ -102,14 +103,21 @@ class TestMetalPlatform:
         self,
         monkeypatch: pytest.MonkeyPatch,
         is_stt: bool,
+        expected_revision: str | None = None,
     ) -> None:
+        def resolve(model, *, revision):
+            assert revision == expected_revision
+            return model
+
+        def detect(_model, *, revision):
+            assert revision == expected_revision
+            return is_stt
+
         monkeypatch.setattr(
             "vllm_metal.utils.get_model_download_path",
-            lambda model: model,
+            resolve,
         )
-        monkeypatch.setattr(
-            "vllm_metal.stt.detection.is_stt_model", lambda _model: is_stt
-        )
+        monkeypatch.setattr("vllm_metal.stt.detection.is_stt_model", detect)
 
     def test_device_name(self) -> None:
         """Test device name retrieval."""
@@ -343,15 +351,16 @@ class TestMetalPlatform:
         with pytest.raises(NotImplementedError, match="speculative decoding"):
             MetalPlatform.check_and_update_config(vllm_config)
 
+    @pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
     def test_check_and_update_config_rejects_pipeline_with_stt(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, revision: str | None
     ) -> None:
         """PP>1 with an STT model is rejected at config time.
 
         STT checkpoints use a dedicated runner with no pipeline-split path, so
         reject before any worker spawns rather than fail after startup.
         """
-        self._patch_stt_resolution(monkeypatch, is_stt=True)
+        self._patch_stt_resolution(monkeypatch, is_stt=True, expected_revision=revision)
         vllm_config = self._platform_config(
             cache_config=SimpleNamespace(kv_cache_dtype_skip_layers=[]),
             parallel_config=SimpleNamespace(
@@ -363,6 +372,7 @@ class TestMetalPlatform:
             ),
             model_config=SimpleNamespace(
                 model="openai/whisper-tiny",
+                revision=revision,
                 disable_cascade_attn=False,
                 tokenizer=None,
                 multimodal_config=None,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for shared Metal utilities."""
 
-import mlx.core as mx
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
 
-from vllm_metal.utils import set_wired_limit
+import mlx.core as mx
+import pytest
+
+from vllm_metal.utils import get_model_download_path, set_wired_limit
+
+
+@pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
+def test_modelscope_download_preserves_revision(monkeypatch, revision):
+    monkeypatch.setattr("vllm.envs.VLLM_USE_MODELSCOPE", True)
+    monkeypatch.setenv("VLLM_METAL_MODELSCOPE_CACHE", "/model-cache")
+    download = Mock(return_value="/model-cache/snapshot")
+    monkeypatch.setitem(
+        sys.modules,
+        "modelscope.hub.snapshot_download",
+        SimpleNamespace(snapshot_download=download),
+    )
+
+    assert (
+        get_model_download_path("org/model", revision=revision)
+        == "/model-cache/snapshot"
+    )
+    kwargs = {"revision": revision} if revision is not None else {}
+    download.assert_called_once_with("org/model", cache_dir="/model-cache", **kwargs)
+
+
+def test_local_model_path_is_preserved(tmp_path):
+    assert get_model_download_path(str(tmp_path), revision="release-tag") == str(
+        tmp_path
+    )
 
 
 def test_set_wired_limit_uses_pinned_mlx_api(monkeypatch) -> None:

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -393,18 +395,39 @@ class TestSTTRunnerWorkerContract:
         bound = STTModelRunner.supported_worker_tasks.__get__(runner)
         assert bound() == ("transcription",)
 
+    @pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
+    @pytest.mark.parametrize("source", ["huggingface", "modelscope", "local"])
     def test_load_model_wires_model_and_adapter(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path, revision, source
     ) -> None:
+        import vllm_metal.stt.loader as loader
         import vllm_metal.v1.stt_model_runner as smr
+        from vllm_metal.stt.detection import is_stt_model
 
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "whisper"}))
+        model_name = str(tmp_path) if source == "local" else "org/model"
+        download = MagicMock(return_value=str(tmp_path))
+        config_download = MagicMock(return_value=str(tmp_path / "config.json"))
+        monkeypatch.setattr("huggingface_hub.snapshot_download", download)
+        monkeypatch.setattr("vllm_metal.stt.detection.hf_hub_download", config_download)
+        monkeypatch.setattr("vllm.envs.VLLM_USE_MODELSCOPE", source == "modelscope")
+        monkeypatch.setenv("VLLM_METAL_MODELSCOPE_CACHE", "/model-cache")
+        monkeypatch.setitem(
+            sys.modules,
+            "modelscope.hub.snapshot_download",
+            SimpleNamespace(snapshot_download=download),
+        )
         adapter = object()
-        fake_model = SimpleNamespace(create_runtime_adapter=lambda _name: adapter)
-        monkeypatch.setattr(smr, "load_stt_model", lambda _name: fake_model)
-        monkeypatch.setattr(smr, "get_model_download_path", lambda _m: "resolved-path")
+        fake_model = SimpleNamespace(
+            create_runtime_adapter=MagicMock(return_value=adapter)
+        )
+        constructor = MagicMock(return_value=fake_model)
+        monkeypatch.setattr(loader, "get_stt_model_constructor", lambda _: constructor)
+        load_weights = MagicMock(return_value=fake_model)
+        monkeypatch.setattr(loader, "_load_and_init_model", load_weights)
 
         vllm_config = SimpleNamespace(
-            model_config=SimpleNamespace(model="some-model"),
+            model_config=SimpleNamespace(model=model_name, revision=revision),
             cache_config=SimpleNamespace(),
             scheduler_config=SimpleNamespace(),
         )
@@ -414,6 +437,28 @@ class TestSTTRunnerWorkerContract:
         assert runner.model is fake_model
         assert runner.tokenizer is None
         assert runner._stt_runtime_adapter is adapter
+        fake_model.create_runtime_adapter.assert_called_once_with(str(tmp_path))
+        load_weights.assert_called_once_with(
+            fake_model, tmp_path, {"model_type": "whisper"}
+        )
+        if source == "huggingface":
+            download.assert_called_once_with(repo_id=model_name, revision=revision)
+        elif source == "modelscope":
+            kwargs = {"revision": revision} if revision is not None else {}
+            download.assert_called_once_with(
+                model_name, cache_dir="/model-cache", **kwargs
+            )
+        else:
+            download.assert_not_called()
+
+        detection_path = model_name if source == "huggingface" else str(tmp_path)
+        assert is_stt_model(detection_path, revision=revision)
+        if source == "huggingface":
+            config_download.assert_called_once_with(
+                repo_id=model_name, filename="config.json", revision=revision
+            )
+        else:
+            config_download.assert_not_called()
 
 
 class TestWhisperRuntimeAdapterTranscriberCaching:

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -40,6 +40,35 @@ def _make_worker(model_runner: object, *, use_paged_attention: bool) -> MetalWor
 class TestWorkerRunnerBoundaryDelegation:
     """Worker should honor model runner memory-reporting modes."""
 
+    @pytest.mark.parametrize("revision", [None, "release-tag", "a" * 40])
+    def test_init_device_preserves_stt_revision(self, monkeypatch, revision) -> None:
+        from vllm_metal.v1 import worker as worker_module
+        from vllm_metal.v1.stt_model_runner import STTModelRunner
+
+        worker = _make_worker(None, use_paged_attention=False)
+        worker.model_config = SimpleNamespace(
+            model="org/model", revision=revision, seed=0
+        )
+        worker.vllm_config.model_config = worker.model_config
+        worker.vllm_config.scheduler_config = SimpleNamespace()
+        worker.parallel_config = SimpleNamespace(pipeline_parallel_size=1)
+        worker.rank = worker.local_rank = 0
+        worker.distributed_init_method = "unused"
+        monkeypatch.setattr(worker_module, "set_wired_limit", lambda: None)
+        monkeypatch.setattr(
+            worker_module, "init_worker_distributed_environment", lambda *_: None
+        )
+        resolve = MagicMock(return_value="org/model")
+        detect = MagicMock(return_value=True)
+        monkeypatch.setattr("vllm_metal.utils.get_model_download_path", resolve)
+        monkeypatch.setattr("vllm_metal.stt.detection.is_stt_model", detect)
+
+        worker.init_device()
+
+        assert isinstance(worker.model_runner, STTModelRunner)
+        resolve.assert_called_once_with("org/model", revision=revision)
+        detect.assert_called_once_with("org/model", revision=revision)
+
     def test_determine_available_memory_stt_nominal_mode(self) -> None:
         model_runner = SimpleNamespace(
             scheduler_memory_reporting_mode=MagicMock(return_value="stt_nominal"),

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -779,11 +779,13 @@ class MetalPlatform(Platform):
         from vllm_metal.utils import get_model_download_path
 
         resolved_model = (
-            get_model_download_path(model_config.model)
+            get_model_download_path(model_config.model, revision=model_config.revision)
             if model_config is not None
             else None
         )
-        if resolved_model is not None and is_stt_model(resolved_model):
+        if resolved_model is not None and is_stt_model(
+            resolved_model, revision=model_config.revision
+        ):
             # STT checkpoints use a dedicated STTModelRunner with no pipeline-
             # split path. Reject PP here, with the other config-time PP guards,
             # before any worker spawns.

--- a/vllm_metal/quant/awq_loader.py
+++ b/vllm_metal/quant/awq_loader.py
@@ -62,7 +62,9 @@ class AWQQuantLoader:
         }
 
     @classmethod
-    def for_model(cls, model_name: str) -> AWQQuantLoader | None:
+    def for_model(
+        cls, model_name: str, *, revision: str | None = None
+    ) -> AWQQuantLoader | None:
         """Detect AWQ in ``model_name``'s ``config.json`` (local dir or HF
         Hub) and return a configured loader. Returns ``None`` when the
         checkpoint has no quantization config or uses a quant method
@@ -78,7 +80,7 @@ class AWQQuantLoader:
             UnsupportedQuantizationConfigError: AWQ but outside v1 scope,
                 or GPTQ (not yet validated for vllm-metal).
         """
-        raw_qc = cls._read_raw_quantization_config(model_name)
+        raw_qc = cls._read_raw_quantization_config(model_name, revision=revision)
         if raw_qc is None:
             return None
         quant_method = raw_qc.get("quant_method")
@@ -98,6 +100,7 @@ class AWQQuantLoader:
         *,
         target_dtype: Any,
         tokenizer_config: Mapping[str, Any] | None = None,
+        revision: str | None = None,
     ) -> tuple[Any, Any]:
         """Run ``mlx_lm.load`` with the normalized quant config, then align
         non-quantized floating params to ``target_dtype``.
@@ -110,6 +113,7 @@ class AWQQuantLoader:
             model_path,
             tokenizer_config=dict(tokenizer_config) if tokenizer_config else None,
             model_config=self._mlx_lm_model_config,
+            revision=revision,
         )
         n_cast = self._align_non_quantized_dtypes(model, target_dtype)
         logger.info(
@@ -122,7 +126,9 @@ class AWQQuantLoader:
     # -- private helpers (owned by the loader, not module-level) -----------
 
     @staticmethod
-    def _read_raw_quantization_config(model_name: str) -> Mapping[str, Any] | None:
+    def _read_raw_quantization_config(
+        model_name: str, *, revision: str | None = None
+    ) -> Mapping[str, Any] | None:
         """Read ``quantization_config`` from the model's ``config.json``
         without invoking ``mlx_lm.load``. Returns ``None`` if the field is
         absent (the checkpoint genuinely is not quantized) or the local
@@ -148,7 +154,9 @@ class AWQQuantLoader:
             if not config_path.is_file():
                 return None
         else:
-            config_path = Path(hf_hub_download(model_name, "config.json"))
+            config_path = Path(
+                hf_hub_download(model_name, "config.json", revision=revision)
+            )
         with open(config_path, encoding="utf-8") as fid:
             config = json.load(fid)
         qc = config.get("quantization_config")

--- a/vllm_metal/stt/detection.py
+++ b/vllm_metal/stt/detection.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)
 _STT_MODEL_TYPES = frozenset({"whisper", "qwen3_asr"})
 
 
-def _resolve_config_file(model_path: str) -> Path | None:
+def _resolve_config_file(
+    model_path: str, *, revision: str | None = None
+) -> Path | None:
     """Return local or downloaded config.json path for *model_path*."""
     p = Path(model_path)
     if p.is_dir():
@@ -35,7 +37,11 @@ def _resolve_config_file(model_path: str) -> Path | None:
         return None
 
     try:
-        return Path(hf_hub_download(repo_id=model_path, filename="config.json"))
+        return Path(
+            hf_hub_download(
+                repo_id=model_path, filename="config.json", revision=revision
+            )
+        )
     except (OSError, ValueError) as exc:
         logger.debug("Failed to download config.json for %s: %s", model_path, exc)
         return None
@@ -57,13 +63,13 @@ def _read_model_type(config_file: Path) -> str | None:
     return model_type.lower()
 
 
-def is_stt_model(model_path: str) -> bool:
+def is_stt_model(model_path: str, *, revision: str | None = None) -> bool:
     """Return True when *model_path* resolves to a known STT model type.
 
     Detection is based on ``model_type`` in the model's ``config.json``.
     Falls back to ``False`` if the config cannot be read.
     """
-    config_file = _resolve_config_file(model_path)
+    config_file = _resolve_config_file(model_path, revision=revision)
     if config_file is None:
         return False
     model_type = _read_model_type(config_file)

--- a/vllm_metal/stt/loader.py
+++ b/vllm_metal/stt/loader.py
@@ -11,6 +11,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from vllm_metal.stt.registry import get_stt_model_constructor
+from vllm_metal.utils import get_model_download_path
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,12 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_LOAD_DTYPES = frozenset({mx.float16, mx.float32, mx.bfloat16})
 
 
-def load_model(model_path: str | Path, dtype: mx.Dtype = mx.float16):
+def load_model(
+    model_path: str | Path,
+    dtype: mx.Dtype = mx.float16,
+    *,
+    revision: str | None = None,
+):
     """Load an STT model from a local directory or HuggingFace repo."""
     if isinstance(model_path, str) and not model_path.strip():
         raise ValueError(
@@ -26,7 +32,7 @@ def load_model(model_path: str | Path, dtype: mx.Dtype = mx.float16):
         )
     _validate_load_dtype(dtype)
 
-    resolved_model_path = _resolve_model_path(model_path)
+    resolved_model_path = resolve_model_path(model_path, revision=revision)
     config_dict = _read_config(resolved_model_path)
     model_type = config_dict.get("model_type", "").lower()
 
@@ -67,9 +73,9 @@ def _load_weights(model_path: Path) -> dict[str, mx.array]:
     return weights
 
 
-def _resolve_model_path(model_path: str | Path) -> Path:
-    """Resolve model path, downloading from HF if needed."""
-    model_path = Path(model_path)
+def resolve_model_path(model_path: str | Path, *, revision: str | None = None) -> Path:
+    """Resolve a local snapshot for STT weights and tokenizer assets."""
+    model_path = Path(get_model_download_path(str(model_path), revision=revision))
     if model_path.exists():
         return model_path
 
@@ -81,7 +87,7 @@ def _resolve_model_path(model_path: str | Path) -> Path:
         ) from e
 
     try:
-        return Path(snapshot_download(repo_id=str(model_path)))
+        return Path(snapshot_download(repo_id=str(model_path), revision=revision))
     except OSError as e:
         raise ValueError(f"Could not download model: {model_path}") from e
 

--- a/vllm_metal/utils.py
+++ b/vllm_metal/utils.py
@@ -7,7 +7,9 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def get_model_download_path(model_repo_name: str) -> str:
+def get_model_download_path(
+    model_repo_name: str, *, revision: str | None = None
+) -> str:
     """
     Get the path to the model, downloading from ModelScope if configured, otherwise will pass the model_repo_name.
 
@@ -16,6 +18,7 @@ def get_model_download_path(model_repo_name: str) -> str:
 
     Args:
         model_repo_name: Model repo name from HuggingFace or ModelScope
+        revision: Requested ModelScope revision; HuggingFace loaders receive it separately.
 
     Returns:
         Local folder path (string) of repo snapshot
@@ -42,7 +45,11 @@ def get_model_download_path(model_repo_name: str) -> str:
             model_cache_dir = envs.VLLM_METAL_MODELSCOPE_CACHE
 
             logger.info(f"Downloading model {model_repo_name} from ModelScope...")
-            model_path = snapshot_download(model_repo_name, cache_dir=model_cache_dir)
+            model_path = snapshot_download(
+                model_repo_name,
+                cache_dir=model_cache_dir,
+                **({"revision": revision} if revision is not None else {}),
+            )
             logger.info(f"Model downloaded to {model_path}")
             return str(model_path)
         except ImportError:

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -766,8 +766,12 @@ def _load_draft_model(
     # Its own instance (patched to its own draft KV cache, so it must not alias
     # the target). AWQ / variable-head-dim drafts aren't handled here yet
     # (canonical loader: ModelLifecycle._load_generation_model).
-    model_path = get_model_download_path(draft_model_config.model)
+    model_path = get_model_download_path(
+        draft_model_config.model, revision=draft_model_config.revision
+    )
     with mlx_lm_compatible_model_path(model_path) as compatible_path:
-        model, _ = mlx_lm_load(str(compatible_path))
+        model, _ = mlx_lm_load(
+            str(compatible_path), revision=draft_model_config.revision
+        )
 
     return model, dims

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -112,7 +112,9 @@ class GenerationLoadRequest:
             model_name=(
                 gguf_source.weights_path
                 if gguf_source is not None
-                else get_model_download_path(model_config.model)
+                else get_model_download_path(
+                    model_config.model, revision=model_config.revision
+                )
             ),
             model_config=model_config,
             hf_config=hf_config,
@@ -276,7 +278,12 @@ class ModelLifecycle:
                 self._runner.vllm_config.load_config,
             )
         is_gguf = gguf_source is not None
-        awq_loader = None if is_gguf or is_vlm else AWQQuantLoader.for_model(model_name)
+        revision = model_config.revision
+        awq_loader = (
+            None
+            if is_gguf or is_vlm
+            else AWQQuantLoader.for_model(model_name, revision=revision)
+        )
 
         if is_gguf:
             load_label = "GGUF model"
@@ -288,7 +295,9 @@ class ModelLifecycle:
 
         elif is_vlm:
             load_label = "MLX-VLM model"
-            model, tokenizer = mlx_vlm_load(model_name, lazy=lazy_weights)
+            model, tokenizer = mlx_vlm_load(
+                model_name, lazy=lazy_weights, revision=revision
+            )
 
         elif awq_loader is not None:
             load_label = "AWQ model"
@@ -297,6 +306,7 @@ class ModelLifecycle:
                 awq_loader,
                 target_dtype,
                 tokenizer_config,
+                revision=revision,
             )
 
         else:
@@ -305,6 +315,7 @@ class ModelLifecycle:
                 model_name,
                 tokenizer_config,
                 lazy=lazy_weights,
+                revision=revision,
             )
 
         loaded_from = (
@@ -342,12 +353,15 @@ class ModelLifecycle:
         awq_loader: AWQQuantLoader,
         target_dtype: Any,
         tokenizer_config: Mapping[str, Any],
+        *,
+        revision: str | None = None,
     ) -> tuple[Any, Any]:
         with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
             return awq_loader.load(
                 str(compatible_model_name),
                 target_dtype=target_dtype,
                 tokenizer_config=tokenizer_config,
+                revision=revision,
             )
 
     def _load_mlx_lm_text_model(
@@ -356,12 +370,14 @@ class ModelLifecycle:
         tokenizer_config: Mapping[str, Any],
         *,
         lazy: bool = False,
+        revision: str | None = None,
     ) -> tuple[Any, Any]:
         with _mlx_lm_compatible_model_path(model_name) as compatible_model_name:
             model, tokenizer = mlx_lm_load(
                 str(compatible_model_name),
                 tokenizer_config=tokenizer_config,
                 lazy=lazy,
+                revision=revision,
             )
         return model, tokenizer
 

--- a/vllm_metal/v1/stt_model_runner.py
+++ b/vllm_metal/v1/stt_model_runner.py
@@ -30,10 +30,10 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.outputs import DraftTokenIds, ModelRunnerOutput
 
+from vllm_metal.stt.loader import resolve_model_path
 from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES, STT_SCHED_NOMINAL_HEAD_SIZE
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.serve import VLLMSTTRequestAdapter
-from vllm_metal.utils import get_model_download_path
 from vllm_metal.v1.model_lifecycle import load_stt_model
 
 logger = init_logger(__name__)
@@ -63,7 +63,11 @@ class STTModelRunner:
 
     def load_model(self) -> None:
         """Load the STT model and build its per-model runtime adapter."""
-        model_name = get_model_download_path(self.model_config.model)
+        model_name = str(
+            resolve_model_path(
+                self.model_config.model, revision=self.model_config.revision
+            )
+        )
         model = load_stt_model(model_name)
         self.model = model
         self.tokenizer = None

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -177,7 +177,11 @@ class MetalWorker(WorkerBase):
         from vllm_metal.stt.detection import is_stt_model
         from vllm_metal.utils import get_model_download_path
 
-        if is_stt_model(get_model_download_path(self.model_config.model)):
+        revision = self.model_config.revision
+        if is_stt_model(
+            get_model_download_path(self.model_config.model, revision=revision),
+            revision=revision,
+        ):
             from vllm_metal.v1.stt_model_runner import STTModelRunner
 
             self.model_runner = STTModelRunner(


### PR DESCRIPTION
Forward requested revisions to text, multimodal, AWQ, draft-model, and ModelScope loaders. Keep AWQ config detection on the same revision as weight loading.