### PR TITLE
[Bugfix] Match Whisper reference audio features

### DIFF
--- a/tests/test_stt.py
+++ b/tests/test_stt.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 import mlx.core as mx
 import numpy as np
 import pytest
+from transformers import WhisperFeatureExtractor
 from transformers.models.whisper.tokenization_whisper import LANGUAGES
 from vllm.model_executor.models.whisper_utils import ISO639_1_SUPPORTED_LANGS
 
@@ -69,6 +70,25 @@ class TestValidateLanguage:
 
 class TestAudioPipeline:
     """Tests for core audio processing functions."""
+
+    @pytest.mark.parametrize("n_mels", [80, 128])
+    def test_log_mel_spectrogram_matches_whisper(self, n_mels: int) -> None:
+        # Non-silent boundaries expose STFT padding differences; the partial
+        # final hop also checks Whisper's trailing-frame convention.
+        audio = (
+            np.random.default_rng(0).normal(0, 0.1, SAMPLE_RATE + 57).astype(np.float32)
+        )
+        expected = WhisperFeatureExtractor(feature_size=n_mels)(
+            audio,
+            sampling_rate=SAMPLE_RATE,
+            padding="do_not_pad",
+            truncation=False,
+            return_tensors="np",
+        ).input_features[0]
+
+        actual = log_mel_spectrogram(audio, n_mels=n_mels)
+
+        np.testing.assert_allclose(np.array(actual), expected, atol=2e-4, rtol=1e-5)
 
     def test_log_mel_spectrogram_shape(self) -> None:
         """Log-mel spectrogram should have expected shape."""

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -9,11 +9,12 @@ from types import SimpleNamespace
 from typing import cast
 
 import mlx.core as mx
+import numpy as np
 import pytest
-from transformers import WhisperTokenizer
+from transformers import WhisperFeatureExtractor, WhisperTokenizer
 from vllm.config import SpeechToTextConfig
 
