### PR TITLE
Bump MLX to 0.32.1 and update the mlx-lm pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,10 @@ dependencies = [
     # libmlx.dylib carries no SONAME version (compatibility version 0.0.0), so
     # a wheel built against one MLX is only ABI-safe against that exact MLX.
     # Rebuild and re-release the wheel on every MLX bump.
-    "mlx==0.32.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
-    # Git SHA (2026-08-05), not a version: architectures merged after the
-    # 0.31.3 release (2026-04-22) never reach PyPI. main still self-reports
-    # "0.31.3", so this looks like a no-op upgrade -- it is not.
-    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@254d153fdeb6f150edd4fc5a54f9828638481fa8 ; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx==0.32.1; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    # Git SHA (2026-08-25), not a version: this revision requires MLX >=0.32.1
+    # and includes cache APIs not available in the latest release (0.31.3).
+    "mlx-lm @ git+https://github.com/ml-explore/mlx-lm@9e6acca691e64d6d8bb808c328fcdea459099cca ; platform_system == 'Darwin' and platform_machine == 'arm64'",
     "llguidance>=1.7.0,<1.8.0; platform_machine == 'x86_64' or platform_machine == 'arm64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le'",
     # Temporary cap: xgrammar's prebuilt wheels are compiled against a specific
     # apache-tvm-ffi C++ ABI but declare only `apache-tvm-ffi>=0.1.9`, so a

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -74,10 +74,10 @@ class TestHybridCacheMergeExtract:
         assert isinstance(merged[0], contiguous_cache.ArraysCache)
         assert isinstance(extracted_req0, contiguous_cache.ArraysCache)
         assert isinstance(extracted_req1, contiguous_cache.ArraysCache)
-        assert bool(mx.allclose(extracted_req0.state[0], arrays_cache_req0.state[0]))
-        assert bool(mx.allclose(extracted_req0.state[1], arrays_cache_req0.state[1]))
-        assert bool(mx.allclose(extracted_req1.state[0], arrays_cache_req1.state[0]))
-        assert bool(mx.allclose(extracted_req1.state[1], arrays_cache_req1.state[1]))
+        assert bool(mx.allclose(extracted_req0.cache[0], arrays_cache_req0.cache[0]))
+        assert bool(mx.allclose(extracted_req0.cache[1], arrays_cache_req0.cache[1]))
+        assert bool(mx.allclose(extracted_req1.cache[0], arrays_cache_req1.cache[0]))
+        assert bool(mx.allclose(extracted_req1.cache[1], arrays_cache_req1.cache[1]))
 
     def test_arrays_cache_merge_extract_handles_missing_entries(self) -> None:
         """Missing per-request entries become zeros after merging.
@@ -99,11 +99,11 @@ class TestHybridCacheMergeExtract:
         assert isinstance(extracted_req0, contiguous_cache.ArraysCache)
         assert isinstance(extracted_req1, contiguous_cache.ArraysCache)
 
-        assert bool(mx.allclose(extracted_req0.state[0], arrays_cache_req0.state[0]))
-        assert bool(mx.allclose(extracted_req0.state[1], arrays_cache_req0.state[1]))
-        assert bool(mx.allclose(extracted_req1.state[0], arrays_cache_req1.state[0]))
+        assert bool(mx.allclose(extracted_req0.cache[0], arrays_cache_req0.cache[0]))
+        assert bool(mx.allclose(extracted_req0.cache[1], arrays_cache_req0.cache[1]))
+        assert bool(mx.allclose(extracted_req1.cache[0], arrays_cache_req1.cache[0]))
 
-        missing = extracted_req1.state[1]
+        missing = extracted_req1.cache[1]
         assert missing is not None
         assert missing.shape == (1, self._ARRAYS_CACHE_FEATURES)
         assert bool(mx.allclose(missing, mx.zeros_like(missing)))
@@ -139,10 +139,10 @@ class TestHybridCacheMergeExtract:
         assert bool(mx.allclose(kv_req1_out.keys, kv_cache_req1.keys))
         assert bool(mx.allclose(kv_req1_out.values, kv_cache_req1.values))
 
-        assert bool(mx.allclose(arrays_req0_out.state[0], arrays_cache_req0.state[0]))
-        assert bool(mx.allclose(arrays_req0_out.state[1], arrays_cache_req0.state[1]))
-        assert bool(mx.allclose(arrays_req1_out.state[0], arrays_cache_req1.state[0]))
-        assert bool(mx.allclose(arrays_req1_out.state[1], arrays_cache_req1.state[1]))
+        assert bool(mx.allclose(arrays_req0_out.cache[0], arrays_cache_req0.cache[0]))
+        assert bool(mx.allclose(arrays_req0_out.cache[1], arrays_cache_req0.cache[1]))
+        assert bool(mx.allclose(arrays_req1_out.cache[0], arrays_cache_req1.cache[0]))
+        assert bool(mx.allclose(arrays_req1_out.cache[1], arrays_cache_req1.cache[1]))
 
     def test_rotating_kvcache_merge_extract_preserves_offsets(self) -> None:
         cache_req0 = self._make_rotating_kv_cache(

--- a/vllm_metal/attention/caches/turboquant.py
+++ b/vllm_metal/attention/caches/turboquant.py
@@ -6,6 +6,8 @@ including key/value quantization metadata, bit packing helpers, and the FWHT
 rotation/sign tables used by the Metal dequantization kernels.
 """
 
+from typing import cast
+
 import mlx.core as mx
 from vllm.logger import init_logger
 
@@ -146,7 +148,7 @@ def _compute_lloyd_max_normal(bits: int) -> tuple[mx.array, mx.array]:
         sums = (one_hot * samples[:, None]).sum(axis=0)  # (n,)
         # Empty clusters keep their old centroid to avoid divide-by-zero.
         new_centroids = mx.where(counts > 0, sums / mx.maximum(counts, 1.0), centroids)
-        diff = mx.abs(new_centroids - centroids).max().item()
+        diff = cast(float, mx.abs(new_centroids - centroids).max().item())
         if diff < threshold:
             centroids = new_centroids
             converged = True

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -234,6 +234,8 @@ class GGUFModelLoader:
     ) -> _PartitionedTensors:
         """Route each GGUF tensor to quant-install / plain-load / bias-side-map."""
         arrays = mx.load(str(self._gguf_path))
