### PR TITLE
[Bugfix] Resolve cached GGUF references offline

### DIFF
--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -34,6 +34,11 @@ The source priority is:
 vllm-metal downloads exactly one matching `.gguf` file from the remote
 repository. Missing, ambiguous, or sharded matches fail before model load.
 
+With `HF_HUB_OFFLINE=1`, remote references select from the requested revision
+in the local Hugging Face cache. Cache the matching GGUF file and companion
+config/tokenizer first; missing, ambiguous, or sharded cached matches also fail
+before model load.
+
 ## Current scope
 
 - Supported model families: Qwen2, Qwen3, Llama, and Mistral.

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 import pytest
+from huggingface_hub import constants as hf_constants
 
 gguf = pytest.importorskip("gguf")
 
@@ -23,6 +25,7 @@ import vllm_metal.gguf.loader as gguf_loader  # noqa: E402
 from vllm_metal.gguf.adapter import GGUFModelAdapter  # noqa: E402
 from vllm_metal.gguf.loader import GGUFLoadError, GGUFModelLoader  # noqa: E402
 from vllm_metal.gguf.mlx_native import GGUFMLXQuantizedTensor  # noqa: E402
+from vllm_metal.gguf.source import GGUFLoadSource  # noqa: E402
 from vllm_metal.gguf.wrappers import GGUFLinear  # noqa: E402
 
 QT = gguf.GGMLQuantizationType
@@ -213,6 +216,44 @@ def test_loads_dense_model_installs_wrappers(
     ).load()
     _assert_dense_wrapper_histogram(model)
     _assert_forward_vocab_shape(model)
