### PR TITLE
[Feature] Enable multilingual E5 with encoder mean pooling

### DIFF
--- a/docs/supported_models.md
+++ b/docs/supported_models.md
@@ -37,6 +37,7 @@ validation guidance. The reranker requires Qwen3 sequence-classification
 | Qwen3-Embedding | 🔵 | `pooling` / `embed` (paged) | `mlx-community/Qwen3-Embedding-0.6B-8bit` |
 | Qwen3-Reranker | 🔵 | `pooling` / `classify` (paged) | `mku64/Qwen3-Reranker-0.6B-mlx-8Bit` |
 | BGE-M3 | 🔵 | `pooling` / `embed`, `token_classify` (encoder) | `BAAI/bge-m3` |
+| Multilingual E5 Base | 🔵 | `pooling` / `embed` (encoder) | `intfloat/multilingual-e5-base` |
 
 ## Multimodal Language Models
 

--- a/docs/text_embedding_pooling.md
+++ b/docs/text_embedding_pooling.md
@@ -31,6 +31,8 @@ Current scope is intentionally narrow:
   using `lm_head` for untied checkpoints or `embed_tokens.as_linear` when word
   embeddings are tied
 - BGE-M3 dense embeddings from the CLS hidden state, L2-normalized
+- unquantized XLM-R/RoBERTa encoder embeddings with CLS, LAST, or MEAN
+  pooling and L2 normalization, including `intfloat/multilingual-e5-base`
 - BGE-M3 sparse lexical weights through `/pooling` with
   `pooler_config.task="token_classify"`
 
@@ -170,6 +172,28 @@ vllm serve mku64/Qwen3-Reranker-0.6B-mlx-8Bit \
 curl http://localhost:8000/score \
   -H "Content-Type: application/json" \
   -d '{"text_1":["What is the capital of China?"],"text_2":["The capital of China is Beijing."]}'
