### PR TITLE
[Bugfix] Stop Qwen3-ASR decoding at tokenizer EOS

### DIFF
--- a/tests/test_qwen3_asr.py
+++ b/tests/test_qwen3_asr.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import mlx.core as mx
 import numpy as np
@@ -466,6 +467,28 @@ class TestQwen3ASRModel:
         logits2, cache2 = tiny_model.decode_step(next_tok, cache)
         mx.eval(logits2)
         assert logits2.shape == (1, 1, 100)
+
+
+class TestGreedyDecodeStopping:
+    @pytest.mark.parametrize("stop_token", [2, 3], ids=["model-eos", "tokenizer-eos"])
+    @pytest.mark.parametrize("prefix", [[], [7]], ids=["prefill", "decode"])
+    def test_stops_before_forwarding_eos(self, stop_token, prefix) -> None:
+        model = MagicMock()
+        model.config.eos_token_id = 2
+        # A continuation after EOS must never be decoded.
+        logits = [
+            mx.eye(10)[None, token : token + 1] for token in [*prefix, stop_token, 9, 2]
+        ]
+        model.prefill.return_value = (logits[0], None)
+        model.decode_step.side_effect = [(row, None) for row in logits[1:]]
+        transcriber = Qwen3ASRTranscriber(
+            model, tokenizer=SimpleNamespace(eos_token_id=3)
+        )
+
+        tokens = transcriber.greedy_decode_tokens(mx.zeros((1, 4)), [1])
+
+        assert tokens == prefix
+        assert model.decode_step.call_count == len(prefix)
 
 
 class TestPostProcessOutput:

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -25,6 +25,7 @@ from vllm_metal.stt.audio import (
 from vllm_metal.stt.loader import load_model
 from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.qwen3_asr.adapter import Qwen3ASRRuntimeAdapter
+from vllm_metal.stt.qwen3_asr.transcriber import Qwen3ASRTranscriber
 from vllm_metal.stt.runtime import STTRuntimeAdapter
 from vllm_metal.stt.whisper.adapter import WhisperRuntimeAdapter
 from vllm_metal.v1.stt_model_runner import STTModelRunner
@@ -645,6 +646,26 @@ class TestQwen3ASRRuntimeAdapterDispatch:
         adapter = _make_qwen3_runtime_adapter()
         with pytest.raises(ValueError, match="prompt_token_ids"):
             adapter.decode_tokens(mx.ones((50, 1024)), [])
+
+    def test_runner_ignores_transcript_after_tokenizer_eos(self) -> None:
+        adapter = _make_qwen3_runtime_adapter()
+        tokenizer = adapter.transcriber.tokenizer
+        tokenizer.eos_token_id = 151645
+        # A second ASR span after <|im_end|> must not replace the transcript.
+        token_stream = [151674, 200, 151645, 151674, 300, 151643]
+        logits = [
+            mx.where(mx.arange(151675) == token, 1.0, 0.0)[None, None, :]
+            for token in token_stream
+        ]
+        adapter.model.prefill.return_value = (logits[0], None)
+        adapter.model.decode_step.side_effect = [(row, None) for row in logits[1:]]
+        adapter._transcriber = Qwen3ASRTranscriber(adapter.model, tokenizer=tokenizer)
+        runner = _StubRunner(adapter)
+        request = _make_new_req(mm_features=_make_valid_mm_features())
+
+        runner._execute_stt(_make_scheduler_output(new_reqs=[request]))
+
+        assert runner._pending_output.sampled_token_ids == [[200, 151643]]
 
 
 class TestQwen3ASRUpstreamContract:

--- a/vllm_metal/stt/qwen3_asr/transcriber.py
+++ b/vllm_metal/stt/qwen3_asr/transcriber.py
@@ -48,7 +48,8 @@ class Qwen3ASRTranscriber:
         if not prompt_token_ids:
             raise ValueError("Qwen3-ASR decode requires non-empty prompt_token_ids.")
 
-        eos_token = self.model.config.eos_token_id
+        # Qwen3-ASR also ends assistant turns with the tokenizer's <|im_end|>.
+        eos_tokens = (self.model.config.eos_token_id, self.tokenizer.eos_token_id)
         tokens = mx.array([prompt_token_ids], dtype=mx.int32)
 
         logits, cache = self.model.prefill(tokens, audio_features)
@@ -56,7 +57,7 @@ class Qwen3ASRTranscriber:
 
         output_tokens: list[int] = []
         next_token = int(mx.argmax(logits[:, -1, :], axis=-1).item())
-        if next_token == eos_token:
+        if next_token in eos_tokens:
             return output_tokens
         output_tokens.append(next_token)
 
@@ -65,7 +66,7 @@ class Qwen3ASRTranscriber:
             logits, cache = self.model.decode_step(token_input, cache)
             mx.eval(logits)
             next_token = int(mx.argmax(logits[:, -1, :], axis=-1).item())
-            if next_token == eos_token:
+            if next_token in eos_tokens:
                 break
             output_tokens.append(next_token)
 


### PR DESCRIPTION
Qwen3-ASR ends assistant turns with tokenizer EOS `<|im_end|>` (151645), but Metal's greedy decoder only checks the model EOS, which defaults to `<|endoftext|>` (151643). The published checkpoint's [generation configuration](https://huggingface.co/Qwen/Qwen3-ASR-0.6B/blob/5eb144179a02acc5e5ba31e748d22b0cf3e303b0/generation_config.json) recognizes both. Main consequently feeds `<|im_end|>` back into the model.

Stop on either EOS before appending or forwarding it, after both prefill and decode. Add focused stopping tests and a runner regression showing that a second ASR span generated after EOS must not replace the first transcript.

Verified on Apple M4 / macOS 15.6 with vLLM 0.28.0 and MLX 0.32.1:

- Three tokenizer-EOS regressions fail on unchanged current main; both model-EOS controls pass. All 93 focused tests pass with the patch.
- Native `Qwen/Qwen3-ASR-0.6B`, revision `5eb144179a02acc5e5ba31e748d22b0cf3e303b0`: the published English sample and one second of silence preserve all 49 and five pre-EOS token IDs, respectively, and both processed transcripts. Main emits EOS and a newline afterward; the patch stops at EOS. This comparison covers termination on these two inputs.
- 2,162 non-slow tests pass (15 skipped). Lint, formatting, mypy, native extension/all four metallibs, release-wheel checks, and both standard Qwen serving smoke tests pass. Local smokes use memory fraction 0.1.
