### PR TITLE
[GGUF] Fail fast on local sharded GGUF files

### DIFF
--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -181,6 +181,12 @@ def _gguf_module_histogram(model: nn.Module) -> dict[str, int]:
     return counts
 
 
+def _assert_dense_wrapper_histogram(model: nn.Module) -> None:
+    hist = _gguf_module_histogram(model)
+    assert hist.get("GGUFEmbedding") == 1
+    assert hist.get("GGUFLinear") == 2 * 7
+
+
 def _assert_forward_vocab_shape(model: nn.Module) -> None:
     out = model(mx.array([[1, 2, 3]]))
     mx.eval(out)
@@ -205,9 +211,7 @@ def test_loads_dense_model_installs_wrappers(
         config_dir=cfg_dir,
         target_dtype=mx.float32,
     ).load()
-    hist = _gguf_module_histogram(model)
-    assert hist.get("GGUFEmbedding") == 1
-    assert hist.get("GGUFLinear") == 2 * 7
+    _assert_dense_wrapper_histogram(model)
     _assert_forward_vocab_shape(model)
 
 
@@ -850,9 +854,7 @@ def test_direct_loader_keeps_quantized_wrappers(tmp_path):
     loader = GGUFModelLoader(gguf_path, config_dir=cfg_dir, target_dtype=mx.float32)
     assert isinstance(loader, GGUFModelLoader)
     model, _ = loader.load()
-    hist = _gguf_module_histogram(model)
-    assert hist.get("GGUFEmbedding") == 1
-    assert hist.get("GGUFLinear") == 2 * 7
+    _assert_dense_wrapper_histogram(model)
 
 
 def test_direct_loader_rejects_remote_reference(tmp_path):
@@ -867,3 +869,40 @@ def test_direct_loader_rejects_missing_config_dir(tmp_path):
     gguf_path, _ = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
     with pytest.raises(GGUFLoadError, match="No config.json"):
         GGUFModelLoader(gguf_path, config_dir=gguf_path, target_dtype=mx.float32).load()
+
+
+@pytest.mark.parametrize(
+    "shard_name",
+    [
+        "qwen3-Q8_0-00001-of-00002.gguf",
+        "qwen3-Q8_0-00002-of-00002.gguf",
+        "qwen3-Q8_0-1-of-2.gguf",
+    ],
+)
+def test_rejects_local_sharded_gguf_before_reading(tmp_path, shard_name):
+    # A dummy payload proves the guard fires on the name, before GGUFReader.
+    shard_path = tmp_path / shard_name
+    shard_path.write_bytes(b"not a gguf payload")
+    expected = (
+        f"Sharded GGUF files are not supported yet: {str(shard_path)!r}; "
+        "pass a single-file .gguf or merge the shards."
+    )
+
+    with pytest.raises(GGUFLoadError) as excinfo:
+        GGUFModelLoader(
+            str(shard_path), config_dir=str(tmp_path), target_dtype=mx.float32
+        ).load()
+
+    assert str(excinfo.value) == expected
+
+
+def test_loads_single_file_set_named_like_one_shard(tmp_path):
+    gguf_path, cfg_dir = _build_dense_fixture(tmp_path, "qwen3", has_qk_norm=True)
+    single = tmp_path / "qwen3-Q8_0-00001-of-00001.gguf"
+    Path(gguf_path).rename(single)
+
+    model, _ = GGUFModelLoader(
+        str(single), config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    _assert_dense_wrapper_histogram(model)

--- a/tests/test_gguf_vllm_integration.py
+++ b/tests/test_gguf_vllm_integration.py
@@ -477,15 +477,24 @@ def test_remote_load_source_downloads_one_matching_gguf(tmp_path, monkeypatch) -
     [
         (
             [],
-            "No 'Q8_0' GGUF file",
+            "No 'Q8_0' GGUF file found in remote repository 'Qwen/Qwen3-0.6B-GGUF'.",
         ),
         (
             ["model-a-Q8_0.gguf", "model-b-Q8_0.gguf"],
-            "matched multiple files",
+            "Remote GGUF reference 'Qwen/Qwen3-0.6B-GGUF:Q8_0' matched "
+            "multiple files: model-a-Q8_0.gguf, model-b-Q8_0.gguf.",
         ),
         (
             ["model-Q8_0-00001-of-00002.gguf"],
-            "Remote sharded GGUF files",
+            "Remote sharded GGUF files are not supported yet: "
+            "'Qwen/Qwen3-0.6B-GGUF:Q8_0'.",
+        ),
+        # Remote selection stays N-agnostic: a lone -00001-of-00001 match is
+        # still rejected here; only the local loader guard admits N==1 sets.
+        (
+            ["model-Q8_0-00001-of-00001.gguf"],
+            "Remote sharded GGUF files are not supported yet: "
+            "'Qwen/Qwen3-0.6B-GGUF:Q8_0'.",
         ),
     ],
 )
