### PR TITLE
[Bugfix] Anchor install.sh source-checkout mode to the repo root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -216,8 +216,8 @@ EOF
   # Source shared library functions
   # Try local lib.sh first (when running ./install.sh), fall back to remote (when piped from curl)
   local local_lib=""
+  local script_dir=""
   if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
-    local script_dir
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" && pwd)"
     local_lib="$script_dir/scripts/lib.sh"
   fi
@@ -251,7 +251,11 @@ EOF
 
   local venv="$HOME/.venv-vllm-metal"
   if [[ -n "$local_lib" && -f "$local_lib" ]]; then
-    venv="$PWD/.venv-vllm-metal"
+    # Source checkouts read the release tag file, run the editable install,
+    # and build native artifacts relative to the repo root, so anchor the
+    # working directory there instead of the caller's cwd.
+    cd "$script_dir" || exit 1
+    venv="$script_dir/.venv-vllm-metal"
   fi
 
   ensure_venv "$venv"


### PR DESCRIPTION
Fixes #752

## Problem

`install.sh` detects a source checkout by looking for `scripts/lib.sh` next to its own location, but the source-checkout branch of `main()` then resolves three things against the caller's current directory instead of the repo:

- the venv path (`$PWD/.venv-vllm-metal`)
- the vLLM release tag file (`.github/vllm-release-tag.commit`, read with a relative default)
- the editable install (`uv pip install -e .`)

So running `bash /path/to/vllm-metal/install.sh` from any other directory fails immediately with `Error: Missing vLLM release tag file`, after creating a stray venv in the caller's directory.

## Fix

Hoist `script_dir` out of the inner `if` so it stays in scope, and `cd` to it at the start of the source-checkout branch before creating the venv. Everything downstream (`read_vllm_release_tag`, `uv pip install -e .`, `ensure_metal_toolchain`, `build_native_artifacts`) already assumes the repo root as cwd, so no other changes are needed. The venv now lands at `<repo>/.venv-vllm-metal`, which is the same location as before when running from the repo root.

The `curl | bash` path is unaffected: `local_lib` is empty there and the branch is never taken.

## Verification

Steps from #752: `cd "$(mktemp -d)"`, then `bash /path/to/vllm-metal/install.sh`.

Before this change:

```
=== Creating virtual environment ===
Creating virtual environment with seed packages at: .venv-vllm-metal
Error: Missing vLLM release tag file: .github/vllm-release-tag.commit
```

After this change, from the same kind of directory: the venv is created under the repo, vLLM core installs, the editable install of the repo succeeds, and the script proceeds to `=== Ensuring Metal toolchain ===`. On a machine with Command Line Tools only (no Xcode) it stops there, which is the separate #684 problem and not related to this change.

`bash -n install.sh` passes. I do not have shellcheck installed locally, so I am relying on CI for that.
