### PR TITLE
[Compat] Load official Qwen3-Embedding checkpoints (#730)

### DIFF
--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -921,9 +921,27 @@ class TestQwen3FlatWeightPrefixTransform:
 
         assert out == weights
 
-    def test_untied_headless_checkpoint_drops_lm_head_module(self) -> None:
+    def test_untied_headless_checkpoint_drops_lm_head_module_in_pooling_scope(
+        self,
+    ) -> None:
         # The official 8B embedding checkpoint ships tie_word_embeddings=false
-        # but no lm_head tensor at all; strict load must not demand one.
+        # but no lm_head tensor at all; a pooling load must not demand one.
+        fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)
+        assert fake_self.lm_head is not None
+
+        with compat.pooling_load_scope():
+            out = compat._qwen3_flat_weight_prefix(
+                fake_self, _flat_official_qwen3_weights()
+            )
+
+        assert "model.norm.weight" in out
+        assert not hasattr(fake_self, "lm_head")
+
+    def test_untied_headless_checkpoint_keeps_lm_head_module_outside_pooling(
+        self,
+    ) -> None:
+        # Generation and classify need the head. Outside the pooling scope the
+        # module stays, so strict load fails with the missing-tensor error.
         fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)
         assert fake_self.lm_head is not None
 
@@ -932,7 +950,7 @@ class TestQwen3FlatWeightPrefixTransform:
         )
 
         assert "model.norm.weight" in out
-        assert not hasattr(fake_self, "lm_head")
+        assert fake_self.lm_head is not None
 
     def test_headful_checkpoint_keeps_lm_head_module(self) -> None:
         fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -810,35 +810,44 @@ class TestInstallMetalOverride:
                 delattr(RayWorkerProc, "_metal_patched")
 
 
-def _install_fake_qwen3_module(monkeypatch):
-    mlx_lm_pkg = ModuleType("mlx_lm")
-    mlx_lm_models = ModuleType("mlx_lm.models")
-    mlx_lm_pkg.models = mlx_lm_models
-    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm_pkg)
-    monkeypatch.setitem(sys.modules, "mlx_lm.models", mlx_lm_models)
+def _unwrap_qwen3_sanitize(model_cls) -> bool:
+    """Restore upstream sanitize if this session already wrapped it."""
+    original = getattr(model_cls.sanitize, "_vllm_metal_original_sanitize", None)
+    if original is None:
+        return False
+    model_cls.sanitize = original
+    return True
 
-    qwen3_module = ModuleType("mlx_lm.models.qwen3")
 
-    class Model:
-        def __init__(self, tie_word_embeddings: bool = False) -> None:
-            self.args = SimpleNamespace(tie_word_embeddings=tie_word_embeddings)
+def _tiny_qwen3_args(tie_word_embeddings: bool):
+    from mlx_lm.models.qwen3 import ModelArgs
 
-        def sanitize(self, weights):
-            if self.args.tie_word_embeddings:
-                weights.pop("lm_head.weight", None)
-            return weights
+    return ModelArgs(
+        model_type="qwen3",
+        hidden_size=16,
+        num_hidden_layers=1,
+        intermediate_size=32,
+        num_attention_heads=2,
+        rms_norm_eps=1e-6,
+        vocab_size=32,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        rope_theta=10000.0,
+        head_dim=8,
+        tie_word_embeddings=tie_word_embeddings,
+    )
 
-    qwen3_module.Model = Model
-    monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3", qwen3_module)
-    mlx_lm_models.qwen3 = qwen3_module
 
-    def _fake_find_spec(name: str):
-        if name == "mlx_lm.models.qwen3":
-            return object()
-        return None
+def _official_flat_weights(model) -> dict[str, object]:
+    """Backbone tensors in the official flat layout: no ``model.`` prefix."""
+    from mlx.nn.utils import tree_flatten
 
-    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
-    return qwen3_module
+    flat = dict(tree_flatten(model.parameters()))
+    return {
+        key.removeprefix("model."): value
+        for key, value in flat.items()
+        if key.startswith("model.")
+    }
 
 
 def _flat_official_qwen3_weights() -> dict[str, object]:
@@ -974,37 +983,88 @@ class TestQwen3FlatWeightPrefixTransform:
         assert not hasattr(fake_self, "lm_head")
 
 
-class TestQwen3FlatPrefixCompatPatch:
-    def test_wraps_sanitize_and_remaps_flat_checkpoints(self, monkeypatch) -> None:
-        qwen3_module = _install_fake_qwen3_module(monkeypatch)
+class TestQwen3FlatPrefixRealStrictLoad:
+    """Prove the #730 failure path on the real mlx_lm qwen3.Model.
 
-        compat._patch_mlx_lm_qwen3_flat_weight_prefix()
-        # A second registration must not stack a second remap.
-        compat._patch_mlx_lm_qwen3_flat_weight_prefix()
+    ``mlx_lm.load`` calls ``model.sanitize(weights)`` and then
+    ``model.load_weights(..., strict=True)``, so the tests below exercise the
+    same sequence with the real class instead of a local stand-in.
+    """
 
