### PR TITLE
[Multimodal] Adapter hooks for image-capable text backbones

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@
 | `VLLM_METAL_MEMORY_FRACTION` | `auto` | Metal memory budget mode; see [KV Cache Memory Settings](#kv-cache-memory-settings) |
 | `VLLM_MLX_DEVICE` | `gpu` | MLX device (`gpu` or `cpu`) |
 | `VLLM_METAL_DISABLE_NAX` | `0` | Emergency override for automatic M5 NAX prefill attention. Set to `1` to force the non-NAX fallback. |
-| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` uses the compatibility allowlist; `multimodal-native` disables overrides |
+| `VLLM_METAL_MULTIMODAL_MODE` | `auto` | Multimodal serve mode: `auto` uses the compatibility allowlist (Gemma 4 gets the vision sidecar when its checkpoint allows); `multimodal-native` disables overrides; `text-only` forces the text-only path for every multimodal checkpoint |
 | `VLLM_USE_MODELSCOPE` | `False` | Set True to change model registry to <https://www.modelscope.cn/> |
 | `VLLM_METAL_MODELSCOPE_CACHE` | None | Specify the absolute path of the local model |
 | `VLLM_METAL_GDN_LAZY_KERNELS` | `1` | Enable lazy GDN kernels for eligible hybrid batches. Set to `0` to force the eager conv / C++ recurrent fallback path. |
@@ -38,8 +38,9 @@ wins. Outputs are unaffected.
 
 ## Multimodal Serve Modes
 
-- `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Gemma4 and Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers.
+- `auto`: use the text-only compatibility path for checkpoints on the compatibility allowlist, such as Qwen3.5/Qwen3.6 FP8 conditional-generation wrappers. Gemma 4 checkpoints with vision weights, a loadable HF processor, no per-layer inputs and no speculative decoding serve images through the vision sidecar on the mlx_lm text backbone (see [Supported Models](supported_models.md)); otherwise they stay text-only with a logged reason.
 - `multimodal-native`: disable the compatibility fallback and keep the native multimodal path active when validating or developing real multimodal support.
+- `text-only`: force the text-only backbone for every multimodal checkpoint, including Gemma 4 (the pre-sidecar behaviour).
 
 ## Speculative Decoding
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,3 +142,11 @@ class TestMetalConfig:
                 k_quant="q8_0",
                 v_quant="fp16",
             )
+
+    def test_text_only_multimodal_mode_is_accepted(self, monkeypatch) -> None:
+        monkeypatch.setenv("VLLM_METAL_MULTIMODAL_MODE", "text-only")
+        reset_config()
+        try:
+            assert get_config().multimodal_mode == "text-only"
+        finally:
+            reset_config()

--- a/tests/test_model_runner_profile.py
+++ b/tests/test_model_runner_profile.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the encoder dummy pass inside ``profile_run``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
+
+from tests.stub_runner import make_stub_runner
+from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
+
+
+class _ProfilingAdapter:
+    forward_ready = True
+
+    def __init__(self) -> None:
+        self.encode_calls: list[list[MultiModalFeatureSpec]] = []
+
+    def profile_features(self) -> list[MultiModalFeatureSpec]:
+        return [
+            MultiModalFeatureSpec(
+                data=None,
+                modality="image",
+                identifier="profile-image",
+                mm_position=PlaceholderRange(offset=0, length=4),
+            )
+        ]
+
+    def encode_multimodal(self, features: list[MultiModalFeatureSpec]) -> list[Any]:
+        self.encode_calls.append(list(features))
+        return [SimpleNamespace(hidden_states=mx.zeros((4, 8)))]
+
+
+class _PlainAdapter:
+    forward_ready = True
+
+    def __init__(self) -> None:
+        self.encode_calls: list[list[MultiModalFeatureSpec]] = []
+
+    def encode_multimodal(self, features: list[MultiModalFeatureSpec]) -> list[Any]:
+        self.encode_calls.append(list(features))
+        return []
+
+
+def _runner(adapter: Any) -> Any:
+    runner = make_stub_runner(
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+        model_config=SimpleNamespace(max_model_len=8),
+        _multimodal_adapter=adapter,
+        _is_pooling=False,
+        _pooling_backend=None,
+    )
+    runner._dummy_forward_outputs = lambda input_ids: [mx.zeros((1, 1, 8))]  # type: ignore[method-assign]
+    runner._uses_encoder_pooling_backend = lambda: False  # type: ignore[method-assign]
+    return runner
+
+
+class TestProfileRunEncoder:
+    def test_adapter_with_profile_features_is_encoded_once(self) -> None:
+        adapter = _ProfilingAdapter()
+        runner = _runner(adapter)
+
+        runner.profile_run()
+
+        assert len(adapter.encode_calls) == 1
+        assert adapter.encode_calls[0][0].identifier == "profile-image"
+
+    def test_adapter_without_profile_features_is_skipped(self) -> None:
+        adapter = _PlainAdapter()
+        runner = _runner(adapter)
+
+        runner.profile_run()
+
+        assert adapter.encode_calls == []
+
+    def test_not_forward_ready_adapter_is_skipped(self) -> None:
+        adapter = _ProfilingAdapter()
+        adapter.forward_ready = False
+        runner = _runner(adapter)
+
+        runner.profile_run()
+
+        assert adapter.encode_calls == []
+
+    def test_no_adapter_is_fine(self) -> None:
+        runner = _runner(None)
+        assert runner.profile_run() >= 0