@@ -502,8 +511,10 @@ def test_remote_load_source_rejects_unsupported_remote_matches(
     )
     monkeypatch.setattr(gguf_source, "snapshot_download", fail_snapshot_download)
 
-    with pytest.raises(ValueError, match=error):
+    with pytest.raises(ValueError) as excinfo:
         gguf_source.GGUFLoadSource.from_model_config(_remote_gguf_model_config())
+
+    assert str(excinfo.value) == error
 
 
 def test_remote_load_source_rejects_unsupported_qtype_before_download(

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -148,6 +148,12 @@ class GGUFModelLoader:
             or not self._gguf_path.is_file()
         ):
             raise GGUFLoadError(f"Not a local .gguf file: {str(self._gguf_path)!r}")
+        if GGUFLoadSource.is_sharded_weights_path(self._gguf_path.name):
+            raise GGUFLoadError(
+                "Sharded GGUF files are not supported yet: "
+                f"{str(self._gguf_path)!r}; pass a single-file .gguf or merge "
+                "the shards."
+            )
         if not (self._config_dir / "config.json").is_file():
             raise GGUFLoadError(
                 f"No config.json in config_dir {str(self._config_dir)!r}"

--- a/vllm_metal/gguf/source.py
+++ b/vllm_metal/gguf/source.py
@@ -22,7 +22,7 @@ _QUANT_TAG_RE = re.compile(
 )
 _REMOTE_PREFIXES = ("*.", "*-")
 _REMOTE_SUFFIXES = ("-*", "")
-_REMOTE_SHARD_RE = re.compile(r"-\d+-of-\d+\.gguf$")
+_SHARD_NAME_RE = re.compile(r"-\d+-of-(\d+)\.gguf$")
 _SUPPORTED_REMOTE_QTYPES = frozenset({"Q8_0", "Q4_0", "Q4_1"})
 _CONFIG_ALLOW_PATTERNS = ("config.json", "generation_config.json")
 _TOKENIZER_ALLOW_PATTERNS = (
@@ -110,7 +110,7 @@ class RemoteGGUFReference:
                 f"No {self.quant_type!r} GGUF file found in remote repository "
                 f"{self.repo_id!r}."
             )
-        if any(_REMOTE_SHARD_RE.search(filename) for filename in filenames):
+        if any(_SHARD_NAME_RE.search(filename) for filename in filenames):
             raise ValueError(
                 f"Remote sharded GGUF files are not supported yet: {self.value!r}."
             )
@@ -181,6 +181,12 @@ class GGUFLoadSource:
     @staticmethod
     def is_weights_path(value: str) -> bool:
         return value.endswith(_GGUF_SUFFIX)
+
+    @staticmethod
+    def is_sharded_weights_path(value: str) -> bool:
+        # A -00001-of-00001.gguf set is one complete file and loads as such.
+        match = _SHARD_NAME_RE.search(value)
+        return match is not None and int(match.group(1)) > 1
 
     @staticmethod
     def _resolve_companion_source(


### PR DESCRIPTION
Passing one shard of a split GGUF to vllm-metal today loads the whole file and then dies in the completeness check with a confusing "Incomplete GGUF load" error. The remote path already rejects sharded matches before download (#635); the local path had no guard.

This adds one: the loader now rejects shard-named paths like `model-00001-of-00002.gguf` up front, before opening the file. A `-00001-of-00001.gguf` file is one complete file and still loads. Remote selection behavior is unchanged.