+        if not isinstance(arrays, dict):
+            raise ValueError(f"Expected named tensors in {self._gguf_path}")
         if tied:
             skipped_output = arrays.pop("output.weight", None)
             if skipped_output is not None:

--- a/vllm_metal/gguf/mlx_native.py
+++ b/vllm_metal/gguf/mlx_native.py
@@ -20,14 +20,12 @@ from dataclasses import dataclass
 import mlx.core as mx
 
 try:
-    import gguf
+    from gguf import GGMLQuantizationType
 except ImportError as exc:  # pragma: no cover - exercised only without the extra
     raise ImportError(
         "GGUF support requires the optional 'gguf' dependency. "
         "Install it with: pip install 'vllm-metal[gguf]'"
     ) from exc
-
-GGMLQuantizationType = gguf.GGMLQuantizationType
 
 # qtypes MLX repacks into its affine representation.
 _BITS: dict[GGMLQuantizationType, int] = {

--- a/vllm_metal/v1/contiguous_cache.py
+++ b/vllm_metal/v1/contiguous_cache.py
@@ -24,12 +24,12 @@ def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
     if not caches:
         raise ValueError("caches must be non-empty")
 
-    num_entries = len(caches[0].state)
+    num_entries = len(caches[0].cache)
     batch_size = len(caches)
 
     merged = ArraysCache(num_entries)
     for entry_idx in range(num_entries):
-        values = [cache.state[entry_idx] for cache in caches]
+        values = [cache.cache[entry_idx] for cache in caches]
         template = next((value for value in values if value is not None), None)
         if template is None:
             continue
@@ -49,9 +49,9 @@ def _merge_arrays_caches(caches: list[ArraysCache]) -> ArraysCache:
 
 def _extract_arrays_cache(batch_cache: ArraysCache, idx: int) -> ArraysCache:
     """Extract one request's ArraysCache, preserving all-``None`` entries."""
-    state = batch_cache.state
+    state = batch_cache.cache
     extracted = ArraysCache(len(state))
-    extracted.state = [
+    extracted.cache = [
         None if value is None else value[idx : idx + 1] for value in state
     ]
     return extracted

--- a/vllm_metal/v1/lora/peft_loader.py
+++ b/vllm_metal/v1/lora/peft_loader.py
@@ -57,6 +57,11 @@ def load_peft_adapter(
     if lora_config is not None:
         helper.validate_legal(lora_config)
     raw = mx.load(str(safetensors_path))
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"Expected safetensors weights in {safetensors_path}, got "
+            f"{type(raw).__name__}"
+        )
     # Preserve eager loading: later in-place adapter updates must not change
     # tensors already returned to the adapter manager.
     mx.eval(raw)

--- a/vllm_metal/v1/pooling/backends/encoder/models/loading.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/loading.py
@@ -57,4 +57,7 @@ def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
             for name, value in state_dict.items()
             if isinstance(value, torch.Tensor)
         }
-    return mx.load(str(weight_file))
+    weights = mx.load(str(weight_file))
+    if not isinstance(weights, dict):
+        raise ValueError(f"Expected named tensors in {weight_file}")
+    return weights

--- a/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/xlm_roberta.py
@@ -75,7 +75,7 @@ class XLMRobertaEmbeddings(nn.Module):
         )
 
     def _position_ids(self, input_ids: mx.array) -> mx.array:
