### PR TITLE
[Experimental] Reuse upstream vLLM models on PyTorch MPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ vLLM Metal is a plugin that enables vLLM to run on Apple Silicon Macs using MLX 
 
 Upstream vLLM supplies the API server, scheduler, and paged block manager; mlx_lm supplies the token-wise model layers; vllm-metal owns the request-aware attention path — the paged varlen kernel, M5 NAX prefill, and speculative decoding.
 
+An opt-in [PyTorch/MPS compatibility backend](docs/pytorch_backend.md) executes
+upstream vLLM model implementations directly. It is experimental and currently
+targets unquantized dense text generation on one Mac.
+
 ![vllm-metal in the vLLM stack](https://raw.githubusercontent.com/vllm-project/vllm-metal/main/docs/assets/architecture.svg)
 
 ## Requirements

--- a/docs/pytorch_backend.md
+++ b/docs/pytorch_backend.md
@@ -1,0 +1,89 @@
+# Experimental PyTorch/MPS backend
+
+Set `VLLM_METAL_MODEL_BACKEND=torch` before starting vLLM to execute upstream
+vLLM model implementations on Apple Silicon through PyTorch MPS. The default
+remains `mlx`.
+
+This is a compatibility prototype for unquantized dense decoder models. It
+does not establish support for every model in vLLM's registry. Models still need
+PyTorch-native implementations of all their operations, and this path is not
+optimized for throughput.
+
+## Usage
+
+Use the normal vllm-metal development installation, including the macOS vLLM
+CPU wheel and its native extension. An `empty` vLLM build is insufficient:
+the upstream CPU runner uses its native slot-mapping operation.
+
+Start with a small original Hugging Face checkpoint:
+
+```bash
+VLLM_METAL_MODEL_BACKEND=torch vllm serve HuggingFaceTB/SmolLM2-135M \
+  --host 127.0.0.1 --dtype float32 --max-model-len 256 \
+  --max-num-seqs 2 --max-num-batched-tokens 64 \
+  --kv-cache-memory-bytes 16777216
+```
+
+The same environment variable selects this backend for `LLM(...)`. Eager
+execution and synchronous scheduling are configured by the platform. The model
+loader honors upstream checkpoint loading and architecture resolution; no MLX
+model conversion is involved.
+
+The default KV budget is capped at 512 MiB and reduced when system or MPS
+headroom is lower. `--kv-cache-memory-bytes` overrides that cap within the
+available budget. These limits cover KV storage, not total process memory:
+weights, activations, and attention scratch space also consume unified memory.
+Use small context and batch limits on memory-constrained Macs.
+
+## Reused upstream components
+
+The plugin selects a separate out-of-tree platform before applying the MLX
+compatibility patches. Its worker reuses `CPUModelRunner` for request updates,
+batching, slot mapping, cache planning/binding, prompt logprobs, and sampling.
+The model is instantiated by vLLM's `get_model` and `ModelRegistry`, so model
+classes and weight-loading rules stay upstream.
+
+Scheduling tensors and the sampler stay on CPU. A small model wrapper moves
+inputs to MPS and returns logits to CPU. Parameters, intermediate activations,
+and KV tensors remain on MPS. Standard layers use vLLM's native PyTorch
+implementations through the existing out-of-tree custom-op dispatch.
+
+The attention backend consumes upstream `CommonAttentionMetadata`, updates the
+paged KV cache, and calls PyTorch scaled dot-product attention per request.
+It handles causal prefill, chunked prefill, decode, GQA, prefix reuse, and sliding
+windows. It accepts the split-cache layout in vLLM 0.28 and the packed per-layer
+layout in current main. The upstream allocator still owns allocation and binding.
+
+This avoids maintaining another scheduler, sampler, model registry, or set of
+model implementations. It also establishes a small boundary where optimized
+Metal attention could be added later without changing model classes.
+
+## Limits
+
+The initial scope excludes quantization, MoE, SSM/hybrid models, multimodal and
+encoder-decoder models, pooling, LoRA, speculative decoding, distributed and
+context-parallel execution, KV/weight offloading or transfer, and profiling.
+These configurations fail during setup. Attention rejects ALiBi, logit soft
+capping, attention sinks, and cross-layer KV sharing. CUDA-specific operations
+in other architectures can still fail when their model is loaded or executed.
+
+Attention gathers each request's visible cache into contiguous tensors; GQA
+also expands KV heads. This is intentionally a simple correctness path and can
+use substantial scratch memory for long contexts. There is no throughput or
+full model-matrix parity claim with the MLX backend.
+
+## Validation
+
+```bash
+python -m pytest tests/test_pytorch_attention.py \
+  tests/test_pytorch_model_runner.py tests/test_pytorch_models.py \
+  tests/test_register.py -q
+```
+
+The model tests create tiny Llama, Qwen2, and Qwen3 checkpoints locally and
+compare greedy tokens against Hugging Face CPU and MLX references. They also
+exercise chunked prefill, prefix reuse, logit bias, and prompt/output logprobs.
+They run in separate interpreters because vLLM selects its platform once per
+process. No checkpoint download is needed. Attention tests cover real MPS
+execution in float32, float16, and bfloat16, both cache layouts, and physical
+block addressing. Worker tests check the KV budget without allocating it.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -68,6 +68,7 @@ nav:
   - Models:
     - Supported Models: supported_models.md
   - Features:
+    - Experimental PyTorch Backend: pytorch_backend.md
     - GGUF: gguf.md
     - Speculative Decoding: speculative_decoding.md
     - Text Pooling: text_embedding_pooling.md

--- a/tests/test_pytorch_attention.py
+++ b/tests/test_pytorch_attention.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral tests for the native PyTorch SDPA attention backend."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+from torch.nn import functional
+from vllm.v1.attention.backend import CommonAttentionMetadata
+
+from vllm_metal.pytorch_backend.attention import (
+    TorchAttentionBackend,
+    TorchAttentionImpl,
+)
+
+
+def _impl(*, heads: int = 2, kv_heads: int = 2, window: int | None = None):
+    return TorchAttentionImpl(
+        num_heads=heads,
+        num_kv_heads=kv_heads,
+        head_size=4,
+        scale=0.5,
+        sliding_window=window,
+    )
+
+
+def _metadata(
+    query_lens: list[int],
+    seq_lens: list[int],
+    block_table: list[list[int]],
+    slots: list[int],
+    *,
+    num_actual_tokens: int | None = None,
+) -> CommonAttentionMetadata:
+    starts = [0]
+    for length in query_lens:
+        starts.append(starts[-1] + length)
+    query_start_loc = torch.tensor(starts, dtype=torch.int32)
+    return CommonAttentionMetadata(
+        query_start_loc=query_start_loc,
+        query_start_loc_cpu=query_start_loc.clone(),
+        num_reqs=len(query_lens),
+        num_actual_tokens=sum(query_lens)
+        if num_actual_tokens is None
+        else num_actual_tokens,
+        max_query_len=max(query_lens),
+        max_seq_len=max(seq_lens),
+        seq_lens=torch.tensor(seq_lens, dtype=torch.int32),
+        block_table_tensor=torch.tensor(block_table, dtype=torch.int32),
+        slot_mapping=torch.tensor(slots, dtype=torch.int64),
+    )
+
+
+def _forward(impl, q, k, v, cache, metadata, output_rows=None):
+    rows = q.shape[0] if output_rows is None else output_rows
+    output = torch.full(
+        (rows, impl.num_heads, impl.head_size), math.nan, device=q.device
+    )
+    return impl.forward(None, q, k, v, cache, metadata, output)
+
+
+def test_full_prefill_matches_uncached_sdpa() -> None:
+    torch.manual_seed(4)
+    impl = _impl()
+    q = torch.randn(4, 2, 4)
+    k = torch.randn(4, 2, 4)
+    v = torch.randn(4, 2, 4)
+    cache = torch.zeros(TorchAttentionBackend.get_kv_cache_shape(2, 2, 2, 4))
+    metadata = _metadata([4], [4], [[0, 1]], [0, 1, 2, 3])
+
+    actual = _forward(impl, q, k, v, cache, metadata)
+    expected = functional.scaled_dot_product_attention(
+        q.transpose(0, 1),
+        k.transpose(0, 1),
+        v.transpose(0, 1),
+        is_causal=True,
+        scale=0.5,
+    ).transpose(0, 1)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_chunked_prefill_uses_causal_offset_and_physical_blocks() -> None:
+    torch.manual_seed(5)
+    impl = _impl()
+    all_q = torch.randn(5, 2, 4)
+    all_k = torch.randn(5, 2, 4)
+    all_v = torch.randn(5, 2, 4)
+    cache = torch.zeros(TorchAttentionBackend.get_kv_cache_shape(4, 2, 2, 4))
+
+    _forward(
+        impl,
+        all_q[:3],
+        all_k[:3],
+        all_v[:3],
+        cache,
+        _metadata([3], [3], [[2, 0, 3]], [4, 5, 0]),
+    )
+    actual = _forward(
+        impl,
+        all_q[3:],
+        all_k[3:],
+        all_v[3:],
+        cache,
+        _metadata([2], [5], [[2, 0, 3]], [1, 6]),
+    )
+    full = functional.scaled_dot_product_attention(
+        all_q.transpose(0, 1),
+        all_k.transpose(0, 1),
+        all_v.transpose(0, 1),
+        is_causal=True,
+        scale=0.5,
+    ).transpose(0, 1)
+
+    torch.testing.assert_close(actual, full[3:])
+
+
+def test_decode_reuses_prefix_cache_and_supports_gqa() -> None:
+    torch.manual_seed(6)
+    impl = _impl(heads=4, kv_heads=2)
+    q = torch.randn(4, 4, 4)
+    k = torch.randn(4, 2, 4)
+    v = torch.randn(4, 2, 4)
+    cache = torch.zeros(TorchAttentionBackend.get_kv_cache_shape(2, 2, 2, 4))
+
+    _forward(impl, q[:3], k[:3], v[:3], cache, _metadata([3], [3], [[0, 1]], [0, 1, 2]))
+    actual = _forward(
+        impl, q[3:], k[3:], v[3:], cache, _metadata([1], [4], [[0, 1]], [3])
+    )
+    repeated_k = k.repeat_interleave(2, dim=1)
+    repeated_v = v.repeat_interleave(2, dim=1)
+    expected = functional.scaled_dot_product_attention(
+        q[3:].transpose(0, 1),
+        repeated_k.transpose(0, 1),
+        repeated_v.transpose(0, 1),
+        scale=0.5,
+    ).transpose(0, 1)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_padding_slots_are_ignored_and_output_padding_is_untouched() -> None:
+    torch.manual_seed(7)
+    impl = _impl()
+    q = torch.randn(3, 2, 4)
+    k = torch.randn(3, 2, 4)
+    v = torch.randn(3, 2, 4)
+    cache = torch.zeros(TorchAttentionBackend.get_kv_cache_shape(1, 2, 2, 4))
+    metadata = _metadata([2], [2], [[0]], [0, 1, -1], num_actual_tokens=2)
+
+    actual = _forward(impl, q, k, v, cache, metadata, output_rows=3)
+
+    assert torch.isnan(actual[2]).all()
+    torch.testing.assert_close(cache[0, 0], k[:2])
+    torch.testing.assert_close(cache[1, 0], v[:2])
+
+
+def test_negative_slot_inside_active_cache_update_is_ignored() -> None:
+    key = torch.arange(24, dtype=torch.float32).reshape(3, 2, 4)
+    value = key + 100
+    key_cache = torch.zeros(1, 2, 2, 4)
+    value_cache = torch.zeros_like(key_cache)
+
+    TorchAttentionImpl._write_cache(
+        key,
+        value,
+        key_cache,
+        value_cache,
+        torch.tensor([0, -1, 1]),
+        3,
+    )
+
+    torch.testing.assert_close(key_cache[0, 0], key[0])
+    torch.testing.assert_close(key_cache[0, 1], key[2])
+    torch.testing.assert_close(value_cache[0, 0], value[0])
+    torch.testing.assert_close(value_cache[0, 1], value[2])
+
+
+def test_current_main_packed_strided_cache_updates_backing_storage() -> None:
+    torch.manual_seed(8)
+    impl = _impl()
+    # Current main exposes each layer as logical [block, head, token, 2 * dim].
+    # A transposed backing makes this view non-contiguous, like layout selection.
+    backing = torch.zeros(2, 2, 2, 8)
+    cache = backing.permute(0, 2, 1, 3)
+    assert not cache.is_contiguous()
+    q = torch.randn(2, 2, 4)
+    k = torch.randn(2, 2, 4)
+    v = torch.randn(2, 2, 4)
+
+    actual = _forward(impl, q, k, v, cache, _metadata([2], [2], [[0]], [0, 1]))
+    expected = functional.scaled_dot_product_attention(
+        q.transpose(0, 1),
+        k.transpose(0, 1),
+        v.transpose(0, 1),
+        is_causal=True,
+        scale=0.5,
+    ).transpose(0, 1)
+
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(cache[0, :, :, :4], k.permute(1, 0, 2))
+    torch.testing.assert_close(cache[0, :, :, 4:], v.permute(1, 0, 2))
+    assert torch.count_nonzero(backing).item() > 0
+
+
+def test_sliding_window_does_not_read_freed_prefix_blocks() -> None:
+    torch.manual_seed(9)
+    impl = _impl(window=2)
+    q = torch.randn(1, 2, 4)
+    k = torch.randn(1, 2, 4)
+    v = torch.randn(1, 2, 4)
+    cache = torch.randn(TorchAttentionBackend.get_kv_cache_shape(2, 2, 2, 4))
+    # At sequence length four, a two-token window only needs logical block 1.
+    # The scheduler may have released logical block 0 and left a null entry.
+    metadata = _metadata([1], [4], [[-1, 1]], [3])
+
+    actual = _forward(impl, q, k, v, cache, metadata)
+
+    assert torch.isfinite(actual).all()
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"alibi_slopes": [1.0, 1.0]}, "ALiBi"),
+        ({"logits_soft_cap": 30.0}, "soft-cap"),
+        ({"kv_cache_dtype": "fp8"}, "Quantized KV"),
+    ],
+)
+def test_unsupported_modifiers_fail_loudly(kwargs, match) -> None:
+    with pytest.raises(NotImplementedError, match=match):
+        TorchAttentionImpl(2, 4, 0.5, num_kv_heads=2, **kwargs)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS unavailable")
+def test_tiny_mps_decode_matches_cpu(dtype: torch.dtype) -> None:
+    torch.manual_seed(10)
+    device = torch.device("mps")
+    impl = _impl()
+    q_cpu = torch.randn(1, 2, 4, dtype=dtype)
+    k_cpu = torch.randn(1, 2, 4, dtype=dtype)
+    v_cpu = torch.randn(1, 2, 4, dtype=dtype)
+    cpu_cache = torch.zeros(
+        TorchAttentionBackend.get_kv_cache_shape(1, 2, 2, 4), dtype=dtype
+    )
+    expected = _forward(
+        impl, q_cpu, k_cpu, v_cpu, cpu_cache, _metadata([1], [1], [[0]], [0])
+    )
+    q = q_cpu.to(device)
+    k = k_cpu.to(device)
+    v = v_cpu.to(device)
+    cache = torch.zeros(
+        TorchAttentionBackend.get_kv_cache_shape(1, 2, 2, 4),
+        dtype=dtype,
+        device=device,
+    )
+    metadata = _metadata([1], [1], [[0]], [0])
+
+    output = _forward(impl, q, k, v, cache, metadata)
+
+    assert output.device.type == "mps"
+    assert torch.isfinite(output).all().item()
+    torch.testing.assert_close(
+        output.cpu(), expected, rtol=2e-2, atol=2e-2, check_dtype=True
+    )

