### PR TITLE
[Bugfix] Select compatible Whisper fallback tokenizers

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -152,6 +152,24 @@ class TestEncodePrompt:
         assert len(result) <= MAX_PROMPT_TOKENS + 1
 
 
+class TestTokenizerFallback:
+    @pytest.mark.parametrize("n_vocab", [51864, 51865, 51866])
+    @pytest.mark.parametrize("with_model_path", [False, True])
+    def test_fallback_matches_model_vocabulary(
+        self, tmp_path: Path, n_vocab: int, with_model_path: bool
+    ) -> None:
+        # MLX-format Whisper snapshots can contain only config and weights.
+        (tmp_path / "config.json").write_text(json.dumps({"n_vocab": n_vocab}))
+        model = cast(
+            WhisperModel, SimpleNamespace(config=WhisperConfig(n_vocab=n_vocab))
+        )
+        transcriber = WhisperTranscriber(
+            model, model_path=str(tmp_path) if with_model_path else None
+        )
+
+        assert len(transcriber.tokenizer) == n_vocab
+
+
 class TestLoadModel:
     def test_missing_config_json(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="config.json not found"):

--- a/tests/test_v1_stt_integration.py
+++ b/tests/test_v1_stt_integration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -27,6 +28,7 @@ from vllm_metal.stt.policy import STT_SCHED_BLOCK_BYTES
 from vllm_metal.stt.qwen3_asr.adapter import Qwen3ASRRuntimeAdapter
 from vllm_metal.stt.qwen3_asr.transcriber import Qwen3ASRTranscriber
 from vllm_metal.stt.runtime import STTRuntimeAdapter
+from vllm_metal.stt.whisper import WhisperConfig
 from vllm_metal.stt.whisper.adapter import WhisperRuntimeAdapter
 from vllm_metal.v1.stt_model_runner import STTModelRunner
 
@@ -143,6 +145,35 @@ class TestWhisperRuntimeAdapterDecode:
         )
 
         assert result[-1] == 50257
+
+    @pytest.mark.parametrize("n_vocab", [51864, 51865, 51866])
+    def test_runner_uses_fallback_eot_for_tokenizer_free_snapshot(
+        self, tmp_path: Path, n_vocab: int
+    ) -> None:
+        (tmp_path / "config.json").write_text(json.dumps({"n_vocab": n_vocab}))
+        eot = 50256 if n_vocab == 51864 else 50257
+        logits = []
+        for token in (200, eot):
+            step = mx.full((1, 1, n_vocab), -float("inf"))
+            step[:, :, token] = 0
+            logits.append((step, None))
+        model = SimpleNamespace(
+            config=WhisperConfig(n_vocab=n_vocab),
+            encode=lambda _: mx.zeros((1, 1, 1)),
+            decode=MagicMock(
+                side_effect=[*logits, AssertionError("Decoded past the model EOT")]
+            ),
+        )
+        runner = _StubRunner(WhisperRuntimeAdapter(model, str(tmp_path)))
+        request = _make_new_req(
+            prompt_token_ids=[eot + 1], mm_features=_make_valid_mm_features()
+        )
+
+        runner._execute_stt(
+            _make_scheduler_output(new_reqs=[request], cached_req_ids=["cached"])
+        )
+
+        assert runner._pending_output.sampled_token_ids == [[200, eot], [eot]]
 
 
 class TestExtractAudioFeatures:

--- a/vllm_metal/stt/whisper/transcriber.py
+++ b/vllm_metal/stt/whisper/transcriber.py
@@ -78,24 +78,34 @@ class WhisperTranscriber:
         self._tokenizer = tokenizer
 
     @staticmethod
-    def load_tokenizer(model_path: str | None) -> WhisperTokenizer:
+    def load_tokenizer(
+        model_path: str | None, *, n_vocab: int = 51865
+    ) -> WhisperTokenizer:
         if model_path:
             try:
-                return WhisperTokenizer.from_pretrained(model_path)
+                tokenizer = WhisperTokenizer.from_pretrained(model_path)
+                # Transformers can construct an empty tokenizer for an MLX
+                # snapshot that contains config and weights but no vocabulary.
+                if tokenizer.vocab_size:
+                    return tokenizer
             except (OSError, ValueError) as e:
                 logger.debug("Local tokenizer load failed for %s: %s", model_path, e)
 
