### PR TITLE
Accept remote plain-typed GGUF reference tags

### DIFF
--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -42,8 +42,7 @@ before model load.
 ## Current scope
 
 - Supported model families: Qwen2, Qwen3, Llama, and Mistral.
-- Supported qtypes: Q8_0, Q4_0, and Q4_1.
-- Remote references additionally accept `:F16`, `:F32`, and `:BF16` tags for
-  the plain-typed checkpoints the loader already executes.
+- Supported qtypes: Q8_0, Q4_0, and Q4_1, plus plain F32/F16/BF16 tensors.
+  The same set applies to local files and remote reference tags.
 - Unsupported: K-quants, MoE, SSM or hybrid models, vision models, fused-QKV
   GGUFs, and sharded GGUF files.

--- a/docs/gguf.md
+++ b/docs/gguf.md
@@ -43,5 +43,7 @@ before model load.
 
 - Supported model families: Qwen2, Qwen3, Llama, and Mistral.
 - Supported qtypes: Q8_0, Q4_0, and Q4_1.
+- Remote references additionally accept `:F16`, `:F32`, and `:BF16` tags for
+  the plain-typed checkpoints the loader already executes.
 - Unsupported: K-quants, MoE, SSM or hybrid models, vision models, fused-QKV
   GGUFs, and sharded GGUF files.

--- a/tests/test_gguf_loader.py
+++ b/tests/test_gguf_loader.py
@@ -947,3 +947,20 @@ def test_loads_single_file_set_named_like_one_shard(tmp_path):
     ).load()
 
     _assert_dense_wrapper_histogram(model)
+
+
+@pytest.mark.parametrize("plain_type", [QT.F16, QT.F32, QT.BF16])
+def test_loads_plain_typed_checkpoint_without_wrappers(tmp_path, plain_type):
+    # llama.cpp plain exports keep norms F32; matrix weights carry the type.
+    gguf_path, cfg_dir = _build_dense_fixture(
+        tmp_path, "qwen3", has_qk_norm=True, quant_type=plain_type
+    )
+
+    model, _ = GGUFModelLoader(
+        gguf_path, config_dir=cfg_dir, target_dtype=mx.float32
+    ).load()
+
+    hist = _gguf_module_histogram(model)
+    assert "GGUFEmbedding" not in hist
+    assert "GGUFLinear" not in hist
+    _assert_forward_vocab_shape(model)

--- a/tests/test_gguf_vllm_integration.py
+++ b/tests/test_gguf_vllm_integration.py
@@ -544,9 +544,38 @@ def test_remote_load_source_rejects_unsupported_qtype_before_download(
     )
     monkeypatch.setattr(gguf_source, "snapshot_download", fail_snapshot_download)
 
-    with pytest.raises(ValueError, match="Remote GGUF qtype 'Q4_K_M'"):
+    with pytest.raises(ValueError) as excinfo:
         gguf_source.GGUFLoadSource.from_model_config(
             _remote_gguf_model_config(
                 model_weights="Qwen/Qwen3-0.6B-GGUF:Q4_K_M",
             )
         )
+
+    assert str(excinfo.value) == (
+        "Remote GGUF qtype 'Q4_K_M' is not supported by vllm-metal; "
+        "supported qtypes: BF16, F16, F32, Q4_0, Q4_1, Q8_0."
+    )
+
+
+@pytest.mark.parametrize("offline", [False, True])
+@pytest.mark.parametrize("tag", ["F16", "F32", "BF16"])
+def test_remote_plain_type_tags_resolve(tmp_path, monkeypatch, tag, offline) -> None:
+    monkeypatch.setattr(hf_constants, "HF_HUB_OFFLINE", offline)
+    snapshot = tmp_path / "weights"
+    snapshot.mkdir()
+    gguf_name = f"model-{tag}.gguf"
+    (snapshot / gguf_name).write_text("dummy")
+    monkeypatch.setattr(
+        gguf_source,
+        "HfApi",
+        lambda: SimpleNamespace(list_repo_files=lambda **_: ["README.md", gguf_name]),
+    )
+    monkeypatch.setattr(gguf_source, "snapshot_download", lambda **_: str(snapshot))
+    reference = gguf_source.RemoteGGUFReference.parse(f"org/model:{tag}")
+    assert reference is not None
+
+    resolved = reference.resolve(
+        cache_dir=None, revision=None, ignore_patterns=None, token=None
+    )
+
+    assert resolved == str(snapshot / gguf_name)

--- a/vllm_metal/gguf/source.py
+++ b/vllm_metal/gguf/source.py
@@ -24,7 +24,7 @@ _QUANT_TAG_RE = re.compile(
 _REMOTE_PREFIXES = ("*.", "*-")
 _REMOTE_SUFFIXES = ("-*", "")
 _SHARD_NAME_RE = re.compile(r"-\d+-of-(\d+)\.gguf$")
-_SUPPORTED_REMOTE_QTYPES = frozenset({"Q8_0", "Q4_0", "Q4_1"})
+_SUPPORTED_REMOTE_QTYPES = frozenset({"Q8_0", "Q4_0", "Q4_1", "F16", "F32", "BF16"})
 _CONFIG_ALLOW_PATTERNS = ("config.json", "generation_config.json")
 _TOKENIZER_ALLOW_PATTERNS = (
     "*.json",


### PR DESCRIPTION
A local F16/F32/BF16 GGUF file loads today, but the same checkpoint referenced as `org/repo:F16` is rejected. The tag grammar already accepts these; the only block is the qtype allowlist in `resolve()`. This lifts that allowlist to match what the loader already executes, one line. K-quant and IQ tags stay rejected, and the gate still sits before both the online and offline branches from #732.

Before: `Remote GGUF qtype 'F16' is not supported by vllm-metal; supported qtypes: Q4_0, Q4_1, Q8_0.` After, the reference resolves and serves. For evidence I served `unsloth/Qwen3-0.6B-GGUF:BF16` (revision 50968a44) end to end with `tools/gguf_serve_smoke.py` and the greedy continuation is correct. One note: `mx.load` reads BF16 tensors as float16, exact within f16 range, same as the local path already does. 83/83 in the touched test files with eleven new cases, full suite 2143, ruff and mypy clean.