--- a/tests/test_pytorch_model_runner.py
+++ b/tests/test_pytorch_model_runner.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Whole-model bridge and cache-allocation contracts."""
+
+from types import SimpleNamespace
+
+import psutil
+import pytest
+import torch
+from torch import nn
+from vllm.config import get_current_vllm_config, set_current_vllm_config
+from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+
+from vllm_metal.pytorch_backend.model_runner import TorchModelRunner, _HostInputModel
+from vllm_metal.pytorch_backend.worker import TorchWorker
+
+
+class _Model(nn.Module):
+    supports_pp = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(8, 4)
+        self.head = nn.Linear(4, 8)
+
+    def forward(
+        self, input_ids, positions, intermediate_tensors=None, inputs_embeds=None
+    ):
+        return self.embedding(input_ids) + positions[:, None]
+
+    def compute_logits(self, hidden_states):
+        return self.head(hidden_states)
+
+    def embed_input_ids(self, input_ids):
+        return self.embedding(input_ids)
+
+
+@pytest.mark.parametrize("device", ["cpu", "mps"])
+def test_model_bridge_preserves_hidden_states_logits_and_capabilities(device):
+    if device == "mps" and not torch.backends.mps.is_available():
+        pytest.skip("MPS is unavailable")
+    model = _Model().to(device)
+    bridge = _HostInputModel(model, torch.device(device))
+    inputs = {"input_ids": torch.tensor([1, 2]), "positions": torch.tensor([0, 1])}
+
+    hidden = bridge(**inputs)
+
+    torch.testing.assert_close(
+        hidden, model(**{name: value.to(device) for name, value in inputs.items()})
+    )
+    # The CPU runner indexes the MPS hidden states using CPU logits indices.
+    indices = torch.tensor([1])
+    logits = bridge.compute_logits(hidden[indices])
+    torch.testing.assert_close(logits, model.compute_logits(hidden[indices]).cpu())
+    torch.testing.assert_close(
+        bridge.embed_input_ids(inputs["input_ids"]),
+        model.embed_input_ids(inputs["input_ids"].to(device)).cpu(),
+    )
+    assert bridge.supports_pp is model.supports_pp
+    assert hidden.device.type == device
+    assert logits.device.type == "cpu"
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_kv_allocation_restores_control_device(monkeypatch, fails):
+    runner = object.__new__(TorchModelRunner)
+    runner.device = torch.device("cpu")
+    runner.compute_device = torch.device("meta")
+    config = SimpleNamespace()
+    cache = {"layer": torch.empty(1)}
+
+    def allocate(self, kv_cache_config, kernel_block_sizes, **kwargs):
+        assert self.device == torch.device("meta")
+        assert kv_cache_config is config
+        assert kernel_block_sizes == [16]
+        if fails:
+            raise RuntimeError("allocation failed")
+        return cache
+
+    monkeypatch.setattr(CPUModelRunner, "initialize_kv_cache_tensors", allocate)
+
+    if fails:
+        with pytest.raises(RuntimeError, match="allocation failed"):
+            runner.initialize_kv_cache_tensors(config, [16])
+    else:
+        assert runner.initialize_kv_cache_tensors(config, [16]) is cache
+    assert runner.device == torch.device("cpu")
+
+
+def test_worker_load_makes_config_available_to_upstream_weight_loader():
+    worker = object.__new__(TorchWorker)
+    worker.vllm_config = SimpleNamespace()
+
+    def load_model(load_dummy_weights):
+        assert get_current_vllm_config() is worker.vllm_config
+        assert not load_dummy_weights
+
+    worker.model_runner = SimpleNamespace(load_model=load_model)
+    outer_config = SimpleNamespace()
+    with set_current_vllm_config(outer_config):
+        worker.load_model()
+        assert get_current_vllm_config() is outer_config
+
+
+@pytest.mark.parametrize(
+    "available_mb,recommended_mb,allocated_mb,requested_mb,expected_mb",
+    [
+        pytest.param(4096, 2048, 0, None, 512, id="default-cap"),
+        pytest.param(125, 2048, 0, None, 100, id="system-memory-limit"),
+        pytest.param(4096, 250, 25, None, 100, id="mps-memory-limit"),
+        pytest.param(4096, 2048, 0, 700, 700, id="explicit-overrides-default-cap"),
+        pytest.param(4096, 250, 25, 101, None, id="explicit-exceeds-budget"),
+        pytest.param(4096, 100, 51, None, None, id="mps-budget-exhausted"),
+    ],
+)
+def test_worker_respects_kv_memory_limits(
+    monkeypatch, available_mb, recommended_mb, allocated_mb, requested_mb, expected_mb
+):
+    """Cache sizing preserves RAM headroom and honors safe explicit requests."""
+    mib = 1024**2
+    worker = object.__new__(TorchWorker)
+    worker.cache_config = SimpleNamespace(
+        gpu_memory_utilization=0.5,
+        kv_cache_memory_bytes=None if requested_mb is None else requested_mb * mib,
+    )
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: SimpleNamespace(available=available_mb * mib),
+    )
+    monkeypatch.setattr(torch.mps, "synchronize", lambda: None)
+    monkeypatch.setattr(torch.mps, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.mps, "recommended_max_memory", lambda: recommended_mb * mib
+    )
+    monkeypatch.setattr(
+        torch.mps, "driver_allocated_memory", lambda: allocated_mb * mib
+    )
+
+    if expected_mb is None:
+        with pytest.raises(ValueError, match="memory|budget"):
+            worker.determine_available_memory()
+    else:
+        assert worker.determine_available_memory() == expected_mb * mib

--- a/tests/test_pytorch_models.py
+++ b/tests/test_pytorch_models.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tiny end-to-end checks for upstream PyTorch models on Apple MPS.
+
+The model weights are created locally, and raw token IDs are used throughout,
+so these tests never need a tokenizer or network access.  Every case runs in a
+new interpreter because vLLM selects its platform while importing plugins.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_CASES = ("llama", "qwen2", "qwen3")
+
+
+def _run_case(case: str, model_dir: Path, *, scheduler_stress: bool = False) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "VLLM_METAL_MODEL_BACKEND": "torch",
+            "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
+        }
+    )
+    command = [sys.executable, str(Path(__file__).resolve()), "--child", case]
+    if scheduler_stress:
+        command.append("--scheduler-stress")
+    command.append(str(model_dir))
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+    if result.returncode == 77:
+        pytest.skip("PyTorch MPS is unavailable")
+    assert result.returncode == 0, (
+        f"{case} PyTorch/MPS parity failed (exit {result.returncode}):\n"
+        f"{result.stdout[-4000:]}\n{result.stderr[-4000:]}"
+    )
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_tiny_upstream_model_matches_hf_and_mlx(case: str, tmp_path: Path) -> None:
+    _run_case(case, tmp_path / case)
+
+
+def test_chunked_prefill_and_prefix_cache_match_hf_cpu(tmp_path: Path) -> None:
+    _run_case("llama", tmp_path / "llama-scheduler", scheduler_stress=True)
+
+
+def _make_model(case: str):
+    import torch
+    from transformers import (
+        AutoModelForCausalLM,
+        LlamaConfig,
+        Qwen2Config,
+        Qwen3Config,
+    )
+
+    common = {
+        "vocab_size": 128,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 128,
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+        "pad_token_id": 0,
+        "tie_word_embeddings": False,
+    }
+    config_classes = {
+        "llama": LlamaConfig,
+        "qwen2": Qwen2Config,
+        "qwen3": Qwen3Config,
+    }
+    if case == "qwen3":
+        common["head_dim"] = 32
+    torch.manual_seed(20260907)
+    model = AutoModelForCausalLM.from_config(config_classes[case](**common))
+    return model.eval()
+
+
+def _hf_greedy(model, prompts: list[list[int]], max_tokens: int) -> list[list[int]]:
+    import torch
+
+    generated: list[list[int]] = []
+    with torch.inference_mode():
+        for prompt in prompts:
+            sequence = list(prompt)
+            new_tokens: list[int] = []
+            for _ in range(max_tokens):
+                input_ids = torch.tensor([sequence], dtype=torch.long)
+                token = int(model(input_ids=input_ids).logits[0, -1].argmax())
+                sequence.append(token)
+                new_tokens.append(token)
+            generated.append(new_tokens)
+    return generated
+
+
+def _mlx_greedy(
+    model_dir: Path, prompts: list[list[int]], max_tokens: int
+) -> list[list[int]]:
+    import mlx.core as mx
+    from mlx_lm.utils import load_model
+
+    config = json.loads((model_dir / "config.json").read_text())
+    rope_config = config.get("rope_parameters") or config
+    rope_theta = rope_config["rope_theta"]
+    model, _ = load_model(
+        model_dir, lazy=False, model_config={"rope_theta": rope_theta}
+    )
+    generated: list[list[int]] = []
+    try:
+        for prompt in prompts:
+            sequence = list(prompt)
+            new_tokens: list[int] = []
+            for _ in range(max_tokens):
+                logits = model(mx.array([sequence]))
+                token = int(mx.argmax(logits[0, -1]).item())
+                sequence.append(token)
+                new_tokens.append(token)
+            generated.append(new_tokens)
+    finally:
+        del model
+        mx.clear_cache()
+    return generated
+
+
+def _child(case: str, model_dir: Path, scheduler_stress: bool) -> None:
+    import torch
+
+    if not torch.backends.mps.is_available():
+        raise SystemExit(77)
+
+    if scheduler_stress:
+        prefix = list(range(10, 42))
+        prompts = [
+            prefix + [51, 52, 53, 54, 55],
+            prefix + [61, 62, 63],
+            [7, 9, 11, 13, 15, 17, 19],
+        ]
+        max_tokens = 6
+    else:
+        prompts = [
+            [1, 7, 11, 19, 23],
+            [1, 31, 29],
+            [1, 5, 8, 13, 21, 34, 55, 89],
+        ]
+        max_tokens = 4
+
+    model = _make_model(case)
+    expected = _hf_greedy(model, prompts, max_tokens)
+    model.save_pretrained(model_dir, safe_serialization=True)
+    del model
+    mlx_expected = _mlx_greedy(model_dir, prompts, max_tokens)
+    assert mlx_expected == expected, f"HF CPU: {expected}; MLX: {mlx_expected}"
+
+    # Import only after the backend selector has been set by the parent.
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(
+        model=str(model_dir),
+        skip_tokenizer_init=True,
+        max_model_len=128 if scheduler_stress else 64,
+        max_num_seqs=4,
+        max_num_batched_tokens=32 if scheduler_stress else 64,
+        kv_cache_memory_bytes=8 * 1024**2,
+        enable_chunked_prefill=scheduler_stress,
+        enable_prefix_caching=scheduler_stress,
+        enforce_eager=True,
+        dtype="float32",
+        seed=0,
+    )
+    placement = llm.apply_model(
+        lambda model: (
+            type(model).__module__.startswith("vllm."),
+            all(parameter.device.type == "mps" for parameter in model.parameters()),
+        )
+    )
+    assert placement == [(True, True)]
+    params = SamplingParams(
+        temperature=0,
+        max_tokens=max_tokens,
+        ignore_eos=True,
+    )
+    raw_prompts = [{"prompt_token_ids": prompt} for prompt in prompts]
+
+    def generate() -> list[list[int]]:
+        outputs = llm.generate(raw_prompts, params, use_tqdm=False)
+        return [list(output.outputs[0].token_ids) for output in outputs]
+
+    actual = generate()
+    assert actual == expected, f"HF CPU: {expected}; vLLM MPS: {actual}"
+    if scheduler_stress:
+        cached = generate()
+        assert cached == expected, f"HF CPU: {expected}; cached MPS: {cached}"
+
+        controls = SamplingParams(
+            logit_bias={7: 100.0},
+            temperature=0,
+            max_tokens=2,
+            ignore_eos=True,
+            logprobs=1,
+            prompt_logprobs=1,
+        )
+        controlled = llm.generate([raw_prompts[-1]], controls, use_tqdm=False)[0]
+        assert list(controlled.outputs[0].token_ids) == [7, 7]
+        assert controlled.outputs[0].logprobs is not None
+        assert controlled.prompt_logprobs is not None
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (4, 5) or sys.argv[1] != "--child":
+        raise SystemExit(
+            "usage: test_pytorch_models.py --child CASE [--scheduler-stress] DIR"
+        )
+    stress = sys.argv[3] == "--scheduler-stress"
+    directory = Path(sys.argv[4] if stress else sys.argv[3])
+    _child(sys.argv[2], directory, stress)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import vllm.envs
 
 import vllm_metal as vm
@@ -13,3 +14,69 @@ def test_register_merges_metal_env_vars_into_vllm() -> None:
 
     missing = [k for k in metal_env_vars if k not in vllm.envs.environment_variables]
     assert not missing, f"metal env vars not registered with vllm: {missing}"
+
+
+def test_unset_model_backend_retains_mlx(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vllm_metal import compat
+    from vllm_metal.platform import MetalPlatform
+
+    applied = 0
+
+    def apply_compat_patches() -> None:
+        nonlocal applied
+        applied += 1
+
+    monkeypatch.delenv("VLLM_METAL_MODEL_BACKEND", raising=False)
+    monkeypatch.setattr(compat, "apply_compat_patches", apply_compat_patches)
+    monkeypatch.setattr(MetalPlatform, "is_available", classmethod(lambda cls: True))
+
+    assert vm._register() == "vllm_metal.platform.MetalPlatform"
+    assert applied == 1
+
+
+def test_torch_backend_skips_mlx_compat(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vllm_metal import compat
+    from vllm_metal.pytorch_backend.platform import TorchPlatform
+
+    applied = 0
+
+    def apply_compat_patches() -> None:
+        nonlocal applied
+        applied += 1
+
+    monkeypatch.setenv("VLLM_METAL_MODEL_BACKEND", "torch")
+    monkeypatch.setattr(compat, "apply_compat_patches", apply_compat_patches)
+    monkeypatch.setattr(TorchPlatform, "is_available", classmethod(lambda cls: True))
+
+    assert vm._register() == "vllm_metal.pytorch_backend.platform.TorchPlatform"
+    assert applied == 0
+
+
+def test_invalid_model_backend_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    from vllm.platforms import resolve_current_platform_cls_qualname
+    from vllm.utils.import_utils import resolve_obj_by_qualname
+
+    monkeypatch.setenv("VLLM_METAL_MODEL_BACKEND", "cuda")
+    monkeypatch.delenv("VLLM_TARGET_DEVICE", raising=False)
+
+    platform_cls = resolve_obj_by_qualname(resolve_current_platform_cls_qualname())
+    with pytest.raises(ValueError, match="must be 'mlx' or 'torch'"):
+        platform_cls()
+
+
+def test_unavailable_torch_backend_does_not_fall_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from vllm.platforms import resolve_current_platform_cls_qualname
+    from vllm.utils.import_utils import resolve_obj_by_qualname
+
+    from vllm_metal.pytorch_backend.platform import TorchPlatform
+
+    monkeypatch.setenv("VLLM_METAL_MODEL_BACKEND", "torch")
+    monkeypatch.delenv("VLLM_TARGET_DEVICE", raising=False)
+    monkeypatch.setattr(TorchPlatform, "is_available", classmethod(lambda cls: False))
+
+    platform_cls = resolve_obj_by_qualname(resolve_current_platform_cls_qualname())
+    assert platform_cls is TorchPlatform
+    with pytest.raises(RuntimeError, match="requires PyTorch MPS"):
+        platform_cls()

--- a/vllm_metal/__init__.py
+++ b/vllm_metal/__init__.py
@@ -126,7 +126,6 @@ def _register() -> str | None:
     """
     _configure_logging()
     _apply_macos_defaults()