+
+
+def test_loads_cached_remote_model_offline(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "hub"
+    repository = cache_dir / "models--org--tiny-GGUF"
+    revision = "a" * 40
+    snapshot = repository / "snapshots" / revision
+    snapshot.mkdir(parents=True)
+    (repository / "refs").mkdir()
+    (repository / "refs" / "weights-revision").write_text(revision)
+    gguf_path, config_dir = _build_dense_fixture(snapshot, "qwen3", has_qk_norm=True)
+    weights_path = snapshot / "tiny-Q8_0.gguf"
+    Path(gguf_path).rename(weights_path)
+    monkeypatch.setattr(hf_constants, "HF_HUB_OFFLINE", True)
+    source = GGUFLoadSource.from_model_config(
+        SimpleNamespace(
+            quantization="gguf",
+            model_weights="org/tiny-GGUF:Q8_0",
+            model=config_dir,
+            tokenizer=config_dir,
+            revision="weights-revision",
+            tokenizer_revision=None,
+            hf_token=None,
+        ),
+        SimpleNamespace(download_dir=str(cache_dir), ignore_patterns=None),
+    )
+    assert source is not None
+    model, _ = GGUFModelLoader(
+        source.weights_path,
+        config_dir=source.config_dir,
+        tokenizer_dir=source.tokenizer_dir,
+        target_dtype=mx.float32,
+    ).load()
+    reference, _ = GGUFModelLoader(
+        weights_path, config_dir=config_dir, target_dtype=mx.float32
+    ).load()
+    tokens = mx.array([[1, 2, 3]])
+    np.testing.assert_array_equal(np.array(model(tokens)), np.array(reference(tokens)))
 
 
 def test_skips_tie_redundant_output(tmp_path, monkeypatch, caplog):

--- a/tests/test_gguf_vllm_integration.py
+++ b/tests/test_gguf_vllm_integration.py
@@ -22,6 +22,7 @@ from types import SimpleNamespace
 
 import pytest
 import vllm.engine.arg_utils as arg_utils_module
+from huggingface_hub import constants as hf_constants
 from vllm.engine.arg_utils import EngineArgs
 
 from vllm_metal.gguf import source as gguf_source
@@ -210,7 +211,11 @@ def test_non_gguf_model_is_untouched(config_dir) -> None:
     assert model_config.model_weights == ""
 
 
-def test_create_model_config_routes_remote_gguf_reference(config_dir) -> None:
+@pytest.mark.parametrize("offline", [False, True])
+def test_create_model_config_routes_remote_gguf_reference(
+    config_dir, monkeypatch, offline
+) -> None:
+    monkeypatch.setattr(hf_constants, "HF_HUB_OFFLINE", offline)
     reference = "Qwen/Qwen3-0.6B-GGUF:Q8_0"
 
     model_config = _engine_args(
@@ -235,11 +240,13 @@ def test_remote_gguf_reference_defaults_config_to_weights_repo() -> None:
 def test_register_is_idempotent() -> None:
     before_config = EngineArgs.create_model_config
     before_probe = arg_utils_module.maybe_override_with_speculators
+    before_model_path = arg_utils_module.get_model_path
     vllm_integration.register()
     vllm_integration.register()
 
     assert EngineArgs.create_model_config is before_config
     assert arg_utils_module.maybe_override_with_speculators is before_probe
+    assert arg_utils_module.get_model_path is before_model_path
 
 
 def test_integration_imports_without_gguf_package(monkeypatch) -> None:
@@ -321,12 +328,13 @@ def test_broken_official_plugin_does_not_disable_integration(
     assert arg_utils_module.maybe_override_with_speculators is not sentinel
 
 
+@pytest.mark.parametrize("offline_remote", [False, True])
 def test_entry_point_mounts_without_manual_register(
-    gguf_file, config_dir, tmp_path
+    gguf_file, config_dir, tmp_path, offline_remote
 ) -> None:
     """The regression boundary #463 actually crossed: a fresh process where
     vLLM itself discovers and loads the ``vllm.general_plugins`` entry point —
-    no manual import or register() — must route a local .gguf. Uses a
+    no manual import or register() — must route local and offline remote GGUFs. Uses a
     dist-info scaffold because a PYTHONPATH checkout carries no entry-point
     metadata.
     """
@@ -342,6 +350,9 @@ def test_entry_point_mounts_without_manual_register(
     repo_root = Path(vllm_integration.__file__).resolve().parents[2]
     env = dict(os.environ)
     env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{tmp_path}"
+    if offline_remote:
+        gguf_file = "Qwen/Qwen3-0.6B-GGUF:Q8_0"
+        env["HF_HUB_OFFLINE"] = "1"
     script = (
         "from vllm.engine.arg_utils import EngineArgs\n"
         f"mc = EngineArgs(model={gguf_file!r}, tokenizer={config_dir!r})"

--- a/vllm_metal/gguf/source.py
+++ b/vllm_metal/gguf/source.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Self
 
 from huggingface_hub import HfApi, snapshot_download
+from huggingface_hub import constants as hf_constants
 from huggingface_hub.utils import filter_repo_objects
 
 _GGUF_SUFFIX = ".gguf"
@@ -79,11 +80,30 @@ class RemoteGGUFReference:
                 f"Remote GGUF qtype {self.quant_type!r} is not supported by "
                 f"vllm-metal; supported qtypes: {supported}."
             )
-        repo_files = HfApi().list_repo_files(
-            repo_id=self.repo_id,
-            revision=revision,
-            token=token,
-        )
+        snapshot_dir = None
+        if hf_constants.HF_HUB_OFFLINE:
+            snapshot_dir = Path(
+                snapshot_download(
+                    repo_id=self.repo_id,
+                    cache_dir=cache_dir,
+                    allow_patterns=list(self.allow_patterns),
+                    ignore_patterns=ignore_patterns,
+                    revision=revision,
+                    token=token,
+                    local_files_only=True,
+                )
+            )
+            repo_files = [
+                path.relative_to(snapshot_dir).as_posix()
+                for path in snapshot_dir.rglob("*")
+                if path.is_file()
+            ]
+        else:
+            repo_files = HfApi().list_repo_files(
+                repo_id=self.repo_id,
+                revision=revision,
+                token=token,
+            )
         filename = self._select_single_filename(
             sorted(
                 filter_repo_objects(
@@ -93,15 +113,16 @@ class RemoteGGUFReference:
                 )
             )
         )
-        snapshot_dir = Path(
-            snapshot_download(
-                repo_id=self.repo_id,
-                cache_dir=cache_dir,
-                allow_patterns=[filename],
-                revision=revision,
-                token=token,
+        if snapshot_dir is None:
+            snapshot_dir = Path(
+                snapshot_download(
+                    repo_id=self.repo_id,
+                    cache_dir=cache_dir,
+                    allow_patterns=[filename],
+                    revision=revision,
+                    token=token,
+                )
             )
-        )
         return str(snapshot_dir / filename)
 
     def _select_single_filename(self, filenames: list[str]) -> str:

--- a/vllm_metal/gguf/vllm_integration.py
+++ b/vllm_metal/gguf/vllm_integration.py
@@ -6,9 +6,10 @@ vLLM 0.24 migrated in-tree GGUF support to the CUDA/ROCm-only
 sets ``quantization="gguf"`` for a ``.gguf`` model anymore and vllm-metal's
 GGUF routing went dead. This module restores the engine-facing layer with the
 same semantics as the official plugin for the fields the Metal path consumes:
-a marker quantization config so ``quantization="gguf"`` validates, and two
-narrow wraps that detect a local GGUF file, carry it in
-``model_config.model_weights``, and point ``model`` at the config source.
+a marker quantization config so ``quantization="gguf"`` validates, and narrow
+wraps that preserve GGUF references through online/offline initialization,
+carry them in ``model_config.model_weights``, and point ``model`` at the config
+source.
 
 Mounted through the ``vllm.general_plugins`` entry point (the official
 plugin's own mechanism), which vLLM loads in ``EngineArgs.__post_init__`` and
@@ -187,11 +188,21 @@ class GGUFEngineIntegration:
 
     @classmethod
     def _patch_engine_args(cls) -> None:
+        import vllm.engine.arg_utils as arg_utils_module
         from vllm.engine.arg_utils import EngineArgs
 
         if getattr(EngineArgs, "_metal_gguf_patched", False):
             return
         original = EngineArgs.create_model_config
+        original_get_model_path = arg_utils_module.get_model_path
+
+        @wraps(original_get_model_path)
+        def get_model_path(model, *args, **kwargs):
+            # __post_init__ resolves offline Hub paths before create_model_config.
+            # Preserve the quant selector until the GGUF owner routes the weights.
+            if isinstance(model, str) and cls.is_remote_gguf_reference(model):
+                return model
+            return original_get_model_path(model, *args, **kwargs)
 
         @wraps(original)
         def create_model_config(self, *args, **kwargs):
@@ -229,6 +240,7 @@ class GGUFEngineIntegration:
             return original(self, *args, **kwargs)
 
         EngineArgs.create_model_config = create_model_config
+        arg_utils_module.get_model_path = get_model_path
         EngineArgs._metal_gguf_patched = True
 
     @classmethod


### PR DESCRIPTION
`HF_HUB_OFFLINE=1 vllm serve org/model-GGUF:Q8_0 --tokenizer <cached-config>` fails even when the GGUF is cached: `EngineArgs` validates the colon-qualified reference as a Hub repo ID. Bypassing that error exposes a second failure because the weight resolver calls the online Hub listing API.

Preserve the GGUF reference until the existing config rewrite, then resolve the requested cached snapshot in offline mode. Keep the existing qtype, ambiguity, shard and ignore-pattern rules, along with the online single-file download path. Offline operation requires the requested GGUF and companion config/tokenizer to be cached.

Three regression cases cover offline engine initialization, first-process plugin registration, and cached GGUF loading followed by native model execution. All three fail for the expected reasons on unchanged main (`d2d66aa`); the execution case compares full logits with direct local loading.

Validation on Apple M4 / macOS 15.6 at `ca3ace04afb7325062e02e067edea2b1b8da33a9`:

- Focused tests: 134 passed, one optional checkpoint test skipped. Full non-slow suite: 2,098 passed, 15 skipped, 53 deselected; unchanged main: 2,095 passed with the same skips.
- GGUF loader/integration tests and cache counterexamples pass with Hugging Face Hub 1.27.0 and 1.29.0.
- Ruff, formatting, mypy, ShellCheck, native extension/all four Metal libraries, release wheel checks, and both repository Qwen serving smokes pass. Serving smokes used memory fraction 0.1.
- Offline `/v1/completions` with `bartowski/Qwen_Qwen3-0.6B-GGUF:Q8_0` at revision `60b85c0e`: all 32 token IDs across two prompts match direct local-file serving on unchanged main.

Runtime: Python 3.12.13, vLLM 0.28.0+cpu, MLX 0.32.1, pinned mlx-lm `9e6acca`, Transformers 5.16.1.
