### PR TITLE
Support newer mlx-vlm Qwen3.5 MLP calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,7 @@ dependencies = [
     "apache-tvm-ffi>=0.1.9,<0.1.13; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # mlx-vlm 0.6.8 drives MLX-quantized Qwen3.5/3.6 wrappers with correct
     # mRoPE state; 0.6.4 leaves it unset and garbles their output (#685).
-    # Capped below 0.6.16, which drops `target_verify` from
-    # Qwen3_5MLP.__call__ and trips the CompiledMLPBlocks wrapper guard.
-    "mlx-vlm>=0.6.8,<0.6.16; platform_system == 'Darwin' and platform_machine == 'arm64'",
+    "mlx-vlm>=0.6.8,<0.7.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     # Model loading and weights
     # Keep aligned with vLLM 0.28.0's Transformers lower bound.
     "transformers>=5.5.3",

--- a/tests/test_compiled_mlp.py
+++ b/tests/test_compiled_mlp.py
@@ -111,6 +111,11 @@ def _spy_compiled(wrapper: CompiledMLPBlock) -> dict[str, int]:
     return calls
 
 
+class _TargetVerifyMLPContract(nn.Module):
+    def __call__(self, x: mx.array, target_verify: bool = False) -> mx.array:
+        return x
+
+
 class TestInstall:
     def test_flag_defaults_off(self):
         # Assert — opt-in while the dispatch gathers serve mileage.
@@ -191,9 +196,6 @@ class TestInstall:
         assert not isinstance(wrapper.inner.shared_expert, CompiledMLPBlock)
 
     def test_vlm_moe_family_is_registered(self, monkeypatch):
-        # Arrange — the qwen3_5_moe package's blocks use the target_verify
-        # convention; the dense variant is cheap to construct, the sparse
-        # block's registration and wrapper class are pinned via the policy.
         _require_metal()
         from mlx_vlm.models.qwen3_5_moe.language import (
             Qwen3_5MoeMLP,
@@ -201,7 +203,9 @@ class TestInstall:
         )
 
         policies = CompiledMLPBlocks._target_policies()
-        assert policies[Qwen3_5MoeSparseMoeBlock] is CompiledTargetVerifyMLPBlock
+        assert policies[
+            Qwen3_5MoeSparseMoeBlock
+        ] is CompiledMLPBlocks.wrapper_for_target(Qwen3_5MoeSparseMoeBlock)
         mx.random.seed(15)
         inner = Qwen3_5MoeMLP(DIM, HIDDEN)
         inner.eval()
@@ -210,16 +214,13 @@ class TestInstall:
         x = mx.random.normal((1, 2, DIM)).astype(mx.float16)
         reference = inner(x)
 
-        # Act
         assert _install(monkeypatch, host) == 1
         calls = _spy_compiled(host.mlp)
         out = host.mlp(x)
-        out_verify = host.mlp(x, True)
 
-        # Assert
-        assert isinstance(host.mlp, CompiledTargetVerifyMLPBlock)
-        assert calls["n"] == 1  # plain engaged; target_verify=True eager
-        mx.eval(reference, out, out_verify)
+        assert isinstance(host.mlp, CompiledMLPBlocks.wrapper_for_target(Qwen3_5MoeMLP))
+        assert calls["n"] == 1
+        mx.eval(reference, out)
         np.testing.assert_array_equal(
             np.array(reference.astype(mx.float32)),
             np.array(out.astype(mx.float32)),
@@ -300,9 +301,25 @@ class TestDispatch:
         assert engaged_at_cap == 1
         assert calls["n"] == 1  # over-cap call stayed eager
 
-    def test_vlm_mlp_wraps_and_extra_args_stay_eager(self, monkeypatch):
-        # Arrange — mlx_vlm's dense MLP takes a target_verify kwarg; the
-        # plain call compiles, the kwarg-carrying call stays eager.
+    def test_target_verify_wrapper_keeps_verify_eager(self):
+        _require_metal()
+        inner = _TargetVerifyMLPContract()
+        inner.eval()
+        wrapper_cls = CompiledMLPBlocks.wrapper_for_target(_TargetVerifyMLPContract)
+        assert wrapper_cls is CompiledTargetVerifyMLPBlock
+        wrapper = wrapper_cls(inner)
+        calls = _spy_compiled(wrapper)
+        x = mx.random.normal((1, 2, DIM)).astype(mx.float16)
+
+        wrapper(x)
+        wrapper(x, target_verify=False)
+        wrapper(x, True)
+        with pytest.raises(TypeError):
+            wrapper(x, False, target_verify=False)
+
+        assert calls["n"] == 2
+
+    def test_vlm_mlp_uses_signature_matched_wrapper(self, monkeypatch):
         _require_metal()
         mx.random.seed(13)
         inner = Qwen3_5MLP(DIM, HIDDEN)
@@ -314,19 +331,11 @@ class TestDispatch:
         assert _install(monkeypatch, host) == 1
         calls = _spy_compiled(host.mlp)
 
-        # Act — default-off target_verify (positional or named) is the
-        # plain call and engages; a truthy flag stays eager, and an invalid
-        # duplicate raises at the wrapper exactly like the unwrapped module.
-        assert isinstance(host.mlp, CompiledTargetVerifyMLPBlock)
+        expected_wrapper = CompiledMLPBlocks.wrapper_for_target(Qwen3_5MLP)
+        assert isinstance(host.mlp, expected_wrapper)
         out_plain = host.mlp(x)
-        out_default = host.mlp(x, target_verify=False)
-        out_verify = host.mlp(x, True)
-        with pytest.raises(TypeError):
-            host.mlp(x, False, target_verify=False)
-
-        # Assert
-        assert calls["n"] == 2  # plain + default-off engaged; others eager
-        mx.eval(reference, out_plain, out_default, out_verify)
+        assert calls["n"] == 1
+        mx.eval(reference, out_plain)
         np.testing.assert_array_equal(
             np.array(reference.astype(mx.float32)),
             np.array(out_plain.astype(mx.float32)),

--- a/tests/test_compiled_mlp.py
+++ b/tests/test_compiled_mlp.py
@@ -111,6 +111,11 @@ def _spy_compiled(wrapper: CompiledMLPBlock) -> dict[str, int]:
     return calls
 
 
+class _UnaryMLPContract(nn.Module):
+    def __call__(self, x: mx.array) -> mx.array:
+        return x
+
+
 class _TargetVerifyMLPContract(nn.Module):
     def __call__(self, x: mx.array, target_verify: bool = False) -> mx.array:
         return x
@@ -177,6 +182,20 @@ class TestInstall:
         assert all(isinstance(h.mlp, CompiledMLPBlock) for h in deep.layers)
         assert isinstance(deep.head.mlp, CompiledMLPBlock)
 
+    @pytest.mark.parametrize(
+        ("target", "expected_wrapper"),
+        [
+            (_UnaryMLPContract, CompiledMLPBlock),
+            (_TargetVerifyMLPContract, CompiledTargetVerifyMLPBlock),
+        ],
+    )
+    def test_wrapper_matches_released_vlm_call_contract(
+        self,
+        target: type[nn.Module],
+        expected_wrapper: type[CompiledMLPBlock],
+    ):
+        assert CompiledMLPBlocks.wrapper_for_target(target) is expected_wrapper
+
     def test_install_is_idempotent(self, monkeypatch):
         # Arrange — the MoE block nests another target (its shared-expert
         # MLP); a re-install must not wrap anything beneath the existing
@@ -218,7 +237,7 @@ class TestInstall:
         calls = _spy_compiled(host.mlp)
         out = host.mlp(x)
 
-        assert isinstance(host.mlp, CompiledMLPBlocks.wrapper_for_target(Qwen3_5MoeMLP))
+        assert type(host.mlp) is CompiledMLPBlocks.wrapper_for_target(Qwen3_5MoeMLP)
         assert calls["n"] == 1
         mx.eval(reference, out)
         np.testing.assert_array_equal(
@@ -332,7 +351,7 @@ class TestDispatch:
         calls = _spy_compiled(host.mlp)
 
         expected_wrapper = CompiledMLPBlocks.wrapper_for_target(Qwen3_5MLP)
-        assert isinstance(host.mlp, expected_wrapper)
+        assert type(host.mlp) is expected_wrapper
         out_plain = host.mlp(x)
         assert calls["n"] == 1
         mx.eval(reference, out_plain)

--- a/vllm_metal/compiled_mlp.py
+++ b/vllm_metal/compiled_mlp.py
@@ -190,11 +190,10 @@ class CompiledMLPBlock(nn.Module):
 
 
 class CompiledTargetVerifyMLPBlock(CompiledMLPBlock):
-    """Wrapper for blocks called as ``__call__(x, target_verify=False)``.
+    """Wrapper for older blocks called as ``__call__(x, target_verify=False)``.
 
-    mlx_vlm's decoder layers pass the flag on every call; its default-off
-    form is the plain call, while a truthy flag (spec-decode verify)
-    delegates to the eager inner block unchanged.
+    The default-off form is the plain call; a truthy spec-decode verify
+    call delegates to the eager inner block unchanged.
     """
 
     def __call__(self, x: mx.array, target_verify: bool = False) -> mx.array:

--- a/vllm_metal/compiled_mlp.py
+++ b/vllm_metal/compiled_mlp.py
@@ -106,19 +106,8 @@ class CompiledMLPBlocks:
         return len(replacements)
 
     @classmethod
-    def _target_policies(cls) -> dict[type, type]:
-        """Target block type -> wrapper class (one per calling convention).
-
-        The Qwen3-Next family blocks (Qwen3.5/3.6/3.8 share them via the
-        qwen3_5 arch) take a plain activations-only call; mlx_vlm's dense
-        and MoE variants add a default-off ``target_verify`` flag, whose
-        signatures are validated here so an mlx-vlm bump that changes them
-        fails fast instead of silently mis-routing. All targets are
-        stateless by construction — extending this table requires the same
-        property.
-        """
-        import inspect
-
+    def _target_policies(cls) -> dict[type[nn.Module], type[CompiledMLPBlock]]:
+        """Target block type -> wrapper class."""
         from mlx_lm.models.qwen3_next import Qwen3NextMLP, Qwen3NextSparseMoeBlock
         from mlx_vlm.models.qwen3_5.language import Qwen3_5MLP
         from mlx_vlm.models.qwen3_5_moe.language import (
@@ -126,21 +115,35 @@ class CompiledMLPBlocks:
             Qwen3_5MoeSparseMoeBlock,
         )
 
-        for target in (Qwen3_5MLP, Qwen3_5MoeMLP, Qwen3_5MoeSparseMoeBlock):
-            params = list(inspect.signature(target.__call__).parameters)
-            if params != ["self", "x", "target_verify"]:
-                raise RuntimeError(
-                    f"mlx_vlm {target.__name__}.__call__ signature changed "
-                    f"({params}); update CompiledMLPBlocks' wrapper policy "
-                    "before wrapping it."
-                )
-        return {
+        policies: dict[type[nn.Module], type[CompiledMLPBlock]] = {
             Qwen3NextSparseMoeBlock: CompiledMLPBlock,
             Qwen3NextMLP: CompiledMLPBlock,
-            Qwen3_5MLP: CompiledTargetVerifyMLPBlock,
-            Qwen3_5MoeMLP: CompiledTargetVerifyMLPBlock,
-            Qwen3_5MoeSparseMoeBlock: CompiledTargetVerifyMLPBlock,
         }
+        for target in (Qwen3_5MLP, Qwen3_5MoeMLP, Qwen3_5MoeSparseMoeBlock):
+            policies[target] = cls.wrapper_for_target(target)
+        return policies
+
+    @staticmethod
+    def wrapper_for_target(target: type[nn.Module]) -> type[CompiledMLPBlock]:
+        """Select a wrapper for a released mlx-vlm MLP call contract."""
+        import inspect
+
+        signature = inspect.signature(target.__call__)
+        parameters = list(signature.parameters.values())
+        names = [parameter.name for parameter in parameters]
+        if names == ["self", "x"]:
+            return CompiledMLPBlock
+        if (
+            names == ["self", "x", "target_verify"]
+            and parameters[2].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+            and parameters[2].default is False
+        ):
+            return CompiledTargetVerifyMLPBlock
+        raise RuntimeError(
+            f"mlx_vlm {target.__name__}.__call__ signature changed "
+            f"{signature}; update CompiledMLPBlocks' wrapper policy "
+            "before wrapping it."
+        )
 
 
 class CompiledMLPBlock(nn.Module):


### PR DESCRIPTION
This PR is:

- To remove the temporary `mlx-vlm<0.6.16` cap added in #712
- To support both released Qwen3.5 MLP call contracts: `(x, target_verify=False)` and `(x)`
- To keep compiled MLP wrapper selection explicit for the installed `mlx-vlm` contract

PR #712 capped `mlx-vlm` below 0.6.16 because newer Qwen3.5 MLP blocks changed their call signature and broke compiled MLP wrapping. This PR handles both signatures: older blocks keep the `target_verify` wrapper, and newer unary blocks use the plain compiled wrapper.

Proof from local checks:

- Checked the `mlx-vlm 0.6.17` wheel: Qwen3.5 dense and MoE MLP blocks use unary `(x)` calls
- Served `Qwen/Qwen3.5-0.8B` with `mlx-vlm 0.6.17` and compiled MLP enabled; the model loaded, compiled MLP wrapped 24 blocks, and `/v1/completions` returned HTTP 200