+        fallback = {
+            51864: "openai/whisper-small.en",
+            51866: "openai/whisper-large-v3",
+        }.get(n_vocab, "openai/whisper-small")
         try:
-            return WhisperTokenizer.from_pretrained("openai/whisper-small")
+            return WhisperTokenizer.from_pretrained(fallback)
         except OSError:
-            return WhisperTokenizer.from_pretrained(
-                "openai/whisper-small", local_files_only=True
-            )
+            return WhisperTokenizer.from_pretrained(fallback, local_files_only=True)
 
     @property
     def tokenizer(self) -> WhisperTokenizer:
         if self._tokenizer is None:
-            self._tokenizer = self.load_tokenizer(self._model_path)
+            self._tokenizer = self.load_tokenizer(
+                self._model_path, n_vocab=self.model.config.n_vocab
+            )
         return self._tokenizer
 
     @tokenizer.setter


### PR DESCRIPTION
Whisper's native transcriber accepts an empty tokenizer for MLX snapshots that contain configuration and weights only. It then uses token 0 for the decoder prefix and EOT, decodes past the model EOT, and returns empty text. Its existing fallback always selects multilingual Whisper Small, whose token layout differs from English-only and large-v3 checkpoints.

Skip empty local vocabularies and select the canonical fallback from the loaded model's vocabulary size. Usable local tokenizers, explicitly supplied tokenizers, and offline retry keep their existing behavior. Tests cover vocabulary selection separately from EOT consumption through the real transcriber and STT runner.

Matched before/after on Apple M4, 32 GiB, macOS 15.6, Python 3.12.13, vLLM 0.29.0+cpu, MLX 0.32.1, Transformers 5.17.0 and librosa 1.0.0:

| Tiny English / 11-second JFK input | Main `b7d419b` | This head `52e7e14` |
| --- | --- | --- |
| Tokenizer size / EOT | 1 / 0 | 51,864 / 50,256 |
| Decoder prefix | `[0, 0]` | `[50257, 50362]` |
| Native transcript | Empty | Spoken sentence; all 24 IDs match an explicit official-tokenizer control |
| New regression cases | 8 fail, 1 control passes | All 9 pass |

The checkpoint is pinned to `5f4dafbb28e62a53c1b10426ff7eed36ca733bf7`; the tokenizer control uses `openai/whisper-tiny.en` at `87c7102498dcde7456f24cfd30239ca606ed9063`. Both runs use identical decoded audio samples and dependencies. The real runtime adapter also stops at the correct EOT; a one-second silence control retains the official-tokenizer result.

<details>
<summary>Reproduce the native before/after on either checkout</summary>

After `./install.sh` and installing `.[stt]` into its environment, activate `.venv-vllm-metal` and run:

```bash
curl -fL https://raw.githubusercontent.com/openai/whisper/86098128c0b4f24f0e2aa2994de830614b474227/tests/jfk.flac -o jfk.flac
python - <<'PY'
import librosa
from huggingface_hub import snapshot_download
from vllm_metal.stt.loader import load_model
from vllm_metal.stt.whisper import WhisperTranscriber

snapshot = snapshot_download(
    "mlx-community/whisper-tiny.en-mlx",
    revision="5f4dafbb28e62a53c1b10426ff7eed36ca733bf7",
    allow_patterns=["config.json", "weights.npz"],
)
transcriber = WhisperTranscriber(load_model(snapshot), model_path=snapshot)
audio, _ = librosa.load("jfk.flac", sr=16000, mono=True)
print("tokenizer size / EOT:", len(transcriber.tokenizer), transcriber.tokenizer.eos_token_id)
print("transcript:", repr(transcriber.transcribe(audio, language="en").text))
PY
```

Main prints `1 0` and an empty transcript. This head prints `51864 50256` and the JFK sentence.

</details>

Exact-head validation: `scripts/test.sh` and `scripts/lint.sh` pass, including 2,167 non-slow tests, native Metal/shader builds, the release-wheel guard, Ruff, mypy and ShellCheck. The focused STT selection passes 128 tests. Additional probes verify local/injected precedence, all three vocabularies, timestamp prompts, interleaved model owners, load cancellation and retry; three deliberately broken variants are rejected.

This covers native transcription and runtime-adapter behavior. HTTP startup for this raw snapshot still fails on its missing frontend `preprocessor_config.json`, identically on main and this patch. Large-v3 vocabulary selection is tested; large-v3 model execution is not claimed.
