### PR TITLE
Remove stale prompt-logprobs decode gate

### DIFF
--- a/tests/test_decode_pipeline.py
+++ b/tests/test_decode_pipeline.py
@@ -52,7 +52,6 @@ _CLEAN_STEP_KWARGS = {
 _GREEDY_SAMPLING_KWARGS = {
     "native_greedy": True,
     "native_random": False,
-    "has_prompt_logprobs": False,
 }
 
 
@@ -227,7 +226,6 @@ class TestGate:
         ("flag", "value", "reason"),
         [
             ("native_greedy", False, "non-native sampling"),
-            ("has_prompt_logprobs", True, "prompt logprobs requested"),
         ],
     )
     def test_each_sampling_blocker_rejects_with_its_reason(self, flag, value, reason):

--- a/tests/test_prompt_logprobs.py
+++ b/tests/test_prompt_logprobs.py
@@ -162,7 +162,6 @@ class TestPromptLogprobsTracker:
         # Delivery clears all lifecycle state so decode preemption cannot
         # re-emit prompt logprobs for the same request.
         assert not tracker.wants("req-a")
-        assert not tracker.wants_any(["req-a"])
 
     def test_single_chunk_prompt_completes_immediately(self) -> None:
         tracker = PromptLogprobsTracker()

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -2629,30 +2629,6 @@ class TestPipelineGateSpecDecodeDerivation:
             num_spec_tokens_to_schedule=0,
         )
 
-    def test_prompt_logprobs_request_disables_pipeline(self) -> None:
-        # Arrange — an active prompt-logprobs request must keep the synchronous
-        # sample path until the prompt scores are delivered.
-        runner = self._runner(drafter=None)
-        runner._prompt_logprobs_tracker.register("r0", 5)
-        runner._request_states = {
-            "r0": mr.RequestState(
-                token_ids=[1, 7],
-                prompt_len=1,
-                cache=[],
-                sampling_params=SamplingParams(temperature=0.0, prompt_logprobs=5),
-                generator=None,
-                generated_tokens=1,
-            )
-        }
-        scheduler_output = self._cached_decode_output("r0")
-
-        # Act
-        decision = runner._evaluate_pipeline_gate(scheduler_output)
-
-        # Assert
-        assert decision.eligible is False
-        assert decision.reason == "prompt logprobs requested"
-
     def test_state_family_without_pipeline_support_disables_pipeline(self) -> None:
         runner = self._runner(drafter=None)
         runner.model_config.is_hybrid = True

--- a/vllm_metal/v1/decode_pipeline.py
+++ b/vllm_metal/v1/decode_pipeline.py
@@ -133,20 +133,17 @@ class SamplingShape:
 
     native_greedy: bool
     native_random: bool
-    has_prompt_logprobs: bool
 
     def block_reason(self) -> str | None:
         """First sampling fact that rules the pipeline out, or ``None``.
 
-        Checked in order: native sampling mode first, then prompt logprobs.
         Either native mode (greedy argmax or eligible random sampling with
-        ``VLLM_METAL_NATIVE_SAMPLING``) keeps the step deferrable.
+        ``VLLM_METAL_NATIVE_SAMPLING``) keeps the step deferrable.  Prompt
+        logprobs are gathered on the completing prefill step before decode
+        rows enter ``decode_req_ids``, so they never reach this gate.
         """
         if not (self.native_greedy or self.native_random):
             return "non-native sampling"
-        # Prompt logprobs need eager logits on the sampling step.
-        if self.has_prompt_logprobs:
-            return "prompt logprobs requested"
         return None
 
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1624,7 +1624,6 @@ class MetalModelRunner:
                 and not states_missing
                 and SamplingBatch.params_allow_native_random(decode_params)
             ),
-            has_prompt_logprobs=self._prompt_logprobs_tracker.wants_any(decode_req_ids),
         )
         return self._decode_pipeline.evaluate_gate(capabilities, step, sampling)
 


### PR DESCRIPTION
This PR is:

- To remove the decode-pipeline prompt-logprobs blocker made stale by #694
- To let pure decode steps use the existing decode pipeline after prompt logprobs are delivered during prefill
- To delete the unit test that constructed an unreachable active prompt-logprobs decode state

After #694, prompt logprobs are tracked per request and delivered on the completing prefill step. Pure decode steps no longer need prompt-logprob rows, and prefill steps are already blocked from the decode pipeline by `has_prefill_phase_requests`.