-        mask = (input_ids != self.padding_idx).astype(mx.int32)
+        mask = mx.array(input_ids != self.padding_idx, dtype=mx.int32)
         return mx.cumsum(mask, axis=1) * mask + self.padding_idx
 
 


### PR DESCRIPTION
## Summary

- Bump the exact MLX runtime pin from 0.32.0 to 0.32.1.
- Advance the MLX-LM pin from `254d153f` to `9e6acca6`.
- Update contiguous-cache handling for MLX-LM's `ArraysCache.state` to `ArraysCache.cache` rename.
- Adapt GGUF, LoRA, TurboQuant, pooling, and XLM-RoBERTa code to the updated dependency APIs and type information.

## Motivation

This repository-wide dependency and compatibility update was split from #607 so that the Ling-3.0 MLA/KDA implementation can remain model-scoped. PR #607 will be rebased on top of this change.

The pinned MLX-LM revision requires MLX 0.32.1 and contains APIs not present in the latest MLX-LM release. No other open PR was found for the same MLX 0.32.1 or `ArraysCache` compatibility update.

## Validation

Environment: Apple M3 Pro with 18 GB unified memory, macOS 14.4.1, Python 3.12.12, MLX 0.32.1, and MLX-LM at `9e6acca691e64d6d8bb808c328fcdea459099cca`.

```bash
VLLM_METAL_BUILD_FROM_SOURCE=1 \
  .venv/bin/python -m pytest -p no:cacheprovider \
  -m "not slow" tests -q

.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check .
.venv/bin/python -m mypy vllm_metal
git diff --check origin/main...HEAD
```

Results:

- Pytest: `1997 passed, 18 skipped, 40 deselected`.
- Ruff: all checks passed; 291 files already formatted.
- Mypy: no issues in 137 source files.
- Git whitespace check: passed.

## AI assistance

AI assistance was used to inspect the dependency changes, separate the compatibility update from #607, review the diff, and run the reported tests. The submitter reviewed the changed code and remains responsible for the contribution.
