### PR TITLE
[Feature] Support Matryoshka embedding dimensions

### DIFF
--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -99,8 +99,17 @@ Without a configured default or request override, embeddings keep their full siz
 
 [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B)
 supports dimensions from 32 to 1024. The MLX conversion used above omits the
-Matryoshka metadata, so add `--hf-overrides '{"is_matryoshka":true}'` to that
-server command, then request a shorter vector:
+Matryoshka metadata. Setting `is_matryoshka=true` alone lets vLLM accept any
+dimension from 1 to 1024, including values below Qwen's published minimum.
+Add an explicit allowlist to the server command, for example:
+
+```bash
+--hf-overrides '{"is_matryoshka":true,"matryoshka_dimensions":[32,64,128,256,512,1024]}'
+```
+
+This example permits only the listed dimensions. Add other values within
+Qwen's published 32–1024 range to `matryoshka_dimensions` as needed.
+Then request a shorter vector:
 
 ```bash
 curl http://localhost:8000/v1/embeddings \

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -90,6 +90,29 @@ curl http://localhost:8000/v1/embeddings \
   -d '{"model":"mlx-community/Qwen3-Embedding-0.6B-8bit","input":["hello metal","semantic search"]}'
 ```
 
+### Reduced Embedding Dimensions
+
+Dense `embed` requests support `dimensions` for Matryoshka-trained models.
+vLLM validates the model's Matryoshka metadata and allowed dimensions before
+scheduling. Metal truncates the pooled hidden state before L2 normalization.
+Without a configured default or request override, embeddings keep their full size.
+
+[Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B)
+supports dimensions from 32 to 1024. The MLX conversion used above omits the
+Matryoshka metadata, so add `--hf-overrides '{"is_matryoshka":true}'` to that
+server command, then request a shorter vector:
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"model":"mlx-community/Qwen3-Embedding-0.6B-8bit","input":["hello metal","semantic search"],"dimensions":256}'
+```
+
+For offline requests, pass `PoolingParams(dimensions=256)` to `LLM.embed`.
+`--pooler-config '{"dimensions":256}'` sets a server default; an explicit
+request dimension overrides it. Use the checkpoint's published Matryoshka
+capabilities when supplying this metadata.
+
 ### Offline Qwen3 Reranking
 
 Original Qwen3 reranker checkpoints need vLLM's sequence-classification

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -384,16 +384,18 @@ def _scheduler_output(
     )
 
 
-def _expected_embedding(token_id: int) -> torch.Tensor:
-    vector = torch.tensor([float(token_id), float(token_id + 1), 1.0])
+def _expected_embedding(token_id: int, dimensions: int | None = None) -> torch.Tensor:
+    vector = torch.tensor([float(token_id), float(token_id + 1), 1.0])[:dimensions]
     return vector / vector.norm()
 
 
-def _assert_embedding(tensor: torch.Tensor | None, token_id: int) -> None:
+def _assert_embedding(
+    tensor: torch.Tensor | None, token_id: int, dimensions: int | None = None
+) -> None:
     assert tensor is not None
     assert tensor.device.type == "cpu"
-    assert tensor.shape == (3,)
-    assert torch.allclose(tensor, _expected_embedding(token_id), atol=1e-6)
+    assert tensor.shape == (3 if dimensions is None else dimensions,)
+    assert torch.allclose(tensor, _expected_embedding(token_id, dimensions), atol=1e-6)
 
 
 def _expected_score(token_id: int, *, activated: bool = True) -> torch.Tensor:
@@ -682,9 +684,11 @@ class TestMetalPoolingCapabilities:
                 (_SupportedEmbedPooler(), _SupportedEmbedPooler()),
             )
 
+    @pytest.mark.parametrize("dimensions", [None, 4])
     def test_xlm_roberta_checkpoint_matches_transformers(
         self,
         tmp_path,
+        dimensions,
     ) -> None:
         torch.manual_seed(0)
         torch_config, transformers_model = _save_tiny_xlm_roberta_checkpoint(tmp_path)
@@ -695,6 +699,10 @@ class TestMetalPoolingCapabilities:
             tokenizer_revision="tokenizer-revision",
             hf_config=torch_config,
             dtype=torch.float32,
+            pooler_config=_pooler_config(seq_pooling_type="CLS", dimensions=dimensions),
+            is_matryoshka=True,
+            matryoshka_dimensions=None,
+            embedding_size=torch_config.hidden_size,
         )
 
         with patch(
@@ -735,12 +743,14 @@ class TestMetalPoolingCapabilities:
             rtol=1e-5,
         )
 
-        request = _new_req("req-0", [0, 5, 6, 2], task="embed")
+        pooling_params = _pooling_params(task="embed")
+        pooling_params.verify(model_config)
+        request = _new_req("req-0", [0, 5, 6, 2], pooling_params=pooling_params)
         outputs = loaded_backend.pooling_backend.pool_scheduler_output(
             _scheduler_output(new_reqs=[request]),
             model_config,
         )
-        expected_cls = normalize(expected_hidden[0, 0].float(), dim=0)
+        expected_cls = normalize(expected_hidden[0, 0, :dimensions].float(), dim=0)
 
         assert len(outputs) == 1
         assert torch.allclose(
@@ -873,9 +883,12 @@ class TestMetalPoolingCapabilities:
 
 
 class TestMetalPoolingRunnerOutput:
-    def test_paged_embed_preserves_request_order(self) -> None:
+    @pytest.mark.parametrize("dimensions", [None, 2])
+    def test_paged_embed_preserves_request_order(self, dimensions) -> None:
         runner = _make_runner()
-        req_b = _new_req("req-b", [4, 5])
+        req_b = _new_req(
+            "req-b", [4, 5], pooling_params=_pooling_params(dimensions=dimensions)
+        )
         req_a = _new_req("req-a", [7, 8, 9])
         sched = _scheduler_output(new_reqs=[req_b, req_a])
 
@@ -888,11 +901,13 @@ class TestMetalPoolingRunnerOutput:
         assert out.req_ids == ["req-b", "req-a"]
         assert out.sampled_token_ids == [[], []]
         assert out.pooler_output is not None
-        _assert_embedding(out.pooler_output[0], 5)
+        _assert_embedding(out.pooler_output[0], 5, dimensions)
         _assert_embedding(out.pooler_output[1], 9)
 
+    @pytest.mark.parametrize("dimensions", [None, 2])
     def test_encoder_embed_preserves_request_order_without_paged_attention(
         self,
+        dimensions,
     ) -> None:
         runner = _make_runner(
             paged=False,
@@ -902,7 +917,9 @@ class TestMetalPoolingRunnerOutput:
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
         )
-        req_b = _new_req("req-b", [4, 5])
+        req_b = _new_req(
+            "req-b", [4, 5], pooling_params=_pooling_params(dimensions=dimensions)
+        )
         req_a = _new_req("req-a", [7, 8, 9])
 
         with patch("vllm_metal.v1.model_runner.prepare_grouped") as prepare:
@@ -912,12 +929,17 @@ class TestMetalPoolingRunnerOutput:
         assert out.req_ids == ["req-b", "req-a"]
         assert out.sampled_token_ids == [[], []]
         assert out.pooler_output is not None
-        _assert_embedding(out.pooler_output[0], 4)
+        _assert_embedding(out.pooler_output[0], 4, dimensions)
         _assert_embedding(out.pooler_output[1], 7)
 
-    def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(self) -> None:
+    @pytest.mark.parametrize("dimensions", [None, 2])
+    def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(
+        self, dimensions
+    ) -> None:
         runner = _make_runner()
-        req = _new_req("req-0", [1, 2, 3, 4])
+        req = _new_req(
+            "req-0", [1, 2, 3, 4], pooling_params=_pooling_params(dimensions=dimensions)
+        )
         first = _scheduler_output(
             new_reqs=[req],
             num_scheduled_tokens={"req-0": 2},
@@ -946,7 +968,7 @@ class TestMetalPoolingRunnerOutput:
 
         assert final.sampled_token_ids == [[]]
         assert final.pooler_output is not None
-        _assert_embedding(final.pooler_output[0], 4)
+        _assert_embedding(final.pooler_output[0], 4, dimensions)
 
     def test_paged_classify_returns_qwen3_reranker_scores(self) -> None:
         runner = _make_runner(
@@ -1239,7 +1261,6 @@ class TestMetalPoolingFailFast:
             (_pooling_params(returned_token_ids=[1]), "returned_token_ids"),
             (_pooling_params(extra_kwargs={"foo": True}), "extra pooling kwargs"),
             (_pooling_params(use_activation=False), "use_activation=False"),
-            (_pooling_params(dimensions=2), "dimension"),
             (
                 _pooling_params(requires_token_ids=True, dimensions=2),
                 "token-level ALL",

--- a/vllm_metal/v1/pooling/backends/decoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/decoder/runtime.py
@@ -79,9 +79,13 @@ class LastTokenEmbeddingPooler:
         span: DecoderPoolingSpan,
     ) -> torch.Tensor:
         token_index = span.start_row + span.num_tokens - 1
-        return self._pool_token(hidden_states, token_index)
+        return self._pool_token(
+            hidden_states, token_index, span.pooling_params.dimensions
+        )
 
-    def _pool_token(self, hidden_states: mx.array, token_index: int) -> torch.Tensor:
+    def _pool_token(
+        self, hidden_states: mx.array, token_index: int, dimensions: int | None
+    ) -> torch.Tensor:
         if hidden_states.ndim != 3 or hidden_states.shape[0] != 1:
             raise ValueError(
                 "Metal embed pooling expected hidden states with shape "
@@ -94,7 +98,7 @@ class LastTokenEmbeddingPooler:
                 f"state shape {hidden_states.shape} for model={self.config.label}."
             )
 
-        vector = hidden_states[0, token_index, :].astype(mx.float32)
+        vector = hidden_states[0, token_index, :dimensions].astype(mx.float32)
         vector = self._normalize_vector(vector)
         tensor = mlx_to_torch(vector, device="cpu", already_contiguous=True)
         return tensor.detach().clone()

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -61,7 +61,8 @@ class EncoderEmbeddingPooler:
             if self.config.sequence_pooling_type != "LAST"
             else len(request.token_ids) - 1
         )
-        vector = hidden_states[0, token_index, :].astype(mx.float32)
+        dimensions = request.pooling_params.dimensions
+        vector = hidden_states[0, token_index, :dimensions].astype(mx.float32)
         norm = mx.sqrt(mx.sum(vector * vector))
         norm = mx.maximum(norm, mx.array(_MIN_NORM, dtype=mx.float32))
         tensor = mlx_to_torch(mx.contiguous(vector / norm), device="cpu")

--- a/vllm_metal/v1/pooling/validation.py
+++ b/vllm_metal/v1/pooling/validation.py
@@ -107,10 +107,6 @@ class PoolingConfigView:
         return bool(self.pooler_config.enable_chunked_processing)
 
     @property
-    def has_embedding_dimension_override(self) -> bool:
-        return self.pooler_config.dimensions is not None
-
-    @property
     def supports_decoder_embed_config(self) -> bool:
         return (
             self.is_text_only
@@ -159,11 +155,6 @@ class PoolingConfigView:
             and pooling_params.use_activation is False
         ):
             return "use_activation=False"
-        if (
-            pooling_params.dimensions is not None
-            or self.has_embedding_dimension_override
-        ):
-            return "embedding-dimension truncation"
         return None
 
 


### PR DESCRIPTION
Matryoshka embedding models let applications choose shorter vectors. Metal currently rejects a valid `dimensions` request even after vLLM validates it: the supported Qwen3 MLX conversion serves full-size embeddings, but requesting 256 dimensions fails in the worker.

Honor the resolved `PoolingParams.dimensions` in decoder LAST and encoder CLS/LAST pooling. Truncate before L2 normalization, matching vLLM's embedding head. Existing vLLM validation still checks Matryoshka support and allowed dimensions; pooler defaults and per-request overrides use the existing parameter flow. Document the API/offline usage and metadata override needed by the example MLX conversion.

Validation on M4 / macOS 15.6, vLLM 0.28.0, MLX 0.32.1:

- 58 pooling tests pass. Four new parameter cases fail on unchanged main, covering mixed dimensions/request order, chunked prefill, and a native XLM-R checkpoint against Transformers.
- Real HTTP requests using `mlx-community/Qwen3-Embedding-0.6B-8bit` at `407ad2329cd30702720aafe83f74a1ba30fdfbca` return normalized 32/128/256/1024-element vectors, including concurrent and chunked requests. Controlled outputs match truncation and renormalization of full-size main outputs within `5e-8`; full-size controls are unchanged. A 256-dimensional server default, explicit overrides, and HTTP 400 validation for invalid/non-Matryoshka requests pass.
- 2,137 non-slow tests pass (15 skipped); lint, formatting, mypy, native extension/all four metallib builds, release-wheel checks, and both standard serving smoke tests pass.

This adds output-dimension support to the existing pooling backends; retrieval quality and performance were not benchmarked.