--- a/tests/test_model_runner_profile.py
+++ b/tests/test_model_runner_profile.py
@@ -44,6 +44,11 @@ class _PlainAdapter:
         return []
 
 
+class _EmptyProfileAdapter(_ProfilingAdapter):
+    def profile_features(self) -> list[MultiModalFeatureSpec]:
+        return []
+
+
 def _runner(adapter: Any) -> Any:
     runner = make_stub_runner(
         scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
@@ -87,3 +92,11 @@ class TestProfileRunEncoder:
     def test_no_adapter_is_fine(self) -> None:
         runner = _runner(None)
         assert runner.profile_run() >= 0
+
+    def test_empty_profile_features_skips_encoding(self) -> None:
+        adapter = _EmptyProfileAdapter()
+        runner = _runner(adapter)
+
+        runner.profile_run()
+
+        assert adapter.encode_calls == []

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -846,3 +846,55 @@ class TestMmIdentifierFlowsEncoderToCallLm:
         # Placeholder rows at offsets 1, 2 carry the encoder output rows.
         assert mx.allclose(embeds[0, 1], sentinel[0]).item()
         assert mx.allclose(embeds[0, 2], sentinel[1]).item()
+
+
+class _SequentialPositionsAdapter(_MmAdapter):
+    """Adapter whose language model derives RoPE from ``ctx.offsets``."""
+
+    supplies_segment_positions = False
+
+
+class TestSegmentPositionsOptOut:
+    def _captured_segment_positions(self, adapter: _MmAdapter) -> Any:
+        runner = _runner(adapter)
+        runner.encoder_cache.add_request(
+            "req-0", [_feature("img-0", offset=1, length=2)]
+        )
+        _put_encode(runner, "img-0", hidden_states=mx.ones((2, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+        captured: dict[str, Any] = {}
+        original_call_lm = adapter.call_lm
+
+        def _call_lm(*args: Any, **kwargs: Any) -> Any:
+            ctx = get_context()
+            captured["segment_positions"] = (
+                None if ctx is None else ctx.segment_positions
+            )
+            return original_call_lm(*args, **kwargs)
+
+        adapter.call_lm = _call_lm  # type: ignore[method-assign]
+        prefill = _mm_prefill(
+            "req-0",
+            token_ids=[10, 99, 99, 11],
+            prompt_len=4,
+            full_prompt=[10, 99, 99, 11],
+        )
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[prefill],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+        assert "segment_positions" in captured
+        return captured["segment_positions"]
+
+    def test_opt_out_leaves_context_positions_none(self) -> None:
+        assert self._captured_segment_positions(_SequentialPositionsAdapter()) is None
+
+    def test_default_adapter_still_supplies_positions(self) -> None:
+        positions = self._captured_segment_positions(_MmAdapter())
+        assert isinstance(positions, list)
+        assert len(positions) == 1
+        assert positions[0].shape == (3, 1, 4)

--- a/tests/v1/mm/test_paged_forward_mm.py
+++ b/tests/v1/mm/test_paged_forward_mm.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest
+import torch
 from vllm.sampling_params import SamplingParams
 
 from tests.stub_runner import make_stub_runner
@@ -898,3 +899,125 @@ class TestSegmentPositionsOptOut:
         assert isinstance(positions, list)
         assert len(positions) == 1
         assert positions[0].shape == (3, 1, 4)
+
+
+def _boi_eoi_feature(
+    identifier: str, *, offset: int, num_embeds: int
+) -> MultiModalFeatureSpec:
+    """Gemma 4 style placeholder: boi + image tokens + eoi, embeds only inside."""
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(
+            offset=offset,
+            length=num_embeds + 2,
+            is_embed=torch.tensor([False] + [True] * num_embeds + [False]),
+        ),
+    )
+
+
+class TestIsEmbedSplice:
+    def test_single_chunk_splices_only_masked_rows(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        # tokens: text, boi, img, img, eoi, text
+        tokens = [10, 5, 99, 99, 6, 11]
+        runner.encoder_cache.add_request(
+            "req-0", [_boi_eoi_feature("img-0", offset=1, num_embeds=2)]
+        )
+        _put_encode(runner, "img-0", hidden_states=mx.ones((2, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[
+                _mm_prefill("req-0", token_ids=tokens, prompt_len=6, full_prompt=tokens)
+            ],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+
+        call = adapter.call_lm_calls[0]
+        assert call["visual_pos_masks"].tolist() == [
+            [False, False, True, True, False, False]
+        ]
+        embeds = call["inputs_embeds"]
+        ones = mx.ones(adapter.hidden_size, dtype=mx.float32)
+        zeros = mx.zeros(adapter.hidden_size, dtype=mx.float32)
+        assert mx.allclose(embeds[0, 2], ones).item()
+        assert mx.allclose(embeds[0, 3], ones).item()
+        assert mx.allclose(embeds[0, 1], zeros).item()  # boi keeps its text embedding
+        assert mx.allclose(embeds[0, 4], zeros).item()  # eoi keeps its text embedding
+
+    def test_chunk_with_only_boi_skips_the_feature(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        tokens = [10, 5, 99, 99, 6, 11]
+        runner.encoder_cache.add_request(
+            "req-0", [_boi_eoi_feature("img-0", offset=1, num_embeds=2)]
+        )
+        _put_encode(runner, "img-0", hidden_states=mx.ones((2, adapter.hidden_size)))
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        # First chunk: [text, boi] -- the feature overlaps but carries no embeds.
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[
+                _mm_prefill(
+                    "req-0",
+                    token_ids=tokens[:2],
+                    prompt_len=None,
+                    start_pos=0,
+                    full_prompt=tokens,
+                )
+            ],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+        call = adapter.call_lm_calls[-1]
+        assert call["visual_pos_masks"].tolist() == [[False, False]]
+        assert mx.allclose(
+            call["inputs_embeds"], mx.zeros((1, 2, adapter.hidden_size))
+        ).item()
+
+    def test_second_chunk_takes_remaining_rows_and_eoi_stays_text(self) -> None:
+        adapter = _MmAdapter()
+        runner = _runner(adapter)
+        tokens = [10, 5, 99, 99, 6, 11]
+        runner.encoder_cache.add_request(
+            "req-0", [_boi_eoi_feature("img-0", offset=1, num_embeds=2)]
+        )
+        rows = mx.array([[1.0] * adapter.hidden_size, [2.0] * adapter.hidden_size])
+        _put_encode(runner, "img-0", hidden_states=rows)
+        runner._spec_decode_controller.build_decode_segments = MagicMock(
+            return_value=()
+        )
+
+        # Second chunk: [img, img, eoi, text] starting at position 2.
+        runner._start_paged_forward(
+            batch=MagicMock(),
+            prefill_reqs=[
+                _mm_prefill(
+                    "req-0",
+                    token_ids=tokens[2:],
+                    prompt_len=6,
+                    start_pos=2,
+                    full_prompt=tokens,
+                )
+            ],
+            decode_reqs=[],
+            scheduler_output=_scheduler_output(),
+        )
+        call = adapter.call_lm_calls[-1]
+        assert call["visual_pos_masks"].tolist() == [[True, True, False, False]]
+        embeds = call["inputs_embeds"]
+        assert mx.allclose(embeds[0, 0], rows[0]).item()
+        assert mx.allclose(embeds[0, 1], rows[1]).item()
+        assert mx.allclose(
+            embeds[0, 2], mx.zeros(adapter.hidden_size, dtype=mx.float32)
+        ).item()

--- a/tests/v1/mm/test_paged_forward_mm_gate.py
+++ b/tests/v1/mm/test_paged_forward_mm_gate.py
@@ -9,6 +9,7 @@ not allow an mm request to slip into the text path silently.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import mlx.core as mx
@@ -19,7 +20,7 @@ from tests.stub_runner import make_stub_runner
 from vllm_metal.attention.runtime.mha import MHAPagedAttentionRuntime
 from vllm_metal.multimodal import MultiModalFeatureSpec, PlaceholderRange
 from vllm_metal.v1.mm import EncoderCache
-from vllm_metal.v1.model_runner import RequestState
+from vllm_metal.v1.model_runner import RequestState, text_path_selective_logits_allowed
 
 
 def _feature(identifier: str) -> MultiModalFeatureSpec:
@@ -128,3 +129,21 @@ class TestStartPagedForwardMmFailFast:
                 decode_reqs=[("req-mm", state)],
                 scheduler_output=self._scheduler_output(),
             )
+
+
+class TestTextPathSelectiveLogitsAllowed:
+    def test_text_only_model_is_allowed(self) -> None:
+        assert text_path_selective_logits_allowed(False, None) is True
+
+    def test_vlm_without_flag_is_refused(self) -> None:
+        adapter = SimpleNamespace(forward_ready=True)
+        assert text_path_selective_logits_allowed(True, adapter) is False
+
+    def test_vlm_with_flag_is_allowed(self) -> None:
+        adapter = SimpleNamespace(
+            forward_ready=True, text_path_selective_logits_ok=True
+        )
+        assert text_path_selective_logits_allowed(True, adapter) is True
+
+    def test_vlm_without_adapter_is_refused(self) -> None:
+        assert text_path_selective_logits_allowed(True, None) is False

--- a/vllm_metal/config.py
+++ b/vllm_metal/config.py
@@ -24,9 +24,9 @@ TURBOQUANT_VALID_V_QUANTS: frozenset[str] = frozenset(
     {"q2_0", "q3_0", "q4_0", "q5_0", "q8_0"}
 )
 
-MultimodalMode = Literal["auto", "multimodal-native"]
+MultimodalMode = Literal["auto", "multimodal-native", "text-only"]
 VALID_MULTIMODAL_MODES: frozenset[MultimodalMode] = frozenset(
-    {"auto", "multimodal-native"}
+    {"auto", "multimodal-native", "text-only"}
 )
 
 

--- a/vllm_metal/envs.py
+++ b/vllm_metal/envs.py
@@ -46,8 +46,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_MLX_DEVICE": lambda: os.getenv("VLLM_MLX_DEVICE", "gpu"),
     # Multimodal serving mode:
     # - "auto": known-incompatible multimodal checkpoints fall back to the
-    #   text-only compatibility path.
+    #   text-only compatibility path; Gemma 4 serves images through the
+    #   vision sidecar on the mlx_lm text backbone when the checkpoint allows.
     # - "multimodal-native": keep native multimodal loading enabled.
+    # - "text-only": force the text-only path for every multimodal checkpoint.
     "VLLM_METAL_MULTIMODAL_MODE": lambda: os.getenv(
         "VLLM_METAL_MULTIMODAL_MODE", "auto"
     ),

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -74,6 +74,14 @@ class MultimodalRuntimeAdapter(Protocol):
     path.  ``call_lm`` still receives ``position_ids`` either way.
     """
 
+    text_path_selective_logits_ok: bool
+    """Whether text-only batches may use selective logits (``logits_indices``).
+
+    Only adapters whose ``text_model()`` is the same object the runner
+    profiles with ``supports_selective_logits`` may set this; the runner
+    assumes False when the attribute is absent.
+    """
+
     def text_model(self) -> Any:
         """Return the callable language model for text-only VLM execution."""
 

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -42,7 +42,14 @@ class MultimodalEncodeResult(Protocol):
 
 
 class MultimodalRuntimeAdapter(Protocol):
-    """Model-owned behavior needed for native multimodal execution."""
+    """Model-owned behavior needed for native multimodal execution.
+
+    Adapters may additionally implement ``profile_features() ->
+    list[MultiModalFeatureSpec]`` returning one feature of the largest
+    encoder input; ``MetalModelRunner.profile_run`` encodes it so the
+    measured allocator overhead covers the vision tower.  Absent method
+    means no encoder profiling (Qwen3-VL, PaddleOCR-VL today).
+    """
 
     forward_ready: bool
     """Whether scheduled multimodal encoder inputs may be executed.

--- a/vllm_metal/v1/model_adapter.py
+++ b/vllm_metal/v1/model_adapter.py
@@ -62,6 +62,18 @@ class MultimodalRuntimeAdapter(Protocol):
     explicit on every batch.
     """
 
+    supplies_segment_positions: bool
+    """Whether the runner hands this adapter's per-segment positions to the
+    paged attention context (``ctx.segment_positions``).
+
+    True for M-RoPE models whose attention reads caller-supplied positions
+    (the runner assumes True when the attribute is absent).  False for
+    models with plain 1-D RoPE driven by ``ctx.offsets``: their mlx_lm
+    ``rope(x, offset=)`` modules reject caller-supplied positions, and
+    keeping the context field ``None`` preserves the batched decode RoPE
+    path.  ``call_lm`` still receives ``position_ids`` either way.
+    """
+
     def text_model(self) -> Any:
         """Return the callable language model for text-only VLM execution."""
 

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -312,6 +312,21 @@ class _PagedLogitsLayout(NamedTuple):
     cu_seqlens: list[int]
 
 
+def text_path_selective_logits_allowed(is_vlm: bool, adapter: Any | None) -> bool:
+    """Whether the split backbone/head path may serve this model's text batches.
+
+    Text-only models always qualify.  A VLM qualifies only when its adapter
+    declares ``text_path_selective_logits_ok``: its text batches run the
+    plain text path on the very object ``runner.model`` refers to, so the
+    bit-exactness probe in ``supports_selective_logits`` applies.  The mm
+    forward never requests selected rows, so the flag affects text batches
+    only.
+    """
+    if not is_vlm:
+        return True
+    return bool(getattr(adapter, "text_path_selective_logits_ok", False))
+
+
 class _PagedForwardState(NamedTuple):
     """State stashed by ``_start_paged_forward`` for ``_sample_paged_batch``."""
 
@@ -636,7 +651,9 @@ class MetalModelRunner:
         # other forward branches that never request selection.
         self._selective_logits_supported = (
             self.pp is None
-            and not self._is_vlm
+            and text_path_selective_logits_allowed(
+                self._is_vlm, self._multimodal_adapter
+            )
             and not self._lora.enabled
             and self._model_adapter.supports_selective_logits(self._forward_model)
         )

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -1937,9 +1937,11 @@ class MetalModelRunner:
         positions for mm prefill chunks, computed as ``cache_start_pos +
         delta + arange(num_query_tokens)`` for mm decode), splices vision
         embeds into the packed text embeds at placeholder positions
-        (chunk-aware: each feature only contributes the slice that lands
-        in *this* chunk), and concatenates per-layer deepstack residual
-        arrays across all mm prefill segments in packed order.
+        flagged by ``mm_position.is_embed`` (all positions when the mask
+        is absent), chunk-aware: each feature only contributes the
+        encoder rows whose placeholders land in *this* chunk, and
+        concatenates per-layer deepstack residual arrays across all mm
+        prefill segments in packed order.
 
         Sets ``ctx.segment_positions`` so ``apply_packed_rope`` reads
         caller-supplied positions on mm segments and falls back to the
@@ -2036,8 +2038,9 @@ class MetalModelRunner:
                 position_ids_parts.append(seg_positions)
 
                 for feature in sorted_features:
-                    f_start = feature.mm_position.offset
-                    f_end = f_start + feature.mm_position.length
+                    position = feature.mm_position
+                    f_start = position.offset
+                    f_end = f_start + position.length
                     chunk_start = pr.start_pos
                     chunk_end = pr.start_pos + n
                     inter_start = max(f_start, chunk_start)
@@ -2048,6 +2051,16 @@ class MetalModelRunner:
                     chunk_local = inter_start - chunk_start
                     feature_local = inter_start - f_start
 
+                    # ``is_embed`` marks which placeholder positions take an
+                    # encoder row: Gemma 4 wraps its image tokens in boi/eoi
+                    # text tokens, so the encoder emits fewer rows than the
+                    # placeholder is long.  ``None`` means every position.
+                    embed_start, embed_end = position.get_embeds_indices_in_range(
+                        feature_local, feature_local + length
+                    )
+                    if embed_start == embed_end:
+                        continue  # only boi/eoi landed in this chunk
+
                     result = encoder_cache.encoder_outputs.get(feature.identifier)
                     if result is None:
                         raise RuntimeError(
@@ -2057,13 +2070,19 @@ class MetalModelRunner:
                         )
 
                     packed_start = cursor + chunk_local
-                    visual_pos_masks_np[packed_start : packed_start + length] = True
+                    is_embed = position.is_embed
+                    if is_embed is None:
+                        visual_pos_masks_np[packed_start : packed_start + length] = True
+                    else:
+                        visual_pos_masks_np[packed_start : packed_start + length] = (
+                            is_embed[feature_local : feature_local + length]
+                            .cpu()
+                            .numpy()
+                        )
 
-                    mm_embeds_parts.append(
-                        result.hidden_states[feature_local : feature_local + length]
-                    )
+                    mm_embeds_parts.append(result.hidden_states[embed_start:embed_end])
 
-                    # Deepstack: same chunk-aware slice per layer.
+                    # Deepstack: same embed-aware slice per layer.
                     layers = result.deepstack_visual_embeds
                     this_has = layers is not None
                     if deepstack_present is None:
@@ -2082,8 +2101,7 @@ class MetalModelRunner:
                     assert layers is not None
                     if not deepstack_per_layer:
                         deepstack_per_layer = [
-                            [layer[feature_local : feature_local + length]]
-                            for layer in layers
+                            [layer[embed_start:embed_end]] for layer in layers
                         ]
                     elif len(deepstack_per_layer) != len(layers):
                         raise RuntimeError(
@@ -2094,7 +2112,7 @@ class MetalModelRunner:
                     else:
                         for layer_idx, layer in enumerate(layers):
                             deepstack_per_layer[layer_idx].append(
-                                layer[feature_local : feature_local + length]
+                                layer[embed_start:embed_end]
                             )
             else:
                 # text prefill: mark segment as None so attention uses the

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -884,9 +884,27 @@ class MetalModelRunner:
         cache_before = mx.get_cache_memory()
         dummy_tokens = mx.zeros((1, warmup_len), dtype=mx.int32)
         mx.eval(*self._dummy_forward_outputs(dummy_tokens))
+        # The vision encoder runs outside the text forward; profile it too so
+        # the buffer-cache cap covers one encoder pass (the runner encodes
+        # features one adapter call per step, so one maximal feature is the
+        # peak).
+        mx.eval(*self._dummy_encoder_outputs())
         overhead = mx.get_cache_memory() - cache_before
         mx.set_cache_limit(overhead)
         return overhead
+
+    def _dummy_encoder_outputs(self) -> list[mx.array]:
+        """Encoder outputs for one profiling feature, when the adapter offers one."""
+        adapter = self._multimodal_adapter
+        if adapter is None or not adapter.forward_ready:
+            return []
+        profile_features = getattr(adapter, "profile_features", None)
+        if profile_features is None:
+            return []
+        features = profile_features()
+        if not features:
+            return []
+        return [result.hidden_states for result in adapter.encode_multimodal(features)]
 
     def _dummy_forward_outputs(self, input_ids: mx.array) -> list[mx.array]:
         if self._is_pooling:

--- a/vllm_metal/v1/model_runner.py
+++ b/vllm_metal/v1/model_runner.py
@@ -2108,11 +2108,18 @@ class MetalModelRunner:
 
         position_ids = mx.concatenate(position_ids_parts, axis=2)
 
-        # Hand per-segment positions to ``apply_packed_rope`` via the
-        # paged context, overriding the sequential-arange policy.
+        # Hand per-segment positions to ``apply_packed_rope`` via the paged
+        # context, unless the adapter's LM derives positions from
+        # ``ctx.offsets`` (mlx_lm ``rope(x, offset=)`` rejects explicit
+        # positions, and a list of ``None`` would also defeat the batched
+        # decode RoPE path).
         ctx = get_context()
         if ctx is not None:
-            ctx.segment_positions = ctx_segment_positions
+            ctx.segment_positions = (
+                ctx_segment_positions
+                if getattr(adapter, "supplies_segment_positions", True)
+                else None
+            )
 
         mm_prefill_deltas = {
             req_id: int(meta[1]) for req_id, meta in mm_request_meta.items()


### PR DESCRIPTION
## Purpose

Three small hooks on the model-adapter contract that a text backbone needs
before it can serve image inputs, plus a `text-only` multimodal serve mode.
Nothing model-specific here — the Gemma 4 vision sidecar that consumes these
hooks follows in a separate PR.

## What changes

- **`supports_per_segment_positions`** — an adapter can opt out of per-segment
  positions when its text backbone wants plain sequential positions instead of
  the mrope-style per-segment layout.
- **`supports_selective_logits`** — an adapter can keep vLLM's selective-logits
  path on a VLM text backbone instead of materializing logits for every row.
- **`PlaceholderRange.is_embed`** is now honoured when splicing multimodal
  embeddings, so a placeholder span that mixes embed and non-embed rows (boi /
  eoi marker tokens around an image block) splices only the embed rows.
- **Encoder profiling** — when an adapter offers `profile_features`, the runner
  runs one encoder pass during profiling so the vision tower's peak allocation
  is part of the memory profile rather than a surprise on the first request.
- **`VLLM_METAL_MULTIMODAL_MODE=text-only`** forces the text-only backbone for
  every multimodal checkpoint. `auto` and `multimodal-native` are unchanged.

## Testing

`pytest -m "not slow" tests/ -q` — 2165 passed, 15 skipped. `ruff check`,
`ruff format --check` and `mypy vllm_metal` are clean. The new behaviour is
covered through stub adapters in `tests/v1/mm/test_paged_forward_mm.py`,
`tests/v1/mm/test_paged_forward_mm_gate.py` and
`tests/test_model_runner_profile.py`, including the empty-`profile_features`
branch. No existing adapter sets any of the new flags, so every current model
keeps its present behaviour.


## What follows

This is the first of four PRs bringing Gemma 4's image inputs to Metal. They
are stacked, so each is opened only once its parent has landed and it has been
rebased on `main` — the sizes below are the incremental ones:

1. **This PR** — the adapter hooks and the `text-only` serve mode (+418, 9
   files).
2. **Vision sidecar** — `vision_tower` and `embed_vision` loaded beside the
   mlx_lm text backbone rather than moving Gemma 4 onto an mlx-vlm composite,
   so MTP drafting, YOCO fast prefill and sliding-window dispatch keep running
   against the same text model (+2577, 20 files).
3. **Bidirectional attention inside image blocks** — HF's
   `create_masks_for_vision_model` semantics, reached by recomputing the image
   rows with MLX SDPA after the paged kernel (+2079, 27 files).
4. **The same mask inside the tiled Metal kernel** — vLLM's `mm_prefix`
   contract behind a function constant, with the recompute kept as a
   switchable reference path (+1269, 14 files).