+```
+
+### Multilingual E5 Embeddings
+
+[`intfloat/multilingual-e5-base`](https://huggingface.co/intfloat/multilingual-e5-base)
+uses the XLM-R encoder with MEAN pooling and returns 768-dimensional,
+L2-normalized embeddings. vLLM reads the pooling strategy from the checkpoint's
+Sentence Transformers configuration.
+
+```bash
+vllm serve intfloat/multilingual-e5-base \
+  --runner pooling \
+  --max-model-len 512
+```
+
+For retrieval, prefix queries with `query: ` and documents with `passage: `,
+including non-English inputs, as specified in the model card.
+
+```bash
+curl http://localhost:8000/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"model":"intfloat/multilingual-e5-base","input":["query: what is semantic search?","passage: Semantic search retrieves documents by meaning."]}'
 ```
 
 ### BGE-M3 Dense Embeddings

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -684,11 +684,13 @@ class TestMetalPoolingCapabilities:
                 (_SupportedEmbedPooler(), _SupportedEmbedPooler()),
             )
 
+    @pytest.mark.parametrize("pooling_type", ["CLS", "MEAN"])
     @pytest.mark.parametrize("dimensions", [None, 4])
     def test_xlm_roberta_checkpoint_matches_transformers(
         self,
         tmp_path,
         dimensions,
+        pooling_type,
     ) -> None:
         torch.manual_seed(0)
         torch_config, transformers_model = _save_tiny_xlm_roberta_checkpoint(tmp_path)
@@ -699,7 +701,9 @@ class TestMetalPoolingCapabilities:
             tokenizer_revision="tokenizer-revision",
             hf_config=torch_config,
             dtype=torch.float32,
-            pooler_config=_pooler_config(seq_pooling_type="CLS", dimensions=dimensions),
+            pooler_config=_pooler_config(
+                seq_pooling_type=pooling_type, dimensions=dimensions
+            ),
             is_matryoshka=True,
             matryoshka_dimensions=None,
             embedding_size=torch_config.hidden_size,
@@ -750,12 +754,18 @@ class TestMetalPoolingCapabilities:
             _scheduler_output(new_reqs=[request]),
             model_config,
         )
-        expected_cls = normalize(expected_hidden[0, 0, :dimensions].float(), dim=0)
+        expected_tokens = expected_hidden[0, :4, :dimensions].float()
+        expected_pooled = (
+            expected_tokens.mean(dim=0)
+            if pooling_type == "MEAN"
+            else expected_tokens[0]
+        )
+        expected_embedding = normalize(expected_pooled, dim=0)
 
         assert len(outputs) == 1
         assert torch.allclose(
             outputs[0].pooler_output,
-            expected_cls,
+            expected_embedding,
             atol=1e-5,
             rtol=1e-5,
         )
@@ -904,21 +914,29 @@ class TestMetalPoolingRunnerOutput:
         _assert_embedding(out.pooler_output[0], 5, dimensions)
         _assert_embedding(out.pooler_output[1], 9)
 
+    @pytest.mark.parametrize(
+        ("pooling_type", "expected_tokens"),
+        [("CLS", (4, 7)), ("MEAN", (5, 8))],
+    )
     @pytest.mark.parametrize("dimensions", [None, 2])
     def test_encoder_embed_preserves_request_order_without_paged_attention(
         self,
         dimensions,
+        pooling_type,
+        expected_tokens,
     ) -> None:
         runner = _make_runner(
             paged=False,
-            model_config=_encoder_model_config(),
+            model_config=_encoder_model_config(
+                pooler_config=_pooler_config(seq_pooling_type=pooling_type)
+            ),
         )
         runner._pooling_backend = MetalEncoderPoolingBackend(
             PoolingConfigView(runner.model_config),
             _EncoderModel(),
         )
         req_b = _new_req(
-            "req-b", [4, 5], pooling_params=_pooling_params(dimensions=dimensions)
+            "req-b", [4, 6], pooling_params=_pooling_params(dimensions=dimensions)
         )
         req_a = _new_req("req-a", [7, 8, 9])
 
@@ -929,8 +947,31 @@ class TestMetalPoolingRunnerOutput:
         assert out.req_ids == ["req-b", "req-a"]
         assert out.sampled_token_ids == [[], []]
         assert out.pooler_output is not None
-        _assert_embedding(out.pooler_output[0], 4, dimensions)
-        _assert_embedding(out.pooler_output[1], 7)
+        _assert_embedding(out.pooler_output[0], expected_tokens[0], dimensions)
+        _assert_embedding(out.pooler_output[1], expected_tokens[1])
+
+    @pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+    def test_encoder_mean_accumulates_in_float32(self, dtype) -> None:
+        model_config = _encoder_model_config(
+            pooler_config=_pooler_config(seq_pooling_type="MEAN")
+        )
+        hidden_states = mx.array(
+            [[[1.0, 1.0, 1.0], [0.0, 0.125, 1.0], [0.0, 0.0, 0.0]]],
+            dtype=dtype,
+        )
+        backend = MetalEncoderPoolingBackend(
+            PoolingConfigView(model_config),
+            lambda input_ids, attention_mask: hidden_states,
+        )
+        outputs = backend.pool_scheduler_output(
+            _scheduler_output(new_reqs=[_new_req("req-0", [0, 5, 2])]),
+            model_config,
+        )
+        expected = normalize(torch.tensor([1.0, 1.125, 2.0]), dim=0)
+
+        torch.testing.assert_close(
+            outputs[0].pooler_output, expected, atol=1e-6, rtol=1e-6
+        )
 
     @pytest.mark.parametrize("dimensions", [None, 2])
     def test_chunked_prefill_returns_pooler_output_only_on_final_chunk(

--- a/vllm_metal/v1/pooling/backends/encoder/runtime.py
+++ b/vllm_metal/v1/pooling/backends/encoder/runtime.py
@@ -29,7 +29,7 @@ from vllm_metal.v1.pooling.validation import (
 )
 
 _MIN_NORM = 1e-12
-_ENCODER_POOLING_TYPES = (None, "CLS", "LAST")
+_ENCODER_POOLING_TYPES = (None, "CLS", "LAST", "MEAN")
 
 
 class EncoderEmbeddingPooler:
@@ -53,16 +53,23 @@ class EncoderEmbeddingPooler:
         hidden_states: mx.array,
         request: EncoderPoolingRequest,
     ) -> torch.Tensor:
-        """Return one normalized CLS or LAST embedding for an encoder request."""
+        """Return one normalized CLS, LAST, or MEAN encoder embedding."""
         if not request.token_ids:
             raise ValueError("Metal encoder pooling requires at least one token.")
-        token_index = (
-            0
-            if self.config.sequence_pooling_type != "LAST"
-            else len(request.token_ids) - 1
-        )
         dimensions = request.pooling_params.dimensions
-        vector = hidden_states[0, token_index, :dimensions].astype(mx.float32)
+        if self.config.sequence_pooling_type == "MEAN":
+            vector = (
+                hidden_states[0, : len(request.token_ids), :dimensions]
+                .astype(mx.float32)
+                .mean(axis=0)
+            )
+        else:
+            token_index = (
+                len(request.token_ids) - 1
+                if self.config.sequence_pooling_type == "LAST"
+                else 0
+            )
+            vector = hidden_states[0, token_index, :dimensions].astype(mx.float32)
         norm = mx.sqrt(mx.sum(vector * vector))
         norm = mx.maximum(norm, mx.array(_MIN_NORM, dtype=mx.float32))
         tensor = mlx_to_torch(mx.contiguous(vector / norm), device="cpu")


### PR DESCRIPTION
Enable `intfloat/multilingual-e5-base` through the existing XLM-R encoder backend. Its Sentence Transformers configuration selects `MEAN`, but main reports no supported tasks and `/v1/embeddings` returns 404 even though the server is healthy.

Average the full prompt in FP32 before L2 normalization. Extend the existing checkpoint-reference and request-order tests, add a reduced-precision accumulation regression, and document the validated model and its query/passage prefixes.

Verified on M4 / macOS 15.6 with vLLM 0.28.0 and MLX 0.32.1:

- 64 pooling tests pass. The MEAN checkpoint/order cases fail on unchanged main; moving the FP32 cast after averaging fails the FP16/BF16 regressions.
- Real `/v1/embeddings` outputs match the [model's Transformers reference](https://huggingface.co/intfloat/multilingual-e5-base#usage): maximum absolute error below `1.4e-6` with FP32 and `2.1e-5` with the default FP16 conversion. Eight inputs cover English/Chinese, 1–512 tokens, mixed lengths, repeated/reordered inputs, and concurrent requests. Outputs have 768 elements and unit norm; unsupported dimensions and overlength requests return 400.
- 2,143 non-slow tests pass (15 skipped). Lint, formatting, mypy, native extension/all four metallibs, release-wheel checks, and both standard Qwen serving smoke tests pass.

Reproduce with the tested checkpoint:

```bash
vllm serve intfloat/multilingual-e5-base \
  --revision d128750597153bb5987e10b1c3493a34e5a4502a \
  --runner pooling --max-model-len 512
```

Send `query: ` / `passage: ` prefixed inputs to `/v1/embeddings`. The reference comparison also used `--dtype float32`.
