### PR TITLE
Reject quantized --kv-cache-dtype values Metal does not store

### DIFF
--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -501,6 +501,7 @@ class TestMetalPlatform:
             "max_model_len": 32768,
             "hf_config": SimpleNamespace(model_type="qwen3"),
             "is_hybrid": False,
+            "dtype": torch.float16,
         }
         model_fields.update(model or {})
         return self._platform_config(
@@ -696,9 +697,9 @@ class TestMetalPlatform:
             MetalPlatform.check_and_update_config(vllm_config)
 
     @pytest.mark.parametrize(
-        "cache_dtype", ["fp8", "fp8_e5m2", "int8_per_token_head", "nvfp4"]
+        "cache_dtype", ["fp8", "fp8_e4m3", "fp8_e5m2", "int8_per_token_head", "nvfp4"]
     )
-    def test_check_and_update_config_rejects_quantized_kv_cache_dtype(
+    def test_check_and_update_config_rejects_resolved_quantized_kv_cache_dtype(
         self, cache_dtype: str
     ) -> None:
         """Quantized KV dtypes are rejected rather than silently ignored.
@@ -710,10 +711,41 @@ class TestMetalPlatform:
         vllm_config.parallel_config.data_parallel_size = 1
         vllm_config.cache_config.cache_dtype = cache_dtype
 
-        with pytest.raises(
-            NotImplementedError, match=f"--kv-cache-dtype {cache_dtype}"
-        ):
+        with pytest.raises(NotImplementedError) as exc_info:
             MetalPlatform.check_and_update_config(vllm_config)
+        message = str(exc_info.value)
+        assert f"--kv-cache-dtype {cache_dtype}" in message
+        assert "--kv-cache-dtype float16" in message
+        assert "--kv-cache-dtype auto" not in message
+
+    @pytest.mark.parametrize(
+        ("model_dtype", "cache_dtype"),
+        [(torch.float16, "bfloat16"), (torch.bfloat16, "float16")],
+        ids=["fp16-model-bf16-cache", "bf16-model-fp16-cache"],
+    )
+    def test_check_and_update_config_rejects_dense_kv_cache_dtype_mismatch(
+        self, model_dtype: torch.dtype, cache_dtype: str
+    ) -> None:
+        vllm_config = self._dp_vllm_config(model={"dtype": model_dtype})
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.cache_config.cache_dtype = cache_dtype
+
+        with pytest.raises(NotImplementedError, match="stored in the model dtype"):
+            MetalPlatform.check_and_update_config(vllm_config)
+
+    @pytest.mark.parametrize(
+        ("model_dtype", "cache_dtype"),
+        [(torch.float16, "float16"), (torch.bfloat16, "bfloat16")],
+        ids=["fp16", "bf16"],
+    )
+    def test_check_and_update_config_accepts_matching_dense_kv_cache_dtype(
+        self, model_dtype: torch.dtype, cache_dtype: str
+    ) -> None:
+        vllm_config = self._dp_vllm_config(model={"dtype": model_dtype})
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.cache_config.cache_dtype = cache_dtype
+
+        MetalPlatform.check_and_update_config(vllm_config)
 
     def test_check_and_update_config_rejects_heterogeneous_draft_vocab(self) -> None:
         """A draft vocabulary that differs from the target is unsupported.

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -695,6 +695,26 @@ class TestMetalPlatform:
         with pytest.raises(NotImplementedError, match="heterogeneous KV cache dtypes"):
             MetalPlatform.check_and_update_config(vllm_config)
 
+    @pytest.mark.parametrize(
+        "cache_dtype", ["fp8", "fp8_e5m2", "int8_per_token_head", "nvfp4"]
+    )
+    def test_check_and_update_config_rejects_quantized_kv_cache_dtype(
+        self, cache_dtype: str
+    ) -> None:
+        """Quantized KV dtypes are rejected rather than silently ignored.
+
+        vLLM logs the quantized dtype as in use, but Metal stores the paged KV
+        cache in the model dtype, so the memory saving would never happen.
+        """
+        vllm_config = self._dp_vllm_config()
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.cache_config.cache_dtype = cache_dtype
+
+        with pytest.raises(
+            NotImplementedError, match=f"--kv-cache-dtype {cache_dtype}"
+        ):
+            MetalPlatform.check_and_update_config(vllm_config)
+
     def test_check_and_update_config_rejects_heterogeneous_draft_vocab(self) -> None:
         """A draft vocabulary that differs from the target is unsupported.
 

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -33,6 +33,13 @@ _MB_BUFFER_MAX_BATCHED_TOKENS = 4096
 # Only the local executors share this process's memory and inherit its
 # environment; Ray workers must not receive a driver-derived value.
 _MB_BUFFER_LOCAL_BACKENDS = ("uni", "mp")
+_METAL_DENSE_KV_CACHE_DTYPES: dict[str, torch.dtype] = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+_METAL_DENSE_KV_CACHE_DTYPE_NAMES: dict[torch.dtype, str] = {
+    dtype: name for name, dtype in _METAL_DENSE_KV_CACHE_DTYPES.items()
+}
 
 
 def _pick_mb_buffer_default(
@@ -476,16 +483,32 @@ class MetalPlatform(Platform):
 
         # vLLM accepts quantized KV cache dtypes and logs them as in use, but the
         # Metal paged KV cache is always stored in the model dtype, so the
-        # requested memory saving would silently never happen. Half-precision
-        # names keep today's behavior; TurboQuant is Metal's quantized KV cache.
+        # requested memory saving would silently never happen. TurboQuant is
+        # Metal's quantized KV cache.
         cache_dtype = vllm_config.cache_config.cache_dtype
-        if cache_dtype not in ("auto", "float16", "bfloat16"):
-            raise NotImplementedError(
-                f"vllm-metal does not support --kv-cache-dtype {cache_dtype}: the "
-                "paged KV cache is stored in the model dtype. Use "
-                "--kv-cache-dtype auto, or enable TurboQuant with "
-                "--additional-config '{\"turboquant\": true}'."
-            )
+        if cache_dtype != "auto":
+            model_dtype = vllm_config.model_config.dtype
+            model_cache_dtype = _METAL_DENSE_KV_CACHE_DTYPE_NAMES.get(model_dtype)
+            if cache_dtype in _METAL_DENSE_KV_CACHE_DTYPES:
+                if _METAL_DENSE_KV_CACHE_DTYPES[cache_dtype] != model_dtype:
+                    dtype_detail = model_cache_dtype or str(model_dtype)
+                    raise NotImplementedError(
+                        f"vllm-metal does not support --kv-cache-dtype {cache_dtype} "
+                        f"with model dtype {dtype_detail}: the paged KV cache is "
+                        "stored in the model dtype."
+                    )
+            else:
+                dense_dtype_hint = (
+                    f"--kv-cache-dtype {model_cache_dtype}"
+                    if model_cache_dtype is not None
+                    else "--kv-cache-dtype auto"
+                )
+                raise NotImplementedError(
+                    f"vllm-metal does not support --kv-cache-dtype {cache_dtype}: "
+                    "the paged KV cache is stored in the model dtype. Use "
+                    f"{dense_dtype_hint}, or enable TurboQuant with "
+                    "--additional-config '{\"turboquant\": true}'."
+                )
 
         # Upstream skips verify_equal_vocab_size_if_draft_model() when this is set,
         # so a draft model with a different vocabulary reaches the proposer, which

--- a/vllm_metal/platform.py
+++ b/vllm_metal/platform.py
@@ -474,6 +474,19 @@ class MetalPlatform(Platform):
                 "--additional-config '{\"turboquant\": true}' instead."
             )
 
+        # vLLM accepts quantized KV cache dtypes and logs them as in use, but the
+        # Metal paged KV cache is always stored in the model dtype, so the
+        # requested memory saving would silently never happen. Half-precision
+        # names keep today's behavior; TurboQuant is Metal's quantized KV cache.
+        cache_dtype = vllm_config.cache_config.cache_dtype
+        if cache_dtype not in ("auto", "float16", "bfloat16"):
+            raise NotImplementedError(
+                f"vllm-metal does not support --kv-cache-dtype {cache_dtype}: the "
+                "paged KV cache is stored in the model dtype. Use "
+                "--kv-cache-dtype auto, or enable TurboQuant with "
+                "--additional-config '{\"turboquant\": true}'."
+            )
+
         # Upstream skips verify_equal_vocab_size_if_draft_model() when this is set,
         # so a draft model with a different vocabulary reaches the proposer, which
         # verifies draft ids against the target vocabulary with no mapping.


### PR DESCRIPTION
## Purpose

`--kv-cache-dtype fp8` (and `fp8_*`, `int8_per_token_head`, `int4_per_token_head`, `nvfp4*`) is accepted, logs appear as below and starts serving. 

```
[cache.py:335] Using fp8 data type to store kv cache. It reduces the GPU memory footprint and boosts the performance. ...
```

We only reject the `turboquant_*` names, and only because those populate `kv_cache_dtype_skip_layers` and trip the guard at `vllm_metal/platform.py:470`. Everything else falls through and the paged KV cache is still allocated in the model dtype (`vllm_metal/v1/model_lifecycle.py:125`, stored as `runner.kv_cache_dtype` at `:559`). No saving, no warning.

Rejects those values in `check_and_update_config` next to the existing guard, pointing at `--kv-cache-dtype auto` or TurboQuant. `auto`, `float16` and `bfloat16` unchanged.

It's also admittable to make it a warning instead if breaking existing `fp8` invocations matters..  though that keeps the no-op, just louder. Didn't alias `fp8` to TurboQuant since they're different schemes.

## Test Plan

```bash
pytest tests/test_platform.py -q
pytest -m "not slow" tests/ .github/scripts/test_parity.py -q
ruff check . && ruff format --check . && mypy vllm_metal
```

Runtime check with the offline engine: `LLM("mlx-community/Qwen2.5-0.5B-Instruct-4bit", max_model_len=1024, gpu_memory_utilization=0.2, kv_cache_dtype=...)`.

## Test Result

| `kv_cache_dtype` | before | after |
|---|---|---|
| `auto` | 46,401 blocks × 196,608 B | same |
| `fp8` | 46,401 blocks × 196,608 B, plus the log line above | fails at startup |

```
NotImplementedError: vllm-metal does not support --kv-cache-dtype fp8: the paged KV cache is stored in the model dtype. Use --kv-cache-dtype auto, or enable TurboQuant with --additional-config '{"turboquant": true}'.
```

`test_check_and_update_config_rejects_quantized_kv_cache_dtype` (fp8, fp8_e5m2, int8_per_token_head, nvfp4): 4 failed on main, 4 passed here. Non-slow suite: 2160 passed, 15 skipped, 53 deselected. ruff and mypy clean.

Apple M1 Max 64 GB, macOS 15.7.1, vLLM 0.29.0, MLX 0.32.1.