-from vllm_metal.stt.audio import SAMPLE_RATE
+from vllm_metal.stt.audio import N_SAMPLES, SAMPLE_RATE
 from vllm_metal.stt.loader import load_model
 from vllm_metal.stt.whisper import WhisperConfig, WhisperModel, WhisperTranscriber
 from vllm_metal.stt.whisper.transcriber import (
@@ -407,6 +408,26 @@ class TestGreedyDecode:
 
 
 class TestEncodeChunk:
+    @pytest.mark.parametrize("n_mels", [80, 128])
+    @pytest.mark.parametrize("num_samples", [SAMPLE_RATE, N_SAMPLES])
+    def test_encoder_input_matches_whisper(self, n_mels: int, num_samples: int) -> None:
+        audio = np.random.default_rng(1).normal(0, 0.1, num_samples).astype(np.float32)
+        # Return the encoder input so the assertion covers the real chunk
+        # preprocessing, including padding and the time/mel transpose.
+        model = cast(
+            WhisperModel,
+            SimpleNamespace(
+                config=SimpleNamespace(n_mels=n_mels), encode=lambda mel: mel
+            ),
+        )
+        expected = WhisperFeatureExtractor(feature_size=n_mels)(
+            audio, sampling_rate=SAMPLE_RATE, return_tensors="np"
+        ).input_features.transpose(0, 2, 1)
+
+        actual = WhisperTranscriber(model)._encode_chunk(mx.array(audio))
+
+        np.testing.assert_allclose(np.array(actual), expected, atol=2e-4, rtol=1e-5)
+
     def test_encode_chunk_output_shape(self) -> None:
         transcriber = WhisperTranscriber(
             model=_make_tiny_whisper_model(n_audio_ctx=1500)

--- a/vllm_metal/stt/audio.py
+++ b/vllm_metal/stt/audio.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 
 import mlx.core as mx
 import numpy as np
+from transformers.audio_utils import mel_filter_bank
 
 # ===========================================================================
 # Whisper audio constants (matches OpenAI spec)
@@ -198,7 +199,15 @@ def _stft(
         Complex spectrogram of shape ``(n_fft // 2 + 1, num_frames)``.
     """
     pad_amount = n_fft // 2
-    audio = mx.pad(audio, [(pad_amount, pad_amount)])
+    if audio.shape[0] <= pad_amount:
+        raise ValueError(
+            f"STFT input must contain more than {pad_amount} samples for "
+            "reflect padding; pad the waveform before computing features."
+        )
+    # Match torch.stft's centered reflect padding, excluding the endpoints.
+    audio = mx.concatenate(
+        [audio[1 : pad_amount + 1][::-1], audio, audio[-pad_amount - 1 : -1][::-1]]
+    )
 
     num_frames = (audio.shape[0] - n_fft) // hop_length + 1
 
@@ -226,29 +235,19 @@ def _mel_filters(sample_rate: int, n_fft: int, n_mels: int) -> mx.array:
         Filter-bank of shape ``(n_mels, n_fft // 2 + 1)``.
     """
 
-    def hz_to_mel(hz: float) -> float:
-        return 2595.0 * math.log10(1.0 + hz / 700.0)
-
-    def mel_to_hz(mel: float) -> float:
-        return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
-
-    mel_points = mx.linspace(hz_to_mel(0), hz_to_mel(sample_rate / 2), n_mels + 2)
-    hz_points = mx.array([mel_to_hz(m.item()) for m in mel_points])
-    bin_points = mx.floor((n_fft + 1) * hz_points / sample_rate).astype(mx.int32)
-
-    filters = mx.zeros((n_mels, n_fft // 2 + 1))
-    for i in range(n_mels):
-        left, center, right = (bin_points[j].item() for j in (i, i + 1, i + 2))
-        for j in range(left, center):
-            if center != left:
-                filters[i, j] = (j - left) / (center - left)
-        for j in range(center, right):
-            if right != center:
-                filters[i, j] = (right - j) / (right - center)
-
-    # Slaney normalisation
-    enorm = 2.0 / (hz_points[2 : n_mels + 2] - hz_points[:n_mels])
-    return filters * enorm[:, None]
+    # Whisper uses the Slaney frequency scale as well as Slaney area
+    # normalization. Evaluate triangles at FFT frequencies without rounding
+    # their vertices to bins (which can erase narrow low-frequency filters).
+    filters = mel_filter_bank(
+        num_frequency_bins=n_fft // 2 + 1,
+        num_mel_filters=n_mels,
+        min_frequency=0.0,
+        max_frequency=sample_rate / 2,
+        sampling_rate=sample_rate,
+        norm="slaney",
+        mel_scale="slaney",
+    )
+    return mx.array(filters.T, dtype=mx.float32)
 
 
 def log_mel_spectrogram(
@@ -270,7 +269,8 @@ def log_mel_spectrogram(
         audio = mx.array(audio, mx.float32)
 
     window = _hanning(N_FFT)
-    freqs = _stft(audio, window, N_FFT, HOP_LENGTH)
+    # Whisper drops the final centered STFT frame before Mel projection.
+    freqs = _stft(audio, window, N_FFT, HOP_LENGTH)[:, :-1]
     magnitudes = (freqs * mx.conj(freqs)).real
 
     filters = _mel_filters(SAMPLE_RATE, N_FFT, n_mels)

--- a/vllm_metal/stt/whisper/transcriber.py
+++ b/vllm_metal/stt/whisper/transcriber.py
@@ -15,7 +15,6 @@ from vllm.config import SpeechToTextConfig
 from vllm.model_executor.models.whisper_utils import ISO639_1_SUPPORTED_LANGS
 
 from vllm_metal.stt.audio import (
-    N_FRAMES,
     N_SAMPLES,
     SAMPLE_RATE,
     audio_duration,
@@ -384,8 +383,10 @@ class WhisperTranscriber:
         return segments
 
     def _encode_chunk(self, audio_chunk: mx.array) -> mx.array:
+        # Pad silence in waveform space: zero-valued log-Mel features are
+        # not the spectrogram of silence, and padding affects normalization.
+        audio_chunk = pad_or_trim(audio_chunk, N_SAMPLES)
         mel = log_mel_spectrogram(audio_chunk, n_mels=self.model.config.n_mels)
-        mel = pad_or_trim(mel, N_FRAMES, axis=-1)
         if mel.ndim == 2:
             mel = mel[None, ...]
         mel = mel.transpose(0, 2, 1)


### PR DESCRIPTION
Standalone `WhisperTranscriber.transcribe()` was feeding Whisper incorrect audio features. With `openai/whisper-tiny`, the [JFK speech fixture](https://github.com/openai/whisper/blob/86098128c0b4f24f0e2aa2994de830614b474227/tests/jfk.flac) produced `[Music]`. After this change it produces the spoken sentence, matching all 23 greedy token IDs from the same model supplied with Hugging Face reference features.

Match [Whisper's reference frontend](https://github.com/openai/whisper/blob/86098128c0b4f24f0e2aa2994de830614b474227/whisper/audio.py#L92-L157): use Slaney-scaled mel filters evaluated at FFT frequencies, reflect the centered STFT boundaries, drop the terminal frame, and pad the waveform before computing log-Mel features. The filter builder comes from the existing Transformers dependency. Padding normalized features with zeros previously supplied a different signal from padded silence.

Add six reference comparisons covering raw partial-hop audio and the actual encoder input for short/full-window clips, with both 80 and 128 mel bands. All six fail on unchanged main (`9c1d230`); independently restoring each old behavior also breaks the comparisons.

Validation on Apple M4 / macOS 15.6 at `9dd416852df61b6d2ec5980b12dbc8f8c20b9950`:

- STT tests: 119 passed. Full `pytest -m "not slow" tests/`: 2,103 passed, 15 skipped, 53 deselected.
- Independent OpenAI filter assets and additional silence, impulse, low-amplitude, short-input, strided-input, and tone checks passed.
- Mono 16 kHz JFK clip, Whisper Tiny revision `169d4a4341b33bc18d8881c4b69c2e104e1cc0af`: public transcription and the 23-token reference comparison passed.
- Ruff, formatting, mypy, ShellCheck, native Metal builds, release-wheel artifact checks, and both repository Qwen serving smoke tests passed.

Runtime: Python 3.12.13, vLLM 0.28.0+cpu, MLX 0.32.1, pinned mlx-lm `9e6acca`, mlx-vlm 0.6.8, Transformers 5.16.1.
