### PR TITLE
[Bugfix] Added min_p filtering natively in MLX ops

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -144,11 +144,10 @@ class TestMetalPlatform:
     @pytest.mark.parametrize(
         ("sampling_params", "control"),
         [
-            (SamplingParams(min_p=0.1), "min_p"),
             (SamplingParams(logit_bias={1: 2.0}), "logit_bias"),
             (SamplingParams(min_tokens=2), "min_tokens"),
         ],
-        ids=["min-p", "logit-bias", "min-tokens"],
+        ids=["logit-bias", "min-tokens"],
     )
     def test_validate_request_rejects_logits_processor_controls(
         self,
@@ -158,6 +157,9 @@ class TestMetalPlatform:
         with pytest.raises(VLLMValidationError, match=control) as exc_info:
             MetalPlatform.validate_request({}, sampling_params)
         assert exc_info.value.parameter == control
+
+    def test_validate_request_accepts_min_p(self) -> None:
+        MetalPlatform.validate_request({}, SamplingParams(min_p=0.2))
 
     def test_check_and_update_config_rejects_pipeline_with_tensor_parallel(
         self,

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -26,6 +26,8 @@ from vllm_metal.v1.model_runner import (
 from vllm_metal.v1.sampling_batch import (
     SamplingBatch,
     sample_decode_tokens,
+    _apply_min_p_mlx,
+    _apply_min_p_torch,
     sample_from_logits,
 )
 
@@ -1101,3 +1103,107 @@ class TestV1PenaltyTokenAccounting:
         output = Sampler().forward(logits, metadata)
 
         assert int(output.sampled_token_ids[0, 0].item()) == alternative_token
+
+
+class TestMinP:
+    """Tests for min_p sampling support."""
+
+    def _make_logits_mlx(self) -> mx.array:
+        """Logits where token 0 dominates, tokens 1-3 are small, rest tiny.
+
+        softmax ≈ [0.73, 0.09, 0.09, 0.09, ~0, ...]
+        """
+        logits = mx.full((1, VOCAB_SIZE), -10.0)
+        logits = logits.at[0, 0].add(12.0)  # ~0.73
+        logits = logits.at[0, 1].add(10.0)  # ~0.09
+        logits = logits.at[0, 2].add(10.0)  # ~0.09
+        logits = logits.at[0, 3].add(10.0)  # ~0.09
+        mx.eval(logits)
+        return logits
+
+    def test_min_p_mlx_masks_low_prob_tokens(self) -> None:
+        """Tokens below min_p * max_prob should be masked to -inf."""
+        logits = self._make_logits_mlx()
+        # min_p=0.2 → threshold = 0.2 * 0.73 ≈ 0.146
+        # tokens 1-3 have prob ~0.09 < 0.146, so they should be masked
+        sp = SamplingParams(temperature=1.0, min_p=0.2)
+        result = _apply_min_p_mlx(logits, [sp])
+        mx.eval(result)
+        # Token 0 should survive, tokens 1-3 should be -inf
+        assert result[0, 0].item() > -1e9
+        assert result[0, 1].item() == float("-inf")
+        assert result[0, 2].item() == float("-inf")
+        assert result[0, 3].item() == float("-inf")
+
+    def test_min_p_mlx_zero_is_noop(self) -> None:
+        """min_p=0 should not change logits."""
+        logits = self._make_logits_mlx()
+        sp = SamplingParams(temperature=1.0, min_p=0.0)
+        result = _apply_min_p_mlx(logits, [sp])
+        mx.eval(result)
+        assert mx.allclose(result, logits).item()
+
+    def test_min_p_mlx_keeps_top_token(self) -> None:
+        """Even with high min_p, the top token should always survive."""
+        logits = self._make_logits_mlx()
+        sp = SamplingParams(temperature=1.0, min_p=0.99)
+        result = _apply_min_p_mlx(logits, [sp])
+        mx.eval(result)
+        assert result[0, 0].item() > -1e9
+
+    def test_min_p_mlx_per_row(self) -> None:
+        """Different min_p values per row in a batch."""
+        logits = mx.concatenate([self._make_logits_mlx()] * 2, axis=0)
+        mx.eval(logits)
+        sp0 = SamplingParams(temperature=1.0, min_p=0.0)  # no filtering
+        sp1 = SamplingParams(temperature=1.0, min_p=0.2)  # filters tokens 1-3
+        result = _apply_min_p_mlx(logits, [sp0, sp1])
+        mx.eval(result)
+        # Row 0: no filtering, token 1 survives
+        assert result[0, 1].item() > -1e9
+        # Row 1: filtered, token 1 masked
+        assert result[1, 1].item() == float("-inf")
+
+    def test_min_p_torch_masks_low_prob_tokens(self) -> None:
+        """Torch path: tokens below threshold should be masked."""
+        logits = mlx_to_torch(self._make_logits_mlx(), device="cpu")
+        sp = SamplingParams(temperature=1.0, min_p=0.2)
+        result = _apply_min_p_torch(logits, [sp])
+        assert result[0, 0].item() > -1e9
+        assert result[0, 1].item() == float("-inf")
+
+    def test_min_p_torch_zero_is_noop(self) -> None:
+        """Torch path: min_p=0 should not change logits."""
+        logits = mlx_to_torch(self._make_logits_mlx(), device="cpu")
+        sp = SamplingParams(temperature=1.0, min_p=0.0)
+        result = _apply_min_p_torch(logits, [sp])
+        assert torch.equal(result, logits)
+
+    def test_min_p_native_random_sampling(self) -> None:
+        """End-to-end: native random path with min_p should not error."""
+        logits = self._make_logits_mlx()
+        sp = SamplingParams(temperature=1.0, min_p=0.2)
+        batch = SamplingBatch(
+            [sp],
+            [[0, 1, 2]],
+            [[3]],
+            vocab_size=VOCAB_SIZE,
+        )
+        sampler = Sampler()
+        result = sample_from_logits(logits, batch, sampler)
+        assert len(result.token_ids) == 1
+
+    def test_min_p_torch_fallback_sampling(self) -> None:
+        """End-to-end: torch fallback path with min_p (seeded) should work."""
+        logits = self._make_logits_mlx()
+        sp = SamplingParams(temperature=1.0, min_p=0.2, seed=42)
+        batch = SamplingBatch(
+            [sp],
+            [[0, 1, 2]],
+            [[3]],
+            vocab_size=VOCAB_SIZE,
+            generators={0: torch.Generator(device="cpu").manual_seed(42)},
+        )
+        sampler = Sampler()
+        result = sample_from_logits(logits, batch, sampler)
+        assert len(result.token_ids) == 1

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -26,8 +26,6 @@ from vllm_metal.v1.model_runner import (
 from vllm_metal.v1.sampling_batch import (
     SamplingBatch,
     sample_decode_tokens,
-    _apply_min_p_mlx,
-    _apply_min_p_torch,
     sample_from_logits,
 )
 
@@ -536,6 +534,72 @@ class TestV1SamplingBatch:
         assert result.token_ids[0] == VOCAB_SIZE - 1
         # Top-k row stays inside the top-64 candidates (values 960..1023).
         assert VOCAB_SIZE - top_k <= result.token_ids[1] < VOCAB_SIZE
+
+    def test_min_p_narrows_candidates_before_top_p(self) -> None:
+        """min_p must be applied before top_p on the native MLX path.
+
+        probs are [0.5, 0.4, 0.1]. min_p=0.25 masks token 2, and the softmax
+        over the survivors then reaches top_p=0.55 inside token 0 alone, so
+        token 0 is the only candidate. Measuring top_p first — or skipping
+        min_p — leaves the un-renormalized mass below 0.55 at token 1 and
+        wrongly admits it. Mirrors vLLM's order: MinPLogitsProcessor, then
+        apply_top_k_top_p.
+        """
+        probs = [0.5, 0.4, 0.1]
+        logits = mx.array([[float(np.log(p)) for p in probs]], dtype=mx.float32)
+        params = [SamplingParams(temperature=1.0, top_p=0.55, min_p=0.25)]
+        # Shared (top_k, top_p, min_p) keeps the batch on the native path.
+        assert SamplingBatch.params_allow_native_random(params)
+
+        keys = iter([mx.random.key(seed) for seed in range(64)])
+        sampled = {
+            int(
+                SamplingBatch.native_decode_tokens(
+                    logits,
+                    params,
+                    vocab_size=len(probs),
+                    next_key=lambda: next(keys),
+                ).item()
+            )
+            for _ in range(64)
+        }
+        # min_p then top_p leaves one candidate; either error admits token 1.
+        assert sampled == {0}
+
+    def test_min_p_masks_after_temperature_on_torch_path(self) -> None:
+        """Seeded requests must get min_p from the sampler, after temperature.
+
+        At temperature 2.0 the scaled probs are [0.64, 0.24, 0.09, 0.03], so
+        min_p=0.3 keeps tokens 0 and 1. Thresholding the raw logits instead —
+        as masking before Sampler.forward() does — sees [0.87, 0.12, ...] and
+        keeps only token 0, while an empty LogitsProcessors drops min_p and
+        admits tokens 2 and 3. Exercises the real Sampler.forward() path via
+        sample_from_logits (seeded requests are excluded from the native
+        path).
+        """
+        sampler = Sampler()
+        sampled = set()
+        for seed in range(40):
+            # Fresh logits per call: mlx_to_torch hands the sampler a
+            # zero-copy view and apply_temperature scales it in place.
+            logits = mx.array([[4.0, 2.0, 0.0, -2.0]], dtype=mx.float32)
+            sp = SamplingParams(temperature=2.0, min_p=0.3, seed=seed)
+            assert not SamplingBatch.params_allow_native_random([sp])
+            batch = SamplingBatch(
+                [sp],
+                [[1]],
+                [[]],
+                vocab_size=4,
+                generators={0: torch.Generator().manual_seed(seed)},
+            )
+            # min_p must ride the argmax-invariant slot, which the sampler
+            # applies after temperature and before top-k/top-p.
+            metadata = batch.make_sampling_metadata(torch.zeros(1, 4))
+            assert len(list(metadata.logitsprocs.argmax_invariant)) == 1
+
+            sampled.add(sample_from_logits(logits, batch, sampler).token_ids[0])
+        # Tokens 2 and 3 fall under min_p * max_prob on the scaled logits.
+        assert sampled == {0, 1}
 
     def test_bad_words_blocks_greedy_token(self) -> None:
         """Greedy + bad_words_token_ids must fall back and block the banned token."""
@@ -1103,107 +1167,3 @@ class TestV1PenaltyTokenAccounting:
         output = Sampler().forward(logits, metadata)
 
         assert int(output.sampled_token_ids[0, 0].item()) == alternative_token
-
-
-class TestMinP:
-    """Tests for min_p sampling support."""
-
-    def _make_logits_mlx(self) -> mx.array:
-        """Logits where token 0 dominates, tokens 1-3 are small, rest tiny.
-
-        softmax ≈ [0.73, 0.09, 0.09, 0.09, ~0, ...]
-        """
-        logits = mx.full((1, VOCAB_SIZE), -10.0)
-        logits = logits.at[0, 0].add(12.0)  # ~0.73
-        logits = logits.at[0, 1].add(10.0)  # ~0.09
-        logits = logits.at[0, 2].add(10.0)  # ~0.09
-        logits = logits.at[0, 3].add(10.0)  # ~0.09
-        mx.eval(logits)
-        return logits
-
-    def test_min_p_mlx_masks_low_prob_tokens(self) -> None:
-        """Tokens below min_p * max_prob should be masked to -inf."""
-        logits = self._make_logits_mlx()
-        # min_p=0.2 → threshold = 0.2 * 0.73 ≈ 0.146
-        # tokens 1-3 have prob ~0.09 < 0.146, so they should be masked
-        sp = SamplingParams(temperature=1.0, min_p=0.2)
-        result = _apply_min_p_mlx(logits, [sp])
-        mx.eval(result)
-        # Token 0 should survive, tokens 1-3 should be -inf
-        assert result[0, 0].item() > -1e9
-        assert result[0, 1].item() == float("-inf")
-        assert result[0, 2].item() == float("-inf")
-        assert result[0, 3].item() == float("-inf")
-
-    def test_min_p_mlx_zero_is_noop(self) -> None:
-        """min_p=0 should not change logits."""
-        logits = self._make_logits_mlx()
-        sp = SamplingParams(temperature=1.0, min_p=0.0)
-        result = _apply_min_p_mlx(logits, [sp])
-        mx.eval(result)
-        assert mx.allclose(result, logits).item()
-
-    def test_min_p_mlx_keeps_top_token(self) -> None:
-        """Even with high min_p, the top token should always survive."""
-        logits = self._make_logits_mlx()
-        sp = SamplingParams(temperature=1.0, min_p=0.99)
-        result = _apply_min_p_mlx(logits, [sp])
-        mx.eval(result)
-        assert result[0, 0].item() > -1e9
-
-    def test_min_p_mlx_per_row(self) -> None:
-        """Different min_p values per row in a batch."""
-        logits = mx.concatenate([self._make_logits_mlx()] * 2, axis=0)
-        mx.eval(logits)
-        sp0 = SamplingParams(temperature=1.0, min_p=0.0)  # no filtering
-        sp1 = SamplingParams(temperature=1.0, min_p=0.2)  # filters tokens 1-3
-        result = _apply_min_p_mlx(logits, [sp0, sp1])
-        mx.eval(result)
-        # Row 0: no filtering, token 1 survives
-        assert result[0, 1].item() > -1e9
-        # Row 1: filtered, token 1 masked
-        assert result[1, 1].item() == float("-inf")
-
-    def test_min_p_torch_masks_low_prob_tokens(self) -> None:
-        """Torch path: tokens below threshold should be masked."""
-        logits = mlx_to_torch(self._make_logits_mlx(), device="cpu")
-        sp = SamplingParams(temperature=1.0, min_p=0.2)
-        result = _apply_min_p_torch(logits, [sp])
-        assert result[0, 0].item() > -1e9
-        assert result[0, 1].item() == float("-inf")
-
-    def test_min_p_torch_zero_is_noop(self) -> None:
-        """Torch path: min_p=0 should not change logits."""
-        logits = mlx_to_torch(self._make_logits_mlx(), device="cpu")
-        sp = SamplingParams(temperature=1.0, min_p=0.0)
-        result = _apply_min_p_torch(logits, [sp])
-        assert torch.equal(result, logits)
-
-    def test_min_p_native_random_sampling(self) -> None:
-        """End-to-end: native random path with min_p should not error."""
-        logits = self._make_logits_mlx()
-        sp = SamplingParams(temperature=1.0, min_p=0.2)
-        batch = SamplingBatch(
-            [sp],
-            [[0, 1, 2]],
-            [[3]],
-            vocab_size=VOCAB_SIZE,
-        )
-        sampler = Sampler()
-        result = sample_from_logits(logits, batch, sampler)
-        assert len(result.token_ids) == 1
-
-    def test_min_p_torch_fallback_sampling(self) -> None:
-        """End-to-end: torch fallback path with min_p (seeded) should work."""
-        logits = self._make_logits_mlx()
-        sp = SamplingParams(temperature=1.0, min_p=0.2, seed=42)
-        batch = SamplingBatch(
-            [sp],
-            [[0, 1, 2]],
-            [[3]],
-            vocab_size=VOCAB_SIZE,
-            generators={0: torch.Generator(device="cpu").manual_seed(42)},
-        )
-        sampler = Sampler()
-        result = sample_from_logits(logits, batch, sampler)
-        assert len(result.token_ids) == 1

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -536,19 +536,10 @@ class TestV1SamplingBatch:
         assert VOCAB_SIZE - top_k <= result.token_ids[1] < VOCAB_SIZE
 
     def test_min_p_narrows_candidates_before_top_p(self) -> None:
-        """min_p must be applied before top_p on the native MLX path.
-
-        probs are [0.5, 0.4, 0.1]. min_p=0.25 masks token 2, and the softmax
-        over the survivors then reaches top_p=0.55 inside token 0 alone, so
-        token 0 is the only candidate. Measuring top_p first — or skipping
-        min_p — leaves the un-renormalized mass below 0.55 at token 1 and
-        wrongly admits it. Mirrors vLLM's order: MinPLogitsProcessor, then
-        apply_top_k_top_p.
-        """
+        """Native sampling applies min_p before top_p."""
         probs = [0.5, 0.4, 0.1]
         logits = mx.array([[float(np.log(p)) for p in probs]], dtype=mx.float32)
         params = [SamplingParams(temperature=1.0, top_p=0.55, min_p=0.25)]
-        # Shared (top_k, top_p, min_p) keeps the batch on the native path.
         assert SamplingBatch.params_allow_native_random(params)
 
         keys = iter([mx.random.key(seed) for seed in range(64)])
@@ -563,25 +554,13 @@ class TestV1SamplingBatch:
             )
             for _ in range(64)
         }
-        # min_p then top_p leaves one candidate; either error admits token 1.
         assert sampled == {0}
 
     def test_min_p_masks_after_temperature_on_torch_path(self) -> None:
-        """Seeded requests must get min_p from the sampler, after temperature.
-
-        At temperature 2.0 the scaled probs are [0.64, 0.24, 0.09, 0.03], so
-        min_p=0.3 keeps tokens 0 and 1. Thresholding the raw logits instead —
-        as masking before Sampler.forward() does — sees [0.87, 0.12, ...] and
-        keeps only token 0, while an empty LogitsProcessors drops min_p and
-        admits tokens 2 and 3. Exercises the real Sampler.forward() path via
-        sample_from_logits (seeded requests are excluded from the native
-        path).
-        """
+        """Torch sampling applies min_p after temperature."""
         sampler = Sampler()
         sampled = set()
         for seed in range(40):
-            # Fresh logits per call: mlx_to_torch hands the sampler a
-            # zero-copy view and apply_temperature scales it in place.
             logits = mx.array([[4.0, 2.0, 0.0, -2.0]], dtype=mx.float32)
             sp = SamplingParams(temperature=2.0, min_p=0.3, seed=seed)
             assert not SamplingBatch.params_allow_native_random([sp])
@@ -592,13 +571,10 @@ class TestV1SamplingBatch:
                 vocab_size=4,
                 generators={0: torch.Generator().manual_seed(seed)},
             )
-            # min_p must ride the argmax-invariant slot, which the sampler
-            # applies after temperature and before top-k/top-p.
             metadata = batch.make_sampling_metadata(torch.zeros(1, 4))
             assert len(list(metadata.logitsprocs.argmax_invariant)) == 1
 
             sampled.add(sample_from_logits(logits, batch, sampler).token_ids[0])
-        # Tokens 2 and 3 fall under min_p * max_prob on the scaled logits.
         assert sampled == {0, 1}
 
     def test_bad_words_blocks_greedy_token(self) -> None:

--- a/tools/native_sampling_microbench.py
+++ b/tools/native_sampling_microbench.py
@@ -1,15 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Sampling-step microbench: the torch production path vs the native graph.
+"""Sampling-step microbench for the torch path and native MLX graph.
 
-Times one non-greedy sampling step over a full Qwen-sized vocabulary at
-decode-like batch sizes. The torch arm measures the full production cost the
-native path removes: evaluating the MLX logits, bridging them to torch
-(``mlx_to_torch`` after the fp32 cast), then the vLLM sampler math
-(``BatchMinPLogitsProcessor`` + ``apply_top_k_top_p`` + softmax + exponential
-+ argmax on CPU), in the order ``Sampler`` applies them. The native arm times
-the ``SamplingBatch`` mask + categorical graph synchronously — in the decode
-pipeline the same graph defers with the step and overlaps the next forward, so
-its effective cost is lower than reported here.
+Times one non-greedy sampling step over a Qwen-sized vocabulary. The torch arm
+includes MLX evaluation, torch bridging, min-p, top-k/top-p, and categorical
+sampling. The native arm times the equivalent ``SamplingBatch`` graph.
 
 Usage:
 

--- a/tools/native_sampling_microbench.py
+++ b/tools/native_sampling_microbench.py
@@ -5,10 +5,11 @@ Times one non-greedy sampling step over a full Qwen-sized vocabulary at
 decode-like batch sizes. The torch arm measures the full production cost the
 native path removes: evaluating the MLX logits, bridging them to torch
 (``mlx_to_torch`` after the fp32 cast), then the vLLM sampler math
-(``apply_top_k_top_p`` + softmax + exponential + argmax on CPU). The native
-arm times the ``SamplingBatch`` mask + categorical graph synchronously — in
-the decode pipeline the same graph defers with the step and overlaps the
-next forward, so its effective cost is lower than reported here.
+(``BatchMinPLogitsProcessor`` + ``apply_top_k_top_p`` + softmax + exponential
++ argmax on CPU), in the order ``Sampler`` applies them. The native arm times
+the ``SamplingBatch`` mask + categorical graph synchronously — in the decode
+pipeline the same graph defers with the step and overlaps the next forward, so
+its effective cost is lower than reported here.
 
 Usage:
 
@@ -25,22 +26,26 @@ from vllm.sampling_params import SamplingParams
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+from vllm_metal.v1.logits_processors import BatchMinPLogitsProcessor
 from vllm_metal.v1.sampling_batch import SamplingBatch
 
 VOCAB_SIZE = 151936
 TOP_K = 20
 TOP_P = 0.95
+MIN_P = 0.05
 WARMUP_ITERS = 5
 TIMED_ITERS = 50
 
 
 def _time_torch(logits_mx: mx.array, batch: int) -> float:
+    min_p_proc = BatchMinPLogitsProcessor(torch.full((batch,), MIN_P))
+
     def step() -> torch.Tensor:
         logits_f32 = logits_mx.astype(mx.float32)
         mx.eval(logits_f32)
-        logits = mlx_to_torch(logits_f32, device="cpu")
+        logits = mlx_to_torch(logits_f32, device="cpu").clone()
         filtered = apply_top_k_top_p(
-            logits.clone(),
+            min_p_proc.apply(logits),
             torch.full((batch,), TOP_K),
             torch.full((batch,), TOP_P),
         )
@@ -75,7 +80,9 @@ def _time_native(logits: mx.array, params: list[SamplingParams]) -> float:
 
 
 def main() -> None:
-    sampling_params = SamplingParams(temperature=0.7, top_k=TOP_K, top_p=TOP_P)
+    sampling_params = SamplingParams(
+        temperature=0.7, top_k=TOP_K, top_p=TOP_P, min_p=MIN_P
+    )
     for batch in (1, 8):
         logits_mx = mx.random.normal((batch, VOCAB_SIZE), key=mx.random.key(0))
         mx.eval(logits_mx)

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -255,7 +255,6 @@ class MetalPlatform(Platform):
         unsupported_controls = [
             name
             for name, enabled in (
-                ("min_p", params.min_p > 0.0),
                 ("logit_bias", bool(params.logit_bias)),
                 ("min_tokens", params.min_tokens > 0),
             )

--- a/vllm_metal/v1/logits_processors.py
+++ b/vllm_metal/v1/logits_processors.py
@@ -1,37 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
-"""vLLM logits processors for the Metal v1 torch sampler path.
-
-``SamplingBatch`` hands these to ``SamplingMetadata.logitsprocs`` so that
-``Sampler`` applies them in upstream order, rather than masking logits
-before ``Sampler.forward``.
-"""
+"""Logits processors used by Metal's torch sampler bridge."""
 
 import torch
 from vllm.v1.sample.logits_processor import BatchUpdate, LogitsProcessor
 
 
 class BatchMinPLogitsProcessor(LogitsProcessor):
-    """Per-row ``min_p`` mask for the torch sampler path.
-
-    vLLM's own ``MinPLogitsProcessor`` tracks a persistent batch through
-    ``BatchUpdate`` deltas; the Metal ``SamplingBatch`` is rebuilt from
-    scratch each step, so this variant takes the row values directly.
-
-    Registered as argmax-invariant so ``Sampler`` applies it after
-    temperature and before top-k/top-p — the upstream order. Masking ahead
-    of ``Sampler.forward`` instead would threshold un-scaled probabilities
-    and leave ``-inf`` in the raw logprobs the sampler reports.
-    """
+    """Per-step ``min_p`` mask for ``SamplingBatch``."""
 
     def __init__(self, min_p: torch.Tensor) -> None:
         self.min_p = min_p.unsqueeze(-1)
 
     def is_argmax_invariant(self) -> bool:
-        """Min-p never impacts greedy sampling."""
+        """Apply after temperature and before top-k/top-p."""
         return True
 
     def update_state(self, batch_update: BatchUpdate | None) -> None:
-        """No-op: the batch is rebuilt per step, so there are no deltas."""
+        """No-op because ``SamplingBatch`` is rebuilt per step."""
 
     def apply(self, logits: torch.Tensor) -> torch.Tensor:
         probs = torch.softmax(logits, dim=-1)

--- a/vllm_metal/v1/logits_processors.py
+++ b/vllm_metal/v1/logits_processors.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM logits processors for the Metal v1 torch sampler path.
+
+``SamplingBatch`` hands these to ``SamplingMetadata.logitsprocs`` so that
+``Sampler`` applies them in upstream order, rather than masking logits
+before ``Sampler.forward``.
+"""
+
+import torch
+from vllm.v1.sample.logits_processor import BatchUpdate, LogitsProcessor
+
+
+class BatchMinPLogitsProcessor(LogitsProcessor):
+    """Per-row ``min_p`` mask for the torch sampler path.
+
+    vLLM's own ``MinPLogitsProcessor`` tracks a persistent batch through
+    ``BatchUpdate`` deltas; the Metal ``SamplingBatch`` is rebuilt from
+    scratch each step, so this variant takes the row values directly.
+
+    Registered as argmax-invariant so ``Sampler`` applies it after
+    temperature and before top-k/top-p — the upstream order. Masking ahead
+    of ``Sampler.forward`` instead would threshold un-scaled probabilities
+    and leave ``-inf`` in the raw logprobs the sampler reports.
+    """
+
+    def __init__(self, min_p: torch.Tensor) -> None:
+        self.min_p = min_p.unsqueeze(-1)
+
+    def is_argmax_invariant(self) -> bool:
+        """Min-p never impacts greedy sampling."""
+        return True
+
+    def update_state(self, batch_update: BatchUpdate | None) -> None:
+        """No-op: the batch is rebuilt per step, so there are no deltas."""
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        probs = torch.softmax(logits, dim=-1)
+        threshold = probs.amax(dim=-1, keepdim=True).mul_(self.min_p)
+        return logits.masked_fill(probs < threshold, float("-inf"))

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -202,12 +202,8 @@ class SamplingBatch:
     ) -> bool:
         """Whether MLX categorical sampling matches *sampling_params_list*.
 
-        Mirror of :meth:`params_allow_native_greedy` for the non-greedy case:
-        every request must use plain temperature/top-k/top-p/min-p sampling,
-        with one shared ``(top_k, top_p, min_p)`` across the batch so a single mask
-        graph covers every row.
-        Seeded requests keep the torch path, whose per-request
-        ``torch.Generator`` contract MLX keys do not reproduce.
+        Requests must use plain temperature/top-k/top-p/min-p sampling with
+        one shared mask. Seeded requests stay on the torch path.
         """
         if not sampling_params_list:
             return False
@@ -273,19 +269,11 @@ class SamplingBatch:
         top_p: float,
         min_p: float,
     ) -> mx.array:
-        """Mask temperature-scaled logits to the top-k/top-p/min-p candidate set.
-
-        Mask semantics match vLLM's ``MinPLogitsProcessor`` followed by
-        ``apply_top_k_top_p``, in that order: ties at the top-k threshold
-        survive, while top-p masks sorted positions individually (boundary
-        ties do NOT all survive; which tied token survives follows sort
-        order). The leading sorted position carries zero leading mass, so
-        every valid ``top_p > 0`` keeps at least one candidate, and min-p
-        compares against that same leading position's probability so it
-        keeps at least one too. Non-candidates become ``-inf``.
-        """
+        """Mask temperature-scaled logits to the native candidate set."""
         vocab_size = int(scaled_logits.shape[-1])
         if 0 < top_k < vocab_size:
+            # Top-k can run before min-p: it preserves probability ratios
+            # among survivors and removes only tokens top-k would drop anyway.
             kth_largest = mx.min(
                 mx.topk(scaled_logits, k=top_k, axis=-1), axis=-1, keepdims=True
             )
@@ -318,11 +306,7 @@ class SamplingBatch:
         sampling_params_list: Sequence[SamplingParams],
         key: mx.array,
     ) -> mx.array:
-        """Lazy temperature/top-k/top-p/min-p token ids, one per row.
-
-        Only valid for batches that pass :meth:`params_allow_native_random`:
-        per-row temperature with one shared ``(top_k, top_p, min_p)``.
-        """
+        """Lazy temperature/top-k/top-p/min-p token ids, one per row."""
         temperatures = mx.array(
             [sp.temperature for sp in sampling_params_list], dtype=mx.float32
         )

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -19,6 +19,7 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch
+from vllm_metal.v1.logits_processors import BatchMinPLogitsProcessor
 
 GREEDY_TEMPERATURE_EPS = 1e-5
 _EMPTY_LOGITSPROCS = LogitsProcessors()
@@ -203,8 +204,8 @@ class SamplingBatch:
 
         Mirror of :meth:`params_allow_native_greedy` for the non-greedy case:
         every request must use plain temperature/top-k/top-p/min-p sampling,
-        with one shared ``(top_k, top_p)`` across the batch so a single mask
-        graph covers every row.  Per-row ``min_p`` is handled natively.
+        with one shared ``(top_k, top_p, min_p)`` across the batch so a single mask
+        graph covers every row.
         Seeded requests keep the torch path, whose per-request
         ``torch.Generator`` contract MLX keys do not reproduce.
         """
@@ -212,9 +213,11 @@ class SamplingBatch:
             return False
         shared_top_k = len({sp.top_k for sp in sampling_params_list}) == 1
         shared_top_p = len({sp.top_p for sp in sampling_params_list}) == 1
+        shared_min_p = len({sp.min_p for sp in sampling_params_list}) == 1
         return (
             shared_top_k
             and shared_top_p
+            and shared_min_p
             and all(
                 sp.temperature >= GREEDY_TEMPERATURE_EPS
                 and sp.seed is None
@@ -264,19 +267,22 @@ class SamplingBatch:
         )
 
     @staticmethod
-    def _top_k_top_p_masked_logits(
+    def _top_k_top_p_min_p_masked_logits(
         scaled_logits: mx.array,
         top_k: int,
         top_p: float,
+        min_p: float,
     ) -> mx.array:
-        """Mask temperature-scaled logits to the top-k/top-p candidate set.
+        """Mask temperature-scaled logits to the top-k/top-p/min-p candidate set.
 
-        Mask semantics match vLLM's ``apply_top_k_top_p``: ties at the top-k
-        threshold survive, while top-p masks sorted positions individually
-        (boundary ties do NOT all survive; which tied token survives follows
-        sort order). The leading sorted position carries zero leading mass,
-        so every valid ``top_p > 0`` keeps at least one candidate.
-        Non-candidates become ``-inf``.
+        Mask semantics match vLLM's ``MinPLogitsProcessor`` followed by
+        ``apply_top_k_top_p``, in that order: ties at the top-k threshold
+        survive, while top-p masks sorted positions individually (boundary
+        ties do NOT all survive; which tied token survives follows sort
+        order). The leading sorted position carries zero leading mass, so
+        every valid ``top_p > 0`` keeps at least one candidate, and min-p
+        compares against that same leading position's probability so it
+        keeps at least one too. Non-candidates become ``-inf``.
         """
         vocab_size = int(scaled_logits.shape[-1])
         if 0 < top_k < vocab_size:
@@ -286,17 +292,21 @@ class SamplingBatch:
             scaled_logits = mx.where(
                 scaled_logits < kth_largest, -mx.inf, scaled_logits
             )
-        if top_p < 1.0:
+        if top_p < 1.0 or min_p > 0.0:
             order_desc = mx.argsort(scaled_logits, axis=-1)[..., ::-1]
             sorted_desc = mx.take_along_axis(scaled_logits, order_desc, axis=-1)
-            sorted_probs = mx.softmax(sorted_desc, axis=-1)
-            leading_mass = mx.cumsum(sorted_probs, axis=-1) - sorted_probs
-            keep = leading_mass < top_p
-            masked_sorted = mx.where(keep, sorted_desc, -mx.inf)
+            if min_p > 0.0:
+                sorted_probs = mx.softmax(sorted_desc, axis=-1)
+                keep = sorted_probs >= min_p * sorted_probs[..., :1]
+                sorted_desc = mx.where(keep, sorted_desc, -mx.inf)
+            if top_p < 1.0:
+                sorted_probs = mx.softmax(sorted_desc, axis=-1)
+                leading_mass = mx.cumsum(sorted_probs, axis=-1) - sorted_probs
+                sorted_desc = mx.where(leading_mass < top_p, sorted_desc, -mx.inf)
             scaled_logits = mx.put_along_axis(
                 mx.full(scaled_logits.shape, -mx.inf, dtype=scaled_logits.dtype),
                 order_desc,
-                masked_sorted,
+                sorted_desc,
                 axis=-1,
             )
         return scaled_logits
@@ -311,17 +321,17 @@ class SamplingBatch:
         """Lazy temperature/top-k/top-p/min-p token ids, one per row.
 
         Only valid for batches that pass :meth:`params_allow_native_random`:
-        per-row temperature with one shared ``(top_k, top_p)``.
+        per-row temperature with one shared ``(top_k, top_p, min_p)``.
         """
         temperatures = mx.array(
             [sp.temperature for sp in sampling_params_list], dtype=mx.float32
         )
         scaled = logits_2d.astype(mx.float32) / temperatures[:, None]
-        scaled = _apply_min_p_mlx(scaled, sampling_params_list)
-        masked = cls._top_k_top_p_masked_logits(
+        masked = cls._top_k_top_p_min_p_masked_logits(
             scaled,
             sampling_params_list[0].top_k,
             sampling_params_list[0].top_p,
+            sampling_params_list[0].min_p,
         )
         return mx.random.categorical(masked, axis=-1, key=key)
 
@@ -487,6 +497,22 @@ class SamplingBatch:
                 token_ids_by_row[i] = []
         return None, token_ids_by_row
 
+    def _make_logitsprocs(self) -> LogitsProcessors:
+        min_p_vals = [sp.min_p for sp in self.sampling_params_list]
+        if not any(min_p > 0.0 for min_p in min_p_vals):
+            return _EMPTY_LOGITSPROCS
+        return LogitsProcessors(
+            [
+                BatchMinPLogitsProcessor(
+                    torch.tensor(
+                        min_p_vals,
+                        dtype=torch.float32,
+                        device=self.SAMPLER_DEVICE,
+                    )
+                )
+            ]
+        )
+
     def make_sampling_metadata(
         self, logits: torch.Tensor | None = None
     ) -> SamplingMetadata:
@@ -514,49 +540,9 @@ class SamplingBatch:
             no_penalties=self.no_penalties,
             allowed_token_ids_mask=self._make_allowed_token_ids_mask(),
             bad_words_token_ids=self._make_bad_words_token_ids(),
-            logitsprocs=_EMPTY_LOGITSPROCS,
+            logitsprocs=self._make_logitsprocs(),
             logprob_token_ids=logprob_token_ids,
         )
-
-
-# ---------------------------------------------------------------------------
-# min_p helpers
-# ---------------------------------------------------------------------------
-
-
-def _apply_min_p_mlx(
-    logits: mx.array, sampling_params_list: Sequence[SamplingParams]
-) -> mx.array:
-    """Mask logits below the per-row min_p threshold (MLX path).
-
-    Tokens whose probability is less than ``min_p * max_prob`` for that row
-    are set to ``-inf``.  Matches upstream vLLM's ``MinPLogitsProcessor``
-    order: applied after temperature, before top-k/top-p.
-    """
-    min_p_vals = [sp.min_p for sp in sampling_params_list]
-    if not any(v > 0.0 for v in min_p_vals):
-        return logits
-    probs = mx.softmax(logits, axis=-1)
-    max_prob = mx.max(probs, axis=-1, keepdims=True)
-    threshold = mx.array(min_p_vals, dtype=mx.float32)[:, None] * max_prob
-    return mx.where(probs < threshold, -mx.inf, logits)
-
-
-def _apply_min_p_torch(
-    logits: torch.Tensor, sampling_params_list: Sequence[SamplingParams]
-) -> torch.Tensor:
-    """Mask logits below the per-row min_p threshold (torch path)."""
-    min_p_vals = [sp.min_p for sp in sampling_params_list]
-    if not any(v > 0.0 for v in min_p_vals):
-        return logits
-    probs = torch.softmax(logits, dim=-1)
-    max_prob = probs.max(dim=-1, keepdim=True).values
-    threshold = (
-        torch.tensor(min_p_vals, dtype=torch.float32, device=logits.device)
-        .unsqueeze(-1)
-        .mul_(max_prob)
-    )
-    return logits.masked_fill(probs < threshold, float("-inf"))
 
 
 # ---------------------------------------------------------------------------
@@ -597,8 +583,6 @@ def sample_from_logits(
     logits_torch = mlx_to_torch(
         logits_2d.astype(mx.float32), device=SamplingBatch.SAMPLER_DEVICE
     )
-    # min_p: applied before the vLLM sampler since logitsprocs are not wired up.
-    logits_torch = _apply_min_p_torch(logits_torch, batch.sampling_params_list)
     metadata = batch.make_sampling_metadata(logits_torch)
     output = sampler.forward(logits_torch, metadata)
     logprobs = (

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -202,12 +202,11 @@ class SamplingBatch:
         """Whether MLX categorical sampling matches *sampling_params_list*.
 
         Mirror of :meth:`params_allow_native_greedy` for the non-greedy case:
-        every request must use plain temperature/top-k/top-p sampling, with
-        one shared ``(top_k, top_p)`` across the batch so a single mask graph
-        covers every row. Seeded requests keep the torch path, whose
-        per-request ``torch.Generator`` contract MLX keys do not reproduce.
-        Options the platform rejects outright (``min_p``, ``logit_bias``)
-        are not re-checked here.
+        every request must use plain temperature/top-k/top-p/min-p sampling,
+        with one shared ``(top_k, top_p)`` across the batch so a single mask
+        graph covers every row.  Per-row ``min_p`` is handled natively.
+        Seeded requests keep the torch path, whose per-request
+        ``torch.Generator`` contract MLX keys do not reproduce.
         """
         if not sampling_params_list:
             return False
@@ -309,7 +308,7 @@ class SamplingBatch:
         sampling_params_list: Sequence[SamplingParams],
         key: mx.array,
     ) -> mx.array:
-        """Lazy temperature/top-k/top-p token ids, one per row.
+        """Lazy temperature/top-k/top-p/min-p token ids, one per row.
 
         Only valid for batches that pass :meth:`params_allow_native_random`:
         per-row temperature with one shared ``(top_k, top_p)``.
@@ -318,6 +317,7 @@ class SamplingBatch:
             [sp.temperature for sp in sampling_params_list], dtype=mx.float32
         )
         scaled = logits_2d.astype(mx.float32) / temperatures[:, None]
+        scaled = _apply_min_p_mlx(scaled, sampling_params_list)
         masked = cls._top_k_top_p_masked_logits(
             scaled,
             sampling_params_list[0].top_k,
@@ -520,6 +520,46 @@ class SamplingBatch:
 
 
 # ---------------------------------------------------------------------------
+# min_p helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_min_p_mlx(
+    logits: mx.array, sampling_params_list: Sequence[SamplingParams]
+) -> mx.array:
+    """Mask logits below the per-row min_p threshold (MLX path).
+
+    Tokens whose probability is less than ``min_p * max_prob`` for that row
+    are set to ``-inf``.  Matches upstream vLLM's ``MinPLogitsProcessor``
+    order: applied after temperature, before top-k/top-p.
+    """
+    min_p_vals = [sp.min_p for sp in sampling_params_list]
+    if not any(v > 0.0 for v in min_p_vals):
+        return logits
+    probs = mx.softmax(logits, axis=-1)
+    max_prob = mx.max(probs, axis=-1, keepdims=True)
+    threshold = mx.array(min_p_vals, dtype=mx.float32)[:, None] * max_prob
+    return mx.where(probs < threshold, -mx.inf, logits)
+
+
+def _apply_min_p_torch(
+    logits: torch.Tensor, sampling_params_list: Sequence[SamplingParams]
+) -> torch.Tensor:
+    """Mask logits below the per-row min_p threshold (torch path)."""
+    min_p_vals = [sp.min_p for sp in sampling_params_list]
+    if not any(v > 0.0 for v in min_p_vals):
+        return logits
+    probs = torch.softmax(logits, dim=-1)
+    max_prob = probs.max(dim=-1, keepdim=True).values
+    threshold = (
+        torch.tensor(min_p_vals, dtype=torch.float32, device=logits.device)
+        .unsqueeze(-1)
+        .mul_(max_prob)
+    )
+    return logits.masked_fill(probs < threshold, float("-inf"))
+
+
+# ---------------------------------------------------------------------------
 # Pure sampling functions
 # ---------------------------------------------------------------------------
 
@@ -557,6 +597,8 @@ def sample_from_logits(
     logits_torch = mlx_to_torch(
         logits_2d.astype(mx.float32), device=SamplingBatch.SAMPLER_DEVICE
     )
+    # min_p: applied before the vLLM sampler since logitsprocs are not wired up.
+    logits_torch = _apply_min_p_torch(logits_torch, batch.sampling_params_list)
     metadata = batch.make_sampling_metadata(logits_torch)
     output = sampler.forward(logits_torch, metadata)
     logprobs = (

--- a/vllm_metal/v1/sampling_batch.py
+++ b/vllm_metal/v1/sampling_batch.py
@@ -263,11 +263,11 @@ class SamplingBatch:
         )
 
     @staticmethod
-    def _top_k_top_p_min_p_masked_logits(
+    def _top_k_top_p_masked_logits(
         scaled_logits: mx.array,
         top_k: int,
         top_p: float,
-        min_p: float,
+        min_p: float = 0.0,
     ) -> mx.array:
         """Mask temperature-scaled logits to the native candidate set."""
         vocab_size = int(scaled_logits.shape[-1])
@@ -311,11 +311,11 @@ class SamplingBatch:
             [sp.temperature for sp in sampling_params_list], dtype=mx.float32
         )
         scaled = logits_2d.astype(mx.float32) / temperatures[:, None]
-        masked = cls._top_k_top_p_min_p_masked_logits(
+        masked = cls._top_k_top_p_masked_logits(
             scaled,
             sampling_params_list[0].top_k,
             sampling_params_list[0].top_p,
-            sampling_params_list[0].min_p,
+            min_p=sampling_params_list[0].min_p,
         )
         return mx.random.categorical(masked, axis=-1, key=key)
 


### PR DESCRIPTION
Fix: Implement min_p filtering natively in MLX ops (softmax → max → threshold → mask), matching upstream vLLM's sampling order (after temperature, before top-k/top-p). Covers both the native MLX path  
  and the torch fallback path. Remove min_p from the rejection list in validate_request. 
Closes #727