### PR TITLE
Use MLX 0.32 APIs in loader and TurboQuant paths

### DIFF
--- a/vllm_metal/attention/caches/turboquant.py
+++ b/vllm_metal/attention/caches/turboquant.py
@@ -136,9 +136,11 @@ def _compute_lloyd_max_normal(bits: int) -> tuple[mx.array, mx.array]:
     for _ in range(500):
         boundaries = (centroids[:-1] + centroids[1:]) * 0.5
         # assign[i] = cluster index for sample[i] (in [0, n))
-        assign = mx.searchsorted(boundaries, samples).astype(mx.int32)
+        assign = cast(mx.array, mx.searchsorted(boundaries, samples)).astype(mx.int32)
         # one_hot: (N, n)
-        one_hot = (assign[:, None] == cluster_ids[None, :]).astype(mx.float32)
+        one_hot = cast(mx.array, assign[:, None] == cluster_ids[None, :]).astype(
+            mx.float32
+        )
         counts = one_hot.sum(axis=0)  # (n,)
         sums = (one_hot * samples[:, None]).sum(axis=0)  # (n,)
         # Empty clusters keep their old centroid to avoid divide-by-zero.

--- a/vllm_metal/attention/caches/turboquant.py
+++ b/vllm_metal/attention/caches/turboquant.py
@@ -83,11 +83,6 @@ V_QUANT_PARAMS = {
     "q8_0": {"signed": False, "bits": 8, "dtype": mx.uint8, "block_size": 32},
 }
 
-
-def searchsorted(boundaries, x):
-    return (x[..., None] > boundaries).sum(axis=-1)
-
-
 FWHT_SUPPORTED_HEAD_DIMS = (64, 128, 256, 512)
 
 
@@ -141,7 +136,7 @@ def _compute_lloyd_max_normal(bits: int) -> tuple[mx.array, mx.array]:
     for _ in range(500):
         boundaries = (centroids[:-1] + centroids[1:]) * 0.5
         # assign[i] = cluster index for sample[i] (in [0, n))
-        assign = searchsorted(boundaries, samples).astype(mx.int32)
+        assign = mx.searchsorted(boundaries, samples).astype(mx.int32)
         # one_hot: (N, n)
         one_hot = (assign[:, None] == cluster_ids[None, :]).astype(mx.float32)
         counts = one_hot.sum(axis=0)  # (n,)
@@ -212,7 +207,7 @@ def lm_quant(x: mx.array, bits: int = 3) -> tuple[mx.array, mx.array]:
     x = x.reshape(*shape[:-1], -1, BLOCK_SIZE)
     scale = mx.sqrt(mx.mean(x**2, axis=-1, keepdims=True))
     x_norm = x / (scale + 1e-8)
-    indices = searchsorted(boundaries, x_norm).reshape(shape)
+    indices = mx.searchsorted(boundaries, x_norm).reshape(shape)
     return indices.astype(mx.uint8), scale.squeeze(-1).astype(mx.float16)
 
 

--- a/vllm_metal/gguf/loader.py
+++ b/vllm_metal/gguf/loader.py
@@ -239,9 +239,7 @@ class GGUFModelLoader:
         adapter: GGUFModelAdapter,
     ) -> _PartitionedTensors:
         """Route each GGUF tensor to quant-install / plain-load / bias-side-map."""
-        arrays = mx.load(str(self._gguf_path))
-        if not isinstance(arrays, dict):
-            raise ValueError(f"Expected named tensors in {self._gguf_path}")
+        arrays = cast(dict[str, mx.array], mx.load(str(self._gguf_path)))
         if tied:
             skipped_output = arrays.pop("output.weight", None)
             if skipped_output is not None:

--- a/vllm_metal/v1/lora/peft_loader.py
+++ b/vllm_metal/v1/lora/peft_loader.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import mlx.core as mx
 from vllm.lora.peft_helper import PEFTHelper
@@ -56,12 +56,7 @@ def load_peft_adapter(
     helper = PEFTHelper.from_local_dir(str(adapter_path), max_position_embeddings)
     if lora_config is not None:
         helper.validate_legal(lora_config)
-    raw = mx.load(str(safetensors_path))
-    if not isinstance(raw, dict):
-        raise ValueError(
-            f"Expected safetensors weights in {safetensors_path}, got "
-            f"{type(raw).__name__}"
-        )
+    raw = cast(dict[str, mx.array], mx.load(str(safetensors_path)))
     # Preserve eager loading: later in-place adapter updates must not change
     # tensors already returned to the adapter manager.
     mx.eval(raw)

--- a/vllm_metal/v1/pooling/backends/encoder/models/loading.py
+++ b/vllm_metal/v1/pooling/backends/encoder/models/loading.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import mlx.core as mx
 import torch
@@ -57,7 +57,4 @@ def load_encoder_weight_file(weight_file: Path) -> dict[str, mx.array]:
             for name, value in state_dict.items()
             if isinstance(value, torch.Tensor)
         }
-    weights = mx.load(str(weight_file))
-    if not isinstance(weights, dict):
-        raise ValueError(f"Expected named tensors in {weight_file}")
-    return weights
+    return cast(dict[str, mx.array], mx.load(str(weight_file)))


### PR DESCRIPTION
This PR is:

- To use native `mx.searchsorted` in TurboQuant quantization now that MLX 0.32.1 is pinned
- To remove redundant `mx.load()` runtime type guards from GGUF, LoRA, and encoder loading paths
- To keep file-format validation at the loader boundary and trust MLX’s named-tensor load contract internally

The TurboQuant change removes a local `searchsorted` workaround. The loader cleanup keeps the same runtime behavior for valid files while reducing repeated defensive checks after the MLX dependency bump.
