### PR TITLE
Fetch the docs logos from upstream vLLM

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,10 +15,9 @@ build:
     install:
       - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --no-cache-dir -r docs/requirements-docs.txt
     pre_build:
-      # Logos stay out of git (#246); pin upstream's copies so no release can vanish.
       - mkdir -p docs/assets/logos
-      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.ico https://raw.githubusercontent.com/vllm-project/vllm/a1fe24d961d85089c8a254032d35e4bdbca278d6/docs/assets/logos/vllm-logo-only-light.ico
-      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.png https://raw.githubusercontent.com/vllm-project/vllm/a1fe24d961d85089c8a254032d35e4bdbca278d6/docs/assets/logos/vllm-logo-only-light.png
+      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.ico https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-only-light.ico
+      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.png https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-only-light.png
 
 mkdocs:
   configuration: mkdocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,9 +15,10 @@ build:
     install:
       - uv pip install --python $READTHEDOCS_VIRTUALENV_PATH/bin/python --no-cache-dir -r docs/requirements-docs.txt
     pre_build:
+      # Logos stay out of git (#246); pin upstream's copies so no release can vanish.
       - mkdir -p docs/assets/logos
-      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.ico https://github.com/vllm-project/vllm-metal/releases/download/logos/vllm-logo-only-light.ico
-      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.png https://github.com/vllm-project/vllm-metal/releases/download/logos/vllm-logo-only-light.png
+      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.ico https://raw.githubusercontent.com/vllm-project/vllm/a1fe24d961d85089c8a254032d35e4bdbca278d6/docs/assets/logos/vllm-logo-only-light.ico
+      - curl -fsSL -o docs/assets/logos/vllm-logo-only-light.png https://raw.githubusercontent.com/vllm-project/vllm/a1fe24d961d85089c8a254032d35e4bdbca278d6/docs/assets/logos/vllm-logo-only-light.png
 
 mkdocs:
   configuration: mkdocs.yaml


### PR DESCRIPTION
Every Read the Docs build has failed since 2026-09-01 (first failure 8707642, last success 4a9d9b9), so docs.vllm.ai/projects/vllm-metal still serves the April site. The pre_build step curls the two logos from the `logos` GitHub release, and that release is gone; the tag is still there but both assets return 404 and `curl -f` fails the build. The release script only prunes `.dev` prereleases, so this was a manual cleanup, and a release with no version on it will keep looking like one.

This keeps the #246 rule that the logos stay out of git and only changes where they come from: upstream vllm's `docs/assets/logos` at a pinned commit, the same files upstream's own site uses. `mkdocs build --strict` passes locally after running the same two curls.