-        model = qwen3_module.Model(tie_word_embeddings=True)
-        sanitized = model.sanitize(
-            {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
-        )
+    @pytest.fixture()
+    def real_qwen3_cls(self):
+        pytest.importorskip("mlx.core")
+        qwen3 = pytest.importorskip("mlx_lm.models.qwen3")
+        pre_test_sanitize = qwen3.Model.__dict__.get("sanitize")
+        yield qwen3.Model
+        if pre_test_sanitize is None:
+            delattr(qwen3.Model, "sanitize")
+        else:
+            qwen3.Model.sanitize = pre_test_sanitize
 
-        assert "model.embed_tokens.weight" in sanitized
-        assert "model.norm.weight" in sanitized
-        assert "embed_tokens.weight" not in sanitized
-        # The tied lm_head is dropped by upstream sanitize, not by the remap.
-        assert "lm_head.weight" not in sanitized
+    @staticmethod
+    def _load_like_mlx_lm(model, flat) -> None:
+        """Mirror ``mlx_lm.load``: sanitize first, then strict load."""
+        weights = model.sanitize(dict(flat))
+        model.load_weights(list(weights.items()), strict=True)
 
-    def test_untied_checkpoint_keeps_top_level_lm_head_after_sanitize(
-        self, monkeypatch
+    def test_flat_tied_checkpoint_strict_loads_after_patch(
+        self, real_qwen3_cls
     ) -> None:
-        qwen3_module = _install_fake_qwen3_module(monkeypatch)
+        import mlx.core as mx
 
-        compat._patch_mlx_lm_qwen3_flat_weight_prefix()
+        model_cls = real_qwen3_cls
+        _unwrap_qwen3_sanitize(model_cls)
+        try:
+            # The #730 failure: official flat keys, upstream sanitize, strict load.
+            flat = _official_flat_weights(
+                model_cls(_tiny_qwen3_args(tie_word_embeddings=True))
+            )
+            flat["norm.weight"] = mx.full((16,), 7.0)
+            with pytest.raises(ValueError, match="embed_tokens.weight"):
+                self._load_like_mlx_lm(
+                    model_cls(_tiny_qwen3_args(tie_word_embeddings=True)), flat
+                )
 
-        model = qwen3_module.Model(tie_word_embeddings=False)
-        sanitized = model.sanitize(
-            {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
-        )
+            assert compat._patch_mlx_lm_qwen3_flat_weight_prefix() is True
+            # A second install must not stack a second remap.
+            assert compat._patch_mlx_lm_qwen3_flat_weight_prefix() is False
 
-        assert sanitized["lm_head.weight"] == "W-head"
-        assert "model.lm_head.weight" not in sanitized
-        assert "model.layers.0.self_attn.q_proj.weight" in sanitized
+            loaded = model_cls(_tiny_qwen3_args(tie_word_embeddings=True))
+            self._load_like_mlx_lm(loaded, flat)
+            assert float(loaded.model.norm.weight[0]) == 7.0
+        finally:
+            _unwrap_qwen3_sanitize(model_cls)
+
+    def test_headless_untied_checkpoint_loads_only_under_pooling_scope(
+        self, real_qwen3_cls
+    ) -> None:
+        model_cls = real_qwen3_cls
+        _unwrap_qwen3_sanitize(model_cls)
+        try:
+            # The official 8B shape: untied config, but no lm_head tensor.
+            flat = _official_flat_weights(
+                model_cls(_tiny_qwen3_args(tie_word_embeddings=False))
+            )
+            assert "lm_head.weight" not in flat
+            with pytest.raises(ValueError, match="embed_tokens.weight"):
+                self._load_like_mlx_lm(
+                    model_cls(_tiny_qwen3_args(tie_word_embeddings=False)), flat
+                )
+
+            assert compat._patch_mlx_lm_qwen3_flat_weight_prefix() is True
+
+            # Generation keeps the module: strict load fails with the honest
+            # missing-tensor error instead of a failure at first logits.
+            generation = model_cls(_tiny_qwen3_args(tie_word_embeddings=False))
+            with pytest.raises(ValueError, match="Missing 1 parameters"):
+                self._load_like_mlx_lm(generation, flat)
+            assert generation.lm_head is not None
+
+            # Pooling never calls logits: the module is dropped, load passes.
+            with compat.pooling_load_scope():
+                pooling = model_cls(_tiny_qwen3_args(tie_word_embeddings=False))
+                self._load_like_mlx_lm(pooling, flat)
+            assert not hasattr(pooling, "lm_head")
+        finally:
+            _unwrap_qwen3_sanitize(model_cls)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -8,7 +8,7 @@ import importlib.util
 import json
 import os
 import sys
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
@@ -270,10 +270,15 @@ class TestGemma4MTPConfigCompatPatch:
             "_patch_mlx_lm_qwen35_fp8_sanitize",
             lambda: calls.append("qwen35_fp8"),
         )
+        monkeypatch.setattr(
+            compat,
+            "_patch_mlx_lm_qwen3_flat_weight_prefix",
+            lambda: calls.append("qwen3_flat_prefix"),
+        )
 
         compat.apply_compat_patches()
 
-        assert calls == ["bytelevel", "qwen35_fp8"]
+        assert calls == ["bytelevel", "qwen35_fp8", "qwen3_flat_prefix"]
 
 
 def _install_fake_qwen35_modules(monkeypatch, *, include_moe: bool):
@@ -803,3 +808,185 @@ class TestInstallMetalOverride:
                 delattr(RayWorkerProc, "get_node_and_physical_gpu_ids")
             if not had_sentinel and "_metal_patched" in RayWorkerProc.__dict__:
                 delattr(RayWorkerProc, "_metal_patched")
+
+
+def _install_fake_qwen3_module(monkeypatch):
+    mlx_lm_pkg = ModuleType("mlx_lm")
+    mlx_lm_models = ModuleType("mlx_lm.models")
+    mlx_lm_pkg.models = mlx_lm_models
+    monkeypatch.setitem(sys.modules, "mlx_lm", mlx_lm_pkg)
+    monkeypatch.setitem(sys.modules, "mlx_lm.models", mlx_lm_models)
+
+    qwen3_module = ModuleType("mlx_lm.models.qwen3")
+
+    class Model:
+        def __init__(self, tie_word_embeddings: bool = False) -> None:
+            self.args = SimpleNamespace(tie_word_embeddings=tie_word_embeddings)
+
+        def sanitize(self, weights):
+            if self.args.tie_word_embeddings:
+                weights.pop("lm_head.weight", None)
+            return weights
+
+    qwen3_module.Model = Model
+    monkeypatch.setitem(sys.modules, "mlx_lm.models.qwen3", qwen3_module)
+    mlx_lm_models.qwen3 = qwen3_module
+
+    def _fake_find_spec(name: str):
+        if name == "mlx_lm.models.qwen3":
+            return object()
+        return None
+
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+    return qwen3_module
+
+
+def _flat_official_qwen3_weights() -> dict[str, object]:
+    """Backbone keys exactly as the official Qwen3-Embedding repo stores them."""
+    return {
+        "embed_tokens.weight": "W-embed",
+        "layers.0.input_layernorm.weight": "W-ln",
+        "layers.0.self_attn.q_proj.weight": "W-q",
+        "norm.weight": "W-norm",
+    }
+
+
+def _qwen3_self(tie_word_embeddings: bool):
+    return SimpleNamespace(
+        args=SimpleNamespace(tie_word_embeddings=tie_word_embeddings)
+    )
+
+
+class _HeadfulQwen3Self:
+    """Duck-typed mlx_lm Qwen3 model: owns an lm_head module when untied."""
+
+    def __init__(self, tie_word_embeddings: bool) -> None:
+        self.args = SimpleNamespace(tie_word_embeddings=tie_word_embeddings)
+        if not tie_word_embeddings:
+            self.lm_head = SimpleNamespace(weight="W-head-module")
+
+
+class TestQwen3FlatWeightPrefixTransform:
+    """Unit tests for the remap applied before mlx_lm's Qwen3 sanitize."""
+
+    def test_flat_backbone_keys_get_model_prefix(self) -> None:
+        out = compat._qwen3_flat_weight_prefix(
+            _qwen3_self(tie_word_embeddings=True), _flat_official_qwen3_weights()
+        )
+
+        assert set(out) == {
+            "model.embed_tokens.weight",
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.0.self_attn.q_proj.weight",
+            "model.norm.weight",
+        }
+        assert out["model.embed_tokens.weight"] == "W-embed"
+
+    def test_untied_lm_head_stays_at_top_level(self) -> None:
+        # The 8B checkpoint ships tie_word_embeddings=false; mlx_lm's Model
+        # expects a top-level lm_head.weight there, not model.lm_head.weight.
+        weights = {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
+
+        out = compat._qwen3_flat_weight_prefix(
+            _qwen3_self(tie_word_embeddings=False), weights
+        )
+
+        assert out["lm_head.weight"] == "W-head"
+        assert "model.lm_head.weight" not in out
+
+    def test_tied_lm_head_stays_flat_for_upstream_to_drop(self) -> None:
+        weights = {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
+
+        out = compat._qwen3_flat_weight_prefix(
+            _qwen3_self(tie_word_embeddings=True), weights
+        )
+
+        assert out["lm_head.weight"] == "W-head"
+
+    def test_already_prefixed_checkpoint_passes_through(self) -> None:
+        weights = {"model.embed_tokens.weight": "W-embed", "lm_head.weight": "W-head"}
+
+        out = compat._qwen3_flat_weight_prefix(
+            _qwen3_self(tie_word_embeddings=True), weights
+        )
+
+        assert out == weights
+
+    def test_unrelated_flat_layout_passes_through(self) -> None:
+        weights = {"decoder.layers.0.weight": "W", "embed.tbl.weight": "W"}
+
+        out = compat._qwen3_flat_weight_prefix(
+            _qwen3_self(tie_word_embeddings=False), weights
+        )
+
+        assert out == weights
+
+    def test_untied_headless_checkpoint_drops_lm_head_module(self) -> None:
+        # The official 8B embedding checkpoint ships tie_word_embeddings=false
+        # but no lm_head tensor at all; strict load must not demand one.
+        fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)
+        assert fake_self.lm_head is not None
+
+        out = compat._qwen3_flat_weight_prefix(
+            fake_self, _flat_official_qwen3_weights()
+        )
+
+        assert "model.norm.weight" in out
+        assert not hasattr(fake_self, "lm_head")
+
+    def test_headful_checkpoint_keeps_lm_head_module(self) -> None:
+        fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)
+        weights = {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
+
+        out = compat._qwen3_flat_weight_prefix(fake_self, weights)
+
+        assert out["lm_head.weight"] == "W-head"
+        assert fake_self.lm_head is not None
+
+    def test_tied_headless_checkpoint_keeps_lm_head_module(self) -> None:
+        # Tied models never construct the module; upstream sanitize owns the
+        # flat key, and the transform has nothing to drop.
+        fake_self = _HeadfulQwen3Self(tie_word_embeddings=True)
+
+        out = compat._qwen3_flat_weight_prefix(
+            fake_self, _flat_official_qwen3_weights()
+        )
+
+        assert "model.norm.weight" in out
+        assert not hasattr(fake_self, "lm_head")
+
+
+class TestQwen3FlatPrefixCompatPatch:
+    def test_wraps_sanitize_and_remaps_flat_checkpoints(self, monkeypatch) -> None:
+        qwen3_module = _install_fake_qwen3_module(monkeypatch)
+
+        compat._patch_mlx_lm_qwen3_flat_weight_prefix()
+        # A second registration must not stack a second remap.
+        compat._patch_mlx_lm_qwen3_flat_weight_prefix()
+
+        model = qwen3_module.Model(tie_word_embeddings=True)
+        sanitized = model.sanitize(
+            {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
+        )
+
+        assert "model.embed_tokens.weight" in sanitized
+        assert "model.norm.weight" in sanitized
+        assert "embed_tokens.weight" not in sanitized
+        # The tied lm_head is dropped by upstream sanitize, not by the remap.
+        assert "lm_head.weight" not in sanitized
+
+    def test_untied_checkpoint_keeps_top_level_lm_head_after_sanitize(
+        self, monkeypatch
+    ) -> None:
+        qwen3_module = _install_fake_qwen3_module(monkeypatch)
+
+        compat._patch_mlx_lm_qwen3_flat_weight_prefix()
+
+        model = qwen3_module.Model(tie_word_embeddings=False)
+        sanitized = model.sanitize(
+            {**_flat_official_qwen3_weights(), "lm_head.weight": "W-head"}
+        )
+
+        assert sanitized["lm_head.weight"] == "W-head"
+        assert "model.lm_head.weight" not in sanitized
+        assert "model.layers.0.self_attn.q_proj.weight" in sanitized

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -938,7 +938,7 @@ class TestQwen3FlatWeightPrefixTransform:
         fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)
         assert fake_self.lm_head is not None
 
-        with compat.pooling_load_scope():
+        with compat.embedding_load_scope():
             out = compat._qwen3_flat_weight_prefix(
                 fake_self, _flat_official_qwen3_weights()
             )
@@ -949,8 +949,8 @@ class TestQwen3FlatWeightPrefixTransform:
     def test_untied_headless_checkpoint_keeps_lm_head_module_outside_pooling(
         self,
     ) -> None:
-        # Generation and classify need the head. Outside the pooling scope the
-        # module stays, so strict load fails with the missing-tensor error.
+        # Generation and classify need the head. Outside the embedding scope
+        # the module stays, so strict load fails with the missing-tensor error.
         fake_self = _HeadfulQwen3Self(tie_word_embeddings=False)
         assert fake_self.lm_head is not None
 
@@ -1061,8 +1061,9 @@ class TestQwen3FlatPrefixRealStrictLoad:
                 self._load_like_mlx_lm(generation, flat)
             assert generation.lm_head is not None
 
-            # Pooling never calls logits: the module is dropped, load passes.
-            with compat.pooling_load_scope():
+            # Embedding pooling never calls logits: the module is dropped, the
+            # strict load passes.
+            with compat.embedding_load_scope():
                 pooling = model_cls(_tiny_qwen3_args(tie_word_embeddings=False))
                 self._load_like_mlx_lm(pooling, flat)
             assert not hasattr(pooling, "lm_head")

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -35,6 +35,7 @@ from vllm_metal.v1.pooling.backends.decoder.models.qwen3 import (  # noqa: E402
 from vllm_metal.v1.pooling.backends.decoder.runtime import (  # noqa: E402
     DecoderModelView,
     MetalDecoderPoolingBackend,
+    is_embed_pooling_architecture,
 )
 from vllm_metal.v1.pooling.backends.encoder.factory import (  # noqa: E402
     load_encoder_pooling_backend,
@@ -419,6 +420,21 @@ def _execute_pooling(runner, sched):
     out = runner.execute_model(sched)
     assert out is not None
     return out
+
+
+class TestEmbedPoolingArchitecture:
+    def test_accepts_embedding_architectures(self) -> None:
+        assert is_embed_pooling_architecture(["Qwen3ForCausalLM"]) is True
+        assert is_embed_pooling_architecture(["Qwen3EmbeddingModel"]) is True
+
+    def test_rejects_pooling_classify_architectures(self) -> None:
+        # Qwen3 reranker classify reads lm_head; it is not an embedding arch.
+        assert (
+            is_embed_pooling_architecture(["Qwen3ForSequenceClassification"]) is False
+        )
+
+    def test_rejects_empty_architectures(self) -> None:
+        assert is_embed_pooling_architecture([]) is False
 
 
 class TestMetalPoolingCapabilities:

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 _APPLIED = False
 _QWEN35_FP8_BLOCK_SIZE = 128
+_QWEN3_BACKBONE_ROOTS = frozenset({"embed_tokens", "layers", "norm", "lm_head"})
 _EXAONE4_LAYER_TYPE = {"L": "sliding_attention", "G": "full_attention"}
 
 
@@ -32,6 +33,7 @@ def apply_compat_patches() -> None:
     _apply_bytelevel_patch_during_registration()
     ensure_vllm_auto_fit_null_block_patch()
     _patch_mlx_lm_qwen35_fp8_sanitize()
+    _patch_mlx_lm_qwen3_flat_weight_prefix()
     _patch_transformers_exaone4_config()
 
 
@@ -913,3 +915,78 @@ def _wrap_model_sanitize(
     setattr(_patched_sanitize, sentinel_attr, True)
     model_cls.sanitize = _patched_sanitize
     return True
+
+
+def _qwen3_flat_weight_prefix(
+    model: Any, weights: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    """Re-key flat official Qwen3 checkpoints to mlx_lm's ``model.*`` layout.
+
+    Official Qwen3-Embedding checkpoints (0.6B/4B/8B) store backbone tensors
+    without the ``model.`` prefix that mlx_lm's wrapper ``Model`` expects, so
+    ``load_weights(strict=True)`` rejects every tensor. Only remap when every
+    top-level key is a Qwen3 backbone root; anything already in the
+    ``model.*`` layout (every mlx-community repo) passes through untouched.
+
+    ``lm_head.weight`` keeps its top-level name: upstream ``sanitize`` drops it
+    for tied embeddings, and untied checkpoints own it there. When an untied
+    checkpoint ships no head tensor at all (the official 8B embedding), drop
+    the module mlx_lm constructed: embed pooling reads body hidden states and
+    never this module, and mlx ``nn.Module.__delattr__`` removes it from
+    ``parameters()``, so strict load stops demanding a tensor Qwen never
+    wrote.
+    """
+    keys = [str(key) for key in weights]
+    if any(key.startswith("model.") for key in keys):
+        return weights
+    roots = {key.split(".", 1)[0] for key in keys}
+    if not roots or not roots <= _QWEN3_BACKBONE_ROOTS:
+        return weights
+    if (
+        "lm_head.weight" not in weights
+        and not model.args.tie_word_embeddings
+        and getattr(model, "lm_head", None) is not None
+    ):
+        delattr(model, "lm_head")
+    return {
+        key if key.startswith("lm_head.") else f"model.{key}": value
+        for key, value in weights.items()
+    }
+
+
+def _patch_mlx_lm_qwen3_flat_weight_prefix() -> None:
+    """Teach mlx_lm's Qwen3 loader to accept flat official Qwen3 checkpoints.
+
+    Qwen ships the Qwen3-Embedding checkpoints (0.6B/4B/8B) with backbone keys
+    such as ``layers.0....`` while mlx_lm's ``qwen3`` wrapper expects
+    ``model.layers.0....``; upstream ``sanitize`` never remaps, so
+    ``load_weights(strict=True)`` rejects all tensors. Mirrors the Qwen3.5 FP8
+    patch: narrow to the affected model module, upstream control flow intact.
+    """
+    from importlib import import_module
+    from importlib.util import find_spec
+
+    if find_spec("mlx_lm.models.qwen3") is None:
+        return
+    try:
+        qwen3 = import_module("mlx_lm.models.qwen3")
+    except ImportError as exc:
+        logger.warning(
+            "Could not import mlx_lm.models.qwen3 while installing the flat "
+            "Qwen3 weight prefix compatibility patch: %s",
+            exc,
+        )
+        return
+    model_cls = getattr(qwen3, "Model", None)
+    if model_cls is None:
+        logger.warning(
+            "Could not install the flat Qwen3 weight prefix compatibility "
+            "patch: mlx_lm.models.qwen3 has no Model class."
+        )
+        return
+    if _wrap_model_sanitize(
+        model_cls,
+        "_vllm_metal_qwen3_flat_prefix_patch",
+        _qwen3_flat_weight_prefix,
+    ):
+        logger.debug("Patched mlx_lm Qwen3 flat weight prefix compatibility")

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -12,6 +12,7 @@ import json
 import logging
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
+from contextvars import ContextVar
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -19,7 +20,9 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
-_POOLING_LOAD_SCOPE = False
+_EMBEDDING_LOAD_SCOPE: ContextVar[bool] = ContextVar(
+    "vllm_metal_embedding_load_scope", default=False
+)
 _QWEN35_FP8_BLOCK_SIZE = 128
 _QWEN3_BACKBONE_ROOTS = frozenset({"embed_tokens", "layers", "norm", "lm_head"})
 _EXAONE4_LAYER_TYPE = {"L": "sliding_attention", "G": "full_attention"}
@@ -921,24 +924,23 @@ def _wrap_model_sanitize(
 
 
 @contextmanager
-def pooling_load_scope(*, enabled: bool = True) -> Iterator[None]:
-    """Mark the wrapped model load as a pooling load for compat shims.
+def embedding_load_scope(*, enabled: bool = True) -> Iterator[None]:
+    """Mark the wrapped model load as embedding-only for compat shims.
 
     The Qwen3 flat-prefix shim below drops mlx_lm's ``lm_head`` module only
-    inside this scope. Pooling reads body hidden states and never calls
-    logits. Generation and classify need the head, so outside this scope the
-    module stays and strict load fails with the honest missing-tensor error.
+    inside this scope. Embedding pooling reads body hidden states and never
+    calls logits. Classify rerankers read ``lm_head`` logits and generation
+    needs the head tensor, so outside this scope the module stays and strict
+    load fails with the honest missing-tensor error.
     """
-    global _POOLING_LOAD_SCOPE  # noqa: PLW0603
     if not enabled:
         yield
         return
-    previous = _POOLING_LOAD_SCOPE
-    _POOLING_LOAD_SCOPE = True
+    token = _EMBEDDING_LOAD_SCOPE.set(True)
     try:
         yield
     finally:
-        _POOLING_LOAD_SCOPE = previous
+        _EMBEDDING_LOAD_SCOPE.reset(token)
 
 
 def _qwen3_flat_weight_prefix(
@@ -955,7 +957,7 @@ def _qwen3_flat_weight_prefix(
     ``lm_head.weight`` keeps its top-level name: upstream ``sanitize`` drops it
     for tied embeddings, and untied checkpoints own it there. When an untied
     checkpoint ships no head tensor at all (the official 8B embedding) and the
-    load runs inside ``pooling_load_scope()``, drop the module mlx_lm
+    load runs inside ``embedding_load_scope()``, drop the module mlx_lm
     constructed: embed pooling reads body hidden states and never this
     module, and mlx ``nn.Module.__delattr__`` removes it from
     ``parameters()``, so strict load stops demanding a tensor Qwen never
@@ -971,7 +973,7 @@ def _qwen3_flat_weight_prefix(
         "lm_head.weight" not in weights
         and not model.args.tie_word_embeddings
         and getattr(model, "lm_head", None) is not None
-        and _POOLING_LOAD_SCOPE
+        and _EMBEDDING_LOAD_SCOPE.get()
     ):
         delattr(model, "lm_head")
     return {

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -915,6 +915,7 @@ def _wrap_model_sanitize(
         return original_sanitize(self, transform(self, weights))
 
     setattr(_patched_sanitize, sentinel_attr, True)
+    _patched_sanitize._vllm_metal_original_sanitize = original_sanitize
     model_cls.sanitize = _patched_sanitize
     return True
 
@@ -979,7 +980,7 @@ def _qwen3_flat_weight_prefix(
     }
 
 
-def _patch_mlx_lm_qwen3_flat_weight_prefix() -> None:
+def _patch_mlx_lm_qwen3_flat_weight_prefix() -> bool:
     """Teach mlx_lm's Qwen3 loader to accept flat official Qwen3 checkpoints.
 
     Qwen ships the Qwen3-Embedding checkpoints (0.6B/4B/8B) with backbone keys
@@ -999,7 +1000,7 @@ def _patch_mlx_lm_qwen3_flat_weight_prefix() -> None:
     from importlib.util import find_spec
 
     if find_spec("mlx_lm.models.qwen3") is None:
-        return
+        return False
     try:
         qwen3 = import_module("mlx_lm.models.qwen3")
     except ImportError as exc:
@@ -1008,17 +1009,19 @@ def _patch_mlx_lm_qwen3_flat_weight_prefix() -> None:
             "Qwen3 weight prefix compatibility patch: %s",
             exc,
         )
-        return
+        return False
     model_cls = getattr(qwen3, "Model", None)
     if model_cls is None:
         logger.warning(
             "Could not install the flat Qwen3 weight prefix compatibility "
             "patch: mlx_lm.models.qwen3 has no Model class."
         )
-        return
-    if _wrap_model_sanitize(
+        return False
+    patched = _wrap_model_sanitize(
         model_cls,
         "_vllm_metal_qwen3_flat_prefix_patch",
         _qwen3_flat_weight_prefix,
-    ):
+    )
+    if patched:
         logger.debug("Patched mlx_lm Qwen3 flat weight prefix compatibility")
+    return patched

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
+_POOLING_LOAD_SCOPE = False
 _QWEN35_FP8_BLOCK_SIZE = 128
 _QWEN3_BACKBONE_ROOTS = frozenset({"embed_tokens", "layers", "norm", "lm_head"})
 _EXAONE4_LAYER_TYPE = {"L": "sliding_attention", "G": "full_attention"}
@@ -917,6 +919,27 @@ def _wrap_model_sanitize(
     return True
 
 
+@contextmanager
+def pooling_load_scope(*, enabled: bool = True) -> Iterator[None]:
+    """Mark the wrapped model load as a pooling load for compat shims.
+
+    The Qwen3 flat-prefix shim below drops mlx_lm's ``lm_head`` module only
+    inside this scope. Pooling reads body hidden states and never calls
+    logits. Generation and classify need the head, so outside this scope the
+    module stays and strict load fails with the honest missing-tensor error.
+    """
+    global _POOLING_LOAD_SCOPE  # noqa: PLW0603
+    if not enabled:
+        yield
+        return
+    previous = _POOLING_LOAD_SCOPE
+    _POOLING_LOAD_SCOPE = True
+    try:
+        yield
+    finally:
+        _POOLING_LOAD_SCOPE = previous
+
+
 def _qwen3_flat_weight_prefix(
     model: Any, weights: Mapping[str, Any]
 ) -> Mapping[str, Any]:
@@ -930,9 +953,10 @@ def _qwen3_flat_weight_prefix(
 
     ``lm_head.weight`` keeps its top-level name: upstream ``sanitize`` drops it
     for tied embeddings, and untied checkpoints own it there. When an untied
-    checkpoint ships no head tensor at all (the official 8B embedding), drop
-    the module mlx_lm constructed: embed pooling reads body hidden states and
-    never this module, and mlx ``nn.Module.__delattr__`` removes it from
+    checkpoint ships no head tensor at all (the official 8B embedding) and the
+    load runs inside ``pooling_load_scope()``, drop the module mlx_lm
+    constructed: embed pooling reads body hidden states and never this
+    module, and mlx ``nn.Module.__delattr__`` removes it from
     ``parameters()``, so strict load stops demanding a tensor Qwen never
     wrote.
     """
@@ -946,6 +970,7 @@ def _qwen3_flat_weight_prefix(
         "lm_head.weight" not in weights
         and not model.args.tie_word_embeddings
         and getattr(model, "lm_head", None) is not None
+        and _POOLING_LOAD_SCOPE
     ):
         delattr(model, "lm_head")
     return {

--- a/vllm_metal/compat.py
+++ b/vllm_metal/compat.py
@@ -987,6 +987,13 @@ def _patch_mlx_lm_qwen3_flat_weight_prefix() -> None:
     ``model.layers.0....``; upstream ``sanitize`` never remaps, so
     ``load_weights(strict=True)`` rejects all tensors. Mirrors the Qwen3.5 FP8
     patch: narrow to the affected model module, upstream control flow intact.
+
+    This is an upstream key-layout shim, not permanent vllm-metal behavior.
+
+    TODO: remove when the pinned mlx_lm remaps flat official
+    checkpoints in ``mlx_lm.models.qwen3.Model.sanitize``. No upstream
+    mlx-lm issue or PR tracks this layout as of 0.32.0; vllm-metal
+    issue #730 carries the report.
     """
     from importlib import import_module
     from importlib.util import find_spec

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -15,7 +15,7 @@ from vllm.logger import init_logger
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
-from vllm_metal.compat import apply_compat_patches, pooling_load_scope
+from vllm_metal.compat import apply_compat_patches, embedding_load_scope
 from vllm_metal.compiled_mlp import CompiledMLPBlocks
 from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
@@ -29,6 +29,9 @@ from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_adapter import ModelAdapter
 from vllm_metal.v1.pooling.backends.decoder.factory import (
     build_decoder_pooling_backend,
+)
+from vllm_metal.v1.pooling.backends.decoder.runtime import (
+    is_embed_pooling_architecture,
 )
 from vllm_metal.v1.pooling.backends.encoder.factory import (
     load_encoder_pooling_backend,
@@ -153,10 +156,16 @@ class ModelLifecycle:
             return
 
         request = GenerationLoadRequest.from_runner(self._runner, self._model_adapter)
-        # Pooling-only compat shims (the Qwen3 headless lm_head drop) must stay
-        # off for generation loads: strict load has to fail there, not the
-        # first forward pass.
-        with pooling_load_scope(enabled=self._runner._is_pooling):
+        # The headless lm_head shim is embedding-only: embedding pooling never
+        # calls logits. Pooling classify (Qwen3 reranker) reads lm_head, and
+        # generation loads must fail strict load on a headless checkpoint
+        # instead of the first forward pass.
+        with embedding_load_scope(
+            enabled=self._runner._is_pooling
+            and is_embed_pooling_architecture(
+                getattr(request.hf_config, "architectures", None) or ()
+            )
+        ):
             loaded_model = self._load_generation(request)
 
         self._install_generation_model(loaded_model, request)

--- a/vllm_metal/v1/model_lifecycle.py
+++ b/vllm_metal/v1/model_lifecycle.py
@@ -15,7 +15,7 @@ from vllm.logger import init_logger
 
 from vllm_metal.attention.impls.mla import MLA_DEFAULT_QK_ROPE_HEAD_DIM
 from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
-from vllm_metal.compat import apply_compat_patches
+from vllm_metal.compat import apply_compat_patches, pooling_load_scope
 from vllm_metal.compiled_mlp import CompiledMLPBlocks
 from vllm_metal.gguf.source import GGUFLoadSource
 from vllm_metal.pytorch_backend.tensor_bridge import torch_to_mlx
@@ -153,7 +153,11 @@ class ModelLifecycle:
             return
 
         request = GenerationLoadRequest.from_runner(self._runner, self._model_adapter)
-        loaded_model = self._load_generation(request)
+        # Pooling-only compat shims (the Qwen3 headless lm_head drop) must stay
+        # off for generation loads: strict load has to fail there, not the
+        # first forward pass.
+        with pooling_load_scope(enabled=self._runner._is_pooling):
+            loaded_model = self._load_generation(request)
 
         self._install_generation_model(loaded_model, request)
 

--- a/vllm_metal/v1/pooling/backends/decoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/decoder/runtime.py
@@ -53,6 +53,22 @@ class DecoderModelView:
         return body if callable(body) else None
 
 
+EMBED_POOLING_ARCH_SUFFIXES = ("ForCausalLM", "ForTextEncoding", "EmbeddingModel")
+
+
+def is_embed_pooling_architecture(architectures: Any) -> bool:
+    """True when the architecture list reads as a decoder embedding model.
+
+    Shared between the LAST-token pooler support check and the load-time
+    embedding-only compat scope, so both apply the same rule: pooling
+    classify archs (for example Qwen3 rerankers) never count as embedding.
+    """
+    return any(
+        str(architecture).endswith(EMBED_POOLING_ARCH_SUFFIXES)
+        for architecture in architectures
+    )
+
+
 class LastTokenEmbeddingPooler:
     """Pool decoder hidden states into normalized LAST-token embeddings."""
 
@@ -109,12 +125,7 @@ class LastTokenEmbeddingPooler:
         return mx.contiguous(vector / norm)
 
     def _is_decoder_embedding(self) -> bool:
-        return any(
-            architecture.endswith("ForCausalLM")
-            or architecture.endswith("ForTextEncoding")
-            or architecture.endswith("EmbeddingModel")
-            for architecture in self.config.architectures
-        )
+        return is_embed_pooling_architecture(self.config.architectures)
 
 
 class MetalDecoderPoolingBackend:


### PR DESCRIPTION
Fixes #730

## Summary

Official Qwen3-Embedding checkpoints (0.6B, 4B, 8B) fail to load on
vllm-metal with `ValueError: Received 310 parameters not in model`. The
root cause is two stacked defects at the `vllm_metal` ↔ `mlx_lm` boundary;
this PR fixes both with one narrow compat patch in `vllm_metal/compat.py`.

## Root cause

1. **Flat backbone keys.** Qwen ships these checkpoints with keys like
   `embed_tokens.weight`, `layers.0....`, `norm.weight`, but mlx_lm's
   `qwen3.Model` wraps the backbone as `self.model = Qwen3Model(args)` and
   expects `model.`-prefixed keys. Upstream `sanitize()` only drops a tied
   `lm_head.weight` — it never remaps — so strict load rejects every
   backbone tensor.
2. **Headless but untied (8B only).** `Qwen/Qwen3-Embedding-8B` sets
   `tie_word_embeddings: false` yet ships **no** `lm_head.weight` at all
   (398 keys, roots `{embed_tokens, layers, norm}`). mlx_lm constructs the
   head when untied, so even with correct prefixes, strict load fails with
   `Missing 1 parameters: lm_head.weight`. Neither the issue's proposed
   patch nor plain mlx_lm handles this.

## Fix

`_patch_mlx_lm_qwen3_flat_weight_prefix()` wraps `mlx_lm.models.qwen3`
`Model.sanitize` via the existing `_wrap_model_sanitize()` helper (same
pattern as the Qwen3.5 FP8 patch), with a transform that:

- passes through unchanged when **any** key already starts with `model.`
  (every mlx-community repo), or when top-level keys are not all Qwen3
  backbone roots;
- otherwise adds the `model.` prefix to backbone keys;
- keeps `lm_head.weight` top-level — upstream `sanitize` drops it when
  tied, untied checkpoints own it there;
- when an untied flat checkpoint ships no head tensor, deletes the
  `mlx.nn` module mlx_lm just constructed (`__delattr__` removes it from
  `parameters()`), so strict load stops demanding a tensor Qwen never
  wrote. Embed pooling reads body hidden states via `forward_packed` and
  never touches `lm_head`; reranker checkpoints always ship the head
  (their classify path needs it), so that path is unaffected.

The wrapper is idempotent via the shared sanitize-wrap sentinel.

## Testing

All runs on M5 / 32 GB, vLLM 0.28 pooling runner, `max_model_len=600`:

- Pre-fix: `Qwen/Qwen3-Embedding-0.6B` fails with the issue's exact error.
- Post-fix, real checkpoints load and embed (L2-normalized):

  | Checkpoint | Embedding dim | Result |
  |---|---|---|
  | `Qwen/Qwen3-Embedding-0.6B` | 1024 | pass |
  | `Qwen/Qwen3-Embedding-4B` | 2560 | pass |
  | `Qwen/Qwen3-Embedding-8B` | 4096 | pass |
  | `mlx-community/Qwen3-Embedding-0.6B-8bit` (regression) | 1024 | unchanged |

- 12 new unit tests in `tests/test_compat.py`: remap rules, tied/untied/
  headless `lm_head` cases, pass-through for prefixed and non-Qwen3
  layouts, idempotent wrap. `python -m pytest tests/test_compat.py` →
  42 passed, 3 pre-existing skips. `scripts/lint.sh` clean.

Reviewer repro:

```bash
vllm serve Qwen/Qwen3-Embedding-0.6B --runner pooling --max-model-len 600
```

## Notes / follow-ups

- `docs/supported_models.md` still lists only the mlx-community 8bit
  repo; updating the table is a deliberate non-goal here and can follow
  once this lands.
- The 8B headless case is per-checkpoint detection (flat layout + untied
  config + absent tensor), not a general "skip lm_head" loader change;
  a pooling-path fix could subsume it later if more headless checkpoints
  appear.