-    _apply_mlx_buffer_defaults()
 
     # Register our env vars with vLLM's registry so validate_environ()
     # does not warn about unknown VLLM_METAL_* / VLLM_MLX_* variables.
@@ -135,6 +134,15 @@ def _register() -> str | None:
     from vllm_metal.envs import environment_variables as metal_env_vars
 
     vllm.envs.environment_variables.update(metal_env_vars)
+
+    from vllm_metal import envs
+
+    if envs.VLLM_METAL_MODEL_BACKEND != "mlx":
+        # vLLM swallows exceptions during platform probing. Validate explicit
+        # selections when the platform is instantiated, outside that probe.
+        return "vllm_metal.pytorch_backend.platform.TorchPlatform"
+
+    _apply_mlx_buffer_defaults()
 
     from vllm_metal.compat import apply_compat_patches
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    VLLM_METAL_MODEL_BACKEND: str = "mlx"
     VLLM_METAL_MEMORY_FRACTION: str = "auto"
     VLLM_MLX_DEVICE: str = "gpu"
     VLLM_METAL_USE_PAGED_ATTENTION: bool = True
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
     VLLM_METAL_RING_BASE_PORT: int = 32323
 
 environment_variables: dict[str, Callable[[], Any]] = {
+    # Opt in to upstream vLLM model implementations on PyTorch MPS.
+    "VLLM_METAL_MODEL_BACKEND": lambda: os.getenv("VLLM_METAL_MODEL_BACKEND", "mlx"),
     # Fraction of unified memory to use.  "auto" (the default) means the
     # plugin calculates the minimal amount needed at startup.
     # Returns the raw string; config.py handles "auto" → sentinel conversion.

--- a/vllm_metal/pytorch_backend/__init__.py
+++ b/vllm_metal/pytorch_backend/__init__.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """PyTorch backend for model loading and tensor interop."""
 
-from vllm_metal.pytorch_backend.tensor_bridge import (
-    get_torch_device,
-    mlx_to_torch,
-    torch_to_mlx,
-)
-
 __all__ = [
     "mlx_to_torch",
     "torch_to_mlx",
     "get_torch_device",
 ]
+
+
+def __getattr__(name):
+    if name in __all__:
+        from vllm_metal.pytorch_backend import tensor_bridge
+
+        return getattr(tensor_bridge, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/vllm_metal/pytorch_backend/attention.py
+++ b/vllm_metal/pytorch_backend/attention.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native PyTorch SDPA attention for the experimental MPS model path."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import torch
+from torch.nn import functional
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionImpl,
+    AttentionLayer,
+    AttentionMetadataBuilder,
+    AttentionType,
+    CommonAttentionMetadata,
+    MultipleOf,
+)
+
+try:
+    from vllm.v1.kv_cache_layout import KVCacheLayout
+except ImportError:  # vLLM 0.28 and older
+    KVCacheLayout = None  # type: ignore[assignment,misc]
+
+
+class TorchAttentionMetadataBuilder(AttentionMetadataBuilder[CommonAttentionMetadata]):
+    """Pass through the common scheduler metadata needed by torch SDPA."""
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> CommonAttentionMetadata:
+        del common_prefix_len, fast_build
+        if common_attn_metadata.causal is not True:
+            raise NotImplementedError(
+                "PyTorch SDPA attention currently supports causal decoder attention only."
+            )
+        return common_attn_metadata
+
+
+class TorchAttentionBackend(AttentionBackend):
+    """Portable MPS/CPU backend using only native PyTorch operations."""
+
+    forward_includes_kv_cache_update = True
+    supported_dtypes: ClassVar[list[torch.dtype]] = [
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ]
+    supported_kv_cache_dtypes = ["auto", "float16", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "CUSTOM"
+
+    @staticmethod
+    def get_impl_cls() -> type[TorchAttentionImpl]:
+        return TorchAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[TorchAttentionMetadataBuilder]:
+        return TorchAttentionMetadataBuilder
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(1)]
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        del cache_dtype_str
+        return 2, num_blocks, block_size, num_kv_heads, head_size
+
+    @classmethod
+    def supported_kv_cache_layouts(cls):
+        """Prefer main's head-major packed per-layer cache view."""
+        if KVCacheLayout is None:
+            return None
+        return (KVCacheLayout.LBHNC,)
+
+    @classmethod
+    def supports_non_causal(cls) -> bool:
+        return False
+
+    @classmethod
+    def supports_sliding_window(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_attn_type(cls, attn_type: str) -> bool:
+        return attn_type == AttentionType.DECODER
+
+    @staticmethod
+    def use_cascade_attention(*args, **kwargs) -> bool:
+        return False
+
+
+class TorchAttentionImpl(AttentionImpl):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int | None = None,
+        alibi_slopes: list[float] | None = None,
+        sliding_window: int | None = None,
+        kv_cache_dtype: str = "auto",
+        logits_soft_cap: float | None = None,
+        attn_type: str = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+        sinks: torch.Tensor | None = None,
+    ) -> None:
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError("Only causal decoder attention is supported.")
+        if alibi_slopes is not None:
+            raise NotImplementedError(
+                "ALiBi is not supported by PyTorch SDPA attention."
+            )
+        if logits_soft_cap is not None:
+            raise NotImplementedError(
+                "Logits soft-cap is not supported by PyTorch SDPA attention."
+            )
+        if sinks is not None:
+            raise NotImplementedError(
+                "Attention sinks are not supported by PyTorch SDPA attention."
+            )
+        if kv_sharing_target_layer_name is not None:
+            raise NotImplementedError(
+                "KV-cache sharing is not supported by PyTorch SDPA attention."
+            )
+        if kv_cache_dtype not in ("auto", "float16", "bfloat16"):
+            raise NotImplementedError(
+                f"Quantized KV cache {kv_cache_dtype!r} is not supported."
+            )
+        num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
+        if num_heads % num_kv_heads:
+            raise ValueError("num_heads must be divisible by num_kv_heads.")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.sliding_window = sliding_window
+        self.kv_cache_dtype = kv_cache_dtype
+
+    @staticmethod
+    def _cache_views(
+        kv_cache: torch.Tensor,
+        head_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return logical ``[block, token, head, dim]`` K/V views.
+
+        vLLM 0.28 gives backends a 5D split cache. Current main allocates a
+        logical ``[block, head, token, 2 * dim]`` per-layer view whose strides
+        encode the selected physical layout. Slicing and permuting the latter
+        preserves those strides, so cache updates reach the shared allocation.
+        """
+        if kv_cache.ndim == 5:
+            if kv_cache.shape[0] != 2:
+                raise ValueError(f"Unexpected split KV cache shape: {kv_cache.shape}")
+            return kv_cache[0], kv_cache[1]
+        if kv_cache.ndim == 4 and kv_cache.shape[-1] == 2 * head_size:
+            key_cache = kv_cache[..., :head_size].permute(0, 2, 1, 3)
+            value_cache = kv_cache[..., head_size:].permute(0, 2, 1, 3)
+            return key_cache, value_cache
+        raise ValueError(f"Unexpected KV cache shape: {kv_cache.shape}")
+
+    @staticmethod
+    def _write_cache(
+        key: torch.Tensor,
+        value: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        num_tokens: int,
+    ) -> None:
+        block_size = key_cache.shape[1]
+        slots = slot_mapping[:num_tokens].to(device=key.device, dtype=torch.long)
+        valid = slots >= 0
+        slots = slots[valid]
+        if slots.numel() == 0:
+            return
+        blocks = torch.div(slots, block_size, rounding_mode="floor")
+        offsets = torch.remainder(slots, block_size)
+        key_cache[blocks, offsets] = key[:num_tokens][valid]
+        value_cache[blocks, offsets] = value[:num_tokens][valid]
+
+    @staticmethod
+    def _gather_cache(
+        cache: torch.Tensor,
+        block_table_row: torch.Tensor,
+        start: int,
+        seq_len: int,
+    ) -> torch.Tensor:
+        block_size = cache.shape[1]
+        first_block = start // block_size
+        end_block = (seq_len + block_size - 1) // block_size
+        blocks = block_table_row[first_block:end_block].to(
+            device=cache.device, dtype=torch.long
+        )
+        offset = start % block_size
+        return cache.index_select(0, blocks).flatten(0, 1)[
+            offset : offset + seq_len - start
+        ]
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: CommonAttentionMetadata | None,
+        output: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del layer
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("Fused output quantization is not supported.")
+        if attn_metadata is None:
+            return output
+
+        num_tokens = attn_metadata.num_actual_tokens
+        key_cache, value_cache = self._cache_views(kv_cache, self.head_size)
+        self._write_cache(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            attn_metadata.slot_mapping,
+            num_tokens,
+        )
+        query_starts = attn_metadata.query_start_loc.tolist()
+        seq_lens = attn_metadata.seq_lens.tolist()
+        repeats = self.num_heads // self.num_kv_heads
+
+        for req_idx, seq_len in enumerate(seq_lens):
+            q_start, q_end = query_starts[req_idx : req_idx + 2]
+            if q_start == q_end:
+                continue
+            query_len = q_end - q_start
+            key_start = 0
+            if self.sliding_window is not None:
+                key_start = max(0, seq_len - query_len - self.sliding_window + 1)
+            keys = self._gather_cache(
+                key_cache,
+                attn_metadata.block_table_tensor[req_idx],
+                key_start,
+                seq_len,
+            )
+            values = self._gather_cache(
+                value_cache,
+                attn_metadata.block_table_tensor[req_idx],
+                key_start,
+                seq_len,
+            )
+            if repeats != 1:
+                keys = keys.repeat_interleave(repeats, dim=1)
+                values = values.repeat_interleave(repeats, dim=1)
+
+            query_positions = torch.arange(
+                seq_len - query_len, seq_len, device=query.device
+            )
+            key_positions = torch.arange(key_start, seq_len, device=query.device)
+            mask = key_positions[None, :] <= query_positions[:, None]
+            if self.sliding_window is not None:
+                mask &= key_positions[None, :] > (
+                    query_positions[:, None] - self.sliding_window
+                )
+
+            result = functional.scaled_dot_product_attention(
+                query[q_start:q_end].transpose(0, 1).unsqueeze(0),
+                keys.transpose(0, 1).unsqueeze(0),
+                values.transpose(0, 1).unsqueeze(0),
+                attn_mask=mask[None, None],
+                dropout_p=0.0,
+                scale=self.scale,
+            )
+            output_slice = output[q_start:q_end]
+            output_slice.copy_(
+                result.squeeze(0).transpose(0, 1).reshape_as(output_slice)
+            )
+        return output

--- a/vllm_metal/pytorch_backend/model_runner.py
+++ b/vllm_metal/pytorch_backend/model_runner.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Upstream vLLM execution with an MPS model and CPU scheduling tensors."""
+
+from typing import Any, cast
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.model_executor.model_loader import get_model
+from vllm.model_executor.models.interfaces_base import VllmModelForTextGeneration
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+
+
+class _HostInputModel(nn.Module):
+    """Keep device transfers at model boundaries while sampling on the CPU."""
+
+    def __init__(self, model: nn.Module, device: torch.device) -> None:
+        super().__init__()
+        self.wrapped_model = model
+        self.compute_device = device
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(super().__getattr__("wrapped_model"), name)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        positions: torch.Tensor | None = None,
+        intermediate_tensors: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if intermediate_tensors is not None:
+            raise NotImplementedError("The PyTorch Metal backend requires one stage.")
+        inputs = {
+            "input_ids": input_ids,
+            "positions": positions,
+            "inputs_embeds": inputs_embeds,
+            **kwargs,
+        }
+        inputs = {
+            key: value.to(self.compute_device)
+            if isinstance(value, torch.Tensor)
+            else value
+            for key, value in inputs.items()
+        }
+        hidden_states = self.wrapped_model(intermediate_tensors=None, **inputs)
+        if not isinstance(hidden_states, torch.Tensor):
+            raise NotImplementedError(
+                "The PyTorch Metal backend requires tensor hidden states."
+            )
+        return hidden_states
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        model = cast(VllmModelForTextGeneration[torch.Tensor], self.wrapped_model)
+        logits = model.compute_logits(hidden_states.to(self.compute_device))
+        return None if logits is None else logits.cpu()
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        model = cast(VllmModelForTextGeneration[torch.Tensor], self.wrapped_model)
+        return model.embed_input_ids(input_ids.to(self.compute_device)).cpu()
+
+
+class TorchModelRunner(CPUModelRunner):
+    """Reuse upstream batching, cache management, model loading, and sampling."""
+
+    def __init__(self, vllm_config: VllmConfig) -> None:
+        self.compute_device = torch.device("mps")
+        # CPUModelRunner installs process-wide no-ops for accelerator APIs. MPS
+        # is a real accelerator, so retain only its CPU buffer initialization.
+        synchronize = torch.accelerator.synchronize
+        empty_cache = torch.accelerator.empty_cache
+        try:
+            super().__init__(vllm_config, torch.device("cpu"))
+        finally:
+            torch.accelerator.synchronize = synchronize
+            torch.accelerator.empty_cache = empty_cache
+
+    def load_model(self, load_dummy_weights: bool = False) -> None:
+        if load_dummy_weights:
+            raise NotImplementedError("Elastic model loading is not supported on MPS.")
+        self.vllm_config.load_config.device = str(self.compute_device)
+        model = get_model(vllm_config=self.vllm_config)
+        self.model = _HostInputModel(model, self.compute_device)
+        self._setup_eagle3_aux_hidden_state_outputs()
+
+    def get_model(self) -> nn.Module:
+        return self.model.wrapped_model
+
+    def initialize_kv_cache_tensors(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int],
+        **kwargs: Any,
+    ) -> dict[str, torch.Tensor]:
+        # vLLM 0.28 allocates then reshapes; main allocates structured views.
+        # Both use self.device only for allocation in this method, so retain
+        # upstream layout and binding logic without moving scheduler buffers.
+        control_device = self.device
+        self.device = self.compute_device
+        try:
+            return super().initialize_kv_cache_tensors(
+                kv_cache_config, kernel_block_sizes, **kwargs
+            )
+        finally:
+            self.device = control_device
+
+    def _sync_device(self) -> None:
+        torch.mps.synchronize()

--- a/vllm_metal/pytorch_backend/platform.py
+++ b/vllm_metal/pytorch_backend/platform.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Experimental upstream vLLM models with a CPU control plane and MPS compute."""
+
+import platform
+from typing import TYPE_CHECKING
+
+import psutil
+import torch
+from vllm.logger import init_logger
+from vllm.platforms.interface import Platform, PlatformEnum
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+    from vllm.v1.attention.selector import AttentionSelectorConfig
+
+logger = init_logger(__name__)
+
+
+class TorchPlatform(Platform):
+    _enum = PlatformEnum.OOT
+    # The upstream CPU runner owns scheduling tensors and sampling. Model
+    # parameters, activations, and KV cache are allocated separately on MPS.
+    device_name = "cpu"
+    device_type = "cpu"
+    dispatch_key = "CPU"
+    dist_backend = "gloo"
+    simple_compile_backend = "eager"
+
+    def __init__(self) -> None:
+        from vllm_metal import envs
+
+        if envs.VLLM_METAL_MODEL_BACKEND != "torch":
+            raise ValueError("VLLM_METAL_MODEL_BACKEND must be 'mlx' or 'torch'.")
+        if not self.is_available():
+            raise RuntimeError(
+                "The torch Metal backend requires PyTorch MPS on Apple Silicon."
+            )
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return platform.machine() == "arm64" and torch.backends.mps.is_available()
+
+    @classmethod
+    def get_device_name(cls, device_id: int = 0) -> str:
+        return "Apple Silicon (PyTorch MPS)"
+
+    @classmethod
+    def get_device_total_memory(cls, device_id: int = 0) -> int:
+        return psutil.virtual_memory().total
+
+    @classmethod
+    def is_pin_memory_available(cls) -> bool:
+        return False
+
+    @classmethod
+    def manual_seed_all(cls, seed: int) -> None:
+        torch.mps.manual_seed(seed)
+
+    @classmethod
+    def set_device(cls, device: torch.device) -> None:
+        if device.index not in (None, 0):
+            raise ValueError("The torch Metal backend supports one device.")
+
+    @classmethod
+    def get_device_communicator_cls(cls) -> str:
+        return "vllm.distributed.device_communicators.cpu_communicator.CpuCommunicator"
+
+    @classmethod
+    def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        from vllm.config import CompilationMode, CUDAGraphMode
+
+        model = vllm_config.model_config
+        parallel = vllm_config.parallel_config
+        unsupported = {
+            "distributed execution": (
+                parallel.world_size != 1 or parallel.data_parallel_size != 1
+            ),
+            "context parallelism": (
+                parallel.decode_context_parallel_size != 1
+                or parallel.prefill_context_parallel_size != 1
+            ),
+            "speculative decoding": vllm_config.speculative_config is not None,
+            "LoRA": vllm_config.lora_config is not None,
+            "KV transfer": vllm_config.kv_transfer_config is not None,
+            "KV offloading": vllm_config.cache_config.kv_offloading_size is not None,
+            "weight offloading": (
+                vllm_config.offload_config.uva.cpu_offload_gb > 0
+                or vllm_config.offload_config.prefetch.offload_group_size > 0
+            ),
+            "weight transfer": vllm_config.weight_transfer_config is not None,
+            "profiling": vllm_config.profiler_config.profiler is not None,
+            "quantized KV cache": vllm_config.cache_config.cache_dtype != "auto",
+            "dual batch overlap": parallel.enable_dbo,
+            "V2 model runner": vllm_config.use_v2_model_runner,
+        }
+        if model is not None:
+            unsupported.update(
+                {
+                    "pooling": model.runner_type != "generate",
+                    "quantization": model.quantization is not None,
+                    "hybrid/SSM models": model.is_hybrid or model.has_inner_state,
+                    "multimodal models": model.is_multimodal_model,
+                    "encoder-decoder models": model.is_encoder_decoder,
+                    "MoE models": model.is_moe,
+                }
+            )
+        for feature, enabled in unsupported.items():
+            if enabled:
+                raise NotImplementedError(
+                    f"The experimental torch Metal backend does not support {feature}."
+                )
+
+        if parallel.distributed_executor_backend in (None, "auto"):
+            parallel.distributed_executor_backend = "uni"
+        if parallel.distributed_executor_backend not in ("uni", "mp"):
+            raise NotImplementedError(
+                "The torch Metal backend requires a local 'uni' or 'mp' executor."
+            )
+        if parallel.worker_cls == "auto":
+            parallel.worker_cls = "vllm_metal.pytorch_backend.worker.TorchWorker"
+        parallel.disable_custom_all_reduce = True
+        if model is not None:
+            model.enforce_eager = True
+            model.disable_cascade_attn = True
+        compilation = vllm_config.compilation_config
+        compilation.mode = CompilationMode.NONE
+        compilation.cudagraph_mode = CUDAGraphMode.NONE
+        compilation.cudagraph_capture_sizes = []
+        compilation.backend = "eager"
+        compilation.custom_ops = ["none"]
+        compilation.ir_enable_torch_wrap = False
+        vllm_config.scheduler_config.async_scheduling = False
+        vllm_config.load_config.device = "mps"
+        logger.warning_once(
+            "Using experimental upstream vLLM models on MPS. "
+            "Model compatibility depends on PyTorch-native operator support."
+        )
+
+    @classmethod
+    def get_attn_backend_cls(
+        cls,
+        selected_backend: "AttentionBackendEnum",
+        attn_selector_config: "AttentionSelectorConfig",
+        num_heads: int | None = None,
+    ) -> str:
+        from vllm.v1.attention.backend import AttentionType
+        from vllm.v1.attention.backends.registry import (
+            AttentionBackendEnum,
+            register_backend,
+        )
+
+        if selected_backend not in (None, AttentionBackendEnum.CUSTOM):
+            raise NotImplementedError(
+                "The torch Metal backend requires its custom SDPA attention backend."
+            )
+
+        config = attn_selector_config
+        if (
+            config.use_mla
+            or config.use_sparse
+            or config.has_sink
+            or config.use_mm_prefix
+            or config.use_per_head_quant_scales
+            or config.attn_type != AttentionType.DECODER
+            or config.use_non_causal
+        ):
+            raise NotImplementedError(
+                "The torch Metal backend supports causal decoder SDPA only."
+            )
+        backend_path = "vllm_metal.pytorch_backend.attention.TorchAttentionBackend"
+        register_backend(AttentionBackendEnum.CUSTOM, backend_path)
+        return backend_path

--- a/vllm_metal/pytorch_backend/worker.py
+++ b/vllm_metal/pytorch_backend/worker.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Single-device worker for upstream PyTorch models on Apple MPS."""
+
+from collections.abc import Callable
+from typing import cast
+
+import psutil
+import torch
+from torch import nn
+from vllm.config import set_current_vllm_config
+from vllm.distributed import (
+    ensure_model_parallel_initialized,
+    init_distributed_environment,
+)
+from vllm.logger import init_logger
+from vllm.sequence import IntermediateTensors
+from vllm.tasks import SupportedTask
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
+from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
+from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
+
+from vllm_metal.pytorch_backend.model_runner import TorchModelRunner
+
+logger = init_logger(__name__)
+_DEFAULT_KV_CACHE_BYTES = 512 * 1024**2
+
+
+class TorchWorker(WorkerBase):
+    """Use the upstream CPU control plane with MPS model and cache storage."""
+
+    model_runner: TorchModelRunner  # type: ignore[assignment]
+
+    def init_device(self) -> None:
+        if not torch.backends.mps.is_available():
+            raise RuntimeError("The PyTorch Metal backend requires Apple MPS.")
+        self.device = torch.device("cpu")
+        self.parallel_config.disable_custom_all_reduce = True
+        init_distributed_environment(
+            self.parallel_config.world_size,
+            self.rank,
+            self.distributed_init_method,
+            self.local_rank,
+            backend="gloo",
+        )
+        ensure_model_parallel_initialized(
+            self.parallel_config.tensor_parallel_size,
+            self.parallel_config.pipeline_parallel_size,
+        )
+        set_random_seed(self.model_config.seed)
+        self.model_runner = TorchModelRunner(self.vllm_config)
+
+    def load_model(self, *, load_dummy_weights: bool = False) -> None:
+        with set_current_vllm_config(self.vllm_config):
+            self.model_runner.load_model(load_dummy_weights)
+
+    def determine_available_memory(self) -> int:
+        torch.mps.synchronize()
+        torch.mps.empty_cache()
+        available = int(psutil.virtual_memory().available * 0.8)
+        device_budget = (
+            int(
+                torch.mps.recommended_max_memory()
+                * self.cache_config.gpu_memory_utilization
+            )
+            - torch.mps.driver_allocated_memory()
+        )
+        budget = max(0, min(available, device_budget))
+        requested = self.cache_config.kv_cache_memory_bytes
+        if requested is not None:
+            if requested > budget:
+                raise ValueError(
+                    f"Requested KV cache ({requested} bytes) exceeds the available "
+                    f"MPS memory budget ({budget} bytes)."
+                )
+            cache_bytes = requested
+        else:
+            cache_bytes = min(_DEFAULT_KV_CACHE_BYTES, budget)
+        if cache_bytes <= 0:
+            raise ValueError("Insufficient MPS memory for the KV cache.")
+        logger.info("PyTorch Metal KV cache budget: %d bytes", cache_bytes)
+        return cache_bytes
+
+    def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
+        return self.model_runner.get_kv_cache_spec()
+
+    def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
+        self.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
+        with set_current_vllm_config(self.vllm_config):
+            self.model_runner.initialize_kv_cache(kv_cache_config)
+
+    def initialize_cache(self, num_gpu_blocks: int, num_cpu_blocks: int) -> None:
+        self.cache_config.num_gpu_blocks = num_gpu_blocks
+        self.cache_config.num_cpu_blocks = num_cpu_blocks
+
+    def compile_or_warm_up_model(self) -> CompilationTimes:
+        # Execution is eager; there are no graphs or compiled kernels to prepare.
+        torch.mps.synchronize()
+        set_random_seed(self.model_config.seed)
+        return CompilationTimes(language_model=0.0, encoder=0.0)
+
+    def get_model(self) -> nn.Module:
+        return self.model_runner.get_model()
+
+    def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
+        return self.model_runner.get_supported_tasks()
+
+    def execute_model(
+        self, scheduler_output: SchedulerOutput
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
+        with set_current_vllm_config(self.vllm_config):
+            output = self.model_runner.execute_model(scheduler_output)
+        assert not isinstance(output, IntermediateTensors), "Expected a single stage."
+        return output
+
+    def sample_tokens(
+        self, grammar_output: GrammarOutput | None
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
+        with set_current_vllm_config(self.vllm_config):
+            sample = cast(
+                Callable[
+                    [GrammarOutput | None],
+                    ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors,
+                ],
+                self.model_runner.sample_tokens,
+            )
+            output = sample(grammar_output)
+        assert not isinstance(output, IntermediateTensors), "Expected a single stage."
+        return output
+
+    def take_draft_token_ids(self) -> None:
+        return None
+
+    def update_max_model_len(self, max_model_len: int) -> None:
+        self.model_config.max_model_len = max_model_len
+        self.model_runner.update_max_model_len(max_model_len)
+
+    def shutdown(self) -> None:
+        if getattr(self, "model_runner", None) is not None:
+            torch.mps.synchronize()
+            self.model_runner.shutdown()
+            del self.model_runner
+            torch.mps.empty_cache()


### PR DESCRIPTION
The current Metal runner loads model implementations through MLX, so supporting an upstream vLLM architecture still depends on a separate MLX implementation and adapter. This draft explores a smaller compatibility boundary: execute **upstream vLLM model classes and weight loaders on PyTorch MPS**, while reusing upstream request handling and sampling.

`VLLM_METAL_MODEL_BACKEND=torch` selects an experimental out-of-tree platform. The existing MLX path remains the default. The implementation adds four backend files (about 720 lines including types, comments, and whitespace), with no changes to vLLM core and no copied model implementations.

### Reuse and scope

- `get_model` / `ModelRegistry` own architecture resolution and weight loading.
- `CPUModelRunner` owns request updates, batching, slot mapping, KV allocation/binding, prompt logprobs, and sampling. A small wrapper transfers inputs to MPS and logits to CPU; parameters, hidden states, and KV storage stay on MPS.
- Attention consumes `CommonAttentionMetadata` and uses native PyTorch SDPA over vLLM's paged cache. It supports causal/chunked prefill, decode, GQA, prefix reuse, and sliding windows. The cache adapter accepts both the 0.28 split layout and main's packed per-layer layout without copying cache storage.
- Setup rejects features outside the initial dense, unquantized, single-device, eager text-generation scope. An explicit but unavailable MPS selection fails after plugin probing, where vLLM cannot silently swallow the error and fall back to CPU.
- KV storage defaults to at most 512 MiB, bounded by system/MPS headroom. An explicit `kv_cache_memory_bytes` is checked against that budget. This is a KV limit, not a total-memory guarantee.

This is **not full upstream model coverage or a performance claim**. MoE, SSM/hybrid models, quantization, multimodal/pooling, LoRA, speculative decoding, distributed execution, and transfer/offload paths need further backend work. CUDA-only operations in otherwise dense architectures may still fail. SDPA gathers visible cache tensors and expands GQA heads, so long-context scratch memory and throughput need work. The normal macOS vLLM CPU extension is required for the inherited slot-mapping operation; an `empty` build is insufficient.

The alternative loader-only approach would still have to translate upstream Torch forward contexts and KV caches into the MLX runner's model-specific contract. Keeping model execution behind the existing upstream runner avoids that additional model-porting layer. Details and usage are in `docs/pytorch_backend.md`.

### Validation

Tested on Apple M4, 24 GB unified RAM, macOS 26.6.2, Python 3.12.13, PyTorch 2.13.0, the official vLLM 0.28 macOS CPU wheel, and this repository's pinned MLX dependencies. Large-model and performance suites were not run given the machine's memory pressure.

```bash
python -m pytest tests/test_register.py tests/test_macos_defaults.py \
  tests/test_platform.py tests/test_pytorch_attention.py \
  tests/test_pytorch_model_runner.py tests/test_tensor_bridge.py -q
# 137 passed, 10 skipped

python -m pytest tests/test_pytorch_models.py -q
# 4 passed

ruff check .
ruff format --check .
mypy vllm_metal
# All pass; 299 files formatted, 141 source files type-checked.
```

The model tests create tiny Llama, Qwen2, and Qwen3 checkpoints locally. Greedy token IDs match both Hugging Face CPU and `mlx_lm` references, including chunked prefill and repeated prefix-cache use. They assert that actual upstream model classes and all parameters are on MPS, and exercise logit bias plus prompt/output logprobs. Attention tests include real MPS float32/float16/bfloat16 execution, physical block addressing, released sliding-window prefix blocks, and both cache layouts. Memory-budget tests allocate no large buffers.

Additional manual checks:

- **SmolLM2-135M**, revision `93efa2f097d58c2a74874c7e644dbc9b0cee75a2`: all **36/36 greedy generated token IDs** matched the HF CPU reference across three prompts, in float32 with a **16 MiB KV cache**. Post-generation MPS allocation was 557,486,848 bytes; this is not a peak-process-memory measurement.
- A normally spawned localhost `vllm serve` process returned HTTP 200 for `/health` and `/v1/completions`, with expected continuation text and output logprobs. SIGTERM cleanup logged a forced-worker shutdown/semaphore warning; clean server shutdown needs further validation.
- Against upstream vLLM Python sources at **`537af2c3a4ba7462ddc9bc94ec7a4ea496da6d2e`**, tiny Llama/Qwen2/Qwen3 greedy checks and Llama chunked-prefill/prefix-cache/sampling-control checks passed. These used the installed 0.28 macOS wheel's C extension through a source overlay, **not a fresh native build of main**. The plugin's vLLM version pin is unchanged.

### Draft review

Checked open vllm-metal and upstream vLLM proposals on 2026-09-07. No open PR implements this upstream-model/MPS runner path. Existing MLX sampling, model-adapter, and KV-offload proposals operate on the existing MLX path; this does not replace their work or the version-migration checklist in #700.

AI assistance was used for investigation, implementation, and tests. This is intentionally a draft for human review of the reuse boundary before expanding model coverage or optimizing kernels. Broader checkpoint/dtype evaluation and a fresh current-main macOS build remain follow-up validation.
