### PR TITLE
[Spec Decode] Lazily catch up draft KV after zero-K steps

### DIFF
--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -141,37 +141,23 @@ def _prefills_context(
     prefills: list[tuple[str, list[int]]],
     *,
     start_pos: int = 0,
-    end_pos: int | None = None,
     result_mode: str = "final",
+    full_prompt_token_ids: list[int] | None = None,
     num_speculative_tokens: int = 1,
-    sampled_token_id: int = 42,
-    committed_block_ids: tuple[int, ...] = (0,),
 ) -> ProposeContext:
-    """Build a proposer context for one or more prefill requests."""
+    """Context whose requests are final-chunk prefills (greedy, drafting)."""
     prefill_reqs = [
         PrefillRequest(
             req_id=req_id,
-            token_ids=list(
-                full_prompt_token_ids[
-                    start_pos : (
-                        len(full_prompt_token_ids) if end_pos is None else end_pos
-                    )
-                ]
-            ),
+            token_ids=list(token_ids),
             sampling_params=SamplingParams(temperature=0.0),
-            block_ids=[list(committed_block_ids)],
+            block_ids=[[0]],
             generator=None,
-            prompt_len=(
-                None
-                if result_mode in {"intermediate", "final"}
-                else len(full_prompt_token_ids)
-            ),
+            prompt_len=None,
             start_pos=start_pos,
-            full_prompt_token_ids=(
-                list(full_prompt_token_ids) if start_pos > 0 else None
-            ),
+            full_prompt_token_ids=full_prompt_token_ids,
         )
-        for req_id, full_prompt_token_ids in prefills
+        for req_id, token_ids in prefills
     ]
     return ProposeContext(
         target_hidden_states=None,
@@ -179,14 +165,10 @@ def _prefills_context(
         decode_segments=[],
         decode_token_ids=[],
         prefill_reqs=prefill_reqs,
-        prefill_token_ids=[sampled_token_id] * len(prefill_reqs),
+        prefill_token_ids=[42] * len(prefill_reqs),
         prefill_result_modes=[result_mode] * len(prefill_reqs),
         request_states={
-            req_id: _request_state(
-                committed_block_ids=list(committed_block_ids),
-                token_ids=full_prompt_token_ids,
-            )
-            for req_id, full_prompt_token_ids in prefills
+            req_id: _request_state(committed_block_ids=[0]) for req_id, _ in prefills
         },
         cu_seqlens=[],
         num_decode_segments=0,
@@ -321,21 +303,16 @@ def test_intermediate_prefill_chunk_ingests_without_drafting() -> None:
     assert len(model.block_tables) == 1
 
 
-def test_zero_k_eagerly_ingests_when_prefix_caching_is_enabled() -> None:
+def test_eager_zero_k_still_ingests() -> None:
     """Prefix-cache mode must materialize scheduler-publishable draft KV."""
     model = _StubDraftModel()
     proposer = _proposer(model)
-    prompt = list(range(PROMPT_LEN))
 
     drafts = proposer.propose(
         _prefills_context(
-            [("r1", prompt)],
-            start_pos=0,
-            end_pos=8,
+            [("r1", list(range(8)))],
             result_mode="intermediate",
             num_speculative_tokens=0,
-            sampled_token_id=VOCAB_SIZE - 1,
-            committed_block_ids=(0, 1),
         )
     )
 
@@ -344,112 +321,39 @@ def test_zero_k_eagerly_ingests_when_prefix_caching_is_enabled() -> None:
     assert proposer._draft_seq_lens == {"r1": 8}
 
 
-def test_first_seen_at_zero_k_catches_up_from_initial_prefill_boundary() -> None:
-    """A deferred first chunk must not be forgotten by the next prefill."""
+def test_lazy_zero_to_positive_k_catches_up_before_drafting() -> None:
     model = _PositionEncodingDraftModel()
     proposer = _proposer(model, defer_zero_k_ingest=True)
-    prompt = list(range(PROMPT_LEN))
+    prompt = list(range(12))
 
-    assert (
-        proposer.propose(
-            _prefills_context(
-                [("r1", prompt)],
-                start_pos=0,
-                end_pos=8,
-                result_mode="intermediate",
-                num_speculative_tokens=0,
-                sampled_token_id=VOCAB_SIZE - 1,
-                committed_block_ids=(0, 1),
-            )
+    zero_k_drafts = proposer.propose(
+        _prefills_context(
+            [("r1", prompt[:4])],
+            result_mode="intermediate",
+            num_speculative_tokens=0,
         )
-        is None
     )
+
+    assert zero_k_drafts is None
     assert model.input_lens == []
     assert proposer._draft_seq_lens == {"r1": 0}
 
     drafts = proposer.propose(
         _prefills_context(
-            [("r1", prompt)],
-            start_pos=8,
-            end_pos=PROMPT_LEN,
-            result_mode="cached_final",
-            num_speculative_tokens=1,
-            sampled_token_id=VOCAB_SIZE - 1,
-            committed_block_ids=(0, 1),
+            [("r1", prompt[4:])],
+            start_pos=4,
+            full_prompt_token_ids=prompt,
         )
     )
 
     assert drafts is not None
-    assert drafts.draft_token_ids == [[PROMPT_LEN % VOCAB_SIZE]]
-    assert model.input_lens == [PROMPT_LEN + 1]
-    assert proposer._draft_seq_lens == {"r1": PROMPT_LEN + 1}
+    assert drafts.draft_token_ids == [[len(prompt) % VOCAB_SIZE]]
+    assert model.input_lens == [len(prompt) + 1]
+    assert proposer._draft_seq_lens == {"r1": len(prompt) + 1}
 
 
-def test_consecutive_zero_k_prefills_catch_up_on_first_decode() -> None:
-    """Repeated K=0 prefills catch up once when decode resumes drafting."""
-    model = _PositionEncodingDraftModel()
-    proposer = _proposer(model, defer_zero_k_ingest=True)
-    prompt = list(range(PROMPT_LEN))
-
-    assert (
-        proposer.propose(
-            _prefills_context(
-                [("r1", prompt)],
-                start_pos=0,
-                end_pos=8,
-                result_mode="intermediate",
-                num_speculative_tokens=0,
-                sampled_token_id=VOCAB_SIZE - 1,
-                committed_block_ids=(0, 1),
-            )
-        )
-        is None
-    )
-    assert (
-        proposer.propose(
-            _prefills_context(
-                [("r1", prompt)],
-                start_pos=8,
-                end_pos=PROMPT_LEN,
-                result_mode="cached_final",
-                num_speculative_tokens=0,
-                sampled_token_id=VOCAB_SIZE - 1,
-                committed_block_ids=(0, 1),
-            )
-        )
-        is None
-    )
-
-    # Neither K=0 prefill runs the draft model, and the second chunk must not
-    # advance the physical-validity boundary established by the first one.
-    assert model.input_lens == []
-    assert proposer._draft_seq_lens == {"r1": 0}
-
-    # By proposer time, target execution has committed one token at final
-    # prefill and another at the first decode step.
-    committed_tokens = [*prompt, VOCAB_SIZE - 2, VOCAB_SIZE - 1]
-    decode_state = _request_state(
-        committed_block_ids=[0, 1],
-        token_ids=committed_tokens,
-    )
-    decode_state.prompt_len = PROMPT_LEN
-    drafts = proposer.propose(
-        _context(
-            "r1",
-            decode_state,
-            {"r1": decode_state},
-            num_speculative_tokens=1,
-        )
-    )
-
-    assert drafts is not None
-    assert drafts.draft_token_ids == [[(len(committed_tokens) - 1) % VOCAB_SIZE]]
-    assert model.input_lens == [len(committed_tokens)]
-    assert proposer._draft_seq_lens == {"r1": len(committed_tokens)}
-
-
-def test_zero_k_preserves_existing_boundary_until_decode_catch_up() -> None:
-    """Scheduler progress during K=0 must not claim unwritten KV is valid."""
+def test_lazy_positive_to_zero_k_preserves_boundary() -> None:
+    """Keep the physical boundary when traced decode progress reports zero."""
     model = _StubDraftModel()
     proposer = _proposer(model, defer_zero_k_ingest=True)
 
@@ -457,31 +361,24 @@ def test_zero_k_preserves_existing_boundary_until_decode_catch_up() -> None:
         committed_block_ids=[0, 1],
         token_ids=list(range(8)),
     )
-    assert (
-        proposer.propose(_context("r1", initial_state, {"r1": initial_state}))
-        is not None
-    )
-    assert model.input_lens == [8]
+    proposer.propose(_context("r1", initial_state, {"r1": initial_state}))
     assert proposer._draft_seq_lens == {"r1": 8}
 
     zero_k_state = _request_state(
         committed_block_ids=[0, 1],
-        # This remains zero in real decode traces, so K=0 must use setdefault
-        # rather than overwrite an already-established physical boundary.
         num_computed_tokens=0,
         token_ids=list(range(16)),
     )
-    assert (
-        proposer.propose(
-            _context(
-                "r1",
-                zero_k_state,
-                {"r1": zero_k_state},
-                num_speculative_tokens=0,
-            )
+    zero_k_drafts = proposer.propose(
+        _context(
+            "r1",
+            zero_k_state,
+            {"r1": zero_k_state},
+            num_speculative_tokens=0,
         )
-        is None
     )
+
+    assert zero_k_drafts is None
     assert model.input_lens == [8]
     assert proposer._draft_seq_lens == {"r1": 8}
 
@@ -489,10 +386,8 @@ def test_zero_k_preserves_existing_boundary_until_decode_catch_up() -> None:
         committed_block_ids=[0, 1],
         token_ids=list(range(PROMPT_LEN)),
     )
-    assert (
-        proposer.propose(_context("r1", resumed_state, {"r1": resumed_state}))
-        is not None
-    )
+    proposer.propose(_context("r1", resumed_state, {"r1": resumed_state}))
+
     assert model.input_lens == [8, PROMPT_LEN - 8]
     assert proposer._draft_seq_lens == {"r1": PROMPT_LEN}
 

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -79,6 +79,7 @@ def _proposer(
     *,
     committed_num_blocks: int = COMMITTED_NUM_BLOCKS,
     scratch_reserve_blocks: int = SCRATCH_RESERVE_BLOCKS,
+    enable_prefix_caching: bool = True,
 ) -> DraftModelProposer:
     proposer = DraftModelProposer(
         model=model,
@@ -88,6 +89,7 @@ def _proposer(
         num_layers=1,
         controller=SpeculativeDecodeController(),
         extract_logits=lambda output: output,
+        enable_prefix_caching=enable_prefix_caching,
     )
     proposer.adopt_committed_group(COMMITTED_GROUP_INDEX)
     return proposer
@@ -138,21 +140,38 @@ def _context(
 def _prefills_context(
     prefills: list[tuple[str, list[int]]],
     *,
+    start_pos: int = 0,
+    end_pos: int | None = None,
+    result_mode: str = "final",
     num_speculative_tokens: int = 1,
+    sampled_token_id: int = 42,
+    committed_block_ids: tuple[int, ...] = (0,),
 ) -> ProposeContext:
-    """Context whose requests are final-chunk prefills (greedy, drafting)."""
+    """Build a proposer context for one or more prefill requests."""
     prefill_reqs = [
         PrefillRequest(
             req_id=req_id,
-            token_ids=list(token_ids),
+            token_ids=list(
+                full_prompt_token_ids[
+                    start_pos : (
+                        len(full_prompt_token_ids) if end_pos is None else end_pos
+                    )
+                ]
+            ),
             sampling_params=SamplingParams(temperature=0.0),
-            block_ids=[[0]],
+            block_ids=[list(committed_block_ids)],
             generator=None,
-            prompt_len=None,
-            start_pos=0,
-            full_prompt_token_ids=None,
+            prompt_len=(
+                None
+                if result_mode in {"intermediate", "final"}
+                else len(full_prompt_token_ids)
+            ),
+            start_pos=start_pos,
+            full_prompt_token_ids=(
+                list(full_prompt_token_ids) if start_pos > 0 else None
+            ),
         )
-        for req_id, token_ids in prefills
+        for req_id, full_prompt_token_ids in prefills
     ]
     return ProposeContext(
         target_hidden_states=None,
@@ -160,10 +179,14 @@ def _prefills_context(
         decode_segments=[],
         decode_token_ids=[],
         prefill_reqs=prefill_reqs,
-        prefill_token_ids=[42] * len(prefill_reqs),
-        prefill_result_modes=["final"] * len(prefill_reqs),
+        prefill_token_ids=[sampled_token_id] * len(prefill_reqs),
+        prefill_result_modes=[result_mode] * len(prefill_reqs),
         request_states={
-            req_id: _request_state(committed_block_ids=[0]) for req_id, _ in prefills
+            req_id: _request_state(
+                committed_block_ids=list(committed_block_ids),
+                token_ids=full_prompt_token_ids,
+            )
+            for req_id, full_prompt_token_ids in prefills
         },
         cu_seqlens=[],
         num_decode_segments=0,
@@ -296,6 +319,182 @@ def test_intermediate_prefill_chunk_ingests_without_drafting() -> None:
 
     assert drafts is None
     assert len(model.block_tables) == 1
+
+
+def test_zero_k_eagerly_ingests_when_prefix_caching_is_enabled() -> None:
+    """Prefix-cache mode must materialize scheduler-publishable draft KV."""
+    model = _StubDraftModel()
+    proposer = _proposer(model)
+    prompt = list(range(PROMPT_LEN))
+
+    drafts = proposer.propose(
+        _prefills_context(
+            [("r1", prompt)],
+            start_pos=0,
+            end_pos=8,
+            result_mode="intermediate",
+            num_speculative_tokens=0,
+            sampled_token_id=VOCAB_SIZE - 1,
+            committed_block_ids=(0, 1),
+        )
+    )
+
+    assert drafts is None
+    assert model.input_lens == [8]
+    assert proposer._draft_seq_lens == {"r1": 8}
+
+
+def test_first_seen_at_zero_k_catches_up_from_initial_prefill_boundary() -> None:
+    """A deferred first chunk must not be forgotten by the next prefill."""
+    model = _PositionEncodingDraftModel()
+    proposer = _proposer(model, enable_prefix_caching=False)
+    prompt = list(range(PROMPT_LEN))
+
+    assert (
+        proposer.propose(
+            _prefills_context(
+                [("r1", prompt)],
+                start_pos=0,
+                end_pos=8,
+                result_mode="intermediate",
+                num_speculative_tokens=0,
+                sampled_token_id=VOCAB_SIZE - 1,
+                committed_block_ids=(0, 1),
+            )
+        )
+        is None
+    )
+    assert model.input_lens == []
+    assert proposer._draft_seq_lens == {"r1": 0}
+
+    drafts = proposer.propose(
+        _prefills_context(
+            [("r1", prompt)],
+            start_pos=8,
+            end_pos=PROMPT_LEN,
+            result_mode="cached_final",
+            num_speculative_tokens=1,
+            sampled_token_id=VOCAB_SIZE - 1,
+            committed_block_ids=(0, 1),
+        )
+    )
+
+    assert drafts is not None
+    assert drafts.draft_token_ids == [[PROMPT_LEN % VOCAB_SIZE]]
+    assert model.input_lens == [PROMPT_LEN + 1]
+    assert proposer._draft_seq_lens == {"r1": PROMPT_LEN + 1}
+
+
+def test_consecutive_zero_k_prefills_catch_up_on_first_decode() -> None:
+    """Repeated K=0 prefills catch up once when decode resumes drafting."""
+    model = _PositionEncodingDraftModel()
+    proposer = _proposer(model, enable_prefix_caching=False)
+    prompt = list(range(PROMPT_LEN))
+
+    assert (
+        proposer.propose(
+            _prefills_context(
+                [("r1", prompt)],
+                start_pos=0,
+                end_pos=8,
+                result_mode="intermediate",
+                num_speculative_tokens=0,
+                sampled_token_id=VOCAB_SIZE - 1,
+                committed_block_ids=(0, 1),
+            )
+        )
+        is None
+    )
+    assert (
+        proposer.propose(
+            _prefills_context(
+                [("r1", prompt)],
+                start_pos=8,
+                end_pos=PROMPT_LEN,
+                result_mode="cached_final",
+                num_speculative_tokens=0,
+                sampled_token_id=VOCAB_SIZE - 1,
+                committed_block_ids=(0, 1),
+            )
+        )
+        is None
+    )
+
+    # Neither K=0 prefill runs the draft model, and the second chunk must not
+    # advance the physical-validity boundary established by the first one.
+    assert model.input_lens == []
+    assert proposer._draft_seq_lens == {"r1": 0}
+
+    # By proposer time, target execution has committed one token at final
+    # prefill and another at the first decode step.
+    committed_tokens = [*prompt, VOCAB_SIZE - 2, VOCAB_SIZE - 1]
+    decode_state = _request_state(
+        committed_block_ids=[0, 1],
+        token_ids=committed_tokens,
+    )
+    decode_state.prompt_len = PROMPT_LEN
+    drafts = proposer.propose(
+        _context(
+            "r1",
+            decode_state,
+            {"r1": decode_state},
+            num_speculative_tokens=1,
+        )
+    )
+
+    assert drafts is not None
+    assert drafts.draft_token_ids == [[(len(committed_tokens) - 1) % VOCAB_SIZE]]
+    assert model.input_lens == [len(committed_tokens)]
+    assert proposer._draft_seq_lens == {"r1": len(committed_tokens)}
+
+
+def test_zero_k_preserves_existing_boundary_until_decode_catch_up() -> None:
+    """Scheduler progress during K=0 must not claim unwritten KV is valid."""
+    model = _StubDraftModel()
+    proposer = _proposer(model, enable_prefix_caching=False)
+
+    initial_state = _request_state(
+        committed_block_ids=[0, 1],
+        token_ids=list(range(8)),
+    )
+    assert (
+        proposer.propose(_context("r1", initial_state, {"r1": initial_state}))
+        is not None
+    )
+    assert model.input_lens == [8]
+    assert proposer._draft_seq_lens == {"r1": 8}
+
+    zero_k_state = _request_state(
+        committed_block_ids=[0, 1],
+        # This remains zero in real decode traces, so K=0 must use setdefault
+        # rather than overwrite an already-established physical boundary.
+        num_computed_tokens=0,
+        token_ids=list(range(16)),
+    )
+    assert (
+        proposer.propose(
+            _context(
+                "r1",
+                zero_k_state,
+                {"r1": zero_k_state},
+                num_speculative_tokens=0,
+            )
+        )
+        is None
+    )
+    assert model.input_lens == [8]
+    assert proposer._draft_seq_lens == {"r1": 8}
+
+    resumed_state = _request_state(
+        committed_block_ids=[0, 1],
+        token_ids=list(range(PROMPT_LEN)),
+    )
+    assert (
+        proposer.propose(_context("r1", resumed_state, {"r1": resumed_state}))
+        is not None
+    )
+    assert model.input_lens == [8, PROMPT_LEN - 8]
+    assert proposer._draft_seq_lens == {"r1": PROMPT_LEN}
 
 
 def test_release_requests_returns_scratch_blocks_to_the_free_pool() -> None:

--- a/tests/test_draft_model_proposer.py
+++ b/tests/test_draft_model_proposer.py
@@ -79,7 +79,7 @@ def _proposer(
     *,
     committed_num_blocks: int = COMMITTED_NUM_BLOCKS,
     scratch_reserve_blocks: int = SCRATCH_RESERVE_BLOCKS,
-    enable_prefix_caching: bool = True,
+    defer_zero_k_ingest: bool = False,
 ) -> DraftModelProposer:
     proposer = DraftModelProposer(
         model=model,
@@ -89,7 +89,7 @@ def _proposer(
         num_layers=1,
         controller=SpeculativeDecodeController(),
         extract_logits=lambda output: output,
-        enable_prefix_caching=enable_prefix_caching,
+        defer_zero_k_ingest=defer_zero_k_ingest,
     )
     proposer.adopt_committed_group(COMMITTED_GROUP_INDEX)
     return proposer
@@ -347,7 +347,7 @@ def test_zero_k_eagerly_ingests_when_prefix_caching_is_enabled() -> None:
 def test_first_seen_at_zero_k_catches_up_from_initial_prefill_boundary() -> None:
     """A deferred first chunk must not be forgotten by the next prefill."""
     model = _PositionEncodingDraftModel()
-    proposer = _proposer(model, enable_prefix_caching=False)
+    proposer = _proposer(model, defer_zero_k_ingest=True)
     prompt = list(range(PROMPT_LEN))
 
     assert (
@@ -388,7 +388,7 @@ def test_first_seen_at_zero_k_catches_up_from_initial_prefill_boundary() -> None
 def test_consecutive_zero_k_prefills_catch_up_on_first_decode() -> None:
     """Repeated K=0 prefills catch up once when decode resumes drafting."""
     model = _PositionEncodingDraftModel()
-    proposer = _proposer(model, enable_prefix_caching=False)
+    proposer = _proposer(model, defer_zero_k_ingest=True)
     prompt = list(range(PROMPT_LEN))
 
     assert (
@@ -451,7 +451,7 @@ def test_consecutive_zero_k_prefills_catch_up_on_first_decode() -> None:
 def test_zero_k_preserves_existing_boundary_until_decode_catch_up() -> None:
     """Scheduler progress during K=0 must not claim unwritten KV is valid."""
     model = _StubDraftModel()
-    proposer = _proposer(model, enable_prefix_caching=False)
+    proposer = _proposer(model, defer_zero_k_ingest=True)
 
     initial_state = _request_state(
         committed_block_ids=[0, 1],

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -152,16 +152,13 @@ class DraftModelProposer:
         controller: SpeculativeDecodeController,
         extract_logits: Callable[[Any], mx.array],
         merge_ingest_windows: bool = False,
-        enable_prefix_caching: bool = True,
+        defer_zero_k_ingest: bool = False,
     ) -> None:
         self._model = model
         self._block_size = block_size
         self._controller = controller
         self._extract_logits = extract_logits
-        # Deferring K=0 ingest is safe only when prefix caching is disabled.
-        # Otherwise the scheduler may publish a full draft-group block as a
-        # cache hit even though its physical KV has not been materialized.
-        self._defer_zero_k_ingest = not enable_prefix_caching
+        self._defer_zero_k_ingest = defer_zero_k_ingest
         # Structural half of the ingest window gate (see `build`); the
         # operator half (VLLM_METAL_SPEC_VERIFY_WINDOW) is read per call
         # like the runner's `merge_verify_windows` property.  The same
@@ -222,7 +219,7 @@ class DraftModelProposer:
         scratch_reserve_blocks: int,
         block_size: int,
         dtype: mx.Dtype,
-        enable_prefix_caching: bool,
+        defer_zero_k_ingest: bool,
     ) -> DraftModelProposer:
         model, dims = _load_draft_model(speculative_config, parallel_config)
         total_blocks = committed_num_blocks + scratch_reserve_blocks
@@ -262,7 +259,7 @@ class DraftModelProposer:
             # vacuous, and `_load_draft_model` resolves one uniform
             # head_dim.  Only the decode kernel's head bound remains.
             merge_ingest_windows=dims.head_dim <= PA_WINDOW_MAX_HEAD_SIZE,
-            enable_prefix_caching=enable_prefix_caching,
+            defer_zero_k_ingest=defer_zero_k_ingest,
         )
 
     def adopt_committed_group(self, group_index: int) -> None:
@@ -298,7 +295,21 @@ class DraftModelProposer:
 
         self._prune_finished(ctx.request_states)
         if num_speculative_tokens <= 0 and self._defer_zero_k_ingest:
-            self._record_deferred_ingest_boundaries(ctx)
+            # Remember where lazy K=0 catch-up must start without running MLX.
+            # No speculative lookahead is needed while K=0, so return its
+            # private tail to the free pool. The speculative-write ledger is
+            # retained and validated before any later reuse.
+            for req_id, state in ctx.decode_reqs:
+                self._draft_seq_lens.setdefault(req_id, state.num_computed_tokens)
+                blocks = self._scratch_req_blocks.pop(req_id, None)
+                if blocks is not None:
+                    self._scratch_free_blocks.extend(blocks)
+            for prefill in ctx.prefill_reqs:
+                self._draft_seq_lens.setdefault(prefill.req_id, prefill.start_pos)
+                blocks = self._scratch_req_blocks.pop(prefill.req_id, None)
+                if blocks is not None:
+                    self._scratch_free_blocks.extend(blocks)
+
             return None
 
         plans = self._collect_draft_plans(ctx, num_speculative_tokens)
@@ -377,25 +388,6 @@ class DraftModelProposer:
             self._spec_kv_writes.pop(req_id, None)
 
     # -- internals -----------------------------------------------------------
-
-    def _record_deferred_ingest_boundaries(self, ctx: ProposeContext) -> None:
-        """Remember where lazy K=0 catch-up must start without running MLX."""
-        boundaries = [
-            (req_id, state.num_computed_tokens) for req_id, state in ctx.decode_reqs
-        ]
-        boundaries.extend(
-            (prefill.req_id, prefill.start_pos) for prefill in ctx.prefill_reqs
-        )
-        for req_id, boundary in boundaries:
-            self._draft_seq_lens.setdefault(req_id, boundary)
-
-            # No speculative lookahead is needed while K=0. Returning its
-            # private tail avoids pinning scratch capacity during a long
-            # zero-budget interval. The speculative-write ledger is retained;
-            # entries are block/token validated before any later reuse.
-            blocks = self._scratch_req_blocks.pop(req_id, None)
-            if blocks is not None:
-                self._scratch_free_blocks.extend(blocks)
 
     def _prune_finished(self, request_states: Mapping[str, RequestState]) -> None:
         for req_id in list(self._scratch_req_blocks.keys()):
@@ -508,32 +500,25 @@ class DraftModelProposer:
             is_drafting=is_drafting,
         )
 
-    def _make_prefill_plan(
+    def _select_prefill_ingest_tokens(
         self,
         prefill: PrefillRequest,
-        result_mode: str,
-        num_speculative_tokens: int,
-        drafting_req_ids: set[str],
-    ) -> _DraftPlan | None:
-        if not prefill.token_ids:
-            return None
-        req_id = prefill.req_id
-        committed_len = prefill.start_pos + len(prefill.token_ids)
-        draft_seq_len = self._draft_seq_lens.setdefault(req_id, prefill.start_pos)
-        if draft_seq_len >= committed_len:
-            return None
-
+        draft_seq_len: int,
+        committed_len: int,
+    ) -> list[int]:
+        """Select the contiguous prefill range missing from the draft KV."""
         if draft_seq_len < prefill.start_pos:
-            # K may have been zero for earlier prefill chunks. The packed continuation
-            # carries the full original prompt, allowing reconstruction before this
-            # chunk. Slice only through committed_len because the full prompt may also
-            # contain future, unscheduled prompt tokens.
+            # K may have been zero for earlier prefill chunks. The packed
+            # continuation carries the full original prompt, allowing
+            # reconstruction before this chunk. Slice only through
+            # committed_len because the full prompt may also contain future,
+            # unscheduled prompt tokens.
             full_prompt_token_ids = prefill.full_prompt_token_ids
             if full_prompt_token_ids is None:
                 raise RuntimeError(
                     "Cannot catch up deferred draft KV for request "
-                    f"{req_id!r}: valid boundary {draft_seq_len} precedes "
-                    f"prefill start {prefill.start_pos}, but "
+                    f"{prefill.req_id!r}: valid boundary {draft_seq_len} "
+                    f"precedes prefill start {prefill.start_pos}, but "
                     "full_prompt_token_ids is missing"
                 )
             catch_up_token_ids = list(full_prompt_token_ids)
@@ -552,10 +537,30 @@ class DraftModelProposer:
         if len(ingest_tokens) != expected_ingest_len:
             raise RuntimeError(
                 "Cannot catch up deferred draft KV for request "
-                f"{req_id!r}: expected {expected_ingest_len} tokens from "
-                f"position {draft_seq_len} through {committed_len}, got "
+                f"{prefill.req_id!r}: expected {expected_ingest_len} tokens "
+                f"from position {draft_seq_len} through {committed_len}, got "
                 f"{len(ingest_tokens)}"
             )
+        return ingest_tokens
+
+    def _make_prefill_plan(
+        self,
+        prefill: PrefillRequest,
+        result_mode: str,
+        num_speculative_tokens: int,
+        drafting_req_ids: set[str],
+    ) -> _DraftPlan | None:
+        if not prefill.token_ids:
+            return None
+        req_id = prefill.req_id
+        committed_len = prefill.start_pos + len(prefill.token_ids)
+        draft_seq_len = self._draft_seq_lens.setdefault(req_id, prefill.start_pos)
+
+        if draft_seq_len >= committed_len:
+            return None
+        ingest_tokens = self._select_prefill_ingest_tokens(
+            prefill, draft_seq_len, committed_len
+        )
 
         is_drafting = result_mode != "intermediate" and req_id in drafting_req_ids
         assert self._committed_group_index is not None

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -32,7 +32,9 @@ position in ``[draft_seq_len, committed_len)`` *before* the block can be
 hashed: the scheduler only content-hashes a block once it is fully filled,
 and by that point a future ingest step will have overwritten the speculative
 slots with the correct committed KV.  No stale draft KV can leak into a
-prefix-cache match.
+prefix-cache match. K=0 remains eager when prefix caching is enabled.
+Deferred unwritten KV is allowed only when prefix caching is disabled, so it
+cannot be exposed as a cross-request prefix-cache hit.
 
 **Why every active row ingests, not just drafting-eligible ones.** The
 scheduler advances a request's ``num_computed_tokens`` and marks the
@@ -150,11 +152,16 @@ class DraftModelProposer:
         controller: SpeculativeDecodeController,
         extract_logits: Callable[[Any], mx.array],
         merge_ingest_windows: bool = False,
+        enable_prefix_caching: bool = True,
     ) -> None:
         self._model = model
         self._block_size = block_size
         self._controller = controller
         self._extract_logits = extract_logits
+        # Deferring K=0 ingest is safe only when prefix caching is disabled.
+        # Otherwise the scheduler may publish a full draft-group block as a
+        # cache hit even though its physical KV has not been materialized.
+        self._defer_zero_k_ingest = not enable_prefix_caching
         # Structural half of the ingest window gate (see `build`); the
         # operator half (VLLM_METAL_SPEC_VERIFY_WINDOW) is read per call
         # like the runner's `merge_verify_windows` property.  The same
@@ -215,6 +222,7 @@ class DraftModelProposer:
         scratch_reserve_blocks: int,
         block_size: int,
         dtype: mx.Dtype,
+        enable_prefix_caching: bool,
     ) -> DraftModelProposer:
         model, dims = _load_draft_model(speculative_config, parallel_config)
         total_blocks = committed_num_blocks + scratch_reserve_blocks
@@ -254,6 +262,7 @@ class DraftModelProposer:
             # vacuous, and `_load_draft_model` resolves one uniform
             # head_dim.  Only the decode kernel's head bound remains.
             merge_ingest_windows=dims.head_dim <= PA_WINDOW_MAX_HEAD_SIZE,
+            enable_prefix_caching=enable_prefix_caching,
         )
 
     def adopt_committed_group(self, group_index: int) -> None:
@@ -288,6 +297,10 @@ class DraftModelProposer:
             )
 
         self._prune_finished(ctx.request_states)
+        if num_speculative_tokens <= 0 and self._defer_zero_k_ingest:
+            self._record_deferred_ingest_boundaries(ctx)
+            return None
+
         plans = self._collect_draft_plans(ctx, num_speculative_tokens)
         if not plans:
             return None
@@ -301,9 +314,9 @@ class DraftModelProposer:
         for plan in plans:
             self._draft_seq_lens[plan.req_id] = plan.committed_len
 
-        # A scheduler step can have no speculative-token budget while still
-        # advancing committed prefill tokens. Keep the draft KV cache in sync,
-        # but do not generate any draft tokens for that step.
+        # If K=0 reaches this point, lazy ingest is disabled (currently because
+        # prefix caching is enabled). Keep physical draft KV synchronized with the
+        # scheduler, but do not return draft tokens.
         if num_speculative_tokens <= 0:
             return None
 
@@ -364,6 +377,25 @@ class DraftModelProposer:
             self._spec_kv_writes.pop(req_id, None)
 
     # -- internals -----------------------------------------------------------
+
+    def _record_deferred_ingest_boundaries(self, ctx: ProposeContext) -> None:
+        """Remember where lazy K=0 catch-up must start without running MLX."""
+        boundaries = [
+            (req_id, state.num_computed_tokens) for req_id, state in ctx.decode_reqs
+        ]
+        boundaries.extend(
+            (prefill.req_id, prefill.start_pos) for prefill in ctx.prefill_reqs
+        )
+        for req_id, boundary in boundaries:
+            self._draft_seq_lens.setdefault(req_id, boundary)
+
+            # No speculative lookahead is needed while K=0. Returning its
+            # private tail avoids pinning scratch capacity during a long
+            # zero-budget interval. The speculative-write ledger is retained;
+            # entries are block/token validated before any later reuse.
+            blocks = self._scratch_req_blocks.pop(req_id, None)
+            if blocks is not None:
+                self._scratch_free_blocks.extend(blocks)
 
     def _prune_finished(self, request_states: Mapping[str, RequestState]) -> None:
         for req_id in list(self._scratch_req_blocks.keys()):
@@ -487,6 +519,44 @@ class DraftModelProposer:
             return None
         req_id = prefill.req_id
         committed_len = prefill.start_pos + len(prefill.token_ids)
+        draft_seq_len = self._draft_seq_lens.setdefault(req_id, prefill.start_pos)
+        if draft_seq_len >= committed_len:
+            return None
+
+        if draft_seq_len < prefill.start_pos:
+            # K may have been zero for earlier prefill chunks. The packed continuation
+            # carries the full original prompt, allowing reconstruction before this
+            # chunk. Slice only through committed_len because the full prompt may also
+            # contain future, unscheduled prompt tokens.
+            full_prompt_token_ids = prefill.full_prompt_token_ids
+            if full_prompt_token_ids is None:
+                raise RuntimeError(
+                    "Cannot catch up deferred draft KV for request "
+                    f"{req_id!r}: valid boundary {draft_seq_len} precedes "
+                    f"prefill start {prefill.start_pos}, but "
+                    "full_prompt_token_ids is missing"
+                )
+            catch_up_token_ids = list(full_prompt_token_ids)
+            if committed_len > len(catch_up_token_ids):
+                # A final prefill plan includes the target's just-sampled
+                # output token after the prompt chunk (#721). Preserve it when
+                # rebuilding an ingest range that starts in an older chunk.
+                current_chunk_offset = len(catch_up_token_ids) - prefill.start_pos
+                catch_up_token_ids.extend(prefill.token_ids[current_chunk_offset:])
+            ingest_tokens = catch_up_token_ids[draft_seq_len:committed_len]
+        else:
+            chunk_offset = draft_seq_len - prefill.start_pos
+            ingest_tokens = list(prefill.token_ids[chunk_offset:])
+
+        expected_ingest_len = committed_len - draft_seq_len
+        if len(ingest_tokens) != expected_ingest_len:
+            raise RuntimeError(
+                "Cannot catch up deferred draft KV for request "
+                f"{req_id!r}: expected {expected_ingest_len} tokens from "
+                f"position {draft_seq_len} through {committed_len}, got "
+                f"{len(ingest_tokens)}"
+            )
+
         is_drafting = result_mode != "intermediate" and req_id in drafting_req_ids
         assert self._committed_group_index is not None
         # The ingest includes the target's sampled token. Producing K drafts
@@ -501,8 +571,8 @@ class DraftModelProposer:
             req_id=req_id,
             block_ids=block_ids,
             committed_len=committed_len,
-            draft_seq_len=prefill.start_pos,
-            ingest_tokens=list(prefill.token_ids),
+            draft_seq_len=draft_seq_len,
+            ingest_tokens=ingest_tokens,
             is_drafting=is_drafting,
         )
         return plan

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1000,6 +1000,10 @@ class MetalModelRunner:
         if Gemma4MTPAssistantSource.is_gemma4_mtp(spec):
             self._drafter = Gemma4MTPProposer(self)
         elif spec.uses_draft_model():
+            defer_zero_k_ingest = (
+                not self.vllm_config.cache_config.enable_prefix_caching
+            )
+
             from vllm_metal.v1.draft_model_proposer import DraftModelProposer
 
             # `num_blocks` is the scheduler-visible committed-KV capacity for
@@ -1019,7 +1023,7 @@ class MetalModelRunner:
                 scratch_reserve_blocks=self.draft_scratch_reserve_blocks(),
                 block_size=block_size,
                 dtype=self.kv_cache_dtype,
-                enable_prefix_caching=self.vllm_config.cache_config.enable_prefix_caching,
+                defer_zero_k_ingest=defer_zero_k_ingest,
             )
         elif spec.method == "ngram":
             from vllm_metal.v1.ngram_proposer import NgramProposer

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1019,6 +1019,7 @@ class MetalModelRunner:
                 scratch_reserve_blocks=self.draft_scratch_reserve_blocks(),
                 block_size=block_size,
                 dtype=self.kv_cache_dtype,
+                enable_prefix_caching=self.vllm_config.cache_config.enable_prefix_caching,
             )
         elif spec.method == "ngram":
             from vllm_metal.v1.ngram_proposer import NgramProposer
@@ -2626,6 +2627,10 @@ class MetalModelRunner:
         one past this chunk's own tokens.  All conditions share the same
         two-source resolution (RequestState first, new_req fallback) and
         the same contract-bug raises.
+
+        Continuation chunks also expose the full original prompt so consumers such
+        as DraftModelProposer can reconstruct a deferred KV range that begins before
+        the current chunk.
         """
         prefill_pack: list[PrefillRequest] = []
         for entry in batch.paged_prefill_entries:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -2631,10 +2631,6 @@ class MetalModelRunner:
         one past this chunk's own tokens.  All conditions share the same
         two-source resolution (RequestState first, new_req fallback) and
         the same contract-bug raises.
-
-        Continuation chunks also expose the full original prompt so consumers such
-        as DraftModelProposer can reconstruct a deferred KV range that begins before
-        the current chunk.
         """
         prefill_pack: list[PrefillRequest] = []
         for entry in batch.paged_prefill_entries:


### PR DESCRIPTION
## Motivation

This is a follow-up to #716.

#716 keeps the draft KV cache synchronized by running draft-model ingest even
when dynamic speculative decoding selects K=0. This fixes the missing-KV
problem, but adds draft-model work to every zero-K scheduler step.

During the review and validation of #716, a more efficient alternative was
suggested: record the earliest missing draft-KV position during K=0 without
running the draft model, then lazily ingest the complete missing range before
the next K>0 proposal.

This draft PR implements that approach.

## Summary

When `enable_prefix_caching=False`, K=0 now records the earliest valid draft-KV
boundary without running the draft model. The missing range is ingested once,
immediately before the next K>0 proposal. This preserves cache correctness
while avoiding work for requests that finish before drafting resumes.

`enable_prefix_caching=True` keeps the eager #716 behavior so scheduler-visible cache hits
cannot reference draft KV that has not been materialized.

## Implementation

- Preserve the physical KV boundary with `setdefault()` during K=0.
- Reconstruct deferred prefill ranges in `_make_prefill_plan()`
- Return unused speculative scratch blocks during zero-budget steps.
- Pass the prefix-caching setting `enable_prefix_caching ` from the runner to the proposer.

## Performance

Three alternating eager/lazy pairs were run in fresh processes using
`Qwen/Qwen3-0.6B` as both target and draft. Dynamic-K used K=3 for batch size 1
and K=0 for batch size 2.

| Metric | Eager (#716) | Lazy (this PR) |
|---|---:|---:|
| Median wall time | 0.8610 s | 0.7754 s |
| K=0 ingest tokens | 426 | 0 |
| Total ingest tokens | 439 | 184 |
| Peak per-request ingest | 128 | 172 |
| Accepted/proposed | 18/18 | 18/18 |

Median wall time decreased by **9.94%**, while total ingest decreased by
**58.09%**. Proposal hashes, target outputs, and acceptance counts were
identical across all six processes. Lazy catch-up increases the largest resume
ingest from 128 to 172 tokens; the result is specific to this workload.

The 255-token reduction comes from the companion request, which finishes while
K=0 and therefore never needs draft KV. Eager mode still ingests its 127- and
128-token chunks; lazy mode only records its boundary and later drops the
request. The survivor performs the same 172 tokens of catch-up work in both
modes: eager spreads it across `127 + 44 + 1` tokens, while lazy performs one
172-token ingest before drafting resumes. If every K=0 request later returns to
K>0, total ingest tokens may be similar; the remaining difference would be
forward scheduling and peak catch-up size.

## Test

```shell
pytest -m "not slow" tests/ -q --tb=short
2108 passed, 15 skipped, 53 deselected, 16 warnings
```