### PR TITLE
Move KV placement helpers out of the MHA layout

### DIFF
--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -13,7 +13,7 @@ from vllm.config import CacheConfig
 from vllm.v1.attention.backends.utils import record_kv_cache_layout
 
 import vllm_metal.v1.model_runner as mr
-from vllm_metal.attention.caches.mha_layout import KV_CACHE_LAYOUT
+from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
 from vllm_metal.attention.runtime.factory import build_hybrid_runtime_plan
 from vllm_metal.attention.runtime.hybrid_plan import (
     ATTENTION_LAYER,

--- a/tests/stub_runner.py
+++ b/tests/stub_runner.py
@@ -158,7 +158,7 @@ def make_stub_runner(
     return runner
 
 
-def make_gemma4_mixed_mha_runner(
+def make_gemma4_mixed_attention_runner(
     num_layers: int,
     sliding_kv_heads: int,
     full_kv_heads: int,
@@ -168,7 +168,7 @@ def make_gemma4_mixed_mha_runner(
     disable_hybrid_manager: bool = False,
     num_gpu_blocks_override: int | None = None,
 ) -> mr.MetalModelRunner:
-    """Create a Gemma4 mixed sliding/full MHA runner stub."""
+    """Create a Gemma4 mixed sliding/full attention runner stub."""
     layer_types = [
         "full_attention" if (index + 1) % 6 == 0 else "sliding_attention"
         for index in range(num_layers)

--- a/tests/test_attention_sdpa.py
+++ b/tests/test_attention_sdpa.py
@@ -25,11 +25,11 @@ from vllm_metal.attention.attention_contracts import (
     AttentionContract,
     attention_contract_for,
 )
-from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
-from vllm_metal.attention.caches.mha_layout import (
-    MHAKVCacheLayout,
-    MHALayerKVLayout,
+from vllm_metal.attention.caches.attention_layout import (
+    AttentionKVCacheLayout,
+    AttentionLayerKVLayout,
 )
+from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.context import (
     PagedAttentionContext,
     clear_context,
@@ -747,12 +747,12 @@ class TestSDPAForward:
 
     def test_mixed_batch_routes_slots_and_page_tables_by_layer_group(self) -> None:
         """Full and sliding layers consume their scheduler-group metadata."""
-        layout = MHAKVCacheLayout(
+        layout = AttentionKVCacheLayout(
             num_blocks=11,
             allocation_bytes=2,
             layers=(
-                MHALayerKVLayout(0, 0, 32, _N_KV_HEADS, _HEAD_DIM, -1),
-                MHALayerKVLayout(1, 1, 16, _N_KV_HEADS, _HEAD_DIM, 1024),
+                AttentionLayerKVLayout(0, 0, 32, _N_KV_HEADS, _HEAD_DIM, -1),
+                AttentionLayerKVLayout(1, 1, 16, _N_KV_HEADS, _HEAD_DIM, 1024),
             ),
             group_block_sizes=(32, 16),
             slot_layers=((0,), (1,)),

--- a/tests/test_gemma4_mtp_kv_sharing.py
+++ b/tests/test_gemma4_mtp_kv_sharing.py
@@ -584,7 +584,7 @@ def test_cache_policy_installs_gemma4_mtp_kv_sharing() -> None:
     assert runner._gemma4_mtp_assistant is installed
 
 
-def test_cache_policy_rejects_gemma4_mtp_without_mha_backend() -> None:
+def test_cache_policy_rejects_gemma4_mtp_without_sdpa_backend() -> None:
     runner = make_stub_runner(
         model_args=_target_args(),
         _gemma4_mtp_assistant=object(),

--- a/tests/test_gemma4_mtp_kv_sharing.py
+++ b/tests/test_gemma4_mtp_kv_sharing.py
@@ -16,7 +16,7 @@ from vllm_metal.attention.impls.sdpa_wrapper import (
     SDPAPagedAttentionWrapper,
     patch_sdpa_attention,
 )
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.v1.gemma4_mtp import (
     Gemma4MTPAssistantMetadata,
     Gemma4MTPAssistantRuntime,
@@ -537,7 +537,7 @@ def test_reused_wrapper_rebinds_cache_through_owner_method() -> None:
 
 
 def test_cache_policy_installs_gemma4_mtp_kv_sharing() -> None:
-    backend = MHAPagedAttentionRuntime(
+    backend = SDPAPagedAttentionRuntime(
         num_layers=3,
         num_kv_heads=1,
         head_dim=4,
@@ -590,7 +590,7 @@ def test_cache_policy_rejects_gemma4_mtp_without_mha_backend() -> None:
         _gemma4_mtp_assistant=object(),
     )
 
-    with pytest.raises(NotImplementedError, match="requires the MHA paged"):
+    with pytest.raises(NotImplementedError, match="requires the SDPA paged"):
         runner._cache_policy.install_gemma4_mtp_kv_sharing(
             object(),
             block_size=_BLOCK_SIZE,

--- a/tests/test_model_adapter.py
+++ b/tests/test_model_adapter.py
@@ -931,7 +931,7 @@ class TestYocoCacheIntegration:
         assert block_bytes == expected
 
     def test_backend_uses_compact_layer_count(self) -> None:
-        """Runner backend factory should create MHA backend with reduced num_layers."""
+        """Runner backend factory should create the SDPA backend with reduced num_layers."""
         import mlx.core as mx
 
         from tests.stub_runner import make_stub_runner

--- a/tests/test_model_lifecycle.py
+++ b/tests/test_model_lifecycle.py
@@ -1358,7 +1358,7 @@ class TestResolveModelDims:
 
         assert runner.head_dim == 2688 // 32
 
-    def test_standard_mha(self) -> None:
+    def test_standard_attention(self) -> None:
         runner = self._resolve(
             {
                 "num_hidden_layers": 32,

--- a/tests/test_paged_prefix_caching.py
+++ b/tests/test_paged_prefix_caching.py
@@ -25,7 +25,7 @@ from vllm.v1.core.sched.output import (
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention import context as pac
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.v1.sampling_batch import _SamplingResult
 
 
@@ -34,7 +34,7 @@ def _make_paged_runner(num_layers: int = 2) -> mr.MetalModelRunner:
     return make_stub_runner(
         model_args={"vocab_size": 32000},
         model=MagicMock(),
-        _paged_attention_runtime=MHAPagedAttentionRuntime(
+        _paged_attention_runtime=SDPAPagedAttentionRuntime(
             num_layers=num_layers,
             num_kv_heads=1,
             head_dim=4,

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -25,8 +25,8 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from tests.stub_runner import make_gemma4_mixed_mha_runner, make_stub_runner
+from vllm_metal.attention.caches.attention_layout import AttentionKVCacheLayout
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
-from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
 from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
 from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
 from vllm_metal.attention.runtime.mha import (
@@ -342,8 +342,8 @@ class TestCachePolicyPerLayerBytes:
             runner.get_kv_cache_spec()
 
 
-class TestMHAKVCacheLayout:
-    """vLLM-managed standard-MHA cache layout contracts."""
+class TestAttentionKVCacheLayout:
+    """vLLM-managed standard attention cache layout contracts."""
 
     def gemma4_mixed_runner(
         self,
@@ -402,7 +402,7 @@ class TestMHAKVCacheLayout:
     def test_translates_upstream_slots_and_groups(self) -> None:
         config, names = self._mixed_mha_config()
 
-        layout = MHAKVCacheLayout.from_config(config, names)
+        layout = AttentionKVCacheLayout.from_config(config, names)
 
         assert layout.group_block_sizes == (32, 16)
         assert layout.slot_layers == ((0, 1), (2, 3))
@@ -414,7 +414,7 @@ class TestMHAKVCacheLayout:
 
     def test_allocates_shared_slots_from_layout(self) -> None:
         config, names = self._mixed_mha_config()
-        layout = MHAKVCacheLayout.from_config(config, names)
+        layout = AttentionKVCacheLayout.from_config(config, names)
 
         cache = MetalPagedKVCache.from_layout(layout, mx.bfloat16)
 
@@ -677,7 +677,7 @@ class TestMHAKVCacheLayout:
     def test_rebind_updates_every_layer_sharing_the_slot(self) -> None:
         config, names = self._mixed_mha_config()
         cache = MetalPagedKVCache.from_layout(
-            MHAKVCacheLayout.from_config(config, names), mx.bfloat16
+            AttentionKVCacheLayout.from_config(config, names), mx.bfloat16
         )
 
         new_key = cache.key_caches[1] + mx.array(1, dtype=mx.bfloat16)
@@ -697,4 +697,4 @@ class TestMHAKVCacheLayout:
         config, names = self._mixed_mha_config(vllm_config)
 
         with pytest.raises(NotImplementedError, match="layer-outermost"):
-            MHAKVCacheLayout.from_config(config, names)
+            AttentionKVCacheLayout.from_config(config, names)

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -29,8 +29,8 @@ from vllm_metal.attention.caches.attention_layout import AttentionKVCacheLayout
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
 from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
-from vllm_metal.attention.runtime.mha import (
-    MHAPagedAttentionRuntime,
+from vllm_metal.attention.runtime.sdpa import (
+    SDPAPagedAttentionRuntime,
 )
 from vllm_metal.config import (
     AUTO_MEMORY_FRACTION,
@@ -189,14 +189,14 @@ class TestMetalPagedKVCachePerLayer:
         assert "4.7 MB" not in messages[0]
 
 
-class TestMHABackendPerLayer:
-    """MHAPagedAttentionRuntime passes per-layer shapes to cache."""
+class TestSDPARuntimePerLayer:
+    """SDPAPagedAttentionRuntime passes per-layer shapes to cache."""
 
     def test_backend_propagates_per_layer_shapes(self) -> None:
         kv_heads = [16, 4]
         head_dims = [256, 512]
 
-        backend = MHAPagedAttentionRuntime(
+        backend = SDPAPagedAttentionRuntime(
             num_layers=2,
             num_kv_heads=kv_heads[0],
             head_dim=head_dims[0],
@@ -433,7 +433,7 @@ class TestAttentionKVCacheLayout:
             kv_cache_dtype=mx.bfloat16,
             cache_config=SimpleNamespace(block_size=32),
         )
-        backend = MHAPagedAttentionRuntime(
+        backend = SDPAPagedAttentionRuntime(
             num_layers=4,
             num_kv_heads=4,
             head_dim=512,
@@ -481,7 +481,7 @@ class TestAttentionKVCacheLayout:
             kv_heads_per_layer=[16, 16, 4, 4],
             head_dim_per_layer=[256, 256, 512, 512],
         )
-        backend = MHAPagedAttentionRuntime(
+        backend = SDPAPagedAttentionRuntime(
             num_layers=4,
             num_kv_heads=16,
             head_dim=256,
@@ -578,7 +578,7 @@ class TestAttentionKVCacheLayout:
         runner.initialize_kv_cache(config)
 
         backend = runner.paged_attention_runtime
-        assert isinstance(backend, MHAPagedAttentionRuntime)
+        assert isinstance(backend, SDPAPagedAttentionRuntime)
         assert backend.num_blocks() == config.num_blocks
         assert runner._paged_scheduler_group_indices == (0, 1, 2, 3, 4, 5)
         assert runner._paged_group_block_sizes == (16, 16, 16, 16, 16, 32)

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -26,7 +26,8 @@ from vllm.v1.kv_cache_interface import (
 
 from tests.stub_runner import make_gemma4_mixed_mha_runner, make_stub_runner
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
-from vllm_metal.attention.caches.mha_layout import KV_CACHE_LAYOUT, MHAKVCacheLayout
+from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
+from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
 from vllm_metal.attention.impls.sdpa_wrapper import SDPAPagedAttentionWrapper
 from vllm_metal.attention.runtime.mha import (
     MHAPagedAttentionRuntime,

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -406,7 +406,7 @@ class TestAttentionKVCacheLayout:
 
         assert layout.group_block_sizes == (32, 16)
         assert layout.slot_layers == ((0, 1), (2, 3))
-        assert [layer.tensor_index for layer in layout.layers] == [0, 0, 1, 1]
+        assert [layer.slot_index for layer in layout.layers] == [0, 0, 1, 1]
         assert [layer.group_index for layer in layout.layers] == [0, 1, 0, 1]
         assert [layer.sliding_window for layer in layout.layers] == [-1, 1024, -1, 1024]
         # Every tensor describes the same backing allocation the slots partition.

--- a/tests/test_per_layer_kv_cache.py
+++ b/tests/test_per_layer_kv_cache.py
@@ -24,7 +24,7 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 
-from tests.stub_runner import make_gemma4_mixed_mha_runner, make_stub_runner
+from tests.stub_runner import make_gemma4_mixed_attention_runner, make_stub_runner
 from vllm_metal.attention.caches.attention_layout import AttentionKVCacheLayout
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
 from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
@@ -62,7 +62,7 @@ def config_from_vllm_groups(
     )
 
 
-def merged_full_mha_config() -> tuple[KVCacheConfig, tuple[str, ...]]:
+def merged_full_attention_config() -> tuple[KVCacheConfig, tuple[str, ...]]:
     names = tuple(f"layers.{index}.self_attn" for index in range(4))
     specs = {
         names[0]: FullAttentionSpec(
@@ -354,7 +354,7 @@ class TestAttentionKVCacheLayout:
         disable_hybrid_manager: bool = False,
         num_gpu_blocks_override: int | None = None,
     ):
-        return make_gemma4_mixed_mha_runner(
+        return make_gemma4_mixed_attention_runner(
             num_layers=num_layers,
             sliding_kv_heads=sliding_kv_heads,
             full_kv_heads=full_kv_heads,
@@ -362,7 +362,7 @@ class TestAttentionKVCacheLayout:
             num_gpu_blocks_override=num_gpu_blocks_override,
         )
 
-    def _mixed_mha_config(
+    def _mixed_attention_config(
         self, vllm_config: VllmConfig | None = None
     ) -> tuple[KVCacheConfig, tuple[str, ...]]:
         names = tuple(f"layers.{index}.self_attn" for index in range(4))
@@ -400,7 +400,7 @@ class TestAttentionKVCacheLayout:
         return config_from_vllm_groups(groups, 3, vllm_config), names
 
     def test_translates_upstream_slots_and_groups(self) -> None:
-        config, names = self._mixed_mha_config()
+        config, names = self._mixed_attention_config()
 
         layout = AttentionKVCacheLayout.from_config(config, names)
 
@@ -413,7 +413,7 @@ class TestAttentionKVCacheLayout:
         assert layout.total_bytes == config.kv_cache_tensors[0].size
 
     def test_allocates_shared_slots_from_layout(self) -> None:
-        config, names = self._mixed_mha_config()
+        config, names = self._mixed_attention_config()
         layout = AttentionKVCacheLayout.from_config(config, names)
 
         cache = MetalPagedKVCache.from_layout(layout, mx.bfloat16)
@@ -424,7 +424,7 @@ class TestAttentionKVCacheLayout:
         assert cache.block_size_for_layer(1) == 16
 
     def test_cache_policy_adopts_engine_layout(self, monkeypatch) -> None:
-        config, _ = self._mixed_mha_config()
+        config, _ = self._mixed_attention_config()
         runner = make_stub_runner(
             num_layers=4,
             num_kv_cache_layers=4,
@@ -470,7 +470,7 @@ class TestAttentionKVCacheLayout:
     def test_cache_policy_keeps_merged_single_group_on_existing_runtime(
         self, monkeypatch
     ) -> None:
-        config, _ = merged_full_mha_config()
+        config, _ = merged_full_attention_config()
         runner = make_stub_runner(
             num_layers=4,
             num_kv_cache_layers=4,
@@ -675,7 +675,7 @@ class TestAttentionKVCacheLayout:
             runner.initialize_kv_cache(config)
 
     def test_rebind_updates_every_layer_sharing_the_slot(self) -> None:
-        config, names = self._mixed_mha_config()
+        config, names = self._mixed_attention_config()
         cache = MetalPagedKVCache.from_layout(
             AttentionKVCacheLayout.from_config(config, names), mx.bfloat16
         )
@@ -694,7 +694,7 @@ class TestAttentionKVCacheLayout:
         """vLLM's block-outermost layout interleaves layers inside each block."""
         vllm_config = VllmConfig()
         record_kv_cache_layout(vllm_config.cache_config, KVCacheLayout.BLHNC.name)
-        config, names = self._mixed_mha_config(vllm_config)
+        config, names = self._mixed_attention_config(vllm_config)
 
         with pytest.raises(NotImplementedError, match="layer-outermost"):
             AttentionKVCacheLayout.from_config(config, names)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -28,7 +28,7 @@ from vllm.v1.kv_cache_interface import (
 import vllm_metal.compat as compat
 import vllm_metal.config as vm_config
 import vllm_metal.platform as platform_module
-from tests.stub_runner import make_gemma4_mixed_mha_runner
+from tests.stub_runner import make_gemma4_mixed_attention_runner
 from vllm_metal.config import reset_config
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import WorkerCachePlanner
@@ -1656,7 +1656,7 @@ class TestKvBudgetBytes:
 class TestAutoFitMaxModelLenChain:
     """The -1 sentinel drives the null-block auto-fit contract on Metal shapes.
 
-    Builds the gemma-4-31B mixed-MHA KV shape and runs vLLM's
+    Builds the gemma-4-31B mixed-attention KV shape and runs vLLM's
     ``get_kv_cache_configs`` against fixed synthetic memory budgets: the
     fitted length leaves the null block free, a too-small pool fails, and
     the mixed layout keeps its budget shape (issue #505).
@@ -1674,7 +1674,7 @@ class TestAutoFitMaxModelLenChain:
     def gemma4_config_and_specs(
         self, *, original_max_model_len: int | None
     ) -> tuple[VllmConfig, dict[str, KVCacheSpec]]:
-        runner = make_gemma4_mixed_mha_runner(
+        runner = make_gemma4_mixed_attention_runner(
             num_layers=self._NUM_LAYERS,
             sliding_kv_heads=16,
             full_kv_heads=4,

--- a/tests/test_sliding_window_wiring.py
+++ b/tests/test_sliding_window_wiring.py
@@ -6,8 +6,8 @@ Verifies the full chain from model config to Metal KV cache:
     config.layer_types + config.sliding_window
       -> DefaultModelAdapter.build_sliding_window_per_layer
       -> MetalModelRunner.sliding_window_per_layer
-      -> ModelCachePolicy._build_mha_backend (slice to num_cache_layers)
-      -> MHAPagedAttentionRuntime (kwarg)
+      -> ModelCachePolicy._build_sdpa_backend (slice to num_cache_layers)
+      -> SDPAPagedAttentionRuntime (kwarg)
       -> MetalPagedKVCache.sliding_window_per_layer
 
 Kernel-level correctness (that a ``sliding_window`` value actually

--- a/tests/test_turboquant_hybrid_sizing.py
+++ b/tests/test_turboquant_hybrid_sizing.py
@@ -18,7 +18,7 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 
 from tests.stub_runner import make_gdn_hybrid_plan, make_stub_runner
-from vllm_metal.attention.caches.mha_layout import KV_CACHE_LAYOUT
+from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
 from vllm_metal.config import MetalConfig
 from vllm_metal.platform import MetalPlatform
 from vllm_metal.v1.cache_policy import (

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -23,7 +23,7 @@ import vllm_metal.envs as metal_envs
 import vllm_metal.v1.model_runner as mr
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.caches.gdn_cache import GDNPagedStateCache
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.attention.state import RequestStateManager
 from vllm_metal.distributed.pipeline import PipelineGroup
 from vllm_metal.v1.gemma4_mtp import Gemma4MTPDraftSeed
@@ -1397,7 +1397,7 @@ class TestV1MetalModelRunnerExecuteModel:
 
     def test_paged_cached_request_without_state_raises(self) -> None:
         runner = self._make_runner()
-        runner._paged_attention_runtime = MHAPagedAttentionRuntime(
+        runner._paged_attention_runtime = SDPAPagedAttentionRuntime(
             num_layers=1,
             num_kv_heads=1,
             head_dim=4,
@@ -1476,7 +1476,7 @@ class TestV1MetalModelRunnerExecuteModel:
 
     def test_paged_spec_decode_failure_does_not_mutate_request_setup(self) -> None:
         runner = self._make_runner()
-        runner._paged_attention_runtime = MHAPagedAttentionRuntime(
+        runner._paged_attention_runtime = SDPAPagedAttentionRuntime(
             num_layers=1,
             num_kv_heads=1,
             head_dim=4,
@@ -1679,7 +1679,7 @@ class TestV1MetalModelRunnerGDNSubmit:
     def test_prefill_non_hybrid_submits_logits_only(self, monkeypatch) -> None:
         submitted: list[tuple[object, ...]] = []
         runner = make_stub_runner(
-            _paged_attention_runtime=MHAPagedAttentionRuntime(
+            _paged_attention_runtime=SDPAPagedAttentionRuntime(
                 num_layers=1,
                 num_kv_heads=1,
                 head_dim=4,

--- a/tests/test_v1_model_runner_generate.py
+++ b/tests/test_v1_model_runner_generate.py
@@ -1992,7 +1992,7 @@ class TestRunnerMlaProperties:
         runner = self._make_runner({"kv_lora_rank": 512})
         assert runner.is_mla is True
 
-    def test_is_mla_false_for_standard_mha(self) -> None:
+    def test_is_mla_false_for_standard_attention(self) -> None:
         runner = self._make_runner(
             {"num_hidden_layers": 32, "num_attention_heads": 32, "hidden_size": 4096}
         )
@@ -2240,7 +2240,7 @@ class TestMergeVerifyWindows:
     def test_false_by_default_without_opt_in(self) -> None:
         assert make_stub_runner().merge_verify_windows is False
 
-    def test_true_for_plain_mha_when_opted_in(self, monkeypatch) -> None:
+    def test_true_for_plain_attention_when_opted_in(self, monkeypatch) -> None:
         monkeypatch.setenv("VLLM_METAL_SPEC_VERIFY_WINDOW", "1")
         assert make_stub_runner().merge_verify_windows is True
 

--- a/tests/test_v1_pooling.py
+++ b/tests/test_v1_pooling.py
@@ -21,7 +21,7 @@ from vllm.v1.core.sched.output import NewRequestData  # noqa: E402
 from vllm.v1.kv_cache_interface import KVCacheConfig  # noqa: E402
 
 from tests.stub_runner import make_stub_runner  # noqa: E402
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime  # noqa: E402
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime  # noqa: E402
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange  # noqa: E402
 from vllm_metal.pytorch_backend.tensor_bridge import mlx_to_torch  # noqa: E402
 from vllm_metal.v1 import model_runner as mr  # noqa: E402
@@ -296,7 +296,7 @@ def _make_runner(
         model_config=model_config or _pooling_model_config(),
         tokenizer=tokenizer,
         _paged_attention_runtime=(
-            MHAPagedAttentionRuntime(
+            SDPAPagedAttentionRuntime(
                 num_layers=1,
                 num_kv_heads=1,
                 head_dim=4,

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -24,7 +24,7 @@ from vllm.v1.kv_cache_interface import (  # noqa: E402
 )
 
 from tests.stub_runner import make_stub_runner  # noqa: E402
-from vllm_metal.attention.caches.mha_layout import KV_CACHE_LAYOUT  # noqa: E402
+from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT  # noqa: E402
 from vllm_metal.attention.runtime.families.gdn import build_gdn_hybrid_plan
 from vllm_metal.config import AUTO_MEMORY_FRACTION, MetalConfig
 from vllm_metal.stt.policy import STT_SCHED_AVAILABLE_BYTES  # noqa: E402

--- a/tests/test_v1_worker.py
+++ b/tests/test_v1_worker.py
@@ -38,7 +38,7 @@ from vllm_metal.v1.worker import MetalWorker  # noqa: E402
 class TestKVCacheLayoutRpcs:
     """The engine core resolves one KV layout from every worker's list."""
 
-    _MIXED_MHA_SPECS = (
+    _MIXED_ATTENTION_SPECS = (
         FullAttentionSpec(
             block_size=32, num_kv_heads=4, head_size=512, dtype=torch.bfloat16
         ),
@@ -63,7 +63,7 @@ class TestKVCacheLayoutRpcs:
         layout = resolve_kv_cache_layout(
             vllm_config,
             [worker.get_supported_kv_cache_layouts()],
-            self._MIXED_MHA_SPECS,
+            self._MIXED_ATTENTION_SPECS,
         )
 
         assert layout is KVCacheLayout.LBNHC
@@ -83,7 +83,7 @@ class TestKVCacheLayoutRpcs:
             resolve_kv_cache_layout(
                 VllmConfig(),
                 [worker.get_supported_kv_cache_layouts()],
-                self._MIXED_MHA_SPECS,
+                self._MIXED_ATTENTION_SPECS,
             )
 
     def test_initialize_from_config_records_resolved_layout(self) -> None:

--- a/tests/v1/mm/test_model_runner_multimodal_cache.py
+++ b/tests/v1/mm/test_model_runner_multimodal_cache.py
@@ -15,7 +15,7 @@ from vllm.v1.core.sched.output import (
 )
 
 from tests.stub_runner import make_stub_runner
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
 from vllm_metal.multimodal.qwen3_vl import (
     Qwen3VLMultimodalAdapter,
@@ -95,7 +95,7 @@ def _runner_with_encoder_cache():
 def _paged_runner_with_encoder_cache():
     runner = make_stub_runner(
         encoder_cache=EncoderCache(),
-        _paged_attention_runtime=MHAPagedAttentionRuntime(
+        _paged_attention_runtime=SDPAPagedAttentionRuntime(
             num_layers=1,
             num_kv_heads=1,
             head_dim=4,

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -12,7 +12,7 @@ from vllm.sampling_params import SamplingParams
 
 from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.context import get_context
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
 from vllm_metal.multimodal.qwen3_vl import Qwen3VLVisionEncodeResult
 from vllm_metal.v1.mm import EncoderCache
@@ -120,7 +120,7 @@ def _runner(adapter: _MmAdapter, *, num_layers: int = 1):
     runner = make_stub_runner(
         encoder_cache=EncoderCache(),
         _is_vlm=True,
-        _paged_attention_runtime=MHAPagedAttentionRuntime(
+        _paged_attention_runtime=SDPAPagedAttentionRuntime(
             num_layers=num_layers,
             num_kv_heads=1,
             head_dim=4,

--- a/tests/v1/mm/test_paged_forward_mm_gate.py
+++ b/tests/v1/mm/test_paged_forward_mm_gate.py
@@ -16,7 +16,7 @@ import pytest
 from vllm.sampling_params import SamplingParams
 
 from tests.stub_runner import make_stub_runner
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
 from vllm_metal.v1.mm import EncoderCache
 from vllm_metal.v1.model_runner import RequestState
@@ -36,7 +36,7 @@ class TestStartPagedForwardMmFailFast:
         runner = make_stub_runner(
             encoder_cache=EncoderCache(),
             _is_vlm=True,
-            _paged_attention_runtime=MHAPagedAttentionRuntime(
+            _paged_attention_runtime=SDPAPagedAttentionRuntime(
                 num_layers=1,
                 num_kv_heads=1,
                 head_dim=4,

--- a/vllm_metal/attention/caches/attention_layout.py
+++ b/vllm_metal/attention/caches/attention_layout.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Immutable Metal layout translated from vLLM's standard MHA cache DTOs.
+"""Immutable Metal layout translated from vLLM's standard attention cache DTOs.
 
 vLLM owns KV-cache grouping and capacity planning. This module only validates
 and translates the resulting ``KVCacheConfig`` for the standard mixed
-full/sliding-window MHA path.
+full/sliding-window attention path.
 """
 
 from __future__ import annotations
@@ -21,14 +21,14 @@ from vllm.v1.kv_cache_interface import (
 from vllm_metal.attention.caches.placement import layer_addresses
 
 NO_SLIDING_WINDOW = -1
-StandardMHASpec: TypeAlias = FullAttentionSpec | SlidingWindowSpec
+StandardAttentionSpec: TypeAlias = FullAttentionSpec | SlidingWindowSpec
 
 
 @dataclass(frozen=True, slots=True)
-class MHAGroupLayout:
+class AttentionGroupLayout:
     """vLLM cache-group specs and layer-to-group mapping."""
 
-    specs: tuple[StandardMHASpec, ...]
+    specs: tuple[StandardAttentionSpec, ...]
     layer_indices: dict[str, int]
 
 
@@ -41,7 +41,7 @@ class MHATensorLayout:
 
 
 @dataclass(frozen=True, slots=True)
-class MHALayerKVLayout:
+class AttentionLayerKVLayout:
     """KV-cache shape and vLLM mapping for one model layer."""
 
     tensor_index: int
@@ -57,12 +57,12 @@ class MHALayerKVLayout:
 
 
 @dataclass(frozen=True, slots=True)
-class MHAKVCacheLayout:
-    """Immutable standard-MHA cache layout derived from vLLM's DTOs."""
+class AttentionKVCacheLayout:
+    """Immutable standard attention cache layout derived from vLLM's DTOs."""
 
     num_blocks: int
     allocation_bytes: int
-    layers: tuple[MHALayerKVLayout, ...]
+    layers: tuple[AttentionLayerKVLayout, ...]
     group_block_sizes: tuple[int, ...]
     slot_layers: tuple[tuple[int, ...], ...]
 
@@ -74,23 +74,23 @@ class MHAKVCacheLayout:
     @classmethod
     def from_config(
         cls, config: KVCacheConfig, model_layer_names: tuple[str, ...]
-    ) -> MHAKVCacheLayout:
-        """Translate a standard mixed-MHA ``KVCacheConfig`` without regrouping.
+    ) -> AttentionKVCacheLayout:
+        """Translate a standard mixed-attention ``KVCacheConfig`` without regrouping.
 
         ``model_layer_names`` is the runner's ordered attention-layer sequence.
         Each layer must occur exactly once in vLLM's group and tensor mappings.
         """
-        return MHAKVCacheLayoutTranslator(config, model_layer_names).translate()
+        return AttentionKVCacheLayoutTranslator(config, model_layer_names).translate()
 
 
 @dataclass(frozen=True, slots=True)
-class MHAKVCacheLayoutTranslator:
-    """Translate vLLM's standard-MHA KV cache config into Metal's layout DTO."""
+class AttentionKVCacheLayoutTranslator:
+    """Translate vLLM's standard attention KV cache config into Metal's layout DTO."""
 
     config: KVCacheConfig
     model_layer_names: tuple[str, ...]
 
-    def translate(self) -> MHAKVCacheLayout:
+    def translate(self) -> AttentionKVCacheLayout:
         """Translate without changing vLLM's grouping."""
         group_layout = self._group_layout()
         self._require_model_layers(group_layout.layer_indices, "group")
@@ -98,7 +98,7 @@ class MHAKVCacheLayoutTranslator:
         tensor_layout = self._tensor_layout(group_layout)
         self._require_model_layers(tensor_layout.layer_indices, "tensor")
 
-        return MHAKVCacheLayout(
+        return AttentionKVCacheLayout(
             num_blocks=self.config.num_blocks,
             allocation_bytes=self.config.kv_cache_tensors[0].size,
             layers=self._layer_layouts(group_layout, tensor_layout),
@@ -110,27 +110,28 @@ class MHAKVCacheLayoutTranslator:
     def _model_layer_indices(self) -> dict[str, int]:
         return {name: index for index, name in enumerate(self.model_layer_names)}
 
-    def _group_layout(self) -> MHAGroupLayout:
-        specs: list[StandardMHASpec] = []
+    def _group_layout(self) -> AttentionGroupLayout:
+        specs: list[StandardAttentionSpec] = []
         layer_indices: dict[str, int] = {}
         for group_index, group in enumerate(self.config.kv_cache_groups):
             spec = group.kv_cache_spec
             if not isinstance(spec, (FullAttentionSpec, SlidingWindowSpec)):
                 raise NotImplementedError(
-                    "standard MHA layout requires FullAttentionSpec or "
+                    "standard attention layout requires FullAttentionSpec or "
                     "SlidingWindowSpec groups"
                 )
             if spec.head_size_v != spec.head_size:
                 raise NotImplementedError(
-                    "standard MHA layout requires matching key and value head sizes"
+                    "standard attention layout requires matching key and value "
+                    "head sizes"
                 )
 
             specs.append(spec)
             for layer_name in group.layer_names:
                 layer_indices[layer_name] = group_index
-        return MHAGroupLayout(specs=tuple(specs), layer_indices=layer_indices)
+        return AttentionGroupLayout(specs=tuple(specs), layer_indices=layer_indices)
 
-    def _tensor_layout(self, group_layout: MHAGroupLayout) -> MHATensorLayout:
+    def _tensor_layout(self, group_layout: AttentionGroupLayout) -> MHATensorLayout:
         layer_indices: dict[str, int] = {}
         slot_layers: list[list[int]] = []
         slot_by_address: dict[int, int] = {}
@@ -153,9 +154,9 @@ class MHAKVCacheLayoutTranslator:
 
     def _layer_layouts(
         self,
-        group_layout: MHAGroupLayout,
+        group_layout: AttentionGroupLayout,
         tensor_layout: MHATensorLayout,
-    ) -> tuple[MHALayerKVLayout, ...]:
+    ) -> tuple[AttentionLayerKVLayout, ...]:
         return tuple(
             self._layer_layout(layer_name, group_layout, tensor_layout)
             for layer_name in self.model_layer_names
@@ -164,12 +165,12 @@ class MHAKVCacheLayoutTranslator:
     def _layer_layout(
         self,
         layer_name: str,
-        group_layout: MHAGroupLayout,
+        group_layout: AttentionGroupLayout,
         tensor_layout: MHATensorLayout,
-    ) -> MHALayerKVLayout:
+    ) -> AttentionLayerKVLayout:
         group_index = group_layout.layer_indices[layer_name]
         spec = group_layout.specs[group_index]
-        return MHALayerKVLayout(
+        return AttentionLayerKVLayout(
             tensor_index=tensor_layout.layer_indices[layer_name],
             group_index=group_index,
             block_size=spec.block_size,
@@ -190,7 +191,7 @@ class MHAKVCacheLayoutTranslator:
             )
 
     def _require_layer_outermost(
-        self, tensor: KVCacheTensor, tensor_index: int, spec: StandardMHASpec
+        self, tensor: KVCacheTensor, tensor_index: int, spec: StandardAttentionSpec
     ) -> None:
         region_bytes = self.config.num_blocks * spec.page_size_bytes
         if (
@@ -198,7 +199,7 @@ class MHAKVCacheLayoutTranslator:
             or tensor.layer_stride != region_bytes
         ):
             raise NotImplementedError(
-                "standard MHA layout requires layer-outermost KV tensors "
+                "standard attention layout requires layer-outermost KV tensors "
                 f"(block_stride {spec.page_size_bytes}, layer_stride "
                 f"{region_bytes}); tensor {tensor_index} has block_stride "
                 f"{tensor.block_stride}, layer_stride {tensor.layer_stride}"

--- a/vllm_metal/attention/caches/attention_layout.py
+++ b/vllm_metal/attention/caches/attention_layout.py
@@ -33,7 +33,7 @@ class AttentionGroupLayout:
 
 
 @dataclass(frozen=True, slots=True)
-class MHATensorLayout:
+class SlotLayout:
     """vLLM physical slots (distinct region addresses) and layer-to-slot mapping."""
 
     layer_indices: dict[str, int]
@@ -44,7 +44,7 @@ class MHATensorLayout:
 class AttentionLayerKVLayout:
     """KV-cache shape and vLLM mapping for one model layer."""
 
-    tensor_index: int
+    slot_index: int
     group_index: int
     block_size: int
     num_kv_heads: int
@@ -95,15 +95,15 @@ class AttentionKVCacheLayoutTranslator:
         group_layout = self._group_layout()
         self._require_model_layers(group_layout.layer_indices, "group")
 
-        tensor_layout = self._tensor_layout(group_layout)
-        self._require_model_layers(tensor_layout.layer_indices, "tensor")
+        slot_layout = self._slot_layout(group_layout)
+        self._require_model_layers(slot_layout.layer_indices, "tensor")
 
         return AttentionKVCacheLayout(
             num_blocks=self.config.num_blocks,
             allocation_bytes=self.config.kv_cache_tensors[0].size,
-            layers=self._layer_layouts(group_layout, tensor_layout),
+            layers=self._layer_layouts(group_layout, slot_layout),
             group_block_sizes=tuple(spec.block_size for spec in group_layout.specs),
-            slot_layers=tensor_layout.slot_layers,
+            slot_layers=slot_layout.slot_layers,
         )
 
     @property
@@ -131,7 +131,7 @@ class AttentionKVCacheLayoutTranslator:
                 layer_indices[layer_name] = group_index
         return AttentionGroupLayout(specs=tuple(specs), layer_indices=layer_indices)
 
-    def _tensor_layout(self, group_layout: AttentionGroupLayout) -> MHATensorLayout:
+    def _slot_layout(self, group_layout: AttentionGroupLayout) -> SlotLayout:
         layer_indices: dict[str, int] = {}
         slot_layers: list[list[int]] = []
         slot_by_address: dict[int, int] = {}
@@ -147,7 +147,7 @@ class AttentionKVCacheLayoutTranslator:
                 layer_indices[layer_name] = slot
                 slot_layers[slot].append(model_layer_indices[layer_name])
 
-        return MHATensorLayout(
+        return SlotLayout(
             layer_indices=layer_indices,
             slot_layers=tuple(tuple(layers) for layers in slot_layers),
         )
@@ -155,10 +155,10 @@ class AttentionKVCacheLayoutTranslator:
     def _layer_layouts(
         self,
         group_layout: AttentionGroupLayout,
-        tensor_layout: MHATensorLayout,
+        slot_layout: SlotLayout,
     ) -> tuple[AttentionLayerKVLayout, ...]:
         return tuple(
-            self._layer_layout(layer_name, group_layout, tensor_layout)
+            self._layer_layout(layer_name, group_layout, slot_layout)
             for layer_name in self.model_layer_names
         )
 
@@ -166,12 +166,12 @@ class AttentionKVCacheLayoutTranslator:
         self,
         layer_name: str,
         group_layout: AttentionGroupLayout,
-        tensor_layout: MHATensorLayout,
+        slot_layout: SlotLayout,
     ) -> AttentionLayerKVLayout:
         group_index = group_layout.layer_indices[layer_name]
         spec = group_layout.specs[group_index]
         return AttentionLayerKVLayout(
-            tensor_index=tensor_layout.layer_indices[layer_name],
+            slot_index=slot_layout.layer_indices[layer_name],
             group_index=group_index,
             block_size=spec.block_size,
             num_kv_heads=spec.num_kv_heads,

--- a/vllm_metal/attention/caches/attention_layout.py
+++ b/vllm_metal/attention/caches/attention_layout.py
@@ -78,7 +78,7 @@ class AttentionKVCacheLayout:
         """Translate a standard mixed-attention ``KVCacheConfig`` without regrouping.
 
         ``model_layer_names`` is the runner's ordered attention-layer sequence.
-        Each layer must occur exactly once in vLLM's group and tensor mappings.
+        Each layer must occur exactly once in vLLM's group and slot mappings.
         """
         return AttentionKVCacheLayoutTranslator(config, model_layer_names).translate()
 
@@ -96,7 +96,7 @@ class AttentionKVCacheLayoutTranslator:
         self._require_model_layers(group_layout.layer_indices, "group")
 
         slot_layout = self._slot_layout(group_layout)
-        self._require_model_layers(slot_layout.layer_indices, "tensor")
+        self._require_model_layers(slot_layout.layer_indices, "slot")
 
         return AttentionKVCacheLayout(
             num_blocks=self.config.num_blocks,

--- a/vllm_metal/attention/caches/kv_cache.py
+++ b/vllm_metal/attention/caches/kv_cache.py
@@ -41,7 +41,7 @@ class MetalPagedKVCache:
     and ``head_dim_per_layer`` are provided, each cache layer is allocated
     with its own ``(num_kv_heads, head_dim)`` pair.  When omitted, all
     layers share the scalar ``num_kv_heads`` / ``head_dim`` (backward
-    compat for MLA, Hybrid, and uniform MHA models).
+    compat for MLA, Hybrid, and uniform attention models).
     """
 
     def __init__(
@@ -280,7 +280,7 @@ class MetalPagedKVCache:
     def from_layout(
         cls, layout: AttentionKVCacheLayout, dtype: mx.Dtype
     ) -> MetalPagedKVCache:
-        """Allocate one physical K/V pair for every upstream tensor slot."""
+        """Allocate one physical K/V pair for every upstream slot."""
         first_layer = layout.layers[0]
         return cls(
             num_layers=len(layout.layers),
@@ -345,7 +345,7 @@ class MetalPagedKVCache:
                 arrays.extend(self.value_scale_caches)
                 arrays.extend(self.key_zero_caches)
         else:
-            # Logical layer views can share one upstream tensor slot. Copy the
+            # Logical layer views can share one upstream slot. Copy the
             # physical arrays once instead of repeating the same write through
             # every alias.
             arrays = [*self._key_slots, *self._value_slots]

--- a/vllm_metal/attention/caches/kv_cache.py
+++ b/vllm_metal/attention/caches/kv_cache.py
@@ -245,12 +245,12 @@ class MetalPagedKVCache:
 
         for layer in layout.layers:
             self.key_caches.append(
-                self._key_slots[layer.tensor_index].reshape(
+                self._key_slots[layer.slot_index].reshape(
                     layer.cache_shape(self.num_blocks)
                 )
             )
             self.value_caches.append(
-                self._value_slots[layer.tensor_index].reshape(
+                self._value_slots[layer.slot_index].reshape(
                     layer.cache_shape(self.num_blocks)
                 )
             )
@@ -316,7 +316,7 @@ class MetalPagedKVCache:
             self.value_caches[layer_idx] = value_cache
             return
 
-        slot = self._layout.layers[layer_idx].tensor_index
+        slot = self._layout.layers[layer_idx].slot_index
         self._key_slots[slot] = key_cache
         self._value_slots[slot] = value_cache
         for shared_layer in self._layout.slot_layers[slot]:

--- a/vllm_metal/attention/caches/kv_cache.py
+++ b/vllm_metal/attention/caches/kv_cache.py
@@ -22,7 +22,7 @@ from collections.abc import Sequence
 import mlx.core as mx
 from vllm.logger import init_logger
 
-from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
+from vllm_metal.attention.caches.attention_layout import AttentionKVCacheLayout
 from vllm_metal.attention.caches.turboquant import (
     BLOCK_SIZE,
     FWHT_SUPPORTED_HEAD_DIMS,
@@ -59,7 +59,7 @@ class MetalPagedKVCache:
         kv_heads_per_layer: list[int] | None = None,
         head_dim_per_layer: list[int] | None = None,
         sliding_window_per_layer: list[int] | None = None,
-        layout: MHAKVCacheLayout | None = None,
+        layout: AttentionKVCacheLayout | None = None,
     ) -> None:
         self.num_layers = num_layers
         self.num_kv_heads = num_kv_heads
@@ -234,7 +234,7 @@ class MetalPagedKVCache:
         mx.eval(*self.key_caches, *self.value_caches)
 
     def _allocate_layout_caches(
-        self, layout: MHAKVCacheLayout, dtype: mx.Dtype
+        self, layout: AttentionKVCacheLayout, dtype: mx.Dtype
     ) -> None:
         """Allocate shared physical K/V slots and per-layer logical views."""
         for slot_layers in layout.slot_layers:
@@ -269,7 +269,7 @@ class MetalPagedKVCache:
             f"{self.block_size} tokens/block)"
         )
 
-    def _log_layout_cache(self, layout: MHAKVCacheLayout) -> None:
+    def _log_layout_cache(self, layout: AttentionKVCacheLayout) -> None:
         logger.info(
             f"KV cache: {layout.total_bytes / 1e6:.1f} MB "
             f"({len(layout.slot_layers)} physical slots across "
@@ -278,7 +278,7 @@ class MetalPagedKVCache:
 
     @classmethod
     def from_layout(
-        cls, layout: MHAKVCacheLayout, dtype: mx.Dtype
+        cls, layout: AttentionKVCacheLayout, dtype: mx.Dtype
     ) -> MetalPagedKVCache:
         """Allocate one physical K/V pair for every upstream tensor slot."""
         first_layer = layout.layers[0]

--- a/vllm_metal/attention/caches/mha_layout.py
+++ b/vllm_metal/attention/caches/mha_layout.py
@@ -14,28 +14,14 @@ from typing import TypeAlias
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
-    KVCacheLayout,
     KVCacheTensor,
     SlidingWindowSpec,
 )
 
+from vllm_metal.attention.caches.placement import layer_addresses
+
 NO_SLIDING_WINDOW = -1
-# vLLM's name for the page order Metal stores: [block, token, head, dim].
-KV_CACHE_LAYOUT = KVCacheLayout.LBNHC.name
 StandardMHASpec: TypeAlias = FullAttentionSpec | SlidingWindowSpec
-
-
-def layer_addresses(tensor: KVCacheTensor) -> list[tuple[str, int]]:
-    """Return each layer's region start in the KV allocation.
-
-    vLLM overlays every cache group on one allocation and places layer ``l``
-    of a tensor at ``offset + l * layer_stride``; layers whose regions start at
-    the same address alias the same bytes (their groups own disjoint block ids).
-    """
-    return [
-        (layer_name, tensor.offset + position * tensor.layer_stride)
-        for position, layer_name in enumerate(tensor.layers)
-    ]
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_metal/attention/caches/placement.py
+++ b/vllm_metal/attention/caches/placement.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""vLLM's KV cache placement contract as Metal consumes it.
+
+vLLM resolves one physical layout per model from the layouts each worker
+reports, then overlays every cache group on one backing allocation and
+describes each group's layers with a ``KVCacheTensor`` that places layer
+``l`` at ``offset + l * layer_stride``. Layers whose regions start at the
+same address alias the same bytes (their groups own disjoint block ids);
+Metal's per-runtime layouts derive their physical slots and state pools
+from those addresses.
+"""
+
+from __future__ import annotations
+
+from vllm.v1.kv_cache_interface import KVCacheLayout, KVCacheTensor
+
+# vLLM's name for the page order Metal stores: [block, token, head, dim].
+KV_CACHE_LAYOUT = KVCacheLayout.LBNHC.name
+
+
+def layer_addresses(tensor: KVCacheTensor) -> list[tuple[str, int]]:
+    """Return each layer's region start in the KV allocation."""
+    return [
+        (layer_name, tensor.offset + position * tensor.layer_stride)
+        for position, layer_name in enumerate(tensor.layers)
+    ]

--- a/vllm_metal/attention/runtime/base.py
+++ b/vllm_metal/attention/runtime/base.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Shared lifecycle base for the paged attention runtimes.
 
-The three concrete runtimes (MHA, MLA, hybrid) differ only in which caches they
+The three concrete runtimes (SDPA, MLA, hybrid) differ only in which caches they
 allocate and how they wrap layers; their initialise-guard, warm-up, and
 block-count plumbing is identical.  That shared plumbing lives here so there is
 one copy instead of three.

--- a/vllm_metal/attention/runtime/mha.py
+++ b/vllm_metal/attention/runtime/mha.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import mlx.core as mx
 
+from vllm_metal.attention.caches.attention_layout import AttentionKVCacheLayout
 from vllm_metal.attention.caches.kv_cache import MetalPagedKVCache
-from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
 from vllm_metal.attention.impls.sdpa_wrapper import (
     patch_sdpa_attention,
 )
@@ -50,7 +50,7 @@ class MHAPagedAttentionRuntime(PagedAttentionRuntimeBase):
         self._kv_heads_per_layer = kv_heads_per_layer
         self._head_dim_per_layer = head_dim_per_layer
         self._sliding_window_per_layer = sliding_window_per_layer
-        self._layout: MHAKVCacheLayout | None = None
+        self._layout: AttentionKVCacheLayout | None = None
 
     def initialize(self, num_blocks: int) -> None:
         self._cache = MetalPagedKVCache(
@@ -68,7 +68,7 @@ class MHAPagedAttentionRuntime(PagedAttentionRuntimeBase):
             sliding_window_per_layer=self._sliding_window_per_layer,
         )
 
-    def adopt_layout(self, layout: MHAKVCacheLayout) -> None:
+    def adopt_layout(self, layout: AttentionKVCacheLayout) -> None:
         """Use vLLM's grouped MHA layout as the runtime KV cache."""
         if self._turboquant:
             raise NotImplementedError(

--- a/vllm_metal/attention/runtime/sdpa.py
+++ b/vllm_metal/attention/runtime/sdpa.py
@@ -13,8 +13,8 @@ from vllm_metal.attention.impls.sdpa_wrapper import (
 from vllm_metal.attention.runtime.base import PagedAttentionRuntimeBase
 
 
-class MHAPagedAttentionRuntime(PagedAttentionRuntimeBase):
-    """Paged attention runtime for standard MHA models.
+class SDPAPagedAttentionRuntime(PagedAttentionRuntimeBase):
+    """Paged attention runtime for SDPA attention models (MHA, GQA, MQA).
 
     Orchestrates native Metal SDPA attention: allocates MetalPagedKVCache, patches
     model attention layers with the vendored C++/Metal kernel, and warms up
@@ -69,10 +69,10 @@ class MHAPagedAttentionRuntime(PagedAttentionRuntimeBase):
         )
 
     def adopt_layout(self, layout: AttentionKVCacheLayout) -> None:
-        """Use vLLM's grouped MHA layout as the runtime KV cache."""
+        """Use vLLM's grouped attention layout as the runtime KV cache."""
         if self._turboquant:
             raise NotImplementedError(
-                "layout-backed MHA runtime does not support TurboQuant"
+                "layout-backed SDPA runtime does not support TurboQuant"
             )
 
         self._layout = layout

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -20,7 +20,7 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 
-from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
+from vllm_metal.attention.caches.attention_layout import AttentionKVCacheLayout
 from vllm_metal.attention.caches.placement import layer_addresses
 from vllm_metal.attention.caches.turboquant import (
     BLOCK_SIZE as TQ_BLOCK_SIZE,
@@ -568,7 +568,7 @@ class ModelCachePolicy:
 
     def _initialize_deferred_mha_layout(self, kv_cache_config: KVCacheConfig) -> None:
         model_layer_names = self._mha_model_layer_names()
-        layout = MHAKVCacheLayout.from_config(kv_cache_config, model_layer_names)
+        layout = AttentionKVCacheLayout.from_config(kv_cache_config, model_layer_names)
         runtime = self._build_mha_backend(block_size=layout.group_block_sizes[0])
         runtime.adopt_layout(layout)
         runtime.patch_model(self._runner.model)
@@ -611,7 +611,7 @@ class ModelCachePolicy:
         if len(group_indices) == 1:
             return
 
-        layout = MHAKVCacheLayout.from_config(kv_cache_config, model_layer_names)
+        layout = AttentionKVCacheLayout.from_config(kv_cache_config, model_layer_names)
         runtime.adopt_layout(layout)
         runtime.patch_model(self._runner.model)
         self.install_gemma4_mtp_kv_sharing(

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -297,7 +297,7 @@ class ModelCachePolicy:
         self,
     ) -> Literal[
         "paged_attention_capacity",
-        "paged_attention_mha_layout_budget",
+        "paged_attention_layout_budget",
         "pooling_no_kv",
     ]:
         """Return which scheduler memory-reporting mode worker should use."""
@@ -307,8 +307,8 @@ class ModelCachePolicy:
             and not pooling_backend.capabilities.uses_kv_cache
         ):
             return "pooling_no_kv"
-        if self._uses_deferred_mha_layout():
-            return "paged_attention_mha_layout_budget"
+        if self._uses_deferred_layout():
+            return "paged_attention_layout_budget"
         return "paged_attention_capacity"
 
     def _hybrid_plan(self) -> HybridRuntimePlan:
@@ -321,8 +321,8 @@ class ModelCachePolicy:
             )
         return plan
 
-    def _uses_deferred_mha_layout(self) -> bool:
-        """Return whether vLLM's grouped MHA config must own allocation."""
+    def _uses_deferred_layout(self) -> bool:
+        """Return whether vLLM's grouped attention config must own allocation."""
         kv_heads = self._runner.kv_heads_per_layer
         head_dims = self._runner.head_dim_per_layer
         sliding_windows = self._runner.sliding_window_per_layer
@@ -360,7 +360,7 @@ class ModelCachePolicy:
 
         kv_heads, head_dims = self._cache_layer_shapes(self._runner.num_layers)
         # Under YOCO KV sharing only the leading ``num_cache_layers`` layers own
-        # a cache; the trailing ones reuse it (see ``_mha_cache_layout``, whose
+        # a cache; the trailing ones reuse it (see ``_cache_layer_mapping``, whose
         # mapping assigns the owners first).  Emit no spec for the sharers, so
         # the engine sizes against the layers that were actually allocated --
         # the same way upstream expresses sharing by omission in
@@ -369,7 +369,7 @@ class ModelCachePolicy:
         if self._runner._yoco_cache_mapping is not None:
             num_spec_layers, _ = self._runner._yoco_cache_mapping
         specs: dict[str, KVCacheSpec] = {}
-        use_deferred_mha_layout = self._uses_deferred_mha_layout()
+        use_deferred_layout = self._uses_deferred_layout()
 
         def attention_spec(layer_idx: int) -> KVCacheSpec:
             return self._attention_layer_spec(
@@ -380,7 +380,7 @@ class ModelCachePolicy:
                 torch_dtype=torch_dtype,
                 use_turboquant=use_turboquant,
                 config=config,
-                use_deferred_mha_layout=use_deferred_mha_layout,
+                use_deferred_layout=use_deferred_layout,
             )
 
         if self._runner.is_hybrid:
@@ -424,7 +424,7 @@ class ModelCachePolicy:
         torch_dtype: torch.dtype,
         use_turboquant: bool,
         config: MetalConfig,
-        use_deferred_mha_layout: bool,
+        use_deferred_layout: bool,
     ) -> KVCacheSpec:
         """Build the scheduler-visible spec for one attention layer."""
         if use_turboquant:
@@ -448,8 +448,8 @@ class ModelCachePolicy:
                 head_size=head_dim,
                 dtype=torch_dtype,
             )
-        if use_deferred_mha_layout:
-            return self._build_mha_attention_spec(
+        if use_deferred_layout:
+            return self._build_attention_spec(
                 layer_idx=layer_idx,
                 block_size=block_size,
                 num_kv_heads=num_kv_heads,
@@ -486,7 +486,7 @@ class ModelCachePolicy:
             for layer_idx in range(draft_dims.num_layers)
         }
 
-    def _build_mha_attention_spec(
+    def _build_attention_spec(
         self,
         layer_idx: int,
         block_size: int,
@@ -494,7 +494,7 @@ class ModelCachePolicy:
         head_dim: int,
         torch_dtype: torch.dtype,
     ) -> FullAttentionSpec | SlidingWindowSpec:
-        """Build the scheduler spec for one standard MHA cache layer."""
+        """Build the scheduler spec for one standard attention cache layer."""
         sliding_windows = self._runner.sliding_window_per_layer
         if sliding_windows is not None and sliding_windows[layer_idx] >= 0:
             return SlidingWindowSpec(
@@ -537,12 +537,12 @@ class ModelCachePolicy:
             logger.info("Encoder pooling: no KV cache initialized.")
             return
 
-        if self._uses_deferred_mha_layout():
+        if self._uses_deferred_layout():
             if runtime is not None:
                 raise RuntimeError(
-                    "deferred MHA layout path must not preallocate paged KV cache"
+                    "deferred layout path must not preallocate paged KV cache"
                 )
-            self._initialize_deferred_mha_layout(kv_cache_config)
+            self._initialize_deferred_layout(kv_cache_config)
             logger.info(
                 "KV cache config received: %d grouped blocks "
                 "(MLX layout initialized from vLLM config)",
@@ -566,8 +566,8 @@ class ModelCachePolicy:
             kv_cache_config.num_blocks,
         )
 
-    def _initialize_deferred_mha_layout(self, kv_cache_config: KVCacheConfig) -> None:
-        model_layer_names = self._mha_model_layer_names()
+    def _initialize_deferred_layout(self, kv_cache_config: KVCacheConfig) -> None:
+        model_layer_names = self._attention_layer_names()
         layout = AttentionKVCacheLayout.from_config(kv_cache_config, model_layer_names)
         runtime = self._build_sdpa_backend(block_size=layout.group_block_sizes[0])
         runtime.adopt_layout(layout)
@@ -587,17 +587,19 @@ class ModelCachePolicy:
         if self._runner.is_hybrid:
             self._adopt_hybrid_scheduler_group(runtime, kv_cache_config)
             return
-        self._adopt_mha_layout(runtime, kv_cache_config)
+        self._adopt_layout(runtime, kv_cache_config)
 
-    def _adopt_mha_layout(
+    def _adopt_layout(
         self,
         runtime: PagedAttentionRuntime,
         kv_cache_config: KVCacheConfig,
     ) -> None:
         if not isinstance(runtime, SDPAPagedAttentionRuntime):
-            raise RuntimeError("MHA cache config requires SDPAPagedAttentionRuntime")
+            raise RuntimeError(
+                "attention cache config requires SDPAPagedAttentionRuntime"
+            )
 
-        model_layer_names = self._mha_model_layer_names()
+        model_layer_names = self._attention_layer_names()
         group_indices = self._scheduler_group_indices_for_layers(
             kv_cache_config,
             model_layer_names,
@@ -605,7 +607,7 @@ class ModelCachePolicy:
         if get_config().turboquant:
             if group_indices != (0,):
                 raise NotImplementedError(
-                    "TurboQuant MHA currently supports one scheduler KV group"
+                    "TurboQuant attention layout currently supports one scheduler KV group"
                 )
             return
         if len(group_indices) == 1:
@@ -738,7 +740,7 @@ class ModelCachePolicy:
         ``kv_cache_config.kv_cache_groups`` exists, and resolves which group
         the synthetic ``draft_layers.*`` names from
         ``ModelCachePolicy._draft_layer_specs`` landed in -- mirroring
-        ``_adopt_mha_layout``'s resolution for the target. No-op without a
+        ``_adopt_layout``'s resolution for the target. No-op without a
         draft model configured.
         """
         draft_dims = self._runner._draft_dims
@@ -787,8 +789,8 @@ class ModelCachePolicy:
             )
         return tuple(dict.fromkeys(layer_to_group[name] for name in layer_names))
 
-    def _mha_model_layer_names(self) -> tuple[str, ...]:
-        num_layers, _ = self._mha_cache_layout()
+    def _attention_layer_names(self) -> tuple[str, ...]:
+        num_layers, _ = self._cache_layer_mapping()
         return tuple(f"layers.{layer_idx}.self_attn" for layer_idx in range(num_layers))
 
     def get_cache_block_size_bytes(self) -> int:
@@ -962,7 +964,7 @@ class ModelCachePolicy:
         )
 
     def _build_sdpa_backend(self, block_size: int) -> SDPAPagedAttentionRuntime:
-        num_layers, cache_idx_map = self._mha_cache_layout()
+        num_layers, cache_idx_map = self._cache_layer_mapping()
         config = get_config()
         kv_heads, head_dims = self._cache_layer_shapes(num_layers)
         # YOCO's ``build_yoco_cache_mapping`` assigns the first
@@ -1052,7 +1054,7 @@ class ModelCachePolicy:
     def _kv_factor(self) -> int:
         return 1 if self._runner.is_mla else 2
 
-    def _mha_cache_layout(self) -> tuple[int, dict[int, int] | None]:
+    def _cache_layer_mapping(self) -> tuple[int, dict[int, int] | None]:
         if self._runner._yoco_cache_mapping is None:
             return self._runner.num_kv_cache_layers, None
 
@@ -1158,14 +1160,14 @@ class WorkerCachePlanner:
             )
             return available
 
-        if mode == "paged_attention_mha_layout_budget":
+        if mode == "paged_attention_layout_budget":
             overhead = self._worker.model_runner.profile_run()
             plan = self._paged_attention_plan(
                 overhead=overhead,
                 require_min_blocks=False,
             )
             logger.info(
-                "Mixed MHA paged attention: reporting %.2f GB KV budget; "
+                "Mixed attention layout: reporting %.2f GB KV budget; "
                 "runtime allocation deferred until vLLM KVCacheConfig",
                 plan.kv_budget / 1e9,
             )

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -20,10 +20,8 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 
-from vllm_metal.attention.caches.mha_layout import (
-    MHAKVCacheLayout,
-    layer_addresses,
-)
+from vllm_metal.attention.caches.mha_layout import MHAKVCacheLayout
+from vllm_metal.attention.caches.placement import layer_addresses
 from vllm_metal.attention.caches.turboquant import (
     BLOCK_SIZE as TQ_BLOCK_SIZE,
 )

--- a/vllm_metal/v1/cache_policy.py
+++ b/vllm_metal/v1/cache_policy.py
@@ -32,9 +32,9 @@ from vllm_metal.attention.caches.turboquant import (
 )
 from vllm_metal.attention.runtime.hybrid import HybridPagedAttentionRuntime
 from vllm_metal.attention.runtime.hybrid_plan import HybridRuntimePlan
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.attention.runtime.mla import MLAPagedAttentionRuntime
 from vllm_metal.attention.runtime.protocol import PagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.attention.yoco import try_enable_gemma4_yoco_fast_prefill
 from vllm_metal.config import (
     PAGED_ATTENTION_MIN_BLOCKS,
@@ -569,7 +569,7 @@ class ModelCachePolicy:
     def _initialize_deferred_mha_layout(self, kv_cache_config: KVCacheConfig) -> None:
         model_layer_names = self._mha_model_layer_names()
         layout = AttentionKVCacheLayout.from_config(kv_cache_config, model_layer_names)
-        runtime = self._build_mha_backend(block_size=layout.group_block_sizes[0])
+        runtime = self._build_sdpa_backend(block_size=layout.group_block_sizes[0])
         runtime.adopt_layout(layout)
         runtime.patch_model(self._runner.model)
         self._runner.install_paged_attention_runtime(
@@ -594,8 +594,8 @@ class ModelCachePolicy:
         runtime: PagedAttentionRuntime,
         kv_cache_config: KVCacheConfig,
     ) -> None:
-        if not isinstance(runtime, MHAPagedAttentionRuntime):
-            raise RuntimeError("MHA cache config requires MHAPagedAttentionRuntime")
+        if not isinstance(runtime, SDPAPagedAttentionRuntime):
+            raise RuntimeError("MHA cache config requires SDPAPagedAttentionRuntime")
 
         model_layer_names = self._mha_model_layer_names()
         group_indices = self._scheduler_group_indices_for_layers(
@@ -904,7 +904,7 @@ class ModelCachePolicy:
             return self._build_hybrid_backend(block_size)
         if self._runner.is_mla:
             return self._build_mla_backend(block_size)
-        return self._build_mha_backend(block_size)
+        return self._build_sdpa_backend(block_size)
 
     def install_gemma4_mtp_kv_sharing(
         self,
@@ -916,9 +916,9 @@ class ModelCachePolicy:
         assistant = self._runner._gemma4_mtp_assistant
         if assistant is None:
             return
-        if not isinstance(backend, MHAPagedAttentionRuntime):
+        if not isinstance(backend, SDPAPagedAttentionRuntime):
             raise NotImplementedError(
-                "Gemma4 MTP assistant KV sharing requires the MHA paged "
+                "Gemma4 MTP assistant KV sharing requires the SDPA paged "
                 "attention backend on Metal."
             )
         target_metadata = Gemma4MTPTargetMetadata.from_model_args(
@@ -961,7 +961,7 @@ class ModelCachePolicy:
             dtype=self._require_kv_cache_dtype(),
         )
 
-    def _build_mha_backend(self, block_size: int) -> MHAPagedAttentionRuntime:
+    def _build_sdpa_backend(self, block_size: int) -> SDPAPagedAttentionRuntime:
         num_layers, cache_idx_map = self._mha_cache_layout()
         config = get_config()
         kv_heads, head_dims = self._cache_layer_shapes(num_layers)
@@ -973,7 +973,7 @@ class ModelCachePolicy:
         # which points back to a same-type unique layer by construction.
         sw = self._runner.sliding_window_per_layer
         sw_list = sw[:num_layers] if sw is not None else None
-        return MHAPagedAttentionRuntime(
+        return SDPAPagedAttentionRuntime(
             num_layers=num_layers,
             num_kv_heads=self._runner.num_kv_heads,
             head_dim=self._runner.head_dim,

--- a/vllm_metal/v1/draft_model_proposer.py
+++ b/vllm_metal/v1/draft_model_proposer.py
@@ -88,7 +88,7 @@ from vllm_metal.attention.context import (
     clear_context,
     prepare_unified,
 )
-from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
+from vllm_metal.attention.runtime.sdpa import SDPAPagedAttentionRuntime
 from vllm_metal.metal.constants import PA_WINDOW_MAX_HEAD_SIZE
 from vllm_metal.utils import get_model_download_path
 from vllm_metal.v1.mlx_lm_paths import mlx_lm_compatible_model_path
@@ -218,7 +218,7 @@ class DraftModelProposer:
     ) -> DraftModelProposer:
         model, dims = _load_draft_model(speculative_config, parallel_config)
         total_blocks = committed_num_blocks + scratch_reserve_blocks
-        backend = MHAPagedAttentionRuntime(
+        backend = SDPAPagedAttentionRuntime(
             num_layers=dims.num_layers,
             num_kv_heads=dims.num_kv_heads,
             head_dim=dims.head_dim,
@@ -249,7 +249,7 @@ class DraftModelProposer:
             extract_logits=extract_logits,
             # Mirror of the runner's `merge_verify_windows` structural
             # conditions, reduced to what can arise here: this proposer
-            # patches drafts through `MHAPagedAttentionRuntime`, so the
+            # patches drafts through `SDPAPagedAttentionRuntime`, so the
             # runner's MLA-native-decode and GDN-pure-decode arms are
             # vacuous, and `_load_draft_model` resolves one uniform
             # head_dim.  Only the decode kernel's head bound remains.

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -130,7 +130,7 @@ logger = init_logger(__name__)
 SchedulerMemoryReportingMode: TypeAlias = Literal[
     "stt_nominal",
     "paged_attention_capacity",
-    "paged_attention_mha_layout_budget",
+    "paged_attention_layout_budget",
     "pooling_no_kv",
 ]
 
@@ -678,7 +678,7 @@ class MetalModelRunner:
         (``_start_paged_forward``) and the KV-cache spec size only this stage's
         layers — not the full model.
 
-        Only the validated path (uniform MHA, e.g. Qwen3) is supported under
+        Only the validated path (uniform SDPA attention, e.g. Qwen3) is supported under
         pipeline parallelism: fail loud on YOCO / hybrid / MLA models whose
         KV-cache layer accounting does not map cleanly onto a contiguous layer
         slice yet.

--- a/vllm_metal/v1/worker.py
+++ b/vllm_metal/v1/worker.py
@@ -27,7 +27,7 @@ from vllm.v1.outputs import (
 )
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 
-from vllm_metal.attention.caches.mha_layout import KV_CACHE_LAYOUT
+from vllm_metal.attention.caches.placement import KV_CACHE_LAYOUT
 from vllm_metal.config import get_config
 from vllm_metal.distributed import PipelineGroup
 from vllm_metal.platform import MetalPlatform


### PR DESCRIPTION
pointed out on #744 that layer_addresses is about vLLM's KVCacheTensor placement, not MHA, yet it lived in mha_layout.py and the hybrid state-pool derivation imported it from there. The KV_CACHE_LAYOUT name the worker reports had the same problem.

This moves both into attention/caches/placement.py, a small module that only states vLLM's placement contract (the layout the worker reports and the byte address a tensor assigns to each layer). mha_layout.py keeps its translator and cache_policy imports the helper from the new owner. 