### PR TITLE
[Bugfix] [Spec Decoding] Fix the first draft window after prefill

### DIFF
--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -160,7 +160,7 @@ def _prefills_context(
         decode_segments=[],
         decode_token_ids=[],
         prefill_reqs=prefill_reqs,
-        prefill_token_ids=[],
+        prefill_token_ids=[42] * len(prefill_reqs),
         prefill_result_modes=["final"] * len(prefill_reqs),
         request_states={
             req_id: _request_state(committed_block_ids=[0]) for req_id, _ in prefills
@@ -536,29 +536,29 @@ def test_chunked_ingest_forwards_per_chunk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A >16-token cold ingest runs one forward per chunk: a 20-token prompt
-    with a 16-token chunk runs 16 then 4, and the predicted token comes from
-    the final ingested row (position 19), not a chunk boundary."""
+    plus the sampled token runs 16 then 5, and the predicted token comes from
+    the sampled token's row (position 20), not a chunk boundary."""
     monkeypatch.setenv("VLLM_METAL_SPEC_INGEST_CHUNK", "16")
     model = _PositionEncodingDraftModel()
     proposer = _proposer(model)
 
     drafts = proposer.propose(_prefills_context([("r1", list(range(20)))]))
 
-    assert model.input_lens == [16, 4]
+    assert model.input_lens == [16, 5]
     assert drafts is not None
-    assert drafts.draft_token_ids == [[19 % VOCAB_SIZE]]
+    assert drafts.draft_token_ids == [[20 % VOCAB_SIZE]]
 
 
 def test_ingest_chunk_exact_multiple_two_equal_rounds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A 32-token ingest with a 16-token chunk splits 16 / 16; the final
+    """A 31-token prompt plus its sampled token splits 16 / 16; the final
     row of the second round (position 31) predicts."""
     monkeypatch.setenv("VLLM_METAL_SPEC_INGEST_CHUNK", "16")
     model = _PositionEncodingDraftModel()
     proposer = _proposer(model)
 
-    drafts = proposer.propose(_prefills_context([("r1", list(range(32)))]))
+    drafts = proposer.propose(_prefills_context([("r1", list(range(31)))]))
 
     assert model.input_lens == [16, 16]
     assert drafts is not None
@@ -575,9 +575,9 @@ def test_ingest_chunk_larger_than_prompt_single_forward(
 
     drafts = proposer.propose(_prefills_context([("r1", list(range(20)))]))
 
-    assert model.input_lens == [20]
+    assert model.input_lens == [21]
     assert drafts is not None
-    assert drafts.draft_token_ids == [[19 % VOCAB_SIZE]]
+    assert drafts.draft_token_ids == [[20 % VOCAB_SIZE]]
 
 
 def test_ingest_chunk_size_zero_single_forward(
@@ -590,9 +590,9 @@ def test_ingest_chunk_size_zero_single_forward(
 
     drafts = proposer.propose(_prefills_context([("r1", list(range(20)))]))
 
-    assert model.input_lens == [20]
+    assert model.input_lens == [21]
     assert drafts is not None
-    assert drafts.draft_token_ids == [[19 % VOCAB_SIZE]]
+    assert drafts.draft_token_ids == [[20 % VOCAB_SIZE]]
 
 
 def test_small_ingest_ignores_chunk_knob(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -602,7 +602,7 @@ def test_small_ingest_ignores_chunk_knob(monkeypatch: pytest.MonkeyPatch) -> Non
     model = _PositionEncodingDraftModel()
     proposer = _proposer(model)
 
-    drafts = proposer.propose(_prefills_context([("r1", list(range(16)))]))
+    drafts = proposer.propose(_prefills_context([("r1", list(range(15)))]))
 
     assert model.input_lens == [16]
     assert drafts is not None
@@ -610,9 +610,9 @@ def test_small_ingest_ignores_chunk_knob(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_mixed_chunk_lengths_share_rounds(monkeypatch: pytest.MonkeyPatch) -> None:
-    """20- and 25-token ingests with a 16-token chunk: round 0 carries both
+    """21- and 26-token ingests with a 16-token chunk: round 0 carries both
     plans' first 16 tokens, round 1 the two tails; each plan predicts from
-    its own final row (positions 19 and 24)."""
+    its own sampled-token row (positions 20 and 25)."""
     monkeypatch.setenv("VLLM_METAL_SPEC_INGEST_CHUNK", "16")
     model = _PositionEncodingDraftModel()
     proposer = _proposer(model)
@@ -621,10 +621,10 @@ def test_mixed_chunk_lengths_share_rounds(monkeypatch: pytest.MonkeyPatch) -> No
         _prefills_context([("r1", list(range(20))), ("r2", list(range(25)))])
     )
 
-    assert model.input_lens == [32, 13]
+    assert model.input_lens == [32, 15]
     assert drafts is not None
     assert drafts.req_ids == ["r1", "r2"]
-    assert drafts.draft_token_ids == [[19 % VOCAB_SIZE], [24 % VOCAB_SIZE]]
+    assert drafts.draft_token_ids == [[20 % VOCAB_SIZE], [25 % VOCAB_SIZE]]
 
 
 # -- Sliding-window / hybrid draft rejection ---------------------------------

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -398,12 +398,18 @@ class DraftModelProposer:
                 plans.append(plan)
 
         seen = {plan.req_id for plan in plans}
-        for prefill, result_mode in zip(
-            ctx.prefill_reqs, ctx.prefill_result_modes, strict=True
+        for prefill_index, (prefill, result_mode) in enumerate(
+            zip(ctx.prefill_reqs, ctx.prefill_result_modes, strict=True)
         ):
             if prefill.req_id in seen:
                 continue
             seen.add(prefill.req_id)
+            if prefill.req_id in drafting_req_ids:
+                # Target prefill already committed its first output token.
+                # Ingest it so the first draft predicts the following token.
+                prefill = prefill._replace(
+                    token_ids=[*prefill.token_ids, ctx.prefill_token_ids[prefill_index]]
+                )
             plan = self._make_prefill_plan(
                 prefill, result_mode, num_speculative_tokens, drafting_req_ids
             )
@@ -479,11 +485,13 @@ class DraftModelProposer:
         committed_len = prefill.start_pos + len(prefill.token_ids)
         is_drafting = result_mode != "intermediate" and req_id in drafting_req_ids
         assert self._committed_group_index is not None
+        # The ingest includes the target's sampled token. Producing K drafts
+        # then feeds only K-1 more tokens through the draft model.
         block_ids = self._ensure_blocks(
             req_id,
             committed_group_block_ids=prefill.block_ids[self._committed_group_index],
             total_positions=committed_len
-            + (num_speculative_tokens if is_drafting else 0),
+            + (max(num_speculative_tokens - 1, 0) if is_drafting else 0),
         )
         plan = _DraftPlan(
             req_id=req_id,


### PR DESCRIPTION
<img width="2680" height="792" alt="comparison" src="https://github.com/user-attachments/assets/ca1a7f1d-aca0-46dd-9726-4c524ce0ea6f" />

Fixes a regression from #630 that leaves the first draft window one token behind. Target prefill has already committed its first output token, but the drafter ingested only the prompt and predicted that token again. This fix ingests the sampled token before drafting, aligning the first proposal with the verifier's next position.

With **Qwen3-0.6B as both drafter and target**, greedy acceptance should be near 100%, apart from numerical differences. Measured acceptance rises from **65.3% to 98.1%** (40 prompts × 3 runs, batch 1, K=3, 10 output tokens).

### Why the first draft was rejected

For `The capital of France is`, target prefill emits ` Paris`. Verification now checks the token **after Paris**, which is `.` in this trace:

| | Drafter input | First proposal | Verifier expects |
|---|---|---|---|
| Before | Prompt only | ` Paris` | `.` |
| After | Prompt + ` Paris` | `.` | `.` |

Minimal same-model regression repro, from a configured checkout. It fails before the fix (`Paris` versus `.`, logit gap 8.125) and passes on this branch:

```bash
PYTHONPATH=. VLLM_METAL_MEMORY_FRACTION=0.108 python -m pytest \
  tools/test_spec_decode_draft_model_e2e.py -q -m slow -k capital
```

Validation: all 64 focused proposer/cache tests pass after updating the sampled-token fixtures and ingest expectations.

### NAX precision issue (out of scope)

below are the notes from GPT6-astral. NAX has some numeric bugs. The fix is non-trivial. (my fix result in performance degradation). So future work. 

> On M5, the expanded same-model corpus retains one later full-prefill rejection: the translation prompt's third verification window has a logit gap of **0.1875**, after two fully accepted windows. Replaying identical attention inputs isolates precision loss in NAX's `P × V` multiplication; draft prefill and target decode use different numerical paths. Disabling NAX removes this rejection. This precision loss also reproduces in standalone native MLX 0.32.0 attention. Attention-kernel changes are outside this PR; the **two-BF16-ULP rejection tolerance remains unchanged**.
